### PR TITLE
Add counters admin panel and sync docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -220,8 +220,10 @@ Copy `.env.example` → `.env` and fill in all values.
 |-------|---------|-------------|
 | 0     | User    | View dashboard only |
 | 1     | Mod     | View dashboard + join/leave voice channel |
-| 2     | Manager | View dashboard + user list + join/leave voice + stream monitor management |
+| 2     | Manager | View dashboard + user list + join/leave voice + Manager+ admin routes (stream monitor, custom commands, and counters) |
 | 3     | Admin   | Full access: add/update/remove users + all above |
+
+`Manager+` in the route table means access level 2 or 3 (`Manager` or `Admin`).
 
 > **First-time setup:** Manually INSERT a row into the `user` table with your Discord ID and `access_level = 3` before first login.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,17 +26,21 @@ BCUK_Bot_4/
 │   ├── twitchApi.ts          — Twitch Helix API wrapper (app token, getUsers, getStreams)
 │   ├── twitchMonitor.ts      — Polling-based stream monitor + Discord announcements
 │   ├── monitorSettings.ts    — Read/write monitor-settings.json (toggle only)
+│   ├── twitchChannelName.ts   — Twitch channel-name normalization helper
 │   ├── types/
 │   │   └── express.d.ts      — Augments express-session SessionData
 │   └── web/
 │       ├── server.ts         — Express app + startWebPanel()
