### PR TITLE
Feature/user management twitch sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,6 @@ DISCORD_CLIENT_ID=your_discord_oauth_app_client_id
 DISCORD_CLIENT_SECRET=your_discord_oauth_app_client_secret
 
 # Twitch (chat bot)
-# Comma-separated list of channels to listen to
-TWITCH_CHANNELS=channel1,channel2
 TWITCH_OAUTH_TOKEN=oauth:your_token_here
 TWITCH_USERNAME=your_bot_username
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -256,7 +256,7 @@ Buffer.isBuffer(row.hidden) ? row.hidden[0] === 1 : row.hidden == 1
 Apply this same pattern whenever reading any boolean/tinyint column.
 
 ### MySQL 8 upsert syntax
-The project targets MySQL 8 semantics. For `INSERT ... ON DUPLICATE KEY UPDATE`, prefer the row-alias form (`VALUES (...) AS new_row`) instead of deprecated `VALUES(column)` expressions.
+The project targets MySQL 8 semantics. For `INSERT ... ON DUPLICATE KEY UPDATE`, prefer the row-alias form (`VALUES (...) AS new_row`) instead of deprecated `VALUES(column)` expressions. This alias form requires MySQL 8.0.19 or later; earlier 8.0 releases do not support row aliases in `INSERT ... VALUES (...) AS alias`.
 
 ### Session cookie in production
 `src/web/server.ts` automatically sets `cookie: { secure: true }` and `app.set('trust proxy', 1)` when `NODE_ENV=production`. In development (default), `secure: false` is used so cookies work over plain HTTP. No manual code changes are needed — just set `NODE_ENV=production` when deploying behind an HTTPS reverse proxy.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -70,7 +70,7 @@ BCUK_Bot_4/
 
 ## Database Schema
 
-Tables in the existing MySQL/MariaDB database:
+Tables in the existing MySQL 8 database:
 
 ### `sfxtrigger`
 
@@ -157,7 +157,6 @@ Copy `.env.example` → `.env` and fill in all values.
 | `DISCORD_VOICE_CHANNEL_ID` | ✅ | Voice channel to join |
 | `TWITCH_USERNAME`       | ✅ | Bot account username |
 | `TWITCH_OAUTH_TOKEN`    | ✅ | Format: `oauth:xxxx` |
-| `TWITCH_CHANNELS`       | ✅ | Comma-separated channel names |
 | `TIKTOK_CHANNELS`       | ❌ | Comma-separated usernames (@ optional) |
 | `TIKTOK_SIGN_API_KEY`   | ❌ | From eulerstream.com, improves reliability |
 | `DB_HOST`               | ✅ | Default: localhost |
@@ -219,11 +218,17 @@ Copy `.env.example` → `.env` and fill in all values.
 ### Exported Discord client
 `src/discordBot.ts` exports `discordClient: Client | null`. It is `null` until the `ready` event fires, then set to the live `Client` instance. Other modules (e.g. `src/web/routes/api.ts`) import this to call Discord APIs without holding a circular reference to the full bot module.
 
+### Twitch channels are DB-driven
+`TWITCH_CHANNELS` is no longer used. `startTwitchBot()` loads enabled Twitch channels from the `user` table via `getTwitchEnabledChannels()`, and admin user updates/toggles reconcile live channel membership with `joinTwitchChannel()` / `partTwitchChannel()`.
+
 ### Voice join/leave from web panel
 `audioPlayer.ts` exports both `connect(client)` (join) and `disconnect()` (leave). `POST /api/voice/join` and `POST /api/voice/leave` in `src/web/routes/api.ts` are guarded by `requireMod` (access level ≥ 1). The dashboard shows a **Join Voice** / **Leave Voice** toggle button to Mod+ users; the button label and state are kept in sync by `applyStatus()` on every poll.
 
 ### Auth
 `passport` and `passport-discord` were **not used** — they are deprecated. Discord OAuth2 is implemented directly in `src/web/routes/auth.ts` using `fetch` calls to the Discord API.
+
+### Login-time Discord name sync
+During OAuth login, `auth.ts` treats Discord display-name sync as non-blocking: it prefers the current guild display name from `fetchMemberDisplayName(..., true)`, falls back to the stored `discord_name` (or OAuth username if none exists), and only updates the DB when the final value changed.
 
 ### dotenv override
 `config.ts` uses `dotenv.config({ override: true })` to ensure `.env` values always take precedence over any system/user environment variables with the same name.
@@ -244,11 +249,14 @@ The web panel is PWA-enabled. `public/service-worker.js` pre-caches core static 
 `tiktokBot.ts` uses a per-connection `reconnectScheduled` boolean to prevent duplicate `setTimeout` calls when both `STREAM_END` and `DISCONNECTED` fire for the same connection.
 
 ### MySQL tinyint(1) / bit columns returned as Buffer
-MariaDB (and some MySQL configs) return `tinyint(1)` columns as a single-byte `Buffer` rather than `0`/`1`. All boolean reads in `db.ts` use the pattern:
+Some MySQL configurations/drivers can return `tinyint(1)` or `bit` columns as a single-byte `Buffer` rather than `0`/`1`. All boolean reads in `db.ts` use the pattern:
 ```ts
 Buffer.isBuffer(row.hidden) ? row.hidden[0] === 1 : row.hidden == 1
 ```
 Apply this same pattern whenever reading any boolean/tinyint column.
+
+### MySQL 8 upsert syntax
+The project targets MySQL 8 semantics. For `INSERT ... ON DUPLICATE KEY UPDATE`, prefer the row-alias form (`VALUES (...) AS new_row`) instead of deprecated `VALUES(column)` expressions.
 
 ### Session cookie in production
 `src/web/server.ts` automatically sets `cookie: { secure: true }` and `app.set('trust proxy', 1)` when `NODE_ENV=production`. In development (default), `secure: false` is used so cookies work over plain HTTP. No manual code changes are needed — just set `NODE_ENV=production` when deploying behind an HTTPS reverse proxy.
@@ -315,6 +323,7 @@ npm start        # node dist/index.js (production)
 | POST   | `/api/voice/join`       | Mod+        | Join configured voice channel |
 | POST   | `/api/voice/leave`      | Mod+        | Leave voice channel |
 | GET    | `/admin/users`          | Manager+    | User list |
+| GET    | `/admin/users/refresh-status` | Manager+ | JSON status for background Discord-name refresh |
 | POST   | `/admin/users/add`      | Admin       | Add/update user |
 | POST   | `/admin/users/update`   | Admin       | Change access level |
 | POST   | `/admin/users/remove`   | Admin       | Remove user |
@@ -348,8 +357,10 @@ In-memory singleton. Functions:
 - `findSoundFiles(triggerId)` — returns all `sfx` rows for a trigger including hidden ones; used by `commandRouter.ts`
 - `getAllSfxTriggers()` — **dashboard aggregate**: single JOIN query across `sfxtrigger`, `sfxcategory`, and `sfx`; returns `SfxTriggerRow[]` where each entry has a `files[]` array already grouped
 - `findUser(discordId)` / `getAllUsers()` — user lookups for auth and admin panel
-- `upsertUser(discordId, discordName, accessLevel)` — INSERT … ON DUPLICATE KEY UPDATE; validates `accessLevel` is a known `AccessLevel` value
+- `upsertUser(discordId, discordName, accessLevel, twitchName?)` — INSERT … ON DUPLICATE KEY UPDATE using MySQL 8 alias syntax; validates `accessLevel`, preserves existing `twitch_name` when `twitchName` is `undefined`, and clears `twitch_name` when `twitchName` is provided as an empty string
 - `updateAccessLevel(discordId, accessLevel)` / `removeUser(discordId)` — admin mutations; `updateAccessLevel` validates `accessLevel` before executing SQL
+- `updateDiscordName(discordId, name)` — persists the resolved Discord display name after login sync or bulk refresh
+- `getTwitchEnabledChannels()` / `updateTwitchBotEnabled(discordId, enabled)` — DB-driven Twitch channel enablement used by startup and admin user management
 - `AccessLevel` const object (`USER=0 MOD=1 MANAGER=2 ADMIN=3`) and `AccessLevelValue` type are exported from `db.ts` — use these instead of raw numbers
 - `getAllStreamersWithGroups()` — JOIN query returning `DbStreamerFull[]` (each row includes full `DbStreamGroup` as `.group`); used by `twitchMonitor.ts`
 - `getAllStreamGroups()` — returns all `stream_group` rows as `DbStreamGroup[]`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -221,6 +221,9 @@ Copy `.env.example` → `.env` and fill in all values.
 ### Twitch channels are DB-driven
 `TWITCH_CHANNELS` is no longer used. `startTwitchBot()` loads enabled Twitch channels from the `user` table via `getTwitchEnabledChannels()`, and admin user updates/toggles reconcile live channel membership with `joinTwitchChannel()` / `partTwitchChannel()`.
 
+### Twitch user ownership is unique
+Each `user.twitch_name` must belong to at most one user row. The admin add/update flow rejects duplicate Twitch names so live channel membership stays a direct reflection of the enabled-user set.
+
 ### Voice join/leave from web panel
 `audioPlayer.ts` exports both `connect(client)` (join) and `disconnect()` (leave). `POST /api/voice/join` and `POST /api/voice/leave` in `src/web/routes/api.ts` are guarded by `requireMod` (access level ≥ 1). The dashboard shows a **Join Voice** / **Leave Voice** toggle button to Mod+ users; the button label and state are kept in sync by `applyStatus()` on every poll.
 
@@ -323,8 +326,10 @@ npm start        # node dist/index.js (production)
 | POST   | `/api/voice/join`       | Mod+        | Join configured voice channel |
 | POST   | `/api/voice/leave`      | Mod+        | Leave voice channel |
 | GET    | `/admin/users`          | Manager+    | User list |
+| POST   | `/admin/users/refresh-names` | Manager+ | Start background Discord-name refresh |
 | GET    | `/admin/users/refresh-status` | Manager+ | JSON status for background Discord-name refresh |
 | POST   | `/admin/users/add`      | Admin       | Add/update user |
+| POST   | `/admin/users/toggle-twitch` | Manager+ | Enable/disable Twitch bot participation for one user |
 | POST   | `/admin/users/update`   | Admin       | Change access level |
 | POST   | `/admin/users/remove`   | Admin       | Remove user |
 | GET    | `/admin/streams`        | Manager+    | Stream monitor management page |
@@ -356,7 +361,7 @@ In-memory singleton. Functions:
 - `findTrigger(command)` — looks up an `sfxtrigger` row by its full command string (case-insensitive); includes hidden triggers (hidden = listing-only flag, not a playback gate)
 - `findSoundFiles(triggerId)` — returns all `sfx` rows for a trigger including hidden ones; used by `commandRouter.ts`
 - `getAllSfxTriggers()` — **dashboard aggregate**: single JOIN query across `sfxtrigger`, `sfxcategory`, and `sfx`; returns `SfxTriggerRow[]` where each entry has a `files[]` array already grouped
-- `findUser(discordId)` / `getAllUsers()` — user lookups for auth and admin panel
+- `findUser(discordId)` / `findUserByTwitchName(twitchName, excludeDiscordId?)` / `getAllUsers()` — user lookups for auth and admin panel; duplicate Twitch-name assignments are rejected by the admin route
 - `upsertUser(discordId, discordName, accessLevel, twitchName?)` — INSERT … ON DUPLICATE KEY UPDATE using MySQL 8 alias syntax; validates `accessLevel`, preserves existing `twitch_name` when `twitchName` is `undefined`, and clears `twitch_name` when `twitchName` is provided as an empty string
 - `updateAccessLevel(discordId, accessLevel)` / `removeUser(discordId)` — admin mutations; `updateAccessLevel` validates `accessLevel` before executing SQL
 - `updateDiscordName(discordId, name)` — persists the resolved Discord display name after login sync or bulk refresh

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -222,7 +222,7 @@ Copy `.env.example` → `.env` and fill in all values.
 `TWITCH_CHANNELS` is no longer used. `startTwitchBot()` loads enabled Twitch channels from the `user` table via `getTwitchEnabledChannels()`, and admin user updates/toggles reconcile live channel membership with `joinTwitchChannel()` / `partTwitchChannel()`.
 
 ### Twitch user ownership is unique
-Each `user.twitch_name` must belong to at most one user row. The database enforces this with a unique index on `user.twitch_name` using a case-insensitive collation, and the admin add/update flow also pre-checks for duplicates so most conflicts can be shown as a friendly validation error before the write races the database constraint.
+Each `user.twitch_name` must belong to at most one user row. The database enforces this with a unique index on `user.twitch_name` using a case-insensitive collation, and the admin add/update flow also pre-checks for duplicates so most conflicts can be shown as a friendly validation error before the write races the database constraint. `findUserByTwitchName()` compares directly against the normalized parameter so MySQL can use that index.
 
 ### Voice join/leave from web panel
 `audioPlayer.ts` exports both `connect(client)` (join) and `disconnect()` (leave). `POST /api/voice/join` and `POST /api/voice/leave` in `src/web/routes/api.ts` are guarded by `requireMod` (access level ≥ 1). The dashboard shows a **Join Voice** / **Leave Voice** toggle button to Mod+ users; the button label and state are kept in sync by `applyStatus()` on every poll.
@@ -367,8 +367,8 @@ In-memory singleton. Functions:
 - `findTrigger(command)` — looks up an `sfxtrigger` row by its full command string (case-insensitive); includes hidden triggers (hidden = listing-only flag, not a playback gate)
 - `findSoundFiles(triggerId)` — returns all `sfx` rows for a trigger including hidden ones; used by `commandRouter.ts`
 - `getAllSfxTriggers()` — **dashboard aggregate**: single JOIN query across `sfxtrigger`, `sfxcategory`, and `sfx`; returns `SfxTriggerRow[]` where each entry has a `files[]` array already grouped
-- `findUser(discordId)` / `findUserByTwitchName(twitchName, excludeDiscordId?)` / `getAllUsers()` — user lookups for auth and admin panel; duplicate Twitch-name assignments are pre-checked in the admin route and ultimately enforced by the DB unique index on `user.twitch_name`
-- `upsertUser(discordId, discordName, accessLevel, twitchName?)` — INSERT … ON DUPLICATE KEY UPDATE using MySQL 8 alias syntax; validates `accessLevel`, preserves existing `twitch_name` when `twitchName` is `undefined`, and normalizes blank Twitch names to `NULL` so the unique index allows multiple “no Twitch name” rows
+- `findUser(discordId)` / `findUserByTwitchName(twitchName, excludeDiscordId?)` / `getAllUsers()` — user lookups for auth and admin panel; duplicate Twitch-name assignments are pre-checked in the admin route and ultimately enforced by the DB unique index on `user.twitch_name`. `findUserByTwitchName()` uses `twitch_name = ?` against the case-insensitive column so the lookup stays index-friendly.
+- `upsertUser(discordId, discordName, accessLevel, twitchName?)` — INSERT … ON DUPLICATE KEY UPDATE using MySQL 8 alias syntax; validates `accessLevel`, preserves existing `twitch_name` when `twitchName` is `undefined`, and treats `null` or blank strings as an explicit update to `NULL` so the unique index allows multiple “no Twitch name” rows
 - `updateAccessLevel(discordId, accessLevel)` / `removeUser(discordId)` — admin mutations; `updateAccessLevel` validates `accessLevel` before executing SQL
 - `updateDiscordName(discordId, name)` — persists the resolved Discord display name after login sync or bulk refresh
 - `getTwitchEnabledChannels()` / `updateTwitchBotEnabled(discordId, enabled)` — DB-driven Twitch channel enablement used by startup and admin user management

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -105,10 +105,10 @@ Tables in the existing MySQL 8 database:
 
 | Column                 | Type         | Notes                      |
 |------------------------|--------------|----------------------------|
-| `discord_id`           | varchar PK   | Discord numeric user ID    |
+| `discord_id`           | bigint PK    | Discord numeric user ID    |
 | `discord_name`         | varchar      | nullable                   |
-| `is_twitch_bot_enabled`| tinyint(1)   |                            |
-| `twitch_name`          | varchar      | nullable                   |
+| `is_twitch_bot_enabled`| bit(1)       |                            |
+| `twitch_name`          | varchar      | nullable, UNIQUE, case-insensitive (`utf8mb4_0900_ai_ci`) |
 | `twitchoauth`          | varchar      | nullable                   |
 | `access_level`         | int          | 0=USER 1=MOD 2=MANAGER 3=ADMIN |
 
@@ -222,7 +222,7 @@ Copy `.env.example` → `.env` and fill in all values.
 `TWITCH_CHANNELS` is no longer used. `startTwitchBot()` loads enabled Twitch channels from the `user` table via `getTwitchEnabledChannels()`, and admin user updates/toggles reconcile live channel membership with `joinTwitchChannel()` / `partTwitchChannel()`.
 
 ### Twitch user ownership is unique
-Each `user.twitch_name` must belong to at most one user row. The admin add/update flow rejects duplicate Twitch names so live channel membership stays a direct reflection of the enabled-user set.
+Each `user.twitch_name` must belong to at most one user row. The database enforces this with a unique index on `user.twitch_name` using a case-insensitive collation, and the admin add/update flow also pre-checks for duplicates so most conflicts can be shown as a friendly validation error before the write races the database constraint.
 
 ### Voice join/leave from web panel
 `audioPlayer.ts` exports both `connect(client)` (join) and `disconnect()` (leave). `POST /api/voice/join` and `POST /api/voice/leave` in `src/web/routes/api.ts` are guarded by `requireMod` (access level ≥ 1). The dashboard shows a **Join Voice** / **Leave Voice** toggle button to Mod+ users; the button label and state are kept in sync by `applyStatus()` on every poll.
@@ -260,6 +260,9 @@ Apply this same pattern whenever reading any boolean/tinyint column.
 
 ### MySQL BIGINT IDs must stay as strings
 Discord IDs and other snowflake-style values in MySQL can exceed JavaScript's safe integer range. `db.ts` configures mysql2 with `supportBigNumbers: true` and `bigNumberStrings: true` so BIGINT values are returned as exact strings instead of rounded numbers. Preserve that behavior for any future pool or connection changes.
+
+### Blank Twitch names should be stored as NULL
+Because `user.twitch_name` is protected by a unique index, blank values must not be stored as empty strings. `upsertUser()` normalizes blank Twitch names to `NULL`, which allows multiple users with no Twitch channel while still enforcing uniqueness for real channel names.
 
 ### MySQL 8 upsert syntax
 The project targets MySQL 8 semantics. For `INSERT ... ON DUPLICATE KEY UPDATE`, prefer the row-alias form (`VALUES (...) AS new_row`) instead of deprecated `VALUES(column)` expressions. This alias form requires MySQL 8.0.19 or later; earlier 8.0 releases do not support row aliases in `INSERT ... VALUES (...) AS alias`.
@@ -364,8 +367,8 @@ In-memory singleton. Functions:
 - `findTrigger(command)` — looks up an `sfxtrigger` row by its full command string (case-insensitive); includes hidden triggers (hidden = listing-only flag, not a playback gate)
 - `findSoundFiles(triggerId)` — returns all `sfx` rows for a trigger including hidden ones; used by `commandRouter.ts`
 - `getAllSfxTriggers()` — **dashboard aggregate**: single JOIN query across `sfxtrigger`, `sfxcategory`, and `sfx`; returns `SfxTriggerRow[]` where each entry has a `files[]` array already grouped
