### PR TITLE
feat: expand Live Now stream details

### DIFF
--- a/public/streams.js
+++ b/public/streams.js
@@ -232,11 +232,15 @@ function renderLiveRows(enabled, streams) {
   if (!tbody) return;
   clearChildren(tbody);
   liveItemsByKey = Object.create(null);
+  var nextExpandedLiveRows = Object.create(null);
 
   for (var i = 0; i < streams.length; i++) {
     var item = streams[i];
     var key = getLiveRowKey(item);
     liveItemsByKey[key] = item;
+    if (expandedLiveRows[key]) {
+      nextExpandedLiveRows[key] = true;
+    }
     var tr = document.createElement('tr');
     tr.className = 'sfx-row';
     tr.dataset.liveKey = key;
@@ -279,10 +283,12 @@ function renderLiveRows(enabled, streams) {
     tbody.appendChild(tr);
     tbody.appendChild(createDetailRow(item));
 
-    if (expandedLiveRows[key]) {
+    if (nextExpandedLiveRows[key]) {
       hydrateLivePreviewGrid(key);
     }
   }
+
+  expandedLiveRows = nextExpandedLiveRows;
 }
 
 document.addEventListener('click', function (event) {
@@ -351,6 +357,8 @@ function refreshLiveNow() {
       var enabled = data.enabled;
       var streams = data.streams;
       if (!streams || !streams.length) {
+        expandedLiveRows = Object.create(null);
+        liveItemsByKey = Object.create(null);
         setLiveTableMessage('No streamers currently live.');
       } else {
         renderLiveRows(enabled, streams);

--- a/public/streams.js
+++ b/public/streams.js
@@ -6,12 +6,17 @@ function toggleGroupEdit(id) {
 
 var expandedLiveRows = Object.create(null);
 
-var LIVE_TABLE_COLUMNS = (function () {
-  // Derive the column count from the Live Now header row at runtime.
+var liveTableColumnsCache = null;
+
+function getLiveTableColumns() {
+  if (liveTableColumnsCache !== null) return liveTableColumnsCache;
+
   var headerRow = document.querySelector('#live-table thead tr');
-  if (!headerRow) return 1;
-  return headerRow.children ? headerRow.children.length : 1;
-})();
+  liveTableColumnsCache = headerRow && headerRow.children
+    ? headerRow.children.length
+    : 1;
+  return liveTableColumnsCache;
+}
 
 function clearChildren(el) {
   while (el.firstChild) el.removeChild(el.firstChild);
@@ -79,7 +84,7 @@ function renderLink(url, label) {
 }
 
 function renderEmbedFields(fields) {
-  if (!fields || !fields.length) {
+  if (!Array.isArray(fields) || fields.length === 0) {
     return '<div class="discord-embed-field"><span class="muted">No embed fields</span></div>';
   }
 
@@ -158,7 +163,7 @@ function createDetailRow(item) {
   detailTr.style.display = expandedLiveRows[key] ? 'table-row' : 'none';
 
   var detailTd = document.createElement('td');
-  detailTd.colSpan = LIVE_TABLE_COLUMNS;
+  detailTd.colSpan = getLiveTableColumns();
   detailTd.innerHTML = '' +
     '<div class="live-detail-shell">' +
       '<div class="live-detail-grid">' +
@@ -196,7 +201,7 @@ function setLiveTableMessage(text) {
   clearChildren(tbody);
   var tr = document.createElement('tr');
   var td = document.createElement('td');
-  td.colSpan = LIVE_TABLE_COLUMNS;
+  td.colSpan = getLiveTableColumns();
   td.className = 'empty-msg';
   td.textContent = text;
   tr.appendChild(td);

--- a/public/streams.js
+++ b/public/streams.js
@@ -65,6 +65,11 @@ function sanitizeUrl(url, options) {
   var raw = String(url).trim();
   if (!raw) return null;
 
+  // Twitch/CDN URLs may occasionally arrive protocol-relative (//host/path).
+  if (raw.indexOf('//') === 0) {
+    raw = 'https:' + raw;
+  }
+
   var parsed;
   try {
     parsed = new URL(raw);
@@ -122,8 +127,11 @@ function renderMessagePreview(title, preview) {
                 : escapeHtml(formatValue(embed.title))) + '</div>' +
               '<div class="discord-embed-fields">' + renderEmbedFields(embed.fields) + '</div>' +
               '<div class="discord-embed-image">' + (safeImageUrl
-                ? '<img src="' + escapeHtml(safeImageUrl) + '" alt="Stream thumbnail preview">'
+                ? '<img src="' + escapeHtml(safeImageUrl) + '" alt="Stream thumbnail preview" loading="lazy" referrerpolicy="no-referrer">'
                 : '<span class="muted">Thumbnail unavailable</span>') + '</div>' +
+              (safeImageUrl
+                ? '<div class="discord-embed-footer">Image: ' + renderLink(safeImageUrl, 'open thumbnail') + '</div>'
+                : '') +
               (embed.footer ? '<div class="discord-embed-footer">' + escapeHtml(embed.footer) + '</div>' : '<div class="discord-embed-footer muted">No footer</div>') +
             '</div>' +
           '</div>' : '') +

--- a/public/streams.js
+++ b/public/streams.js
@@ -50,9 +50,32 @@ function renderMetadataItem(label, value, extraClass) {
     '</div>';
 }
 
+function sanitizeUrl(url, options) {
+  if (!url) return null;
+  var raw = String(url).trim();
+  if (!raw) return null;
+
+  var parsed;
+  try {
+    parsed = new URL(raw);
+  } catch (_err) {
+    return null;
+  }
+
+  var protocol = parsed.protocol.toLowerCase();
+  var requireHttps = !!(options && options.requireHttps);
+  if (requireHttps) {
+    return protocol === 'https:' ? parsed.href : null;
+  }
+
+  if (protocol === 'https:' || protocol === 'http:') return parsed.href;
+  return null;
+}
+
 function renderLink(url, label) {
-  if (!url) return '<span class="muted">—</span>';
-  return '<a href="' + escapeHtml(url) + '" target="_blank" rel="noreferrer">' + escapeHtml(label || url) + '</a>';
+  var safeUrl = sanitizeUrl(url);
+  if (!safeUrl) return '<span class="muted">—</span>';
+  return '<a href="' + escapeHtml(safeUrl) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(label || safeUrl) + '</a>';
 }
 
 function renderEmbedFields(fields) {
@@ -72,6 +95,8 @@ function renderEmbedFields(fields) {
 function renderMessagePreview(title, preview) {
   var embed = preview && preview.embed ? preview.embed : null;
   var content = preview ? formatValue(preview.content, '') : '';
+  var safeEmbedUrl = embed ? sanitizeUrl(embed.url) : null;
+  var safeImageUrl = embed ? sanitizeUrl(embed.imageUrl, { requireHttps: true }) : null;
 
   return '' +
     '<section class="live-message-preview">' +
@@ -82,9 +107,13 @@ function renderMessagePreview(title, preview) {
           '<div class="discord-embed-preview">' +
             '<div class="discord-embed-accent"></div>' +
             '<div class="discord-embed-body">' +
-              '<div class="discord-embed-title"><a href="' + escapeHtml(embed.url) + '" target="_blank" rel="noreferrer">' + escapeHtml(formatValue(embed.title)) + '</a></div>' +
+              '<div class="discord-embed-title">' + (safeEmbedUrl
+                ? '<a href="' + escapeHtml(safeEmbedUrl) + '" target="_blank" rel="noopener noreferrer">' + escapeHtml(formatValue(embed.title)) + '</a>'
+                : escapeHtml(formatValue(embed.title))) + '</div>' +
               '<div class="discord-embed-fields">' + renderEmbedFields(embed.fields) + '</div>' +
-              '<div class="discord-embed-image"><img src="' + escapeHtml(embed.imageUrl) + '" alt="Stream thumbnail preview"></div>' +
+              '<div class="discord-embed-image">' + (safeImageUrl
+                ? '<img src="' + escapeHtml(safeImageUrl) + '" alt="Stream thumbnail preview">'
+                : '<span class="muted">Thumbnail unavailable</span>') + '</div>' +
               (embed.footer ? '<div class="discord-embed-footer">' + escapeHtml(embed.footer) + '</div>' : '<div class="discord-embed-footer muted">No footer</div>') +
             '</div>' +
           '</div>' : '') +
@@ -206,7 +235,7 @@ function renderLiveRows(enabled, streams) {
     var postTd = document.createElement('td');
     if (!enabled) {
       var disabledSpan = document.createElement('span');
-      disabledSpan.style.color = 'var(--text-muted)';
+      disabledSpan.style.color = 'var(--muted)';
       disabledSpan.textContent = '— disabled';
       postTd.appendChild(disabledSpan);
     } else if (item.messageId) {
@@ -216,7 +245,7 @@ function renderLiveRows(enabled, streams) {
       postTd.appendChild(postedBadge);
     } else {
       var noneSpan = document.createElement('span');
-      noneSpan.style.color = 'var(--text-muted)';
+      noneSpan.style.color = 'var(--muted)';
       noneSpan.textContent = '— none';
       postTd.appendChild(noneSpan);
     }

--- a/public/streams.js
+++ b/public/streams.js
@@ -4,6 +4,9 @@ function toggleGroupEdit(id) {
   row.style.display = row.style.display === 'none' ? 'table-row' : 'none';
 }
 
+var LIVE_TABLE_COLUMNS = 6;
+var expandedLiveRows = Object.create(null);
+
 function clearChildren(el) {
   while (el.firstChild) el.removeChild(el.firstChild);
 }
@@ -15,13 +18,150 @@ function makeCell(text, className) {
   return td;
 }
 
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function formatValue(value, fallback) {
+  if (value === null || value === undefined || value === '') return fallback || '—';
+  return String(value);
+}
+
+function renderBadge(label, className) {
+  return '<span class="badge ' + className + '">' + escapeHtml(label) + '</span>';
+}
+
+function renderMetadataItem(label, value, extraClass) {
+  return '' +
+    '<div class="live-meta-item">' +
+      '<span class="live-meta-label">' + escapeHtml(label) + '</span>' +
+      '<span class="live-meta-value' + (extraClass ? ' ' + extraClass : '') + '">' + escapeHtml(formatValue(value)) + '</span>' +
+    '</div>';
+}
+
+function renderLink(url, label) {
+  if (!url) return '<span class="muted">—</span>';
+  return '<a href="' + escapeHtml(url) + '" target="_blank" rel="noreferrer">' + escapeHtml(label || url) + '</a>';
+}
+
+function renderEmbedFields(fields) {
+  if (!fields || !fields.length) {
+    return '<div class="discord-embed-field"><span class="muted">No embed fields</span></div>';
+  }
+
+  return fields.map(function(field) {
+    return '' +
+      '<div class="discord-embed-field">' +
+        '<div class="discord-embed-field-name">' + escapeHtml(formatValue(field.name)) + '</div>' +
+        '<div class="discord-embed-field-value">' + escapeHtml(formatValue(field.value)) + '</div>' +
+      '</div>';
+  }).join('');
+}
+
+function renderMessagePreview(title, preview) {
+  var embed = preview && preview.embed ? preview.embed : null;
+  var content = preview ? formatValue(preview.content, '') : '';
+
+  return '' +
+    '<section class="live-message-preview">' +
+      '<h4 class="live-message-title">' + escapeHtml(title) + '</h4>' +
+      '<div class="discord-message-box">' +
+        '<div class="discord-message-content">' + (content ? escapeHtml(content) : '<span class="muted">No message content</span>') + '</div>' +
+        (embed ? '' +
+          '<div class="discord-embed-preview">' +
+            '<div class="discord-embed-accent"></div>' +
+            '<div class="discord-embed-body">' +
+              '<div class="discord-embed-title"><a href="' + escapeHtml(embed.url) + '" target="_blank" rel="noreferrer">' + escapeHtml(formatValue(embed.title)) + '</a></div>' +
+              '<div class="discord-embed-fields">' + renderEmbedFields(embed.fields) + '</div>' +
+              '<div class="discord-embed-image"><img src="' + escapeHtml(embed.imageUrl) + '" alt="Stream thumbnail preview"></div>' +
+              (embed.footer ? '<div class="discord-embed-footer">' + escapeHtml(embed.footer) + '</div>' : '<div class="discord-embed-footer muted">No footer</div>') +
+            '</div>' +
+          '</div>' : '') +
+      '</div>' +
+    '</section>';
+}
+
+function getLiveRowKey(item) {
+  return String(item.streamerId || '') + ':' + String(item.groupId || '');
+}
+
+function renderMultiTwitchDetails(multiTwitch) {
+  var participants = multiTwitch && multiTwitch.participants && multiTwitch.participants.length
+    ? multiTwitch.participants.join(', ')
+    : '—';
+  var footerState = multiTwitch && multiTwitch.renderedFooter
+    ? renderBadge('Footer active', 'badge-active')
+    : '<span class="muted">No footer rendered</span>';
+
+  return '' +
+    '<section class="live-detail-section">' +
+      '<h4 class="live-message-title">Multi-Twitch</h4>' +
+      '<div class="live-meta-grid">' +
+        renderMetadataItem('Setting', multiTwitch && multiTwitch.enabled ? 'Enabled' : 'Disabled') +
+        renderMetadataItem('Applicable Now', multiTwitch && multiTwitch.applicable ? 'Yes' : 'No') +
+        renderMetadataItem('Participants', participants, 'mono') +
+        renderMetadataItem('Footer', multiTwitch && multiTwitch.renderedFooter ? multiTwitch.renderedFooter : '—', 'mono') +
+      '</div>' +
+      '<div class="live-link-row">' +
+        '<span class="live-meta-label">Computed link</span>' +
+        '<span class="live-meta-value mono">' + renderLink(multiTwitch ? multiTwitch.url : null, multiTwitch && multiTwitch.url ? multiTwitch.url : '—') + '</span>' +
+      '</div>' +
+      '<div class="live-footer-state">' + footerState + '</div>' +
+    '</section>';
+}
+
+function createDetailRow(item) {
+  var key = getLiveRowKey(item);
+  var detailTr = document.createElement('tr');
+  detailTr.className = 'files-row live-detail-row';
+  detailTr.dataset.liveKey = key;
+  detailTr.style.display = expandedLiveRows[key] ? 'table-row' : 'none';
+
+  var detailTd = document.createElement('td');
+  detailTd.colSpan = LIVE_TABLE_COLUMNS;
+  detailTd.innerHTML = '' +
+    '<div class="live-detail-shell">' +
+      '<div class="live-detail-grid">' +
+        '<section class="live-detail-section">' +
+          '<h4 class="live-message-title">Current Details</h4>' +
+          '<div class="live-meta-grid">' +
+            renderMetadataItem('Streamer ID', item.streamerId, 'mono') +
+            renderMetadataItem('Group ID', item.groupId, 'mono') +
+            renderMetadataItem('Group', item.groupName) +
+            renderMetadataItem('Target Discord Channel', item.groupDiscordChannelId, 'mono') +
+            renderMetadataItem('Posted Channel', item.channelId, 'mono') +
+            renderMetadataItem('Discord Message ID', item.messageId, 'mono') +
+            renderMetadataItem('Delete Old Posts', item.deleteOldPosts ? 'Yes' : 'No') +
+            renderMetadataItem('Current Game', item.currentGame) +
+          '</div>' +
+          '<div class="live-link-row">' +
+            '<span class="live-meta-label">Twitch</span>' +
+            '<span class="live-meta-value mono">' + renderLink(item.twitchUrl, item.twitchUrl) + '</span>' +
+          '</div>' +
+        '</section>' +
+        renderMultiTwitchDetails(item.multiTwitch) +
+      '</div>' +
+      '<div class="live-preview-grid">' +
+        renderMessagePreview('Live Announcement Preview', item.liveMessagePreview) +
+        renderMessagePreview('Game Change Preview', item.gameChangePreview) +
+      '</div>' +
+    '</div>';
+  detailTr.appendChild(detailTd);
+  return detailTr;
+}
+
 function setLiveTableMessage(text) {
   var tbody = document.getElementById('live-tbody');
   if (!tbody) return;
   clearChildren(tbody);
   var tr = document.createElement('tr');
   var td = document.createElement('td');
-  td.colSpan = 5;
+  td.colSpan = LIVE_TABLE_COLUMNS;
   td.className = 'empty-msg';
   td.textContent = text;
   tr.appendChild(td);
@@ -35,7 +175,20 @@ function renderLiveRows(enabled, streams) {
 
   for (var i = 0; i < streams.length; i++) {
     var item = streams[i];
+    var key = getLiveRowKey(item);
     var tr = document.createElement('tr');
+    tr.className = 'sfx-row';
+    tr.dataset.liveKey = key;
+
+    var toggleTd = document.createElement('td');
+    var toggleBtn = document.createElement('button');
+    toggleBtn.type = 'button';
+    toggleBtn.className = 'btn btn-sm btn-ghost btn-toggle-live-details';
+    toggleBtn.dataset.liveKey = key;
+    toggleBtn.setAttribute('aria-expanded', expandedLiveRows[key] ? 'true' : 'false');
+    toggleBtn.textContent = expandedLiveRows[key] ? '▼' : '▶';
+    toggleTd.appendChild(toggleBtn);
+    tr.appendChild(toggleTd);
 
     tr.appendChild(makeCell(String(item.login || ''), 'mono'));
     tr.appendChild(makeCell(String(item.groupName || '')));
@@ -61,6 +214,7 @@ function renderLiveRows(enabled, streams) {
     }
     tr.appendChild(postTd);
     tbody.appendChild(tr);
+    tbody.appendChild(createDetailRow(item));
   }
 }
 
@@ -72,6 +226,25 @@ document.addEventListener('click', function (event) {
   if (toggleBtn instanceof HTMLElement) {
     var id = toggleBtn.dataset.groupId;
     if (id) toggleGroupEdit(id);
+    return;
+  }
+
+  var liveToggleBtn = target.closest('.btn-toggle-live-details');
+  if (liveToggleBtn instanceof HTMLElement) {
+    var liveKey = liveToggleBtn.dataset.liveKey;
+    if (!liveKey) return;
+    expandedLiveRows[liveKey] = !expandedLiveRows[liveKey];
+
+    var detailRow = document.querySelector('tr.live-detail-row[data-live-key="' + liveKey + '"]');
+    if (detailRow instanceof HTMLElement) {
+      detailRow.style.display = expandedLiveRows[liveKey] ? 'table-row' : 'none';
+    }
+
+    var summaryButton = document.querySelector('.btn-toggle-live-details[data-live-key="' + liveKey + '"]');
+    if (summaryButton instanceof HTMLElement) {
+      summaryButton.textContent = expandedLiveRows[liveKey] ? '▼' : '▶';
+      summaryButton.setAttribute('aria-expanded', expandedLiveRows[liveKey] ? 'true' : 'false');
+    }
   }
 });
 

--- a/public/streams.js
+++ b/public/streams.js
@@ -5,6 +5,7 @@ function toggleGroupEdit(id) {
 }
 
 var expandedLiveRows = Object.create(null);
+var liveItemsByKey = Object.create(null);
 
 var liveTableColumnsCache = null;
 
@@ -39,7 +40,11 @@ function escapeHtml(value) {
 }
 
 function formatValue(value, fallback) {
-  if (value === null || value === undefined || value === '') return fallback || '—';
+  if (value === null || value === undefined || value === '') {
+    return fallback === undefined || fallback === null
+      ? '—'
+      : String(fallback);
+  }
   return String(value);
 }
 
@@ -186,13 +191,27 @@ function createDetailRow(item) {
         '</section>' +
         renderMultiTwitchDetails(item.multiTwitch) +
       '</div>' +
-      '<div class="live-preview-grid">' +
-        renderMessagePreview('Live Announcement Preview', item.liveMessagePreview) +
-        renderMessagePreview('Game Change Preview', item.gameChangePreview) +
-      '</div>' +
+      '<div class="live-preview-grid" data-live-key="' + escapeHtml(key) + '" data-hydrated="false"></div>' +
     '</div>';
   detailTr.appendChild(detailTd);
   return detailTr;
+}
+
+function hydrateLivePreviewGrid(liveKey) {
+  var detailRow = document.querySelector('tr.live-detail-row[data-live-key="' + liveKey + '"]');
+  if (!(detailRow instanceof HTMLElement)) return;
+
+  var grid = detailRow.querySelector('.live-preview-grid');
+  if (!(grid instanceof HTMLElement)) return;
+  if (grid.dataset.hydrated === 'true') return;
+
+  var item = liveItemsByKey[liveKey];
+  if (!item) return;
+
+  grid.innerHTML = '' +
+    renderMessagePreview('Live Announcement Preview', item.liveMessagePreview) +
+    renderMessagePreview('Game Change Preview', item.gameChangePreview);
+  grid.dataset.hydrated = 'true';
 }
 
 function setLiveTableMessage(text) {
@@ -212,10 +231,12 @@ function renderLiveRows(enabled, streams) {
   var tbody = document.getElementById('live-tbody');
   if (!tbody) return;
   clearChildren(tbody);
+  liveItemsByKey = Object.create(null);
 
   for (var i = 0; i < streams.length; i++) {
     var item = streams[i];
     var key = getLiveRowKey(item);
+    liveItemsByKey[key] = item;
     var tr = document.createElement('tr');
     tr.className = 'sfx-row';
     tr.dataset.liveKey = key;
@@ -257,6 +278,10 @@ function renderLiveRows(enabled, streams) {
     tr.appendChild(postTd);
     tbody.appendChild(tr);
     tbody.appendChild(createDetailRow(item));
+
+    if (expandedLiveRows[key]) {
+      hydrateLivePreviewGrid(key);
+    }
   }
 }
 
@@ -280,6 +305,10 @@ document.addEventListener('click', function (event) {
     var detailRow = document.querySelector('tr.live-detail-row[data-live-key="' + liveKey + '"]');
     if (detailRow instanceof HTMLElement) {
       detailRow.style.display = expandedLiveRows[liveKey] ? 'table-row' : 'none';
+    }
+
+    if (expandedLiveRows[liveKey]) {
+      hydrateLivePreviewGrid(liveKey);
     }
 
     liveToggleBtn.textContent = expandedLiveRows[liveKey] ? '▼' : '▶';

--- a/public/streams.js
+++ b/public/streams.js
@@ -248,11 +248,8 @@ document.addEventListener('click', function (event) {
       detailRow.style.display = expandedLiveRows[liveKey] ? 'table-row' : 'none';
     }
 
-    var summaryButton = document.querySelector('.btn-toggle-live-details[data-live-key="' + liveKey + '"]');
-    if (summaryButton instanceof HTMLElement) {
-      summaryButton.textContent = expandedLiveRows[liveKey] ? '▼' : '▶';
-      summaryButton.setAttribute('aria-expanded', expandedLiveRows[liveKey] ? 'true' : 'false');
-    }
+    liveToggleBtn.textContent = expandedLiveRows[liveKey] ? '▼' : '▶';
+    liveToggleBtn.setAttribute('aria-expanded', expandedLiveRows[liveKey] ? 'true' : 'false');
   }
 });
 

--- a/public/streams.js
+++ b/public/streams.js
@@ -4,8 +4,14 @@ function toggleGroupEdit(id) {
   row.style.display = row.style.display === 'none' ? 'table-row' : 'none';
 }
 
-var LIVE_TABLE_COLUMNS = 6;
 var expandedLiveRows = Object.create(null);
+
+var LIVE_TABLE_COLUMNS = (function () {
+  // Derive the column count from the Live Now header row at runtime.
+  var headerRow = document.querySelector('#live-table thead tr');
+  if (!headerRow) return 1;
+  return headerRow.children ? headerRow.children.length : 1;
+})();
 
 function clearChildren(el) {
   while (el.firstChild) el.removeChild(el.firstChild);
@@ -186,6 +192,8 @@ function renderLiveRows(enabled, streams) {
     toggleBtn.className = 'btn btn-sm btn-ghost btn-toggle-live-details';
     toggleBtn.dataset.liveKey = key;
     toggleBtn.setAttribute('aria-expanded', expandedLiveRows[key] ? 'true' : 'false');
+    toggleBtn.setAttribute('aria-label', 'Toggle stream details for ' + String(item.login || 'stream'));
+    toggleBtn.title = 'Toggle stream details';
     toggleBtn.textContent = expandedLiveRows[key] ? '▼' : '▶';
     toggleTd.appendChild(toggleBtn);
     tr.appendChild(toggleTd);

--- a/public/style.css
+++ b/public/style.css
@@ -107,11 +107,46 @@ a:hover { text-decoration: underline; }
 .table tr:last-child td { border-bottom: none; }
 .table tr.row-hidden td { opacity: .5; }
 .table tr.sfx-row:hover td { background: var(--bg-hover); }
+.table tr.live-detail-row td { background: rgba(7, 10, 22, .92); }
 
 .inner-table { width: 100%; border-collapse: collapse; font-size: .82rem; background: var(--bg); border-radius: 6px; overflow: hidden; }
 .inner-table th { padding: .4rem .75rem; color: var(--muted); font-size: .75rem; border-bottom: 1px solid var(--border); }
 .inner-table td { padding: .4rem .75rem; border-bottom: 1px solid var(--border); }
 .inner-table tr:last-child td { border-bottom: none; }
+
+.live-detail-shell { padding: 1rem; background: linear-gradient(180deg, rgba(20,24,42,.95), rgba(12,15,28,.98)); border-radius: 8px; border: 1px solid rgba(88,101,242,.22); }
+.live-detail-grid { display: grid; grid-template-columns: 1.4fr 1fr; gap: 1rem; margin-bottom: 1rem; }
+.live-preview-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1rem; }
+.live-detail-section,
+.live-message-preview { background: rgba(9, 12, 24, .86); border: 1px solid var(--border); border-radius: 8px; padding: 1rem; }
+.live-message-title { font-size: .82rem; color: var(--muted); text-transform: uppercase; letter-spacing: .08em; margin-bottom: .75rem; }
+.live-meta-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .65rem .9rem; }
+.live-meta-item { display: flex; flex-direction: column; gap: .2rem; min-width: 0; }
+.live-meta-label { color: var(--muted); font-size: .72rem; text-transform: uppercase; letter-spacing: .06em; }
+.live-meta-value { color: var(--text); word-break: break-word; }
+.live-link-row { display: flex; gap: .75rem; align-items: flex-start; margin-top: .9rem; padding-top: .9rem; border-top: 1px solid var(--border); }
+.live-link-row .live-meta-value { min-width: 0; overflow-wrap: anywhere; }
+.live-footer-state { margin-top: .75rem; }
+
+.discord-message-box { display: grid; gap: .85rem; }
+.discord-message-content { white-space: pre-wrap; word-break: break-word; padding: .8rem .9rem; background: rgba(17, 20, 33, .96); border: 1px solid rgba(255,255,255,.05); border-radius: 8px; }
+.discord-embed-preview { display: grid; grid-template-columns: 4px minmax(0, 1fr); background: rgba(49, 51, 56, .75); border: 1px solid rgba(255,255,255,.05); border-radius: 8px; overflow: hidden; }
+.discord-embed-accent { background: #9146FF; }
+.discord-embed-body { padding: .9rem; display: grid; gap: .75rem; }
+.discord-embed-title a { color: #ffffff; font-weight: 700; text-decoration: none; }
+.discord-embed-title a:hover { text-decoration: underline; }
+.discord-embed-fields { display: grid; gap: .55rem; }
+.discord-embed-field-name { color: var(--muted); font-size: .72rem; text-transform: uppercase; letter-spacing: .06em; }
+.discord-embed-field-value { color: var(--text); font-size: .84rem; }
+.discord-embed-image { border-radius: 6px; overflow: hidden; border: 1px solid rgba(255,255,255,.05); background: #0c0e18; }
+.discord-embed-image img { display: block; width: 100%; height: auto; }
+.discord-embed-footer { color: var(--muted); font-size: .78rem; word-break: break-word; }
+
+@media (max-width: 980px) {
+  .live-detail-grid,
+  .live-preview-grid,
+  .live-meta-grid { grid-template-columns: 1fr; }
+}
 
 /* ── Forms ─────────────────────────────────────────────── */
 .input { background: var(--bg); border: 1px solid var(--border); border-radius: 6px; color: var(--text); padding: .45rem .75rem; font-size: .85rem; transition: border-color .15s; }

--- a/public/style.css
+++ b/public/style.css
@@ -129,7 +129,7 @@ a:hover { text-decoration: underline; }
 .live-footer-state { margin-top: .75rem; }
 
 .discord-message-box { display: grid; gap: .85rem; }
-.discord-message-content { white-space: pre-wrap; overflow-wrap: break-word; word-wrap: break-word; padding: .8rem .9rem; background: rgba(17, 20, 33, .96); border: 1px solid rgba(255,255,255,.05); border-radius: 8px; }
+.discord-message-content { white-space: pre-wrap; overflow-wrap: break-word; padding: .8rem .9rem; background: rgba(17, 20, 33, .96); border: 1px solid rgba(255,255,255,.05); border-radius: 8px; }
 .discord-embed-preview { display: grid; grid-template-columns: 4px minmax(0, 1fr); background: rgba(49, 51, 56, .75); border: 1px solid rgba(255,255,255,.05); border-radius: 8px; overflow: hidden; }
 .discord-embed-accent { background: #9146FF; }
 .discord-embed-body { padding: .9rem; display: grid; gap: .75rem; }

--- a/public/style.css
+++ b/public/style.css
@@ -123,13 +123,13 @@ a:hover { text-decoration: underline; }
 .live-meta-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .65rem .9rem; }
 .live-meta-item { display: flex; flex-direction: column; gap: .2rem; min-width: 0; }
 .live-meta-label { color: var(--muted); font-size: .72rem; text-transform: uppercase; letter-spacing: .06em; }
-.live-meta-value { color: var(--text); word-break: break-word; }
+.live-meta-value { color: var(--text); overflow-wrap: break-word; }
 .live-link-row { display: flex; gap: .75rem; align-items: flex-start; margin-top: .9rem; padding-top: .9rem; border-top: 1px solid var(--border); }
 .live-link-row .live-meta-value { min-width: 0; overflow-wrap: anywhere; }
 .live-footer-state { margin-top: .75rem; }
 
 .discord-message-box { display: grid; gap: .85rem; }
-.discord-message-content { white-space: pre-wrap; word-break: break-word; padding: .8rem .9rem; background: rgba(17, 20, 33, .96); border: 1px solid rgba(255,255,255,.05); border-radius: 8px; }
+.discord-message-content { white-space: pre-wrap; overflow-wrap: break-word; word-wrap: break-word; padding: .8rem .9rem; background: rgba(17, 20, 33, .96); border: 1px solid rgba(255,255,255,.05); border-radius: 8px; }
 .discord-embed-preview { display: grid; grid-template-columns: 4px minmax(0, 1fr); background: rgba(49, 51, 56, .75); border: 1px solid rgba(255,255,255,.05); border-radius: 8px; overflow: hidden; }
 .discord-embed-accent { background: #9146FF; }
 .discord-embed-body { padding: .9rem; display: grid; gap: .75rem; }
@@ -140,7 +140,7 @@ a:hover { text-decoration: underline; }
 .discord-embed-field-value { color: var(--text); font-size: .84rem; }
 .discord-embed-image { border-radius: 6px; overflow: hidden; border: 1px solid rgba(255,255,255,.05); background: #0c0e18; }
 .discord-embed-image img { display: block; width: 100%; height: auto; }
-.discord-embed-footer { color: var(--muted); font-size: .78rem; word-break: break-word; }
+.discord-embed-footer { color: var(--muted); font-size: .78rem; word-break: normal; overflow-wrap: break-word; }
 
 @media (max-width: 980px) {
   .live-detail-grid,

--- a/src/twitchMonitor.ts
+++ b/src/twitchMonitor.ts
@@ -367,19 +367,26 @@ async function handleStreamOffline(login: string): Promise<void> {
     if (state.offlineTimer) clearTimeout(state.offlineTimer);
 
     state.offlineTimer = setTimeout(async () => {
-      // Re-fetch current state to guard against stale closure after monitor restart.
-      const currentState = liveStates.get(stateKey);
-      if (!currentState) return;
-      currentState.offlineTimer = null;
-      const userId = loginToUserId.get(key);
-      if (!userId) return;
+      let currentState: LiveState | undefined;
+      try {
+        // Re-fetch current state to guard against stale closure after monitor restart.
+        currentState = liveStates.get(stateKey);
+        if (!currentState) return;
 
-      const streams = await getStreams([userId]);
-      const isLive = streams.some((s) => s.user_id === userId && s.type === 'live');
+        const userId = loginToUserId.get(key);
+        if (!userId) return;
 
-      if (!isLive) {
-        await deleteAnnouncement(stateKey);
-        console.log(`[TwitchMonitor] ${login} confirmed offline — announcement removed`);
+        const streams = await getStreams([userId]);
+        const isLive = streams.some((s) => s.user_id === userId && s.type === 'live');
+
+        if (!isLive) {
+          await deleteAnnouncement(stateKey);
+          console.log(`[TwitchMonitor] ${login} confirmed offline — announcement removed`);
+        }
+      } catch (err) {
+        console.error(`[TwitchMonitor] Offline-check failed for ${key} (${stateKey}):`, err);
+      } finally {
+        if (currentState) currentState.offlineTimer = null;
       }
     }, OFFLINE_GRACE_MS);
   }
@@ -459,13 +466,11 @@ async function performStartupLiveCheck(): Promise<void> {
             currentStream: liveStream,
             offlineTimer: null,
           });
-          groupsWithChanges.add(streamer.group.id);
           continue;
         }
       }
       // Post fresh announcement
       await postAnnouncement(streamer, liveStream);
-      groupsWithChanges.add(streamer.group.id);
     } else if (hasStoredMsg) {
       // Stream ended while bot was offline — liveStates is empty at startup so
       // deleteAnnouncement() would early-return without clearing DB state. Do it directly.
@@ -691,7 +696,6 @@ export function getLiveStates(): LiveStateSnapshot[] {
  */
 export async function catchUpDiscordPosts(): Promise<void> {
   if (!discordClient) return;
-  const groupsToUpdate = new Set<number>();
 
   const states = Array.from(liveStates.values());
   // Batch all live-state user IDs into a single Helix request instead of one per streamer.
@@ -724,7 +728,6 @@ export async function catchUpDiscordPosts(): Promise<void> {
       if (!stream) {
         // Went offline while posts were disabled — clean up any stale message
         await deleteAnnouncement(String(state.streamerId));
-        groupsToUpdate.add(state.groupId);
         continue;
       }
 
@@ -735,13 +738,8 @@ export async function catchUpDiscordPosts(): Promise<void> {
         // No message yet — post fresh
         await postAnnouncement(streamerInfo, stream);
       }
-      groupsToUpdate.add(state.groupId);
     } catch (err) {
       console.error(`[TwitchMonitor] Catch-up post failed for ${state.login}:`, err);
     }
-  }
-
-  for (const gid of groupsToUpdate) {
-    await updateMultitwitch(gid);
   }
 }

--- a/src/twitchMonitor.ts
+++ b/src/twitchMonitor.ts
@@ -153,11 +153,21 @@ function getMultitwitchPreview(state: LiveState, context?: MultiTwitchContext): 
     : buildMultiTwitchContext(liveStates.values()).participantsByGroupAndGame.get(groupGameKey(state.groupId, state.currentGame));
   const applicable = !!participants && participants.length >= 2;
 
-  if (!state.group.multi_twitch || !applicable) {
+  if (!applicable) {
     return {
       enabled: state.group.multi_twitch,
       applicable: false,
       participants: [state.login],
+      url: null,
+      renderedFooter: null,
+    };
+  }
+
+  if (!state.group.multi_twitch) {
+    return {
+      enabled: false,
+      applicable: true,
+      participants,
       url: null,
       renderedFooter: null,
     };

--- a/src/twitchMonitor.ts
+++ b/src/twitchMonitor.ts
@@ -47,6 +47,11 @@ export interface MultiTwitchPreview {
   renderedFooter: string | null;
 }
 
+interface MultiTwitchContext {
+  statesByGroupId: Map<number, LiveState[]>;
+  participantsByGroupAndGame: Map<string, string[]>;
+}
+
 // ─── Module-level state ──────────────────────────────────────────────────────
 
 /** Keyed by lowercase broadcaster login */
@@ -112,13 +117,44 @@ function templateVars(login: string, stream: TwitchStream, multitwitch?: string)
   };
 }
 
-function getMultitwitchPreview(state: LiveState): MultiTwitchPreview {
-  const groupLive = Array.from(liveStates.values()).filter((entry) => entry.groupId === state.groupId);
-  const sameGame = groupLive.filter(
-    (entry) => entry.currentGame === state.currentGame && entry.login !== state.login,
-  );
+function groupGameKey(groupId: number, game: string): string {
+  return `${groupId}::${game.toLowerCase()}`;
+}
 
-  if (!state.group.multi_twitch || sameGame.length === 0) {
+function buildMultiTwitchContext(states: Iterable<LiveState>): MultiTwitchContext {
+  const statesByGroupId = new Map<number, LiveState[]>();
+  const participantSets = new Map<string, Set<string>>();
+
+  for (const state of states) {
+    const groupStates = statesByGroupId.get(state.groupId);
+    if (groupStates) {
+      groupStates.push(state);
+    } else {
+      statesByGroupId.set(state.groupId, [state]);
+    }
+
+    const key = groupGameKey(state.groupId, state.currentGame);
+    const participants = participantSets.get(key);
+    if (participants) {
+      participants.add(state.login);
+    } else {
+      participantSets.set(key, new Set([state.login]));
+    }
+  }
+
+  const participantsByGroupAndGame = new Map<string, string[]>();
+  for (const [key, participants] of participantSets.entries()) {
+    participantsByGroupAndGame.set(key, Array.from(participants).sort((left, right) => left.localeCompare(right)));
+  }
+
+  return { statesByGroupId, participantsByGroupAndGame };
+}
+
+function getMultitwitchPreview(state: LiveState, context?: MultiTwitchContext): MultiTwitchPreview {
+  const participants = context?.participantsByGroupAndGame.get(groupGameKey(state.groupId, state.currentGame));
+  const applicable = !!participants && participants.length >= 2;
+
+  if (!state.group.multi_twitch || !applicable) {
     return {
       enabled: state.group.multi_twitch,
       applicable: false,
@@ -128,7 +164,6 @@ function getMultitwitchPreview(state: LiveState): MultiTwitchPreview {
     };
   }
 
-  const participants = [state.login, ...sameGame.map((entry) => entry.login)];
   const url = `https://www.multitwitch.tv/${participants.join('/')}`;
   const renderedFooter = fillTemplate(state.group.multi_twitch_message, { multitwitch: url }) || null;
 
@@ -165,10 +200,11 @@ async function updateMultitwitch(groupId: number): Promise<void> {
   if (!getMonitorEnabled() || !discordClient) return;
 
   const groupLive = Array.from(liveStates.values()).filter((s) => s.groupId === groupId);
+  const context = buildMultiTwitchContext(groupLive);
 
   for (const state of groupLive) {
     if (!state.messageId || !state.channelId) continue;
-    const multiTwitch = getMultitwitchPreview(state);
+    const multiTwitch = getMultitwitchPreview(state, context);
     const footer = multiTwitch.renderedFooter ?? undefined;
 
     try {
@@ -617,9 +653,12 @@ export interface LiveStateSnapshot {
 }
 
 export function getLiveStates(): LiveStateSnapshot[] {
-  return Array.from(liveStates.values())
+  const states = Array.from(liveStates.values());
+  const multiTwitchContext = buildMultiTwitchContext(states);
+
+  return states
     .map((state) => {
-      const multiTwitch = getMultitwitchPreview(state);
+      const multiTwitch = getMultitwitchPreview(state, multiTwitchContext);
 
       return {
         streamerId: state.streamerId,

--- a/src/twitchMonitor.ts
+++ b/src/twitchMonitor.ts
@@ -48,7 +48,6 @@ export interface MultiTwitchPreview {
 }
 
 interface MultiTwitchContext {
-  statesByGroupId: Map<number, LiveState[]>;
   participantsByGroupAndGame: Map<string, string[]>;
 }
 
@@ -93,13 +92,19 @@ function buildEmbedPreview(stream: TwitchStream, footer?: string): DiscordEmbedP
   };
 }
 
+function parseHexColor(color: string): number {
+  const normalized = color.trim().replace(/^#/, '');
+  if (!/^[0-9a-fA-F]{6}$/.test(normalized)) return 0x9146ff;
+  return parseInt(normalized, 16);
+}
+
 function buildEmbed(stream: TwitchStream, footer?: string): EmbedBuilder {
   const preview = buildEmbedPreview(stream, footer);
 
   const embed = new EmbedBuilder()
     .setTitle(preview.title)
     .setURL(preview.url)
-    .setColor(0x9146ff)
+    .setColor(parseHexColor(preview.color))
     .addFields(...preview.fields)
     .setImage(preview.imageUrl);
 
@@ -122,17 +127,9 @@ function groupGameKey(groupId: number, game: string): string {
 }
 
 function buildMultiTwitchContext(states: Iterable<LiveState>): MultiTwitchContext {
-  const statesByGroupId = new Map<number, LiveState[]>();
   const participantSets = new Map<string, Set<string>>();
 
   for (const state of states) {
-    const groupStates = statesByGroupId.get(state.groupId);
-    if (groupStates) {
-      groupStates.push(state);
-    } else {
-      statesByGroupId.set(state.groupId, [state]);
-    }
-
     const key = groupGameKey(state.groupId, state.currentGame);
     const participants = participantSets.get(key);
     if (participants) {
@@ -147,11 +144,13 @@ function buildMultiTwitchContext(states: Iterable<LiveState>): MultiTwitchContex
     participantsByGroupAndGame.set(key, Array.from(participants).sort((left, right) => left.localeCompare(right)));
   }
 
-  return { statesByGroupId, participantsByGroupAndGame };
+  return { participantsByGroupAndGame };
 }
 
 function getMultitwitchPreview(state: LiveState, context?: MultiTwitchContext): MultiTwitchPreview {
-  const participants = context?.participantsByGroupAndGame.get(groupGameKey(state.groupId, state.currentGame));
+  const participants = context
+    ? context.participantsByGroupAndGame.get(groupGameKey(state.groupId, state.currentGame))
+    : buildMultiTwitchContext(liveStates.values()).participantsByGroupAndGame.get(groupGameKey(state.groupId, state.currentGame));
   const applicable = !!participants && participants.length >= 2;
 
   if (!state.group.multi_twitch || !applicable) {

--- a/src/twitchMonitor.ts
+++ b/src/twitchMonitor.ts
@@ -144,17 +144,18 @@ function getMultitwitchPreview(state: LiveState): MultiTwitchPreview {
 function buildMessagePreview(
   state: LiveState,
   templateKey: 'live_message' | 'new_game_message',
+  multiTwitch?: MultiTwitchPreview,
 ): DiscordMessagePreview {
   const stream = state.currentStream;
-  const multiTwitch = getMultitwitchPreview(state);
+  const resolvedMultiTwitch = multiTwitch ?? getMultitwitchPreview(state);
   const template = templateKey === 'new_game_message'
     ? state.group.new_game_message
     : state.group.live_message;
-  const vars = templateVars(state.login, stream, multiTwitch.url ?? undefined);
+  const vars = templateVars(state.login, stream, resolvedMultiTwitch.url ?? undefined);
 
   return {
     content: fillTemplate(template, vars),
-    embed: buildEmbedPreview(stream, multiTwitch.renderedFooter ?? undefined),
+    embed: buildEmbedPreview(stream, resolvedMultiTwitch.renderedFooter ?? undefined),
   };
 }
 
@@ -617,23 +618,27 @@ export interface LiveStateSnapshot {
 
 export function getLiveStates(): LiveStateSnapshot[] {
   return Array.from(liveStates.values())
-    .map((state) => ({
-      streamerId: state.streamerId,
-      login: state.login,
-      twitchUrl: getStreamUrl(state.login),
-      groupId: state.groupId,
-      groupName: state.group.name,
-      groupDiscordChannelId: state.group.discord_channel,
-      multiTwitchEnabled: state.group.multi_twitch,
-      deleteOldPosts: state.group.delete_old_posts,
-      currentGame: state.currentGame,
-      title: state.title,
-      messageId: state.messageId,
-      channelId: state.channelId,
-      multiTwitch: getMultitwitchPreview(state),
-      liveMessagePreview: buildMessagePreview(state, 'live_message'),
-      gameChangePreview: buildMessagePreview(state, 'new_game_message'),
-    }))
+    .map((state) => {
+      const multiTwitch = getMultitwitchPreview(state);
+
+      return {
+        streamerId: state.streamerId,
+        login: state.login,
+        twitchUrl: getStreamUrl(state.login),
+        groupId: state.groupId,
+        groupName: state.group.name,
+        groupDiscordChannelId: state.group.discord_channel,
+        multiTwitchEnabled: state.group.multi_twitch,
+        deleteOldPosts: state.group.delete_old_posts,
+        currentGame: state.currentGame,
+        title: state.title,
+        messageId: state.messageId,
+        channelId: state.channelId,
+        multiTwitch,
+        liveMessagePreview: buildMessagePreview(state, 'live_message', multiTwitch),
+        gameChangePreview: buildMessagePreview(state, 'new_game_message', multiTwitch),
+      };
+    })
     .sort((left, right) => {
       const groupCompare = left.groupName.localeCompare(right.groupName);
       if (groupCompare !== 0) return groupCompare;

--- a/src/twitchMonitor.ts
+++ b/src/twitchMonitor.ts
@@ -21,7 +21,30 @@ interface LiveState {
   channelId: string | null;
   currentGame: string;
   title: string;
+  currentStream: TwitchStream;
   offlineTimer: ReturnType<typeof setTimeout> | null;
+}
+
+export interface DiscordEmbedPreview {
+  title: string;
+  url: string;
+  color: string;
+  fields: Array<{ name: string; value: string }>;
+  imageUrl: string;
+  footer: string | null;
+}
+
+export interface DiscordMessagePreview {
+  content: string;
+  embed: DiscordEmbedPreview;
+}
+
+export interface MultiTwitchPreview {
+  enabled: boolean;
+  applicable: boolean;
+  participants: string[];
+  url: string | null;
+  renderedFooter: string | null;
 }
 
 // ─── Module-level state ──────────────────────────────────────────────────────
@@ -44,19 +67,38 @@ function fillTemplate(template: string, vars: Record<string, string>): string {
   return template.replace(/\{(\w+)\}/g, (_, key: string) => vars[key] ?? `{${key}}`);
 }
 
-function buildEmbed(stream: TwitchStream, footer?: string): EmbedBuilder {
-  const thumbnailUrl = stream.thumbnail_url
+function getStreamUrl(login: string): string {
+  return `https://www.twitch.tv/${login}`;
+}
+
+function getThumbnailUrl(stream: TwitchStream): string {
+  return stream.thumbnail_url
     .replace('{width}', '640')
     .replace('{height}', '360');
+}
+
+function buildEmbedPreview(stream: TwitchStream, footer?: string): DiscordEmbedPreview {
+  return {
+    title: stream.title,
+    url: getStreamUrl(stream.user_login),
+    color: '#9146FF',
+    fields: [{ name: 'Game', value: stream.game_name || 'Unknown' }],
+    imageUrl: getThumbnailUrl(stream),
+    footer: footer || null,
+  };
+}
+
+function buildEmbed(stream: TwitchStream, footer?: string): EmbedBuilder {
+  const preview = buildEmbedPreview(stream, footer);
 
   const embed = new EmbedBuilder()
-    .setTitle(stream.title)
-    .setURL(`https://www.twitch.tv/${stream.user_login}`)
+    .setTitle(preview.title)
+    .setURL(preview.url)
     .setColor(0x9146ff)
-    .addFields({ name: 'Game', value: stream.game_name || 'Unknown' })
-    .setImage(thumbnailUrl);
+    .addFields(...preview.fields)
+    .setImage(preview.imageUrl);
 
-  if (footer) embed.setFooter({ text: footer });
+  if (preview.footer) embed.setFooter({ text: preview.footer });
   return embed;
 }
 
@@ -65,8 +107,54 @@ function templateVars(login: string, stream: TwitchStream, multitwitch?: string)
     streamer: login,
     game: stream.game_name || 'Unknown',
     title: stream.title,
-    url: `https://www.twitch.tv/${login}`,
+    url: getStreamUrl(login),
     multitwitch: multitwitch ?? '',
+  };
+}
+
+function getMultitwitchPreview(state: LiveState): MultiTwitchPreview {
+  const groupLive = Array.from(liveStates.values()).filter((entry) => entry.groupId === state.groupId);
+  const sameGame = groupLive.filter(
+    (entry) => entry.currentGame === state.currentGame && entry.login !== state.login,
+  );
+
+  if (!state.group.multi_twitch || sameGame.length === 0) {
+    return {
+      enabled: state.group.multi_twitch,
+      applicable: false,
+      participants: [state.login],
+      url: null,
+      renderedFooter: null,
+    };
+  }
+
+  const participants = [state.login, ...sameGame.map((entry) => entry.login)];
+  const url = `https://www.multitwitch.tv/${participants.join('/')}`;
+  const renderedFooter = fillTemplate(state.group.multi_twitch_message, { multitwitch: url }) || null;
+
+  return {
+    enabled: true,
+    applicable: true,
+    participants,
+    url,
+    renderedFooter,
+  };
+}
+
+function buildMessagePreview(
+  state: LiveState,
+  templateKey: 'live_message' | 'new_game_message',
+): DiscordMessagePreview {
+  const stream = state.currentStream;
+  const multiTwitch = getMultitwitchPreview(state);
+  const template = templateKey === 'new_game_message'
+    ? state.group.new_game_message
+    : state.group.live_message;
+  const vars = templateVars(state.login, stream, multiTwitch.url ?? undefined);
+
+  return {
+    content: fillTemplate(template, vars),
+    embed: buildEmbedPreview(stream, multiTwitch.renderedFooter ?? undefined),
   };
 }
 
@@ -79,17 +167,8 @@ async function updateMultitwitch(groupId: number): Promise<void> {
 
   for (const state of groupLive) {
     if (!state.messageId || !state.channelId) continue;
-
-    const sameGame = groupLive.filter(
-      (s) => s.currentGame === state.currentGame && s.login !== state.login,
-    );
-
-    let footer: string | undefined;
-    if (state.group.multi_twitch && sameGame.length >= 1) {
-      const logins = [state.login, ...sameGame.map((s) => s.login)];
-      const multitwitchUrl = `https://www.multitwitch.tv/${logins.join('/')}`;
-      footer = fillTemplate(state.group.multi_twitch_message, { multitwitch: multitwitchUrl });
-    }
+    const multiTwitch = getMultitwitchPreview(state);
+    const footer = multiTwitch.renderedFooter ?? undefined;
 
     try {
       const channel = await discordClient.channels.fetch(state.channelId);
@@ -130,6 +209,7 @@ async function postAnnouncement(streamerData: DbStreamerFull, stream: TwitchStre
       channelId: null,
       currentGame: stream.game_name,
       title: stream.title,
+        currentStream: stream,
       offlineTimer: null,
     });
     return;
@@ -157,6 +237,7 @@ async function postAnnouncement(streamerData: DbStreamerFull, stream: TwitchStre
       channelId: msg.channelId,
       currentGame: stream.game_name,
       title: stream.title,
+      currentStream: stream,
       offlineTimer: null,
     });
 
@@ -175,6 +256,7 @@ async function editAnnouncement(
   // Always update in-memory state so liveStates stays current even when posts are disabled
   state.currentGame = stream.game_name;
   state.title = stream.title;
+  state.currentStream = stream;
 
   if (!getMonitorEnabled() || !discordClient || !state.messageId || !state.channelId) return;
 
@@ -316,6 +398,7 @@ async function performStartupLiveCheck(): Promise<void> {
                 channelId: streamer.discord_channel_id,
                 currentGame: liveStream.game_name,
                 title: liveStream.title,
+                currentStream: liveStream,
                 offlineTimer: null,
               });
               await setStreamerLive(streamer.id, streamer.discord_message_id!, streamer.discord_channel_id!, liveStream.game_name);
@@ -336,6 +419,7 @@ async function performStartupLiveCheck(): Promise<void> {
             channelId: streamer.discord_channel_id,
             currentGame: liveStream.game_name,
             title: liveStream.title,
+            currentStream: liveStream,
             offlineTimer: null,
           });
           groupsWithChanges.add(streamer.group.id);
@@ -413,7 +497,9 @@ async function pollStreams(): Promise<void> {
           console.log(`[TwitchMonitor] ${loginKey} game changed to ${pollStream.game_name}`);
         } else if (existing) {
           // Still live — keep title in sync
+          existing.currentGame = pollStream.game_name;
           existing.title = pollStream.title;
+          existing.currentStream = pollStream;
         }
       } else if (existing && !existing.offlineTimer) {
         // Appears offline — start grace period (handleStreamOffline handles all groups for this login)
@@ -512,25 +598,47 @@ export async function restartTwitchMonitor(): Promise<void> {
 // ─── Live state snapshot (for web panel) ─────────────────────────────────────
 
 export interface LiveStateSnapshot {
+  streamerId: number;
   login: string;
+  twitchUrl: string;
   groupId: number;
   groupName: string;
+  groupDiscordChannelId: string;
+  multiTwitchEnabled: boolean;
+  deleteOldPosts: boolean;
   currentGame: string;
   title: string;
   messageId: string | null;
   channelId: string | null;
+  multiTwitch: MultiTwitchPreview;
+  liveMessagePreview: DiscordMessagePreview;
+  gameChangePreview: DiscordMessagePreview;
 }
 
 export function getLiveStates(): LiveStateSnapshot[] {
-  return Array.from(liveStates.values()).map((s) => ({
-    login: s.login,
-    groupId: s.groupId,
-    groupName: s.group.name,
-    currentGame: s.currentGame,
-    title: s.title,
-    messageId: s.messageId,
-    channelId: s.channelId,
-  }));
+  return Array.from(liveStates.values())
+    .map((state) => ({
+      streamerId: state.streamerId,
+      login: state.login,
+      twitchUrl: getStreamUrl(state.login),
+      groupId: state.groupId,
+      groupName: state.group.name,
+      groupDiscordChannelId: state.group.discord_channel,
+      multiTwitchEnabled: state.group.multi_twitch,
+      deleteOldPosts: state.group.delete_old_posts,
+      currentGame: state.currentGame,
+      title: state.title,
+      messageId: state.messageId,
+      channelId: state.channelId,
+      multiTwitch: getMultitwitchPreview(state),
+      liveMessagePreview: buildMessagePreview(state, 'live_message'),
+      gameChangePreview: buildMessagePreview(state, 'new_game_message'),
+    }))
+    .sort((left, right) => {
+      const groupCompare = left.groupName.localeCompare(right.groupName);
+      if (groupCompare !== 0) return groupCompare;
+      return left.login.localeCompare(right.login);
+    });
 }
 
 /**

--- a/src/twitchMonitor.ts
+++ b/src/twitchMonitor.ts
@@ -185,7 +185,8 @@ function buildMessagePreview(
   const template = templateKey === 'new_game_message'
     ? state.group.new_game_message
     : state.group.live_message;
-  const vars = templateVars(state.login, stream, resolvedMultiTwitch.url ?? undefined);
+  // Match production content generation: announcements do not currently inject {multitwitch} in content.
+  const vars = templateVars(state.login, stream);
 
   return {
     content: fillTemplate(template, vars),

--- a/src/twitchMonitor.ts
+++ b/src/twitchMonitor.ts
@@ -209,7 +209,7 @@ async function postAnnouncement(streamerData: DbStreamerFull, stream: TwitchStre
       channelId: null,
       currentGame: stream.game_name,
       title: stream.title,
-        currentStream: stream,
+      currentStream: stream,
       offlineTimer: null,
     });
     return;

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -26,7 +26,7 @@ app.use(
         scriptSrc: ["'self'"],
         scriptSrcAttr: ["'none'"],
         styleSrc: ["'self'", "'unsafe-inline'"],
-        imgSrc: ["'self'", 'data:', 'https://cdn.discordapp.com'],
+        imgSrc: ["'self'", 'data:', 'https://cdn.discordapp.com', 'https://static-cdn.jtvnw.net'],
         connectSrc: ["'self'"],
         objectSrc: ["'none'"],
         baseUri: ["'self'"],

--- a/views/streams.ejs
+++ b/views/streams.ejs
@@ -36,7 +36,7 @@
               <%= monitorEnabled ? '⏹ Disable Discord Posts' : '▶ Enable Discord Posts' %>
             </button>
           </form>
-          <span style="color:var(--text-muted);font-size:.85rem">Stream tracking always runs — use <strong>Live Now</strong> below to verify data before enabling posts.</span>
+          <span style="color:var(--muted);font-size:.85rem">Stream tracking always runs — use <strong>Live Now</strong> below to verify data before enabling posts.</span>
         </div>
       </div>
     </section>
@@ -48,12 +48,12 @@
         <div class="card-header">
           <span class="card-icon">🔴</span>
           <span class="card-label">Currently Tracked Live Streams</span>
-          <span id="live-updated" style="margin-left:auto;font-size:.75rem;color:var(--text-muted)"></span>
+          <span id="live-updated" style="margin-left:auto;font-size:.75rem;color:var(--muted)"></span>
         </div>
         <table class="table" id="live-table">
           <thead>
             <tr>
-              <th></th>
+              <th>Details</th>
               <th>Streamer</th>
               <th>Group</th>
               <th>Game</th>

--- a/views/streams.ejs
+++ b/views/streams.ejs
@@ -50,7 +50,7 @@
           <span class="card-label">Currently Tracked Live Streams</span>
           <span id="live-updated" style="margin-left:auto;font-size:.75rem;color:var(--text-muted)"></span>
         </div>
-        <table class="table">
+        <table class="table" id="live-table">
           <thead>
             <tr>
               <th></th>

--- a/views/streams.ejs
+++ b/views/streams.ejs
@@ -53,6 +53,7 @@
         <table class="table">
           <thead>
             <tr>
+              <th></th>
               <th>Streamer</th>
               <th>Group</th>
               <th>Game</th>
@@ -61,7 +62,7 @@
             </tr>
           </thead>
           <tbody id="live-tbody">
-            <tr><td colspan="5" class="empty-msg">Loading…</td></tr>
+            <tr><td colspan="6" class="empty-msg">Loading…</td></tr>
           </tbody>
         </table>
       </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expandable per-stream detail rows with multitwitch links, multi-section previews (announcements, game changes), and persistent expand/collapse controls.
  * New Details column in the Live Now table and periodic automatic refresh with updated timestamp.

* **Improvements**
  * Discord-style embed/message previews and safer HTML/URL handling for rendered content.
  * Responsive styling and improved layout for the live-detail UI on mobile and desktop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->