### PR TITLE
fix(twitchMonitor): proper error discrimination in startup Discord message delete

### DIFF
--- a/src/twitchMonitor.ts
+++ b/src/twitchMonitor.ts
@@ -357,9 +357,8 @@ async function deleteAnnouncement(stateKey: string): Promise<void> {
         await msg.delete();
       }
     } catch (err) {
-      if (!isDiscordNotFoundError(err)) {
-        console.error(`[TwitchMonitor] Failed to delete message for ${state.login}:`, err);
-      }
+      if (!isDiscordNotFoundError(err)) throw err;
+      // not-found: message already gone — fall through to clear DB state
     }
   }
 
@@ -660,7 +659,11 @@ export async function shutdownTwitchMonitor(): Promise<void> {
   // Delete all live announcements and clear DB state
   const stateKeys = Array.from(liveStates.keys());
   for (const key of stateKeys) {
-    await deleteAnnouncement(key);
+    try {
+      await deleteAnnouncement(key);
+    } catch (err) {
+      console.error('[TwitchMonitor] Shutdown: failed to delete announcement:', err);
+    }
   }
 
   liveStates.clear();

--- a/src/twitchMonitor.ts
+++ b/src/twitchMonitor.ts
@@ -1,4 +1,4 @@
-import { EmbedBuilder, TextChannel } from 'discord.js';
+import { DiscordAPIError, EmbedBuilder, TextChannel } from 'discord.js';
 import { discordClient } from './discordBot';
 import { getMonitorEnabled } from './monitorSettings';
 import {
@@ -431,9 +431,7 @@ async function tryEditStartupMessage(streamer: DbStreamerFull, liveStream: Twitc
     await setStreamerLive(streamer.id, streamer.discord_message_id, streamer.discord_channel_id, liveStream.game_name);
     return true;
   } catch (err) {
-    const e = err as { code?: number | string; status?: number };
-    const code = typeof e.code === 'string' ? Number(e.code) : e.code;
-    if (code === 10008 || e.status === 404) return false;
+    if (err instanceof DiscordAPIError && (err.code === 10008 || err.status === 404)) return false;
     console.error(`[TwitchMonitor] Failed to edit startup message for ${streamer.name}:`, err);
     throw err;
   }
@@ -447,9 +445,7 @@ async function tryDeleteDiscordMessage(channelId: string, messageId: string): Pr
     const msg = await ch.messages.fetch(messageId);
     await msg.delete();
   } catch (err) {
-    const e = err as { code?: number | string; status?: number };
-    const code = typeof e.code === 'string' ? Number(e.code) : e.code;
-    if (code === 10008 || code === 10003 || e.status === 404) return;
+    if (err instanceof DiscordAPIError && (err.code === 10008 || err.code === 10003 || err.status === 404)) return;
     console.error(`[TwitchMonitor] Failed to delete Discord message ${messageId} in channel ${channelId}:`, err);
     throw err;
   }

--- a/src/twitchMonitor.ts
+++ b/src/twitchMonitor.ts
@@ -444,9 +444,15 @@ async function tryDeleteDiscordMessage(channelId: string, messageId: string): Pr
   try {
     const ch = await discordClient.channels.fetch(channelId);
     if (!ch || !ch.isTextBased()) return;
-    const msg = await ch.messages.fetch(messageId).catch(() => null);
-    if (msg) await msg.delete();
-  } catch { /* already deleted */ }
+    const msg = await ch.messages.fetch(messageId);
+    await msg.delete();
+  } catch (err) {
+    const e = err as { code?: number | string; status?: number };
+    const code = typeof e.code === 'string' ? Number(e.code) : e.code;
+    if (code === 10008 || code === 10003 || e.status === 404) return;
+    console.error(`[TwitchMonitor] Failed to delete Discord message ${messageId} in channel ${channelId}:`, err);
+    throw err;
+  }
 }
 
 // ─── Startup live-check ───────────────────────────────────────────────────────