-- `findUser(discordId)` / `findUserByTwitchName(twitchName, excludeDiscordId?)` / `getAllUsers()` — user lookups for auth and admin panel; duplicate Twitch-name assignments are rejected by the admin route
-- `upsertUser(discordId, discordName, accessLevel, twitchName?)` — INSERT … ON DUPLICATE KEY UPDATE using MySQL 8 alias syntax; validates `accessLevel`, preserves existing `twitch_name` when `twitchName` is `undefined`, and clears `twitch_name` when `twitchName` is provided as an empty string
+- `findUser(discordId)` / `findUserByTwitchName(twitchName, excludeDiscordId?)` / `getAllUsers()` — user lookups for auth and admin panel; duplicate Twitch-name assignments are pre-checked in the admin route and ultimately enforced by the DB unique index on `user.twitch_name`
+- `upsertUser(discordId, discordName, accessLevel, twitchName?)` — INSERT … ON DUPLICATE KEY UPDATE using MySQL 8 alias syntax; validates `accessLevel`, preserves existing `twitch_name` when `twitchName` is `undefined`, and normalizes blank Twitch names to `NULL` so the unique index allows multiple “no Twitch name” rows
 - `updateAccessLevel(discordId, accessLevel)` / `removeUser(discordId)` — admin mutations; `updateAccessLevel` validates `accessLevel` before executing SQL
 - `updateDiscordName(discordId, name)` — persists the resolved Discord display name after login sync or bulk refresh
 - `getTwitchEnabledChannels()` / `updateTwitchBotEnabled(discordId, enabled)` — DB-driven Twitch channel enablement used by startup and admin user management

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -258,6 +258,9 @@ Buffer.isBuffer(row.hidden) ? row.hidden[0] === 1 : row.hidden == 1
 ```
 Apply this same pattern whenever reading any boolean/tinyint column.
 
+### MySQL BIGINT IDs must stay as strings
+Discord IDs and other snowflake-style values in MySQL can exceed JavaScript's safe integer range. `db.ts` configures mysql2 with `supportBigNumbers: true` and `bigNumberStrings: true` so BIGINT values are returned as exact strings instead of rounded numbers. Preserve that behavior for any future pool or connection changes.
+
 ### MySQL 8 upsert syntax
 The project targets MySQL 8 semantics. For `INSERT ... ON DUPLICATE KEY UPDATE`, prefer the row-alias form (`VALUES (...) AS new_row`) instead of deprecated `VALUES(column)` expressions. This alias form requires MySQL 8.0.19 or later; earlier 8.0 releases do not support row aliases in `INSERT ... VALUES (...) AS alias`.
 

--- a/public/admin.js
+++ b/public/admin.js
@@ -31,7 +31,7 @@ function scheduleRefreshStatusPolling(retryCount) {
       return response.json();
     }).then(function (state) {
       if (!state) return;
-      if (state && state.outcome === 'running') {
+      if (state.outcome === 'running') {
         scheduleRefreshStatusPolling(0);
         return;
       }

--- a/public/admin.js
+++ b/public/admin.js
@@ -8,3 +8,27 @@ document.addEventListener('submit', function (event) {
     event.preventDefault();
   }
 });
+
+function scheduleRefreshStatusPolling() {
+  var refreshBanner = document.querySelector('[data-refresh-running="true"]');
+  if (!refreshBanner) return;
+
+  window.setTimeout(function () {
+    window.fetch('/admin/users/refresh-status', {
+      headers: { Accept: 'application/json' }
+    }).then(function (response) {
+      if (!response.ok) throw new Error('Failed to read refresh status');
+      return response.json();
+    }).then(function (state) {
+      if (state && state.outcome === 'running') {
+        scheduleRefreshStatusPolling();
+        return;
+      }
+      window.location.reload();
+    }).catch(function () {
+      scheduleRefreshStatusPolling();
+    });
+  }, 2000);
+}
+
+scheduleRefreshStatusPolling();

--- a/public/admin.js
+++ b/public/admin.js
@@ -9,6 +9,56 @@ document.addEventListener('submit', function (event) {
   }
 });
 
+function syncTwitchNameControls(form) {
+  if (!(form instanceof HTMLFormElement)) return;
+
+  var twitchNameInput = form.querySelector('[data-twitch-name-input]');
+  var clearTwitchNameInput = form.querySelector('[data-clear-twitch-name-input]');
+  if (!(twitchNameInput instanceof HTMLInputElement) || !(clearTwitchNameInput instanceof HTMLInputElement)) {
+    return;
+  }
+
+  var hasTwitchName = twitchNameInput.value.trim().length > 0;
+  if (hasTwitchName) {
+    clearTwitchNameInput.checked = false;
+    clearTwitchNameInput.disabled = true;
+    twitchNameInput.disabled = false;
+    return;
+  }
+
+  if (clearTwitchNameInput.checked) {
+    twitchNameInput.value = '';
+    twitchNameInput.disabled = true;
+    clearTwitchNameInput.disabled = false;
+    return;
+  }
+
+  twitchNameInput.disabled = false;
+  clearTwitchNameInput.disabled = false;
+}
+
+document.querySelectorAll('form[action="/admin/users/add"]').forEach(function (form) {
+  if (!(form instanceof HTMLFormElement)) return;
+
+  var twitchNameInput = form.querySelector('[data-twitch-name-input]');
+  var clearTwitchNameInput = form.querySelector('[data-clear-twitch-name-input]');
+  if (!(twitchNameInput instanceof HTMLInputElement) || !(clearTwitchNameInput instanceof HTMLInputElement)) {
+    return;
+  }
+
+  twitchNameInput.addEventListener('input', function () {
+    syncTwitchNameControls(form);
+  });
+  clearTwitchNameInput.addEventListener('change', function () {
+    syncTwitchNameControls(form);
+  });
+  form.addEventListener('submit', function () {
+    syncTwitchNameControls(form);
+  });
+
+  syncTwitchNameControls(form);
+});
+
 function scheduleRefreshStatusPolling(retryCount) {
   var refreshBanner = document.querySelector('[data-refresh-running="true"]');
   if (!refreshBanner) return;

--- a/public/admin.js
+++ b/public/admin.js
@@ -9,26 +9,39 @@ document.addEventListener('submit', function (event) {
   }
 });
 
-function scheduleRefreshStatusPolling() {
+function scheduleRefreshStatusPolling(retryCount) {
   var refreshBanner = document.querySelector('[data-refresh-running="true"]');
   if (!refreshBanner) return;
+  var attempt = typeof retryCount === 'number' ? retryCount : 0;
 
   window.setTimeout(function () {
     window.fetch('/admin/users/refresh-status', {
       headers: { Accept: 'application/json' }
     }).then(function (response) {
-      if (!response.ok) throw new Error('Failed to read refresh status');
+      var contentType = response.headers.get('content-type') || '';
+      if (response.status === 401 || response.status === 403) {
+        window.location.reload();
+        return null;
+      }
+      if (!response.ok || contentType.indexOf('application/json') === -1) {
+        throw new Error('Failed to read refresh status');
+      }
       return response.json();
     }).then(function (state) {
+      if (!state) return;
       if (state && state.outcome === 'running') {
-        scheduleRefreshStatusPolling();
+        scheduleRefreshStatusPolling(0);
         return;
       }
       window.location.reload();
     }).catch(function () {
-      scheduleRefreshStatusPolling();
+      if (attempt >= 4) {
+        refreshBanner.textContent = 'Refresh status unavailable. Reload the page to check progress.';
+        return;
+      }
+      scheduleRefreshStatusPolling(attempt + 1);
     });
   }, 2000);
 }
 
-scheduleRefreshStatusPolling();
+scheduleRefreshStatusPolling(0);

--- a/public/admin.js
+++ b/public/admin.js
@@ -23,8 +23,10 @@ function scheduleRefreshStatusPolling(retryCount) {
         window.location.reload();
         return null;
       }
+      // Treat HTML/error responses as terminal so expired sessions do not loop forever.
       if (!response.ok || contentType.indexOf('application/json') === -1) {
-        throw new Error('Failed to read refresh status');
+        refreshBanner.textContent = 'Refresh status unavailable. Reload the page to check progress.';
+        return null;
       }
       return response.json();
     }).then(function (state) {

--- a/public/style.css
+++ b/public/style.css
@@ -159,7 +159,7 @@ textarea.input, .stream-textarea { width: 100%; resize: vertical; font-family: v
 .inline-form    { display: flex; flex-wrap: wrap; gap: .5rem; align-items: center; padding: .75rem 1rem; }
 .inline-form-sm { display: flex; gap: .35rem; align-items: center; }
 .twitch-bot-controls { display: inline-flex; gap: .5rem; align-items: center; flex-wrap: nowrap; }
-.actions        { display: inline-flex; gap: .5rem; align-items: center; flex-wrap: nowrap; }
+.actions        { display: inline-flex; gap: .5rem; align-items: center; flex-wrap: wrap; }
 .hint           { font-size: .78rem; color: var(--muted); padding: 0 1rem .75rem; }
 .search-input   { background: var(--bg); border: 1px solid var(--border); border-radius: 6px; color: var(--text); padding: .4rem .75rem; font-size: .85rem; width: 220px; }
 .search-input:focus { outline: none; border-color: var(--primary); }

--- a/public/style.css
+++ b/public/style.css
@@ -158,7 +158,8 @@ a:hover { text-decoration: underline; }
 textarea.input, .stream-textarea { width: 100%; resize: vertical; font-family: var(--mono); font-size: .82rem; line-height: 1.5; }
 .inline-form    { display: flex; flex-wrap: wrap; gap: .5rem; align-items: center; padding: .75rem 1rem; }
 .inline-form-sm { display: flex; gap: .35rem; align-items: center; }
-.actions        { display: flex; gap: .5rem; align-items: center; }
+.twitch-bot-controls { display: inline-flex; gap: .5rem; align-items: center; flex-wrap: nowrap; }
+.actions        { display: inline-flex; gap: .5rem; align-items: center; flex-wrap: nowrap; }
 .hint           { font-size: .78rem; color: var(--muted); padding: 0 1rem .75rem; }
 .search-input   { background: var(--bg); border: 1px solid var(--border); border-radius: 6px; color: var(--text); padding: .4rem .75rem; font-size: .85rem; width: 220px; }
 .search-input:focus { outline: none; border-color: var(--primary); }

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,10 +13,6 @@ export const DISCORD_VOICE_CHANNEL_ID = require_env('DISCORD_VOICE_CHANNEL_ID');
 
 export const TWITCH_USERNAME = require_env('TWITCH_USERNAME');
 export const TWITCH_OAUTH_TOKEN = require_env('TWITCH_OAUTH_TOKEN');
-export const TWITCH_CHANNELS: string[] = require_env('TWITCH_CHANNELS')
-  .split(',')
-  .map((c) => c.trim().replace(/^#/, ''))
-  .filter(Boolean);
 
 // Twitch stream monitor (stream announcements — separate from chat bot)
 // Client credentials for Twitch API / EventSub

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,5 +1,6 @@
 import mysql from 'mysql2/promise';
 import { DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME } from './config';
+import { normalizeTwitchChannelName } from './twitchChannelName';
 
 export interface SfxTrigger {
   id: bigint;
@@ -179,8 +180,8 @@ export async function getTwitchEnabledChannels(): Promise<string[]> {
        AND twitch_name <> ''`,
   );
   return rows
