### PR TITLE
feat: counter runtime + yearly scheduler (Block B shadow mode, PR2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,8 +36,10 @@ DB_USER=root
 GLOBAL_COOLDOWN_MS=3000
 # Path to the folder containing .mp3/.wav sound files
 SFX_FOLDER=./sfx
-# Set to 'true' to enable live Twitch/Discord replies for custom commands (default: false = shadow/monitor mode)
+# Set to 'true' to enable live Twitch/Discord replies for custom commands and counters (default: false = shadow/monitor mode)
 # CUSTOM_COMMANDS_LIVE_REPLIES=false
+# Set to 'true' to enable live counter increments on trigger commands (default: false = shadow/monitor mode)
+# COUNTER_LIVE_WRITES=false
 
 # Web panel
 # Random secret string for signing session cookies — MUST be changed to a long random value

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,8 @@ BCUK_Bot_4/
 │   ├── twitchMonitor.ts      — Polling-based stream monitor + Discord announcements
 │   ├── monitorSettings.ts    — Read/write monitor-settings.json (toggle only)
 │   ├── twitchChannelName.ts   — Twitch channel-name normalization helper
+│   ├── counterHandler.ts     — Counter command execution (increment/check, shadow mode)
+│   ├── counterScheduler.ts   — Yearly Jan 1 archive-and-reset scheduler
 │   ├── types/
 │   │   └── express.d.ts      — Augments express-session SessionData
 │   └── web/
@@ -211,7 +213,8 @@ Copy `.env.example` → `.env` and fill in all values.
 | `DISCORD_CALLBACK_URL`  | ✅ | e.g. `http://localhost:3000/auth/discord/callback` |
 | `TWITCH_CLIENT_ID`      | ✅ | Twitch app Client ID — for stream monitoring (separate from chat bot) |
 | `TWITCH_CLIENT_SECRET`  | ✅ | Twitch app Client Secret — for stream monitoring |
-| `CUSTOM_COMMANDS_LIVE_REPLIES` | ❌ | Default: `false`. When `false`, custom command matches are recorded for monitoring but no reply is sent (shadow mode). Set to `true` to enable live replies. |
+| `CUSTOM_COMMANDS_LIVE_REPLIES` | ❌ | Default: `false`. When `false`, custom command and counter matches are recorded for monitoring but no reply is sent (shadow mode). Set to `true` to enable live replies. |
+| `COUNTER_LIVE_WRITES` | ❌ | Default: `false`. When `false`, counter trigger commands are matched and logged but `current_value` is not incremented (shadow mode). Set to `true` to enable live increments. |
 
 ---
 
@@ -340,7 +343,9 @@ Local file (`monitor-settings.json` at `process.cwd()`) persists one value: `twi
 
 **Custom command runtime** is implemented in `src/customCommandHandler.ts`. Commands are matched and recorded for monitoring on both Twitch and Discord. Live replies are gated behind `CUSTOM_COMMANDS_LIVE_REPLIES` (default `false` — shadow mode). Multi-Twitch broadcast (shared-chat dedup via Helix) is wired and ready.
 
-**Counter runtime** is not yet implemented. The counter path in `src/customCommandHandler.ts` returns a preview response with `(preview only — counter not incremented)` and does not mutate `current_value`. Counter increment logic and the yearly reset scheduler remain to be implemented.
+**Counter runtime** is implemented in `src/counterHandler.ts`. Counter trigger commands increment `current_value` when `COUNTER_LIVE_WRITES=true`; counter check commands read the current value without writing. Both trigger and check replies are gated behind `CUSTOM_COMMANDS_LIVE_REPLIES`. In shadow mode, trigger commands log `(preview only — counter not incremented)` to the command monitor but do not mutate the DB.
+
+**Counter yearly scheduler** (`src/counterScheduler.ts`) runs once per year at midnight Jan 1. For all counters with `reset_yearly=true` it copies `current_value` to the `value{YYYY}` archive column (e.g. `value2024`) and resets `current_value` to 0. The `value{YYYY}` column must exist in the DB before the scheduler runs — add it manually each year (see DATABASE-SCHEMA.md).
 
 ---
 

--- a/src/commandUtils.ts
+++ b/src/commandUtils.ts
@@ -1,0 +1,5 @@
+export function extractCommand(rawMessage: string): string | null {
+  const trimmed = rawMessage.trim();
+  if (!trimmed) return null;
+  return trimmed.split(/\s+/)[0]?.toLowerCase() ?? null;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -55,3 +55,6 @@ export const DISCORD_CALLBACK_URL = require_env('DISCORD_CALLBACK_URL');
 
 // Default false (shadow mode). Set to 'true' only when ready to send live replies.
 export const CUSTOM_COMMANDS_LIVE_REPLIES = process.env.CUSTOM_COMMANDS_LIVE_REPLIES === 'true';
+
+// Default false (shadow mode). Set to 'true' only when ready to write live counter increments.
+export const COUNTER_LIVE_WRITES = process.env.COUNTER_LIVE_WRITES === 'true';

--- a/src/counterHandler.ts
+++ b/src/counterHandler.ts
@@ -2,6 +2,7 @@ import type { Message } from 'discord.js';
 import { CUSTOM_COMMANDS_LIVE_REPLIES, COUNTER_LIVE_WRITES } from './config';
 import { findCounterByCommand, incrementCounter } from './db';
 import { recordCommandTestEntry } from './commandMonitorStore';
+import { extractCommand } from './commandUtils';
 
 // ─── Twitch runtime (registered from index.ts before startTwitchBot) ─────────
 //
@@ -20,14 +21,48 @@ export function registerCounterTwitchRuntime(runtime: TwitchSendRuntime): void {
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function extractCommand(rawMessage: string): string | null {
-  const trimmed = rawMessage.trim();
-  if (!trimmed) return null;
-  return trimmed.split(/\s+/)[0]?.toLowerCase() ?? null;
-}
-
 function formatCounterMessage(template: string, value: number): string {
   return template.replace(/%d/g, String(value));
+}
+
+interface CounterResult {
+  response: string;
+  monitorResponse: string;
+  label: string;
+}
+
+async function _buildCounterResponse(
+  command: string,
+  errorPrefix: string,
+): Promise<CounterResult | null> {
+  const counter = await findCounterByCommand(command);
+  if (!counter) return null;
+
+  const isTrigger = counter.matchType === 'trigger';
+  const label = isTrigger ? 'counter command' : 'counter check';
+
+  let displayValue = counter.current_value;
+  let didIncrement = false;
+
+  if (isTrigger && COUNTER_LIVE_WRITES) {
+    try {
+      displayValue = await incrementCounter(counter.id);
+      didIncrement = true;
+    } catch (err) {
+      console.error(`${errorPrefix} Failed to increment counter ${counter.id} for command '${command}':`, err);
+      return null;
+    }
+  }
+
+  const response = isTrigger
+    ? formatCounterMessage(counter.increment_message, displayValue)
+    : formatCounterMessage(counter.message, displayValue);
+
+  const monitorResponse = isTrigger && !didIncrement
+    ? `${response} (preview only — counter not incremented)`
+    : response;
+
+  return { response, monitorResponse, label };
 }
 
 // ─── Execute functions ────────────────────────────────────────────────────────
@@ -39,50 +74,26 @@ export async function executeCounterCommandForDiscord(
   const command = extractCommand(message.content);
   if (!command) return;
 
-  const counter = await findCounterByCommand(command);
-  if (!counter) return;
-
-  const isTrigger = counter.matchType === 'trigger';
-  const label = isTrigger ? 'counter command' : 'counter check';
-
-  let displayValue = counter.current_value;
-  let didIncrement = false;
-
-  if (isTrigger && COUNTER_LIVE_WRITES) {
-    try {
-      displayValue = await incrementCounter(counter.id);
-      didIncrement = true;
-    } catch (err) {
-      console.error(`[Discord] Failed to increment counter ${counter.id} for command '${command}':`, err);
-      return;
-    }
-  }
-
-  const response = isTrigger
-    ? formatCounterMessage(counter.increment_message, displayValue)
-    : formatCounterMessage(counter.message, displayValue);
-
-  const monitorResponse = isTrigger && !didIncrement
-    ? `${response} (preview only — counter not incremented)`
-    : response;
+  const result = await _buildCounterResponse(command, '[Discord]');
+  if (!result) return;
 
   recordCommandTestEntry({
     source: 'discord',
     command,
-    response: monitorResponse,
+    response: result.monitorResponse,
     channel: null,
     user: username ?? null,
   });
 
   if (CUSTOM_COMMANDS_LIVE_REPLIES) {
     try {
-      await message.reply(response);
-      console.log(`[Discord] Sent ${label} '${command}' (recorded for monitoring).`);
+      await message.reply(result.response);
+      console.log(`[Discord] Sent ${result.label} '${command}' (recorded for monitoring).`);
     } catch (err) {
-      console.error(`[Discord] Failed to reply to message ${message.id} for ${label} '${command}':`, err);
+      console.error(`[Discord] Failed to reply to message ${message.id} for ${result.label} '${command}':`, err);
     }
   } else {
-    console.log(`[Discord] Preview ${label} '${command}' (recorded for monitoring).`);
+    console.log(`[Discord] Preview ${result.label} '${command}' (recorded for monitoring).`);
   }
 }
 
@@ -94,37 +105,13 @@ export async function executeCounterCommandForTwitch(
   const command = extractCommand(rawMessage);
   if (!command) return;
 
-  const counter = await findCounterByCommand(command);
-  if (!counter) return;
-
-  const isTrigger = counter.matchType === 'trigger';
-  const label = isTrigger ? 'counter command' : 'counter check';
-
-  let displayValue = counter.current_value;
-  let didIncrement = false;
-
-  if (isTrigger && COUNTER_LIVE_WRITES) {
-    try {
-      displayValue = await incrementCounter(counter.id);
-      didIncrement = true;
-    } catch (err) {
-      console.error(`[Twitch] Failed to increment counter ${counter.id} for command '${command}' in ${channel}:`, err);
-      return;
-    }
-  }
-
-  const response = isTrigger
-    ? formatCounterMessage(counter.increment_message, displayValue)
-    : formatCounterMessage(counter.message, displayValue);
-
-  const monitorResponse = isTrigger && !didIncrement
-    ? `${response} (preview only — counter not incremented)`
-    : response;
+  const result = await _buildCounterResponse(command, `[Twitch:${channel}]`);
+  if (!result) return;
 
   recordCommandTestEntry({
     source: 'twitch',
     command,
-    response: monitorResponse,
+    response: result.monitorResponse,
     channel,
     user: username ?? null,
   });
@@ -132,12 +119,12 @@ export async function executeCounterCommandForTwitch(
   const runtime = _twitchRuntime;
   if (CUSTOM_COMMANDS_LIVE_REPLIES && runtime) {
     try {
-      await runtime.send(channel, response);
-      console.log(`[Twitch] Sent ${label} '${command}' in ${channel} (recorded for monitoring).`);
+      await runtime.send(channel, result.response);
+      console.log(`[Twitch] Sent ${result.label} '${command}' in ${channel} (recorded for monitoring).`);
     } catch (err) {
-      console.error(`[Twitch] Failed to send ${label} '${command}' in ${channel}:`, err);
+      console.error(`[Twitch] Failed to send ${result.label} '${command}' in ${channel}:`, err);
     }
   } else {
-    console.log(`[Twitch] Preview ${label} '${command}' in ${channel} (recorded for monitoring).`);
+    console.log(`[Twitch] Preview ${result.label} '${command}' in ${channel} (recorded for monitoring).`);
   }
 }

--- a/src/counterHandler.ts
+++ b/src/counterHandler.ts
@@ -29,6 +29,7 @@ interface CounterResult {
   response: string;
   monitorResponse: string;
   label: string;
+  canReply: boolean;
 }
 
 async function _buildCounterResponse(
@@ -50,7 +51,13 @@ async function _buildCounterResponse(
       didIncrement = true;
     } catch (err) {
       console.error(`${errorPrefix} Failed to increment counter ${counter.id} for command '${command}':`, err);
-      return null;
+      const response = formatCounterMessage(counter.increment_message, displayValue);
+      return {
+        response,
+        monitorResponse: `${response} (write error — counter not incremented)`,
+        label,
+        canReply: false,
+      };
     }
   }
 
@@ -62,7 +69,7 @@ async function _buildCounterResponse(
     ? `${response} (preview only — counter not incremented)`
     : response;
 
-  return { response, monitorResponse, label };
+  return { response, monitorResponse, label, canReply: true };
 }
 
 // ─── Execute functions ────────────────────────────────────────────────────────
@@ -84,6 +91,8 @@ export async function executeCounterCommandForDiscord(
     channel: null,
     user: username ?? null,
   });
+
+  if (!result.canReply) return;
 
   if (CUSTOM_COMMANDS_LIVE_REPLIES) {
     try {
@@ -115,6 +124,8 @@ export async function executeCounterCommandForTwitch(
     channel,
     user: username ?? null,
   });
+
+  if (!result.canReply) return;
 
   const runtime = _twitchRuntime;
   if (CUSTOM_COMMANDS_LIVE_REPLIES && runtime) {

--- a/src/counterHandler.ts
+++ b/src/counterHandler.ts
@@ -1,0 +1,143 @@
+import type { Message } from 'discord.js';
+import { CUSTOM_COMMANDS_LIVE_REPLIES, COUNTER_LIVE_WRITES } from './config';
+import { findCounterByCommand, incrementCounter } from './db';
+import { recordCommandTestEntry } from './commandMonitorStore';
+
+// ─── Twitch runtime (registered from index.ts before startTwitchBot) ─────────
+//
+// Same pattern as customCommandHandler.ts to avoid a circular import between
+// twitchBot.ts and counterHandler.ts.
+
+interface TwitchSendRuntime {
+  send: (channel: string, message: string) => Promise<void>;
+}
+
+let _twitchRuntime: TwitchSendRuntime | null = null;
+
+export function registerCounterTwitchRuntime(runtime: TwitchSendRuntime): void {
+  _twitchRuntime = runtime;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function extractCommand(rawMessage: string): string | null {
+  const trimmed = rawMessage.trim();
+  if (!trimmed) return null;
+  return trimmed.split(/\s+/)[0]?.toLowerCase() ?? null;
+}
+
+function formatCounterMessage(template: string, value: number): string {
+  return template.replace(/%d/g, String(value));
+}
+
+// ─── Execute functions ────────────────────────────────────────────────────────
+
+export async function executeCounterCommandForDiscord(
+  message: Message,
+  username?: string | null,
+): Promise<void> {
+  const command = extractCommand(message.content);
+  if (!command) return;
+
+  const counter = await findCounterByCommand(command);
+  if (!counter) return;
+
+  const isTrigger = counter.matchType === 'trigger';
+  const label = isTrigger ? 'counter command' : 'counter check';
+
+  let displayValue = counter.current_value;
+  let didIncrement = false;
+
+  if (isTrigger && COUNTER_LIVE_WRITES) {
+    try {
+      displayValue = await incrementCounter(counter.id);
+      didIncrement = true;
+    } catch (err) {
+      console.error(`[Discord] Failed to increment counter ${counter.id} for command '${command}':`, err);
+      return;
+    }
+  }
+
+  const response = isTrigger
+    ? formatCounterMessage(counter.increment_message, displayValue)
+    : formatCounterMessage(counter.message, displayValue);
+
+  const monitorResponse = isTrigger && !didIncrement
+    ? `${response} (preview only — counter not incremented)`
+    : response;
+
+  recordCommandTestEntry({
+    source: 'discord',
+    command,
+    response: monitorResponse,
+    channel: null,
+    user: username ?? null,
+  });
+
+  if (CUSTOM_COMMANDS_LIVE_REPLIES) {
+    try {
+      await message.reply(response);
+      console.log(`[Discord] Sent ${label} '${command}' (recorded for monitoring).`);
+    } catch (err) {
+      console.error(`[Discord] Failed to reply to message ${message.id} for ${label} '${command}':`, err);
+    }
+  } else {
+    console.log(`[Discord] Preview ${label} '${command}' (recorded for monitoring).`);
+  }
+}
+
+export async function executeCounterCommandForTwitch(
+  channel: string,
+  rawMessage: string,
+  username?: string | null,
+): Promise<void> {
+  const command = extractCommand(rawMessage);
+  if (!command) return;
+
+  const counter = await findCounterByCommand(command);
+  if (!counter) return;
+
+  const isTrigger = counter.matchType === 'trigger';
+  const label = isTrigger ? 'counter command' : 'counter check';
+
+  let displayValue = counter.current_value;
+  let didIncrement = false;
+
+  if (isTrigger && COUNTER_LIVE_WRITES) {
+    try {
+      displayValue = await incrementCounter(counter.id);
+      didIncrement = true;
+    } catch (err) {
+      console.error(`[Twitch] Failed to increment counter ${counter.id} for command '${command}' in ${channel}:`, err);
+      return;
+    }
+  }
+
+  const response = isTrigger
+    ? formatCounterMessage(counter.increment_message, displayValue)
+    : formatCounterMessage(counter.message, displayValue);
+
+  const monitorResponse = isTrigger && !didIncrement
+    ? `${response} (preview only — counter not incremented)`
+    : response;
+
+  recordCommandTestEntry({
+    source: 'twitch',
+    command,
+    response: monitorResponse,
+    channel,
+    user: username ?? null,
+  });
+
+  const runtime = _twitchRuntime;
+  if (CUSTOM_COMMANDS_LIVE_REPLIES && runtime) {
+    try {
+      await runtime.send(channel, response);
+      console.log(`[Twitch] Sent ${label} '${command}' in ${channel} (recorded for monitoring).`);
+    } catch (err) {
+      console.error(`[Twitch] Failed to send ${label} '${command}' in ${channel}:`, err);
+    }
+  } else {
+    console.log(`[Twitch] Preview ${label} '${command}' in ${channel} (recorded for monitoring).`);
+  }
+}

--- a/src/counterScheduler.ts
+++ b/src/counterScheduler.ts
@@ -1,0 +1,41 @@
+import { archiveAndResetYearlyCounters } from './db';
+
+let schedulerTimer: ReturnType<typeof setTimeout> | null = null;
+
+function msUntilNextJan1(): number {
+  const now = new Date();
+  const nextJan1 = new Date(now.getFullYear() + 1, 0, 1, 0, 0, 0, 0);
+  return nextJan1.getTime() - now.getTime();
+}
+
+async function runYearlyArchive(): Promise<void> {
+  // Archive the year that just ended (scheduler fires on Jan 1 of the new year)
+  const year = new Date().getFullYear() - 1;
+  try {
+    const count = await archiveAndResetYearlyCounters(year);
+    console.log(`[CounterScheduler] Archived and reset ${count} counter(s) for year ${year}.`);
+  } catch (err) {
+    console.error(`[CounterScheduler] Failed to archive counters for year ${year}:`, err);
+  }
+  scheduleNextArchive();
+}
+
+function scheduleNextArchive(): void {
+  const delay = msUntilNextJan1();
+  schedulerTimer = setTimeout(() => {
+    runYearlyArchive().catch((err) => console.error('[CounterScheduler] Unhandled error:', err));
+  }, delay);
+}
+
+export function startCounterScheduler(): void {
+  scheduleNextArchive();
+  const hoursUntil = Math.round(msUntilNextJan1() / 3_600_000);
+  console.log(`[CounterScheduler] Started — next yearly archive in ~${hoursUntil}h.`);
+}
+
+export function stopCounterScheduler(): void {
+  if (schedulerTimer !== null) {
+    clearTimeout(schedulerTimer);
+    schedulerTimer = null;
+  }
+}

--- a/src/counterScheduler.ts
+++ b/src/counterScheduler.ts
@@ -1,36 +1,37 @@
 import { archiveAndResetYearlyCounters } from './db';
 
+// Node.js clamps setTimeout delays longer than 2^31-1 ms (~24.8 days) to 1 ms,
+// so a single year-long timeout would fire immediately. Poll hourly instead.
+const POLL_INTERVAL_MS = 3_600_000;
+
 let schedulerTimer: ReturnType<typeof setTimeout> | null = null;
+let lastArchivedYear: number | null = null;
 
-function msUntilNextJan1(): number {
+async function tick(): Promise<void> {
   const now = new Date();
-  const nextJan1 = new Date(now.getFullYear() + 1, 0, 1, 0, 0, 0, 0);
-  return nextJan1.getTime() - now.getTime();
-}
+  const prevYear = now.getFullYear() - 1;
 
-async function runYearlyArchive(): Promise<void> {
-  // Archive the year that just ended (scheduler fires on Jan 1 of the new year)
-  const year = new Date().getFullYear() - 1;
-  try {
-    const count = await archiveAndResetYearlyCounters(year);
-    console.log(`[CounterScheduler] Archived and reset ${count} counter(s) for year ${year}.`);
-  } catch (err) {
-    console.error(`[CounterScheduler] Failed to archive counters for year ${year}:`, err);
+  if (now.getMonth() === 0 && now.getDate() === 1 && lastArchivedYear !== prevYear) {
+    try {
+      const count = await archiveAndResetYearlyCounters(prevYear);
+      console.log(`[CounterScheduler] Archived and reset ${count} counter(s) for year ${prevYear}.`);
+      lastArchivedYear = prevYear;
+    } catch (err) {
+      console.error(`[CounterScheduler] Failed to archive counters for year ${prevYear}:`, err);
+      // lastArchivedYear is not set on failure, so the next hourly poll will retry.
+    }
   }
-  scheduleNextArchive();
-}
 
-function scheduleNextArchive(): void {
-  const delay = msUntilNextJan1();
-  schedulerTimer = setTimeout(() => {
-    runYearlyArchive().catch((err) => console.error('[CounterScheduler] Unhandled error:', err));
-  }, delay);
+  schedulerTimer = setTimeout(
+    () => tick().catch((err) => console.error('[CounterScheduler] Unhandled error:', err)),
+    POLL_INTERVAL_MS,
+  );
 }
 
 export function startCounterScheduler(): void {
-  scheduleNextArchive();
+  tick().catch((err) => console.error('[CounterScheduler] Startup error:', err));
   const hoursUntil = Math.round(msUntilNextJan1() / 3_600_000);
-  console.log(`[CounterScheduler] Started — next yearly archive in ~${hoursUntil}h.`);
+  console.log(`[CounterScheduler] Started — polling hourly, next yearly archive in ~${hoursUntil}h.`);
 }
 
 export function stopCounterScheduler(): void {
@@ -38,4 +39,10 @@ export function stopCounterScheduler(): void {
     clearTimeout(schedulerTimer);
     schedulerTimer = null;
   }
+}
+
+function msUntilNextJan1(): number {
+  const now = new Date();
+  const nextJan1 = new Date(now.getFullYear() + 1, 0, 1, 0, 0, 0, 0);
+  return nextJan1.getTime() - now.getTime();
 }

--- a/src/customCommandHandler.ts
+++ b/src/customCommandHandler.ts
@@ -1,6 +1,6 @@
 import type { Message } from 'discord.js';
 import { CUSTOM_COMMANDS_LIVE_REPLIES } from './config';
-import { findCounterByCommand, getCustomCommandForDiscord, getCustomCommandForTwitchChannel } from './db';
+import { getCustomCommandForDiscord, getCustomCommandForTwitchChannel } from './db';
 import { recordCommandTestEntry } from './commandMonitorStore';
 import { getSharedChatSession } from './twitchApi';
 
@@ -29,17 +29,10 @@ function extractCommand(rawMessage: string): string | null {
   return trimmed.split(/\s+/)[0]?.toLowerCase() ?? null;
 }
 
-function formatCounterMessage(template: string, value: number): string {
-  return template.replace(/%d/g, String(value));
-}
-
 // ─── Lookup ───────────────────────────────────────────────────────────────────
-
-type LogType = 'custom-command' | 'counter-command' | 'counter-check';
 
 interface LookupResult {
   response: string;
-  logType: LogType;
   isMultiTwitch: boolean;
 }
 
@@ -51,23 +44,9 @@ async function lookupCommand(
   if (customCommand) {
     return {
       response: customCommand.output,
-      logType: 'custom-command',
       isMultiTwitch: customCommand.is_multi_twitch,
     };
   }
-
-  const counter = await findCounterByCommand(command);
-  if (counter) {
-    const isTrigger = counter.matchType === 'trigger';
-    return {
-      response: isTrigger
-        ? `${formatCounterMessage(counter.increment_message, counter.current_value)} (preview only — counter not incremented)`
-        : formatCounterMessage(counter.message, counter.current_value),
-      logType: isTrigger ? 'counter-command' : 'counter-check',
-      isMultiTwitch: false,
-    };
-  }
-
   return null;
 }
 
@@ -169,22 +148,15 @@ export async function executeCustomCommandForDiscord(
     user: username ?? null,
   });
 
-  const willSend = CUSTOM_COMMANDS_LIVE_REPLIES && result.logType === 'custom-command';
-  const label = result.logType === 'counter-check'
-    ? 'counter check'
-    : result.logType === 'counter-command'
-      ? 'counter command'
-      : 'custom command';
-
-  if (willSend) {
+  if (CUSTOM_COMMANDS_LIVE_REPLIES) {
     try {
       await message.reply(result.response);
-      console.log(`[Discord] Sent ${label} '${command}' (recorded for monitoring).`);
+      console.log(`[Discord] Sent custom command '${command}' (recorded for monitoring).`);
     } catch (err) {
       console.error(`[Discord] Failed to reply to message ${message.id} for command '${command}':`, err);
     }
   } else {
-    console.log(`[Discord] Preview ${label} '${command}' (recorded for monitoring).`);
+    console.log(`[Discord] Preview custom command '${command}' (recorded for monitoring).`);
   }
 }
 
@@ -208,34 +180,27 @@ export async function executeCustomCommandForTwitch(
   });
 
   const runtime = _twitchRuntime;
-  const willSend = CUSTOM_COMMANDS_LIVE_REPLIES && !!runtime && result.logType === 'custom-command';
-  const label = result.logType === 'counter-check'
-    ? 'counter check'
-    : result.logType === 'counter-command'
-      ? 'counter command'
-      : 'custom command';
-
-  if (willSend && runtime) {
+  if (CUSTOM_COMMANDS_LIVE_REPLIES && runtime) {
     if (result.isMultiTwitch) {
       try {
         const sent = await broadcastToActiveChannels(channel, command, result.response);
         if (sent) {
-          console.log(`[Twitch] Sent ${label} '${command}' in ${channel} (recorded for monitoring).`);
+          console.log(`[Twitch] Sent custom command '${command}' in ${channel} (recorded for monitoring).`);
         } else {
-          console.log(`[Twitch] Broadcast ${label} '${command}' in ${channel} reached no channels (recorded for monitoring).`);
+          console.log(`[Twitch] Broadcast custom command '${command}' in ${channel} reached no channels (recorded for monitoring).`);
         }
       } catch (err) {
-        console.error(`[Twitch] Failed to broadcast ${label} '${command}' in ${channel}:`, err);
+        console.error(`[Twitch] Failed to broadcast custom command '${command}' in ${channel}:`, err);
       }
     } else {
       try {
         await runtime.send(channel, result.response);
-        console.log(`[Twitch] Sent ${label} '${command}' in ${channel} (recorded for monitoring).`);
+        console.log(`[Twitch] Sent custom command '${command}' in ${channel} (recorded for monitoring).`);
       } catch (err) {
-        console.error(`[Twitch] Failed to send ${label} '${command}' in ${channel}:`, err);
+        console.error(`[Twitch] Failed to send custom command '${command}' in ${channel}:`, err);
       }
     }
   } else {
-    console.log(`[Twitch] Preview ${label} '${command}' in ${channel} (recorded for monitoring).`);
+    console.log(`[Twitch] Preview custom command '${command}' in ${channel} (recorded for monitoring).`);
   }
 }

--- a/src/customCommandHandler.ts
+++ b/src/customCommandHandler.ts
@@ -3,6 +3,7 @@ import { CUSTOM_COMMANDS_LIVE_REPLIES } from './config';
 import { getCustomCommandForDiscord, getCustomCommandForTwitchChannel } from './db';
 import { recordCommandTestEntry } from './commandMonitorStore';
 import { getSharedChatSession } from './twitchApi';
+import { extractCommand } from './commandUtils';
 
 // ─── Twitch runtime (registered from index.ts before startTwitchBot) ─────────
 //
@@ -19,14 +20,6 @@ let _twitchRuntime: TwitchChatRuntime | null = null;
 
 export function registerTwitchChatRuntime(runtime: TwitchChatRuntime): void {
   _twitchRuntime = runtime;
-}
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function extractCommand(rawMessage: string): string | null {
-  const trimmed = rawMessage.trim();
-  if (!trimmed) return null;
-  return trimmed.split(/\s+/)[0]?.toLowerCase() ?? null;
 }
 
 // ─── Lookup ───────────────────────────────────────────────────────────────────

--- a/src/db.ts
+++ b/src/db.ts
@@ -1701,6 +1701,7 @@ export async function resetCounterCurrentValue(id: number): Promise<void> {
 export async function incrementCounter(id: number): Promise<number> {
   const conn = await getPool().getConnection();
   try {
+    await conn.beginTransaction();
     const [result] = await conn.execute<mysql.ResultSetHeader>(
       'UPDATE counter SET current_value = current_value + 1 WHERE id = ?',
       [id],
@@ -1710,7 +1711,13 @@ export async function incrementCounter(id: number): Promise<number> {
       'SELECT current_value FROM counter WHERE id = ?',
       [id],
     );
-    return (rows[0] as mysql.RowDataPacket).current_value as number;
+    const newValue = (rows[0] as mysql.RowDataPacket).current_value as number;
+    await conn.commit();
+    invalidateCounterLookupCache();
+    return newValue;
+  } catch (err) {
+    await conn.rollback().catch(() => {});
+    throw err;
   } finally {
     conn.release();
   }
@@ -1720,6 +1727,8 @@ export async function archiveAndResetYearlyCounters(year: number): Promise<numbe
   if (!Number.isInteger(year) || year < 2020 || year > 2100) {
     throw new Error(`[DB] Invalid archive year: ${year}`);
   }
+  // MySQL doesn't support parameterised column names, so the name is built from
+  // `year` which is validated to a safe integer in [2020, 2100] above.
   const columnName = `value${year}`;
   const [result] = await getPool().execute<mysql.ResultSetHeader>(
     `UPDATE counter SET \`${columnName}\` = current_value, current_value = 0 WHERE reset_yearly = 1`,

--- a/src/db.ts
+++ b/src/db.ts
@@ -1698,6 +1698,36 @@ export async function resetCounterCurrentValue(id: number): Promise<void> {
   invalidateCounterLookupCache();
 }
 
+export async function incrementCounter(id: number): Promise<number> {
+  const conn = await getPool().getConnection();
+  try {
+    const [result] = await conn.execute<mysql.ResultSetHeader>(
+      'UPDATE counter SET current_value = current_value + 1 WHERE id = ?',
+      [id],
+    );
+    if (result.affectedRows === 0) throw new CounterNotFoundError(id);
+    const [rows] = await conn.execute<mysql.RowDataPacket[]>(
+      'SELECT current_value FROM counter WHERE id = ?',
+      [id],
+    );
+    return (rows[0] as mysql.RowDataPacket).current_value as number;
+  } finally {
+    conn.release();
+  }
+}
+
+export async function archiveAndResetYearlyCounters(year: number): Promise<number> {
+  if (!Number.isInteger(year) || year < 2020 || year > 2100) {
+    throw new Error(`[DB] Invalid archive year: ${year}`);
+  }
+  const columnName = `value${year}`;
+  const [result] = await getPool().execute<mysql.ResultSetHeader>(
+    `UPDATE counter SET \`${columnName}\` = current_value, current_value = 0 WHERE reset_yearly = 1`,
+  );
+  invalidateCounterLookupCache();
+  return result.affectedRows;
+}
+
 // ─── Stream monitor ──────────────────────────────────────────────────────────
 
 export interface DbStreamGroup {

--- a/src/db.ts
+++ b/src/db.ts
@@ -1731,7 +1731,7 @@ export async function archiveAndResetYearlyCounters(year: number): Promise<numbe
   // `year` which is validated to a safe integer in [2020, 2100] above.
   const columnName = `value${year}`;
   const [result] = await getPool().execute<mysql.ResultSetHeader>(
-    `UPDATE counter SET \`${columnName}\` = current_value, current_value = 0 WHERE reset_yearly = 1`,
+    `UPDATE counter SET \`${columnName}\` = current_value, current_value = 0 WHERE reset_yearly = 1 AND \`${columnName}\` IS NULL`,
   );
   invalidateCounterLookupCache();
   return result.affectedRows;

--- a/src/discordBot.ts
+++ b/src/discordBot.ts
@@ -3,6 +3,7 @@ import { DISCORD_TOKEN, DISCORD_GUILD_ID } from './config';
 import { connect } from './audioPlayer';
 import { handleCommand } from './commandRouter';
 import { executeCustomCommandForDiscord } from './customCommandHandler';
+import { executeCounterCommandForDiscord } from './counterHandler';
 import { setDiscordReady } from './statusStore';
 
 let client: Client;
@@ -72,6 +73,10 @@ export function startDiscordBot(): void {
 
     executeCustomCommandForDiscord(message, message.member?.displayName ?? message.author.username).catch((err) =>
       console.error('[Discord] Custom command error:', err),
+    );
+
+    executeCounterCommandForDiscord(message, message.member?.displayName ?? message.author.username).catch((err) =>
+      console.error('[Discord] Counter command error:', err),
     );
 
     handleCommand(message.content, 'discord').catch((err) =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,12 @@ import { startTwitchMonitor, stopTwitchMonitor } from './twitchMonitor';
 import { startWebPanel } from './web/server';
 import { disconnect } from './audioPlayer';
 import { registerTwitchChatRuntime } from './customCommandHandler';
+import { registerCounterTwitchRuntime } from './counterHandler';
+import { startCounterScheduler, stopCounterScheduler } from './counterScheduler';
 
 async function shutdown(signal: string): Promise<void> {
   console.log(`[Bot] ${signal} received — disconnecting from voice and shutting down.`);
+  stopCounterScheduler();
   await stopTwitchMonitor();
   disconnect();
   await closePool();
@@ -41,11 +44,13 @@ async function main(): Promise<void> {
     getActiveChannels,
     getLoginUserIds: getActiveChannelUserIds,
   });
+  registerCounterTwitchRuntime({ send: sayInChannel });
 
   startDiscordBot();
   await startTwitchBot();
   startTikTokBot();
   startWebPanel();
+  startCounterScheduler();
   startTwitchMonitor().catch((err) => console.error('[Bot] TwitchMonitor startup error:', err));
 }
 

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -2,6 +2,7 @@ import tmi from 'tmi.js';
 import { TWITCH_USERNAME, TWITCH_OAUTH_TOKEN } from './config';
 import { handleCommand } from './commandRouter';
 import { executeCustomCommandForTwitch } from './customCommandHandler';
+import { executeCounterCommandForTwitch } from './counterHandler';
 import { setTwitchChannel } from './statusStore';
 import { getTwitchEnabledChannels } from './db';
 import { normalizeTwitchChannelName } from './twitchChannelName';
@@ -162,6 +163,10 @@ export async function startTwitchBot(): Promise<void> {
 
     executeCustomCommandForTwitch(normalizedChannel, message, tags['display-name'] ?? tags.username ?? null).catch((err) =>
       console.error('[Twitch] Custom command error:', err),
+    );
+
+    executeCounterCommandForTwitch(normalizedChannel, message, tags['display-name'] ?? tags.username ?? null).catch((err) =>
+      console.error('[Twitch] Counter command error:', err),
     );
 
     handleCommand(message, 'twitch').catch((err) =>


### PR DESCRIPTION
- db.ts: add incrementCounter() (UPDATE + read-back on same connection) and archiveAndResetYearlyCounters(year) (single UPDATE for all reset_yearly counters; validates year 2020-2100 to prevent dynamic SQL risk)
- config.ts / .env.example: add COUNTER_LIVE_WRITES flag (default false)
- counterHandler.ts: executeCounterCommandForDiscord/Twitch — increments on trigger (gated by COUNTER_LIVE_WRITES), reads on check, records to command monitor; replies gated by CUSTOM_COMMANDS_LIVE_REPLIES; Twitch send wired via registerCounterTwitchRuntime (same pattern as custom commands to avoid circular import)
- counterScheduler.ts: fires yearly at Jan 1 midnight, archives previous year into value{YYYY} column and resets current_value; start/stop exported for index.ts lifecycle management
- customCommandHandler.ts: remove counter fallback from lookupCommand (counterHandler handles counters independently); simplify LogType and label logic now that only custom-command matches remain
- twitchBot.ts / discordBot.ts: call executeCounterCommandFor* alongside executeCustomCommandFor* with same fire-and-forget .catch() pattern
- index.ts: register counter Twitch runtime, start/stop scheduler
- AGENTS.md: document new files, COUNTER_LIVE_WRITES env var, scheduler column-per-year requirement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Counter commands now run on Discord and Twitch; replies can be enabled live or shown as preview (shadow mode).
  * Automatic yearly archive and reset of yearly counters runs around Jan 1.

* **Documentation**
  * Environment example and overview docs updated to document live reply and live write toggles and counter runtime behavior.

* **Chores**
  * Scheduler now starts/stops with the app lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->