### PR TITLE
Suppress false-positive Twitch trigger collision logs

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -583,12 +583,12 @@ function pickPreferredTwitchCandidate(
   existingCandidate: TwitchCommandCandidate,
   nextCandidate: TwitchCommandCandidate,
 ): TwitchCommandCandidate {
-  if (nextCandidate.priority !== existingCandidate.priority) {
-    return nextCandidate.priority > existingCandidate.priority ? nextCandidate : existingCandidate;
-  }
-
   if (nextCandidate.command.command_id === existingCandidate.command.command_id) {
     return existingCandidate;
+  }
+
+  if (nextCandidate.priority !== existingCandidate.priority) {
+    return nextCandidate.priority > existingCandidate.priority ? nextCandidate : existingCandidate;
   }
 
   return nextCandidate.command.command_id < existingCandidate.command.command_id
@@ -629,6 +629,10 @@ function registerTwitchCandidate(
 
   const preferredCandidate = pickPreferredTwitchCandidate(existingCandidate, candidate);
   if (preferredCandidate === existingCandidate) {
+    if (existingCandidate.command.command_id === candidate.command.command_id) {
+      return;
+    }
+
     console.warn(
       `[DB] Custom command Twitch trigger collision: '${triggerString}' in channel '${channelName}' already maps to command_id=${existingCandidate.command.command_id} (${existingCandidate.source}:${existingCandidate.owner}); ignoring command_id=${candidate.command.command_id} (${candidate.source}:${candidate.owner}).`,
     );


### PR DESCRIPTION
## Summary
This PR removes noisy false-positive Twitch custom command collision logs emitted during cache build when the same command is registered from both `multi_twitch` and assigned-user sources.

## What changed
- Updated candidate preference logic to short-circuit when both candidates have the same `command_id`.
- Updated collision logging to return silently for same-command duplicates instead of warning/remap logs.
- Kept existing warning behavior for real collisions across different command IDs.

## Validation
- `npm run build` (tsc) passes successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined command conflict resolution to accurately detect and handle identical command entries, preventing unnecessary collision remapping and ensuring consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->