-    .map((r) => String(r.twitch_name).trim().toLowerCase())
-    .filter((v) => v.length > 0);
+    .map((r) => normalizeTwitchChannelName(String(r.twitch_name)))
+    .filter((v): v is string => v !== null);
 }
 
 export async function updateTwitchBotEnabled(discordId: string, enabled: boolean): Promise<void> {

--- a/src/db.ts
+++ b/src/db.ts
@@ -30,6 +30,8 @@ export function getPool(): mysql.Pool {
       user: DB_USER,
       password: DB_PASSWORD,
       database: DB_NAME,
+      supportBigNumbers: true,
+      bigNumberStrings: true,
       waitForConnections: true,
       connectionLimit: 5,
       queueLimit: 0,

--- a/src/db.ts
+++ b/src/db.ts
@@ -143,12 +143,12 @@ export async function findUserByTwitchName(twitchName: string, excludeDiscordId?
   const sql = excludeDiscordId
     ? `SELECT discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level
        FROM \`user\`
-       WHERE LOWER(twitch_name) = ?
+       WHERE twitch_name = ?
          AND discord_id <> ?
        LIMIT 1`
     : `SELECT discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level
        FROM \`user\`
-       WHERE LOWER(twitch_name) = ?
+       WHERE twitch_name = ?
        LIMIT 1`;
   const params = excludeDiscordId
     ? [normalizedTwitchName, excludeDiscordId]
@@ -183,13 +183,17 @@ export async function upsertUser(
   discordId: string,
   discordName: string,
   accessLevel: number,
-  twitchName?: string,
+  twitchName?: string | null,
 ): Promise<void> {
   if (!(Object.values(AccessLevel) as number[]).includes(accessLevel)) {
     throw new Error(`Invalid accessLevel: ${accessLevel}`);
   }
   const twitchNameProvided = twitchName !== undefined;
-  const normalizedTwitchName = twitchNameProvided ? (twitchName!.trim() || null) : null;
+  const normalizedTwitchName = !twitchNameProvided
+    ? null
+    : twitchName === null
+      ? null
+      : (twitchName.trim() || null);
   await getPool().execute(
     `INSERT INTO \`user\` (discord_id, discord_name, access_level, twitch_name, is_twitch_bot_enabled)
      VALUES (?, ?, ?, ?, 0) AS new_user

--- a/src/db.ts
+++ b/src/db.ts
@@ -197,7 +197,7 @@ export async function upsertUser(
   await getPool().execute(
     `INSERT INTO \`user\` (discord_id, discord_name, access_level, twitch_name, is_twitch_bot_enabled)
      VALUES (?, ?, ?, ?, 0) AS new_user
-     ON DUPLICATE KEY UPDATE discord_name = new_user.discord_name, access_level = new_user.access_level, twitch_name = IF(?, new_user.twitch_name, twitch_name)`,
+     ON DUPLICATE KEY UPDATE discord_name = new_user.discord_name, access_level = new_user.access_level, twitch_name = IF(?, new_user.twitch_name, \`user\`.twitch_name)`,
     [discordId, discordName, accessLevel, normalizedTwitchName, twitchNameProvided ? 1 : 0],
   );
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -153,14 +153,13 @@ export async function upsertUser(
   if (!(Object.values(AccessLevel) as number[]).includes(accessLevel)) {
     throw new Error(`Invalid accessLevel: ${accessLevel}`);
   }
-  const normalizedTwitchName = twitchName !== undefined
-    ? (twitchName.trim() || null)
-    : null;
+  const twitchNameProvided = twitchName !== undefined;
+  const normalizedTwitchName = twitchNameProvided ? (twitchName!.trim() || null) : null;
   await getPool().execute(
     `INSERT INTO \`user\` (discord_id, discord_name, access_level, twitch_name, is_twitch_bot_enabled)
      VALUES (?, ?, ?, ?, 0)
-     ON DUPLICATE KEY UPDATE discord_name = VALUES(discord_name), access_level = VALUES(access_level), twitch_name = VALUES(twitch_name)`,
-    [discordId, discordName, accessLevel, normalizedTwitchName],
+     ON DUPLICATE KEY UPDATE discord_name = VALUES(discord_name), access_level = VALUES(access_level), twitch_name = IF(?, VALUES(twitch_name), twitch_name)`,
+    [discordId, discordName, accessLevel, normalizedTwitchName, twitchNameProvided ? 1 : 0],
   );
 }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -148,15 +148,46 @@ export async function upsertUser(
   discordId: string,
   discordName: string,
   accessLevel: number,
+  twitchName?: string,
 ): Promise<void> {
   if (!(Object.values(AccessLevel) as number[]).includes(accessLevel)) {
     throw new Error(`Invalid accessLevel: ${accessLevel}`);
   }
+  const normalizedTwitchName = twitchName !== undefined
+    ? (twitchName.trim() || null)
+    : null;
   await getPool().execute(
-    `INSERT INTO \`user\` (discord_id, discord_name, access_level, is_twitch_bot_enabled)
-     VALUES (?, ?, ?, 0)
-     ON DUPLICATE KEY UPDATE discord_name = VALUES(discord_name), access_level = VALUES(access_level)`,
-    [discordId, discordName, accessLevel],
+    `INSERT INTO \`user\` (discord_id, discord_name, access_level, twitch_name, is_twitch_bot_enabled)
+     VALUES (?, ?, ?, ?, 0)
+     ON DUPLICATE KEY UPDATE discord_name = VALUES(discord_name), access_level = VALUES(access_level), twitch_name = VALUES(twitch_name)`,
+    [discordId, discordName, accessLevel, normalizedTwitchName],
+  );
+}
+
+export async function updateDiscordName(discordId: string, name: string): Promise<void> {
+  await getPool().execute(
+    'UPDATE `user` SET discord_name = ? WHERE discord_id = ?',
+    [name, discordId],
+  );
+}
+
+export async function getTwitchEnabledChannels(): Promise<string[]> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT twitch_name
+     FROM \`user\`
+     WHERE is_twitch_bot_enabled = 1
+       AND twitch_name IS NOT NULL
+       AND twitch_name <> ''`,
+  );
+  return rows
+    .map((r) => String(r.twitch_name).trim().toLowerCase())
+    .filter((v) => v.length > 0);
+}
+
+export async function updateTwitchBotEnabled(discordId: string, enabled: boolean): Promise<void> {
+  await getPool().execute(
+    'UPDATE `user` SET is_twitch_bot_enabled = ? WHERE discord_id = ?',
+    [enabled ? 1 : 0, discordId],
   );
 }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -132,6 +132,38 @@ export async function findUser(discordId: string): Promise<DbUser | null> {
   };
 }
 
+export async function findUserByTwitchName(twitchName: string, excludeDiscordId?: string): Promise<DbUser | null> {
+  const normalizedTwitchName = normalizeTwitchChannelName(twitchName);
+  if (!normalizedTwitchName) {
+    return null;
+  }
+
+  const sql = excludeDiscordId
+    ? `SELECT discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level
+       FROM \`user\`
+       WHERE LOWER(twitch_name) = ?
+         AND discord_id <> ?
+       LIMIT 1`
+    : `SELECT discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level
+       FROM \`user\`
+       WHERE LOWER(twitch_name) = ?
+       LIMIT 1`;
+  const params = excludeDiscordId
+    ? [normalizedTwitchName, excludeDiscordId]
+    : [normalizedTwitchName];
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(sql, params);
+
+  if (rows.length === 0) return null;
+  const r = rows[0];
+  return {
+    discord_id: String(r.discord_id),
+    discord_name: r.discord_name,
+    is_twitch_bot_enabled: Buffer.isBuffer(r.is_twitch_bot_enabled) ? r.is_twitch_bot_enabled[0] === 1 : r.is_twitch_bot_enabled === 1,
+    twitch_name: r.twitch_name,
+    access_level: r.access_level,
+  };
+}
+
 export async function getAllUsers(): Promise<DbUser[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
     'SELECT discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level FROM `user` ORDER BY access_level DESC, discord_name ASC',

--- a/src/db.ts
+++ b/src/db.ts
@@ -157,8 +157,8 @@ export async function upsertUser(
   const normalizedTwitchName = twitchNameProvided ? (twitchName!.trim() || null) : null;
   await getPool().execute(
     `INSERT INTO \`user\` (discord_id, discord_name, access_level, twitch_name, is_twitch_bot_enabled)
-     VALUES (?, ?, ?, ?, 0)
-     ON DUPLICATE KEY UPDATE discord_name = VALUES(discord_name), access_level = VALUES(access_level), twitch_name = IF(?, VALUES(twitch_name), twitch_name)`,
+     VALUES (?, ?, ?, ?, 0) AS new_user
+     ON DUPLICATE KEY UPDATE discord_name = new_user.discord_name, access_level = new_user.access_level, twitch_name = IF(?, new_user.twitch_name, twitch_name)`,
     [discordId, discordName, accessLevel, normalizedTwitchName, twitchNameProvided ? 1 : 0],
   );
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -65,7 +65,7 @@ export async function findTrigger(command: string): Promise<SfxTrigger | null> {
     id: BigInt(row.id),
     trigger_command: row.trigger_command,
     category_id: row.category_id,
-    hidden: Buffer.isBuffer(row.hidden) ? row.hidden[0] === 1 : row.hidden === 1,
+    hidden: Buffer.isBuffer(row.hidden) ? row.hidden[0] === 1 : row.hidden == 1,
     description: row.description,
   };
 }
@@ -87,7 +87,7 @@ export async function findSoundFiles(triggerId: bigint): Promise<SfxFile[]> {
     file: row.file,
     trigger_command: row.trigger_command,
     weight: row.weight,
-    hidden: Buffer.isBuffer(row.hidden) ? row.hidden[0] === 1 : row.hidden === 1,
+    hidden: Buffer.isBuffer(row.hidden) ? row.hidden[0] === 1 : row.hidden == 1,
     category_id: row.category_id,
   }));
 }
@@ -128,7 +128,7 @@ export async function findUser(discordId: string): Promise<DbUser | null> {
   return {
     discord_id: String(r.discord_id),
     discord_name: r.discord_name,
-    is_twitch_bot_enabled: Buffer.isBuffer(r.is_twitch_bot_enabled) ? r.is_twitch_bot_enabled[0] === 1 : r.is_twitch_bot_enabled === 1,
+    is_twitch_bot_enabled: Buffer.isBuffer(r.is_twitch_bot_enabled) ? r.is_twitch_bot_enabled[0] === 1 : r.is_twitch_bot_enabled == 1,
     twitch_name: r.twitch_name,
     access_level: r.access_level,
   };
@@ -160,7 +160,7 @@ export async function findUserByTwitchName(twitchName: string, excludeDiscordId?
   return {
     discord_id: String(r.discord_id),
     discord_name: r.discord_name,
-    is_twitch_bot_enabled: Buffer.isBuffer(r.is_twitch_bot_enabled) ? r.is_twitch_bot_enabled[0] === 1 : r.is_twitch_bot_enabled === 1,
+    is_twitch_bot_enabled: Buffer.isBuffer(r.is_twitch_bot_enabled) ? r.is_twitch_bot_enabled[0] === 1 : r.is_twitch_bot_enabled == 1,
     twitch_name: r.twitch_name,
     access_level: r.access_level,
   };
@@ -173,7 +173,7 @@ export async function getAllUsers(): Promise<DbUser[]> {
   return rows.map((r) => ({
     discord_id: String(r.discord_id),
     discord_name: r.discord_name,
-    is_twitch_bot_enabled: Buffer.isBuffer(r.is_twitch_bot_enabled) ? r.is_twitch_bot_enabled[0] === 1 : r.is_twitch_bot_enabled === 1,
+    is_twitch_bot_enabled: Buffer.isBuffer(r.is_twitch_bot_enabled) ? r.is_twitch_bot_enabled[0] === 1 : r.is_twitch_bot_enabled == 1,
     twitch_name: r.twitch_name,
     access_level: r.access_level,
   }));
@@ -281,9 +281,9 @@ function mapStreamGroup(r: mysql.RowDataPacket): DbStreamGroup {
     discord_channel: String(r.discord_channel),
     live_message: r.live_message,
     new_game_message: r.new_game_message,
-    multi_twitch: Buffer.isBuffer(r.multi_twitch) ? r.multi_twitch[0] === 1 : r.multi_twitch === 1,
+    multi_twitch: Buffer.isBuffer(r.multi_twitch) ? r.multi_twitch[0] === 1 : r.multi_twitch == 1,
     multi_twitch_message: r.multi_twitch_message ?? '',
-    delete_old_posts: Buffer.isBuffer(r.delete_old_posts) ? r.delete_old_posts[0] === 1 : r.delete_old_posts === 1,
+    delete_old_posts: Buffer.isBuffer(r.delete_old_posts) ? r.delete_old_posts[0] === 1 : r.delete_old_posts == 1,
   };
 }
 
@@ -369,9 +369,9 @@ export async function getAllStreamersWithGroups(): Promise<DbStreamerFull[]> {
       discord_channel: String(r.discord_channel),
       live_message: r.live_message,
       new_game_message: r.new_game_message,
-      multi_twitch: Buffer.isBuffer(r.multi_twitch) ? r.multi_twitch[0] === 1 : r.multi_twitch === 1,
+      multi_twitch: Buffer.isBuffer(r.multi_twitch) ? r.multi_twitch[0] === 1 : r.multi_twitch == 1,
       multi_twitch_message: r.multi_twitch_message ?? '',
-      delete_old_posts: Buffer.isBuffer(r.delete_old_posts) ? r.delete_old_posts[0] === 1 : r.delete_old_posts === 1,
+      delete_old_posts: Buffer.isBuffer(r.delete_old_posts) ? r.delete_old_posts[0] === 1 : r.delete_old_posts == 1,
     },
   }));
 }
@@ -446,7 +446,7 @@ export async function getAllSfxTriggers(): Promise<SfxTriggerRow[]> {
         triggerId: r.triggerId,
         triggerCommand: r.triggerCommand,
         description: r.description ?? null,
-        hidden: Buffer.isBuffer(r.triggerHidden) ? r.triggerHidden[0] === 1 : r.triggerHidden === 1,
+        hidden: Buffer.isBuffer(r.triggerHidden) ? r.triggerHidden[0] === 1 : r.triggerHidden == 1,
         categoryName: r.categoryName ?? null,
         files: [],
       });
@@ -456,7 +456,7 @@ export async function getAllSfxTriggers(): Promise<SfxTriggerRow[]> {
         id: r.sfxId,
         file: r.file,
         weight: r.weight,
-        hidden: Buffer.isBuffer(r.sfxHidden) ? r.sfxHidden[0] === 1 : r.sfxHidden === 1,
+        hidden: Buffer.isBuffer(r.sfxHidden) ? r.sfxHidden[0] === 1 : r.sfxHidden == 1,
       });
     }
   }

--- a/src/discordBot.ts
+++ b/src/discordBot.ts
@@ -9,11 +9,11 @@ let client: Client;
 /** The Discord.js Client instance once it has fired `clientReady`, or null before then. */
 export let discordClient: Client | null = null;
 
-export async function fetchMemberDisplayName(discordId: string): Promise<string | null> {
+export async function fetchMemberDisplayName(discordId: string, force = false): Promise<string | null> {
   if (!discordClient) return null;
   try {
     const guild = await discordClient.guilds.fetch(DISCORD_GUILD_ID);
-    const member = await guild.members.fetch({ user: discordId, force: true });
+    const member = await guild.members.fetch({ user: discordId, force });
     return member.displayName;
   } catch {
     return null;

--- a/src/discordBot.ts
+++ b/src/discordBot.ts
@@ -15,7 +15,8 @@ export async function fetchMemberDisplayName(discordId: string, force = false): 
     const guild = await discordClient.guilds.fetch(DISCORD_GUILD_ID);
     const member = await guild.members.fetch({ user: discordId, force });
     return member.displayName;
-  } catch {
+  } catch (err) {
+    console.warn(`[Discord] Failed to fetch display name for ${discordId}:`, err);
     return null;
   }
 }

--- a/src/discordBot.ts
+++ b/src/discordBot.ts
@@ -9,6 +9,17 @@ let client: Client;
 /** The Discord.js Client instance once it has fired `clientReady`, or null before then. */
 export let discordClient: Client | null = null;
 
+export async function fetchMemberDisplayName(discordId: string): Promise<string | null> {
+  if (!discordClient) return null;
+  try {
+    const guild = await discordClient.guilds.fetch(DISCORD_GUILD_ID);
+    const member = await guild.members.fetch({ user: discordId, force: true });
+    return member.displayName;
+  } catch {
+    return null;
+  }
+}
+
 export function startDiscordBot(): void {
   client = new Client({
     intents: [

--- a/src/discordBot.ts
+++ b/src/discordBot.ts
@@ -1,18 +1,38 @@
-import { Client, GatewayIntentBits } from 'discord.js';
+import { Client, GatewayIntentBits, Guild } from 'discord.js';
 import { DISCORD_TOKEN, DISCORD_GUILD_ID } from './config';
 import { connect } from './audioPlayer';
 import { handleCommand } from './commandRouter';
 import { setDiscordReady } from './statusStore';
 
 let client: Client;
+let cachedGuild: Guild | null = null;
 
 /** The Discord.js Client instance once it has fired `clientReady`, or null before then. */
 export let discordClient: Client | null = null;
 
+async function getConfiguredGuild(): Promise<Guild> {
+  if (!discordClient) {
+    throw new Error('Discord client is not ready');
+  }
+
+  const guildFromCache = discordClient.guilds.cache.get(DISCORD_GUILD_ID);
+  if (guildFromCache) {
+    cachedGuild = guildFromCache;
+    return guildFromCache;
+  }
+
+  if (cachedGuild) {
+    return cachedGuild;
+  }
+
+  cachedGuild = await discordClient.guilds.fetch(DISCORD_GUILD_ID);
+  return cachedGuild;
+}
+
 export async function fetchMemberDisplayName(discordId: string, force = false): Promise<string | null> {
   if (!discordClient) return null;
   try {
-    const guild = await discordClient.guilds.fetch(DISCORD_GUILD_ID);
+    const guild = await getConfiguredGuild();
     const member = await guild.members.fetch({ user: discordId, force });
     return member.displayName;
   } catch (err) {
@@ -35,7 +55,7 @@ export function startDiscordBot(): void {
     console.log(`[Discord] Logged in as ${c.user.tag}`);
     discordClient = c;
     try {
-      const guild = await c.guilds.fetch(DISCORD_GUILD_ID);
+      const guild = await getConfiguredGuild();
       setDiscordReady(c.user.tag, guild.name);
       // Small delay to ensure gateway is fully ready before joining voice
       await new Promise((resolve) => setTimeout(resolve, 2000));

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ async function main(): Promise<void> {
   }
 
   startDiscordBot();
-  startTwitchBot();
+  await startTwitchBot();
   startTikTokBot();
   startWebPanel();
   startTwitchMonitor().catch((err) => console.error('[Bot] TwitchMonitor startup error:', err));

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,4 +40,7 @@ async function main(): Promise<void> {
   startTwitchMonitor().catch((err) => console.error('[Bot] TwitchMonitor startup error:', err));
 }
 
-main();
+main().catch((err) => {
+  console.error('[Bot] Fatal startup error:', err);
+  process.exit(1);
+});

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -24,6 +24,7 @@ async function reconcileJoinedChannels(): Promise<void> {
   const joinedChannels = client.getChannels()
     .map((channel) => normalizeChannel(channel))
     .filter((channel) => channel.length > 0);
+  const joinedChannelSet = new Set(joinedChannels);
 
   for (const channel of joinedChannels) {
     if (activeChannels.has(channel)) {
@@ -37,6 +38,19 @@ async function reconcileJoinedChannels(): Promise<void> {
       console.log(`[Twitch] Parted stale channel after reconnect: ${channel}`);
     } catch (err) {
       console.error(`[Twitch] Failed to part stale channel ${channel}:`, err);
+    }
+  }
+
+  for (const channel of activeChannels) {
+    if (joinedChannelSet.has(channel)) continue;
+
+    try {
+      await client.join(channel);
+      setTwitchChannel(channel, true);
+      console.log(`[Twitch] Joined queued channel after reconnect: ${channel}`);
+    } catch (err) {
+      setTwitchChannel(channel, false);
+      console.error(`[Twitch] Failed to join queued channel ${channel}:`, err);
     }
   }
 }
@@ -83,7 +97,7 @@ export async function startTwitchBot(): Promise<void> {
     connected = true;
     console.log(`[Twitch] Connected to ${addr}:${port}`);
     console.log(`[Twitch] Listening on: ${[...activeChannels].join(', ') || '(none)'}`);
-    activeChannels.forEach((ch) => { setTwitchChannel(ch, true); });
+    activeChannels.forEach((ch) => { setTwitchChannel(ch, false); });
     void reconcileJoinedChannels().catch((err) => {
       console.error('[Twitch] Failed to reconcile joined channels:', err);
     });
@@ -111,7 +125,11 @@ export async function joinTwitchChannel(channel: string): Promise<void> {
   if (activeChannels.has(normalized)) return;
 
   if (!client || !connected) {
-    throw new Error(`Cannot join ${normalized}: Twitch client is not connected`);
+    // Queue the desired membership locally so reconnect reconciliation can join
+    // it once the Twitch client is available again.
+    activeChannels.add(normalized);
+    setTwitchChannel(normalized, false);
+    return;
   }
 
   try {

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -66,17 +66,17 @@ export async function joinTwitchChannel(channel: string): Promise<void> {
   const normalized = normalizeChannel(channel);
   if (!normalized || activeChannels.has(normalized)) return;
 
-  activeChannels.add(normalized);
-  setTwitchChannel(normalized, false);
+  if (!client || !connected) {
+    throw new Error(`Cannot join ${normalized}: Twitch client is not connected`);
+  }
 
-  if (!client || !connected) return;
   try {
     await client.join(normalized);
+    activeChannels.add(normalized);
     setTwitchChannel(normalized, true);
   } catch (err) {
     console.error(`[Twitch] Failed to join channel ${normalized}:`, err);
-    activeChannels.delete(normalized);
-    setTwitchChannel(normalized, false);
+    throw err;
   }
 }
 
@@ -84,9 +84,18 @@ export async function partTwitchChannel(channel: string): Promise<void> {
   const normalized = normalizeChannel(channel);
   if (!normalized || !activeChannels.has(normalized)) return;
 
-  activeChannels.delete(normalized);
-  setTwitchChannel(normalized, false);
+  if (!client || !connected) {
+    activeChannels.delete(normalized);
+    setTwitchChannel(normalized, false);
+    return;
+  }
 
-  if (!client || !connected) return;
-  await client.part(normalized);
+  try {
+    await client.part(normalized);
+    activeChannels.delete(normalized);
+    setTwitchChannel(normalized, false);
+  } catch (err) {
+    console.error(`[Twitch] Failed to part channel ${normalized}:`, err);
+    throw err;
+  }
 }

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -18,6 +18,11 @@ function normalizeChannel(channel: string): string {
   return normalizeTwitchChannelName(channel) ?? '';
 }
 
+function isChannelJoined(channel: string): boolean {
+  if (!client || !connected) return false;
+  return client.getChannels().some((joinedChannel) => normalizeChannel(joinedChannel) === channel);
+}
+
 async function reconcileJoinedChannels(): Promise<void> {
   if (!client || !connected) return;
 
@@ -123,7 +128,11 @@ export async function joinTwitchChannel(channel: string): Promise<void> {
   if (!normalized) {
     throw new Error(`[Twitch] Invalid channel name: ${channel}`);
   }
-  if (activeChannels.has(normalized)) return;
+  if (activeChannels.has(normalized)) {
+    // When the desired membership is already queued offline we should still no-op,
+    // but if a previous live join failed we need to retry once the client is connected.
+    if (!client || !connected || isChannelJoined(normalized)) return;
+  }
 
   if (!client || !connected) {
     // Queue the desired membership locally so reconnect reconciliation can join

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -150,6 +150,9 @@ export async function startTwitchBot(): Promise<void> {
     connected = true;
     console.log(`[Twitch] Connected to ${addr}:${port}`);
     console.log(`[Twitch] Listening on: ${[...activeChannels].join(', ') || '(none)'}`);
+    // Reset every activeChannels entry via setTwitchChannel to a pessimistic
+    // disconnected state until reconcileJoinedChannels() asynchronously
+    // rechecks the actual joined memberships and corrects the status.
     activeChannels.forEach((ch) => { setTwitchChannel(ch, false); });
     void reconcileJoinedChannels().catch((err) => {
       console.error('[Twitch] Failed to reconcile joined channels:', err);

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -70,8 +70,14 @@ export async function joinTwitchChannel(channel: string): Promise<void> {
   setTwitchChannel(normalized, false);
 
   if (!client || !connected) return;
-  await client.join(normalized);
-  setTwitchChannel(normalized, true);
+  try {
+    await client.join(normalized);
+    setTwitchChannel(normalized, true);
+  } catch (err) {
+    console.error(`[Twitch] Failed to join channel ${normalized}:`, err);
+    activeChannels.delete(normalized);
+    setTwitchChannel(normalized, false);
+  }
 }
 
 export async function partTwitchChannel(channel: string): Promise<void> {

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -7,9 +7,15 @@ import { getTwitchEnabledChannels } from './db';
 let client: tmi.Client | null = null;
 let connected = false;
 const activeChannels = new Set<string>();
+const TWITCH_CHANNEL_NAME_PATTERN = /^[a-z0-9_]{4,25}$/;
+
+export function normalizeTwitchChannelName(channel: string): string | null {
+  const normalized = channel.trim().replace(/^#/, '').toLowerCase();
+  return TWITCH_CHANNEL_NAME_PATTERN.test(normalized) ? normalized : null;
+}
 
 function normalizeChannel(channel: string): string {
-  return channel.trim().replace(/^#/, '').toLowerCase();
+  return normalizeTwitchChannelName(channel) ?? '';
 }
 
 async function reconcileJoinedChannels(): Promise<void> {

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -59,7 +59,12 @@ export async function startTwitchBot(): Promise<void> {
     activeChannels.forEach((ch) => { setTwitchChannel(ch, false); });
   });
 
-  await client.connect().catch((err) => console.error('[Twitch] Failed to connect:', err));
+  try {
+    await client.connect();
+  } catch (err) {
+    console.error('[Twitch] Failed to connect:', err);
+    throw err;
+  }
 }
 
 export async function joinTwitchChannel(channel: string): Promise<void> {
@@ -85,6 +90,9 @@ export async function partTwitchChannel(channel: string): Promise<void> {
   if (!normalized || !activeChannels.has(normalized)) return;
 
   if (!client || !connected) {
+    // Intentional divergence from join flow: when disabling a channel while the
+    // Twitch client is offline, we still remove local state so auto-reconnect
+    // does not rejoin this channel from stale in-memory data.
     activeChannels.delete(normalized);
     setTwitchChannel(normalized, false);
     return;

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -200,7 +200,8 @@ export async function joinTwitchChannel(channel: string): Promise<void> {
       await client.join(normalized);
       setTwitchChannel(normalized, true);
     } catch (err) {
-      activeChannels.delete(normalized);
+      // Keep the desired membership queued so reconnect reconciliation can retry
+      // instead of permanently desyncing runtime state from the DB.
       setTwitchChannel(normalized, false);
       console.error(`[Twitch] Failed to join channel ${normalized}:`, err);
       throw err;

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -231,8 +231,8 @@ export async function partTwitchChannel(channel: string): Promise<void> {
         await client.part(normalized);
       }
     } catch (err) {
-      activeChannels.add(normalized);
-      setTwitchChannel(normalized, isChannelJoined(normalized));
+      // Keep desired membership removed so later reconciliation can retry
+      // parting any stale runtime join without restoring admin intent here.
       console.error(`[Twitch] Failed to part channel ${normalized}:`, err);
       throw err;
     }

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -118,6 +118,8 @@ export async function partTwitchChannel(channel: string): Promise<void> {
   if (!normalized || !activeChannels.has(normalized)) return;
 
   if (!client || !connected) {
+    // We remove local state immediately and let reconcileJoinedChannels() part
+    // any stale tmi.js channel memberships on the next successful connect.
     activeChannels.delete(normalized);
     setTwitchChannel(normalized, false);
     return;

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -10,8 +10,8 @@ let connected = false;
 const activeChannels = new Set<string>();
 const membershipMutationQueues = new Map<string, Promise<void>>();
 
-function normalizeChannel(channel: string): string {
-  return normalizeTwitchChannelName(channel) ?? '';
+function normalizeChannel(channel: string): string | null {
+  return normalizeTwitchChannelName(channel);
 }
 
 function isChannelJoined(channel: string): boolean {
@@ -56,7 +56,7 @@ async function reconcileJoinedChannels(): Promise<void> {
 
   const joinedChannels = client.getChannels()
     .map((channel) => normalizeChannel(channel))
-    .filter((channel) => channel.length > 0);
+    .filter((channel): channel is string => channel !== null);
   const joinedChannelSet = new Set(joinedChannels);
 
   for (const channel of joinedChannels) {
@@ -139,6 +139,7 @@ export async function startTwitchBot(): Promise<void> {
     // Don't respond to own messages
     if (self) return;
     const normalizedChannel = normalizeChannel(channel);
+    if (!normalizedChannel) return;
     if (!activeChannels.has(normalizedChannel)) return;
     handleCommand(message, 'twitch').catch((err) =>
       console.error('[Twitch] Command handler error:', err),

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -196,8 +196,9 @@ export async function joinTwitchChannel(channel: string): Promise<void> {
     }
 
     try {
-      await client.join(normalized);
       activeChannels.add(normalized);
+      setTwitchChannel(normalized, false);
+      await client.join(normalized);
       setTwitchChannel(normalized, true);
     } catch (err) {
       console.error(`[Twitch] Failed to join channel ${normalized}:`, err);
@@ -222,11 +223,11 @@ export async function partTwitchChannel(channel: string): Promise<void> {
     }
 
     try {
+      activeChannels.delete(normalized);
+      setTwitchChannel(normalized, false);
       if (isChannelJoined(normalized)) {
         await client.part(normalized);
       }
-      activeChannels.delete(normalized);
-      setTwitchChannel(normalized, false);
     } catch (err) {
       console.error(`[Twitch] Failed to part channel ${normalized}:`, err);
       throw err;

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -7,6 +7,7 @@ import { getTwitchEnabledChannels } from './db';
 let client: tmi.Client | null = null;
 let connected = false;
 const activeChannels = new Set<string>();
+const membershipMutationQueues = new Map<string, Promise<void>>();
 const TWITCH_CHANNEL_NAME_PATTERN = /^[a-z0-9_]{4,25}$/;
 
 export function normalizeTwitchChannelName(channel: string): string | null {
@@ -23,6 +24,38 @@ function isChannelJoined(channel: string): boolean {
   return client.getChannels().some((joinedChannel) => normalizeChannel(joinedChannel) === channel);
 }
 
+async function withMembershipMutationLock<T>(channel: string, operation: () => Promise<T>): Promise<T> {
+  const previous = membershipMutationQueues.get(channel) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const queued = (async () => {
+    try {
+      await previous;
+    } catch {
+      // Ignore earlier failures so later membership changes still run.
+    }
+    await current;
+  })();
+  membershipMutationQueues.set(channel, queued);
+
+  try {
+    await previous;
+  } catch {
+    // Ignore earlier failures so later membership changes still run.
+  }
+
+  try {
+    return await operation();
+  } finally {
+    release();
+    if (membershipMutationQueues.get(channel) === queued) {
+      membershipMutationQueues.delete(channel);
+    }
+  }
+}
+
 async function reconcileJoinedChannels(): Promise<void> {
   if (!client || !connected) return;
 
@@ -32,15 +65,21 @@ async function reconcileJoinedChannels(): Promise<void> {
   const joinedChannelSet = new Set(joinedChannels);
 
   for (const channel of joinedChannels) {
-    if (activeChannels.has(channel)) {
-      setTwitchChannel(channel, true);
-      continue;
-    }
-
     try {
-      await client.part(channel);
-      setTwitchChannel(channel, false);
-      console.log(`[Twitch] Parted stale channel after reconnect: ${channel}`);
+      await withMembershipMutationLock(channel, async () => {
+        if (activeChannels.has(channel)) {
+          setTwitchChannel(channel, true);
+          return;
+        }
+        if (!client || !connected || !isChannelJoined(channel)) {
+          setTwitchChannel(channel, false);
+          return;
+        }
+
+        await client.part(channel);
+        setTwitchChannel(channel, false);
+        console.log(`[Twitch] Parted stale channel after reconnect: ${channel}`);
+      });
     } catch (err) {
       console.error(`[Twitch] Failed to part stale channel ${channel}:`, err);
     }
@@ -50,9 +89,21 @@ async function reconcileJoinedChannels(): Promise<void> {
     if (joinedChannelSet.has(channel)) continue;
 
     try {
-      await client.join(channel);
-      setTwitchChannel(channel, true);
-      console.log(`[Twitch] Joined queued channel after reconnect: ${channel}`);
+      await withMembershipMutationLock(channel, async () => {
+        if (!activeChannels.has(channel)) return;
+        if (!client || !connected) {
+          setTwitchChannel(channel, false);
+          return;
+        }
+        if (isChannelJoined(channel)) {
+          setTwitchChannel(channel, true);
+          return;
+        }
+
+        await client.join(channel);
+        setTwitchChannel(channel, true);
+        console.log(`[Twitch] Joined queued channel after reconnect: ${channel}`);
+      });
     } catch (err) {
       setTwitchChannel(channel, false);
       console.error(`[Twitch] Failed to join queued channel ${channel}:`, err);
@@ -128,48 +179,57 @@ export async function joinTwitchChannel(channel: string): Promise<void> {
   if (!normalized) {
     throw new Error(`[Twitch] Invalid channel name: ${channel}`);
   }
-  if (activeChannels.has(normalized)) {
-    // When the desired membership is already queued offline we should still no-op,
-    // but if a previous live join failed we need to retry once the client is connected.
-    if (!client || !connected || isChannelJoined(normalized)) return;
-  }
 
-  if (!client || !connected) {
-    // Queue the desired membership locally so reconnect reconciliation can join
-    // it once the Twitch client is available again.
-    activeChannels.add(normalized);
-    setTwitchChannel(normalized, false);
-    return;
-  }
+  await withMembershipMutationLock(normalized, async () => {
+    if (activeChannels.has(normalized)) {
+      // When the desired membership is already queued offline we should still no-op,
+      // but if a previous live join failed we need to retry once the client is connected.
+      if (!client || !connected || isChannelJoined(normalized)) return;
+    }
 
-  try {
-    await client.join(normalized);
-    activeChannels.add(normalized);
-    setTwitchChannel(normalized, true);
-  } catch (err) {
-    console.error(`[Twitch] Failed to join channel ${normalized}:`, err);
-    throw err;
-  }
+    if (!client || !connected) {
+      // Queue the desired membership locally so reconnect reconciliation can join
+      // it once the Twitch client is available again.
+      activeChannels.add(normalized);
+      setTwitchChannel(normalized, false);
+      return;
+    }
+
+    try {
+      await client.join(normalized);
+      activeChannels.add(normalized);
+      setTwitchChannel(normalized, true);
+    } catch (err) {
+      console.error(`[Twitch] Failed to join channel ${normalized}:`, err);
+      throw err;
+    }
+  });
 }
 
 export async function partTwitchChannel(channel: string): Promise<void> {
   const normalized = normalizeChannel(channel);
-  if (!normalized || !activeChannels.has(normalized)) return;
+  if (!normalized) return;
 
-  if (!client || !connected) {
-    // We remove local state immediately and let reconcileJoinedChannels() part
-    // any stale tmi.js channel memberships on the next successful connect.
-    activeChannels.delete(normalized);
-    setTwitchChannel(normalized, false);
-    return;
-  }
+  await withMembershipMutationLock(normalized, async () => {
+    if (!activeChannels.has(normalized) && !isChannelJoined(normalized)) return;
 
-  try {
-    await client.part(normalized);
-    activeChannels.delete(normalized);
-    setTwitchChannel(normalized, false);
-  } catch (err) {
-    console.error(`[Twitch] Failed to part channel ${normalized}:`, err);
-    throw err;
-  }
+    if (!client || !connected) {
+      // We remove local state immediately and let reconcileJoinedChannels() part
+      // any stale tmi.js channel memberships on the next successful connect.
+      activeChannels.delete(normalized);
+      setTwitchChannel(normalized, false);
+      return;
+    }
+
+    try {
+      if (isChannelJoined(normalized)) {
+        await client.part(normalized);
+      }
+      activeChannels.delete(normalized);
+      setTwitchChannel(normalized, false);
+    } catch (err) {
+      console.error(`[Twitch] Failed to part channel ${normalized}:`, err);
+      throw err;
+    }
+  });
 }

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -12,6 +12,29 @@ function normalizeChannel(channel: string): string {
   return channel.trim().replace(/^#/, '').toLowerCase();
 }
 
+async function reconcileJoinedChannels(): Promise<void> {
+  if (!client || !connected) return;
+
+  const joinedChannels = client.getChannels()
+    .map((channel) => normalizeChannel(channel))
+    .filter((channel) => channel.length > 0);
+
+  for (const channel of joinedChannels) {
+    if (activeChannels.has(channel)) {
+      setTwitchChannel(channel, true);
+      continue;
+    }
+
+    try {
+      await client.part(channel);
+      setTwitchChannel(channel, false);
+      console.log(`[Twitch] Parted stale channel after reconnect: ${channel}`);
+    } catch (err) {
+      console.error(`[Twitch] Failed to part stale channel ${channel}:`, err);
+    }
+  }
+}
+
 export async function startTwitchBot(): Promise<void> {
   const configuredChannels = await getTwitchEnabledChannels();
   configuredChannels.forEach((ch) => {
@@ -38,9 +61,11 @@ export async function startTwitchBot(): Promise<void> {
     },
   });
 
-  client.on('message', (_channel, tags, message, self) => {
+  client.on('message', (channel, tags, message, self) => {
     // Don't respond to own messages
     if (self) return;
+    const normalizedChannel = normalizeChannel(channel);
+    if (!activeChannels.has(normalizedChannel)) return;
     handleCommand(message, 'twitch').catch((err) =>
       console.error('[Twitch] Command handler error:', err),
     );
@@ -51,6 +76,9 @@ export async function startTwitchBot(): Promise<void> {
     console.log(`[Twitch] Connected to ${addr}:${port}`);
     console.log(`[Twitch] Listening on: ${[...activeChannels].join(', ') || '(none)'}`);
     activeChannels.forEach((ch) => { setTwitchChannel(ch, true); });
+    void reconcileJoinedChannels().catch((err) => {
+      console.error('[Twitch] Failed to reconcile joined channels:', err);
+    });
   });
 
   client.on('disconnected', (reason) => {
@@ -90,9 +118,6 @@ export async function partTwitchChannel(channel: string): Promise<void> {
   if (!normalized || !activeChannels.has(normalized)) return;
 
   if (!client || !connected) {
-    // Intentional divergence from join flow: when disabling a channel while the
-    // Twitch client is offline, we still remove local state so auto-reconnect
-    // does not rejoin this channel from stale in-memory data.
     activeChannels.delete(normalized);
     setTwitchChannel(normalized, false);
     return;

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -3,17 +3,12 @@ import { TWITCH_USERNAME, TWITCH_OAUTH_TOKEN } from './config';
 import { handleCommand } from './commandRouter';
 import { setTwitchChannel } from './statusStore';
 import { getTwitchEnabledChannels } from './db';
+import { normalizeTwitchChannelName } from './twitchChannelName';
 
 let client: tmi.Client | null = null;
 let connected = false;
 const activeChannels = new Set<string>();
 const membershipMutationQueues = new Map<string, Promise<void>>();
-const TWITCH_CHANNEL_NAME_PATTERN = /^[a-z0-9_]{4,25}$/;
-
-export function normalizeTwitchChannelName(channel: string): string | null {
-  const normalized = channel.trim().replace(/^#/, '').toLowerCase();
-  return TWITCH_CHANNEL_NAME_PATTERN.test(normalized) ? normalized : null;
-}
 
 function normalizeChannel(channel: string): string {
   return normalizeTwitchChannelName(channel) ?? '';

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -197,6 +197,8 @@ export async function joinTwitchChannel(channel: string): Promise<void> {
       await client.join(normalized);
       setTwitchChannel(normalized, true);
     } catch (err) {
+      activeChannels.delete(normalized);
+      setTwitchChannel(normalized, false);
       console.error(`[Twitch] Failed to join channel ${normalized}:`, err);
       throw err;
     }
@@ -225,6 +227,8 @@ export async function partTwitchChannel(channel: string): Promise<void> {
         await client.part(normalized);
       }
     } catch (err) {
+      activeChannels.add(normalized);
+      setTwitchChannel(normalized, isChannelJoined(normalized));
       console.error(`[Twitch] Failed to part channel ${normalized}:`, err);
       throw err;
     }

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -1,20 +1,36 @@
 import tmi from 'tmi.js';
-import { TWITCH_USERNAME, TWITCH_OAUTH_TOKEN, TWITCH_CHANNELS } from './config';
+import { TWITCH_USERNAME, TWITCH_OAUTH_TOKEN } from './config';
 import { handleCommand } from './commandRouter';
 import { setTwitchChannel } from './statusStore';
+import { getTwitchEnabledChannels } from './db';
 
-let client: tmi.Client;
+let client: tmi.Client | null = null;
+let connected = false;
+const activeChannels = new Set<string>();
 
-export function startTwitchBot(): void {
-  // Seed all configured channels as disconnected so they appear in status immediately
-  TWITCH_CHANNELS.forEach((ch) => { setTwitchChannel(ch, false); });
+function normalizeChannel(channel: string): string {
+  return channel.trim().replace(/^#/, '').toLowerCase();
+}
+
+export async function startTwitchBot(): Promise<void> {
+  const configuredChannels = await getTwitchEnabledChannels();
+  configuredChannels.forEach((ch) => {
+    const normalized = normalizeChannel(ch);
+    if (!normalized) return;
+    activeChannels.add(normalized);
+    setTwitchChannel(normalized, false);
+  });
+
+  if (activeChannels.size === 0) {
+    console.warn('[Twitch] No enabled Twitch channels found in DB; connecting with no joined channels.');
+  }
 
   client = new tmi.Client({
     identity: {
       username: TWITCH_USERNAME,
       password: TWITCH_OAUTH_TOKEN,
     },
-    channels: TWITCH_CHANNELS,
+    channels: [...activeChannels],
     options: { debug: false },
     connection: {
       reconnect: true,
@@ -31,15 +47,40 @@ export function startTwitchBot(): void {
   });
 
   client.on('connected', (addr, port) => {
+    connected = true;
     console.log(`[Twitch] Connected to ${addr}:${port}`);
-    console.log(`[Twitch] Listening on: ${TWITCH_CHANNELS.join(', ')}`);
-    TWITCH_CHANNELS.forEach((ch) => { setTwitchChannel(ch, true); });
+    console.log(`[Twitch] Listening on: ${[...activeChannels].join(', ') || '(none)'}`);
+    activeChannels.forEach((ch) => { setTwitchChannel(ch, true); });
   });
 
   client.on('disconnected', (reason) => {
+    connected = false;
     console.warn(`[Twitch] Disconnected: ${reason}`);
-    TWITCH_CHANNELS.forEach((ch) => { setTwitchChannel(ch, false); });
+    activeChannels.forEach((ch) => { setTwitchChannel(ch, false); });
   });
 
-  client.connect().catch((err) => console.error('[Twitch] Failed to connect:', err));
+  await client.connect().catch((err) => console.error('[Twitch] Failed to connect:', err));
+}
+
+export async function joinTwitchChannel(channel: string): Promise<void> {
+  const normalized = normalizeChannel(channel);
+  if (!normalized || activeChannels.has(normalized)) return;
+
+  activeChannels.add(normalized);
+  setTwitchChannel(normalized, false);
+
+  if (!client || !connected) return;
+  await client.join(normalized);
+  setTwitchChannel(normalized, true);
+}
+
+export async function partTwitchChannel(channel: string): Promise<void> {
+  const normalized = normalizeChannel(channel);
+  if (!normalized || !activeChannels.has(normalized)) return;
+
+  activeChannels.delete(normalized);
+  setTwitchChannel(normalized, false);
+
+  if (!client || !connected) return;
+  await client.part(normalized);
 }

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -57,14 +57,15 @@ async function reconcileJoinedChannels(): Promise<void> {
 
 export async function startTwitchBot(): Promise<void> {
   const configuredChannels = await getTwitchEnabledChannels();
-  configuredChannels.forEach((ch) => {
+  for (const ch of configuredChannels) {
     const normalized = normalizeChannel(ch);
     if (!normalized) {
-      throw new Error(`[Twitch] Invalid enabled channel in DB: ${ch}`);
+      console.error(`[Twitch] Skipping invalid enabled channel in DB: ${ch}`);
+      continue;
     }
     activeChannels.add(normalized);
     setTwitchChannel(normalized, false);
-  });
+  }
 
   if (activeChannels.size === 0) {
     console.warn('[Twitch] No enabled Twitch channels found in DB; connecting with no joined channels.');

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -45,7 +45,9 @@ export async function startTwitchBot(): Promise<void> {
   const configuredChannels = await getTwitchEnabledChannels();
   configuredChannels.forEach((ch) => {
     const normalized = normalizeChannel(ch);
-    if (!normalized) return;
+    if (!normalized) {
+      throw new Error(`[Twitch] Invalid enabled channel in DB: ${ch}`);
+    }
     activeChannels.add(normalized);
     setTwitchChannel(normalized, false);
   });
@@ -103,7 +105,10 @@ export async function startTwitchBot(): Promise<void> {
 
 export async function joinTwitchChannel(channel: string): Promise<void> {
   const normalized = normalizeChannel(channel);
-  if (!normalized || activeChannels.has(normalized)) return;
+  if (!normalized) {
+    throw new Error(`[Twitch] Invalid channel name: ${channel}`);
+  }
+  if (activeChannels.has(normalized)) return;
 
   if (!client || !connected) {
     throw new Error(`Cannot join ${normalized}: Twitch client is not connected`);

--- a/src/twitchChannelName.ts
+++ b/src/twitchChannelName.ts
@@ -1,0 +1,6 @@
+const TWITCH_CHANNEL_NAME_PATTERN = /^[a-z0-9_]{4,25}$/;
+
+export function normalizeTwitchChannelName(channel: string): string | null {
+  const normalized = channel.trim().replace(/^#/, '').toLowerCase();
+  return TWITCH_CHANNEL_NAME_PATTERN.test(normalized) ? normalized : null;
+}

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -49,7 +49,13 @@ router.post('/users/add', requireAdmin, async (req, res) => {
   if (!Number.isFinite(level)) return res.status(400).render('error', { message: 'Invalid access level.', user: req.session.user ?? null });
   if (!(Object.values(AccessLevel) as number[]).includes(level)) return res.status(400).render('error', { message: 'Invalid access level.', user: req.session.user ?? null });
   try {
-    await upsertUser(discord_id.trim(), (discord_name ?? '').trim(), level as AccessLevelValue, twitch_name);
+    const normalizedTwitchName = (twitch_name ?? '').trim();
+    await upsertUser(
+      discord_id.trim(),
+      (discord_name ?? '').trim(),
+      level as AccessLevelValue,
+      normalizedTwitchName.length > 0 ? normalizedTwitchName : undefined,
+    );
   } catch (err) {
     console.error('[Web] Add user error:', err);
     return res.redirect('/admin/users?error=add_failed');
@@ -133,20 +139,25 @@ router.post('/users/toggle-twitch', requireManager, async (req, res) => {
 router.post('/users/refresh-names', requireManager, async (req, res) => {
   try {
     const users = await getAllUsers();
+    let updatedCount = 0;
     for (const u of users) {
       const name = await fetchMemberDisplayName(u.discord_id);
       if (name && name.trim()) {
         await updateDiscordName(u.discord_id, name.trim());
+        updatedCount++;
       }
       // Small delay between requests to stay within Discord API rate limits
       await new Promise((resolve) => setTimeout(resolve, 200));
     }
+
+    if (updatedCount > 0) {
+      return res.redirect('/admin/users?refreshed=1');
+    }
+    return res.redirect('/admin/users?refreshed=0');
   } catch (err) {
     console.error('[Web] Refresh Discord names failed:', err);
     return res.redirect('/admin/users?error=update_failed');
   }
-
-  res.redirect('/admin/users?refreshed=1');
 });
 
 export default router;

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -23,7 +23,7 @@ const KNOWN_ERRORS = new Set(['add_failed', 'update_failed', 'remove_failed', 't
 // shared storage or a DB transaction/row lock before scaling out.
 const userMutationQueues = new Map<string, Promise<void>>();
 
-type RefreshOutcome = 'idle' | 'running' | 'success' | 'noop' | 'error';
+type RefreshOutcome = 'idle' | 'running' | 'success' | 'partial' | 'noop' | 'error';
 
 // This progress state is intentionally in-process because the web panel runs as
 // a single bot instance today. If the panel is ever scaled horizontally, move
@@ -31,11 +31,13 @@ type RefreshOutcome = 'idle' | 'running' | 'success' | 'noop' | 'error';
 const refreshState: {
   outcome: RefreshOutcome;
   updatedCount: number;
+  failureCount: number;
   startedAt: number | null;
   finishedAt: number | null;
 } = {
   outcome: 'idle',
   updatedCount: 0,
+  failureCount: 0,
   startedAt: null,
   finishedAt: null,
 };
@@ -64,6 +66,7 @@ async function withUserMutationLock<T>(discordId: string, operation: () => Promi
 async function runDiscordNameRefresh(): Promise<void> {
   refreshState.outcome = 'running';
   refreshState.updatedCount = 0;
+  refreshState.failureCount = 0;
   refreshState.startedAt = Date.now();
   refreshState.finishedAt = null;
 
@@ -74,6 +77,7 @@ async function runDiscordNameRefresh(): Promise<void> {
 
     const users = await getAllUsers();
     let updatedCount = 0;
+    let failureCount = 0;
 
     for (const user of users) {
       try {
@@ -85,14 +89,20 @@ async function runDiscordNameRefresh(): Promise<void> {
           refreshState.updatedCount = updatedCount;
         }
       } catch (err) {
+        failureCount++;
+        refreshState.failureCount = failureCount;
         console.error(`[Web] Failed to refresh Discord name for ${user.discord_id}:`, err);
       }
       await new Promise((resolve) => setTimeout(resolve, 200));
     }
 
     refreshState.updatedCount = updatedCount;
-    refreshState.outcome = updatedCount > 0 ? 'success' : 'noop';
+    refreshState.failureCount = failureCount;
+    refreshState.outcome = updatedCount > 0
+      ? (failureCount > 0 ? 'partial' : 'success')
+      : (failureCount > 0 ? 'error' : 'noop');
   } catch (err) {
+    refreshState.failureCount = Math.max(refreshState.failureCount, 1);
     refreshState.outcome = 'error';
     console.error('[Web] Refresh Discord names failed:', err);
   } finally {
@@ -277,17 +287,27 @@ router.post('/users/remove', requireAdmin, async (req, res) => {
   try {
     await withUserMutationLock(trimmedDiscordId, async () => {
       const existingUser = await findUser(trimmedDiscordId);
+      let channelParted = false;
       if (existingUser?.is_twitch_bot_enabled && existingUser.twitch_name) {
-        try {
-          await partTwitchChannel(existingUser.twitch_name);
-        } catch (err) {
-          console.error(
-            `[Web] Failed to part Twitch channel "${existingUser.twitch_name}" while removing user ${trimmedDiscordId}; continuing with DB removal:`,
-            err,
-          );
-        }
+        await partTwitchChannel(existingUser.twitch_name);
+        channelParted = true;
       }
-      await removeUser(trimmedDiscordId);
+
+      try {
+        await removeUser(trimmedDiscordId);
+      } catch (err) {
+        if (channelParted && existingUser?.twitch_name) {
+          try {
+            await joinTwitchChannel(existingUser.twitch_name);
+          } catch (rollbackErr) {
+            console.error(
+              `[Web] Failed to rejoin Twitch channel "${existingUser.twitch_name}" after removeUser failed for ${trimmedDiscordId}:`,
+              rollbackErr,
+            );
+          }
+        }
+        throw err;
+      }
     });
   } catch (err) {
     console.error('[Web] Remove user error:', err);

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -131,8 +131,23 @@ router.post('/users/add', requireAdmin, async (req, res) => {
 
     if (existingUser?.is_twitch_bot_enabled && previousTwitchChannel !== nextTwitchChannel) {
       if (!nextTwitchChannel) {
-        await partTwitchChannel(previousTwitchChannel ?? '');
-        await updateTwitchBotEnabled(trimmedDiscordId, false);
+        try {
+          await partTwitchChannel(previousTwitchChannel ?? '');
+          await updateTwitchBotEnabled(trimmedDiscordId, false);
+        } catch (err) {
+          try {
+            await upsertUser(
+              trimmedDiscordId,
+              trimmedDiscordName,
+              level as AccessLevelValue,
+              previousTwitchChannel ?? '',
+            );
+            await updateTwitchBotEnabled(trimmedDiscordId, existingUser.is_twitch_bot_enabled);
+          } catch (rollbackErr) {
+            console.error('[Web] Add user clear Twitch rollback failed:', rollbackErr);
+          }
+          throw err;
+        }
         return res.redirect('/admin/users');
       }
 

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -130,6 +130,12 @@ router.post('/users/add', requireAdmin, async (req, res) => {
     );
 
     if (existingUser?.is_twitch_bot_enabled && previousTwitchChannel !== nextTwitchChannel) {
+      if (!nextTwitchChannel) {
+        await partTwitchChannel(previousTwitchChannel ?? '');
+        await updateTwitchBotEnabled(trimmedDiscordId, false);
+        return res.redirect('/admin/users');
+      }
+
       let previousChannelParted = false;
       try {
         if (previousTwitchChannel) {
@@ -137,11 +143,7 @@ router.post('/users/add', requireAdmin, async (req, res) => {
           previousChannelParted = true;
         }
 
-        if (nextTwitchChannel) {
-          await joinTwitchChannel(nextTwitchChannel);
-        } else {
-          await updateTwitchBotEnabled(trimmedDiscordId, false);
-        }
+        await joinTwitchChannel(nextTwitchChannel);
       } catch (err) {
         if (previousChannelParted && previousTwitchChannel) {
           try {

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -52,6 +52,16 @@ class DuplicateTwitchNameError extends Error {
   }
 }
 
+function isDuplicateTwitchNameDbError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const dbError = error as { code?: string; message?: string };
+  return dbError.code === 'ER_DUP_ENTRY'
+    && (dbError.message?.includes('ux_user_twitch_name') ?? false);
+}
+
 async function withUserMutationLock<T>(discordId: string, operation: () => Promise<T>): Promise<T> {
   const previous = userMutationQueues.get(discordId) ?? Promise.resolve();
   let release!: () => void;
@@ -295,7 +305,7 @@ router.post('/users/add', requireAdmin, async (req, res) => {
     });
   } catch (err) {
     console.error('[Web] Add user error:', err);
-    if (err instanceof DuplicateTwitchNameError) {
+    if (err instanceof DuplicateTwitchNameError || isDuplicateTwitchNameDbError(err)) {
       return res.redirect('/admin/users?error=duplicate_twitch_name');
     }
     return res.redirect('/admin/users?error=add_failed');

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -259,16 +259,23 @@ router.post('/users/update', requireAdmin, async (req, res) => {
 // Remove a user (Admin only)
 router.post('/users/remove', requireAdmin, async (req, res) => {
   const { discord_id } = req.body as { discord_id?: string };
-  if (!discord_id) return res.redirect('/admin/users');
+  const trimmedDiscordId = (discord_id ?? '').trim();
+  if (!trimmedDiscordId) return res.redirect('/admin/users');
 
-  if (discord_id === req.session.user!.discordId) {
+  if (trimmedDiscordId === req.session.user!.discordId) {
     return res.status(400).render('error', {
       message: 'You cannot remove yourself.',
       user: req.session.user ?? null,
     });
   }
   try {
-    await removeUser(discord_id);
+    await withUserMutationLock(trimmedDiscordId, async () => {
+      const existingUser = await findUser(trimmedDiscordId);
+      if (existingUser?.is_twitch_bot_enabled && existingUser.twitch_name) {
+        await partTwitchChannel(existingUser.twitch_name);
+      }
+      await removeUser(trimmedDiscordId);
+    });
   } catch (err) {
     console.error('[Web] Remove user error:', err);
     return res.redirect('/admin/users?error=remove_failed');

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -132,9 +132,18 @@ router.post('/users/add', requireAdmin, async (req, res) => {
   };
   const trimmedDiscordId = (discord_id ?? '').trim();
   if (!trimmedDiscordId || !access_level) return res.redirect('/admin/users');
+  const submittedTwitchName = (twitch_name ?? '').trim();
+  const shouldClearTwitchName = clear_twitch_name === '1';
+  const normalizedTwitchName = submittedTwitchName ? normalizeTwitchChannelName(submittedTwitchName) : null;
   const level = parseInt(access_level, 10);
   if (!Number.isFinite(level)) return res.status(400).render('error', { message: 'Invalid access level.', user: req.session.user ?? null });
   if (!(Object.values(AccessLevel) as number[]).includes(level)) return res.status(400).render('error', { message: 'Invalid access level.', user: req.session.user ?? null });
+  if (!shouldClearTwitchName && submittedTwitchName && !normalizedTwitchName) {
+    return res.status(400).render('error', {
+      message: 'Invalid Twitch name.',
+      user: req.session.user ?? null,
+    });
+  }
   if (trimmedDiscordId === req.session.user?.discordId) {
     return res.status(400).render('error', {
       message: 'You cannot update your own account from this form.',
@@ -144,9 +153,6 @@ router.post('/users/add', requireAdmin, async (req, res) => {
   try {
     await withUserMutationLock(trimmedDiscordId, async () => {
       const trimmedDiscordName = (discord_name ?? '').trim();
-      const submittedTwitchName = (twitch_name ?? '').trim();
-      const normalizedTwitchName = submittedTwitchName ? normalizeTwitchChannelName(submittedTwitchName) : null;
-      const shouldClearTwitchName = clear_twitch_name === '1';
       const existingUser = await findUser(trimmedDiscordId);
       const previousTwitchChannel = existingUser?.twitch_name ? existingUser.twitch_name.trim().toLowerCase() : null;
       const nextTwitchName = shouldClearTwitchName
@@ -272,7 +278,14 @@ router.post('/users/remove', requireAdmin, async (req, res) => {
     await withUserMutationLock(trimmedDiscordId, async () => {
       const existingUser = await findUser(trimmedDiscordId);
       if (existingUser?.is_twitch_bot_enabled && existingUser.twitch_name) {
-        await partTwitchChannel(existingUser.twitch_name);
+        try {
+          await partTwitchChannel(existingUser.twitch_name);
+        } catch (err) {
+          console.error(
+            `[Web] Failed to part Twitch channel "${existingUser.twitch_name}" while removing user ${trimmedDiscordId}; continuing with DB removal:`,
+            err,
+          );
+        }
       }
       await removeUser(trimmedDiscordId);
     });

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -49,10 +49,21 @@ async function withUserMutationLock<T>(discordId: string, operation: () => Promi
   const current = new Promise<void>((resolve) => {
     release = resolve;
   });
-  const queued = previous.catch(() => undefined).then(() => current);
+  const queued = (async () => {
+    try {
+      await previous;
+    } catch {
+      // Ignore failures from earlier queued operations so later mutations still run.
+    }
+    await current;
+  })();
   userMutationQueues.set(discordId, queued);
 
-  await previous.catch(() => undefined);
+  try {
+    await previous;
+  } catch {
+    // Ignore failures from earlier queued operations so later mutations still run.
+  }
 
   try {
     return await operation();
@@ -198,7 +209,10 @@ router.post('/users/add', requireAdmin, async (req, res) => {
         try {
           // Persist disable first so the rollback path can safely restore both DB and runtime state.
           await updateTwitchBotEnabled(trimmedDiscordId, false);
-          await partTwitchChannel(previousTwitchChannel ?? '');
+          const enabledChannels = await getTwitchEnabledChannels();
+          if (previousTwitchChannel && !enabledChannels.includes(previousTwitchChannel)) {
+            await partTwitchChannel(previousTwitchChannel);
+          }
         } catch (err) {
           try {
             await upsertUser(
@@ -296,26 +310,33 @@ router.post('/users/remove', requireAdmin, async (req, res) => {
   try {
     await withUserMutationLock(trimmedDiscordId, async () => {
       const existingUser = await findUser(trimmedDiscordId);
-      let channelParted = false;
-      if (existingUser?.is_twitch_bot_enabled && existingUser.twitch_name) {
-        await partTwitchChannel(existingUser.twitch_name);
-        channelParted = true;
-      }
+      await removeUser(trimmedDiscordId);
 
-      try {
-        await removeUser(trimmedDiscordId);
-      } catch (err) {
-        if (channelParted && existingUser?.twitch_name) {
+      if (existingUser?.is_twitch_bot_enabled && existingUser.twitch_name) {
+        const normalizedChannel = normalizeTwitchChannelName(existingUser.twitch_name);
+        const enabledChannels = await getTwitchEnabledChannels();
+
+        if (normalizedChannel && !enabledChannels.includes(normalizedChannel)) {
           try {
-            await joinTwitchChannel(existingUser.twitch_name);
-          } catch (rollbackErr) {
-            console.error(
-              `[Web] Failed to rejoin Twitch channel "${existingUser.twitch_name}" after removeUser failed for ${trimmedDiscordId}:`,
-              rollbackErr,
-            );
+            await partTwitchChannel(normalizedChannel);
+          } catch (partErr) {
+            try {
+              await upsertUser(
+                existingUser.discord_id,
+                existingUser.discord_name?.trim() ?? '',
+                existingUser.access_level as AccessLevelValue,
+                existingUser.twitch_name,
+              );
+              await updateTwitchBotEnabled(existingUser.discord_id, existingUser.is_twitch_bot_enabled);
+            } catch (rollbackErr) {
+              console.error(
+                `[Web] Failed to restore user ${trimmedDiscordId} after Twitch part failed during removal:`,
+                rollbackErr,
+              );
+            }
+            throw partErr;
           }
         }
-        throw err;
       }
     });
   } catch (err) {

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -51,7 +51,7 @@ async function runDiscordNameRefresh(): Promise<void> {
     let updatedCount = 0;
 
     for (const user of users) {
-      const name = await fetchMemberDisplayName(user.discord_id);
+      const name = await fetchMemberDisplayName(user.discord_id, true);
       const trimmedName = name?.trim();
       if (trimmedName && trimmedName !== user.discord_name) {
         await updateDiscordName(user.discord_id, trimmedName);
@@ -130,9 +130,11 @@ router.post('/users/add', requireAdmin, async (req, res) => {
     );
 
     if (existingUser?.is_twitch_bot_enabled && previousTwitchChannel !== nextTwitchChannel) {
+      let previousChannelParted = false;
       try {
         if (previousTwitchChannel) {
           await partTwitchChannel(previousTwitchChannel);
+          previousChannelParted = true;
         }
 
         if (nextTwitchChannel) {
@@ -141,7 +143,25 @@ router.post('/users/add', requireAdmin, async (req, res) => {
           await updateTwitchBotEnabled(trimmedDiscordId, false);
         }
       } catch (err) {
-        await updateTwitchBotEnabled(trimmedDiscordId, false);
+        if (previousChannelParted && previousTwitchChannel) {
+          try {
+            await joinTwitchChannel(previousTwitchChannel);
+          } catch (rollbackErr) {
+            console.error('[Web] Add user Twitch channel rollback failed:', rollbackErr);
+          }
+        }
+
+        try {
+          await upsertUser(
+            trimmedDiscordId,
+            trimmedDiscordName,
+            level as AccessLevelValue,
+            previousTwitchChannel ?? '',
+          );
+          await updateTwitchBotEnabled(trimmedDiscordId, existingUser.is_twitch_bot_enabled);
+        } catch (rollbackErr) {
+          console.error('[Web] Add user DB rollback failed:', rollbackErr);
+        }
         throw err;
       }
     }

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import {
   getAllUsers,
+  getTwitchEnabledChannels,
   findUser,
   upsertUser,
   removeUser,
@@ -82,6 +83,14 @@ async function runDiscordNameRefresh(): Promise<void> {
     for (const user of users) {
       try {
         const name = await fetchMemberDisplayName(user.discord_id, true);
+        if (name == null) {
+          failureCount++;
+          refreshState.failureCount = failureCount;
+          console.error(`[Web] Failed to refresh Discord name for ${user.discord_id}: Discord lookup returned no display name`);
+          await new Promise((resolve) => setTimeout(resolve, 200));
+          continue;
+        }
+
         const trimmedName = name?.trim();
         if (trimmedName && trimmedName !== user.discord_name) {
           await updateDiscordName(user.discord_id, trimmedName);
@@ -331,16 +340,26 @@ router.post('/users/toggle-twitch', requireManager, async (req, res) => {
 
       const currentEnabled = user.is_twitch_bot_enabled;
       const nextEnabled = !currentEnabled;
+      const normalizedChannel = normalizeTwitchChannelName(user.twitch_name);
+
+      if (!normalizedChannel) {
+        throw new Error('Toggle target user has an invalid Twitch channel');
+      }
 
       await updateTwitchBotEnabled(trimmedDiscordId, nextEnabled);
 
       try {
         // joinTwitchChannel/partTwitchChannel are expected to throw on failure so
         // this rollback keeps DB state aligned with runtime channel membership.
-        if (nextEnabled) {
-          await joinTwitchChannel(user.twitch_name);
+        // Derive desired membership from the committed DB state so duplicate user
+        // rows that share the same Twitch channel do not part it prematurely.
+        const enabledChannels = await getTwitchEnabledChannels();
+        const shouldBeJoined = enabledChannels.includes(normalizedChannel);
+
+        if (shouldBeJoined) {
+          await joinTwitchChannel(normalizedChannel);
         } else {
-          await partTwitchChannel(user.twitch_name);
+          await partTwitchChannel(normalizedChannel);
         }
       } catch (err) {
         try {

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -113,13 +113,14 @@ router.post('/users/toggle-twitch', requireManager, async (req, res) => {
     }
 
     const nextEnabled = !user.is_twitch_bot_enabled;
-    await updateTwitchBotEnabled(discord_id, nextEnabled);
 
     if (nextEnabled) {
       await joinTwitchChannel(user.twitch_name);
     } else {
       await partTwitchChannel(user.twitch_name);
     }
+
+    await updateTwitchBotEnabled(discord_id, nextEnabled);
   } catch (err) {
     console.error('[Web] Toggle twitch user error:', err);
     return res.redirect('/admin/users?error=toggle_failed');
@@ -132,13 +133,14 @@ router.post('/users/toggle-twitch', requireManager, async (req, res) => {
 router.post('/users/refresh-names', requireManager, async (req, res) => {
   try {
     const users = await getAllUsers();
-    await Promise.allSettled(
-      users.map(async (u) => {
-        const name = await fetchMemberDisplayName(u.discord_id);
-        if (!name || !name.trim()) return;
+    for (const u of users) {
+      const name = await fetchMemberDisplayName(u.discord_id);
+      if (name && name.trim()) {
         await updateDiscordName(u.discord_id, name.trim());
-      }),
-    );
+      }
+      // Small delay between requests to stay within Discord API rate limits
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
   } catch (err) {
     console.error('[Web] Refresh Discord names failed:', err);
     return res.redirect('/admin/users?error=update_failed');

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -238,10 +238,11 @@ router.post('/users/remove', requireAdmin, async (req, res) => {
 // Toggle twitch bot participation for a user (Manager+)
 router.post('/users/toggle-twitch', requireManager, async (req, res) => {
   const { discord_id } = req.body as { discord_id?: string };
-  if (!discord_id) return res.redirect('/admin/users');
+  const trimmedDiscordId = (discord_id ?? '').trim();
+  if (!trimmedDiscordId) return res.redirect('/admin/users');
 
   try {
-    const user = await findUser(discord_id);
+    const user = await findUser(trimmedDiscordId);
     if (!user || !user.twitch_name) {
       return res.redirect('/admin/users?error=toggle_failed');
     }
@@ -249,7 +250,7 @@ router.post('/users/toggle-twitch', requireManager, async (req, res) => {
     const currentEnabled = user.is_twitch_bot_enabled;
     const nextEnabled = !currentEnabled;
 
-    await updateTwitchBotEnabled(discord_id, nextEnabled);
+    await updateTwitchBotEnabled(trimmedDiscordId, nextEnabled);
 
     try {
       // joinTwitchChannel/partTwitchChannel are expected to throw on failure so
@@ -261,7 +262,7 @@ router.post('/users/toggle-twitch', requireManager, async (req, res) => {
       }
     } catch (err) {
       try {
-        await updateTwitchBotEnabled(discord_id, currentEnabled);
+        await updateTwitchBotEnabled(trimmedDiscordId, currentEnabled);
       } catch (rollbackErr) {
         console.error('[Web] Toggle twitch user rollback failed:', rollbackErr);
       }

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -3,6 +3,7 @@ import {
   getAllUsers,
   getTwitchEnabledChannels,
   findUser,
+  findUserByTwitchName,
   upsertUser,
   removeUser,
   updateAccessLevel,
@@ -19,7 +20,7 @@ import { normalizeTwitchChannelName } from '../../twitchChannelName';
 
 const router = Router();
 
-const KNOWN_ERRORS = new Set(['add_failed', 'update_failed', 'remove_failed', 'toggle_failed']);
+const KNOWN_ERRORS = new Set(['add_failed', 'duplicate_twitch_name', 'update_failed', 'remove_failed', 'toggle_failed']);
 // Twitch membership changes are serialized per user in-process because this bot
 // currently runs as a single web instance. If that changes, move this lock into
 // shared storage or a DB transaction/row lock before scaling out.
@@ -43,6 +44,13 @@ const refreshState: {
   startedAt: null,
   finishedAt: null,
 };
+
+class DuplicateTwitchNameError extends Error {
+  constructor(twitchChannel: string) {
+    super(`Twitch channel ${twitchChannel} is already assigned to another user`);
+    this.name = 'DuplicateTwitchNameError';
+  }
+}
 
 async function withUserMutationLock<T>(discordId: string, operation: () => Promise<T>): Promise<T> {
   const previous = userMutationQueues.get(discordId) ?? Promise.resolve();
@@ -194,6 +202,13 @@ router.post('/users/add', requireAdmin, async (req, res) => {
           ? normalizedTwitchName
           : undefined;
 
+      if (normalizedTwitchName) {
+        const conflictingUser = await findUserByTwitchName(normalizedTwitchName, trimmedDiscordId);
+        if (conflictingUser) {
+          throw new DuplicateTwitchNameError(normalizedTwitchName);
+        }
+      }
+
       await upsertUser(
         trimmedDiscordId,
         trimmedDiscordName,
@@ -235,26 +250,21 @@ router.post('/users/add', requireAdmin, async (req, res) => {
         return;
       }
 
-      let previousChannelParted = false;
       try {
-        if (previousTwitchChannel) {
+        const enabledChannels = await getTwitchEnabledChannels();
+        const shouldJoinCommittedChannel = enabledChannels.includes(committedTwitchChannel);
+        const shouldPartPreviousChannel = !!previousTwitchChannel
+          && previousTwitchChannel !== committedTwitchChannel
+          && !enabledChannels.includes(previousTwitchChannel);
+
+        if (shouldJoinCommittedChannel) {
+          await joinTwitchChannel(committedTwitchChannel);
+        }
+
+        if (shouldPartPreviousChannel) {
           await partTwitchChannel(previousTwitchChannel);
-          previousChannelParted = true;
         }
-
-        await joinTwitchChannel(committedTwitchChannel);
       } catch (err) {
-        // If the channel swap fails mid-transition, restore the old channel and DB values together.
-        let rollbackSuccess = true;
-        if (previousChannelParted && previousTwitchChannel) {
-          try {
-            await joinTwitchChannel(previousTwitchChannel);
-          } catch (rollbackErr) {
-            rollbackSuccess = false;
-            console.error('[Web] Add user Twitch channel rollback failed:', rollbackErr);
-          }
-        }
-
         try {
           await upsertUser(
             trimmedDiscordId,
@@ -262,7 +272,21 @@ router.post('/users/add', requireAdmin, async (req, res) => {
             level as AccessLevelValue,
             previousTwitchChannel ?? '',
           );
-          await updateTwitchBotEnabled(trimmedDiscordId, rollbackSuccess ? existingUser.is_twitch_bot_enabled : false);
+          await updateTwitchBotEnabled(trimmedDiscordId, existingUser.is_twitch_bot_enabled);
+
+          const rollbackEnabledChannels = await getTwitchEnabledChannels();
+          const shouldRejoinPreviousChannel = !!previousTwitchChannel
+            && rollbackEnabledChannels.includes(previousTwitchChannel);
+          const shouldPartCommittedChannel = committedTwitchChannel !== previousTwitchChannel
+            && !rollbackEnabledChannels.includes(committedTwitchChannel);
+
+          if (shouldRejoinPreviousChannel) {
+            await joinTwitchChannel(previousTwitchChannel);
+          }
+
+          if (shouldPartCommittedChannel) {
+            await partTwitchChannel(committedTwitchChannel);
+          }
         } catch (rollbackErr) {
           console.error('[Web] Add user DB rollback failed:', rollbackErr);
         }
@@ -271,6 +295,9 @@ router.post('/users/add', requireAdmin, async (req, res) => {
     });
   } catch (err) {
     console.error('[Web] Add user error:', err);
+    if (err instanceof DuplicateTwitchNameError) {
+      return res.redirect('/admin/users?error=duplicate_twitch_name');
+    }
     return res.redirect('/admin/users?error=add_failed');
   }
   res.redirect('/admin/users');
@@ -377,8 +404,8 @@ router.post('/users/toggle-twitch', requireManager, async (req, res) => {
       try {
         // joinTwitchChannel/partTwitchChannel are expected to throw on failure so
         // this rollback keeps DB state aligned with runtime channel membership.
-        // Derive desired membership from the committed DB state so duplicate user
-        // rows that share the same Twitch channel do not part it prematurely.
+        // Derive desired membership from the committed DB state so route handlers
+        // always reconcile against the effective enabled-channel set.
         const enabledChannels = await getTwitchEnabledChannels();
         const shouldBeJoined = enabledChannels.includes(normalizedChannel);
 

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -21,6 +21,9 @@ const KNOWN_ERRORS = new Set(['add_failed', 'update_failed', 'remove_failed', 't
 
 type RefreshOutcome = 'idle' | 'running' | 'success' | 'noop' | 'error';
 
+// This progress state is intentionally in-process because the web panel runs as
+// a single bot instance today. If the panel is ever scaled horizontally, move
+// this state into shared storage before relying on /users/refresh-status.
 const refreshState: {
   outcome: RefreshOutcome;
   updatedCount: number;
@@ -49,8 +52,9 @@ async function runDiscordNameRefresh(): Promise<void> {
 
     for (const user of users) {
       const name = await fetchMemberDisplayName(user.discord_id);
-      if (name && name.trim()) {
-        await updateDiscordName(user.discord_id, name.trim());
+      const trimmedName = name?.trim();
+      if (trimmedName && trimmedName !== user.discord_name) {
+        await updateDiscordName(user.discord_id, trimmedName);
         updatedCount++;
       }
       await new Promise((resolve) => setTimeout(resolve, 200));

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -1,18 +1,23 @@
 import { Router } from 'express';
 import {
   getAllUsers,
+  findUser,
   upsertUser,
   removeUser,
   updateAccessLevel,
+  updateDiscordName,
+  updateTwitchBotEnabled,
   ACCESS_LEVEL_LABELS,
   AccessLevel,
   AccessLevelValue,
 } from '../../db';
 import { requireManager, requireAdmin } from '../middleware';
+import { fetchMemberDisplayName } from '../../discordBot';
+import { joinTwitchChannel, partTwitchChannel } from '../../twitchBot';
 
 const router = Router();
 
-const KNOWN_ERRORS = new Set(['add_failed', 'update_failed', 'remove_failed']);
+const KNOWN_ERRORS = new Set(['add_failed', 'update_failed', 'remove_failed', 'toggle_failed']);
 
 // View user list (Manager+)
 router.get('/users', requireManager, async (req, res) => {
@@ -23,6 +28,7 @@ router.get('/users', requireManager, async (req, res) => {
       users,
       accessLevelLabels: ACCESS_LEVEL_LABELS,
       error: KNOWN_ERRORS.has(req.query.error as string) ? (req.query.error as string) : null,
+      refreshed: req.query.refreshed === '1',
     });
   } catch (err) {
     console.error('[Web] Admin users error:', err);
@@ -32,17 +38,18 @@ router.get('/users', requireManager, async (req, res) => {
 
 // Add or update a user (Admin only)
 router.post('/users/add', requireAdmin, async (req, res) => {
-  const { discord_id, discord_name, access_level } = req.body as {
+  const { discord_id, discord_name, access_level, twitch_name } = req.body as {
     discord_id?: string;
     discord_name?: string;
     access_level?: string;
+    twitch_name?: string;
   };
   if (!discord_id || !access_level) return res.redirect('/admin/users');
   const level = parseInt(access_level, 10);
   if (!Number.isFinite(level)) return res.status(400).render('error', { message: 'Invalid access level.', user: req.session.user ?? null });
   if (!(Object.values(AccessLevel) as number[]).includes(level)) return res.status(400).render('error', { message: 'Invalid access level.', user: req.session.user ?? null });
   try {
-    await upsertUser(discord_id.trim(), (discord_name ?? '').trim(), level as AccessLevelValue);
+    await upsertUser(discord_id.trim(), (discord_name ?? '').trim(), level as AccessLevelValue, twitch_name);
   } catch (err) {
     console.error('[Web] Add user error:', err);
     return res.redirect('/admin/users?error=add_failed');
@@ -92,6 +99,52 @@ router.post('/users/remove', requireAdmin, async (req, res) => {
     return res.redirect('/admin/users?error=remove_failed');
   }
   res.redirect('/admin/users');
+});
+
+// Toggle twitch bot participation for a user (Manager+)
+router.post('/users/toggle-twitch', requireManager, async (req, res) => {
+  const { discord_id } = req.body as { discord_id?: string };
+  if (!discord_id) return res.redirect('/admin/users');
+
+  try {
+    const user = await findUser(discord_id);
+    if (!user || !user.twitch_name) {
+      return res.redirect('/admin/users?error=toggle_failed');
+    }
+
+    const nextEnabled = !user.is_twitch_bot_enabled;
+    await updateTwitchBotEnabled(discord_id, nextEnabled);
+
+    if (nextEnabled) {
+      await joinTwitchChannel(user.twitch_name);
+    } else {
+      await partTwitchChannel(user.twitch_name);
+    }
+  } catch (err) {
+    console.error('[Web] Toggle twitch user error:', err);
+    return res.redirect('/admin/users?error=toggle_failed');
+  }
+
+  res.redirect('/admin/users');
+});
+
+// Refresh Discord names for all users (Manager+)
+router.post('/users/refresh-names', requireManager, async (req, res) => {
+  try {
+    const users = await getAllUsers();
+    await Promise.allSettled(
+      users.map(async (u) => {
+        const name = await fetchMemberDisplayName(u.discord_id);
+        if (!name || !name.trim()) return;
+        await updateDiscordName(u.discord_id, name.trim());
+      }),
+    );
+  } catch (err) {
+    console.error('[Web] Refresh Discord names failed:', err);
+    return res.redirect('/admin/users?error=update_failed');
+  }
+
+  res.redirect('/admin/users?refreshed=1');
 });
 
 export default router;

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -14,7 +14,8 @@ import {
 } from '../../db';
 import { requireManager, requireAdmin } from '../middleware';
 import { discordClient, fetchMemberDisplayName } from '../../discordBot';
-import { joinTwitchChannel, normalizeTwitchChannelName, partTwitchChannel } from '../../twitchBot';
+import { joinTwitchChannel, partTwitchChannel } from '../../twitchBot';
+import { normalizeTwitchChannelName } from '../../twitchChannelName';
 
 const router = Router();
 
@@ -184,7 +185,9 @@ router.post('/users/add', requireAdmin, async (req, res) => {
     await withUserMutationLock(trimmedDiscordId, async () => {
       const trimmedDiscordName = (discord_name ?? '').trim();
       const existingUser = await findUser(trimmedDiscordId);
-      const previousTwitchChannel = existingUser?.twitch_name ? existingUser.twitch_name.trim().toLowerCase() : null;
+      const previousTwitchChannel = existingUser?.twitch_name
+        ? normalizeTwitchChannelName(existingUser.twitch_name)
+        : null;
       const nextTwitchName = shouldClearTwitchName
         ? ''
         : normalizedTwitchName
@@ -199,7 +202,9 @@ router.post('/users/add', requireAdmin, async (req, res) => {
       );
 
       const committedUser = await findUser(trimmedDiscordId);
-      const committedTwitchChannel = committedUser?.twitch_name ? committedUser.twitch_name.trim().toLowerCase() : null;
+      const committedTwitchChannel = committedUser?.twitch_name
+        ? normalizeTwitchChannelName(committedUser.twitch_name)
+        : null;
 
       if (!existingUser?.is_twitch_bot_enabled || previousTwitchChannel === committedTwitchChannel) {
         return;

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -93,24 +93,53 @@ router.get('/users/refresh-status', requireManager, (_req, res) => {
 
 // Add or update a user (Admin only)
 router.post('/users/add', requireAdmin, async (req, res) => {
-  const { discord_id, discord_name, access_level, twitch_name } = req.body as {
+  const { discord_id, discord_name, access_level, twitch_name, clear_twitch_name } = req.body as {
     discord_id?: string;
     discord_name?: string;
     access_level?: string;
     twitch_name?: string;
+    clear_twitch_name?: string;
   };
   if (!discord_id || !access_level) return res.redirect('/admin/users');
   const level = parseInt(access_level, 10);
   if (!Number.isFinite(level)) return res.status(400).render('error', { message: 'Invalid access level.', user: req.session.user ?? null });
   if (!(Object.values(AccessLevel) as number[]).includes(level)) return res.status(400).render('error', { message: 'Invalid access level.', user: req.session.user ?? null });
   try {
+    const trimmedDiscordId = discord_id.trim();
+    const trimmedDiscordName = (discord_name ?? '').trim();
     const normalizedTwitchName = (twitch_name ?? '').trim();
+    const shouldClearTwitchName = clear_twitch_name === '1';
+    const existingUser = await findUser(trimmedDiscordId);
+    const previousTwitchChannel = existingUser?.twitch_name ? existingUser.twitch_name.trim().toLowerCase() : null;
+    const nextTwitchName = shouldClearTwitchName
+      ? ''
+      : normalizedTwitchName.length > 0
+        ? normalizedTwitchName
+        : undefined;
+    const nextTwitchChannel = shouldClearTwitchName
+      ? null
+      : normalizedTwitchName.length > 0
+        ? normalizedTwitchName.toLowerCase()
+        : previousTwitchChannel;
+
     await upsertUser(
-      discord_id.trim(),
-      (discord_name ?? '').trim(),
+      trimmedDiscordId,
+      trimmedDiscordName,
       level as AccessLevelValue,
-      normalizedTwitchName.length > 0 ? normalizedTwitchName : undefined,
+      nextTwitchName,
     );
+
+    if (existingUser?.is_twitch_bot_enabled && previousTwitchChannel !== nextTwitchChannel) {
+      if (previousTwitchChannel) {
+        await partTwitchChannel(previousTwitchChannel);
+      }
+
+      if (nextTwitchChannel) {
+        await joinTwitchChannel(nextTwitchChannel);
+      } else {
+        await updateTwitchBotEnabled(trimmedDiscordId, false);
+      }
+    }
   } catch (err) {
     console.error('[Web] Add user error:', err);
     return res.redirect('/admin/users?error=add_failed');

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -390,9 +390,24 @@ router.post('/users/remove', requireAdmin, async (req, res) => {
 
 // Toggle twitch bot participation for a user (Manager+)
 router.post('/users/toggle-twitch', requireManager, async (req, res) => {
-  const { discord_id } = req.body as { discord_id?: string };
+  const { discord_id, is_twitch_bot_enabled } = req.body as {
+    discord_id?: string;
+    is_twitch_bot_enabled?: string;
+  };
   const trimmedDiscordId = (discord_id ?? '').trim();
   if (!trimmedDiscordId) return res.redirect('/admin/users');
+
+  let nextEnabled: boolean;
+  if (is_twitch_bot_enabled === 'true' || is_twitch_bot_enabled === '1') {
+    nextEnabled = true;
+  } else if (is_twitch_bot_enabled === 'false' || is_twitch_bot_enabled === '0') {
+    nextEnabled = false;
+  } else {
+    return res.status(400).render('error', {
+      message: 'Invalid Twitch enabled state.',
+      user: req.session.user ?? null,
+    });
+  }
 
   try {
     await withUserMutationLock(trimmedDiscordId, async () => {
@@ -402,11 +417,14 @@ router.post('/users/toggle-twitch', requireManager, async (req, res) => {
       }
 
       const currentEnabled = user.is_twitch_bot_enabled;
-      const nextEnabled = !currentEnabled;
       const normalizedChannel = normalizeTwitchChannelName(user.twitch_name);
 
       if (!normalizedChannel) {
         throw new Error('Toggle target user has an invalid Twitch channel');
+      }
+
+      if (currentEnabled === nextEnabled) {
+        return;
       }
 
       await updateTwitchBotEnabled(trimmedDiscordId, nextEnabled);

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -130,14 +130,19 @@ router.post('/users/add', requireAdmin, async (req, res) => {
     );
 
     if (existingUser?.is_twitch_bot_enabled && previousTwitchChannel !== nextTwitchChannel) {
-      if (previousTwitchChannel) {
-        await partTwitchChannel(previousTwitchChannel);
-      }
+      try {
+        if (previousTwitchChannel) {
+          await partTwitchChannel(previousTwitchChannel);
+        }
 
-      if (nextTwitchChannel) {
-        await joinTwitchChannel(nextTwitchChannel);
-      } else {
+        if (nextTwitchChannel) {
+          await joinTwitchChannel(nextTwitchChannel);
+        } else {
+          await updateTwitchBotEnabled(trimmedDiscordId, false);
+        }
+      } catch (err) {
         await updateTwitchBotEnabled(trimmedDiscordId, false);
+        throw err;
       }
     }
   } catch (err) {
@@ -208,6 +213,8 @@ router.post('/users/toggle-twitch', requireManager, async (req, res) => {
     await updateTwitchBotEnabled(discord_id, nextEnabled);
 
     try {
+      // joinTwitchChannel/partTwitchChannel are expected to throw on failure so
+      // this rollback keeps DB state aligned with runtime channel membership.
       if (nextEnabled) {
         await joinTwitchChannel(user.twitch_name);
       } else {

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -13,7 +13,7 @@ import {
 } from '../../db';
 import { requireManager, requireAdmin } from '../middleware';
 import { discordClient, fetchMemberDisplayName } from '../../discordBot';
-import { joinTwitchChannel, partTwitchChannel } from '../../twitchBot';
+import { joinTwitchChannel, normalizeTwitchChannelName, partTwitchChannel } from '../../twitchBot';
 
 const router = Router();
 
@@ -76,12 +76,16 @@ async function runDiscordNameRefresh(): Promise<void> {
     let updatedCount = 0;
 
     for (const user of users) {
-      const name = await fetchMemberDisplayName(user.discord_id, true);
-      const trimmedName = name?.trim();
-      if (trimmedName && trimmedName !== user.discord_name) {
-        await updateDiscordName(user.discord_id, trimmedName);
-        updatedCount++;
-        refreshState.updatedCount = updatedCount;
+      try {
+        const name = await fetchMemberDisplayName(user.discord_id, true);
+        const trimmedName = name?.trim();
+        if (trimmedName && trimmedName !== user.discord_name) {
+          await updateDiscordName(user.discord_id, trimmedName);
+          updatedCount++;
+          refreshState.updatedCount = updatedCount;
+        }
+      } catch (err) {
+        console.error(`[Web] Failed to refresh Discord name for ${user.discord_id}:`, err);
       }
       await new Promise((resolve) => setTimeout(resolve, 200));
     }
@@ -131,16 +135,23 @@ router.post('/users/add', requireAdmin, async (req, res) => {
   const level = parseInt(access_level, 10);
   if (!Number.isFinite(level)) return res.status(400).render('error', { message: 'Invalid access level.', user: req.session.user ?? null });
   if (!(Object.values(AccessLevel) as number[]).includes(level)) return res.status(400).render('error', { message: 'Invalid access level.', user: req.session.user ?? null });
+  if (trimmedDiscordId === req.session.user?.discordId) {
+    return res.status(400).render('error', {
+      message: 'You cannot update your own account from this form.',
+      user: req.session.user ?? null,
+    });
+  }
   try {
     await withUserMutationLock(trimmedDiscordId, async () => {
       const trimmedDiscordName = (discord_name ?? '').trim();
-      const normalizedTwitchName = (twitch_name ?? '').trim();
+      const submittedTwitchName = (twitch_name ?? '').trim();
+      const normalizedTwitchName = submittedTwitchName ? normalizeTwitchChannelName(submittedTwitchName) : null;
       const shouldClearTwitchName = clear_twitch_name === '1';
       const existingUser = await findUser(trimmedDiscordId);
       const previousTwitchChannel = existingUser?.twitch_name ? existingUser.twitch_name.trim().toLowerCase() : null;
       const nextTwitchName = shouldClearTwitchName
         ? ''
-        : normalizedTwitchName.length > 0
+        : normalizedTwitchName
           ? normalizedTwitchName
           : undefined;
 
@@ -190,10 +201,12 @@ router.post('/users/add', requireAdmin, async (req, res) => {
         await joinTwitchChannel(committedTwitchChannel);
       } catch (err) {
         // If the channel swap fails mid-transition, restore the old channel and DB values together.
+        let rollbackSuccess = true;
         if (previousChannelParted && previousTwitchChannel) {
           try {
             await joinTwitchChannel(previousTwitchChannel);
           } catch (rollbackErr) {
+            rollbackSuccess = false;
             console.error('[Web] Add user Twitch channel rollback failed:', rollbackErr);
           }
         }
@@ -205,7 +218,7 @@ router.post('/users/add', requireAdmin, async (req, res) => {
             level as AccessLevelValue,
             previousTwitchChannel ?? '',
           );
-          await updateTwitchBotEnabled(trimmedDiscordId, existingUser.is_twitch_bot_enabled);
+          await updateTwitchBotEnabled(trimmedDiscordId, rollbackSuccess ? existingUser.is_twitch_bot_enabled : false);
         } catch (rollbackErr) {
           console.error('[Web] Add user DB rollback failed:', rollbackErr);
         }

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -100,12 +100,12 @@ router.post('/users/add', requireAdmin, async (req, res) => {
     twitch_name?: string;
     clear_twitch_name?: string;
   };
-  if (!discord_id || !access_level) return res.redirect('/admin/users');
+  const trimmedDiscordId = (discord_id ?? '').trim();
+  if (!trimmedDiscordId || !access_level) return res.redirect('/admin/users');
   const level = parseInt(access_level, 10);
   if (!Number.isFinite(level)) return res.status(400).render('error', { message: 'Invalid access level.', user: req.session.user ?? null });
   if (!(Object.values(AccessLevel) as number[]).includes(level)) return res.status(400).render('error', { message: 'Invalid access level.', user: req.session.user ?? null });
   try {
-    const trimmedDiscordId = discord_id.trim();
     const trimmedDiscordName = (discord_name ?? '').trim();
     const normalizedTwitchName = (twitch_name ?? '').trim();
     const shouldClearTwitchName = clear_twitch_name === '1';
@@ -132,8 +132,9 @@ router.post('/users/add', requireAdmin, async (req, res) => {
     if (existingUser?.is_twitch_bot_enabled && previousTwitchChannel !== nextTwitchChannel) {
       if (!nextTwitchChannel) {
         try {
-          await partTwitchChannel(previousTwitchChannel ?? '');
+          // Persist disable first so the rollback path can safely restore both DB and runtime state.
           await updateTwitchBotEnabled(trimmedDiscordId, false);
+          await partTwitchChannel(previousTwitchChannel ?? '');
         } catch (err) {
           try {
             await upsertUser(
@@ -160,6 +161,7 @@ router.post('/users/add', requireAdmin, async (req, res) => {
 
         await joinTwitchChannel(nextTwitchChannel);
       } catch (err) {
+        // If the channel swap fails mid-transition, restore the old channel and DB values together.
         if (previousChannelParted && previousTwitchChannel) {
           try {
             await joinTwitchChannel(previousTwitchChannel);

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -18,6 +18,10 @@ import { joinTwitchChannel, partTwitchChannel } from '../../twitchBot';
 const router = Router();
 
 const KNOWN_ERRORS = new Set(['add_failed', 'update_failed', 'remove_failed', 'toggle_failed']);
+// Twitch membership changes are serialized per user in-process because this bot
+// currently runs as a single web instance. If that changes, move this lock into
+// shared storage or a DB transaction/row lock before scaling out.
+const userMutationQueues = new Map<string, Promise<void>>();
 
 type RefreshOutcome = 'idle' | 'running' | 'success' | 'noop' | 'error';
 
@@ -35,6 +39,27 @@ const refreshState: {
   startedAt: null,
   finishedAt: null,
 };
+
+async function withUserMutationLock<T>(discordId: string, operation: () => Promise<T>): Promise<T> {
+  const previous = userMutationQueues.get(discordId) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const queued = previous.catch(() => undefined).then(() => current);
+  userMutationQueues.set(discordId, queued);
+
+  await previous.catch(() => undefined);
+
+  try {
+    return await operation();
+  } finally {
+    release();
+    if (userMutationQueues.get(discordId) === queued) {
+      userMutationQueues.delete(discordId);
+    }
+  }
+}
 
 async function runDiscordNameRefresh(): Promise<void> {
   refreshState.outcome = 'running';
@@ -56,6 +81,7 @@ async function runDiscordNameRefresh(): Promise<void> {
       if (trimmedName && trimmedName !== user.discord_name) {
         await updateDiscordName(user.discord_id, trimmedName);
         updatedCount++;
+        refreshState.updatedCount = updatedCount;
       }
       await new Promise((resolve) => setTimeout(resolve, 200));
     }
@@ -106,31 +132,33 @@ router.post('/users/add', requireAdmin, async (req, res) => {
   if (!Number.isFinite(level)) return res.status(400).render('error', { message: 'Invalid access level.', user: req.session.user ?? null });
   if (!(Object.values(AccessLevel) as number[]).includes(level)) return res.status(400).render('error', { message: 'Invalid access level.', user: req.session.user ?? null });
   try {
-    const trimmedDiscordName = (discord_name ?? '').trim();
-    const normalizedTwitchName = (twitch_name ?? '').trim();
-    const shouldClearTwitchName = clear_twitch_name === '1';
-    const existingUser = await findUser(trimmedDiscordId);
-    const previousTwitchChannel = existingUser?.twitch_name ? existingUser.twitch_name.trim().toLowerCase() : null;
-    const nextTwitchName = shouldClearTwitchName
-      ? ''
-      : normalizedTwitchName.length > 0
-        ? normalizedTwitchName
-        : undefined;
-    const nextTwitchChannel = shouldClearTwitchName
-      ? null
-      : normalizedTwitchName.length > 0
-        ? normalizedTwitchName.toLowerCase()
-        : previousTwitchChannel;
+    await withUserMutationLock(trimmedDiscordId, async () => {
+      const trimmedDiscordName = (discord_name ?? '').trim();
+      const normalizedTwitchName = (twitch_name ?? '').trim();
+      const shouldClearTwitchName = clear_twitch_name === '1';
+      const existingUser = await findUser(trimmedDiscordId);
+      const previousTwitchChannel = existingUser?.twitch_name ? existingUser.twitch_name.trim().toLowerCase() : null;
+      const nextTwitchName = shouldClearTwitchName
+        ? ''
+        : normalizedTwitchName.length > 0
+          ? normalizedTwitchName
+          : undefined;
 
-    await upsertUser(
-      trimmedDiscordId,
-      trimmedDiscordName,
-      level as AccessLevelValue,
-      nextTwitchName,
-    );
+      await upsertUser(
+        trimmedDiscordId,
+        trimmedDiscordName,
+        level as AccessLevelValue,
+        nextTwitchName,
+      );
 
-    if (existingUser?.is_twitch_bot_enabled && previousTwitchChannel !== nextTwitchChannel) {
-      if (!nextTwitchChannel) {
+      const committedUser = await findUser(trimmedDiscordId);
+      const committedTwitchChannel = committedUser?.twitch_name ? committedUser.twitch_name.trim().toLowerCase() : null;
+
+      if (!existingUser?.is_twitch_bot_enabled || previousTwitchChannel === committedTwitchChannel) {
+        return;
+      }
+
+      if (!committedTwitchChannel) {
         try {
           // Persist disable first so the rollback path can safely restore both DB and runtime state.
           await updateTwitchBotEnabled(trimmedDiscordId, false);
@@ -149,7 +177,7 @@ router.post('/users/add', requireAdmin, async (req, res) => {
           }
           throw err;
         }
-        return res.redirect('/admin/users');
+        return;
       }
 
       let previousChannelParted = false;
@@ -159,7 +187,7 @@ router.post('/users/add', requireAdmin, async (req, res) => {
           previousChannelParted = true;
         }
 
-        await joinTwitchChannel(nextTwitchChannel);
+        await joinTwitchChannel(committedTwitchChannel);
       } catch (err) {
         // If the channel swap fails mid-transition, restore the old channel and DB values together.
         if (previousChannelParted && previousTwitchChannel) {
@@ -183,7 +211,7 @@ router.post('/users/add', requireAdmin, async (req, res) => {
         }
         throw err;
       }
-    }
+    });
   } catch (err) {
     console.error('[Web] Add user error:', err);
     return res.redirect('/admin/users?error=add_failed');
@@ -242,32 +270,34 @@ router.post('/users/toggle-twitch', requireManager, async (req, res) => {
   if (!trimmedDiscordId) return res.redirect('/admin/users');
 
   try {
-    const user = await findUser(trimmedDiscordId);
-    if (!user || !user.twitch_name) {
-      return res.redirect('/admin/users?error=toggle_failed');
-    }
-
-    const currentEnabled = user.is_twitch_bot_enabled;
-    const nextEnabled = !currentEnabled;
-
-    await updateTwitchBotEnabled(trimmedDiscordId, nextEnabled);
-
-    try {
-      // joinTwitchChannel/partTwitchChannel are expected to throw on failure so
-      // this rollback keeps DB state aligned with runtime channel membership.
-      if (nextEnabled) {
-        await joinTwitchChannel(user.twitch_name);
-      } else {
-        await partTwitchChannel(user.twitch_name);
+    await withUserMutationLock(trimmedDiscordId, async () => {
+      const user = await findUser(trimmedDiscordId);
+      if (!user || !user.twitch_name) {
+        throw new Error('Toggle target user is missing or has no Twitch channel');
       }
-    } catch (err) {
+
+      const currentEnabled = user.is_twitch_bot_enabled;
+      const nextEnabled = !currentEnabled;
+
+      await updateTwitchBotEnabled(trimmedDiscordId, nextEnabled);
+
       try {
-        await updateTwitchBotEnabled(trimmedDiscordId, currentEnabled);
-      } catch (rollbackErr) {
-        console.error('[Web] Toggle twitch user rollback failed:', rollbackErr);
+        // joinTwitchChannel/partTwitchChannel are expected to throw on failure so
+        // this rollback keeps DB state aligned with runtime channel membership.
+        if (nextEnabled) {
+          await joinTwitchChannel(user.twitch_name);
+        } else {
+          await partTwitchChannel(user.twitch_name);
+        }
+      } catch (err) {
+        try {
+          await updateTwitchBotEnabled(trimmedDiscordId, currentEnabled);
+        } catch (rollbackErr) {
+          console.error('[Web] Toggle twitch user rollback failed:', rollbackErr);
+        }
+        throw err;
       }
-      throw err;
-    }
+    });
   } catch (err) {
     console.error('[Web] Toggle twitch user error:', err);
     return res.redirect('/admin/users?error=toggle_failed');

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -12,12 +12,59 @@ import {
   AccessLevelValue,
 } from '../../db';
 import { requireManager, requireAdmin } from '../middleware';
-import { fetchMemberDisplayName } from '../../discordBot';
+import { discordClient, fetchMemberDisplayName } from '../../discordBot';
 import { joinTwitchChannel, partTwitchChannel } from '../../twitchBot';
 
 const router = Router();
 
 const KNOWN_ERRORS = new Set(['add_failed', 'update_failed', 'remove_failed', 'toggle_failed']);
+
+type RefreshOutcome = 'idle' | 'running' | 'success' | 'noop' | 'error';
+
+const refreshState: {
+  outcome: RefreshOutcome;
+  updatedCount: number;
+  startedAt: number | null;
+  finishedAt: number | null;
+} = {
+  outcome: 'idle',
+  updatedCount: 0,
+  startedAt: null,
+  finishedAt: null,
+};
+
+async function runDiscordNameRefresh(): Promise<void> {
+  refreshState.outcome = 'running';
+  refreshState.updatedCount = 0;
+  refreshState.startedAt = Date.now();
+  refreshState.finishedAt = null;
+
+  try {
+    if (!discordClient) {
+      throw new Error('Discord client is not ready');
+    }
+
+    const users = await getAllUsers();
+    let updatedCount = 0;
+
+    for (const user of users) {
+      const name = await fetchMemberDisplayName(user.discord_id);
+      if (name && name.trim()) {
+        await updateDiscordName(user.discord_id, name.trim());
+        updatedCount++;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+
+    refreshState.updatedCount = updatedCount;
+    refreshState.outcome = updatedCount > 0 ? 'success' : 'noop';
+  } catch (err) {
+    refreshState.outcome = 'error';
+    console.error('[Web] Refresh Discord names failed:', err);
+  } finally {
+    refreshState.finishedAt = Date.now();
+  }
+}
 
 // View user list (Manager+)
 router.get('/users', requireManager, async (req, res) => {
@@ -28,12 +75,16 @@ router.get('/users', requireManager, async (req, res) => {
       users,
       accessLevelLabels: ACCESS_LEVEL_LABELS,
       error: KNOWN_ERRORS.has(req.query.error as string) ? (req.query.error as string) : null,
-      refreshed: req.query.refreshed === '1',
+      refreshState,
     });
   } catch (err) {
     console.error('[Web] Admin users error:', err);
     res.status(500).render('error', { message: 'Failed to load users.', user: req.session.user ?? null });
   }
+});
+
+router.get('/users/refresh-status', requireManager, (_req, res) => {
+  res.json(refreshState);
 });
 
 // Add or update a user (Admin only)
@@ -118,15 +169,25 @@ router.post('/users/toggle-twitch', requireManager, async (req, res) => {
       return res.redirect('/admin/users?error=toggle_failed');
     }
 
-    const nextEnabled = !user.is_twitch_bot_enabled;
-
-    if (nextEnabled) {
-      await joinTwitchChannel(user.twitch_name);
-    } else {
-      await partTwitchChannel(user.twitch_name);
-    }
+    const currentEnabled = user.is_twitch_bot_enabled;
+    const nextEnabled = !currentEnabled;
 
     await updateTwitchBotEnabled(discord_id, nextEnabled);
+
+    try {
+      if (nextEnabled) {
+        await joinTwitchChannel(user.twitch_name);
+      } else {
+        await partTwitchChannel(user.twitch_name);
+      }
+    } catch (err) {
+      try {
+        await updateTwitchBotEnabled(discord_id, currentEnabled);
+      } catch (rollbackErr) {
+        console.error('[Web] Toggle twitch user rollback failed:', rollbackErr);
+      }
+      throw err;
+    }
   } catch (err) {
     console.error('[Web] Toggle twitch user error:', err);
     return res.redirect('/admin/users?error=toggle_failed');
@@ -137,27 +198,12 @@ router.post('/users/toggle-twitch', requireManager, async (req, res) => {
 
 // Refresh Discord names for all users (Manager+)
 router.post('/users/refresh-names', requireManager, async (req, res) => {
-  try {
-    const users = await getAllUsers();
-    let updatedCount = 0;
-    for (const u of users) {
-      const name = await fetchMemberDisplayName(u.discord_id);
-      if (name && name.trim()) {
-        await updateDiscordName(u.discord_id, name.trim());
-        updatedCount++;
-      }
-      // Small delay between requests to stay within Discord API rate limits
-      await new Promise((resolve) => setTimeout(resolve, 200));
-    }
-
-    if (updatedCount > 0) {
-      return res.redirect('/admin/users?refreshed=1');
-    }
-    return res.redirect('/admin/users?refreshed=0');
-  } catch (err) {
-    console.error('[Web] Refresh Discord names failed:', err);
-    return res.redirect('/admin/users?error=update_failed');
+  if (refreshState.outcome === 'running') {
+    return res.redirect('/admin/users');
   }
+
+  void runDiscordNameRefresh();
+  return res.redirect('/admin/users');
 });
 
 export default router;

--- a/src/web/routes/auth.ts
+++ b/src/web/routes/auth.ts
@@ -1,7 +1,8 @@
 import { Router } from 'express';
 import crypto from 'crypto';
 import { DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET, DISCORD_CALLBACK_URL } from '../../config';
-import { findUser } from '../../db';
+import { findUser, updateDiscordName } from '../../db';
+import { fetchMemberDisplayName } from '../../discordBot';
 
 const router = Router();
 
@@ -71,10 +72,21 @@ router.get('/discord/callback', async (req, res) => {
       });
     }
 
+    let syncedDiscordName = profile.username;
+    try {
+      const displayName = await fetchMemberDisplayName(profile.id);
+      if (displayName && displayName.trim()) {
+        syncedDiscordName = displayName.trim();
+        await updateDiscordName(profile.id, syncedDiscordName);
+      }
+    } catch (syncErr) {
+      console.warn('[Web] Non-blocking discord_name sync failed:', syncErr);
+    }
+
     // 4. Save to session
     req.session.user = {
       discordId: profile.id,
-      discordName: profile.username,
+      discordName: syncedDiscordName,
       discordAvatar: profile.avatar
         ? `https://cdn.discordapp.com/avatars/${profile.id}/${profile.avatar}.png`
         : null,

--- a/src/web/routes/auth.ts
+++ b/src/web/routes/auth.ts
@@ -73,14 +73,10 @@ router.get('/discord/callback', async (req, res) => {
     }
 
     let syncedDiscordName = profile.username;
-    try {
-      const displayName = await fetchMemberDisplayName(profile.id, true);
-      if (displayName && displayName.trim()) {
-        syncedDiscordName = displayName.trim();
-        await updateDiscordName(profile.id, syncedDiscordName);
-      }
-    } catch (syncErr) {
-      console.warn('[Web] Non-blocking discord_name sync failed:', syncErr);
+    const displayName = await fetchMemberDisplayName(profile.id, true);
+    if (displayName && displayName.trim()) {
+      syncedDiscordName = displayName.trim();
+      await updateDiscordName(profile.id, syncedDiscordName);
     }
 
     // 4. Save to session

--- a/src/web/routes/auth.ts
+++ b/src/web/routes/auth.ts
@@ -72,7 +72,7 @@ router.get('/discord/callback', async (req, res) => {
       });
     }
 
-    let syncedDiscordName = profile.username;
+    let syncedDiscordName = dbUser.discord_name?.trim() || profile.username;
     try {
       const displayName = await fetchMemberDisplayName(profile.id, true);
       const trimmedDisplayName = displayName?.trim();

--- a/src/web/routes/auth.ts
+++ b/src/web/routes/auth.ts
@@ -74,7 +74,7 @@ router.get('/discord/callback', async (req, res) => {
 
     let syncedDiscordName = profile.username;
     try {
-      const displayName = await fetchMemberDisplayName(profile.id);
+      const displayName = await fetchMemberDisplayName(profile.id, true);
       if (displayName && displayName.trim()) {
         syncedDiscordName = displayName.trim();
         await updateDiscordName(profile.id, syncedDiscordName);

--- a/src/web/routes/auth.ts
+++ b/src/web/routes/auth.ts
@@ -73,10 +73,14 @@ router.get('/discord/callback', async (req, res) => {
     }
 
     let syncedDiscordName = profile.username;
-    const displayName = await fetchMemberDisplayName(profile.id, true);
-    if (displayName && displayName.trim()) {
-      syncedDiscordName = displayName.trim();
-      await updateDiscordName(profile.id, syncedDiscordName);
+    try {
+      const displayName = await fetchMemberDisplayName(profile.id, false);
+      if (displayName && displayName.trim()) {
+        syncedDiscordName = displayName.trim();
+        await updateDiscordName(profile.id, syncedDiscordName);
+      }
+    } catch (syncErr) {
+      console.warn('[Web] Non-blocking discord_name sync failed:', syncErr);
     }
 
     // 4. Save to session

--- a/src/web/routes/auth.ts
+++ b/src/web/routes/auth.ts
@@ -74,9 +74,12 @@ router.get('/discord/callback', async (req, res) => {
 
     let syncedDiscordName = profile.username;
     try {
-      const displayName = await fetchMemberDisplayName(profile.id, false);
-      if (displayName && displayName.trim()) {
-        syncedDiscordName = displayName.trim();
+      const displayName = await fetchMemberDisplayName(profile.id, true);
+      const trimmedDisplayName = displayName?.trim();
+      if (trimmedDisplayName) {
+        syncedDiscordName = trimmedDisplayName;
+      }
+      if (syncedDiscordName !== dbUser.discord_name) {
         await updateDiscordName(profile.id, syncedDiscordName);
       }
     } catch (syncErr) {

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -16,7 +16,7 @@
 
       <% if (error) { %>
       <div class="card" style="margin-bottom:1rem;border-left:3px solid var(--danger);padding:.75rem 1rem">
-        <span style="color:var(--danger)">&#9888; Operation failed: <%= error.replace(/_/g, ' ') %></span>
+        <span style="color:var(--danger)">&#9888; <%= error === 'duplicate_twitch_name' ? 'Twitch name is already assigned to another user.' : 'Operation failed: ' + error.replace(/_/g, ' ') %></span>
       </div>
       <% } %>
 

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -54,6 +54,10 @@
           <input class="input" type="text" name="discord_id"   placeholder="Discord User ID"  required>
           <input class="input" type="text" name="discord_name" placeholder="Display name (optional)">
           <input class="input" type="text" name="twitch_name" placeholder="Twitch name (optional)">
+          <label class="hint" style="display:flex;align-items:center;gap:.4rem;white-space:nowrap">
+            <input type="checkbox" name="clear_twitch_name" value="1">
+            Clear Twitch name
+          </label>
           <select class="input" name="access_level">
             <% Object.entries(accessLevelLabels).forEach(([val, label]) => { %>
             <option value="<%= val %>"><%= label %></option>

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -57,9 +57,9 @@
         <form method="POST" action="/admin/users/add" class="inline-form">
           <input class="input" type="text" name="discord_id"   placeholder="Discord User ID"  required>
           <input class="input" type="text" name="discord_name" placeholder="Display name (optional)">
-          <input class="input" type="text" name="twitch_name" placeholder="Twitch name (optional)">
+          <input class="input" type="text" name="twitch_name" placeholder="Twitch name (optional)" data-twitch-name-input>
           <label class="hint" style="display:flex;align-items:center;gap:.4rem;white-space:nowrap">
-            <input type="checkbox" name="clear_twitch_name" value="1">
+            <input type="checkbox" name="clear_twitch_name" value="1" data-clear-twitch-name-input>
             Clear Twitch name
           </label>
           <select class="input" name="access_level">
@@ -102,6 +102,7 @@
                     <% if (user.accessLevel >= 2) { %>
                     <form method="POST" action="/admin/users/toggle-twitch" class="inline-form-sm">
                       <input type="hidden" name="discord_id" value="<%= u.discord_id %>">
+                      <input type="hidden" name="is_twitch_bot_enabled" value="<%= u.is_twitch_bot_enabled ? 'false' : 'true' %>">
                       <button type="submit" class="btn btn-sm"><%= u.is_twitch_bot_enabled ? 'Disable' : 'Enable' %></button>
                     </form>
                     <% } %>

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -28,13 +28,17 @@
       <div class="card" style="margin-bottom:1rem;border-left:3px solid var(--success);padding:.75rem 1rem">
         <span style="color:var(--success)">&#10003; Discord names refreshed for <%= refreshState.updatedCount %> user<%= refreshState.updatedCount === 1 ? '' : 's' %>.</span>
       </div>
+      <% } else if (refreshState.outcome === 'partial') { %>
+      <div class="card" style="margin-bottom:1rem;border-left:3px solid var(--warn);padding:.75rem 1rem">
+        <span style="color:var(--warn)">&#9888; Discord names refreshed for <%= refreshState.updatedCount %> user<%= refreshState.updatedCount === 1 ? '' : 's' %>, but <%= refreshState.failureCount %> lookup<%= refreshState.failureCount === 1 ? '' : 's' %> failed.</span>
+      </div>
       <% } else if (refreshState.outcome === 'noop') { %>
       <div class="card" style="margin-bottom:1rem;border-left:3px solid var(--muted);padding:.75rem 1rem">
         <span style="color:var(--text-muted)">No Discord names needed refreshing.</span>
       </div>
       <% } else if (refreshState.outcome === 'error') { %>
       <div class="card" style="margin-bottom:1rem;border-left:3px solid var(--danger);padding:.75rem 1rem">
-        <span style="color:var(--danger)">&#9888; Discord name refresh failed.</span>
+        <span style="color:var(--danger)">&#9888; Discord name refresh failed<%= refreshState.failureCount > 0 ? ' for ' + refreshState.failureCount + ' user' + (refreshState.failureCount === 1 ? '' : 's') : '' %>.</span>
       </div>
       <% } %>
 

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -20,6 +20,20 @@
       </div>
       <% } %>
 
+      <% if (refreshed) { %>
+      <div class="card" style="margin-bottom:1rem;border-left:3px solid var(--success);padding:.75rem 1rem">
+        <span style="color:var(--success)">&#10003; Discord names refreshed.</span>
+      </div>
+      <% } %>
+
+      <% if (user.accessLevel >= 2) { %>
+      <div style="display:flex;justify-content:flex-end;margin-bottom:1rem">
+        <form method="POST" action="/admin/users/refresh-names" class="inline-form-sm">
+          <button type="submit" class="btn btn-sm">Refresh Discord Names</button>
+        </form>
+      </div>
+      <% } %>
+
       <!-- Add user (Admin only) -->
       <% if (user.accessLevel >= 3) { %>
       <div class="card" style="margin-bottom:1.5rem">
@@ -27,6 +41,7 @@
         <form method="POST" action="/admin/users/add" class="inline-form">
           <input class="input" type="text" name="discord_id"   placeholder="Discord User ID"  required>
           <input class="input" type="text" name="discord_name" placeholder="Display name (optional)">
+          <input class="input" type="text" name="twitch_name" placeholder="Twitch name (optional)">
           <select class="input" name="access_level">
             <% Object.entries(accessLevelLabels).forEach(([val, label]) => { %>
             <option value="<%= val %>"><%= label %></option>
@@ -47,6 +62,7 @@
               <th>Discord ID</th>
               <th>Name</th>
               <th>Twitch</th>
+              <th>Twitch Bot</th>
               <th>Level</th>
               <% if (user.accessLevel >= 3) { %><th>Actions</th><% } %>
             </tr>
@@ -57,6 +73,24 @@
               <td class="mono"><%= u.discord_id %></td>
               <td><%= u.discord_name || '—' %></td>
               <td class="mono"><%= u.twitch_name || '—' %></td>
+              <td>
+                <% if (u.twitch_name) { %>
+                  <span class="badge <%= u.is_twitch_bot_enabled ? 'badge-online' : 'badge-offline' %>">
+                    <%= u.is_twitch_bot_enabled ? 'Enabled' : 'Disabled' %>
+                  </span>
+                  <% if (user.accessLevel >= 2) { %>
+                  <form method="POST" action="/admin/users/toggle-twitch" class="inline-form-sm" style="margin-top:.45rem">
+                    <input type="hidden" name="discord_id" value="<%= u.discord_id %>">
+                    <button type="submit" class="btn btn-sm"><%= u.is_twitch_bot_enabled ? 'Disable' : 'Enable' %></button>
+                  </form>
+                  <% } %>
+                <% } else { %>
+                  <span class="badge badge-offline">Unavailable</span>
+                  <% if (user.accessLevel >= 2) { %>
+                  <button type="button" class="btn btn-sm" disabled style="margin-top:.45rem;opacity:.55">Set Twitch Name</button>
+                  <% } %>
+                <% } %>
+              </td>
               <td><span class="badge level-<%= u.access_level %>"><%= accessLevelLabels[u.access_level] || u.access_level %></span></td>
               <% if (user.accessLevel >= 3) { %>
               <td class="actions">
@@ -82,7 +116,7 @@
             </tr>
             <% }) %>
             <% if (users.length === 0) { %>
-            <tr><td colspan="<%= user.accessLevel >= 3 ? 5 : 4 %>" class="empty-msg">No users in the database.</td></tr>
+            <tr><td colspan="<%= user.accessLevel >= 3 ? 6 : 5 %>" class="empty-msg">No users in the database.</td></tr>
             <% } %>
           </tbody>
         </table>

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -95,25 +95,30 @@
               <td class="mono"><%= u.twitch_name || '—' %></td>
               <td>
                 <% if (u.twitch_name) { %>
-                  <span class="badge <%= u.is_twitch_bot_enabled ? 'badge-online' : 'badge-offline' %>">
-                    <%= u.is_twitch_bot_enabled ? 'Enabled' : 'Disabled' %>
-                  </span>
-                  <% if (user.accessLevel >= 2) { %>
-                  <form method="POST" action="/admin/users/toggle-twitch" class="inline-form-sm" style="margin-top:.45rem">
-                    <input type="hidden" name="discord_id" value="<%= u.discord_id %>">
-                    <button type="submit" class="btn btn-sm"><%= u.is_twitch_bot_enabled ? 'Disable' : 'Enable' %></button>
-                  </form>
-                  <% } %>
+                  <div class="twitch-bot-controls">
+                    <span class="badge <%= u.is_twitch_bot_enabled ? 'badge-online' : 'badge-offline' %>">
+                      <%= u.is_twitch_bot_enabled ? 'Enabled' : 'Disabled' %>
+                    </span>
+                    <% if (user.accessLevel >= 2) { %>
+                    <form method="POST" action="/admin/users/toggle-twitch" class="inline-form-sm">
+                      <input type="hidden" name="discord_id" value="<%= u.discord_id %>">
+                      <button type="submit" class="btn btn-sm"><%= u.is_twitch_bot_enabled ? 'Disable' : 'Enable' %></button>
+                    </form>
+                    <% } %>
+                  </div>
                 <% } else { %>
-                  <span class="badge badge-offline">Unavailable</span>
-                  <% if (user.accessLevel >= 2) { %>
-                  <button type="button" class="btn btn-sm" disabled style="margin-top:.45rem;opacity:.55">Set Twitch Name</button>
-                  <% } %>
+                  <div class="twitch-bot-controls">
+                    <span class="badge badge-offline">Unavailable</span>
+                    <% if (user.accessLevel >= 2) { %>
+                    <button type="button" class="btn btn-sm" disabled style="opacity:.55">Set Twitch Name</button>
+                    <% } %>
+                  </div>
                 <% } %>
               </td>
               <td><span class="badge level-<%= u.access_level %>"><%= accessLevelLabels[u.access_level] || u.access_level %></span></td>
               <% if (user.accessLevel >= 3) { %>
-              <td class="actions">
+              <td>
+                <div class="actions">
                 <!-- Change level -->
                 <form method="POST" action="/admin/users/update" class="inline-form-sm">
                   <input type="hidden" name="discord_id" value="<%= u.discord_id %>">
@@ -131,6 +136,7 @@
                   <button type="submit" class="btn btn-danger btn-sm">Remove</button>
                 </form>
                 <% } %>
+                </div>
               </td>
               <% } %>
             </tr>

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -20,16 +20,28 @@
       </div>
       <% } %>
 
-      <% if (refreshed) { %>
+      <% if (refreshState.outcome === 'running') { %>
+      <div class="card" data-refresh-running="true" style="margin-bottom:1rem;border-left:3px solid var(--accent);padding:.75rem 1rem">
+        <span style="color:var(--accent)">Refreshing Discord names in the background...</span>
+      </div>
+      <% } else if (refreshState.outcome === 'success') { %>
       <div class="card" style="margin-bottom:1rem;border-left:3px solid var(--success);padding:.75rem 1rem">
-        <span style="color:var(--success)">&#10003; Discord names refreshed.</span>
+        <span style="color:var(--success)">&#10003; Discord names refreshed for <%= refreshState.updatedCount %> user<%= refreshState.updatedCount === 1 ? '' : 's' %>.</span>
+      </div>
+      <% } else if (refreshState.outcome === 'noop') { %>
+      <div class="card" style="margin-bottom:1rem;border-left:3px solid var(--muted);padding:.75rem 1rem">
+        <span style="color:var(--text-muted)">No Discord names needed refreshing.</span>
+      </div>
+      <% } else if (refreshState.outcome === 'error') { %>
+      <div class="card" style="margin-bottom:1rem;border-left:3px solid var(--danger);padding:.75rem 1rem">
+        <span style="color:var(--danger)">&#9888; Discord name refresh failed.</span>
       </div>
       <% } %>
 
       <% if (user.accessLevel >= 2) { %>
       <div style="display:flex;justify-content:flex-end;margin-bottom:1rem">
         <form method="POST" action="/admin/users/refresh-names" class="inline-form-sm">
-          <button type="submit" class="btn btn-sm">Refresh Discord Names</button>
+          <button type="submit" class="btn btn-sm" <%= refreshState.outcome === 'running' ? 'disabled' : '' %>><%= refreshState.outcome === 'running' ? 'Refreshing...' : 'Refresh Discord Names' %></button>
         </form>
       </div>
       <% } %>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DB-driven Twitch integration: validated/normalized channel names, runtime join/part APIs, per-user enable/disable, admin UI to set/clear Twitch names, and admin endpoints to refresh/toggle.
  * Discord display-name refresh job with status endpoint and client-side polling; manual refresh UI and status banner.

* **Behavior**
  * Startup now awaits Twitch initialization and fails fast on startup errors; OAuth login now syncs and persists Discord display names when changed.

* **Other**
  * UI tweaks and styling for Twitch controls; improved duplicate-Twitch-name feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->