### PR TITLE
refactor(twitchMonitor): split into focused modules to reduce complexity

### DIFF
--- a/src/twitchMonitor.ts
+++ b/src/twitchMonitor.ts
@@ -1,56 +1,28 @@
-import { EmbedBuilder, TextChannel } from 'discord.js';
 import { discordClient } from './discordBot';
-import { isDiscordNotFoundError, tryDeleteDiscordMessage } from './discordUtils';
-import { getMonitorEnabled } from './monitorSettings';
-import {
-  getAllStreamersWithGroups,
-  setStreamerLive,
-  clearStreamerLive,
-  DbStreamerFull,
-  DbStreamGroup,
-} from './db';
+import { getAllStreamersWithGroups, DbStreamerFull } from './db';
 import { getUsers, getStreams, TwitchStream } from './twitchApi';
-
-// ─── Types ───────────────────────────────────────────────────────────────────
-
-interface LiveState {
-  streamerId: number;
-  groupId: number;
-  group: DbStreamGroup;
-  login: string;
-  messageId: string | null;
-  channelId: string | null;
-  currentGame: string;
-  title: string;
-  currentStream: TwitchStream;
-  offlineTimer: ReturnType<typeof setTimeout> | null;
-}
-
-export interface DiscordEmbedPreview {
-  title: string;
-  url: string;
-  color: string;
-  fields: Array<{ name: string; value: string }>;
-  imageUrl: string;
-  footer: string | null;
-}
-
-export interface DiscordMessagePreview {
-  content: string;
-  embed: DiscordEmbedPreview;
-}
-
-export interface MultiTwitchPreview {
-  enabled: boolean;
-  applicable: boolean;
-  participants: string[];
-  url: string | null;
-  renderedFooter: string | null;
-}
-
-interface MultiTwitchContext {
-  participantsByGroupAndGame: Map<string, string[]>;
-}
+import { LiveState } from './twitchMonitorTypes';
+import {
+  DiscordMessagePreview,
+  buildMessagePreview,
+  getStreamUrl,
+} from './twitchMonitorEmbed';
+import {
+  MultiTwitchPreview,
+  MultiTwitchGroupInfo,
+  buildMultiTwitchContext,
+  getMultitwitchPreview,
+} from './twitchMonitorMultitwitch';
+import {
+  postAnnouncement,
+  editAnnouncement,
+  deleteAnnouncement,
+} from './twitchMonitorAnnouncements';
+import {
+  cancelOfflineTimersForLogin,
+  handleStreamOffline,
+} from './twitchMonitorOffline';
+import { performStartupLiveCheck } from './twitchMonitorStartup';
 
 // ─── Module-level state ──────────────────────────────────────────────────────
 
@@ -60,498 +32,12 @@ let loginToUserId = new Map<string, string>();
 let streamersData: DbStreamerFull[] = [];
 
 const POLL_INTERVAL_MS = 60_000;
-const OFFLINE_GRACE_MS = 5 * 60 * 1000;
 
 let pollTimer: ReturnType<typeof setInterval> | null = null;
 let pollRunning = false;
 let currentPollPromise: Promise<void> = Promise.resolve();
 
