### PR TITLE
refactor(db): extract pool management to src/db/pool.ts

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -1,9 +1,10 @@
 import { createHash } from 'node:crypto';
 import mysql from 'mysql2/promise';
-import { DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME } from './config';
 import { normalizeTwitchChannelName } from './twitchChannelName';
 import { createManagedLookupCache, type RefreshingLookupCache } from './db/lookupCache';
+import { getPool } from './db/pool';
 export type { RefreshingLookupCache, ManagedLookupCacheOptions, ManagedLookupCache } from './db/lookupCache';
+export { getPool, closePool } from './db/pool';
 
 /** Coerces a MySQL BIT(1) or TINYINT(1) column to a boolean. */
 function mapBoolColumn(value: unknown): boolean {
@@ -26,34 +27,6 @@ export interface SfxFile {
   weight: number;
   hidden: boolean;
   category_id: number | null;
-}
-
-let pool: mysql.Pool | undefined;
-
-export function getPool(): mysql.Pool {
-  if (!pool) {
-    pool = mysql.createPool({
-      host: DB_HOST,
-      port: DB_PORT,
-      user: DB_USER,
-      password: DB_PASSWORD,
-      database: DB_NAME,
-      supportBigNumbers: true,
-      bigNumberStrings: true,
-      waitForConnections: true,
-      connectionLimit: 5,
-      queueLimit: 0,
-      connectTimeout: 10_000,
-    });
-  }
-  return pool!;
-}
-
-export async function closePool(): Promise<void> {
-  if (pool) {
-    await pool.end();
-    pool = undefined;
-  }
 }
 
 /**

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -1,0 +1,30 @@
+import mysql from 'mysql2/promise';
+import { DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME } from '../config';
+
+let pool: mysql.Pool | undefined;
+
+export function getPool(): mysql.Pool {
+  if (!pool) {
+    pool = mysql.createPool({
+      host: DB_HOST,
+      port: DB_PORT,
+      user: DB_USER,
+      password: DB_PASSWORD,
+      database: DB_NAME,
+      supportBigNumbers: true,
+      bigNumberStrings: true,
+      waitForConnections: true,
+      connectionLimit: 5,
+      queueLimit: 0,
+      connectTimeout: 10_000,
+    });
+  }
+  return pool!;
+}
+
+export async function closePool(): Promise<void> {
+  if (pool) {
+    await pool.end();
+    pool = undefined;
+  }
+}


### PR DESCRIPTION
## Summary
- Moves `getPool` and `closePool` into `src/db/pool.ts` — pool lifecycle is now isolated from all query logic
- Both functions are re-exported from `db.ts` so all 8 callers are unaffected

## Test plan
- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] No runtime behaviour changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured database connection management code organization for improved maintainability and clarity. All database operations and functionality remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->