### PR TITLE
build(deps): update packages and fix axios vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,17 +10,17 @@
       "dependencies": {
         "@discordjs/voice": "^0.19.2",
         "@snazzah/davey": "^0.1.11",
-        "discord.js": "^14.14.1",
-        "dotenv": "^17.3.1",
+        "discord.js": "^14.26.2",
+        "dotenv": "^17.4.1",
         "ejs": "^5.0.1",
         "express": "^5.2.1",
         "express-mysql-session": "^3.0.3",
         "express-session": "^1.19.0",
         "ffmpeg-static": "^5.2.0",
         "helmet": "^8.1.0",
-        "libsodium-wrappers": "^0.8.2",
+        "libsodium-wrappers": "^0.8.3",
         "mediaplex": "^1.0.0",
-        "mysql2": "^3.20.0",
+        "mysql2": "^3.21.1",
         "opusscript": "^0.1.1",
         "tiktok-live-connector": "2.1.1-beta1",
         "tmi.js": "^1.8.5",
@@ -32,7 +32,7 @@
         "@types/express": "^5.0.6",
         "@types/express-mysql-session": "^3.0.8",
         "@types/express-session": "^1.18.2",
-        "@types/node": "^24.12.0",
+        "@types/node": "^24.12.2",
         "@types/tmi.js": "^1.8.6",
         "@types/ws": "^8.18.1",
         "ts-node": "^10.9.2",
@@ -74,15 +74,15 @@
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.13.1.tgz",
-      "integrity": "sha512-cOU0UDHc3lp/5nKByDxkmRiNZBpdp0kx55aarbiAfakfKJHlxv/yFW1zmIqCAmwH5CRlrH9iMFKJMpvW4DPB+w==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.14.1.tgz",
+      "integrity": "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@discordjs/formatters": "^0.6.2",
         "@discordjs/util": "^1.2.0",
         "@sapphire/shapeshift": "^4.0.0",
-        "discord-api-types": "^0.38.33",
+        "discord-api-types": "^0.38.40",
         "fast-deep-equal": "^3.1.3",
         "ts-mixer": "^6.0.4",
         "tslib": "^2.6.3"
@@ -119,20 +119,20 @@
       }
     },
     "node_modules/@discordjs/rest": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz",
-      "integrity": "sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.1.tgz",
+      "integrity": "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@discordjs/collection": "^2.1.1",
-        "@discordjs/util": "^1.1.1",
+        "@discordjs/util": "^1.2.0",
         "@sapphire/async-queue": "^1.5.3",
-        "@sapphire/snowflake": "^3.5.3",
+        "@sapphire/snowflake": "^3.5.5",
         "@vladfrangu/async_event_emitter": "^2.4.6",
-        "discord-api-types": "^0.38.16",
-        "magic-bytes.js": "^1.10.0",
+        "discord-api-types": "^0.38.40",
+        "magic-bytes.js": "^1.13.0",
         "tslib": "^2.6.3",
-        "undici": "6.21.3"
+        "undici": "6.24.1"
       },
       "engines": {
         "node": ">=18"
@@ -151,6 +151,16 @@
       },
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@sapphire/snowflake": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+      "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@discordjs/util": {
@@ -849,9 +859,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
-      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -1017,14 +1027,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/body-parser": {
@@ -1245,24 +1255,24 @@
       ]
     },
     "node_modules/discord.js": {
-      "version": "14.25.1",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.25.1.tgz",
-      "integrity": "sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==",
+      "version": "14.26.2",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.26.2.tgz",
+      "integrity": "sha512-feShi+gULJ6R2MAA4/KkCFnkJcuVrROJrKk4czplzq8gE1oqhqgOy9K0Scu44B8oGeWKe04egquzf+ia6VtXAw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@discordjs/builders": "^1.13.0",
+        "@discordjs/builders": "^1.14.1",
         "@discordjs/collection": "1.5.3",
         "@discordjs/formatters": "^0.6.2",
-        "@discordjs/rest": "^2.6.0",
+        "@discordjs/rest": "^2.6.1",
         "@discordjs/util": "^1.2.0",
         "@discordjs/ws": "^1.2.3",
         "@sapphire/snowflake": "3.5.3",
-        "discord-api-types": "^0.38.33",
+        "discord-api-types": "^0.38.40",
         "fast-deep-equal": "3.1.3",
         "lodash.snakecase": "4.1.1",
-        "magic-bytes.js": "^1.10.0",
+        "magic-bytes.js": "^1.13.0",
         "tslib": "^2.6.3",
-        "undici": "6.21.3"
+        "undici": "6.24.1"
       },
       "engines": {
         "node": ">=18"
@@ -1272,9 +1282,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
-      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
+      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -1879,18 +1889,18 @@
       "license": "ISC"
     },
     "node_modules/libsodium-wrappers": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.8.2.tgz",
