### PR TITLE
refactor(admin): split admin route into focused modules to reduce complexity

### DIFF
--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -1,124 +1,32 @@
 import { Router } from 'express';
 import {
   getAllUsers,
-  getTwitchEnabledChannels,
-  findUser,
-  findUserByTwitchName,
-  upsertUser,
-  removeUser,
   updateAccessLevel,
-  updateDiscordName,
-  updateTwitchBotEnabled,
   ACCESS_LEVEL_LABELS,
   AccessLevel,
   AccessLevelValue,
 } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireManager, requireAdmin } from '../middleware';
-import { discordClient, fetchMemberDisplayName } from '../../discordBot';
-import { joinTwitchChannel, partTwitchChannel } from '../../twitchBot';
 import { normalizeTwitchChannelName } from '../../twitchChannelName';
 import { createMutationQueue } from '../../mutationQueue';
+import adminRefreshRouter, { refreshState } from './adminRefresh';
+import {
+  DuplicateTwitchNameError,
+  isDuplicateTwitchNameDbError,
+  addOrUpdateUserMutation,
+  removeUserMutation,
+  toggleTwitchMutation,
+} from './adminUserMutations';
 
 const router = Router();
+router.use(adminRefreshRouter);
 
 const KNOWN_ERRORS = new Set(['add_failed', 'duplicate_twitch_name', 'update_failed', 'remove_failed', 'toggle_failed']);
 // Twitch membership changes are serialized per user in-process because this bot
 // currently runs as a single web instance. If that changes, move this lock into
 // shared storage or a DB transaction/row lock before scaling out.
 const userMutationQueue = createMutationQueue();