@@ -505,7 +511,12 @@ async function performStartupLiveCheck(): Promise<void> {
       // Stream ended while bot was offline — liveStates is empty at startup so
       // deleteAnnouncement() would early-return without clearing DB state. Do it directly.
       if (streamer.discord_channel_id && streamer.discord_message_id) {
-        await tryDeleteDiscordMessage(streamer.discord_channel_id, streamer.discord_message_id);
+        try {
+          await tryDeleteDiscordMessage(streamer.discord_channel_id, streamer.discord_message_id);
+        } catch {
+          // Delete failed (already logged) — skip DB clear to avoid orphaning the announcement
+          continue;
+        }
       }
       await clearStreamerLive(streamer.id);
       groupsWithChanges.add(streamer.group.id);

--- a/src/twitchMonitor.ts
+++ b/src/twitchMonitor.ts
@@ -1,4 +1,4 @@
-import { DiscordAPIError, EmbedBuilder, TextChannel } from 'discord.js';
+import { DiscordAPIError, EmbedBuilder, RESTJSONErrorCodes, TextChannel } from 'discord.js';
 import { discordClient } from './discordBot';
 import { getMonitorEnabled } from './monitorSettings';
 import {
@@ -410,7 +410,11 @@ async function handleStreamOffline(login: string): Promise<void> {
 // ─── Startup live-check helpers ──────────────────────────────────────────────
 
 function isDiscordNotFoundError(err: unknown): boolean {
-  return err instanceof DiscordAPIError && (err.code === 10008 || err.code === 10003 || err.status === 404);
+  return err instanceof DiscordAPIError && (
+    err.code === RESTJSONErrorCodes.UnknownMessage ||
+    err.code === RESTJSONErrorCodes.UnknownChannel ||
+    err.status === 404
+  );
 }
 
 async function tryEditStartupMessage(streamer: DbStreamerFull, liveStream: TwitchStream): Promise<boolean> {

--- a/src/twitchMonitor.ts
+++ b/src/twitchMonitor.ts
@@ -662,10 +662,12 @@ export async function shutdownTwitchMonitor(): Promise<void> {
 
   // Delete all live announcements and clear DB state
   const stateKeys = Array.from(liveStates.keys());
+  let failedDeletes = 0;
   for (const key of stateKeys) {
     try {
       await deleteAnnouncement(key);
     } catch (err) {
+      failedDeletes++;
       console.error('[TwitchMonitor] Shutdown: failed to delete announcement:', err);
     }
   }
@@ -673,7 +675,11 @@ export async function shutdownTwitchMonitor(): Promise<void> {
   liveStates.clear();
   loginToUserId.clear();
   streamersData = [];
-  console.log('[TwitchMonitor] Shutdown complete — all live messages deleted');
+  if (failedDeletes === 0) {
+    console.log('[TwitchMonitor] Shutdown complete — all live messages deleted');
+  } else {
+    console.warn(`[TwitchMonitor] Shutdown complete with ${failedDeletes} failed delete(s) — some announcements may remain`);
+  }
 }
 
 /**

--- a/src/twitchMonitor.ts
+++ b/src/twitchMonitor.ts
@@ -324,7 +324,9 @@ async function editAnnouncement(
       try {
         const old = await textChannel.messages.fetch(state.messageId);
         await old.delete();
-      } catch { /* already deleted */ }
+      } catch (err) {
+        if (!isDiscordNotFoundError(err)) throw err;
+      }
       const msg = await textChannel.send({ content, embeds: [embed] });
       state.messageId = msg.id;
       state.channelId = msg.channelId;
@@ -351,11 +353,13 @@ async function deleteAnnouncement(stateKey: string): Promise<void> {
     try {
       const channel = await discordClient.channels.fetch(state.channelId);
       if (channel && channel.isTextBased()) {
-        const msg = await channel.messages.fetch(state.messageId).catch(() => null);
-        if (msg) await msg.delete();
+        const msg = await channel.messages.fetch(state.messageId);
+        await msg.delete();
       }
     } catch (err) {
-      console.error(`[TwitchMonitor] Failed to delete message for ${state.login}:`, err);
+      if (!isDiscordNotFoundError(err)) {
+        console.error(`[TwitchMonitor] Failed to delete message for ${state.login}:`, err);
+      }
     }
   }
 
@@ -406,6 +410,10 @@ async function handleStreamOffline(login: string): Promise<void> {
 
 // ─── Startup live-check helpers ──────────────────────────────────────────────
 
+function isDiscordNotFoundError(err: unknown): boolean {
+  return err instanceof DiscordAPIError && (err.code === 10008 || err.code === 10003 || err.status === 404);
+}
+
 async function tryEditStartupMessage(streamer: DbStreamerFull, liveStream: TwitchStream): Promise<boolean> {
   if (!streamer.discord_channel_id || !streamer.discord_message_id) return false;
   try {
@@ -431,7 +439,7 @@ async function tryEditStartupMessage(streamer: DbStreamerFull, liveStream: Twitc
     await setStreamerLive(streamer.id, streamer.discord_message_id, streamer.discord_channel_id, liveStream.game_name);
     return true;
   } catch (err) {
-    if (err instanceof DiscordAPIError && (err.code === 10008 || err.code === 10003 || err.status === 404)) return false;
+    if (isDiscordNotFoundError(err)) return false;
     console.error(`[TwitchMonitor] Failed to edit startup message for ${streamer.name}:`, err);
     throw err;
   }
@@ -445,7 +453,7 @@ async function tryDeleteDiscordMessage(channelId: string, messageId: string): Pr
     const msg = await ch.messages.fetch(messageId);
     await msg.delete();
   } catch (err) {
-    if (err instanceof DiscordAPIError && (err.code === 10008 || err.code === 10003 || err.status === 404)) return;
+    if (isDiscordNotFoundError(err)) return;
     console.error(`[TwitchMonitor] Failed to delete Discord message ${messageId} in channel ${channelId}:`, err);
     throw err;
   }

--- a/src/twitchMonitor.ts
+++ b/src/twitchMonitor.ts
@@ -431,7 +431,7 @@ async function tryEditStartupMessage(streamer: DbStreamerFull, liveStream: Twitc
     await setStreamerLive(streamer.id, streamer.discord_message_id, streamer.discord_channel_id, liveStream.game_name);
     return true;
   } catch (err) {
-    if (err instanceof DiscordAPIError && (err.code === 10008 || err.status === 404)) return false;
+    if (err instanceof DiscordAPIError && (err.code === 10008 || err.code === 10003 || err.status === 404)) return false;
     console.error(`[TwitchMonitor] Failed to edit startup message for ${streamer.name}:`, err);
     throw err;
   }
@@ -496,8 +496,13 @@ async function performStartupLiveCheck(): Promise<void> {
           });
           continue;
         }
-        if (await tryEditStartupMessage(streamer, liveStream)) {
-          groupsWithChanges.add(streamer.group.id);
+        try {
+          if (await tryEditStartupMessage(streamer, liveStream)) {
+            groupsWithChanges.add(streamer.group.id);
+            continue;
+          }
+        } catch {
+          // Edit failed (already logged) — skip postAnnouncement for this streamer
           continue;
         }
       }


### PR DESCRIPTION
## Summary

Fixes the unresolved review comment on #65 for `tryDeleteDiscordMessage`.

**In `tryDeleteDiscordMessage`:**
- Removes `.catch(() => null)` on `ch.messages.fetch` so non-404 fetch errors surface
- Replaces blanket `catch { /* already deleted */ }` with discriminated error handling: codes 10008/10003 or HTTP 404 silently return; all other errors are logged and rethrown

**In the caller (`performStartupLiveCheck`):**
- Wraps the `await tryDeleteDiscordMessage(...)` in try/catch and `continue`s on rethrow, so `clearStreamerLive` is only called when the delete actually succeeded (or the message was already gone) — DB state is preserved on transient failures

## Test plan
- [ ] Startup with a message that no longer exists — DB cleared, no error logged
- [ ] Startup with a permission error on delete — error logged, DB state preserved, next streamer still processed
- [ ] Startup with a network error on `channels.fetch` — error logged, DB state preserved
- [ ] `npx tsc --noEmit` — no new errors in `twitchMonitor.ts`

https://claude.ai/code/session_01MyKCMEZnE6kvcJrykUzRce

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better error handling for Discord interactions: harmless "not found" errors are detected and ignored to prevent crashes.
  * Safer message-deletion flow with a dedicated delete-with-not-found-swallowing path; unexpected errors are still logged.
  * Startup edits/deletions now return/skipped on not-found instead of blocking startup; stored announcements are preserved on failed deletes.
  * Shutdown cleanup counts and logs individual delete failures so one failure won’t abort remaining cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->