-      "integrity": "sha512-VFLmfxkxo+U9q60tjcnSomQBRx2UzlRjKWJqvB4K1pUqsMQg4cu3QXA2nrcsj9A1qRsnJBbi2Ozx1hsiDoCkhw==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.8.3.tgz",
+      "integrity": "sha512-Ri4G16uT3HiJsvIobXp1G1bpvGN4dcIjLONh8CHuzwqsT92F3GZ7EAxk3sL53NeuFCwi1XWSggsMMpGJ4Y+x/g==",
       "license": "ISC",
       "dependencies": {
         "libsodium": "^0.8.0"
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.snakecase": {
@@ -2280,9 +2290,9 @@
       "license": "MIT"
     },
     "node_modules/mysql2": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.20.0.tgz",
-      "integrity": "sha512-eCLUs7BNbgA6nf/MZXsaBO1SfGs0LtLVrJD3WeWq+jPLDWkSufTD+aGMwykfUVPdZnblaUK1a8G/P63cl9FkKg==",
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.21.1.tgz",
+      "integrity": "sha512-vywGTUeqMwPQHJCWTWmmdIpcLfhU0UWIhOYbSWehqL+0Y/NTPGViM0wDtIgLuzqm5RqSygXKLJnxFGhQkhM1wg==",
       "license": "MIT",
       "dependencies": {
         "aws-ssl-profiles": "^1.1.2",
@@ -2469,10 +2479,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/qs": {
       "version": "6.15.0",

--- a/package.json
+++ b/package.json
@@ -10,17 +10,17 @@
   "dependencies": {
     "@discordjs/voice": "^0.19.2",
     "@snazzah/davey": "^0.1.11",
-    "discord.js": "^14.14.1",
-    "dotenv": "^17.3.1",
+    "discord.js": "^14.26.2",
+    "dotenv": "^17.4.1",
     "ejs": "^5.0.1",
     "express": "^5.2.1",
     "express-mysql-session": "^3.0.3",
     "express-session": "^1.19.0",
     "ffmpeg-static": "^5.2.0",
     "helmet": "^8.1.0",
-    "libsodium-wrappers": "^0.8.2",
+    "libsodium-wrappers": "^0.8.3",
     "mediaplex": "^1.0.0",
-    "mysql2": "^3.20.0",
+    "mysql2": "^3.21.1",
     "opusscript": "^0.1.1",
     "tiktok-live-connector": "2.1.1-beta1",
     "tmi.js": "^1.8.5",
@@ -28,6 +28,7 @@
     "ws": "^8.20.0"
   },
   "overrides": {
+    "axios": "^1.15.0",
     "undici": "^7.24.0"
   },
   "devDependencies": {
@@ -35,7 +36,7 @@
     "@types/express": "^5.0.6",
     "@types/express-mysql-session": "^3.0.8",
     "@types/express-session": "^1.18.2",
-    "@types/node": "^24.12.0",
+    "@types/node": "^24.12.2",
     "@types/tmi.js": "^1.8.6",
     "@types/ws": "^8.18.1",
     "ts-node": "^10.9.2",


### PR DESCRIPTION
## Summary
- update discord.js, dotenv, libsodium-wrappers, mysql2, and @types/node
- add an npm override for axios to resolve the remaining critical audit finding
- refresh the lockfile for the new dependency graph
## Verification
- npm audit
- npm run build