-
-type RefreshOutcome = 'idle' | 'running' | 'success' | 'partial' | 'noop' | 'error';
-
-// This progress state is intentionally in-process because the web panel runs as
-// a single bot instance today. If the panel is ever scaled horizontally, move
-// this state into shared storage before relying on /users/refresh-status.
-const refreshState: {
-  outcome: RefreshOutcome;
-  updatedCount: number;
-  failureCount: number;
-  startedAt: number | null;
-  finishedAt: number | null;
-} = {
-  outcome: 'idle',
-  updatedCount: 0,
-  failureCount: 0,
-  startedAt: null,
-  finishedAt: null,
-};
-
-class DuplicateTwitchNameError extends Error {
-  constructor(twitchChannel: string) {
-    super(`Twitch channel ${twitchChannel} is already assigned to another user`);
-    this.name = 'DuplicateTwitchNameError';
-  }
-}
-
-function isDuplicateTwitchNameDbError(error: unknown): boolean {
-  if (!error || typeof error !== 'object') {
-    return false;
-  }
-
-  const dbError = error as { code?: string; message?: string };
-  return dbError.code === 'ER_DUP_ENTRY'
-    && (dbError.message?.includes('ux_user_twitch_name') ?? false);
-}
-
-
-async function runDiscordNameRefresh(): Promise<void> {
-  refreshState.outcome = 'running';
-  refreshState.updatedCount = 0;
-  refreshState.failureCount = 0;
-  refreshState.startedAt = Date.now();
-  refreshState.finishedAt = null;
-
-  try {
-    if (!discordClient) {
-      throw new Error('Discord client is not ready');
-    }
-
-    const users = await getAllUsers();
-    let updatedCount = 0;
-    let failureCount = 0;
-
-    for (const user of users) {
-      try {
-        const name = await fetchMemberDisplayName(user.discord_id, true);
-        if (name == null) {
-          failureCount++;
-          refreshState.failureCount = failureCount;
-          console.error('[Web] Failed to refresh Discord name for ' + user.discord_id + ': Discord lookup returned no display name');
-          await new Promise((resolve) => setTimeout(resolve, 200));
-          continue;
-        }
-
-        const trimmedName = name?.trim();
-        if (trimmedName && trimmedName !== user.discord_name) {
-          await updateDiscordName(user.discord_id, trimmedName);
-          updatedCount++;
-          refreshState.updatedCount = updatedCount;
-        }
-      } catch (err) {
-        failureCount++;
-        refreshState.failureCount = failureCount;
-        console.error('[Web] Failed to refresh Discord name for', user.discord_id, err);
-      }
-      await new Promise((resolve) => setTimeout(resolve, 200));
-    }
-
-    refreshState.updatedCount = updatedCount;
-    refreshState.failureCount = failureCount;
-    refreshState.outcome = updatedCount > 0
-      ? (failureCount > 0 ? 'partial' : 'success')
-      : (failureCount > 0 ? 'error' : 'noop');
-  } catch (err) {
-    refreshState.failureCount = Math.max(refreshState.failureCount, 1);
-    refreshState.outcome = 'error';
-    console.error('[Web] Refresh Discord names failed:', err);
-  } finally {
-    refreshState.finishedAt = Date.now();
-  }
-}
 
 // View user list (Manager+)
 router.get('/users', requireManager, csrfProtection, async (req, res) => {
@@ -136,10 +44,6 @@ router.get('/users', requireManager, csrfProtection, async (req, res) => {
     console.error('[Web] Admin users error:', err);
     res.status(500).render('error', { message: 'Failed to load users.', user: req.session.user ?? null });
   }
-});
-
-router.get('/users/refresh-status', requireManager, (_req, res) => {
-  res.json(refreshState);
 });
 
 // Add or update a user (Admin only)
@@ -160,10 +64,7 @@ router.post('/users/add', requireAdmin, csrfProtection, async (req, res) => {
   if (!Number.isFinite(level)) return res.status(400).render('error', { message: 'Invalid access level.', user: req.session.user ?? null });
   if (!(Object.values(AccessLevel) as number[]).includes(level)) return res.status(400).render('error', { message: 'Invalid access level.', user: req.session.user ?? null });
   if (!shouldClearTwitchName && submittedTwitchName && !normalizedTwitchName) {
-    return res.status(400).render('error', {
-      message: 'Invalid Twitch name.',
-      user: req.session.user ?? null,
-    });
+    return res.status(400).render('error', { message: 'Invalid Twitch name.', user: req.session.user ?? null });
   }
   if (trimmedDiscordId === req.session.user?.discordId) {
     return res.status(400).render('error', {
@@ -172,109 +73,14 @@ router.post('/users/add', requireAdmin, csrfProtection, async (req, res) => {
     });
   }
   try {
-    await userMutationQueue.run(trimmedDiscordId, async () => {
-      const trimmedDiscordName = (discord_name ?? '').trim();
-      const existingUser = await findUser(trimmedDiscordId);
-      const previousTwitchChannel = existingUser?.twitch_name
-        ? normalizeTwitchChannelName(existingUser.twitch_name)
-        : null;
-      const nextTwitchName = shouldClearTwitchName
-        ? ''
-        : normalizedTwitchName
-          ? normalizedTwitchName
-          : undefined;
-
-      if (normalizedTwitchName) {
-        const conflictingUser = await findUserByTwitchName(normalizedTwitchName, trimmedDiscordId);
-        if (conflictingUser) {
-          throw new DuplicateTwitchNameError(normalizedTwitchName);
-        }
-      }
-
-      await upsertUser(
-        trimmedDiscordId,
-        trimmedDiscordName,
-        level as AccessLevelValue,
-        nextTwitchName,
-      );
-
-      const committedUser = await findUser(trimmedDiscordId);
-      const committedTwitchChannel = committedUser?.twitch_name
-        ? normalizeTwitchChannelName(committedUser.twitch_name)
-        : null;
-
-      if (!existingUser?.is_twitch_bot_enabled || previousTwitchChannel === committedTwitchChannel) {
-        return;
-      }
-
-      if (!committedTwitchChannel) {
-        try {
-          // Persist disable first so the rollback path can safely restore both DB and runtime state.
-          await updateTwitchBotEnabled(trimmedDiscordId, false);
-          const enabledChannels = await getTwitchEnabledChannels();
-          if (previousTwitchChannel && !enabledChannels.includes(previousTwitchChannel)) {
-            await partTwitchChannel(previousTwitchChannel);
-          }
-        } catch (err) {
-          try {
-            await upsertUser(
-              trimmedDiscordId,
-              trimmedDiscordName,
-              level as AccessLevelValue,
-              previousTwitchChannel ?? '',
-            );
-            await updateTwitchBotEnabled(trimmedDiscordId, existingUser.is_twitch_bot_enabled);
-          } catch (rollbackErr) {
-            console.error('[Web] Add user clear Twitch rollback failed:', rollbackErr);
-          }
-          throw err;
-        }
-        return;
-      }
-
-      try {
-        const enabledChannels = await getTwitchEnabledChannels();
-        const shouldJoinCommittedChannel = enabledChannels.includes(committedTwitchChannel);
-        const shouldPartPreviousChannel = !!previousTwitchChannel
-          && previousTwitchChannel !== committedTwitchChannel
-          && !enabledChannels.includes(previousTwitchChannel);
-
-        if (shouldJoinCommittedChannel) {
-          await joinTwitchChannel(committedTwitchChannel);
-        }
-
-        if (shouldPartPreviousChannel) {
-          await partTwitchChannel(previousTwitchChannel);
-        }
-      } catch (err) {
-        try {
-          await upsertUser(
-            trimmedDiscordId,
-            trimmedDiscordName,
-            level as AccessLevelValue,
-            previousTwitchChannel ?? '',
-          );
-          await updateTwitchBotEnabled(trimmedDiscordId, existingUser.is_twitch_bot_enabled);
-
-          const rollbackEnabledChannels = await getTwitchEnabledChannels();
-          const shouldRejoinPreviousChannel = !!previousTwitchChannel
-            && rollbackEnabledChannels.includes(previousTwitchChannel);
-          const shouldPartCommittedChannel = committedTwitchChannel !== previousTwitchChannel
-            && !rollbackEnabledChannels.includes(committedTwitchChannel);
-
-          if (shouldRejoinPreviousChannel) {
-            await joinTwitchChannel(previousTwitchChannel);
-          }
-
-          if (shouldPartCommittedChannel) {
-            await partTwitchChannel(committedTwitchChannel);
-          }
-        } catch (rollbackErr) {
-          console.error('[Web] Add user DB rollback failed:', rollbackErr);
-        }
-        throw err;
-      }
-    });
+    const trimmedDiscordName = (discord_name ?? '').trim();
+    await userMutationQueue.run(trimmedDiscordId, () => addOrUpdateUserMutation({
+      discordId: trimmedDiscordId,
+      discordName: trimmedDiscordName,
+      level: level as AccessLevelValue,
+      normalizedTwitchName,
+      shouldClearTwitchName,
+    }));
   } catch (err) {
     console.error('[Web] Add user error:', err);
     if (err instanceof DuplicateTwitchNameError || isDuplicateTwitchNameDbError(err)) {
@@ -294,7 +100,6 @@ router.post('/users/update', requireAdmin, csrfProtection, async (req, res) => {
   if (!Number.isFinite(level)) return res.status(400).render('error', { message: 'Invalid access level.', user: req.session.user ?? null });
   if (!(Object.values(AccessLevel) as number[]).includes(level)) return res.status(400).render('error', { message: 'Invalid access level.', user: req.session.user ?? null });
 
-  // Prevent demoting yourself
   if (trimmedDiscordId === req.session.user!.discordId) {
     return res.status(400).render('error', {
       message: 'You cannot change your own access level.',
@@ -323,38 +128,7 @@ router.post('/users/remove', requireAdmin, csrfProtection, async (req, res) => {
     });
   }
   try {
-    await userMutationQueue.run(trimmedDiscordId, async () => {
-      const existingUser = await findUser(trimmedDiscordId);
-      await removeUser(trimmedDiscordId);
-
-      if (existingUser?.is_twitch_bot_enabled && existingUser.twitch_name) {
-        const normalizedChannel = normalizeTwitchChannelName(existingUser.twitch_name);
-        const enabledChannels = await getTwitchEnabledChannels();
-
-        if (normalizedChannel && !enabledChannels.includes(normalizedChannel)) {
-          try {
-            await partTwitchChannel(normalizedChannel);
-          } catch (partErr) {
-            try {
-              await upsertUser(
-                existingUser.discord_id,
-                existingUser.discord_name?.trim() ?? '',
-                existingUser.access_level as AccessLevelValue,
-                existingUser.twitch_name,
-              );
-              await updateTwitchBotEnabled(existingUser.discord_id, existingUser.is_twitch_bot_enabled);
-            } catch (rollbackErr) {
-              console.error(
-                '[Web] Failed to restore user after Twitch part failed during removal:',
-                trimmedDiscordId,
-                rollbackErr,
-              );
-            }
-            throw partErr;
-          }
-        }
-      }
-    });
+    await userMutationQueue.run(trimmedDiscordId, () => removeUserMutation(trimmedDiscordId));
   } catch (err) {
     console.error('[Web] Remove user error:', err);
     return res.redirect('/admin/users?error=remove_failed');
@@ -384,63 +158,12 @@ router.post('/users/toggle-twitch', requireManager, csrfProtection, async (req, 
   }
 
   try {
-    await userMutationQueue.run(trimmedDiscordId, async () => {
-      const user = await findUser(trimmedDiscordId);
-      if (!user || !user.twitch_name) {
-        throw new Error('Toggle target user is missing or has no Twitch channel');
-      }
-
-      const currentEnabled = user.is_twitch_bot_enabled;
-      const normalizedChannel = normalizeTwitchChannelName(user.twitch_name);
-
-      if (!normalizedChannel) {
-        throw new Error('Toggle target user has an invalid Twitch channel');
-      }
-
-      if (currentEnabled === nextEnabled) {
-        return;
-      }
-
-      await updateTwitchBotEnabled(trimmedDiscordId, nextEnabled);
-
-      try {
-        // joinTwitchChannel/partTwitchChannel are expected to throw on failure so
-        // this rollback keeps DB state aligned with runtime channel membership.
-        // Derive desired membership from the committed DB state so route handlers
-        // always reconcile against the effective enabled-channel set.
-        const enabledChannels = await getTwitchEnabledChannels();
-        const shouldBeJoined = enabledChannels.includes(normalizedChannel);
-
-        if (shouldBeJoined) {
-          await joinTwitchChannel(normalizedChannel);
-        } else {
-          await partTwitchChannel(normalizedChannel);
-        }
-      } catch (err) {
-        try {
-          await updateTwitchBotEnabled(trimmedDiscordId, currentEnabled);
-        } catch (rollbackErr) {
-          console.error('[Web] Toggle twitch user rollback failed:', rollbackErr);
-        }
-        throw err;
-      }
-    });
+    await userMutationQueue.run(trimmedDiscordId, () => toggleTwitchMutation(trimmedDiscordId, nextEnabled));
   } catch (err) {
     console.error('[Web] Toggle twitch user error:', err);
     return res.redirect('/admin/users?error=toggle_failed');
   }
-
   res.redirect('/admin/users');
-});
-
-// Refresh Discord names for all users (Manager+)
-router.post('/users/refresh-names', requireManager, csrfProtection, async (req, res) => {
-  if (refreshState.outcome === 'running') {
-    return res.redirect('/admin/users');
-  }
-
-  void runDiscordNameRefresh();
-  return res.redirect('/admin/users');
 });
 
 export default router;

--- a/src/web/routes/adminRefresh.ts
+++ b/src/web/routes/adminRefresh.ts
@@ -1,0 +1,95 @@
+import { Router } from 'express';
+import { getAllUsers, updateDiscordName } from '../../db';
+import { csrfProtection } from '../csrf';
+import { requireManager } from '../middleware';
+import { discordClient, fetchMemberDisplayName } from '../../discordBot';
+
+export type RefreshOutcome = 'idle' | 'running' | 'success' | 'partial' | 'noop' | 'error';
+
+// This progress state is intentionally in-process because the web panel runs as
+// a single bot instance today. If the panel is ever scaled horizontally, move
+// this state into shared storage before relying on /users/refresh-status.
+export const refreshState: {
+  outcome: RefreshOutcome;
+  updatedCount: number;
+  failureCount: number;
+  startedAt: number | null;
+  finishedAt: number | null;
+} = {
+  outcome: 'idle',
+  updatedCount: 0,
+  failureCount: 0,
+  startedAt: null,
+  finishedAt: null,
+};
+
+async function runDiscordNameRefresh(): Promise<void> {
+  refreshState.outcome = 'running';
+  refreshState.updatedCount = 0;
+  refreshState.failureCount = 0;
+  refreshState.startedAt = Date.now();
+  refreshState.finishedAt = null;
+
+  try {
+    if (!discordClient) {
+      throw new Error('Discord client is not ready');
+    }
+
+    const users = await getAllUsers();
+    let updatedCount = 0;
+    let failureCount = 0;
+
+    for (const user of users) {
+      try {
+        const name = await fetchMemberDisplayName(user.discord_id, true);
+        if (name == null) {
+          failureCount++;
+          refreshState.failureCount = failureCount;
+          console.error('[Web] Failed to refresh Discord name for ' + user.discord_id + ': Discord lookup returned no display name');
+          await new Promise((resolve) => setTimeout(resolve, 200));
+          continue;
+        }
+
+        const trimmedName = name?.trim();
+        if (trimmedName && trimmedName !== user.discord_name) {
+          await updateDiscordName(user.discord_id, trimmedName);
+          updatedCount++;
+          refreshState.updatedCount = updatedCount;
+        }
+      } catch (err) {
+        failureCount++;
+        refreshState.failureCount = failureCount;
+        console.error('[Web] Failed to refresh Discord name for', user.discord_id, err);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+
+    refreshState.updatedCount = updatedCount;
+    refreshState.failureCount = failureCount;
+    refreshState.outcome = updatedCount > 0
+      ? (failureCount > 0 ? 'partial' : 'success')
+      : (failureCount > 0 ? 'error' : 'noop');
+  } catch (err) {
+    refreshState.failureCount = Math.max(refreshState.failureCount, 1);
+    refreshState.outcome = 'error';
+    console.error('[Web] Refresh Discord names failed:', err);
+  } finally {
+    refreshState.finishedAt = Date.now();
+  }
+}
+
+const router = Router();
+
+router.get('/users/refresh-status', requireManager, (_req, res) => {
+  res.json(refreshState);
+});
+
+router.post('/users/refresh-names', requireManager, csrfProtection, async (_req, res) => {
+  if (refreshState.outcome === 'running') {
+    return res.redirect('/admin/users');
+  }
+  void runDiscordNameRefresh();
+  return res.redirect('/admin/users');
+});
+
+export default router;

--- a/src/web/routes/adminUserMutations.ts
+++ b/src/web/routes/adminUserMutations.ts
@@ -1,0 +1,234 @@
+import {
+  getTwitchEnabledChannels,
+  findUser,
+  findUserByTwitchName,
+  upsertUser,
+  removeUser,
+  updateTwitchBotEnabled,
+  AccessLevelValue,
+} from '../../db';
+import { joinTwitchChannel, partTwitchChannel } from '../../twitchBot';
+import { normalizeTwitchChannelName } from '../../twitchChannelName';
+
+export class DuplicateTwitchNameError extends Error {
+  constructor(twitchChannel: string) {
+    super(`Twitch channel ${twitchChannel} is already assigned to another user`);
+    this.name = 'DuplicateTwitchNameError';
+  }
+}
+
+export function isDuplicateTwitchNameDbError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+  const dbError = error as { code?: string; message?: string };
+  return dbError.code === 'ER_DUP_ENTRY'
+    && (dbError.message?.includes('ux_user_twitch_name') ?? false);
+}
+
+async function handleClearTwitchChannel(
+  discordId: string,
+  discordName: string,
+  level: AccessLevelValue,
+  previousChannel: string | null,
+  wasBotEnabled: boolean,
+): Promise<void> {
+  try {
+    // Persist disable first so the rollback path can safely restore both DB and runtime state.
+    await updateTwitchBotEnabled(discordId, false);
+    const enabledChannels = await getTwitchEnabledChannels();
+    if (previousChannel && !enabledChannels.includes(previousChannel)) {
+      await partTwitchChannel(previousChannel);
+    }
+  } catch (err) {
+    try {
+      await upsertUser(discordId, discordName, level, previousChannel ?? '');
+      await updateTwitchBotEnabled(discordId, wasBotEnabled);
+    } catch (rollbackErr) {
+      console.error('[Web] Add user clear Twitch rollback failed:', rollbackErr);
+    }
+    throw err;
+  }
+}
+
+interface ChangeTwitchChannelParams {
+  discordId: string;
+  discordName: string;
+  level: AccessLevelValue;
+  previousChannel: string | null;
+  committedChannel: string;
+  wasBotEnabled: boolean;
+}
+
+async function handleChangeTwitchChannel({
+  discordId,
+  discordName,
+  level,
+  previousChannel,
+  committedChannel,
+  wasBotEnabled,
+}: ChangeTwitchChannelParams): Promise<void> {
+  try {
+    const enabledChannels = await getTwitchEnabledChannels();
+    const shouldJoinCommittedChannel = enabledChannels.includes(committedChannel);
+    const shouldPartPreviousChannel = !!previousChannel
+      && previousChannel !== committedChannel
+      && !enabledChannels.includes(previousChannel);
+
+    if (shouldJoinCommittedChannel) {
+      await joinTwitchChannel(committedChannel);
+    }
+    if (shouldPartPreviousChannel) {
+      await partTwitchChannel(previousChannel);
+    }
+  } catch (err) {
+    try {
+      await upsertUser(discordId, discordName, level, previousChannel ?? '');
+      await updateTwitchBotEnabled(discordId, wasBotEnabled);
+
+      const rollbackEnabledChannels = await getTwitchEnabledChannels();
+      const shouldRejoinPreviousChannel = !!previousChannel
+        && rollbackEnabledChannels.includes(previousChannel);
+      const shouldPartCommittedChannel = committedChannel !== previousChannel
+        && !rollbackEnabledChannels.includes(committedChannel);
+
+      if (shouldRejoinPreviousChannel) {
+        await joinTwitchChannel(previousChannel);
+      }
+      if (shouldPartCommittedChannel) {
+        await partTwitchChannel(committedChannel);
+      }
+    } catch (rollbackErr) {
+      console.error('[Web] Add user DB rollback failed:', rollbackErr);
+    }
+    throw err;
+  }
+}
+
+export interface AddOrUpdateParams {
+  discordId: string;
+  discordName: string;
+  level: AccessLevelValue;
+  normalizedTwitchName: string | null;
+  shouldClearTwitchName: boolean;
+}
+
+export async function addOrUpdateUserMutation({
+  discordId,
+  discordName,
+  level,
+  normalizedTwitchName,
+  shouldClearTwitchName,
+}: AddOrUpdateParams): Promise<void> {
+  const existingUser = await findUser(discordId);
+  const previousChannel = existingUser?.twitch_name
+    ? normalizeTwitchChannelName(existingUser.twitch_name)
+    : null;
+  const nextTwitchName = shouldClearTwitchName
+    ? ''
+    : normalizedTwitchName ?? undefined;
+
+  if (normalizedTwitchName) {
+    const conflictingUser = await findUserByTwitchName(normalizedTwitchName, discordId);
+    if (conflictingUser) {
+      throw new DuplicateTwitchNameError(normalizedTwitchName);
+    }
+  }
+
+  await upsertUser(discordId, discordName, level, nextTwitchName);
+
+  const committedUser = await findUser(discordId);
+  const committedChannel = committedUser?.twitch_name
+    ? normalizeTwitchChannelName(committedUser.twitch_name)
+    : null;
+
+  if (!existingUser?.is_twitch_bot_enabled || previousChannel === committedChannel) {
+    return;
+  }
+
+  if (!committedChannel) {
+    await handleClearTwitchChannel(discordId, discordName, level, previousChannel, existingUser.is_twitch_bot_enabled);
+    return;
+  }
+
+  await handleChangeTwitchChannel({ discordId, discordName, level, previousChannel, committedChannel, wasBotEnabled: existingUser.is_twitch_bot_enabled });
+}
+
+export async function removeUserMutation(discordId: string): Promise<void> {
+  const existingUser = await findUser(discordId);
+  await removeUser(discordId);
+
+  if (!existingUser?.is_twitch_bot_enabled || !existingUser.twitch_name) {
+    return;
+  }
+
+  const normalizedChannel = normalizeTwitchChannelName(existingUser.twitch_name);
+  const enabledChannels = await getTwitchEnabledChannels();
+
+  if (!normalizedChannel || enabledChannels.includes(normalizedChannel)) {
+    return;
+  }
+
+  try {
+    await partTwitchChannel(normalizedChannel);
+  } catch (partErr) {
+    try {
+      await upsertUser(
+        existingUser.discord_id,
+        existingUser.discord_name?.trim() ?? '',
+        existingUser.access_level as AccessLevelValue,
+        existingUser.twitch_name,
+      );
+      await updateTwitchBotEnabled(existingUser.discord_id, existingUser.is_twitch_bot_enabled);
+    } catch (rollbackErr) {
+      console.error(
+        '[Web] Failed to restore user after Twitch part failed during removal:',
+        discordId,
+        rollbackErr,
+      );
+    }
+    throw partErr;
+  }
+}
+
+export async function toggleTwitchMutation(discordId: string, nextEnabled: boolean): Promise<void> {
+  const user = await findUser(discordId);
+  if (!user || !user.twitch_name) {
+    throw new Error('Toggle target user is missing or has no Twitch channel');
+  }
+
+  const currentEnabled = user.is_twitch_bot_enabled;
+  const normalizedChannel = normalizeTwitchChannelName(user.twitch_name);
+
+  if (!normalizedChannel) {
+    throw new Error('Toggle target user has an invalid Twitch channel');
+  }
+
+  if (currentEnabled === nextEnabled) {
+    return;
+  }
+
+  await updateTwitchBotEnabled(discordId, nextEnabled);
+
+  try {
+    // joinTwitchChannel/partTwitchChannel are expected to throw on failure so
+    // this rollback keeps DB state aligned with runtime channel membership.
+    // Derive desired membership from the committed DB state so route handlers
+    // always reconcile against the effective enabled-channel set.
+    const enabledChannels = await getTwitchEnabledChannels();
+    const shouldBeJoined = enabledChannels.includes(normalizedChannel);
+
+    if (shouldBeJoined) {
+      await joinTwitchChannel(normalizedChannel);
+    } else {
+      await partTwitchChannel(normalizedChannel);
+    }
+  } catch (err) {
+    try {
+      await updateTwitchBotEnabled(discordId, currentEnabled);
+    } catch (rollbackErr) {
+      console.error('[Web] Toggle twitch user rollback failed:', rollbackErr);
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary

- Extracts Discord name refresh logic (state, loop, two routes) into `adminRefresh.ts`
- Extracts all user mutation business logic (Twitch channel transitions, rollbacks, error helpers) into `adminUserMutations.ts`
- Leaves `admin.ts` as a thin HTTP routing layer (~155 lines) that imports and delegates to the above
- Converts `handleChangeTwitchChannel` from 6 positional parameters to a parameter-object (`ChangeTwitchChannelParams`) to resolve the `function-parameters` smell

No behaviour changes. `server.ts` is untouched — it still imports the default export from `./routes/admin`.

## Test plan

- [ ] Start the bot and navigate to `/admin/users` — user list renders correctly
- [ ] Add a new user with a Twitch channel — bot joins the channel
- [ ] Toggle Twitch bot off for a user — bot parts the channel
- [ ] Remove a user who has Twitch bot enabled — bot parts the channel
- [ ] Trigger "Refresh Discord names" — progress state updates and names refresh
- [ ] Verify `/admin/users/refresh-status` returns JSON correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Discord display name refresh functionality to update user profiles across the platform
  * Added endpoint to check refresh operation status and results

* **Improvements**
  * Refined error messaging for invalid Twitch names in user management operations

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/77)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->