### PR TITLE
fix(admin): prevent user input from reaching console.error format string

### DIFF
--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -117,7 +117,7 @@ async function runDiscordNameRefresh(): Promise<void> {
         if (name == null) {
           failureCount++;
           refreshState.failureCount = failureCount;
-          console.error(`[Web] Failed to refresh Discord name for ${user.discord_id}: Discord lookup returned no display name`);
+          console.error('[Web] Failed to refresh Discord name for', user.discord_id, ': Discord lookup returned no display name');
           await new Promise((resolve) => setTimeout(resolve, 200));
           continue;
         }
@@ -131,7 +131,7 @@ async function runDiscordNameRefresh(): Promise<void> {
       } catch (err) {
         failureCount++;
         refreshState.failureCount = failureCount;
-        console.error(`[Web] Failed to refresh Discord name for ${user.discord_id}:`, err);
+        console.error('[Web] Failed to refresh Discord name for', user.discord_id, err);
       }
       await new Promise((resolve) => setTimeout(resolve, 200));
     }
@@ -375,7 +375,8 @@ router.post('/users/remove', requireAdmin, csrfProtection, async (req, res) => {
               await updateTwitchBotEnabled(existingUser.discord_id, existingUser.is_twitch_bot_enabled);
             } catch (rollbackErr) {
               console.error(
-                `[Web] Failed to restore user ${trimmedDiscordId} after Twitch part failed during removal:`,
+                '[Web] Failed to restore user after Twitch part failed during removal:',
+                trimmedDiscordId,
                 rollbackErr,
               );
             }

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -117,7 +117,7 @@ async function runDiscordNameRefresh(): Promise<void> {
         if (name == null) {
           failureCount++;
           refreshState.failureCount = failureCount;
-          console.error('[Web] Failed to refresh Discord name for', user.discord_id, ': Discord lookup returned no display name');
+          console.error('[Web] Failed to refresh Discord name for ' + user.discord_id + ': Discord lookup returned no display name');
           await new Promise((resolve) => setTimeout(resolve, 200));
           continue;
         }


### PR DESCRIPTION
## Summary

- In `src/web/routes/admin.ts`, `discord_id` and `trimmedDiscordId` were interpolated into template literals used as the format string for `console.error`
- If a discord ID contained `%s` or `%d`, those specifiers would silently consume the subsequent error argument (`err`/`rollbackErr`), swallowing it from the log output
- Fixed by passing user-controlled values as separate arguments rather than embedding them in the format string

## Test plan

- [ ] Trigger the Discord name refresh failure path with a user whose `discord_id` contains `%s` — verify the error is still logged
- [ ] Trigger the user-removal rollback path — verify `rollbackErr` appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized and clarified error logging in admin workflows: refreshed failure and rollback messages were reformatted to improve consistency and runtime diagnostics.
  * No public API or behavior changes; this is a logging-only update to aid troubleshooting and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->