### PR TITLE
feat: custom command runtime (shadow mode, Block A)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,8 @@ DB_USER=root
 GLOBAL_COOLDOWN_MS=3000
 # Path to the folder containing .mp3/.wav sound files
 SFX_FOLDER=./sfx
+# Set to 'true' to enable live Twitch/Discord replies for custom commands (default: false = shadow/monitor mode)
+# CUSTOM_COMMANDS_LIVE_REPLIES=false
 
 # Web panel
 # Random secret string for signing session cookies — MUST be changed to a long random value

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,6 +211,7 @@ Copy `.env.example` → `.env` and fill in all values.
 | `DISCORD_CALLBACK_URL`  | ✅ | e.g. `http://localhost:3000/auth/discord/callback` |
 | `TWITCH_CLIENT_ID`      | ✅ | Twitch app Client ID — for stream monitoring (separate from chat bot) |
 | `TWITCH_CLIENT_SECRET`  | ✅ | Twitch app Client Secret — for stream monitoring |
+| `CUSTOM_COMMANDS_LIVE_REPLIES` | ❌ | Default: `false`. When `false`, custom command matches are recorded for monitoring but no reply is sent (shadow mode). Set to `true` to enable live replies. |
 
 ---
 
@@ -335,7 +336,11 @@ Any CRUD change to groups or streamers via the web panel calls `restartTwitchMon
 Local file (`monitor-settings.json` at `process.cwd()`) persists one value: `twitchMonitorEnabled` (boolean, default `true` if file missing). It is **gitignored**. Read/write via `src/monitorSettings.ts` helpers only.
 
 ### Custom commands and counters are panel-first
-`/admin/commands` and `/admin/counters` currently provide management CRUD in the web panel. Runtime execution wiring in Twitch/Discord message handlers and counter yearly scheduler logic may be implemented separately from panel work.
+`/admin/commands` and `/admin/counters` currently provide management CRUD in the web panel.
+
+**Custom command runtime** is implemented in `src/customCommandHandler.ts`. Commands are matched and recorded for monitoring on both Twitch and Discord. Live replies are gated behind `CUSTOM_COMMANDS_LIVE_REPLIES` (default `false` — shadow mode). Multi-Twitch broadcast (shared-chat dedup via Helix) is wired and ready.
+
+**Counter runtime** is not yet implemented. The counter path in `src/customCommandHandler.ts` returns a preview response with `(preview only — counter not incremented)` and does not mutate `current_value`. Counter increment logic and the yearly reset scheduler remain to be implemented.
 
 ---
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,3 +52,6 @@ if (SESSION_SECRET === '__REQUIRED_GENERATE_LONG_RANDOM_SECRET__') {
 export const DISCORD_CLIENT_ID = require_env('DISCORD_CLIENT_ID');
 export const DISCORD_CLIENT_SECRET = require_env('DISCORD_CLIENT_SECRET');
 export const DISCORD_CALLBACK_URL = require_env('DISCORD_CALLBACK_URL');
+
+// Default false (shadow mode). Set to 'true' only when ready to send live replies.
+export const CUSTOM_COMMANDS_LIVE_REPLIES = process.env.CUSTOM_COMMANDS_LIVE_REPLIES === 'true';

--- a/src/customCommandHandler.ts
+++ b/src/customCommandHandler.ts
@@ -209,9 +209,13 @@ export async function executeCustomCommandForTwitch(
 
   if (willSend && runtime) {
     if (result.isMultiTwitch) {
-      const sent = await broadcastToActiveChannels(channel, command, result.response);
-      if (sent) {
-        console.log(`[Twitch] Sent ${label} '${command}' in ${channel} (recorded for monitoring).`);
+      try {
+        const sent = await broadcastToActiveChannels(channel, command, result.response);
+        if (sent) {
+          console.log(`[Twitch] Sent ${label} '${command}' in ${channel} (recorded for monitoring).`);
+        }
+      } catch (err) {
+        console.error(`[Twitch] Failed to broadcast ${label} '${command}' in ${channel}:`, err);
       }
     } else {
       try {

--- a/src/customCommandHandler.ts
+++ b/src/customCommandHandler.ts
@@ -213,6 +213,8 @@ export async function executeCustomCommandForTwitch(
         const sent = await broadcastToActiveChannels(channel, command, result.response);
         if (sent) {
           console.log(`[Twitch] Sent ${label} '${command}' in ${channel} (recorded for monitoring).`);
+        } else {
+          console.log(`[Twitch] Broadcast ${label} '${command}' in ${channel} reached no channels (recorded for monitoring).`);
         }
       } catch (err) {
         console.error(`[Twitch] Failed to broadcast ${label} '${command}' in ${channel}:`, err);

--- a/src/customCommandHandler.ts
+++ b/src/customCommandHandler.ts
@@ -1,113 +1,179 @@
+import type { Message } from 'discord.js';
+import { CUSTOM_COMMANDS_LIVE_REPLIES } from './config';
 import { findCounterByCommand, getCustomCommandForDiscord, getCustomCommandForTwitchChannel } from './db';
 import { recordCommandTestEntry } from './commandMonitorStore';
+import { getSharedChatSession } from './twitchApi';
 
-type PreviewLookupResult = {
-  response: string;
-  logType: 'custom-command' | 'counter-command' | 'counter-check';
-};
+// ─── Twitch runtime (registered from index.ts before startTwitchBot) ─────────
+//
+// Avoids a circular import: twitchBot.ts → customCommandHandler.ts → twitchBot.ts.
+// index.ts wires the concrete implementations once both modules are loaded.
 
-function extractCommand(rawMessage: string): string | null {
-  const trimmedMessage = rawMessage.trim();
-  if (!trimmedMessage) return null;
-
-  const command = trimmedMessage.split(/\s+/)[0]?.toLowerCase();
-  if (!command) return null;
-
-  return command;
+interface TwitchChatRuntime {
+  send: (channel: string, message: string) => Promise<void>;
+  getActiveChannels: () => ReadonlySet<string>;
+  getLoginUserIds: () => ReadonlyMap<string, string>;
 }
 
-function formatCounterPreviewMessage(template: string, value: number): string {
+let _twitchRuntime: TwitchChatRuntime | null = null;
+
+export function registerTwitchChatRuntime(runtime: TwitchChatRuntime): void {
+  _twitchRuntime = runtime;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function extractCommand(rawMessage: string): string | null {
+  const trimmed = rawMessage.trim();
+  if (!trimmed) return null;
+  return trimmed.split(/\s+/)[0]?.toLowerCase() ?? null;
+}
+
+function formatCounterMessage(template: string, value: number): string {
   return template.replace(/%d/g, String(value));
 }
 
-function buildCounterTriggerPreviewResponse(currentValue: number, incrementMessage: string): string {
-  const incrementPreview = formatCounterPreviewMessage(incrementMessage, currentValue);
-  return `${incrementPreview} (preview only — counter not incremented)`;
+// ─── Lookup ───────────────────────────────────────────────────────────────────
+
+type LogType = 'custom-command' | 'counter-command' | 'counter-check';
+
+interface LookupResult {
+  response: string;
+  logType: LogType;
+  isMultiTwitch: boolean;
 }
 
-async function findPreviewLookupResult(
+async function lookupCommand(
   command: string,
-  lookupCustomCommand: (command: string) => Promise<{ output: string } | null>,
-): Promise<PreviewLookupResult | null> {
-  const customCommand = await lookupCustomCommand(command);
+  findCustomCommand: (cmd: string) => Promise<{ output: string; is_multi_twitch: boolean } | null>,
+): Promise<LookupResult | null> {
+  const customCommand = await findCustomCommand(command);
   if (customCommand) {
     return {
       response: customCommand.output,
       logType: 'custom-command',
+      isMultiTwitch: customCommand.is_multi_twitch,
     };
   }
 
   const counter = await findCounterByCommand(command);
   if (counter) {
+    const isTrigger = counter.matchType === 'trigger';
     return {
-      response: counter.matchType === 'trigger'
-        ? buildCounterTriggerPreviewResponse(counter.current_value, counter.increment_message)
-        : formatCounterPreviewMessage(counter.message, counter.current_value),
-      logType: counter.matchType === 'trigger' ? 'counter-command' : 'counter-check',
+      response: isTrigger
+        ? `${formatCounterMessage(counter.increment_message, counter.current_value)} (preview only — counter not incremented)`
+        : formatCounterMessage(counter.message, counter.current_value),
+      logType: isTrigger ? 'counter-command' : 'counter-check',
+      isMultiTwitch: false,
     };
   }
 
   return null;
 }
 
-async function previewCustomCommand(
-  rawMessage: string,
-  source: 'discord' | 'twitch',
-  channel: string | null,
-  username: string | null | undefined,
-  lookupCommand: (command: string) => Promise<{ output: string } | null>,
-  buildLogMessage: (command: string, logType: PreviewLookupResult['logType']) => string,
+// ─── Multi-twitch broadcast ───────────────────────────────────────────────────
+
+async function resolveSharedChatSessionId(broadcasterId: string): Promise<string | null> {
+  try {
+    const session = await getSharedChatSession(broadcasterId);
+    return session?.session_id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function broadcastToActiveChannels(sourceChannel: string, output: string): Promise<void> {
+  if (!_twitchRuntime) return;
+
+  const { send, getActiveChannels, getLoginUserIds } = _twitchRuntime;
+  const activeChannels = getActiveChannels();
+  const loginUserIds = getLoginUserIds();
+  const repliedSessionIds = new Set<string>();
+
+  // Build ordered list: source channel first, then the rest
+  const targets = [sourceChannel, ...Array.from(activeChannels).filter((ch) => ch !== sourceChannel)];
+
+  for (const channel of targets) {
+    const userId = loginUserIds.get(channel);
+    if (userId) {
+      const sessionId = await resolveSharedChatSessionId(userId);
+      if (sessionId) {
+        if (repliedSessionIds.has(sessionId)) continue;
+        repliedSessionIds.add(sessionId);
+      }
+    }
+
+    try {
+      await send(channel, output);
+    } catch (err) {
+      console.error(`[CustomCmd] Failed to send to ${channel}:`, err);
+    }
+  }
+}
+
+// ─── Execute functions ────────────────────────────────────────────────────────
+
+export async function executeCustomCommandForDiscord(
+  message: Message,
+  username?: string | null,
 ): Promise<void> {
-  const command = extractCommand(rawMessage);
+  const command = extractCommand(message.content);
   if (!command) return;
 
-  const matchedEntry = await findPreviewLookupResult(command, lookupCommand);
-  if (!matchedEntry) return;
+  const result = await lookupCommand(command, getCustomCommandForDiscord);
+  if (!result) return;
 
   recordCommandTestEntry({
-    source,
+    source: 'discord',
     command,
-    response: matchedEntry.response,
-    channel,
+    response: result.response,
+    channel: null,
     user: username ?? null,
   });
 
-  console.log(buildLogMessage(command, matchedEntry.logType));
+  const label = result.logType === 'counter-check'
+    ? 'counter check'
+    : result.logType === 'counter-command'
+      ? 'counter command'
+      : 'custom command';
+  console.log(`[Discord] Preview ${label} '${command}' matched (recorded for monitoring).`);
+
+  if (CUSTOM_COMMANDS_LIVE_REPLIES) {
+    await message.reply(result.response);
+  }
 }
 
-export async function previewCustomCommandForDiscord(
-  rawMessage: string,
-  username?: string | null,
-): Promise<void> {
-  await previewCustomCommand(
-    rawMessage,
-    'discord',
-    null,
-    username,
-    getCustomCommandForDiscord,
-    (command, logType) => logType === 'counter-check'
-      ? `[Discord] Preview counter check '${command}' matched (recorded for monitoring).`
-      : logType === 'counter-command'
-        ? `[Discord] Preview counter command '${command}' matched (recorded for monitoring).`
-        : `[Discord] Preview custom command '${command}' matched (recorded for monitoring).`,
-  );
-}
-
-export async function previewCustomCommandForTwitch(
+export async function executeCustomCommandForTwitch(
   channel: string,
   rawMessage: string,
   username?: string | null,
 ): Promise<void> {
-  await previewCustomCommand(
-    rawMessage,
-    'twitch',
+  const command = extractCommand(rawMessage);
+  if (!command) return;
+
+  const result = await lookupCommand(command, (cmd) => getCustomCommandForTwitchChannel(channel, cmd));
+  if (!result) return;
+
+  recordCommandTestEntry({
+    source: 'twitch',
+    command,
+    response: result.response,
     channel,
-    username,
-    (command) => getCustomCommandForTwitchChannel(channel, command),
-    (command, logType) => logType === 'counter-check'
-      ? `[Twitch] Preview counter check '${command}' matched in ${channel} (recorded for monitoring).`
-      : logType === 'counter-command'
-        ? `[Twitch] Preview counter command '${command}' matched in ${channel} (recorded for monitoring).`
-        : `[Twitch] Preview custom command '${command}' matched in ${channel} (recorded for monitoring).`,
-  );
+    user: username ?? null,
+  });
+
+  const label = result.logType === 'counter-check'
+    ? 'counter check'
+    : result.logType === 'counter-command'
+      ? 'counter command'
+      : 'custom command';
+  console.log(`[Twitch] Preview ${label} '${command}' matched in ${channel} (recorded for monitoring).`);
+
+  if (CUSTOM_COMMANDS_LIVE_REPLIES && _twitchRuntime) {
+    if (result.isMultiTwitch) {
+      await broadcastToActiveChannels(channel, result.response);
+    } else {
+      await _twitchRuntime.send(channel, result.response);
+    }
+  }
 }

--- a/src/customCommandHandler.ts
+++ b/src/customCommandHandler.ts
@@ -163,7 +163,11 @@ export async function executeCustomCommandForDiscord(
   console.log(`[Discord] ${willSend ? 'Sent' : 'Preview'} ${label} '${command}' (recorded for monitoring).`);
 
   if (willSend) {
-    await message.reply(result.response);
+    try {
+      await message.reply(result.response);
+    } catch (err) {
+      console.error(`[Discord] Failed to reply to message ${message.id} for command '${command}':`, err);
+    }
   }
 }
 

--- a/src/customCommandHandler.ts
+++ b/src/customCommandHandler.ts
@@ -119,7 +119,7 @@ async function broadcastToActiveChannels(sourceChannel: string, command: string,
   const targets = candidates.filter((_, i) => registrationResults[i] !== null);
 
   // Pre-resolve all session IDs in parallel to avoid serial Helix calls per channel
-  const userIds = targets.map((ch) => loginUserIds.get(ch)).filter((id): id is string => id !== undefined);
+  const userIds = [...new Set(targets.map((ch) => loginUserIds.get(ch)).filter((id): id is string => id !== undefined))];
   const resolvedIds = await Promise.all(userIds.map((uid) => resolveSharedChatSessionId(uid)));
   const sessionIdByUserId = new Map(userIds.map((uid, i) => [uid, resolvedIds[i]]));
 

--- a/src/customCommandHandler.ts
+++ b/src/customCommandHandler.ts
@@ -160,14 +160,16 @@ export async function executeCustomCommandForDiscord(
     : result.logType === 'counter-command'
       ? 'counter command'
       : 'custom command';
-  console.log(`[Discord] ${willSend ? 'Sent' : 'Preview'} ${label} '${command}' (recorded for monitoring).`);
 
   if (willSend) {
     try {
       await message.reply(result.response);
+      console.log(`[Discord] Sent ${label} '${command}' (recorded for monitoring).`);
     } catch (err) {
       console.error(`[Discord] Failed to reply to message ${message.id} for command '${command}':`, err);
     }
+  } else {
+    console.log(`[Discord] Preview ${label} '${command}' (recorded for monitoring).`);
   }
 }
 
@@ -197,13 +199,19 @@ export async function executeCustomCommandForTwitch(
     : result.logType === 'counter-command'
       ? 'counter command'
       : 'custom command';
-  console.log(`[Twitch] ${willSend ? 'Sent' : 'Preview'} ${label} '${command}' in ${channel} (recorded for monitoring).`);
 
   if (willSend && runtime) {
-    if (result.isMultiTwitch) {
-      await broadcastToActiveChannels(channel, result.response);
-    } else {
-      await runtime.send(channel, result.response);
+    try {
+      if (result.isMultiTwitch) {
+        await broadcastToActiveChannels(channel, result.response);
+      } else {
+        await runtime.send(channel, result.response);
+      }
+      console.log(`[Twitch] Sent ${label} '${command}' in ${channel} (recorded for monitoring).`);
+    } catch (err) {
+      console.error(`[Twitch] Failed to send ${label} '${command}' in ${channel}:`, err);
     }
+  } else {
+    console.log(`[Twitch] Preview ${label} '${command}' in ${channel} (recorded for monitoring).`);
   }
 }

--- a/src/customCommandHandler.ts
+++ b/src/customCommandHandler.ts
@@ -121,16 +121,13 @@ async function broadcastToActiveChannels(sourceChannel: string, output: string):
 
   for (const channel of targets) {
     const userId = loginUserIds.get(channel);
-    if (userId) {
-      const sessionId = sessionIdByUserId.get(userId) ?? null;
-      if (sessionId) {
-        if (repliedSessionIds.has(sessionId)) continue;
-        repliedSessionIds.add(sessionId);
-      }
-    }
+    const sessionId = userId ? (sessionIdByUserId.get(userId) ?? null) : null;
+
+    if (sessionId && repliedSessionIds.has(sessionId)) continue;
 
     try {
       await send(channel, output);
+      if (sessionId) repliedSessionIds.add(sessionId);
     } catch (err) {
       console.error(`[CustomCmd] Failed to send to ${channel}:`, err);
     }
@@ -189,7 +186,8 @@ export async function executeCustomCommandForTwitch(
     user: username ?? null,
   });
 
-  const willSend = CUSTOM_COMMANDS_LIVE_REPLIES && result.logType === 'custom-command';
+  const runtime = _twitchRuntime;
+  const willSend = CUSTOM_COMMANDS_LIVE_REPLIES && !!runtime && result.logType === 'custom-command';
   const label = result.logType === 'counter-check'
     ? 'counter check'
     : result.logType === 'counter-command'
@@ -197,11 +195,11 @@ export async function executeCustomCommandForTwitch(
       : 'custom command';
   console.log(`[Twitch] ${willSend ? 'Sent' : 'Preview'} ${label} '${command}' in ${channel} (recorded for monitoring).`);
 
-  if (willSend && _twitchRuntime) {
+  if (willSend && runtime) {
     if (result.isMultiTwitch) {
       await broadcastToActiveChannels(channel, result.response);
     } else {
-      await _twitchRuntime.send(channel, result.response);
+      await runtime.send(channel, result.response);
     }
   }
 }

--- a/src/customCommandHandler.ts
+++ b/src/customCommandHandler.ts
@@ -103,7 +103,7 @@ async function resolveSharedChatSessionId(userId: string): Promise<string | null
   }
 }
 
-async function broadcastToActiveChannels(sourceChannel: string, output: string): Promise<void> {
+async function broadcastToActiveChannels(sourceChannel: string, command: string, output: string): Promise<void> {
   if (!_twitchRuntime) return;
 
   const { send, getActiveChannels, getLoginUserIds } = _twitchRuntime;
@@ -112,7 +112,11 @@ async function broadcastToActiveChannels(sourceChannel: string, output: string):
   const repliedSessionIds = new Set<string>();
 
   // Build ordered list: source channel first, then the rest
-  const targets = [sourceChannel, ...Array.from(activeChannels).filter((ch) => ch !== sourceChannel)];
+  const candidates = [sourceChannel, ...Array.from(activeChannels).filter((ch) => ch !== sourceChannel)];
+
+  // Only send to channels where the command is registered (in-memory cache lookup)
+  const registrationResults = await Promise.all(candidates.map((ch) => getCustomCommandForTwitchChannel(ch, command)));
+  const targets = candidates.filter((_, i) => registrationResults[i] !== null);
 
   // Pre-resolve all session IDs in parallel to avoid serial Helix calls per channel
   const userIds = targets.map((ch) => loginUserIds.get(ch)).filter((id): id is string => id !== undefined);
@@ -203,7 +207,7 @@ export async function executeCustomCommandForTwitch(
   if (willSend && runtime) {
     try {
       if (result.isMultiTwitch) {
-        await broadcastToActiveChannels(channel, result.response);
+        await broadcastToActiveChannels(channel, command, result.response);
       } else {
         await runtime.send(channel, result.response);
       }

--- a/src/customCommandHandler.ts
+++ b/src/customCommandHandler.ts
@@ -103,8 +103,8 @@ async function resolveSharedChatSessionId(userId: string): Promise<string | null
   }
 }
 
-async function broadcastToActiveChannels(sourceChannel: string, command: string, output: string): Promise<void> {
-  if (!_twitchRuntime) return;
+async function broadcastToActiveChannels(sourceChannel: string, command: string, output: string): Promise<boolean> {
+  if (!_twitchRuntime) return false;
 
   const { send, getActiveChannels, getLoginUserIds } = _twitchRuntime;
   const activeChannels = getActiveChannels();
@@ -123,6 +123,7 @@ async function broadcastToActiveChannels(sourceChannel: string, command: string,
   const resolvedIds = await Promise.all(userIds.map((uid) => resolveSharedChatSessionId(uid)));
   const sessionIdByUserId = new Map(userIds.map((uid, i) => [uid, resolvedIds[i]]));
 
+  let anySent = false;
   for (const channel of targets) {
     const userId = loginUserIds.get(channel);
     const sessionId = userId ? (sessionIdByUserId.get(userId) ?? null) : null;
@@ -132,10 +133,12 @@ async function broadcastToActiveChannels(sourceChannel: string, command: string,
     try {
       await send(channel, output);
       if (sessionId) repliedSessionIds.add(sessionId);
+      anySent = true;
     } catch (err) {
       console.error(`[CustomCmd] Failed to send to ${channel}:`, err);
     }
   }
+  return anySent;
 }
 
 // ─── Execute functions ────────────────────────────────────────────────────────
@@ -205,15 +208,18 @@ export async function executeCustomCommandForTwitch(
       : 'custom command';
 
   if (willSend && runtime) {
-    try {
-      if (result.isMultiTwitch) {
-        await broadcastToActiveChannels(channel, command, result.response);
-      } else {
-        await runtime.send(channel, result.response);
+    if (result.isMultiTwitch) {
+      const sent = await broadcastToActiveChannels(channel, command, result.response);
+      if (sent) {
+        console.log(`[Twitch] Sent ${label} '${command}' in ${channel} (recorded for monitoring).`);
       }
-      console.log(`[Twitch] Sent ${label} '${command}' in ${channel} (recorded for monitoring).`);
-    } catch (err) {
-      console.error(`[Twitch] Failed to send ${label} '${command}' in ${channel}:`, err);
+    } else {
+      try {
+        await runtime.send(channel, result.response);
+        console.log(`[Twitch] Sent ${label} '${command}' in ${channel} (recorded for monitoring).`);
+      } catch (err) {
+        console.error(`[Twitch] Failed to send ${label} '${command}' in ${channel}:`, err);
+      }
     }
   } else {
     console.log(`[Twitch] Preview ${label} '${command}' in ${channel} (recorded for monitoring).`);

--- a/src/customCommandHandler.ts
+++ b/src/customCommandHandler.ts
@@ -73,10 +73,31 @@ async function lookupCommand(
 
 // ─── Multi-twitch broadcast ───────────────────────────────────────────────────
 
-async function resolveSharedChatSessionId(broadcasterId: string): Promise<string | null> {
+interface SessionCacheEntry {
+  sessionId: string | null;
+  expiry: number;
+}
+const SESSION_CACHE_TTL_MS = 30_000;
+const sessionCache = new Map<string, SessionCacheEntry>();
+
+async function resolveSharedChatSessionId(userId: string): Promise<string | null> {
+  const now = Date.now();
+  const cached = sessionCache.get(userId);
+
+  if (cached) {
+    if (now < cached.expiry) return cached.sessionId;
+    // Stale: serve cached value and refresh in background
+    getSharedChatSession(userId)
+      .then((s) => { sessionCache.set(userId, { sessionId: s?.session_id ?? null, expiry: Date.now() + SESSION_CACHE_TTL_MS }); })
+      .catch(() => { sessionCache.delete(userId); });
+    return cached.sessionId;
+  }
+
   try {
-    const session = await getSharedChatSession(broadcasterId);
-    return session?.session_id ?? null;
+    const session = await getSharedChatSession(userId);
+    const sessionId = session?.session_id ?? null;
+    sessionCache.set(userId, { sessionId, expiry: now + SESSION_CACHE_TTL_MS });
+    return sessionId;
   } catch {
     return null;
   }
@@ -93,10 +114,15 @@ async function broadcastToActiveChannels(sourceChannel: string, output: string):
   // Build ordered list: source channel first, then the rest
   const targets = [sourceChannel, ...Array.from(activeChannels).filter((ch) => ch !== sourceChannel)];
 
+  // Pre-resolve all session IDs in parallel to avoid serial Helix calls per channel
+  const userIds = targets.map((ch) => loginUserIds.get(ch)).filter((id): id is string => id !== undefined);
+  const resolvedIds = await Promise.all(userIds.map((uid) => resolveSharedChatSessionId(uid)));
+  const sessionIdByUserId = new Map(userIds.map((uid, i) => [uid, resolvedIds[i]]));
+
   for (const channel of targets) {
     const userId = loginUserIds.get(channel);
     if (userId) {
-      const sessionId = await resolveSharedChatSessionId(userId);
+      const sessionId = sessionIdByUserId.get(userId) ?? null;
       if (sessionId) {
         if (repliedSessionIds.has(sessionId)) continue;
         repliedSessionIds.add(sessionId);
@@ -131,14 +157,15 @@ export async function executeCustomCommandForDiscord(
     user: username ?? null,
   });
 
+  const willSend = CUSTOM_COMMANDS_LIVE_REPLIES && result.logType === 'custom-command';
   const label = result.logType === 'counter-check'
     ? 'counter check'
     : result.logType === 'counter-command'
       ? 'counter command'
       : 'custom command';
-  console.log(`[Discord] Preview ${label} '${command}' matched (recorded for monitoring).`);
+  console.log(`[Discord] ${willSend ? 'Sent' : 'Preview'} ${label} '${command}' (recorded for monitoring).`);
 
-  if (CUSTOM_COMMANDS_LIVE_REPLIES) {
+  if (willSend) {
     await message.reply(result.response);
   }
 }
@@ -162,14 +189,15 @@ export async function executeCustomCommandForTwitch(
     user: username ?? null,
   });
 
+  const willSend = CUSTOM_COMMANDS_LIVE_REPLIES && result.logType === 'custom-command';
   const label = result.logType === 'counter-check'
     ? 'counter check'
     : result.logType === 'counter-command'
       ? 'counter command'
       : 'custom command';
-  console.log(`[Twitch] Preview ${label} '${command}' matched in ${channel} (recorded for monitoring).`);
+  console.log(`[Twitch] ${willSend ? 'Sent' : 'Preview'} ${label} '${command}' in ${channel} (recorded for monitoring).`);
 
-  if (CUSTOM_COMMANDS_LIVE_REPLIES && _twitchRuntime) {
+  if (willSend && _twitchRuntime) {
     if (result.isMultiTwitch) {
       await broadcastToActiveChannels(channel, result.response);
     } else {

--- a/src/customCommandHandler.ts
+++ b/src/customCommandHandler.ts
@@ -106,6 +106,7 @@ async function resolveSharedChatSessionId(userId: string): Promise<string | null
     sessionCache.set(userId, { sessionId, expiry: now + SESSION_CACHE_TTL_MS });
     return sessionId;
   } catch {
+    sessionCache.set(userId, { sessionId: null, expiry: now + SHORT_RETRY_TTL_MS });
     return null;
   }
 }

--- a/src/customCommandHandler.ts
+++ b/src/customCommandHandler.ts
@@ -78,7 +78,9 @@ interface SessionCacheEntry {
   expiry: number;
 }
 const SESSION_CACHE_TTL_MS = 30_000;
+const SHORT_RETRY_TTL_MS = 5_000;
 const sessionCache = new Map<string, SessionCacheEntry>();
+const inFlightRefreshes = new Map<string, Promise<void>>();
 
 async function resolveSharedChatSessionId(userId: string): Promise<string | null> {
   const now = Date.now();
@@ -86,10 +88,15 @@ async function resolveSharedChatSessionId(userId: string): Promise<string | null
 
   if (cached) {
     if (now < cached.expiry) return cached.sessionId;
-    // Stale: serve cached value and refresh in background
-    getSharedChatSession(userId)
-      .then((s) => { sessionCache.set(userId, { sessionId: s?.session_id ?? null, expiry: Date.now() + SESSION_CACHE_TTL_MS }); })
-      .catch(() => { sessionCache.delete(userId); });
+    // Stale: serve cached value and trigger a single background refresh
+    if (!inFlightRefreshes.has(userId)) {
+      const lastKnown = cached.sessionId;
+      const refresh = getSharedChatSession(userId)
+        .then((s) => { sessionCache.set(userId, { sessionId: s?.session_id ?? null, expiry: Date.now() + SESSION_CACHE_TTL_MS }); })
+        .catch(() => { sessionCache.set(userId, { sessionId: lastKnown, expiry: Date.now() + SHORT_RETRY_TTL_MS }); })
+        .finally(() => { inFlightRefreshes.delete(userId); });
+      inFlightRefreshes.set(userId, refresh);
+    }
     return cached.sessionId;
   }
 

--- a/src/discordBot.ts
+++ b/src/discordBot.ts
@@ -2,7 +2,7 @@ import { Client, GatewayIntentBits, Guild } from 'discord.js';
 import { DISCORD_TOKEN, DISCORD_GUILD_ID } from './config';
 import { connect } from './audioPlayer';
 import { handleCommand } from './commandRouter';
-import { previewCustomCommandForDiscord } from './customCommandHandler';
+import { executeCustomCommandForDiscord } from './customCommandHandler';
 import { setDiscordReady } from './statusStore';
 
 let client: Client;
@@ -70,8 +70,8 @@ export function startDiscordBot(): void {
     if (message.author.bot) return;
     if (message.guildId !== DISCORD_GUILD_ID) return;
 
-    previewCustomCommandForDiscord(message.content, message.member?.displayName ?? message.author.username).catch((err) =>
-      console.error('[Discord] Custom command preview error:', err),
+    executeCustomCommandForDiscord(message, message.member?.displayName ?? message.author.username).catch((err) =>
+      console.error('[Discord] Custom command error:', err),
     );
 
     handleCommand(message.content, 'discord').catch((err) =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,12 @@
 import 'mediaplex'; // Must be imported first to register as Opus provider
 import { getPool, closePool } from './db';
-import { startTwitchBot } from './twitchBot';
+import { startTwitchBot, sayInChannel, getActiveChannels } from './twitchBot';
 import { startDiscordBot } from './discordBot';
 import { startTikTokBot } from './tiktokBot';
-import { startTwitchMonitor, stopTwitchMonitor } from './twitchMonitor';
+import { startTwitchMonitor, stopTwitchMonitor, getMonitoredLoginUserIds } from './twitchMonitor';
 import { startWebPanel } from './web/server';
 import { disconnect } from './audioPlayer';
+import { registerTwitchChatRuntime } from './customCommandHandler';
 
 async function shutdown(signal: string): Promise<void> {
   console.log(`[Bot] ${signal} received — disconnecting from voice and shutting down.`);
@@ -32,6 +33,14 @@ async function main(): Promise<void> {
     console.error('[Bot] Cannot connect to database:', err);
     process.exit(1);
   }
+
+  // Wire Twitch send/channel helpers before the bot connects so the first
+  // message can already use the execute path (functions capture live state).
+  registerTwitchChatRuntime({
+    send: sayInChannel,
+    getActiveChannels,
+    getLoginUserIds: getMonitoredLoginUserIds,
+  });
 
   startDiscordBot();
   await startTwitchBot();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 import 'mediaplex'; // Must be imported first to register as Opus provider
 import { getPool, closePool } from './db';
-import { startTwitchBot, sayInChannel, getActiveChannels } from './twitchBot';
+import { startTwitchBot, sayInChannel, getActiveChannels, getActiveChannelUserIds } from './twitchBot';
 import { startDiscordBot } from './discordBot';
 import { startTikTokBot } from './tiktokBot';
-import { startTwitchMonitor, stopTwitchMonitor, getMonitoredLoginUserIds } from './twitchMonitor';
+import { startTwitchMonitor, stopTwitchMonitor } from './twitchMonitor';
 import { startWebPanel } from './web/server';
 import { disconnect } from './audioPlayer';
 import { registerTwitchChatRuntime } from './customCommandHandler';
@@ -39,7 +39,7 @@ async function main(): Promise<void> {
   registerTwitchChatRuntime({
     send: sayInChannel,
     getActiveChannels,
-    getLoginUserIds: getMonitoredLoginUserIds,
+    getLoginUserIds: getActiveChannelUserIds,
   });
 
   startDiscordBot();

--- a/src/twitchApi.ts
+++ b/src/twitchApi.ts
@@ -107,4 +107,38 @@ export async function getStreams(userIds: string[]): Promise<TwitchStream[]> {
   return results;
 }
 
+export interface SharedChatParticipant {
+  broadcaster_id: string;
+  broadcaster_login: string;
+  broadcaster_name: string;
+}
 
+export interface SharedChatSession {
+  session_id: string;
+  host_broadcaster_id: string;
+  host_broadcaster_login: string;
+  host_broadcaster_name: string;
+  participants: SharedChatParticipant[];
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * Returns the active shared chat session for a broadcaster, or null if none exists.
+ * A 403 response is treated as null — app tokens may lack the required channel scope
+ * for some broadcasters; the caller falls back to no dedup in that case.
+ */
+export async function getSharedChatSession(broadcasterId: string): Promise<SharedChatSession | null> {
+  const token = await getAppToken();
+  const res = await twitchFetch(
+    `https://api.twitch.tv/helix/shared_chat/session?broadcaster_id=${encodeURIComponent(broadcasterId)}`,
+    { headers: authHeaders(token) },
+  );
+  if (res.status === 404 || res.status === 403) return null;
+  if (!res.ok) {
+    if (res.status === 401) { cachedAppToken = null; appTokenExpiry = 0; }
+    throw new Error(`[TwitchAPI] getSharedChatSession failed: ${res.status}`);
+  }
+  const data = await res.json() as { data: SharedChatSession[] };
+  return data.data[0] ?? null;
+}

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -214,6 +214,9 @@ export async function joinTwitchChannel(channel: string): Promise<void> {
       // it once the Twitch client is available again.
       activeChannels.add(normalized);
       setTwitchChannel(normalized, false);
+      getUsers([normalized])
+        .then(([u]) => { if (u) activeChannelUserIds.set(normalized, u.id); })
+        .catch(() => { /* best-effort */ });
       return;
     }
 
