### PR TITLE
fix: chain .catch() on floating IIFE promises in mutation lock helpers

### DIFF
--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -36,7 +36,7 @@ async function withMembershipMutationLock<T>(channel: string, operation: () => P
       // Ignore earlier failures so later membership changes still run.
     }
     await current;
-  })();
+  })().catch(() => {});
   membershipMutationQueues.set(channel, queued);
 
   try {

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -76,7 +76,7 @@ async function withUserMutationLock<T>(discordId: string, operation: () => Promi
       // Ignore failures from earlier queued operations so later mutations still run.
     }
     await current;
-  })();
+  })().catch(() => {});
   userMutationQueues.set(discordId, queued);
 
   try {


### PR DESCRIPTION
## Summary

- `withMembershipMutationLock` (twitchBot.ts) and `withUserMutationLock` (admin.ts) both use an immediately-invoked async IIFE to build a serialised queue of operations
- The IIFE promise (`queued`) cannot be awaited in the outer function — doing so would deadlock because it waits on `current`, which is only resolved in the outer function's `finally` block
- This leaves a floating promise that GitHub Code Quality (CodeQL) flags as "Missing await. The value 'queued' is always a promise."
- Fix: chain `.catch(() => {})` directly on the IIFE to explicitly handle the rejection path; the map type (`Map<string, Promise<void>>`) is unchanged since `.catch(() => {})` returns `Promise<void>`

## Test plan

- [ ] TypeScript compiles without errors (`tsc --noEmit`)
- [ ] Verify CodeQL no longer reports the floating promise finding on these two locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unhandled promise rejections in async queue operations to improve application stability and prevent unexpected error notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->