### PR TITLE
refactor: extract shared createMutationQueue utility

### DIFF
--- a/src/mutationQueue.test.ts
+++ b/src/mutationQueue.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { createMutationQueue } from './mutationQueue';
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+describe('createMutationQueue', () => {
+  // ─── Invariant 1: same-key serialization ──────────────────────────────────
+
+  it('runs same-key operations sequentially in enqueue order', async () => {
+    const queue = createMutationQueue();
+    const order: string[] = [];
+    const { promise: gate, resolve: openGate } = deferred();
+
+    // op1 holds the gate open so op2 cannot start until op1 finishes
+    const op1 = queue.run('k', async () => {
+      order.push('a-start');
+      await gate;
+      order.push('a-end');
+    });
+    const op2 = queue.run('k', async () => {
+      order.push('b-start');
+      order.push('b-end');
+    });
+
+    openGate();
+    await Promise.all([op1, op2]);
+
+    expect(order).toEqual(['a-start', 'a-end', 'b-start', 'b-end']);
+  });
+
+  // ─── Invariant 2: different-key independence ───────────────────────────────
+
+  it('allows concurrent execution across different keys', async () => {
+    const queue = createMutationQueue();
+    const { promise: gate, resolve: openGate } = deferred();
+    const order: string[] = [];
+
+    // opA blocks on the gate; if keys were serialized globally this would deadlock
+    const opA = queue.run('a', async () => {
+      await gate;
+      order.push('a');
+    });
+
+    // Awaiting opB must complete while opA is still blocked — proves independence
+    await queue.run('b', async () => { order.push('b'); });
+    expect(order).toEqual(['b']);
+
+    openGate();
+    await opA;
+    expect(order).toEqual(['b', 'a']);
+  });
+
+  // ─── Invariant 3: failure isolation ───────────────────────────────────────
+
+  it('does not block subsequent same-key operations when a previous one fails', async () => {
+    const queue = createMutationQueue();
+    const order: string[] = [];
+
+    // Enqueue both before either runs so op2 genuinely chains off a failing op1
+    const op1 = queue.run('k', async () => { throw new Error('boom'); });
+    const op2 = queue.run('k', async () => { order.push('second'); });
+
+    await expect(op1).rejects.toThrow('boom');
+    await op2;
+    expect(order).toEqual(['second']);
+  });
+
+  // ─── Queue-map cleanup ────────────────────────────────────────────────────
+
+  it('removes the key from the internal map after the last operation completes', async () => {
+    const queue = createMutationQueue();
+
+    expect(queue.size()).toBe(0);
+
+    const { promise: gate, resolve: openGate } = deferred();
+    const inflight = queue.run('k', async () => { await gate; });
+
+    expect(queue.size()).toBe(1); // entry exists while operation is in flight
+
+    openGate();
+    await inflight;
+
+    expect(queue.size()).toBe(0); // entry removed once queue drains
+  });
+
+  it('keeps the key present while a second operation is queued behind the first', async () => {
+    const queue = createMutationQueue();
+    const { promise: gate, resolve: openGate } = deferred();
+
+    const op1 = queue.run('k', async () => { await gate; });
+    const op2 = queue.run('k', async () => {});
+
+    expect(queue.size()).toBe(1); // one entry covers both pending ops for 'k'
+
+    openGate();
+    await Promise.all([op1, op2]);
+
+    expect(queue.size()).toBe(0);
+  });
+});