-// ─── Template helpers ─────────────────────────────────────────────────────────
-
-function fillTemplate(template: string, vars: Record<string, string>): string {
-  return template.replace(/\{(\w+)\}/g, (_, key: string) => vars[key] ?? `{${key}}`);
-}
-
-function getStreamUrl(login: string): string {
-  return `https://www.twitch.tv/${login}`;
-}
-
-function getThumbnailUrl(stream: TwitchStream): string {
-  return stream.thumbnail_url
-    .replace('{width}', '640')
-    .replace('{height}', '360');
-}
-
-function buildEmbedPreview(stream: TwitchStream, footer?: string): DiscordEmbedPreview {
-  return {
-    title: stream.title,
-    url: getStreamUrl(stream.user_login),
-    color: '#9146FF',
-    fields: [{ name: 'Game', value: stream.game_name || 'Unknown' }],
-    imageUrl: getThumbnailUrl(stream),
-    footer: footer || null,
-  };
-}
-
-function parseHexColor(color: string): number {
-  const normalized = color.trim().replace(/^#/, '');
-  if (!/^[0-9a-fA-F]{6}$/.test(normalized)) return 0x9146ff;
-  return parseInt(normalized, 16);
-}
-
-function buildEmbed(stream: TwitchStream, footer?: string): EmbedBuilder {
-  const preview = buildEmbedPreview(stream, footer);
-
-  const embed = new EmbedBuilder()
-    .setTitle(preview.title)
-    .setURL(preview.url)
-    .setColor(parseHexColor(preview.color))
-    .addFields(...preview.fields)
-    .setImage(preview.imageUrl);
-
-  if (preview.footer) embed.setFooter({ text: preview.footer });
-  return embed;
-}
-
-function templateVars(login: string, stream: TwitchStream, multitwitch?: string): Record<string, string> {
-  return {
-    streamer: login,
-    game: stream.game_name || 'Unknown',
-    title: stream.title,
-    url: getStreamUrl(login),
-    multitwitch: multitwitch ?? '',
-  };
-}
-
-function groupGameKey(groupId: number, game: string): string {
-  return `${groupId}::${game.toLowerCase()}`;
-}
-
-function buildMultiTwitchContext(states: Iterable<LiveState>): MultiTwitchContext {
-  const participantSets = new Map<string, Set<string>>();
-
-  for (const state of states) {
-    const key = groupGameKey(state.groupId, state.currentGame);
-    const participants = participantSets.get(key);
-    if (participants) {
-      participants.add(state.login);
-    } else {
-      participantSets.set(key, new Set([state.login]));
-    }
-  }
-
-  const participantsByGroupAndGame = new Map<string, string[]>();
-  for (const [key, participants] of participantSets.entries()) {
-    participantsByGroupAndGame.set(
-      key,
-      Array.from(participants).sort((participantA, participantB) => participantA.localeCompare(participantB)),
-    );
-  }
-
-  return { participantsByGroupAndGame };
-}
-
-function getMultitwitchPreview(state: LiveState, context?: MultiTwitchContext): MultiTwitchPreview {
-  const participants = context
-    ? context.participantsByGroupAndGame.get(groupGameKey(state.groupId, state.currentGame))
-    : buildMultiTwitchContext(liveStates.values()).participantsByGroupAndGame.get(groupGameKey(state.groupId, state.currentGame));
-  const applicable = !!participants && participants.length >= 2;
-
-  if (!applicable) {
-    return {
-      enabled: state.group.multi_twitch,
-      applicable: false,
-      participants: [state.login],
-      url: null,
-      renderedFooter: null,
-    };
-  }
-
-  if (!state.group.multi_twitch) {
-    return {
-      enabled: false,
-      applicable: true,
-      participants,
-      url: null,
-      renderedFooter: null,
-    };
-  }
-
-  const url = `https://www.multitwitch.tv/${participants.join('/')}`;
-  const renderedFooter = fillTemplate(state.group.multi_twitch_message, { multitwitch: url }) || null;
-
-  return {
-    enabled: true,
-    applicable: true,
-    participants,
-    url,
-    renderedFooter,
-  };
-}
-
-function buildMessagePreview(
-  state: LiveState,
-  templateKey: 'live_message' | 'new_game_message',
-  multiTwitch?: MultiTwitchPreview,
-): DiscordMessagePreview {
-  const stream = state.currentStream;
-  const resolvedMultiTwitch = multiTwitch ?? getMultitwitchPreview(state);
-  const template = templateKey === 'new_game_message'
-    ? state.group.new_game_message
-    : state.group.live_message;
-  // Match production content generation: announcements do not currently inject {multitwitch} in content.
-  const vars = templateVars(state.login, stream);
-
-  return {
-    content: fillTemplate(template, vars),
-    embed: buildEmbedPreview(stream, resolvedMultiTwitch.renderedFooter ?? undefined),
-  };
-}
-
-// ─── Multitwitch ──────────────────────────────────────────────────────────────
-
-async function updateMultitwitch(groupId: number): Promise<void> {
-  if (!getMonitorEnabled() || !discordClient) return;
-
-  const groupLive = Array.from(liveStates.values()).filter((s) => s.groupId === groupId);
-  const context = buildMultiTwitchContext(groupLive);
-
-  for (const state of groupLive) {
-    if (!state.messageId || !state.channelId) continue;
-    const multiTwitch = getMultitwitchPreview(state, context);
-    const footer = multiTwitch.renderedFooter ?? undefined;
-
-    try {
-      const channel = await discordClient.channels.fetch(state.channelId);
-      if (!channel || !channel.isTextBased()) continue;
-      const message = await channel.messages.fetch(state.messageId);
-      const existing = message.embeds[0];
-      if (!existing) continue;
-
-      const updated = EmbedBuilder.from(existing);
-      if (footer) {
-        updated.setFooter({ text: footer });
-      } else {
-        updated.setFooter(null);
-      }
-      await message.edit({ embeds: [updated] });
-    } catch (err) {
-      console.error(`[TwitchMonitor] Failed to update multitwitch for ${state.login}:`, err);
-    }
-  }
-}
-
-// ─── Announcement helpers ─────────────────────────────────────────────────────
-
-async function postAnnouncement(streamerData: DbStreamerFull, stream: TwitchStream): Promise<void> {
-  // Key by DB row id so each streamer×group pair has independent state
-  const key = String(streamerData.id);
-  const login = stream.user_login.toLowerCase();
-  const group = streamerData.group;
-
-  if (!getMonitorEnabled() || !discordClient) {
-    // Track state without posting to Discord
-    liveStates.set(key, {
-      streamerId: streamerData.id,
-      groupId: group.id,
-      group,
-      login,
-      messageId: null,
-      channelId: null,
-      currentGame: stream.game_name,
-      title: stream.title,
-      currentStream: stream,
-      offlineTimer: null,
-    });
-    return;
-  }
-
-  const vars = templateVars(stream.user_login, stream);
-  const content = fillTemplate(group.live_message, vars);
-  const embed = buildEmbed(stream);
-
-  try {
-    const channel = await discordClient.channels.fetch(group.discord_channel);
-    if (!channel || !channel.isTextBased()) {
-      console.error(`[TwitchMonitor] Channel ${group.discord_channel} not found or not text-based`);
-      return;
-    }
-    const textChannel = channel as TextChannel;
-    const msg = await textChannel.send({ content, embeds: [embed] });
-
-    liveStates.set(key, {
-      streamerId: streamerData.id,
-      groupId: group.id,
-      group,
-      login,
-      messageId: msg.id,
-      channelId: msg.channelId,
-      currentGame: stream.game_name,
-      title: stream.title,
-      currentStream: stream,
-      offlineTimer: null,
-    });
-
-    await setStreamerLive(streamerData.id, msg.id, msg.channelId, stream.game_name);
-    await updateMultitwitch(group.id);
-  } catch (err) {
-    console.error(`[TwitchMonitor] Failed to post announcement for ${stream.user_login}:`, err);
-  }
-}
-
-async function editAnnouncement(
-  state: LiveState,
-  stream: TwitchStream,
-  templateKey: 'live_message' | 'new_game_message',
-): Promise<void> {
-  // Always update in-memory state so liveStates stays current even when posts are disabled
-  state.currentGame = stream.game_name;
-  state.title = stream.title;
-  state.currentStream = stream;
-
-  if (!getMonitorEnabled() || !discordClient || !state.messageId || !state.channelId) return;
-
-  const group = state.group;
-  const vars = templateVars(state.login, stream);
-  const content = fillTemplate(
-    templateKey === 'new_game_message' ? group.new_game_message : group.live_message,
-    vars,
-  );
-  const embed = buildEmbed(stream);
-
-  try {
-    const channel = await discordClient.channels.fetch(state.channelId);
-    if (!channel || !channel.isTextBased()) return;
-    const textChannel = channel as TextChannel;
-
-    if (group.delete_old_posts) {
-      try {
-        const old = await textChannel.messages.fetch(state.messageId);
-        await old.delete();
-      } catch (err) {
-        if (!isDiscordNotFoundError(err)) throw err;
-      }
-      const msg = await textChannel.send({ content, embeds: [embed] });
-      state.messageId = msg.id;
-      state.channelId = msg.channelId;
-    } else {
-      const message = await textChannel.messages.fetch(state.messageId);
-      await message.edit({ content, embeds: [embed] });
-    }
-
-    await setStreamerLive(state.streamerId, state.messageId!, state.channelId!, stream.game_name);
-    await updateMultitwitch(group.id);
-  } catch (err) {
-    console.error(`[TwitchMonitor] Failed to edit announcement for ${state.login}:`, err);
-  }
-}
-
-async function deleteAnnouncement(stateKey: string): Promise<void> {
-  const state = liveStates.get(stateKey);
-  if (!state || !state.messageId || !state.channelId) {
-    liveStates.delete(stateKey);
-    return;
-  }
-
-  if (discordClient) {
-    try {
-      const channel = await discordClient.channels.fetch(state.channelId);
-      if (channel && channel.isTextBased()) {
-        const msg = await channel.messages.fetch(state.messageId);
-        await msg.delete();
-      }
-    } catch (err) {
-      if (!isDiscordNotFoundError(err)) throw err;
-      // not-found: message already gone — fall through to clear DB state
-    }
-  }
-
-  await clearStreamerLive(state.streamerId);
-  const groupId = state.groupId;
-  liveStates.delete(stateKey);
-  await updateMultitwitch(groupId);
-}
-
-// ─── Offline grace period ────────────────────────────────────────────────────
-
-// Re-fetches from liveStates rather than using the closure value so the check
-// reflects any concurrent modifications (e.g. the streamer came back online and
-// pollStreams already updated state, or a manual DB change cleared the entry).
-// teardown() clears all offlineTimers on restart, so this is not restart
-// protection — it is a consistency guard. The finally block ensures
-// offlineTimer is nulled on every exit path, including early returns and errors.
-async function runOfflineCheck(stateKey: string, key: string, login: string): Promise<void> {
-  const currentState = liveStates.get(stateKey);
-  if (!currentState) return;
-  try {
-    const userId = loginToUserId.get(key);
-    if (!userId) return;
-    const streams = await getStreams([userId]);
-    const isLive = streams.some((s) => s.user_id === userId && s.type === 'live');
-    if (!isLive) {
-      await deleteAnnouncement(stateKey);
-      console.log(`[TwitchMonitor] ${login} confirmed offline — announcement removed`);
-    }
-  } finally {
-    currentState.offlineTimer = null;
-  }
-}
-
-async function handleStreamOffline(login: string): Promise<void> {
-  const key = login.toLowerCase();
-  // Collect all state entries for this login (one per group they belong to)
-  const matchingEntries = Array.from(liveStates.entries()).filter(([, s]) => s.login === key);
-  if (matchingEntries.length === 0) return;
-
-  for (const [stateKey, state] of matchingEntries) {
-    if (state.offlineTimer) clearTimeout(state.offlineTimer);
-    state.offlineTimer = setTimeout(async () => {
-      try {
-        await runOfflineCheck(stateKey, key, login);
-      } catch (err) {
-        console.error(`[TwitchMonitor] Offline-check failed for ${key} (${stateKey}):`, err);
-      }
-    }, OFFLINE_GRACE_MS);
-  }
-
-  console.log(`[TwitchMonitor] ${login} went offline — grace period started`);
-}
-
-// ─── Startup live-check helpers ──────────────────────────────────────────────
-
-async function tryEditStartupMessage(streamer: DbStreamerFull, liveStream: TwitchStream): Promise<boolean> {
-  if (!discordClient) return false;
-  if (!streamer.discord_channel_id || !streamer.discord_message_id) return false;
-  try {
-    const channel = await discordClient.channels.fetch(streamer.discord_channel_id);
-    if (!channel || !channel.isTextBased()) return false;
-    const vars = templateVars(streamer.name, liveStream);
-    const content = fillTemplate(streamer.group.live_message, vars);
-    const embed = buildEmbed(liveStream);
-    const message = await channel.messages.fetch(streamer.discord_message_id);
-    await message.edit({ content, embeds: [embed] });
-    liveStates.set(String(streamer.id), {
-      streamerId: streamer.id,
-      groupId: streamer.group.id,
-      group: streamer.group,
-      login: streamer.name.toLowerCase(),
-      messageId: streamer.discord_message_id,
-      channelId: streamer.discord_channel_id,
-      currentGame: liveStream.game_name,
-      title: liveStream.title,
-      currentStream: liveStream,
-      offlineTimer: null,
-    });
-    await setStreamerLive(streamer.id, streamer.discord_message_id, streamer.discord_channel_id, liveStream.game_name);
-    return true;
-  } catch (err) {
-    if (isDiscordNotFoundError(err)) return false;
-    console.error(`[TwitchMonitor] Failed to edit startup message for ${streamer.name}:`, err);
-    throw err;
-  }
-}
-
-// ─── Startup live-check ───────────────────────────────────────────────────────
-
-async function handleLiveStreamerOnStartup(
-  streamer: DbStreamerFull,
-  liveStream: TwitchStream,
-  groupsWithChanges: Set<number>,
-): Promise<void> {
-  if (streamer.discord_message_id && streamer.discord_channel_id) {
-    if (!discordClient || !getMonitorEnabled()) {
-      // Disabled or no client: restore stored IDs into liveStates without touching Discord
-      liveStates.set(String(streamer.id), {
-        streamerId: streamer.id,
-        groupId: streamer.group.id,
-        group: streamer.group,
-        login: streamer.name.toLowerCase(),
-        messageId: streamer.discord_message_id,
-        channelId: streamer.discord_channel_id,
-        currentGame: liveStream.game_name,
-        title: liveStream.title,
-        currentStream: liveStream,
-        offlineTimer: null,
-      });
-      return;
-    }
-    try {
-      if (await tryEditStartupMessage(streamer, liveStream)) {
-        groupsWithChanges.add(streamer.group.id);
-        return;
-      }
-    } catch {
-      // Edit failed (already logged) — skip postAnnouncement for this streamer
-      return;
-    }
-  }
-  await postAnnouncement(streamer, liveStream);
-}
-
-async function handleOfflineStreamerOnStartup(
-  streamer: DbStreamerFull,
-  groupsWithChanges: Set<number>,
-): Promise<void> {
-  // Stream ended while bot was offline — liveStates is empty at startup so
-  // deleteAnnouncement() would early-return without clearing DB state. Do it directly.
-  if (streamer.discord_channel_id && streamer.discord_message_id) {
-    try {
-      await tryDeleteDiscordMessage(streamer.discord_channel_id, streamer.discord_message_id);
-    } catch {
-      // Delete failed (already logged) — skip DB clear to avoid orphaning the announcement
-      return;
-    }
-  }
-  await clearStreamerLive(streamer.id);
-  groupsWithChanges.add(streamer.group.id);
-}
-
-async function performStartupLiveCheck(): Promise<void> {
-  const userIds = Array.from(loginToUserId.values());
-  if (userIds.length === 0) return;
-
-  let liveStreams: TwitchStream[] = [];
-  try {
-    liveStreams = await getStreams(userIds);
-  } catch (err) {
-    console.error('[TwitchMonitor] Startup live-check failed:', err);
-    return;
-  }
-
-  const liveByUserId = new Map(
-    liveStreams.filter((s) => s.type === 'live').map((s) => [s.user_id, s]),
-  );
-
-  const groupsWithChanges = new Set<number>();
-
-  for (const streamer of streamersData) {
-    const userId = loginToUserId.get(streamer.name.toLowerCase());
-    if (!userId) continue;
-
-    const liveStream = liveByUserId.get(userId);
-
-    if (liveStream) {
-      await handleLiveStreamerOnStartup(streamer, liveStream, groupsWithChanges);
-    } else if (streamer.discord_message_id) {
-      await handleOfflineStreamerOnStartup(streamer, groupsWithChanges);
-    }
-  }
-
-  for (const gid of groupsWithChanges) {
-    await updateMultitwitch(gid);
-  }
-}
-
 // ─── Polling ───────────────────────────────────────────────────────────────
-
-function cancelOfflineTimersForLogin(loginKey: string): void {
-  for (const state of liveStates.values()) {
-    if (state.login === loginKey && state.offlineTimer) {
-      clearTimeout(state.offlineTimer);
-      state.offlineTimer = null;
-    }
-  }
-}
 
 async function handlePollStreamer(
   streamer: DbStreamerFull,
@@ -568,17 +54,17 @@ async function handlePollStreamer(
   if (pollStream) {
     if (existing?.offlineTimer) {
       // Came back during grace period — cancel offline timers for all groups this login belongs to
-      cancelOfflineTimersForLogin(loginKey);
+      cancelOfflineTimersForLogin(liveStates, loginKey);
       console.log(`[TwitchMonitor] ${loginKey} came back — offline timer(s) cancelled`);
     }
     const isNew = !liveStates.has(stateKey);
     if (isNew || (existing && !existing.messageId)) {
       // Went live, or state exists with no Discord message (e.g. Discord wasn't ready at startup)
-      await postAnnouncement(streamer, pollStream);
+      await postAnnouncement(liveStates, streamer, pollStream);
       if (isNew) console.log(`[TwitchMonitor] ${loginKey} went live in group ${streamer.group.name}`);
     } else if (existing && existing.currentGame !== pollStream.game_name) {
       // Game changed
-      await editAnnouncement(existing, pollStream, 'new_game_message');
+      await editAnnouncement(liveStates, existing, pollStream, 'new_game_message');
       console.log(`[TwitchMonitor] ${loginKey} game changed to ${pollStream.game_name}`);
     } else if (existing) {
       // Still live — keep title in sync
@@ -588,7 +74,7 @@ async function handlePollStreamer(
     }
   } else if (existing && !existing.offlineTimer) {
     // Appears offline — start grace period (handleStreamOffline handles all groups for this login)
-    await handleStreamOffline(loginKey);
+    await handleStreamOffline(liveStates, loginToUserId, loginKey);
   }
 }
 
@@ -641,7 +127,7 @@ export async function startTwitchMonitor(): Promise<void> {
   loginToUserId = new Map(users.map((u) => [u.login.toLowerCase(), u.id]));
 
   // Startup live-check: sync with any streams that went live/offline while bot was down
-  await performStartupLiveCheck();
+  await performStartupLiveCheck(liveStates, loginToUserId, streamersData);
 
   // Begin polling every 60 s
   pollTimer = setInterval(() => {
@@ -674,7 +160,7 @@ export async function shutdownTwitchMonitor(): Promise<void> {
   let failedDeletes = 0;
   for (const key of stateKeys) {
     try {
-      await deleteAnnouncement(key);
+      await deleteAnnouncement(liveStates, key);
     } catch (err) {
       failedDeletes++;
       console.error('[TwitchMonitor] Shutdown: failed to delete announcement:', err);
@@ -708,11 +194,6 @@ export async function restartTwitchMonitor(): Promise<void> {
 }
 
 // ─── Multi-twitch URL query (for !multi command) ─────────────────────────────
-
-export interface MultiTwitchGroupInfo {
-  url: string;
-  participants: string[];
-}
 
 /**
  * Returns the current multitwitch URL and participant logins for the group that
@@ -799,16 +280,16 @@ async function handleCatchUpState(
 
   if (!stream) {
     // Went offline while posts were disabled — clean up any stale message
-    await deleteAnnouncement(String(state.streamerId));
+    await deleteAnnouncement(liveStates, String(state.streamerId));
     return;
   }
 
   if (state.messageId && state.channelId) {
     // Existing Discord message — edit it with current stream info
-    await editAnnouncement(state, stream, 'live_message');
+    await editAnnouncement(liveStates, state, stream, 'live_message');
   } else {
     // No message yet — post fresh
-    await postAnnouncement(streamerInfo, stream);
+    await postAnnouncement(liveStates, streamerInfo, stream);
   }
 }
 

--- a/src/twitchMonitorAnnouncements.ts
+++ b/src/twitchMonitorAnnouncements.ts
@@ -4,7 +4,7 @@ import { isDiscordNotFoundError } from './discordUtils';
 import { getMonitorEnabled } from './monitorSettings';
 import { setStreamerLive, clearStreamerLive, DbStreamerFull } from './db';
 import { TwitchStream } from './twitchApi';
-import { LiveState } from './twitchMonitorTypes';
+import { LiveState, makeLiveState } from './twitchMonitorTypes';
 import { buildEmbed, fillTemplate, templateVars } from './twitchMonitorEmbed';
 import { updateMultitwitch } from './twitchMonitorMultitwitch';
 
@@ -15,23 +15,11 @@ export async function postAnnouncement(
 ): Promise<void> {
   // Key by DB row id so each streamer×group pair has independent state
   const key = String(streamerData.id);
-  const login = stream.user_login.toLowerCase();
   const group = streamerData.group;
 
   if (!getMonitorEnabled() || !discordClient) {
     // Track state without posting to Discord
-    liveStates.set(key, {
-      streamerId: streamerData.id,
-      groupId: group.id,
-      group,
-      login,
-      messageId: null,
-      channelId: null,
-      currentGame: stream.game_name,
-      title: stream.title,
-      currentStream: stream,
-      offlineTimer: null,
-    });
+    liveStates.set(key, makeLiveState(streamerData, stream, null, null));
     return;
   }
 
@@ -48,18 +36,7 @@ export async function postAnnouncement(
     const textChannel = channel as TextChannel;
     const msg = await textChannel.send({ content, embeds: [embed] });
 
-    liveStates.set(key, {
-      streamerId: streamerData.id,
-      groupId: group.id,
-      group,
-      login,
-      messageId: msg.id,
-      channelId: msg.channelId,
-      currentGame: stream.game_name,
-      title: stream.title,
-      currentStream: stream,
-      offlineTimer: null,
-    });
+    liveStates.set(key, makeLiveState(streamerData, stream, msg.id, msg.channelId));
 
     await setStreamerLive(streamerData.id, msg.id, msg.channelId, stream.game_name);
     await updateMultitwitch(group.id, liveStates);

--- a/src/twitchMonitorAnnouncements.ts
+++ b/src/twitchMonitorAnnouncements.ts
@@ -1,0 +1,146 @@
+import { TextChannel } from 'discord.js';
+import { discordClient } from './discordBot';
+import { isDiscordNotFoundError } from './discordUtils';
+import { getMonitorEnabled } from './monitorSettings';
+import { setStreamerLive, clearStreamerLive, DbStreamerFull } from './db';
+import { TwitchStream } from './twitchApi';
+import { LiveState } from './twitchMonitorTypes';
+import { buildEmbed, fillTemplate, templateVars } from './twitchMonitorEmbed';
+import { updateMultitwitch } from './twitchMonitorMultitwitch';
+
+export async function postAnnouncement(
+  liveStates: Map<string, LiveState>,
+  streamerData: DbStreamerFull,
+  stream: TwitchStream,
+): Promise<void> {
+  // Key by DB row id so each streamer×group pair has independent state
+  const key = String(streamerData.id);
+  const login = stream.user_login.toLowerCase();
+  const group = streamerData.group;
+
+  if (!getMonitorEnabled() || !discordClient) {
+    // Track state without posting to Discord
+    liveStates.set(key, {
+      streamerId: streamerData.id,
+      groupId: group.id,
+      group,
+      login,
+      messageId: null,
+      channelId: null,
+      currentGame: stream.game_name,
+      title: stream.title,
+      currentStream: stream,
+      offlineTimer: null,
+    });
+    return;
+  }
+
+  const vars = templateVars(stream.user_login, stream);
+  const content = fillTemplate(group.live_message, vars);
+  const embed = buildEmbed(stream);
+
+  try {
+    const channel = await discordClient.channels.fetch(group.discord_channel);
+    if (!channel || !channel.isTextBased()) {
+      console.error(`[TwitchMonitor] Channel ${group.discord_channel} not found or not text-based`);
+      return;
+    }
+    const textChannel = channel as TextChannel;
+    const msg = await textChannel.send({ content, embeds: [embed] });
+
+    liveStates.set(key, {
+      streamerId: streamerData.id,
+      groupId: group.id,
+      group,
+      login,
+      messageId: msg.id,
+      channelId: msg.channelId,
+      currentGame: stream.game_name,
+      title: stream.title,
+      currentStream: stream,
+      offlineTimer: null,
+    });
+
+    await setStreamerLive(streamerData.id, msg.id, msg.channelId, stream.game_name);
+    await updateMultitwitch(group.id, liveStates);
+  } catch (err) {
+    console.error(`[TwitchMonitor] Failed to post announcement for ${stream.user_login}:`, err);
+  }
+}
+
+export async function editAnnouncement(
+  liveStates: Map<string, LiveState>,
+  state: LiveState,
+  stream: TwitchStream,
+  templateKey: 'live_message' | 'new_game_message',
+): Promise<void> {
+  // Always update in-memory state so liveStates stays current even when posts are disabled
+  state.currentGame = stream.game_name;
+  state.title = stream.title;
+  state.currentStream = stream;
+
+  if (!getMonitorEnabled() || !discordClient || !state.messageId || !state.channelId) return;
+
+  const group = state.group;
+  const vars = templateVars(state.login, stream);
+  const content = fillTemplate(
+    templateKey === 'new_game_message' ? group.new_game_message : group.live_message,
+    vars,
+  );
+  const embed = buildEmbed(stream);
+
+  try {
+    const channel = await discordClient.channels.fetch(state.channelId);
+    if (!channel || !channel.isTextBased()) return;
+    const textChannel = channel as TextChannel;
+
+    if (group.delete_old_posts) {
+      try {
+        const old = await textChannel.messages.fetch(state.messageId);
+        await old.delete();
+      } catch (err) {
+        if (!isDiscordNotFoundError(err)) throw err;
+      }
+      const msg = await textChannel.send({ content, embeds: [embed] });
+      state.messageId = msg.id;
+      state.channelId = msg.channelId;
+    } else {
+      const message = await textChannel.messages.fetch(state.messageId);
+      await message.edit({ content, embeds: [embed] });
+    }
+
+    await setStreamerLive(state.streamerId, state.messageId!, state.channelId!, stream.game_name);
+    await updateMultitwitch(group.id, liveStates);
+  } catch (err) {
+    console.error(`[TwitchMonitor] Failed to edit announcement for ${state.login}:`, err);
+  }
+}
+
+export async function deleteAnnouncement(
+  liveStates: Map<string, LiveState>,
+  stateKey: string,
+): Promise<void> {
+  const state = liveStates.get(stateKey);
+  if (!state || !state.messageId || !state.channelId) {
+    liveStates.delete(stateKey);
+    return;
+  }
+
+  if (discordClient) {
+    try {
+      const channel = await discordClient.channels.fetch(state.channelId);
+      if (channel && channel.isTextBased()) {
+        const msg = await channel.messages.fetch(state.messageId);
+        await msg.delete();
+      }
+    } catch (err) {
+      if (!isDiscordNotFoundError(err)) throw err;
+      // not-found: message already gone — fall through to clear DB state
+    }
+  }
+
+  await clearStreamerLive(state.streamerId);
+  const groupId = state.groupId;
+  liveStates.delete(stateKey);
+  await updateMultitwitch(groupId, liveStates);
+}

--- a/src/twitchMonitorEmbed.ts
+++ b/src/twitchMonitorEmbed.ts
@@ -1,0 +1,95 @@
+import { EmbedBuilder } from 'discord.js';
+import { TwitchStream } from './twitchApi';
+import { LiveState } from './twitchMonitorTypes';
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+export interface DiscordEmbedPreview {
+  title: string;
+  url: string;
+  color: string;
+  fields: Array<{ name: string; value: string }>;
+  imageUrl: string;
+  footer: string | null;
+}
+
+export interface DiscordMessagePreview {
+  content: string;
+  embed: DiscordEmbedPreview;
+}
+
+// ─── Template helpers ─────────────────────────────────────────────────────────
+
+export function fillTemplate(template: string, vars: Record<string, string>): string {
+  return template.replace(/\{(\w+)\}/g, (_, key: string) => vars[key] ?? `{${key}}`);
+}
+
+export function getStreamUrl(login: string): string {
+  return `https://www.twitch.tv/${login}`;
+}
+
+export function getThumbnailUrl(stream: TwitchStream): string {
+  return stream.thumbnail_url
+    .replace('{width}', '640')
+    .replace('{height}', '360');
+}
+
+export function buildEmbedPreview(stream: TwitchStream, footer?: string): DiscordEmbedPreview {
+  return {
+    title: stream.title,
+    url: getStreamUrl(stream.user_login),
+    color: '#9146FF',
+    fields: [{ name: 'Game', value: stream.game_name || 'Unknown' }],
+    imageUrl: getThumbnailUrl(stream),
+    footer: footer || null,
+  };
+}
+
+export function parseHexColor(color: string): number {
+  const normalized = color.trim().replace(/^#/, '');
+  if (!/^[0-9a-fA-F]{6}$/.test(normalized)) return 0x9146ff;
+  return parseInt(normalized, 16);
+}
+
+export function buildEmbed(stream: TwitchStream, footer?: string): EmbedBuilder {
+  const preview = buildEmbedPreview(stream, footer);
+
+  const embed = new EmbedBuilder()
+    .setTitle(preview.title)
+    .setURL(preview.url)
+    .setColor(parseHexColor(preview.color))
+    .addFields(...preview.fields)
+    .setImage(preview.imageUrl);
+
+  if (preview.footer) embed.setFooter({ text: preview.footer });
+  return embed;
+}
+
+export function templateVars(login: string, stream: TwitchStream, multitwitch?: string): Record<string, string> {
+  return {
+    streamer: login,
+    game: stream.game_name || 'Unknown',
+    title: stream.title,
+    url: getStreamUrl(login),
+    multitwitch: multitwitch ?? '',
+  };
+}
+
+// ─── Message preview ──────────────────────────────────────────────────────────
+
+export function buildMessagePreview(
+  state: LiveState,
+  templateKey: 'live_message' | 'new_game_message',
+  multiTwitch: { renderedFooter: string | null },
+): DiscordMessagePreview {
+  const stream = state.currentStream;
+  const template = templateKey === 'new_game_message'
+    ? state.group.new_game_message
+    : state.group.live_message;
+  const vars = templateVars(state.login, stream);
+
+  return {
+    content: fillTemplate(template, vars),
+    embed: buildEmbedPreview(stream, multiTwitch.renderedFooter ?? undefined),
+  };
+}

--- a/src/twitchMonitorMultitwitch.ts
+++ b/src/twitchMonitorMultitwitch.ts
@@ -1,0 +1,123 @@
+import { EmbedBuilder } from 'discord.js';
+import { discordClient } from './discordBot';
+import { getMonitorEnabled } from './monitorSettings';
+import { fillTemplate } from './twitchMonitorEmbed';
+import { LiveState } from './twitchMonitorTypes';
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+export interface MultiTwitchPreview {
+  enabled: boolean;
+  applicable: boolean;
+  participants: string[];
+  url: string | null;
+  renderedFooter: string | null;
+}
+
+export interface MultiTwitchGroupInfo {
+  url: string;
+  participants: string[];
+}
+
+// ─── Internal types ───────────────────────────────────────────────────────────
+
+interface MultiTwitchContext {
+  participantsByGroupAndGame: Map<string, string[]>;
+}
+
+// ─── Multitwitch helpers ──────────────────────────────────────────────────────
+
+export function groupGameKey(groupId: number, game: string): string {
+  return `${groupId}::${game.toLowerCase()}`;
+}
+
+export function buildMultiTwitchContext(states: Iterable<LiveState>): MultiTwitchContext {
+  const participantSets = new Map<string, Set<string>>();
+
+  for (const state of states) {
+    const key = groupGameKey(state.groupId, state.currentGame);
+    const participants = participantSets.get(key);
+    if (participants) {
+      participants.add(state.login);
+    } else {
+      participantSets.set(key, new Set([state.login]));
+    }
+  }
+
+  const participantsByGroupAndGame = new Map<string, string[]>();
+  for (const [key, participants] of participantSets.entries()) {
+    participantsByGroupAndGame.set(
+      key,
+      Array.from(participants).sort((participantA, participantB) => participantA.localeCompare(participantB)),
+    );
+  }
+
+  return { participantsByGroupAndGame };
+}
+
+export function getMultitwitchPreview(state: LiveState, context: MultiTwitchContext): MultiTwitchPreview {
+  const participants = context.participantsByGroupAndGame.get(groupGameKey(state.groupId, state.currentGame));
+  const applicable = !!participants && participants.length >= 2;
+
+  if (!applicable) {
+    return {
+      enabled: state.group.multi_twitch,
+      applicable: false,
+      participants: [state.login],
+      url: null,
+      renderedFooter: null,
+    };
+  }
+
+  if (!state.group.multi_twitch) {
+    return {
+      enabled: false,
+      applicable: true,
+      participants,
+      url: null,
+      renderedFooter: null,
+    };
+  }
+
+  const url = `https://www.multitwitch.tv/${participants.join('/')}`;
+  const renderedFooter = fillTemplate(state.group.multi_twitch_message, { multitwitch: url }) || null;
+
+  return {
+    enabled: true,
+    applicable: true,
+    participants,
+    url,
+    renderedFooter,
+  };
+}
+
+export async function updateMultitwitch(groupId: number, liveStates: ReadonlyMap<string, LiveState>): Promise<void> {
+  if (!getMonitorEnabled() || !discordClient) return;
+
+  const groupLive = Array.from(liveStates.values()).filter((s) => s.groupId === groupId);
+  const context = buildMultiTwitchContext(groupLive);
+
+  for (const state of groupLive) {
+    if (!state.messageId || !state.channelId) continue;
+    const multiTwitch = getMultitwitchPreview(state, context);
+    const footer = multiTwitch.renderedFooter ?? undefined;
+
+    try {
+      const channel = await discordClient.channels.fetch(state.channelId);
+      if (!channel || !channel.isTextBased()) continue;
+      const message = await channel.messages.fetch(state.messageId);
+      const existing = message.embeds[0];
+      if (!existing) continue;
+
+      const updated = EmbedBuilder.from(existing);
+      if (footer) {
+        updated.setFooter({ text: footer });
+      } else {
+        updated.setFooter(null);
+      }
+      await message.edit({ embeds: [updated] });
+    } catch (err) {
+      console.error(`[TwitchMonitor] Failed to update multitwitch for ${state.login}:`, err);
+    }
+  }
+}

--- a/src/twitchMonitorOffline.ts
+++ b/src/twitchMonitorOffline.ts
@@ -1,0 +1,67 @@
+import { getStreams } from './twitchApi';
+import { LiveState } from './twitchMonitorTypes';
+import { deleteAnnouncement } from './twitchMonitorAnnouncements';
+
+const OFFLINE_GRACE_MS = 5 * 60 * 1000;
+
+export function cancelOfflineTimersForLogin(liveStates: Map<string, LiveState>, loginKey: string): void {
+  for (const state of liveStates.values()) {
+    if (state.login === loginKey && state.offlineTimer) {
+      clearTimeout(state.offlineTimer);
+      state.offlineTimer = null;
+    }
+  }
+}
+
+// Re-fetches from liveStates rather than using the closure value so the check
+// reflects any concurrent modifications (e.g. the streamer came back online and
+// pollStreams already updated state, or a manual DB change cleared the entry).
+// teardown() clears all offlineTimers on restart, so this is not restart
+// protection — it is a consistency guard. The finally block ensures
+// offlineTimer is nulled on every exit path, including early returns and errors.
+export async function runOfflineCheck(
+  liveStates: Map<string, LiveState>,
+  loginToUserId: Map<string, string>,
+  stateKey: string,
+  key: string,
+  login: string,
+): Promise<void> {
+  const currentState = liveStates.get(stateKey);
+  if (!currentState) return;
+  try {
+    const userId = loginToUserId.get(key);
+    if (!userId) return;
+    const streams = await getStreams([userId]);
+    const isLive = streams.some((s) => s.user_id === userId && s.type === 'live');
+    if (!isLive) {
+      await deleteAnnouncement(liveStates, stateKey);
+      console.log(`[TwitchMonitor] ${login} confirmed offline — announcement removed`);
+    }
+  } finally {
+    currentState.offlineTimer = null;
+  }
+}
+
+export async function handleStreamOffline(
+  liveStates: Map<string, LiveState>,
+  loginToUserId: Map<string, string>,
+  login: string,
+): Promise<void> {
+  const key = login.toLowerCase();
+  // Collect all state entries for this login (one per group they belong to)
+  const matchingEntries = Array.from(liveStates.entries()).filter(([, s]) => s.login === key);
+  if (matchingEntries.length === 0) return;
+
+  for (const [stateKey, state] of matchingEntries) {
+    if (state.offlineTimer) clearTimeout(state.offlineTimer);
+    state.offlineTimer = setTimeout(async () => {
+      try {
+        await runOfflineCheck(liveStates, loginToUserId, stateKey, key, login);
+      } catch (err) {
+        console.error(`[TwitchMonitor] Offline-check failed for ${key} (${stateKey}):`, err);
+      }
+    }, OFFLINE_GRACE_MS);
+  }
+
+  console.log(`[TwitchMonitor] ${login} went offline — grace period started`);
+}

--- a/src/twitchMonitorStartup.ts
+++ b/src/twitchMonitorStartup.ts
@@ -1,0 +1,139 @@
+import { discordClient } from './discordBot';
+import { isDiscordNotFoundError, tryDeleteDiscordMessage } from './discordUtils';
+import { getMonitorEnabled } from './monitorSettings';
+import { setStreamerLive, clearStreamerLive, DbStreamerFull } from './db';
+import { getStreams, TwitchStream } from './twitchApi';
+import { LiveState } from './twitchMonitorTypes';
+import { buildEmbed, fillTemplate, templateVars } from './twitchMonitorEmbed';
+import { updateMultitwitch } from './twitchMonitorMultitwitch';
+import { postAnnouncement } from './twitchMonitorAnnouncements';
+
+export async function tryEditStartupMessage(
+  liveStates: Map<string, LiveState>,
+  streamer: DbStreamerFull,
+  liveStream: TwitchStream,
+): Promise<boolean> {
+  if (!discordClient) return false;
+  if (!streamer.discord_channel_id || !streamer.discord_message_id) return false;
+  try {
+    const channel = await discordClient.channels.fetch(streamer.discord_channel_id);
+    if (!channel || !channel.isTextBased()) return false;
+    const vars = templateVars(streamer.name, liveStream);
+    const content = fillTemplate(streamer.group.live_message, vars);
+    const embed = buildEmbed(liveStream);
+    const message = await channel.messages.fetch(streamer.discord_message_id);
+    await message.edit({ content, embeds: [embed] });
+    liveStates.set(String(streamer.id), {
+      streamerId: streamer.id,
+      groupId: streamer.group.id,
+      group: streamer.group,
+      login: streamer.name.toLowerCase(),
+      messageId: streamer.discord_message_id,
+      channelId: streamer.discord_channel_id,
+      currentGame: liveStream.game_name,
+      title: liveStream.title,
+      currentStream: liveStream,
+      offlineTimer: null,
+    });
+    await setStreamerLive(streamer.id, streamer.discord_message_id, streamer.discord_channel_id, liveStream.game_name);
+    return true;
+  } catch (err) {
+    if (isDiscordNotFoundError(err)) return false;
+    console.error(`[TwitchMonitor] Failed to edit startup message for ${streamer.name}:`, err);
+    throw err;
+  }
+}
+
+export async function handleLiveStreamerOnStartup(
+  liveStates: Map<string, LiveState>,
+  streamer: DbStreamerFull,
+  liveStream: TwitchStream,
+  groupsWithChanges: Set<number>,
+): Promise<void> {
+  if (streamer.discord_message_id && streamer.discord_channel_id) {
+    if (!discordClient || !getMonitorEnabled()) {
+      // Disabled or no client: restore stored IDs into liveStates without touching Discord
+      liveStates.set(String(streamer.id), {
+        streamerId: streamer.id,
+        groupId: streamer.group.id,
+        group: streamer.group,
+        login: streamer.name.toLowerCase(),
+        messageId: streamer.discord_message_id,
+        channelId: streamer.discord_channel_id,
+        currentGame: liveStream.game_name,
+        title: liveStream.title,
+        currentStream: liveStream,
+        offlineTimer: null,
+      });
+      return;
+    }
+    try {
+      if (await tryEditStartupMessage(liveStates, streamer, liveStream)) {
+        groupsWithChanges.add(streamer.group.id);
+        return;
+      }
+    } catch {
+      // Edit failed (already logged) — skip postAnnouncement for this streamer
+      return;
+    }
+  }
+  await postAnnouncement(liveStates, streamer, liveStream);
+}
+
+export async function handleOfflineStreamerOnStartup(
+  streamer: DbStreamerFull,
+  groupsWithChanges: Set<number>,
+): Promise<void> {
+  // Stream ended while bot was offline — liveStates is empty at startup so
+  // deleteAnnouncement() would early-return without clearing DB state. Do it directly.
+  if (streamer.discord_channel_id && streamer.discord_message_id) {
+    try {
+      await tryDeleteDiscordMessage(streamer.discord_channel_id, streamer.discord_message_id);
+    } catch {
+      // Delete failed (already logged) — skip DB clear to avoid orphaning the announcement
+      return;
+    }
+  }
+  await clearStreamerLive(streamer.id);
+  groupsWithChanges.add(streamer.group.id);
+}
+
+export async function performStartupLiveCheck(
+  liveStates: Map<string, LiveState>,
+  loginToUserId: Map<string, string>,
+  streamersData: DbStreamerFull[],
+): Promise<void> {
+  const userIds = Array.from(loginToUserId.values());
+  if (userIds.length === 0) return;
+
+  let liveStreams: TwitchStream[] = [];
+  try {
+    liveStreams = await getStreams(userIds);
+  } catch (err) {
+    console.error('[TwitchMonitor] Startup live-check failed:', err);
+    return;
+  }
+
+  const liveByUserId = new Map(
+    liveStreams.filter((s) => s.type === 'live').map((s) => [s.user_id, s]),
+  );
+
+  const groupsWithChanges = new Set<number>();
+
+  for (const streamer of streamersData) {
+    const userId = loginToUserId.get(streamer.name.toLowerCase());
+    if (!userId) continue;
+
+    const liveStream = liveByUserId.get(userId);
+
+    if (liveStream) {
+      await handleLiveStreamerOnStartup(liveStates, streamer, liveStream, groupsWithChanges);
+    } else if (streamer.discord_message_id) {
+      await handleOfflineStreamerOnStartup(streamer, groupsWithChanges);
+    }
+  }
+
+  for (const gid of groupsWithChanges) {
+    await updateMultitwitch(gid, liveStates);
+  }
+}

--- a/src/twitchMonitorStartup.ts
+++ b/src/twitchMonitorStartup.ts
@@ -3,7 +3,7 @@ import { isDiscordNotFoundError, tryDeleteDiscordMessage } from './discordUtils'
 import { getMonitorEnabled } from './monitorSettings';
 import { setStreamerLive, clearStreamerLive, DbStreamerFull } from './db';
 import { getStreams, TwitchStream } from './twitchApi';
-import { LiveState } from './twitchMonitorTypes';
+import { LiveState, makeLiveState } from './twitchMonitorTypes';
 import { buildEmbed, fillTemplate, templateVars } from './twitchMonitorEmbed';
 import { updateMultitwitch } from './twitchMonitorMultitwitch';
 import { postAnnouncement } from './twitchMonitorAnnouncements';
@@ -23,18 +23,7 @@ export async function tryEditStartupMessage(
     const embed = buildEmbed(liveStream);
     const message = await channel.messages.fetch(streamer.discord_message_id);
     await message.edit({ content, embeds: [embed] });
-    liveStates.set(String(streamer.id), {
-      streamerId: streamer.id,
-      groupId: streamer.group.id,
-      group: streamer.group,
-      login: streamer.name.toLowerCase(),
-      messageId: streamer.discord_message_id,
-      channelId: streamer.discord_channel_id,
-      currentGame: liveStream.game_name,
-      title: liveStream.title,
-      currentStream: liveStream,
-      offlineTimer: null,
-    });
+    liveStates.set(String(streamer.id), makeLiveState(streamer, liveStream, streamer.discord_message_id, streamer.discord_channel_id));
     await setStreamerLive(streamer.id, streamer.discord_message_id, streamer.discord_channel_id, liveStream.game_name);
     return true;
   } catch (err) {
@@ -53,18 +42,7 @@ export async function handleLiveStreamerOnStartup(
   if (streamer.discord_message_id && streamer.discord_channel_id) {
     if (!discordClient || !getMonitorEnabled()) {
       // Disabled or no client: restore stored IDs into liveStates without touching Discord
-      liveStates.set(String(streamer.id), {
-        streamerId: streamer.id,
-        groupId: streamer.group.id,
-        group: streamer.group,
-        login: streamer.name.toLowerCase(),
-        messageId: streamer.discord_message_id,
-        channelId: streamer.discord_channel_id,
-        currentGame: liveStream.game_name,
-        title: liveStream.title,
-        currentStream: liveStream,
-        offlineTimer: null,
-      });
+      liveStates.set(String(streamer.id), makeLiveState(streamer, liveStream, streamer.discord_message_id, streamer.discord_channel_id));
       return;
     }
     try {

--- a/src/twitchMonitorTypes.ts
+++ b/src/twitchMonitorTypes.ts
@@ -1,0 +1,15 @@
+import { DbStreamGroup } from './db';
+import { TwitchStream } from './twitchApi';
+
+export interface LiveState {
+  streamerId: number;
+  groupId: number;
+  group: DbStreamGroup;
+  login: string;
+  messageId: string | null;
+  channelId: string | null;
+  currentGame: string;
+  title: string;
+  currentStream: TwitchStream;
+  offlineTimer: ReturnType<typeof setTimeout> | null;
+}

--- a/src/twitchMonitorTypes.ts
+++ b/src/twitchMonitorTypes.ts
@@ -1,4 +1,4 @@
-import { DbStreamGroup } from './db';
+import { DbStreamGroup, DbStreamerFull } from './db';
 import { TwitchStream } from './twitchApi';
 
 export interface LiveState {
@@ -12,4 +12,24 @@ export interface LiveState {
   title: string;
   currentStream: TwitchStream;
   offlineTimer: ReturnType<typeof setTimeout> | null;
+}
+
+export function makeLiveState(
+  streamer: DbStreamerFull,
+  stream: TwitchStream,
+  messageId: string | null,
+  channelId: string | null,
+): LiveState {
+  return {
+    streamerId: streamer.id,
+    groupId: streamer.group.id,
+    group: streamer.group,
+    login: stream.user_login.toLowerCase(),
+    messageId,
+    channelId,
+    currentGame: stream.game_name,
+    title: stream.title,
+    currentStream: stream,
+    offlineTimer: null,
+  };
 }


### PR DESCRIPTION
## Summary

- `twitchMonitor.ts` had grown to 846 lines, 33 functions, and a file complexity of 146
- Split into 6 new focused modules along domain boundaries, reducing the main file to 329 lines and 11 functions
- Dependency chain is strictly one-directional — no circular dependencies introduced

| Module | Lines | Responsibility |
|---|---|---|
| `twitchMonitor.ts` | 329 | Polling loop, lifecycle public API, live state queries |
| `twitchMonitorStartup.ts` | 139 | Startup sync (edit/post/skip on boot) |
| `twitchMonitorAnnouncements.ts` | 146 | post / edit / delete Discord announcements |
| `twitchMonitorMultitwitch.ts` | 123 | Multitwitch URL building + footer updates |
| `twitchMonitorEmbed.ts` | 95 | Pure template/embed helpers |
| `twitchMonitorOffline.ts` | 67 | Offline grace period timers |
| `twitchMonitorTypes.ts` | 15 | Shared `LiveState` type |

Stateful functions that previously closed over the module-level `liveStates` Map now accept it as an explicit parameter — Maps are passed by reference so mutations remain visible to callers.

## Test plan

- [x] `npx tsc --noEmit` — zero new errors (two pre-existing errors in `adminUserMutations.ts` unrelated to this change)
- [x] `npm test` — all 10 tests pass
- [ ] Manual smoke test: start bot, verify stream announcements post/edit/delete as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-stream grouping with coordinated multi-stream links and updated announcement footers
  * Richer message previews and embeds for stream announcements

* **Refactor**
  * Reorganized announcement, startup, offline and multitwitch logic for more reliable behavior

* **Bug Fixes**
  * More robust offline grace handling and safer announcement edit/delete flows

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/82)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->