### PR TITLE
feat(commands): add !so built-in shoutout command

### DIFF
--- a/src/db/reservedCommands.ts
+++ b/src/db/reservedCommands.ts
@@ -1,8 +1,18 @@
+interface BuiltInCommandMeta {
+  description: string;
+}
+
 /**
- * Built-in command names that cannot be registered as custom commands or counters.
- * These are handled by dedicated handlers (e.g. multiCommandHandler.ts).
+ * Registry of built-in commands. Add an entry here whenever a new hardcoded
+ * command is introduced so it is automatically protected from being claimed as
+ * a custom command or counter trigger.
  */
-export const RESERVED_BUILT_IN_COMMANDS: ReadonlySet<string> = new Set(['!multi']);
+export const BUILT_IN_COMMANDS: Readonly<Record<string, BuiltInCommandMeta>> = {
+  '!multi': { description: 'Posts a multitwitch.tv link for the active stream group' },
+  '!so': { description: 'Posts a Twitch shoutout for a named streamer (mod/broadcaster only)' },
+};
+
+export const RESERVED_BUILT_IN_COMMANDS: ReadonlySet<string> = new Set(Object.keys(BUILT_IN_COMMANDS));
 
 export class ReservedCommandError extends Error {
   constructor(trigger: string) {

--- a/src/db/reservedCommands.ts
+++ b/src/db/reservedCommands.ts
@@ -1,4 +1,4 @@
-interface BuiltInCommandMeta {
+export interface BuiltInCommandMeta {
   description: string;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { disconnect } from './audioPlayer';
 import { registerTwitchChatRuntime } from './customCommandHandler';
 import { registerCounterTwitchRuntime } from './counterHandler';
 import { registerMultiTwitchRuntime } from './multiCommandHandler';
+import { registerShoutoutRuntime } from './shoutoutHandler';
 import { startCounterScheduler, stopCounterScheduler } from './counterScheduler';
 
 async function shutdown(signal: string): Promise<void> {
@@ -47,6 +48,7 @@ async function main(): Promise<void> {
   });
   registerCounterTwitchRuntime({ send: sayInChannel });
   registerMultiTwitchRuntime({ send: sayInChannel, getActiveChannels, getLoginUserIds: getActiveChannelUserIds });
+  registerShoutoutRuntime({ send: sayInChannel });
 
   startDiscordBot();
   await startTwitchBot();

--- a/src/shoutoutHandler.ts
+++ b/src/shoutoutHandler.ts
@@ -1,5 +1,5 @@
 import { CUSTOM_COMMANDS_LIVE_REPLIES } from './config';
-import { getUsers, getChannelInfo, getStreams } from './twitchApi';
+import { getUsers, getChannelInfo, getStreams, TwitchChannelInfo, TwitchStream } from './twitchApi';
 import { recordCommandTestEntry } from './commandMonitorStore';
 import { extractCommand } from './commandUtils';
 
@@ -17,13 +17,51 @@ export function registerShoutoutRuntime(runtime: ShoutoutRuntime): void {
   _runtime = runtime;
 }
 
-// ─── Message formatting ───────────────────────────────────────────────────────
+// ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function formatShoutoutMessage(login: string, gameName: string | null, isLive: boolean): string {
   const url = `twitch.tv/${login}`;
   if (isLive && gameName) return `Go check out @${login}, they're live playing ${gameName}! ${url}`;
   if (gameName) return `Go give @${login} a follow! They were last seen playing ${gameName} — ${url}`;
   return `Go give @${login} a follow at ${url}!`;
+}
+
+async function resolveShoutoutData(
+  target: string,
+): Promise<{ login: string; gameName: string | null; isLive: boolean } | null> {
+  const users = await getUsers([target]);
+  const user = users[0];
+  if (!user) return null;
+
+  // Independent failures: a bad getStreams response still lets getChannelInfo succeed.
+  const [channelResult, streamsResult] = await Promise.allSettled([
+    getChannelInfo([user.id]),
+    getStreams([user.id]),
+  ]);
+
+  const channelInfos: TwitchChannelInfo[] = channelResult.status === 'fulfilled' ? channelResult.value : [];
+  const streams: TwitchStream[] = streamsResult.status === 'fulfilled' ? streamsResult.value : [];
+  const stream = streams[0];
+
+  return {
+    login: user.login,
+    gameName: stream?.game_name || channelInfos[0]?.game_name || null,
+    isLive: !!stream,
+  };
+}
+
+async function dispatchShoutout(channel: string, message: string): Promise<void> {
+  const runtime = _runtime;
+  if (!CUSTOM_COMMANDS_LIVE_REPLIES || !runtime) {
+    console.log(`[Twitch] Preview !so in ${channel} — would post: ${message}`);
+    return;
+  }
+  try {
+    await runtime.send(channel, message);
+    console.log(`[Twitch] Sent !so in ${channel} — ${message}`);
+  } catch (err) {
+    console.error(`[Twitch] Failed to send !so in ${channel}:`, err);
+  }
 }
 
 // ─── Execute ──────────────────────────────────────────────────────────────────
@@ -34,56 +72,20 @@ export async function executeShoutoutForTwitch(
   username: string | null,
   isModerator: boolean,
 ): Promise<void> {
-  if (extractCommand(rawMessage) !== SO_COMMAND) return;
-  if (!isModerator) return;
+  if (extractCommand(rawMessage) !== SO_COMMAND || !isModerator) return;
 
   const rawTarget = rawMessage.trim().split(/\s+/)[1];
-  if (!rawTarget) return;
-  const target = rawTarget.replace(/^@/, '').toLowerCase();
+  const target = rawTarget?.replace(/^@/, '').toLowerCase();
   if (!target) return;
 
-  const users = await getUsers([target]);
-  const user = users[0];
+  const data = await resolveShoutoutData(target);
+  const response = data
+    ? formatShoutoutMessage(data.login, data.gameName, data.isLive)
+    : `(unknown user: ${target})`;
 
-  if (!user) {
-    recordCommandTestEntry({
-      source: 'twitch',
-      command: SO_COMMAND,
-      response: `(unknown user: ${target})`,
-      channel,
-      user: username,
-    });
-    return;
-  }
+  recordCommandTestEntry({ source: 'twitch', command: SO_COMMAND, response, channel, user: username });
 
-  const [channelInfos, streams] = await Promise.all([
-    getChannelInfo([user.id]),
-    getStreams([user.id]),
-  ]);
-
-  const stream = streams[0];
-  const gameName = stream?.game_name || channelInfos[0]?.game_name || null;
-  const isLive = !!stream;
-  const message = formatShoutoutMessage(user.login, gameName || null, isLive);
-
-  recordCommandTestEntry({
-    source: 'twitch',
-    command: SO_COMMAND,
-    response: message,
-    channel,
-    user: username,
-  });
-
-  const runtime = _runtime;
-  if (!CUSTOM_COMMANDS_LIVE_REPLIES || !runtime) {
-    console.log(`[Twitch] Preview !so in ${channel} — would post: ${message}`);
-    return;
-  }
-
-  try {
-    await runtime.send(channel, message);
-    console.log(`[Twitch] Sent !so in ${channel} — ${message}`);
-  } catch (err) {
-    console.error(`[Twitch] Failed to send !so in ${channel}:`, err);
+  if (data) {
+    await dispatchShoutout(channel, response);
   }
 }

--- a/src/shoutoutHandler.ts
+++ b/src/shoutoutHandler.ts
@@ -1,0 +1,89 @@
+import { CUSTOM_COMMANDS_LIVE_REPLIES } from './config';
+import { getUsers, getChannelInfo, getStreams } from './twitchApi';
+import { recordCommandTestEntry } from './commandMonitorStore';
+import { extractCommand } from './commandUtils';
+
+const SO_COMMAND = '!so';
+
+// ─── Twitch runtime (registered from index.ts before startTwitchBot) ─────────
+
+interface ShoutoutRuntime {
+  send: (channel: string, message: string) => Promise<void>;
+}
+
+let _runtime: ShoutoutRuntime | null = null;
+
+export function registerShoutoutRuntime(runtime: ShoutoutRuntime): void {
+  _runtime = runtime;
+}
+
+// ─── Message formatting ───────────────────────────────────────────────────────
+
+function formatShoutoutMessage(login: string, gameName: string | null, isLive: boolean): string {
+  const url = `twitch.tv/${login}`;
+  if (isLive && gameName) return `Go check out @${login}, they're live playing ${gameName}! ${url}`;
+  if (gameName) return `Go give @${login} a follow! They were last seen playing ${gameName} — ${url}`;
+  return `Go give @${login} a follow at ${url}!`;
+}
+
+// ─── Execute ──────────────────────────────────────────────────────────────────
+
+export async function executeShoutoutForTwitch(
+  channel: string,
+  rawMessage: string,
+  username: string | null,
+  isModerator: boolean,
+): Promise<void> {
+  if (extractCommand(rawMessage) !== SO_COMMAND) return;
+  if (!isModerator) return;
+
+  const rawTarget = rawMessage.trim().split(/\s+/)[1];
+  if (!rawTarget) return;
+  const target = rawTarget.replace(/^@/, '').toLowerCase();
+  if (!target) return;
+
+  const users = await getUsers([target]);
+  const user = users[0];
+
+  if (!user) {
+    recordCommandTestEntry({
+      source: 'twitch',
+      command: SO_COMMAND,
+      response: `(unknown user: ${target})`,
+      channel,
+      user: username,
+    });
+    return;
+  }
+
+  const [channelInfos, streams] = await Promise.all([
+    getChannelInfo([user.id]),
+    getStreams([user.id]),
+  ]);
+
+  const stream = streams[0];
+  const gameName = stream?.game_name || channelInfos[0]?.game_name || null;
+  const isLive = !!stream;
+  const message = formatShoutoutMessage(user.login, gameName || null, isLive);
+
+  recordCommandTestEntry({
+    source: 'twitch',
+    command: SO_COMMAND,
+    response: message,
+    channel,
+    user: username,
+  });
+
+  const runtime = _runtime;
+  if (!CUSTOM_COMMANDS_LIVE_REPLIES || !runtime) {
+    console.log(`[Twitch] Preview !so in ${channel} — would post: ${message}`);
+    return;
+  }
+
+  try {
+    await runtime.send(channel, message);
+    console.log(`[Twitch] Sent !so in ${channel} — ${message}`);
+  } catch (err) {
+    console.error(`[Twitch] Failed to send !so in ${channel}:`, err);
+  }
+}

--- a/src/twitchApi.ts
+++ b/src/twitchApi.ts
@@ -107,6 +107,32 @@ export async function getStreams(userIds: string[]): Promise<TwitchStream[]> {
   return results;
 }
 
+export interface TwitchChannelInfo {
+  broadcaster_id: string;
+  broadcaster_login: string;
+  game_name: string;
+  title: string;
+}
+
+export async function getChannelInfo(broadcasterIds: string[]): Promise<TwitchChannelInfo[]> {
+  if (broadcasterIds.length === 0) return [];
+  const token = await getAppToken();
+  const results: TwitchChannelInfo[] = [];
+  for (const batch of chunks(broadcasterIds, 100)) {
+    const params = batch.map((id) => `broadcaster_id=${encodeURIComponent(id)}`).join('&');
+    const res = await twitchFetch(`https://api.twitch.tv/helix/channels?${params}`, {
+      headers: authHeaders(token),
+    });
+    if (!res.ok) {
+      if (res.status === 401) { cachedAppToken = null; appTokenExpiry = 0; }
+      throw new Error(`[TwitchAPI] getChannelInfo failed: ${res.status}`);
+    }
+    const data = await res.json() as { data: TwitchChannelInfo[] };
+    results.push(...data.data);
+  }
+  return results;
+}
+
 export interface SharedChatParticipant {
   broadcaster_id: string;
   broadcaster_login: string;

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -4,6 +4,7 @@ import { handleCommand } from './commandRouter';
 import { executeCustomCommandForTwitch } from './customCommandHandler';
 import { executeCounterCommandForTwitch } from './counterHandler';
 import { executeMultiCommandForTwitch } from './multiCommandHandler';
+import { executeShoutoutForTwitch } from './shoutoutHandler';
 import { setTwitchChannel } from './statusStore';
 import { getTwitchEnabledChannels } from './db';
 import { normalizeTwitchChannelName } from './twitchChannelName';
@@ -162,16 +163,23 @@ export async function startTwitchBot(): Promise<void> {
     // its source channel.
     if (tags['source-room-id'] && tags['source-room-id'] !== tags['room-id']) return;
 
-    executeCustomCommandForTwitch(normalizedChannel, message, tags['display-name'] ?? tags.username ?? null).catch((err) =>
+    const displayName = tags['display-name'] ?? tags.username ?? null;
+    const isMod = tags.mod === true || !!(tags.badges as Record<string, string> | null | undefined)?.broadcaster;
+
+    executeCustomCommandForTwitch(normalizedChannel, message, displayName).catch((err) =>
       console.error('[Twitch] Custom command error:', err),
     );
 
-    executeCounterCommandForTwitch(normalizedChannel, message, tags['display-name'] ?? tags.username ?? null).catch((err) =>
+    executeCounterCommandForTwitch(normalizedChannel, message, displayName).catch((err) =>
       console.error('[Twitch] Counter command error:', err),
     );
 
-    executeMultiCommandForTwitch(normalizedChannel, message, tags['display-name'] ?? tags.username ?? null).catch((err) =>
+    executeMultiCommandForTwitch(normalizedChannel, message, displayName).catch((err) =>
       console.error('[Twitch] Multi command error:', err),
+    );
+
+    executeShoutoutForTwitch(normalizedChannel, message, displayName, isMod).catch((err) =>
+      console.error('[Twitch] Shoutout error:', err),
     );
 
     handleCommand(message, 'twitch').catch((err) =>


### PR DESCRIPTION
## Summary

- Adds a mod/broadcaster-only `!so @streamer` (or `!so streamer`) command that posts a formatted shoutout to Twitch chat
- Fetches the target's last-played game via the new `/helix/channels` endpoint (works even when the streamer is offline) and checks live status in parallel to tailor the message
- Respects the existing `CUSTOM_COMMANDS_LIVE_REPLIES` shadow-mode flag — runs in preview-only mode until that env var is enabled
- Refactors `reservedCommands.ts` from a plain `Set` to a typed `BUILT_IN_COMMANDS` record with descriptions, so adding future hardcoded commands is a single-entry change that automatically protects the trigger from being claimed as a custom command or counter

## Message formats

| Condition | Output |
|-----------|--------|
| Target is live with game | `Go check out @name, they're live playing Fortnite! twitch.tv/name` |
| Target is offline with known last game | `Go give @name a follow! They were last seen playing Fortnite — twitch.tv/name` |
| No game data available | `Go give @name a follow at twitch.tv/name!` |
| Unknown username | Silent no-op (logged to command monitor) |

## Files changed

- `src/shoutoutHandler.ts` — new handler (same runtime-injection pattern as `multiCommandHandler.ts`)
- `src/twitchApi.ts` — adds `getChannelInfo()` / `TwitchChannelInfo` for the `/helix/channels` endpoint
- `src/db/reservedCommands.ts` — replaces plain `Set` with typed `BUILT_IN_COMMANDS` record; `!so` added alongside `!multi`
- `src/twitchBot.ts` — derives `isMod` from tags and calls `executeShoutoutForTwitch`
- `src/index.ts` — registers shoutout runtime

## Test plan

- [ ] With `CUSTOM_COMMANDS_LIVE_REPLIES=false`: type `!so @somestreamer` as a mod — confirm preview log appears, no message sent to chat
- [ ] With `CUSTOM_COMMANDS_LIVE_REPLIES=true`: type `!so @livestreamer` as a mod — confirm live message with game name posted
- [ ] Type `!so @offlinestreamer` — confirm "last seen playing" message
- [ ] Type `!so @nonexistentuser` — confirm silent no-op (visible in command monitor)
- [ ] Type `!so @someone` as a non-mod viewer — confirm command is ignored
- [ ] Attempt to create a custom command with trigger `!so` via admin panel — confirm `ReservedCommandError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a moderator-only shoutout command (!so) to highlight other Twitch channels with game and live-status info.

* **Improvements**
  * Command reservation now uses a registry for built-in commands.
  * Twitch integration enhanced to fetch channel metadata in batches for richer shoutout details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->