@@ -222,6 +225,9 @@ export async function joinTwitchChannel(channel: string): Promise<void> {
       setTwitchChannel(normalized, false);
       await client.join(normalized);
       setTwitchChannel(normalized, true);
+      getUsers([normalized])
+        .then(([u]) => { if (u) activeChannelUserIds.set(normalized, u.id); })
+        .catch(() => { /* best-effort */ });
     } catch (err) {
       // Keep the desired membership queued so reconnect reconciliation can retry
       // instead of permanently desyncing runtime state from the DB.
@@ -258,12 +264,14 @@ export async function partTwitchChannel(channel: string): Promise<void> {
       // We remove local state immediately and let reconcileJoinedChannels() part
       // any stale tmi.js channel memberships on the next successful connect.
       activeChannels.delete(normalized);
+      activeChannelUserIds.delete(normalized);
       setTwitchChannel(normalized, false);
       return;
     }
 
     try {
       activeChannels.delete(normalized);
+      activeChannelUserIds.delete(normalized);
       setTwitchChannel(normalized, false);
       if (isChannelJoined(normalized)) {
         await client.part(normalized);

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -1,7 +1,7 @@
 import tmi from 'tmi.js';
 import { TWITCH_USERNAME, TWITCH_OAUTH_TOKEN } from './config';
 import { handleCommand } from './commandRouter';
-import { previewCustomCommandForTwitch } from './customCommandHandler';
+import { executeCustomCommandForTwitch } from './customCommandHandler';
 import { setTwitchChannel } from './statusStore';
 import { getTwitchEnabledChannels } from './db';
 import { normalizeTwitchChannelName } from './twitchChannelName';
@@ -149,8 +149,8 @@ export async function startTwitchBot(): Promise<void> {
     // its source channel.
     if (tags['source-room-id'] && tags['source-room-id'] !== tags['room-id']) return;
 
-    previewCustomCommandForTwitch(normalizedChannel, message, tags['display-name'] ?? tags.username ?? null).catch((err) =>
-      console.error('[Twitch] Custom command preview error:', err),
+    executeCustomCommandForTwitch(normalizedChannel, message, tags['display-name'] ?? tags.username ?? null).catch((err) =>
+      console.error('[Twitch] Custom command error:', err),
     );
 
     handleCommand(message, 'twitch').catch((err) =>
@@ -219,6 +219,17 @@ export async function joinTwitchChannel(channel: string): Promise<void> {
       throw err;
     }
   });
+}
+
+export async function sayInChannel(channel: string, message: string): Promise<void> {
+  const normalized = normalizeChannel(channel);
+  if (!normalized) throw new Error(`[Twitch] Invalid channel name: ${channel}`);
+  if (!client || !connected) throw new Error(`[Twitch] Cannot send message — not connected`);
+  await client.say(normalized, message);
+}
+
+export function getActiveChannels(): ReadonlySet<string> {
+  return activeChannels;
 }
 
 export async function partTwitchChannel(channel: string): Promise<void> {

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -5,10 +5,12 @@ import { executeCustomCommandForTwitch } from './customCommandHandler';
 import { setTwitchChannel } from './statusStore';
 import { getTwitchEnabledChannels } from './db';
 import { normalizeTwitchChannelName } from './twitchChannelName';
+import { getUsers } from './twitchApi';
 
 let client: tmi.Client | null = null;
 let connected = false;
 const activeChannels = new Set<string>();
+const activeChannelUserIds = new Map<string, string>();
 const membershipMutationQueues = new Map<string, Promise<void>>();
 
 function normalizeChannel(channel: string): string | null {
@@ -123,6 +125,15 @@ export async function startTwitchBot(): Promise<void> {
     console.warn('[Twitch] No enabled Twitch channels found in DB; connecting with no joined channels.');
   }
 
+  if (activeChannels.size > 0) {
+    try {
+      const users = await getUsers([...activeChannels]);
+      for (const u of users) activeChannelUserIds.set(u.login.toLowerCase(), u.id);
+    } catch (err) {
+      console.error('[Twitch] Failed to resolve channel user IDs (shared-chat dedup unavailable):', err);
+    }
+  }
+
   client = new tmi.Client({
     identity: {
       username: TWITCH_USERNAME,
@@ -230,6 +241,10 @@ export async function sayInChannel(channel: string, message: string): Promise<vo
 
 export function getActiveChannels(): ReadonlySet<string> {
   return activeChannels;
+}
+
+export function getActiveChannelUserIds(): ReadonlyMap<string, string> {
+  return activeChannelUserIds;
 }
 
 export async function partTwitchChannel(channel: string): Promise<void> {

--- a/src/twitchMonitor.ts
+++ b/src/twitchMonitor.ts
@@ -647,6 +647,13 @@ export async function restartTwitchMonitor(): Promise<void> {
   await startTwitchMonitor();
 }
 
+// ─── Broadcaster ID lookup (for shared chat dedup) ───────────────────────────
+
+/** Returns the login → Twitch user ID map populated at monitor startup. */
+export function getMonitoredLoginUserIds(): ReadonlyMap<string, string> {
+  return loginToUserId;
+}
+
 // ─── Live state snapshot (for web panel) ─────────────────────────────────────
 
 export interface LiveStateSnapshot {

--- a/src/twitchMonitor.ts
+++ b/src/twitchMonitor.ts
@@ -647,13 +647,6 @@ export async function restartTwitchMonitor(): Promise<void> {
   await startTwitchMonitor();
 }
 
-// ─── Broadcaster ID lookup (for shared chat dedup) ───────────────────────────
-
-/** Returns the login → Twitch user ID map populated at monitor startup. */
-export function getMonitoredLoginUserIds(): ReadonlyMap<string, string> {
-  return loginToUserId;
-}
-
 // ─── Live state snapshot (for web panel) ─────────────────────────────────────
 
 export interface LiveStateSnapshot {


### PR DESCRIPTION
Wires the execute path for custom commands and counters — all traffic is matched and logged to the command monitor, but live replies remain off by default behind CUSTOM_COMMANDS_LIVE_REPLIES (set to 'true' to enable).

- config.ts / .env.example: CUSTOM_COMMANDS_LIVE_REPLIES flag (default false)
- twitchApi.ts: getSharedChatSession() for outgoing shared-chat dedup
- twitchMonitor.ts: getMonitoredLoginUserIds() exposes login→userId map
- twitchBot.ts: sayInChannel() / getActiveChannels() exports; call site updated
- discordBot.ts: call site updated to executeCustomCommandForDiscord(message)
- customCommandHandler.ts: registerTwitchChatRuntime() breaks circular import; executeCustomCommandForDiscord / executeCustomCommandForTwitch replace preview functions; multi-twitch broadcast with per-channel shared-chat dedup
- index.ts: registers Twitch runtime before startTwitchBot()

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/battle-cattle/bcuk-bot-4/pull/52" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toggle live vs shadow custom-command replies via CUSTOM_COMMANDS_LIVE_REPLIES (default: shadow/monitor).
  * Twitch multi-channel broadcasting with de-duplication across shared chat sessions; Discord replies now sent when enabled with improved error logging.
  * Custom-command matches always recorded for monitoring; counter-trigger responses remain preview-only and do not increment counters.

* **Documentation**
  * Docs updated to explain the env setting, live vs shadow behavior, and preview-only counter semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->