+│       ├── csrf.ts           — CSRF token middleware for web forms
 │       ├── middleware.ts     — requireAuth / requireMod / requireManager / requireAdmin
 │       └── routes/
 │           ├── auth.ts       — Discord OAuth2 (manual, no passport)
 │           ├── dashboard.ts  — GET / → renders dashboard
 │           ├── admin.ts      — User CRUD (GET+POST /admin/users/*)
 │           ├── api.ts        — GET /api/status, POST /api/voice/join|leave
-│           └── streams.ts    — Stream group/streamer CRUD + toggle
+│           ├── streams.ts    — Stream group/streamer CRUD + toggle
+│           ├── commands.ts   — Custom command CRUD + assignment management (web panel)
+│           └── counters.ts   — Counter CRUD + manual reset management (web panel)
 ├── views/
 │   ├── partials/nav.ejs
 │   ├── partials/pwa-head.ejs
@@ -44,6 +48,8 @@ BCUK_Bot_4/
 │   ├── login.ejs
 │   ├── dashboard.ejs
 │   ├── admin.ejs
+│   ├── commands.ejs          — Custom command management page
+│   ├── counters.ejs          — Counter management page
 │   ├── streams.ejs           — Stream monitor management page
 │   └── error.ejs
 ├── public/
@@ -52,6 +58,8 @@ BCUK_Bot_4/
 │   ├── navbar.js             — Mobile nav toggle behavior
 │   ├── admin.js              — Admin users page interactions
 │   ├── streams.js            — Stream monitor admin page interactions
+│   ├── commands.js           — Commands page interactions
+│   ├── counters.js           — Counters page interactions
 │   ├── pwa-register.js       — Service worker registration + update prompt
 │   ├── service-worker.js     — Offline cache + runtime caching strategy
 │   ├── manifest.json         — PWA metadata
@@ -135,6 +143,36 @@ Tables in the existing MySQL 8 database:
 | `discord_message_id`  | varchar(20) | nullable — ID of live announcement message |
 | `discord_channel_id`  | bigint      | nullable — channel the announcement was posted in |
 | `live_game`           | varchar(255)| nullable — game at time of last announcement |
+
+### `custom_command`
+
+| Column              | Type         | Notes                                      |
+|---------------------|--------------|--------------------------------------------|
+| `command_id`        | int PK       |                                            |
+| `trigger_string`    | varchar      | Full command token including prefix        |
+| `output`            | text         | Reply text                                 |
+| `is_discord_enabled`| tinyint(1)   | Enables Discord-side execution             |
+| `is_multi_twitch`   | tinyint(1)   | Enables multi-channel Twitch broadcast mode |
+
+### `twitch_user_commands`
+
+| Column       | Type       | Notes                          |
+|--------------|------------|--------------------------------|
+| `command_id` | int FK→custom_command.command_id | |
+| `discord_id` | bigint FK→user.discord_id        | |
+
+### `counter`
+
+| Column              | Type         | Notes                                      |
+|---------------------|--------------|--------------------------------------------|
+| `id`                | int PK       |                                            |
+| `trigger_command`   | varchar      | Command that increments the counter        |
+| `check_command`     | varchar      | Command that reads current value           |
+| `message`           | text         | Check reply format (`%d` placeholder)      |
+| `increment_message` | text         | Increment reply format (`%d` placeholder)  |
+| `reset_yearly`      | tinyint(1)   | Whether current_value resets on yearly archive |
+| `current_value`     | int          | Live counter value                         |
+| `value2020`-`value2025` | int nullable | Yearly archived values (expanded over time) |
 
 > **DB migration** (run once before first use of stream monitoring):
 > ```sql
@@ -294,6 +332,9 @@ Any CRUD change to groups or streamers via the web panel calls `restartTwitchMon
 ### monitor-settings.json
 Local file (`monitor-settings.json` at `process.cwd()`) persists one value: `twitchMonitorEnabled` (boolean, default `true` if file missing). It is **gitignored**. Read/write via `src/monitorSettings.ts` helpers only.
 
+### Custom commands and counters are panel-first
+`/admin/commands` and `/admin/counters` currently provide management CRUD in the web panel. Runtime execution wiring in Twitch/Discord message handlers and counter yearly scheduler logic may be implemented separately from panel work.
+
 ---
 
 ## Scripts
@@ -346,6 +387,17 @@ npm start        # node dist/index.js (production)
 | POST   | `/admin/streams/groups/remove` | Manager+ | Remove stream group (and its streamers) |
 | POST   | `/admin/streams/streamers/add`    | Manager+ | Add streamer to group |
 | POST   | `/admin/streams/streamers/remove` | Manager+ | Remove streamer |
+| GET    | `/admin/commands`       | Manager+    | Custom command management page |
+| POST   | `/admin/commands/add`   | Manager+    | Add custom command |
+| POST   | `/admin/commands/update`| Manager+    | Update custom command |
+| POST   | `/admin/commands/remove`| Manager+    | Remove custom command |
+| POST   | `/admin/commands/assign`| Manager+    | Assign user to custom command |
+| POST   | `/admin/commands/unassign`| Manager+  | Remove user assignment from custom command |
+| GET    | `/admin/counters`       | Manager+    | Counter management page |
+| POST   | `/admin/counters/add`   | Manager+    | Add counter definition |
+| POST   | `/admin/counters/update`| Manager+    | Update counter definition |
+| POST   | `/admin/counters/remove`| Manager+    | Remove counter definition |
+| POST   | `/admin/counters/reset/:id`| Manager+ | Manually reset current_value to 0 |
 
 ---
 
@@ -381,6 +433,11 @@ In-memory singleton. Functions:
 - `setStreamerLive(id, messageId, channelId, game)` — update `discord_message_id`, `discord_channel_id`, `live_game` on a streamer row
 - `clearStreamerLive(id)` — null out all three live columns on a streamer row
 - `DbStreamGroup` and `DbStreamerFull` interfaces exported from `db.ts`
+- `getAllCustomCommandsWithAssignments()` / `addCustomCommand()` / `updateCustomCommand()` / `removeCustomCommand()` — custom command management
+- `assignUserToCommand()` / `unassignUserFromCommand()` — custom command-to-user assignment management
+- `DbCustomCommand` / `DbCustomCommandAssignedUser` / `DbCustomCommandWithAssignments` interfaces exported from `db.ts`
+- `getAllCounters()` / `addCounter()` / `updateCounter()` / `removeCounter()` / `resetCounterCurrentValue()` — counter management for web panel
+- `DbCounter` interface exported from `db.ts`
 
 > **Note:** State is lost on process restart. Sessions are stored in the `sessions` MySQL table via `express-mysql-session` (created automatically on first run).
 

--- a/DATABASE-SCHEMA.md
+++ b/DATABASE-SCHEMA.md
@@ -166,6 +166,27 @@ Expected constraints and behavior:
 - Foreign key from `discord_id` to `user.discord_id`.
 - `ON DELETE CASCADE` is preferred on both foreign keys so deleting a command or user automatically removes mapping rows.
 
+## `counter`
+
+Stores counter command definitions and values managed through the admin panel.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | `INT` PK | Counter row identifier |
+| `trigger_command` | `VARCHAR(...)` | Full command token used for increment actions (including prefix) |
+| `check_command` | `VARCHAR(...)` | Full command token used for read/check actions |
+| `message` | `TEXT` | Read/check reply template; `%d` placeholder is used for current value |
+| `increment_message` | `TEXT` | Increment reply template; `%d` placeholder is used for incremented value |
+| `reset_yearly` | `BIT(1)` or `TINYINT(1)` | Whether yearly archival should reset `current_value` |
+| `current_value` | `INT` | Current live value |
+| `value2020`-`value2025` | `INT` nullable | Existing yearly archive columns; additional `valueYYYY` columns may be added over time |
+
+Expected constraints and behavior:
+
+- `trigger_command` and `check_command` should be unique.
+- Both command columns should store single-token commands including any prefix.
+- Current panel support includes CRUD and manual reset of `current_value`; runtime command handling/scheduler wiring can be implemented independently.
+
 ## `sessions`
 
 Managed automatically by `express-mysql-session`.

--- a/public/counters.js
+++ b/public/counters.js
@@ -1,0 +1,43 @@
+document.addEventListener('click', function (event) {
+  var target = event.target;
+  if (!(target instanceof Element)) return;
+
+  var button = target.closest('.btn-toggle-counter-edit');
+  if (!(button instanceof HTMLElement)) return;
+
+  var counterId = button.getAttribute('data-counter-id');
+  if (!counterId) return;
+
+  var row = document.getElementById('counter-edit-' + counterId);
+  if (!(row instanceof HTMLElement)) return;
+
+  row.classList.toggle('is-hidden');
+
+  var isOpen = !row.classList.contains('is-hidden');
+  var openerButton = document.querySelector(
+    '.btn-toggle-counter-edit[aria-expanded][data-counter-id="' + counterId + '"]'
+  );
+  if (openerButton instanceof HTMLElement) {
+    openerButton.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+  }
+});
+
+document.addEventListener('submit', function (event) {
+  var target = event.target;
+  if (!(target instanceof HTMLFormElement)) return;
+
+  if (target.classList.contains('js-confirm-remove-counter')) {
+    var triggerString = target.dataset.counterTrigger || 'this counter';
+    if (!window.confirm('Remove counter ' + triggerString + '?')) {
+      event.preventDefault();
+    }
+    return;
+  }
+
+  if (target.classList.contains('js-confirm-reset-counter')) {
+    var resetTriggerString = target.dataset.counterTrigger || 'this counter';
+    if (!window.confirm('Reset current value for ' + resetTriggerString + ' to 0?')) {
+      event.preventDefault();
+    }
+  }
+});

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,5 +1,5 @@
 const APP_CACHE_PREFIX = 'bcuk-panel-';
-const CACHE_VERSION = 'bcuk-panel-v3';
+const CACHE_VERSION = 'bcuk-panel-v4';
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const RUNTIME_CACHE = `${CACHE_VERSION}-runtime`;
 const RUNTIME_CACHE_MAX_ENTRIES = 50;
@@ -11,6 +11,7 @@ const STATIC_ASSETS = [
   '/navbar.js',
   '/admin.js',
   '/commands.js',
+  '/counters.js',
   '/streams.js',
   '/pwa-register.js',
   '/manifest.json',

--- a/public/style.css
+++ b/public/style.css
@@ -190,6 +190,23 @@ textarea.input, .stream-textarea { width: 100%; resize: vertical; font-family: v
 .hint-compact { padding: 0 0 .3rem; }
 .command-output-cell { max-width: 360px; white-space: normal; overflow-wrap: anywhere; }
 .badge-list-wrap { display: flex; flex-wrap: wrap; gap: .35rem; }
+.counter-value-cell { text-align: center; }
+.counter-value-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 3.25rem;
+  padding: .32rem .7rem;
+  border-radius: 8px;
+  font-family: var(--mono);
+  font-size: .96rem;
+  font-weight: 800;
+  line-height: 1;
+  color: #fff;
+  background: linear-gradient(180deg, rgba(88,101,242,.95), rgba(71,82,196,.95));
+  border: 1px solid rgba(147, 197, 253, .22);
+  box-shadow: 0 0 0 1px rgba(255,255,255,.03) inset;
+}
 .command-edit-panel { padding: .75rem 1rem; background: var(--bg); border-radius: 6px; }
 .edit-panel { padding: .75rem 1rem; background: var(--bg); border-radius: 6px; }
 .stack-gap-md { margin-bottom: 1rem; }

--- a/src/db.ts
+++ b/src/db.ts
@@ -464,7 +464,7 @@ export async function updateCounter(
   incrementMessage: string,
   resetYearly: boolean,
 ): Promise<void> {
-  await getPool().execute(
+  const [result] = await getPool().execute<mysql.ResultSetHeader>(
     `UPDATE counter
      SET trigger_command = ?,
          check_command = ?,
@@ -474,17 +474,28 @@ export async function updateCounter(
      WHERE id = ?`,
     [triggerCommand.trim(), checkCommand.trim(), message.trim(), incrementMessage.trim(), resetYearly ? 1 : 0, id],
   );
+
+  if (result.affectedRows === 0) {
+    throw new Error(`Counter not found: ${id}`);
+  }
 }
 
 export async function removeCounter(id: number): Promise<void> {
-  await getPool().execute('DELETE FROM counter WHERE id = ?', [id]);
+  const [result] = await getPool().execute<mysql.ResultSetHeader>('DELETE FROM counter WHERE id = ?', [id]);
+  if (result.affectedRows === 0) {
+    throw new Error(`Counter not found: ${id}`);
+  }
 }
 
 export async function resetCounterCurrentValue(id: number): Promise<void> {
-  await getPool().execute(
+  const [result] = await getPool().execute<mysql.ResultSetHeader>(
     'UPDATE counter SET current_value = 0 WHERE id = ?',
     [id],
   );
+
+  if (result.affectedRows === 0) {
+    throw new Error(`Counter not found: ${id}`);
+  }
 }
 
 // ─── Stream monitor ──────────────────────────────────────────────────────────

--- a/src/db.ts
+++ b/src/db.ts
@@ -456,6 +456,14 @@ export async function addCounter(
   );
 }
 
+async function counterExists(id: number): Promise<boolean> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    'SELECT 1 FROM counter WHERE id = ? LIMIT 1',
+    [id],
+  );
+  return rows.length > 0;
+}
+
 export async function updateCounter(
   id: number,
   triggerCommand: string,
@@ -475,7 +483,7 @@ export async function updateCounter(
     [triggerCommand.trim(), checkCommand.trim(), message.trim(), incrementMessage.trim(), resetYearly ? 1 : 0, id],
   );
 
-  if (result.affectedRows === 0) {
+  if (result.affectedRows === 0 && !(await counterExists(id))) {
     throw new Error(`Counter not found: ${id}`);
   }
 }
@@ -493,7 +501,7 @@ export async function resetCounterCurrentValue(id: number): Promise<void> {
     [id],
   );
 
-  if (result.affectedRows === 0) {
+  if (result.affectedRows === 0 && !(await counterExists(id))) {
     throw new Error(`Counter not found: ${id}`);
   }
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -408,6 +408,85 @@ export async function unassignUserFromCommand(commandId: number, discordId: stri
   );
 }
 
+// ─── Counter commands ───────────────────────────────────────────────────────
+
+export interface DbCounter {
+  id: number;
+  trigger_command: string;
+  check_command: string;
+  message: string;
+  increment_message: string;
+  reset_yearly: boolean;
+  current_value: number;
+}
+
+function mapCounter(row: mysql.RowDataPacket): DbCounter {
+  return {
+    id: row.id,
+    trigger_command: row.trigger_command,
+    check_command: row.check_command,
+    message: row.message,
+    increment_message: row.increment_message,
+    reset_yearly: Buffer.isBuffer(row.reset_yearly) ? row.reset_yearly[0] === 1 : row.reset_yearly == 1,
+    current_value: row.current_value,
+  };
+}
+
+export async function getAllCounters(): Promise<DbCounter[]> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT id, trigger_command, check_command, message, increment_message, reset_yearly, current_value
+     FROM counter
+     ORDER BY trigger_command`,
+  );
+
+  return rows.map(mapCounter);
+}
+
+export async function addCounter(
+  triggerCommand: string,
+  checkCommand: string,
+  message: string,
+  incrementMessage: string,
+  resetYearly: boolean,
+): Promise<void> {
+  await getPool().execute(
+    `INSERT INTO counter (trigger_command, check_command, message, increment_message, reset_yearly, current_value)
+     VALUES (?, ?, ?, ?, ?, 0)`,
+    [triggerCommand.trim(), checkCommand.trim(), message.trim(), incrementMessage.trim(), resetYearly ? 1 : 0],
+  );
+}
+
+export async function updateCounter(
+  id: number,
+  triggerCommand: string,
+  checkCommand: string,
+  message: string,
+  incrementMessage: string,
+  resetYearly: boolean,
+): Promise<void> {
+  await getPool().execute(
+    `UPDATE counter
+     SET trigger_command = ?,
+         check_command = ?,
+         message = ?,
+         increment_message = ?,
+         reset_yearly = ?
+     WHERE id = ?`,
+    [triggerCommand.trim(), checkCommand.trim(), message.trim(), incrementMessage.trim(), resetYearly ? 1 : 0, id],
+  );
+}
+
+export async function removeCounter(id: number): Promise<void> {
+  await getPool().execute('DELETE FROM counter WHERE id = ?', [id]);
+}
+
+export async function resetCounterCurrentValue(id: number): Promise<void> {
+  await getPool().execute(
+    'UPDATE counter SET current_value = 0 WHERE id = ?',
+    [id],
+  );
+}
+
 // ─── Stream monitor ──────────────────────────────────────────────────────────
 
 export interface DbStreamGroup {

--- a/src/db.ts
+++ b/src/db.ts
@@ -420,6 +420,13 @@ export interface DbCounter {
   current_value: number;
 }
 
+export class CounterNotFoundError extends Error {
+  constructor(id: number) {
+    super(`Counter not found: ${id}`);
+    this.name = 'CounterNotFoundError';
+  }
+}
+
 function mapCounter(row: mysql.RowDataPacket): DbCounter {
   return {
     id: row.id,
@@ -484,14 +491,14 @@ export async function updateCounter(
   );
 
   if (result.affectedRows === 0 && !(await counterExists(id))) {
-    throw new Error(`Counter not found: ${id}`);
+    throw new CounterNotFoundError(id);
   }
 }
 
 export async function removeCounter(id: number): Promise<void> {
   const [result] = await getPool().execute<mysql.ResultSetHeader>('DELETE FROM counter WHERE id = ?', [id]);
   if (result.affectedRows === 0) {
-    throw new Error(`Counter not found: ${id}`);
+    throw new CounterNotFoundError(id);
   }
 }
 
@@ -502,7 +509,7 @@ export async function resetCounterCurrentValue(id: number): Promise<void> {
   );
 
   if (result.affectedRows === 0 && !(await counterExists(id))) {
-    throw new Error(`Counter not found: ${id}`);
+    throw new CounterNotFoundError(id);
   }
 }
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -323,20 +323,22 @@ export async function getAllCustomCommandsWithAssignments(): Promise<DbCustomCom
   return Array.from(commandMap.values());
 }
 
+function requireTrimmedString(value: string, fieldName: string): string {
+  const normalizedValue = value.trim();
+  if (!normalizedValue) {
+    throw new Error(`Missing ${fieldName}`);
+  }
+  return normalizedValue;
+}
+
 export async function addCustomCommand(
   triggerString: string,
   output: string,
   isDiscordEnabled: boolean,
   isMultiTwitch: boolean,
 ): Promise<void> {
-  const normalizedTriggerString = triggerString.trim();
-  const normalizedOutput = output.trim();
-  if (!normalizedTriggerString) {
-    throw new Error('Missing trigger_string');
-  }
-  if (!normalizedOutput) {
-    throw new Error('Missing output');
-  }
+  const normalizedTriggerString = requireTrimmedString(triggerString, 'trigger_string');
+  const normalizedOutput = requireTrimmedString(output, 'output');
 
   await getPool().execute(
     `INSERT INTO custom_command (trigger_string, output, is_discord_enabled, is_multi_twitch)
@@ -352,14 +354,8 @@ export async function updateCustomCommand(
   isDiscordEnabled: boolean,
   isMultiTwitch: boolean,
 ): Promise<void> {
-  const normalizedTriggerString = triggerString.trim();
-  const normalizedOutput = output.trim();
-  if (!normalizedTriggerString) {
-    throw new Error('Missing trigger_string');
-  }
-  if (!normalizedOutput) {
-    throw new Error('Missing output');
-  }
+  const normalizedTriggerString = requireTrimmedString(triggerString, 'trigger_string');
+  const normalizedOutput = requireTrimmedString(output, 'output');
 
   await getPool().execute(
     `UPDATE custom_command
@@ -427,6 +423,27 @@ export class CounterNotFoundError extends Error {
   }
 }
 
+interface NormalizedCounterFields {
+  triggerCommand: string;
+  checkCommand: string;
+  message: string;
+  incrementMessage: string;
+}
+
+function normalizeCounterFields(
+  triggerCommand: string,
+  checkCommand: string,
+  message: string,
+  incrementMessage: string,
+): NormalizedCounterFields {
+  return {
+    triggerCommand: requireTrimmedString(triggerCommand, 'trigger_command'),
+    checkCommand: requireTrimmedString(checkCommand, 'check_command'),
+    message: requireTrimmedString(message, 'message'),
+    incrementMessage: requireTrimmedString(incrementMessage, 'increment_message'),
+  };
+}
+
 function mapCounter(row: mysql.RowDataPacket): DbCounter {
   return {
     id: row.id,
@@ -456,10 +473,18 @@ export async function addCounter(
   incrementMessage: string,
   resetYearly: boolean,
 ): Promise<void> {
+  const normalizedFields = normalizeCounterFields(triggerCommand, checkCommand, message, incrementMessage);
+
   await getPool().execute(
     `INSERT INTO counter (trigger_command, check_command, message, increment_message, reset_yearly, current_value)
      VALUES (?, ?, ?, ?, ?, 0)`,
-    [triggerCommand.trim(), checkCommand.trim(), message.trim(), incrementMessage.trim(), resetYearly ? 1 : 0],
+    [
+      normalizedFields.triggerCommand,
+      normalizedFields.checkCommand,
+      normalizedFields.message,
+      normalizedFields.incrementMessage,
+      resetYearly ? 1 : 0,
+    ],
   );
 }
 
@@ -479,6 +504,8 @@ export async function updateCounter(
   incrementMessage: string,
   resetYearly: boolean,
 ): Promise<void> {
+  const normalizedFields = normalizeCounterFields(triggerCommand, checkCommand, message, incrementMessage);
+
   const [result] = await getPool().execute<mysql.ResultSetHeader>(
     `UPDATE counter
      SET trigger_command = ?,
@@ -487,7 +514,14 @@ export async function updateCounter(
          increment_message = ?,
          reset_yearly = ?
      WHERE id = ?`,
-    [triggerCommand.trim(), checkCommand.trim(), message.trim(), incrementMessage.trim(), resetYearly ? 1 : 0, id],
+    [
+      normalizedFields.triggerCommand,
+      normalizedFields.checkCommand,
+      normalizedFields.message,
+      normalizedFields.incrementMessage,
+      resetYearly ? 1 : 0,
+      id,
+    ],
   );
 
   if (result.affectedRows === 0 && !(await counterExists(id))) {

--- a/src/web/routes/counters.ts
+++ b/src/web/routes/counters.ts
@@ -13,12 +13,17 @@ const router = Router();
 
 const KNOWN_ERRORS = new Set([
   'missing_fields',
+  'same_commands',
   'invalid_id',
   'add_failed',
   'update_failed',
   'remove_failed',
   'reset_failed',
 ]);
+
+function isCounterNotFoundError(err: unknown): boolean {
+  return err instanceof Error && err.message.startsWith('Counter not found:');
+}
 
 function normalizeRequiredText(value: string | undefined): string | null {
   if (typeof value !== 'string') return null;
@@ -75,6 +80,10 @@ router.post('/counters/add', requireManager, csrfProtection, async (req, res) =>
     return res.redirect('/admin/counters?error=missing_fields');
   }
 
+  if (normalizedTriggerCommand === normalizedCheckCommand) {
+    return res.redirect('/admin/counters?error=same_commands');
+  }
+
   try {
     await addCounter(
       normalizedTriggerCommand,
@@ -105,6 +114,10 @@ router.post('/counters/update', requireManager, csrfProtection, async (req, res)
     return res.redirect('/admin/counters?error=missing_fields');
   }
 
+  if (normalizedTriggerCommand === normalizedCheckCommand) {
+    return res.redirect('/admin/counters?error=same_commands');
+  }
+
   if (parsedId === null) {
     return res.redirect('/admin/counters?error=invalid_id');
   }
@@ -119,6 +132,10 @@ router.post('/counters/update', requireManager, csrfProtection, async (req, res)
       resetYearly,
     );
   } catch (err) {
+    if (isCounterNotFoundError(err)) {
+      return res.status(404).render('error', { message: 'Counter not found.', user: req.session.user ?? null });
+    }
+
     console.error('[Web] Update counter error:', err);
     return res.redirect('/admin/counters?error=update_failed');
   }
@@ -137,6 +154,10 @@ router.post('/counters/remove', requireManager, csrfProtection, async (req, res)
   try {
     await removeCounter(parsedId);
   } catch (err) {
+    if (isCounterNotFoundError(err)) {
+      return res.status(404).render('error', { message: 'Counter not found.', user: req.session.user ?? null });
+    }
+
     console.error('[Web] Remove counter error:', err);
     return res.redirect('/admin/counters?error=remove_failed');
   }
@@ -154,6 +175,10 @@ router.post('/counters/reset/:id', requireManager, csrfProtection, async (req, r
   try {
     await resetCounterCurrentValue(parsedId);
   } catch (err) {
+    if (isCounterNotFoundError(err)) {
+      return res.status(404).render('error', { message: 'Counter not found.', user: req.session.user ?? null });
+    }
+
     console.error('[Web] Reset counter error:', err);
     return res.redirect('/admin/counters?error=reset_failed');
   }

--- a/src/web/routes/counters.ts
+++ b/src/web/routes/counters.ts
@@ -1,0 +1,164 @@
+import { Router } from 'express';
+import {
+  addCounter,
+  getAllCounters,
+  removeCounter,
+  resetCounterCurrentValue,
+  updateCounter,
+} from '../../db';
+import { csrfProtection } from '../csrf';
+import { requireManager } from '../middleware';
+
+const router = Router();
+
+const KNOWN_ERRORS = new Set([
+  'missing_fields',
+  'invalid_id',
+  'add_failed',
+  'update_failed',
+  'remove_failed',
+  'reset_failed',
+]);
+
+function normalizeRequiredText(value: string | undefined): string | null {
+  if (typeof value !== 'string') return null;
+
+  const normalizedValue = value.trim();
+  return normalizedValue.length > 0 ? normalizedValue : null;
+}
+
+function normalizeSingleTokenRequiredText(value: string | undefined): string | null {
+  const normalizedValue = normalizeRequiredText(value);
+  if (!normalizedValue || /\s/.test(normalizedValue)) {
+    return null;
+  }
+
+  return normalizedValue.toLowerCase();
+}
+
+function parseCounterId(value: string | undefined): number | null {
+  if (typeof value !== 'string' || !/^\d+$/.test(value)) {
+    return null;
+  }
+
+  const parsedValue = Number(value);
+  return Number.isSafeInteger(parsedValue) && parsedValue > 0 ? parsedValue : null;
+}
+
+router.get('/counters', requireManager, csrfProtection, async (req, res) => {
+  try {
+    const counters = await getAllCounters();
+
+    res.render('counters', {
+      user: req.session.user,
+      counters,
+      csrfToken: req.csrfToken(),
+      error: KNOWN_ERRORS.has(req.query.error as string) ? (req.query.error as string) : null,
+      reset: req.query.reset === '1',
+    });
+  } catch (err) {
+    console.error('[Web] Counters page error:', err);
+    res.status(500).render('error', { message: 'Failed to load counters page.', user: req.session.user ?? null });
+  }
+});
+
+router.post('/counters/add', requireManager, csrfProtection, async (req, res) => {
+  const { trigger_command, check_command, message, increment_message } = req.body as Record<string, string | undefined>;
+  const resetYearly = req.body.reset_yearly === 'on';
+
+  const normalizedTriggerCommand = normalizeSingleTokenRequiredText(trigger_command);
+  const normalizedCheckCommand = normalizeSingleTokenRequiredText(check_command);
+  const normalizedMessage = normalizeRequiredText(message);
+  const normalizedIncrementMessage = normalizeRequiredText(increment_message);
+
+  if (!normalizedTriggerCommand || !normalizedCheckCommand || !normalizedMessage || !normalizedIncrementMessage) {
+    return res.redirect('/admin/counters?error=missing_fields');
+  }
+
+  try {
+    await addCounter(
+      normalizedTriggerCommand,
+      normalizedCheckCommand,
+      normalizedMessage,
+      normalizedIncrementMessage,
+      resetYearly,
+    );
+  } catch (err) {
+    console.error('[Web] Add counter error:', err);
+    return res.redirect('/admin/counters?error=add_failed');
+  }
+
+  res.redirect('/admin/counters');
+});
+
+router.post('/counters/update', requireManager, csrfProtection, async (req, res) => {
+  const { id, trigger_command, check_command, message, increment_message } = req.body as Record<string, string | undefined>;
+  const resetYearly = req.body.reset_yearly === 'on';
+
+  const parsedId = parseCounterId(id);
+  const normalizedTriggerCommand = normalizeSingleTokenRequiredText(trigger_command);
+  const normalizedCheckCommand = normalizeSingleTokenRequiredText(check_command);
+  const normalizedMessage = normalizeRequiredText(message);
+  const normalizedIncrementMessage = normalizeRequiredText(increment_message);
+
+  if (!normalizedTriggerCommand || !normalizedCheckCommand || !normalizedMessage || !normalizedIncrementMessage) {
+    return res.redirect('/admin/counters?error=missing_fields');
+  }
+
+  if (parsedId === null) {
+    return res.redirect('/admin/counters?error=invalid_id');
+  }
+
+  try {
+    await updateCounter(
+      parsedId,
+      normalizedTriggerCommand,
+      normalizedCheckCommand,
+      normalizedMessage,
+      normalizedIncrementMessage,
+      resetYearly,
+    );
+  } catch (err) {
+    console.error('[Web] Update counter error:', err);
+    return res.redirect('/admin/counters?error=update_failed');
+  }
+
+  res.redirect('/admin/counters');
+});
+
+router.post('/counters/remove', requireManager, csrfProtection, async (req, res) => {
+  const { id } = req.body as { id?: string };
+  const parsedId = parseCounterId(id);
+
+  if (parsedId === null) {
+    return res.redirect('/admin/counters?error=invalid_id');
+  }
+
+  try {
+    await removeCounter(parsedId);
+  } catch (err) {
+    console.error('[Web] Remove counter error:', err);
+    return res.redirect('/admin/counters?error=remove_failed');
+  }
+
+  res.redirect('/admin/counters');
+});
+
+router.post('/counters/reset/:id', requireManager, csrfProtection, async (req, res) => {
+  const rawId = req.params.id;
+  const parsedId = parseCounterId(typeof rawId === 'string' ? rawId : undefined);
+  if (parsedId === null) {
+    return res.redirect('/admin/counters?error=invalid_id');
+  }
+
+  try {
+    await resetCounterCurrentValue(parsedId);
+  } catch (err) {
+    console.error('[Web] Reset counter error:', err);
+    return res.redirect('/admin/counters?error=reset_failed');
+  }
+
+  res.redirect('/admin/counters?reset=1');
+});
+
+export default router;

--- a/src/web/routes/counters.ts
+++ b/src/web/routes/counters.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import {
   addCounter,
+  CounterNotFoundError,
   getAllCounters,
   removeCounter,
   resetCounterCurrentValue,
@@ -20,10 +21,6 @@ const KNOWN_ERRORS = new Set([
   'remove_failed',
   'reset_failed',
 ]);
-
-function isCounterNotFoundError(err: unknown): boolean {
-  return err instanceof Error && err.message.startsWith('Counter not found:');
-}
 
 function normalizeRequiredText(value: string | undefined): string | null {
   if (typeof value !== 'string') return null;
@@ -50,6 +47,46 @@ function parseCounterId(value: string | undefined): number | null {
   return Number.isSafeInteger(parsedValue) && parsedValue > 0 ? parsedValue : null;
 }
 
+type CounterFormValidationResult =
+  | {
+      error: null;
+      triggerCommand: string;
+      checkCommand: string;
+      message: string;
+      incrementMessage: string;
+      resetYearly: boolean;
+    }
+  | {
+      error: 'missing_fields' | 'same_commands';
+    };
+
+function validateAndNormalizeCounterForm(
+  rawForm: Record<string, string | undefined>,
+): CounterFormValidationResult {
+  const normalizedTriggerCommand = normalizeSingleTokenRequiredText(rawForm.trigger_command);
+  const normalizedCheckCommand = normalizeSingleTokenRequiredText(rawForm.check_command);
+  const normalizedMessage = normalizeRequiredText(rawForm.message);
+  const normalizedIncrementMessage = normalizeRequiredText(rawForm.increment_message);
+  const resetYearly = rawForm.reset_yearly === 'on';
+
+  if (!normalizedTriggerCommand || !normalizedCheckCommand || !normalizedMessage || !normalizedIncrementMessage) {
+    return { error: 'missing_fields' };
+  }
+
+  if (normalizedTriggerCommand === normalizedCheckCommand) {
+    return { error: 'same_commands' };
+  }
+
+  return {
+    error: null,
+    triggerCommand: normalizedTriggerCommand,
+    checkCommand: normalizedCheckCommand,
+    message: normalizedMessage,
+    incrementMessage: normalizedIncrementMessage,
+    resetYearly,
+  };
+}
+
 router.get('/counters', requireManager, csrfProtection, async (req, res) => {
   try {
     const counters = await getAllCounters();
@@ -68,29 +105,18 @@ router.get('/counters', requireManager, csrfProtection, async (req, res) => {
 });
 
 router.post('/counters/add', requireManager, csrfProtection, async (req, res) => {
-  const { trigger_command, check_command, message, increment_message } = req.body as Record<string, string | undefined>;
-  const resetYearly = req.body.reset_yearly === 'on';
-
-  const normalizedTriggerCommand = normalizeSingleTokenRequiredText(trigger_command);
-  const normalizedCheckCommand = normalizeSingleTokenRequiredText(check_command);
-  const normalizedMessage = normalizeRequiredText(message);
-  const normalizedIncrementMessage = normalizeRequiredText(increment_message);
-
-  if (!normalizedTriggerCommand || !normalizedCheckCommand || !normalizedMessage || !normalizedIncrementMessage) {
-    return res.redirect('/admin/counters?error=missing_fields');
-  }
-
-  if (normalizedTriggerCommand === normalizedCheckCommand) {
-    return res.redirect('/admin/counters?error=same_commands');
+  const form = validateAndNormalizeCounterForm(req.body as Record<string, string | undefined>);
+  if (form.error) {
+    return res.redirect(`/admin/counters?error=${form.error}`);
   }
 
   try {
     await addCounter(
-      normalizedTriggerCommand,
-      normalizedCheckCommand,
-      normalizedMessage,
-      normalizedIncrementMessage,
-      resetYearly,
+      form.triggerCommand,
+      form.checkCommand,
+      form.message,
+      form.incrementMessage,
+      form.resetYearly,
     );
   } catch (err) {
     console.error('[Web] Add counter error:', err);
@@ -101,21 +127,12 @@ router.post('/counters/add', requireManager, csrfProtection, async (req, res) =>
 });
 
 router.post('/counters/update', requireManager, csrfProtection, async (req, res) => {
-  const { id, trigger_command, check_command, message, increment_message } = req.body as Record<string, string | undefined>;
-  const resetYearly = req.body.reset_yearly === 'on';
+  const { id } = req.body as Record<string, string | undefined>;
 
   const parsedId = parseCounterId(id);
-  const normalizedTriggerCommand = normalizeSingleTokenRequiredText(trigger_command);
-  const normalizedCheckCommand = normalizeSingleTokenRequiredText(check_command);
-  const normalizedMessage = normalizeRequiredText(message);
-  const normalizedIncrementMessage = normalizeRequiredText(increment_message);
-
-  if (!normalizedTriggerCommand || !normalizedCheckCommand || !normalizedMessage || !normalizedIncrementMessage) {
-    return res.redirect('/admin/counters?error=missing_fields');
-  }
-
-  if (normalizedTriggerCommand === normalizedCheckCommand) {
-    return res.redirect('/admin/counters?error=same_commands');
+  const form = validateAndNormalizeCounterForm(req.body as Record<string, string | undefined>);
+  if (form.error) {
+    return res.redirect(`/admin/counters?error=${form.error}`);
   }
 
   if (parsedId === null) {
@@ -125,14 +142,14 @@ router.post('/counters/update', requireManager, csrfProtection, async (req, res)
   try {
     await updateCounter(
       parsedId,
-      normalizedTriggerCommand,
-      normalizedCheckCommand,
-      normalizedMessage,
-      normalizedIncrementMessage,
-      resetYearly,
+      form.triggerCommand,
+      form.checkCommand,
+      form.message,
+      form.incrementMessage,
+      form.resetYearly,
     );
   } catch (err) {
-    if (isCounterNotFoundError(err)) {
+    if (err instanceof CounterNotFoundError) {
       return res.status(404).render('error', { message: 'Counter not found.', user: req.session.user ?? null });
     }
 
@@ -154,7 +171,7 @@ router.post('/counters/remove', requireManager, csrfProtection, async (req, res)
   try {
     await removeCounter(parsedId);
   } catch (err) {
-    if (isCounterNotFoundError(err)) {
+    if (err instanceof CounterNotFoundError) {
       return res.status(404).render('error', { message: 'Counter not found.', user: req.session.user ?? null });
     }
 
@@ -175,7 +192,7 @@ router.post('/counters/reset/:id', requireManager, csrfProtection, async (req, r
   try {
     await resetCounterCurrentValue(parsedId);
   } catch (err) {
-    if (isCounterNotFoundError(err)) {
+    if (err instanceof CounterNotFoundError) {
       return res.status(404).render('error', { message: 'Counter not found.', user: req.session.user ?? null });
     }
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -13,6 +13,7 @@ import adminRouter from './routes/admin';
 import apiRouter from './routes/api';
 import streamsRouter from './routes/streams';
 import commandsRouter from './routes/commands';
+import countersRouter from './routes/counters';
 import { requireAuth } from './middleware';
 
 const app = express();
@@ -80,6 +81,7 @@ app.use('/api', requireAuth, apiRouter);
 app.use('/admin', requireAuth, adminRouter);
 app.use('/admin', requireAuth, streamsRouter);
 app.use('/admin', requireAuth, commandsRouter);
+app.use('/admin', requireAuth, countersRouter);
 app.use('/', requireAuth, dashboardRouter);
 
 // 404 handler

--- a/views/counters.ejs
+++ b/views/counters.ejs
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BCUK Bot — Counters</title>
+  <link rel="stylesheet" href="/style.css">
+  <%- include('partials/pwa-head') %>
+</head>
+<body>
+  <%- include('partials/nav') %>
+
+  <main class="container">
+    <section class="section">
+      <h2 class="section-title">Counters</h2>
+
+      <% if (error) { %>
+      <div class="card card-alert-danger" role="alert" aria-live="assertive" aria-atomic="true">
+        <span class="text-danger">&#9888; Operation failed: <%= error.replace(/_/g, ' ') %></span>
+      </div>
+      <% } %>
+
+      <% if (reset) { %>
+      <div class="card card-alert-success" role="status" aria-live="polite" aria-atomic="true">
+        <span class="text-success">&#10003; Counter value reset to 0.</span>
+      </div>
+      <% } %>
+
+      <div class="card card-spaced">
+        <div class="card-header">
+          <span class="card-icon">🧮</span>
+          <span class="card-label">Management Only</span>
+        </div>
+        <div class="card-body card-body-muted">
+          This page manages counter definitions and current values. Runtime counter execution and yearly scheduler wiring are not enabled yet.
+        </div>
+      </div>
+
+      <div class="card card-spaced">
+        <div class="card-header"><span class="card-icon">➕</span><span class="card-label">Add Counter</span></div>
+        <div class="card-body">
+          <form method="POST" action="/admin/counters/add">
+            <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+            <div class="form-row-wrap form-section-gap">
+              <div class="form-col-grow">
+                <label for="trigger_command" class="form-label">Trigger Command</label>
+                <input id="trigger_command" class="input full-width" type="text" name="trigger_command" placeholder="e.g. !deaths" required>
+              </div>
+              <div class="form-col-grow">
+                <label for="check_command" class="form-label">Check Command</label>
+                <input id="check_command" class="input full-width" type="text" name="check_command" placeholder="e.g. !deathscheck" required>
+              </div>
+              <label class="input checkbox-input-label">
+                <input type="checkbox" name="reset_yearly"> Reset yearly at Jan 1
+              </label>
+            </div>
+            <div class="form-section-gap">
+              <label for="message" class="form-label">Check Message</label>
+              <p class="hint hint-compact">Shown when check command is used. Use <strong>%d</strong> for current value.</p>
+              <textarea id="message" class="input stream-textarea" name="message" rows="2" placeholder="Current deaths: %d" required></textarea>
+            </div>
+            <div class="form-section-gap">
+              <label for="increment_message" class="form-label">Increment Message</label>
+              <p class="hint hint-compact">Shown when trigger command increments. Use <strong>%d</strong> for new value.</p>
+              <textarea id="increment_message" class="input stream-textarea" name="increment_message" rows="2" placeholder="Deaths increased to %d" required></textarea>
+            </div>
+            <button type="submit" class="btn">Add Counter</button>
+          </form>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="table-scroll">
+          <table class="table" aria-label="Counters">
+            <thead>
+              <tr>
+                <th scope="col">Trigger</th>
+                <th scope="col">Check</th>
+                <th scope="col">Current</th>
+                <th scope="col">Reset Yearly</th>
+                <th scope="col">Check Message</th>
+                <th scope="col">Increment Message</th>
+                <th scope="col">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% counters.forEach(function(counter) { %>
+              <tr class="sfx-row">
+                <td class="mono"><strong><%= counter.trigger_command %></strong></td>
+                <td class="mono"><%= counter.check_command %></td>
+                <td><span class="badge badge-active"><%= counter.current_value %></span></td>
+                <td><span class="badge <%= counter.reset_yearly ? 'badge-active' : 'badge-offline' %>"><%= counter.reset_yearly ? 'Yes' : 'No' %></span></td>
+                <td class="command-output-cell"><%= counter.message %></td>
+                <td class="command-output-cell"><%= counter.increment_message %></td>
+                <td>
+                  <div class="actions">
+                    <button type="button" class="btn btn-sm btn-ghost btn-toggle-counter-edit" data-counter-id="<%= counter.id %>" aria-controls="counter-edit-<%= counter.id %>" aria-expanded="false">✏️ Edit</button>
+                    <form method="POST" action="/admin/counters/reset/<%= counter.id %>" class="inline-form-sm js-confirm-reset-counter" data-counter-trigger="<%= counter.trigger_command %>">
+                      <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                      <button type="submit" class="btn btn-sm">Reset</button>
+                    </form>
+                    <form method="POST" action="/admin/counters/remove" class="inline-form-sm js-confirm-remove-counter" data-counter-trigger="<%= counter.trigger_command %>">
+                      <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                      <input type="hidden" name="id" value="<%= counter.id %>">
+                      <button type="submit" class="btn btn-danger btn-sm">Remove</button>
+                    </form>
+                  </div>
+                </td>
+              </tr>
+              <tr class="files-row is-hidden" id="counter-edit-<%= counter.id %>">
+                <td colspan="7">
+                  <div class="command-edit-panel">
+                    <form method="POST" action="/admin/counters/update" class="stack-gap-md">
+                      <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                      <input type="hidden" name="id" value="<%= counter.id %>">
+                      <div class="form-row-wrap form-section-gap">
+                        <div class="form-col-grow">
+                          <label for="trigger_command_<%= counter.id %>" class="form-label">Trigger Command</label>
+                          <input id="trigger_command_<%= counter.id %>" class="input full-width" type="text" name="trigger_command" value="<%= counter.trigger_command %>" required>
+                        </div>
+                        <div class="form-col-grow">
+                          <label for="check_command_<%= counter.id %>" class="form-label">Check Command</label>
+                          <input id="check_command_<%= counter.id %>" class="input full-width" type="text" name="check_command" value="<%= counter.check_command %>" required>
+                        </div>
+                        <label class="input checkbox-input-label">
+                          <input type="checkbox" name="reset_yearly" <%= counter.reset_yearly ? 'checked' : '' %>> Reset yearly at Jan 1
+                        </label>
+                      </div>
+                      <div class="form-section-gap">
+                        <label for="message_<%= counter.id %>" class="form-label">Check Message</label>
+                        <textarea id="message_<%= counter.id %>" class="input stream-textarea" name="message" rows="2" required><%= counter.message %></textarea>
+                      </div>
+                      <div class="form-section-gap">
+                        <label for="increment_message_<%= counter.id %>" class="form-label">Increment Message</label>
+                        <textarea id="increment_message_<%= counter.id %>" class="input stream-textarea" name="increment_message" rows="2" required><%= counter.increment_message %></textarea>
+                      </div>
+                      <div class="button-row-wrap">
+                        <button type="submit" class="btn">Save Changes</button>
+                        <button type="button" class="btn btn-ghost btn-toggle-counter-edit" data-counter-id="<%= counter.id %>">Cancel</button>
+                      </div>
+                    </form>
+                  </div>
+                </td>
+              </tr>
+              <% }) %>
+              <% if (counters.length === 0) { %>
+              <tr>
+                <td colspan="7" class="empty-msg">No counters configured yet.</td>
+              </tr>
+              <% } %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <%- include('partials/pwa-register') %>
+  <script src="/counters.js"></script>
+</body>
+</html>

--- a/views/counters.ejs
+++ b/views/counters.ejs
@@ -76,7 +76,7 @@
               <tr>
                 <th scope="col">Trigger</th>
                 <th scope="col">Check</th>
-                <th scope="col">Current</th>
+                <th scope="col" class="counter-value-cell">Current</th>
                 <th scope="col">Reset Yearly</th>
                 <th scope="col">Check Message</th>
                 <th scope="col">Increment Message</th>
@@ -88,7 +88,7 @@
               <tr class="sfx-row">
                 <td class="mono"><strong><%= counter.trigger_command %></strong></td>
                 <td class="mono"><%= counter.check_command %></td>
-                <td><span class="badge badge-active"><%= counter.current_value %></span></td>
+                <td class="counter-value-cell"><span class="counter-value-badge"><%= counter.current_value %></span></td>
                 <td><span class="badge <%= counter.reset_yearly ? 'badge-active' : 'badge-offline' %>"><%= counter.reset_yearly ? 'Yes' : 'No' %></span></td>
                 <td class="command-output-cell"><%= counter.message %></td>
                 <td class="command-output-cell"><%= counter.increment_message %></td>

--- a/views/partials/nav.ejs
+++ b/views/partials/nav.ejs
@@ -7,6 +7,7 @@
       <% if (user && user.accessLevel >= 2) { %>
       <a href="/admin/users" class="nav-item">Users</a>
       <a href="/admin/commands" class="nav-item">Commands</a>
+      <a href="/admin/counters" class="nav-item">Counters</a>
       <a href="/admin/streams" class="nav-item">Streams</a>
       <% } %>
     </div>


### PR DESCRIPTION
## Summary
- add manager-facing counters admin panel (CRUD + manual reset)
- wire counters routes into web server and nav
- add counter DB helpers/types
- update docs in copilot instructions and database schema
## Scope
- panel/admin functionality only
- no runtime bot execution wiring in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin "Counters" page: add, edit, delete counters; manual reset of current value; inline edit toggles and confirmation dialogs.
  * Admin "Custom Commands" pages: add, edit, remove commands and assign/unassign users.
  * Manager role updated to access new admin routes; admin nav shows "Counters".
  * Client-side script for counters UI added; service worker now precaches it.

* **Documentation**
  * Database schema updated with counter table specification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->