### PR TITLE
fix(test): add vitest config to exclude dist/ from test discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Twitch & Discord SFX bot",
   "scripts": {
     "dev": "ts-node src/index.ts",
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "start": "node dist/index.js",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
- Vitest had no config file, so its default glob (`**/*.{test,spec}.[jt]s`) matched `dist/db/lookupCache.test.js` (the compiled CJS output of the source test) alongside the real `.test.ts` files
- The compiled file fails immediately with `Vitest cannot be imported in a CommonJS module using require()` because Vitest's entry point is ESM-only
- Added `vitest.config.ts` with `include: ['src/**/*.test.ts']` to scope discovery explicitly to source files

## Root cause
`tsc` compiles everything under `src/` including test files into `dist/`. Without a vitest config, both the source `.test.ts` and the compiled `.test.js` were discovered. The compiled output is CommonJS (matching `tsconfig.json` `"module": "Node16"`), which can't `require()` Vitest's ESM entry.

## Test plan
- [ ] `npm test` passes with no failed suites
- [ ] `dist/` is not mentioned in vitest output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized TypeScript build configuration for improved compilation
  * Added test runner configuration to streamline testing infrastructure

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/76)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->