--- a/src/mutationQueue.ts
+++ b/src/mutationQueue.ts
@@ -7,10 +7,13 @@
  */
 export function createMutationQueue<K = string>(): {
   run<T>(key: K, operation: () => Promise<T>): Promise<T>;
+  /** Number of keys with at least one operation in flight. */
+  size(): number;
 } {
   const queues = new Map<K, Promise<void>>();
 
   return {
+    size: () => queues.size,
     async run<T>(key: K, operation: () => Promise<T>): Promise<T> {
       const previous = queues.get(key) ?? Promise.resolve();
       let release!: () => void;

--- a/src/mutationQueue.ts
+++ b/src/mutationQueue.ts
@@ -1,0 +1,46 @@
+/**
+ * Creates a per-key serializing queue for async operations.
+ *
+ * Operations sharing the same key run sequentially; operations on different
+ * keys are independent. A failure in one queued operation does not prevent
+ * later operations on the same key from running.
+ */
+export function createMutationQueue<K = string>(): {
+  run<T>(key: K, operation: () => Promise<T>): Promise<T>;
+} {
+  const queues = new Map<K, Promise<void>>();
+
+  return {
+    async run<T>(key: K, operation: () => Promise<T>): Promise<T> {
+      const previous = queues.get(key) ?? Promise.resolve();
+      let release!: () => void;
+      const current = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const queued = (async () => {
+        try {
+          await previous;
+        } catch {
+          // Ignore earlier failures so later operations still run.
+        }
+        await current;
+      })().catch(() => {});
+      queues.set(key, queued);
+
+      try {
+        await previous;
+      } catch {
+        // Ignore earlier failures so later operations still run.
+      }
+
+      try {
+        return await operation();
+      } finally {
+        release();
+        if (queues.get(key) === queued) {
+          queues.delete(key);
+        }
+      }
+    },
+  };
+}

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -9,12 +9,13 @@ import { setTwitchChannel } from './statusStore';
 import { getTwitchEnabledChannels } from './db';
 import { normalizeTwitchChannelName } from './twitchChannelName';
 import { getUsers } from './twitchApi';
+import { createMutationQueue } from './mutationQueue';
 
 let client: tmi.Client | null = null;
 let connected = false;
 const activeChannels = new Set<string>();
 const activeChannelUserIds = new Map<string, string>();
-const membershipMutationQueues = new Map<string, Promise<void>>();
+const membershipMutationQueue = createMutationQueue();
 
 function normalizeChannel(channel: string): string | null {
   return normalizeTwitchChannelName(channel);
@@ -25,37 +26,6 @@ function isChannelJoined(channel: string): boolean {
   return client.getChannels().some((joinedChannel) => normalizeChannel(joinedChannel) === channel);
 }
 
-async function withMembershipMutationLock<T>(channel: string, operation: () => Promise<T>): Promise<T> {
-  const previous = membershipMutationQueues.get(channel) ?? Promise.resolve();
-  let release!: () => void;
-  const current = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  const queued = (async () => {
-    try {
-      await previous;
-    } catch {
-      // Ignore earlier failures so later membership changes still run.
-    }
-    await current;
-  })().catch(() => {});
-  membershipMutationQueues.set(channel, queued);
-
-  try {
-    await previous;
-  } catch {
-    // Ignore earlier failures so later membership changes still run.
-  }
-
-  try {
-    return await operation();
-  } finally {
-    release();
-    if (membershipMutationQueues.get(channel) === queued) {
-      membershipMutationQueues.delete(channel);
-    }
-  }
-}
 
 async function reconcileJoinedChannels(): Promise<void> {
   if (!client || !connected) return;
@@ -67,7 +37,7 @@ async function reconcileJoinedChannels(): Promise<void> {
 
   for (const channel of joinedChannels) {
     try {
-      await withMembershipMutationLock(channel, async () => {
+      await membershipMutationQueue.run(channel, async () => {
         if (activeChannels.has(channel)) {
           setTwitchChannel(channel, true);
           return;
@@ -90,7 +60,7 @@ async function reconcileJoinedChannels(): Promise<void> {
     if (joinedChannelSet.has(channel)) continue;
 
     try {
-      await withMembershipMutationLock(channel, async () => {
+      await membershipMutationQueue.run(channel, async () => {
         if (!activeChannels.has(channel)) return;
         if (!client || !connected) {
           setTwitchChannel(channel, false);
@@ -220,7 +190,7 @@ export async function joinTwitchChannel(channel: string): Promise<void> {
     throw new Error(`[Twitch] Invalid channel name: ${channel}`);
   }
 
-  await withMembershipMutationLock(normalized, async () => {
+  await membershipMutationQueue.run(normalized, async () => {
     if (activeChannels.has(normalized)) {
       // When the desired membership is already queued offline we should still no-op,
       // but if a previous live join failed we need to retry once the client is connected.
@@ -275,7 +245,7 @@ export async function partTwitchChannel(channel: string): Promise<void> {
   const normalized = normalizeChannel(channel);
   if (!normalized) return;
 
-  await withMembershipMutationLock(normalized, async () => {
+  await membershipMutationQueue.run(normalized, async () => {
     if (!activeChannels.has(normalized) && !isChannelJoined(normalized)) return;
 
     if (!client || !connected) {

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -27,6 +27,35 @@ function isChannelJoined(channel: string): boolean {
 }
 
 
+async function partStaleChannel(channel: string): Promise<void> {
+  if (activeChannels.has(channel)) {
+    setTwitchChannel(channel, true);
+    return;
+  }
+  if (!client || !connected || !isChannelJoined(channel)) {
+    setTwitchChannel(channel, false);
+    return;
+  }
+  await client.part(channel);
+  setTwitchChannel(channel, false);
+  console.log(`[Twitch] Parted stale channel after reconnect: ${channel}`);
+}
+
+async function joinMissingChannel(channel: string): Promise<void> {
+  if (!activeChannels.has(channel)) return;
+  if (!client || !connected) {
+    setTwitchChannel(channel, false);
+    return;
+  }
+  if (isChannelJoined(channel)) {
+    setTwitchChannel(channel, true);
+    return;
+  }
+  await client.join(channel);
+  setTwitchChannel(channel, true);
+  console.log(`[Twitch] Joined queued channel after reconnect: ${channel}`);
+}
+
 async function reconcileJoinedChannels(): Promise<void> {
   if (!client || !connected) return;
 
@@ -37,20 +66,7 @@ async function reconcileJoinedChannels(): Promise<void> {
 
   for (const channel of joinedChannels) {
     try {
-      await membershipMutationQueue.run(channel, async () => {
-        if (activeChannels.has(channel)) {
-          setTwitchChannel(channel, true);
-          return;
-        }
-        if (!client || !connected || !isChannelJoined(channel)) {
-          setTwitchChannel(channel, false);
-          return;
-        }
-
-        await client.part(channel);
-        setTwitchChannel(channel, false);
-        console.log(`[Twitch] Parted stale channel after reconnect: ${channel}`);
-      });
+      await membershipMutationQueue.run(channel, () => partStaleChannel(channel));
     } catch (err) {
       console.error(`[Twitch] Failed to part stale channel ${channel}:`, err);
     }
@@ -58,23 +74,8 @@ async function reconcileJoinedChannels(): Promise<void> {
 
   for (const channel of activeChannels) {
     if (joinedChannelSet.has(channel)) continue;
-
     try {
-      await membershipMutationQueue.run(channel, async () => {
-        if (!activeChannels.has(channel)) return;
-        if (!client || !connected) {
-          setTwitchChannel(channel, false);
-          return;
-        }
-        if (isChannelJoined(channel)) {
-          setTwitchChannel(channel, true);
-          return;
-        }
-
-        await client.join(channel);
-        setTwitchChannel(channel, true);
-        console.log(`[Twitch] Joined queued channel after reconnect: ${channel}`);
-      });
+      await membershipMutationQueue.run(channel, () => joinMissingChannel(channel));
     } catch (err) {
       setTwitchChannel(channel, false);
       console.error(`[Twitch] Failed to join queued channel ${channel}:`, err);

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -302,7 +302,7 @@ router.post('/users/update', requireAdmin, csrfProtection, async (req, res) => {
     });
   }
   try {
-    await updateAccessLevel(trimmedDiscordId, level);
+    await userMutationQueue.run(trimmedDiscordId, () => updateAccessLevel(trimmedDiscordId, level));
   } catch (err) {
     console.error('[Web] Update access level error:', err);
     return res.redirect('/admin/users?error=update_failed');

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -18,6 +18,7 @@ import { requireManager, requireAdmin } from '../middleware';
 import { discordClient, fetchMemberDisplayName } from '../../discordBot';
 import { joinTwitchChannel, partTwitchChannel } from '../../twitchBot';
 import { normalizeTwitchChannelName } from '../../twitchChannelName';
+import { createMutationQueue } from '../../mutationQueue';
 
 const router = Router();
 
@@ -25,7 +26,7 @@ const KNOWN_ERRORS = new Set(['add_failed', 'duplicate_twitch_name', 'update_fai
 // Twitch membership changes are serialized per user in-process because this bot
 // currently runs as a single web instance. If that changes, move this lock into
 // shared storage or a DB transaction/row lock before scaling out.
-const userMutationQueues = new Map<string, Promise<void>>();
+const userMutationQueue = createMutationQueue();
 
 type RefreshOutcome = 'idle' | 'running' | 'success' | 'partial' | 'noop' | 'error';
 
@@ -63,37 +64,6 @@ function isDuplicateTwitchNameDbError(error: unknown): boolean {
     && (dbError.message?.includes('ux_user_twitch_name') ?? false);
 }
 
-async function withUserMutationLock<T>(discordId: string, operation: () => Promise<T>): Promise<T> {
-  const previous = userMutationQueues.get(discordId) ?? Promise.resolve();
-  let release!: () => void;
-  const current = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  const queued = (async () => {
-    try {
-      await previous;
-    } catch {
-      // Ignore failures from earlier queued operations so later mutations still run.
-    }
-    await current;
-  })().catch(() => {});
-  userMutationQueues.set(discordId, queued);
-
-  try {
-    await previous;
-  } catch {
-    // Ignore failures from earlier queued operations so later mutations still run.
-  }
-
-  try {
-    return await operation();
-  } finally {
-    release();
-    if (userMutationQueues.get(discordId) === queued) {
-      userMutationQueues.delete(discordId);
-    }
-  }
-}
 
 async function runDiscordNameRefresh(): Promise<void> {
   refreshState.outcome = 'running';
@@ -202,7 +172,7 @@ router.post('/users/add', requireAdmin, csrfProtection, async (req, res) => {
     });
   }
   try {
-    await withUserMutationLock(trimmedDiscordId, async () => {
+    await userMutationQueue.run(trimmedDiscordId, async () => {
       const trimmedDiscordName = (discord_name ?? '').trim();
       const existingUser = await findUser(trimmedDiscordId);
       const previousTwitchChannel = existingUser?.twitch_name
@@ -353,7 +323,7 @@ router.post('/users/remove', requireAdmin, csrfProtection, async (req, res) => {
     });
   }
   try {
-    await withUserMutationLock(trimmedDiscordId, async () => {
+    await userMutationQueue.run(trimmedDiscordId, async () => {
       const existingUser = await findUser(trimmedDiscordId);
       await removeUser(trimmedDiscordId);
 
@@ -414,7 +384,7 @@ router.post('/users/toggle-twitch', requireManager, csrfProtection, async (req, 
   }
 
   try {
-    await withUserMutationLock(trimmedDiscordId, async () => {
+    await userMutationQueue.run(trimmedDiscordId, async () => {
       const user = await findUser(trimmedDiscordId);
       if (!user || !user.twitch_name) {
         throw new Error('Toggle target user is missing or has no Twitch channel');


### PR DESCRIPTION
## Summary
- `twitchBot.ts` and `admin.ts` each contained an identical ~30-line per-key serializing queue helper (`withMembershipMutationLock` / `withUserMutationLock`) that differed only in variable names
- Extracted the pattern into `src/mutationQueue.ts` as `createMutationQueue<K>()`, a factory that returns a `{ run(key, operation) }` object
- Replaced both local copies — 6 call sites total — with `queue.run(key, operation)`
- Also removed the now-redundant `Map<string, Promise<void>>` declarations from both files

## Test plan
- [ ] Adding/updating/removing a user via the admin panel still serializes correctly per Discord ID
- [ ] Joining/parting Twitch channels still serializes correctly per channel name
- [ ] Concurrent mutations on different keys remain independent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared per-key mutation queue to serialize related operations and avoid cross-key interference

* **Refactor**
  * Improved concurrency handling for Twitch channel join/part operations using the shared queue
  * Enhanced request serialization for admin user operations to ensure consistent processing

* **Tests**
  * Added tests verifying queue ordering, isolation, failure recovery, and cleanup

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/75)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->