### PR TITLE
feat(commands): add !multi built-in command for multitwitch URL

### DIFF
--- a/src/customCommandHandler.ts
+++ b/src/customCommandHandler.ts
@@ -54,7 +54,7 @@ const SHORT_RETRY_TTL_MS = 5_000;
 const sessionCache = new Map<string, SessionCacheEntry>();
 const inFlightRefreshes = new Map<string, Promise<void>>();
 
-async function resolveSharedChatSessionId(userId: string): Promise<string | null> {
+export async function resolveSharedChatSessionId(userId: string): Promise<string | null> {
   const now = Date.now();
   const cached = sessionCache.get(userId);
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -53,6 +53,7 @@ export {
   CommandNotFoundError, CommandConflictError, isMysqlDuplicateEntryError,
   isCustomCommandTriggerTaken,
 } from './db/commandLocks';
+export { ReservedCommandError, RESERVED_BUILT_IN_COMMANDS } from './db/reservedCommands';
 export type { SqlExecutor } from './db/commandLocks';
 
 // ─── Counter commands ───────────────────────────────────────────────────────

--- a/src/db/counters.ts
+++ b/src/db/counters.ts
@@ -6,6 +6,7 @@ import {
   isAnyCommandTakenAcrossTables, runSerializedCommandWrite,
 } from './commandLocks';
 import type { SqlExecutor } from './commandLocks';
+import { assertNotReservedCommand } from './reservedCommands';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -180,6 +181,9 @@ export async function addCounter(
     throw new Error('Counter trigger_command and check_command must be different');
   }
 
+  assertNotReservedCommand(fields.triggerCommand);
+  assertNotReservedCommand(fields.checkCommand);
+
   await runSerializedCommandWrite(
     [fields.triggerCommand, fields.checkCommand],
     undefined,
@@ -222,6 +226,9 @@ export async function updateCounter(input: UpdateCounterInput): Promise<void> {
   if (fields.triggerCommand === fields.checkCommand) {
     throw new Error('Counter trigger_command and check_command must be different');
   }
+
+  assertNotReservedCommand(fields.triggerCommand);
+  assertNotReservedCommand(fields.checkCommand);
 
   const current = await getCounterCommandsById(id);
   if (!current) throw new CounterNotFoundError(id);

--- a/src/db/customCommands.ts
+++ b/src/db/customCommands.ts
@@ -4,6 +4,7 @@ import { getPool } from './pool';
 import { createManagedLookupCache, type RefreshingLookupCache } from './lookupCache';
 import { AccessLevel, getTwitchEnabledChannels } from './users';
 import type { AccessLevelValue } from './users';
+import { assertNotReservedCommand } from './reservedCommands';
 import {
   requireTrimmedString,
   assertDiscordTriggerAvailable, assertMultiTwitchTriggerAvailable, assertNoSingleTwitchAssignmentOverlap,
@@ -366,6 +367,8 @@ export async function addCustomCommand(
   const normalizedTriggerString = requireTrimmedString(triggerString, 'trigger_string').toLowerCase();
   const normalizedOutput = requireTrimmedString(output, 'output');
 
+  assertNotReservedCommand(normalizedTriggerString);
+
   await runSerializedCommandWrite(
     normalizedTriggerString,
     undefined,
@@ -399,6 +402,8 @@ export async function updateCustomCommand(
 ): Promise<void> {
   const normalizedTriggerString = requireTrimmedString(triggerString, 'trigger_string').toLowerCase();
   const normalizedOutput = requireTrimmedString(output, 'output');
+
+  assertNotReservedCommand(normalizedTriggerString);
 
   await runSerializedCommandWrite(
     normalizedTriggerString,

--- a/src/db/reservedCommands.ts
+++ b/src/db/reservedCommands.ts
@@ -1,0 +1,18 @@
+/**
+ * Built-in command names that cannot be registered as custom commands or counters.
+ * These are handled by dedicated handlers (e.g. multiCommandHandler.ts).
+ */
+export const RESERVED_BUILT_IN_COMMANDS: ReadonlySet<string> = new Set(['!multi']);
+
+export class ReservedCommandError extends Error {
+  constructor(trigger: string) {
+    super(`'${trigger}' is a reserved built-in command and cannot be used as a custom command trigger.`);
+    this.name = 'ReservedCommandError';
+  }
+}
+
+export function assertNotReservedCommand(normalizedTrigger: string): void {
+  if (RESERVED_BUILT_IN_COMMANDS.has(normalizedTrigger)) {
+    throw new ReservedCommandError(normalizedTrigger);
+  }
+}

--- a/src/db/reservedCommands.ts
+++ b/src/db/reservedCommands.ts
@@ -11,8 +11,9 @@ export class ReservedCommandError extends Error {
   }
 }
 
-export function assertNotReservedCommand(normalizedTrigger: string): void {
-  if (RESERVED_BUILT_IN_COMMANDS.has(normalizedTrigger)) {
-    throw new ReservedCommandError(normalizedTrigger);
+export function assertNotReservedCommand(trigger: string): void {
+  const normalized = trigger.trim().toLowerCase();
+  if (RESERVED_BUILT_IN_COMMANDS.has(normalized)) {
+    throw new ReservedCommandError(normalized);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { startWebPanel } from './web/server';
 import { disconnect } from './audioPlayer';
 import { registerTwitchChatRuntime } from './customCommandHandler';
 import { registerCounterTwitchRuntime } from './counterHandler';
+import { registerMultiTwitchRuntime } from './multiCommandHandler';
 import { startCounterScheduler, stopCounterScheduler } from './counterScheduler';
 
 async function shutdown(signal: string): Promise<void> {
@@ -45,6 +46,7 @@ async function main(): Promise<void> {
     getLoginUserIds: getActiveChannelUserIds,
   });
   registerCounterTwitchRuntime({ send: sayInChannel });
+  registerMultiTwitchRuntime({ send: sayInChannel, getActiveChannels, getLoginUserIds: getActiveChannelUserIds });
 
   startDiscordBot();
   await startTwitchBot();

--- a/src/multiCommandHandler.ts
+++ b/src/multiCommandHandler.ts
@@ -1,0 +1,98 @@
+import { CUSTOM_COMMANDS_LIVE_REPLIES } from './config';
+import { getMultiTwitchDataForChannel } from './twitchMonitor';
+import { recordCommandTestEntry } from './commandMonitorStore';
+import { resolveSharedChatSessionId } from './customCommandHandler';
+import { extractCommand } from './commandUtils';
+
+const MULTI_COMMAND = '!multi';
+
+// ─── Twitch runtime (registered from index.ts before startTwitchBot) ─────────
+//
+// Same injection pattern as customCommandHandler.ts to avoid a circular import
+// between twitchBot.ts and multiCommandHandler.ts.
+
+interface MultiTwitchRuntime {
+  send: (channel: string, message: string) => Promise<void>;
+  getActiveChannels: () => ReadonlySet<string>;
+  getLoginUserIds: () => ReadonlyMap<string, string>;
+}
+
+let _runtime: MultiTwitchRuntime | null = null;
+
+export function registerMultiTwitchRuntime(runtime: MultiTwitchRuntime): void {
+  _runtime = runtime;
+}
+
+// ─── Broadcast ────────────────────────────────────────────────────────────────
+
+async function broadcastToGroupChannels(
+  sourceChannel: string,
+  participants: string[],
+  message: string,
+  runtime: MultiTwitchRuntime,
+): Promise<void> {
+  const { send, getActiveChannels, getLoginUserIds } = runtime;
+  const activeChannels = getActiveChannels();
+  const loginUserIds = getLoginUserIds();
+
+  // Source channel first, then the remaining participants — filter to channels the bot has joined
+  const targets = [sourceChannel, ...participants.filter((p) => p !== sourceChannel)]
+    .filter((ch) => activeChannels.has(ch));
+
+  // Pre-resolve all session IDs in parallel to avoid serial Helix calls per channel
+  const userIds = [...new Set(targets.map((ch) => loginUserIds.get(ch)).filter((id): id is string => id !== undefined))];
+  const resolvedIds = await Promise.all(userIds.map((uid) => resolveSharedChatSessionId(uid)));
+  const sessionIdByUserId = new Map(userIds.map((uid, i) => [uid, resolvedIds[i]]));
+
+  const repliedSessionIds = new Set<string>();
+
+  for (const channel of targets) {
+    const userId = loginUserIds.get(channel);
+    const sessionId = userId ? (sessionIdByUserId.get(userId) ?? null) : null;
+
+    if (sessionId && repliedSessionIds.has(sessionId)) continue;
+
+    try {
+      await send(channel, message);
+      if (sessionId) repliedSessionIds.add(sessionId);
+    } catch (err) {
+      console.error(`[MultiCmd] Failed to send to ${channel}:`, err);
+    }
+  }
+}
+
+// ─── Execute ──────────────────────────────────────────────────────────────────
+
+export async function executeMultiCommandForTwitch(
+  channel: string,
+  rawMessage: string,
+  username?: string | null,
+): Promise<void> {
+  const command = extractCommand(rawMessage);
+  if (command !== MULTI_COMMAND) return;
+
+  const groupInfo = getMultiTwitchDataForChannel(channel);
+
+  recordCommandTestEntry({
+    source: 'twitch',
+    command: MULTI_COMMAND,
+    response: groupInfo?.url ?? '(not in an active multitwitch group)',
+    channel,
+    user: username ?? null,
+  });
+
+  if (!groupInfo) return;
+
+  const runtime = _runtime;
+  if (!CUSTOM_COMMANDS_LIVE_REPLIES || !runtime) {
+    console.log(`[Twitch] Preview !multi in ${channel} — would post: ${groupInfo.url}`);
+    return;
+  }
+
+  try {
+    await broadcastToGroupChannels(channel, groupInfo.participants, groupInfo.url, runtime);
+    console.log(`[Twitch] Sent !multi in ${channel} — ${groupInfo.url}`);
+  } catch (err) {
+    console.error(`[Twitch] Failed to broadcast !multi in ${channel}:`, err);
+  }
+}

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -3,6 +3,7 @@ import { TWITCH_USERNAME, TWITCH_OAUTH_TOKEN } from './config';
 import { handleCommand } from './commandRouter';
 import { executeCustomCommandForTwitch } from './customCommandHandler';
 import { executeCounterCommandForTwitch } from './counterHandler';
+import { executeMultiCommandForTwitch } from './multiCommandHandler';
 import { setTwitchChannel } from './statusStore';
 import { getTwitchEnabledChannels } from './db';
 import { normalizeTwitchChannelName } from './twitchChannelName';
@@ -167,6 +168,10 @@ export async function startTwitchBot(): Promise<void> {
 
     executeCounterCommandForTwitch(normalizedChannel, message, tags['display-name'] ?? tags.username ?? null).catch((err) =>
       console.error('[Twitch] Counter command error:', err),
+    );
+
+    executeMultiCommandForTwitch(normalizedChannel, message, tags['display-name'] ?? tags.username ?? null).catch((err) =>
+      console.error('[Twitch] Multi command error:', err),
     );
 
     handleCommand(message, 'twitch').catch((err) =>

--- a/src/twitchMonitor.ts
+++ b/src/twitchMonitor.ts
@@ -678,6 +678,32 @@ export async function restartTwitchMonitor(): Promise<void> {
   await startTwitchMonitor();
 }
 
+// ─── Multi-twitch URL query (for !multi command) ─────────────────────────────
+
+export interface MultiTwitchGroupInfo {
+  url: string;
+  participants: string[];
+}
+
+/**
+ * Returns the current multitwitch URL and participant logins for the group that
+ * the given channel belongs to, or null if the channel is not live, not in a
+ * multitwitch-enabled group, or fewer than two streamers are live in the group.
+ */
+export function getMultiTwitchDataForChannel(login: string): MultiTwitchGroupInfo | null {
+  const loginLower = login.toLowerCase();
+  const state = Array.from(liveStates.values()).find((s) => s.login === loginLower);
+  if (!state) return null;
+
+  const groupLive = Array.from(liveStates.values()).filter((s) => s.groupId === state.groupId);
+  const context = buildMultiTwitchContext(groupLive);
+  const preview = getMultitwitchPreview(state, context);
+
+  if (!preview.enabled || !preview.applicable || !preview.url) return null;
+
+  return { url: preview.url, participants: preview.participants };
+}
+
 // ─── Live state snapshot (for web panel) ─────────────────────────────────────
 
 export interface LiveStateSnapshot {

--- a/src/web/routes/commands.ts
+++ b/src/web/routes/commands.ts
@@ -6,6 +6,7 @@ import {
   CommandNotFoundError,
   DbCustomCommandWithAssignments,
   isMysqlDuplicateEntryError,
+  ReservedCommandError,
   DbUser,
   findUser,
   getAllCustomCommandsWithAssignments,
@@ -22,6 +23,7 @@ const router = Router();
 const KNOWN_ERRORS = new Set([
   'missing_fields',
   'command_taken',
+  'reserved_command',
   'invalid_id',
   'add_failed',
   'update_failed',
@@ -112,6 +114,10 @@ router.post('/commands/add', requireManager, csrfProtection, async (req, res) =>
   try {
     await addCustomCommand(normalizedTriggerString, normalizedOutput, isDiscordEnabled, isMultiTwitch);
   } catch (err) {
+    if (err instanceof ReservedCommandError) {
+      return res.redirect('/admin/commands?error=reserved_command');
+    }
+
     if (err instanceof CommandConflictError || isMysqlDuplicateEntryError(err)) {
       return res.redirect('/admin/commands?error=command_taken');
     }
@@ -144,6 +150,10 @@ router.post('/commands/update', requireManager, csrfProtection, async (req, res)
   } catch (err) {
     if (err instanceof CommandNotFoundError) {
       return res.status(404).render('error', { message: 'Command not found.', user: req.session.user ?? null });
+    }
+
+    if (err instanceof ReservedCommandError) {
+      return res.redirect('/admin/commands?error=reserved_command');
     }
 
     if (err instanceof CommandConflictError || isMysqlDuplicateEntryError(err)) {

--- a/src/web/routes/counters.ts
+++ b/src/web/routes/counters.ts
@@ -4,6 +4,7 @@ import {
   CommandConflictError,
   CounterNotFoundError,
   isMysqlDuplicateEntryError,
+  ReservedCommandError,
   getAllCounters,
   isCounterCommandTaken,
   removeCounter,
@@ -19,6 +20,7 @@ const KNOWN_ERRORS = new Set([
   'missing_fields',
   'same_commands',
   'duplicate_command',
+  'reserved_command',
   'invalid_id',
   'add_failed',
   'update_failed',
@@ -131,6 +133,10 @@ router.post('/counters/add', requireManager, csrfProtection, async (req, res) =>
       form.resetYearly,
     );
   } catch (err) {
+    if (err instanceof ReservedCommandError) {
+      return res.redirect('/admin/counters?error=reserved_command');
+    }
+
     if (err instanceof CommandConflictError || isMysqlDuplicateEntryError(err)) {
       return res.redirect('/admin/counters?error=duplicate_command');
     }
@@ -175,6 +181,10 @@ router.post('/counters/update', requireManager, csrfProtection, async (req, res)
   } catch (err) {
     if (err instanceof CounterNotFoundError) {
       return res.status(404).render('error', { message: 'Counter not found.', user: req.session.user ?? null });
+    }
+
+    if (err instanceof ReservedCommandError) {
+      return res.redirect('/admin/counters?error=reserved_command');
     }
 
     if (err instanceof CommandConflictError || isMysqlDuplicateEntryError(err)) {


### PR DESCRIPTION
## Summary

- Adds a built-in `!multi` Twitch command that posts the current `multitwitch.tv` link into chat
- Only fires when the triggering channel is live **and** part of a multitwitch-enabled group with 2+ streamers currently live; silently no-ops otherwise
- Broadcasts to all live group channels (source channel first), with shared-chat deduplication to avoid duplicate sends in shared-chat sessions
- Gated behind `CUSTOM_COMMANDS_LIVE_REPLIES` — shadow mode logs a preview without posting
- Appears in the command monitor web page with the resolved URL (or `(not in an active multitwitch group)`) for pre-live testing

## Implementation notes

- New `src/multiCommandHandler.ts` follows the same runtime-injection pattern as `customCommandHandler.ts` and `counterHandler.ts` to avoid circular imports
- `getMultiTwitchDataForChannel()` exported from `twitchMonitor.ts` — reuses existing `getMultitwitchPreview` / `buildMultiTwitchContext` logic
- `resolveSharedChatSessionId` exported from `customCommandHandler.ts` so the multi handler shares the same session cache
- Broadcast targets are filtered to channels the bot is actively joined to

## Test plan

- [ ] Trigger `!multi` when no streamer in the channel's group is live → no response in chat, monitor shows `(not in an active multitwitch group)`
- [ ] Trigger `!multi` when only one streamer in the group is live → no response (not applicable)
- [ ] Trigger `!multi` with 2+ streamers in the group live → monitor shows correct `multitwitch.tv/a/b` URL
- [ ] With `CUSTOM_COMMANDS_LIVE_REPLIES=true`, verify the URL is posted to all live group channels
- [ ] Verify shared-chat channels only receive one message (not duplicated per session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Twitch "!multi" to broadcast multi-channel group info to participating channels with deduplication and per-channel reporting.
  * App now obtains multitwitch group data for channels and registers multi-Twitch runtime at startup to enable the above flow.
* **Bug Fixes / Validation**
  * Prevent creating or updating custom commands or counters using reserved triggers (e.g., "!multi"); admin pages now surface a "reserved_command" error on add/update attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->