### PR TITLE
feat(goLive): unified Go Live toggle for all bot outputs

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -53,8 +53,3 @@ export const DISCORD_CLIENT_ID = require_env('DISCORD_CLIENT_ID');
 export const DISCORD_CLIENT_SECRET = require_env('DISCORD_CLIENT_SECRET');
 export const DISCORD_CALLBACK_URL = require_env('DISCORD_CALLBACK_URL');
 
-// Default false (shadow mode). Set to 'true' only when ready to send live replies.
-export const CUSTOM_COMMANDS_LIVE_REPLIES = process.env.CUSTOM_COMMANDS_LIVE_REPLIES === 'true';
-
-// Default false (shadow mode). Set to 'true' only when ready to write live counter increments.
-export const COUNTER_LIVE_WRITES = process.env.COUNTER_LIVE_WRITES === 'true';

--- a/src/counterHandler.ts
+++ b/src/counterHandler.ts
@@ -1,5 +1,5 @@
 import type { Message } from 'discord.js';
-import { CUSTOM_COMMANDS_LIVE_REPLIES, COUNTER_LIVE_WRITES } from './config';
+import { getCustomCommandsLiveReplies, getCounterLiveWrites } from './monitorSettings';
 import { findCounterByCommand, incrementCounter } from './db';
 import { recordCommandTestEntry } from './commandMonitorStore';
 import { extractCommand } from './commandUtils';
@@ -45,7 +45,7 @@ async function _buildCounterResponse(
   let displayValue = counter.current_value;
   let didIncrement = false;
 
-  if (isTrigger && COUNTER_LIVE_WRITES) {
+  if (isTrigger && getCounterLiveWrites()) {
     try {
       displayValue = await incrementCounter(counter.id);
       didIncrement = true;
@@ -94,7 +94,7 @@ export async function executeCounterCommandForDiscord(
 
   if (!result.canReply) return;
 
-  if (CUSTOM_COMMANDS_LIVE_REPLIES) {
+  if (getCustomCommandsLiveReplies()) {
     try {
       await message.reply(result.response);
       console.log(`[Discord] Sent ${result.label} '${command}' (recorded for monitoring).`);
@@ -128,7 +128,7 @@ export async function executeCounterCommandForTwitch(
   if (!result.canReply) return;
 
   const runtime = _twitchRuntime;
-  if (CUSTOM_COMMANDS_LIVE_REPLIES && runtime) {
+  if (getCustomCommandsLiveReplies() && runtime) {
     try {
       await runtime.send(channel, result.response);
       console.log(`[Twitch] Sent ${result.label} '${command}' in ${channel} (recorded for monitoring).`);

--- a/src/customCommandHandler.ts
+++ b/src/customCommandHandler.ts
@@ -1,5 +1,5 @@
 import type { Message } from 'discord.js';
-import { CUSTOM_COMMANDS_LIVE_REPLIES } from './config';
+import { getCustomCommandsLiveReplies } from './monitorSettings';
 import { getCustomCommandForDiscord, getCustomCommandForTwitchChannel } from './db';
 import { recordCommandTestEntry } from './commandMonitorStore';
 import { getSharedChatSession } from './twitchApi';
@@ -141,7 +141,7 @@ export async function executeCustomCommandForDiscord(
     user: username ?? null,
   });
 
-  if (CUSTOM_COMMANDS_LIVE_REPLIES) {
+  if (getCustomCommandsLiveReplies()) {
     try {
       await message.reply(result.response);
       console.log(`[Discord] Sent custom command '${command}' (recorded for monitoring).`);
@@ -173,7 +173,7 @@ export async function executeCustomCommandForTwitch(
   });
 
   const runtime = _twitchRuntime;
-  if (CUSTOM_COMMANDS_LIVE_REPLIES && runtime) {
+  if (getCustomCommandsLiveReplies() && runtime) {
     if (result.isMultiTwitch) {
       try {
         const sent = await broadcastToActiveChannels(channel, command, result.response);

--- a/src/monitorSettings.ts
+++ b/src/monitorSettings.ts
@@ -5,17 +5,17 @@ const SETTINGS_FILE = path.join(process.cwd(), 'monitor-settings.json');
 
 interface MonitorSettings {
   twitchMonitorEnabled: boolean;
+  customCommandsLiveReplies: boolean;
+  counterLiveWrites: boolean;
 }
+
+const DEFAULTS: MonitorSettings = {
+  twitchMonitorEnabled: false,
+  customCommandsLiveReplies: false,
+  counterLiveWrites: false,
+};
 
 let cachedSettings: MonitorSettings | null = null;
-
-function isValidMonitorSettings(v: unknown): v is MonitorSettings {
-  return (
-    typeof v === 'object' &&
-    v !== null &&
-    typeof (v as Record<string, unknown>).twitchMonitorEnabled === 'boolean'
-  );
-}
 
 function readSettings(): MonitorSettings {
   if (cachedSettings) {
@@ -24,16 +24,19 @@ function readSettings(): MonitorSettings {
 
   try {
     const content = fs.readFileSync(SETTINGS_FILE, 'utf-8');
-    const parsed: unknown = JSON.parse(content);
-    if (isValidMonitorSettings(parsed)) {
-      cachedSettings = parsed;
+    const parsed = JSON.parse(content) as Record<string, unknown>;
+    if (typeof parsed.twitchMonitorEnabled === 'boolean') {
+      cachedSettings = {
+        twitchMonitorEnabled: parsed.twitchMonitorEnabled,
+        customCommandsLiveReplies: typeof parsed.customCommandsLiveReplies === 'boolean' ? parsed.customCommandsLiveReplies : false,
+        counterLiveWrites: typeof parsed.counterLiveWrites === 'boolean' ? parsed.counterLiveWrites : false,
+      };
     } else {
       console.warn('[MonitorSettings] Settings file has unexpected shape — using defaults');
-      cachedSettings = { twitchMonitorEnabled: true };
+      cachedSettings = { ...DEFAULTS };
     }
-  } catch (err) {
-    console.warn(`[MonitorSettings] Failed to read ${SETTINGS_FILE}:`, err);
-    cachedSettings = { twitchMonitorEnabled: true };
+  } catch {
+    cachedSettings = { ...DEFAULTS };
   }
 
   return cachedSettings;
@@ -59,7 +62,14 @@ export function getMonitorEnabled(): boolean {
   return readSettings().twitchMonitorEnabled;
 }
 
-export function setMonitorEnabled(enabled: boolean): void {
-  const current = readSettings();
-  writeSettings({ ...current, twitchMonitorEnabled: enabled });
+export function getCustomCommandsLiveReplies(): boolean {
+  return readSettings().customCommandsLiveReplies;
+}
+
+export function getCounterLiveWrites(): boolean {
+  return readSettings().counterLiveWrites;
+}
+
+export function setAllLive(enabled: boolean): void {
+  writeSettings({ twitchMonitorEnabled: enabled, customCommandsLiveReplies: enabled, counterLiveWrites: enabled });
 }

--- a/src/multiCommandHandler.ts
+++ b/src/multiCommandHandler.ts
@@ -1,4 +1,4 @@
-import { CUSTOM_COMMANDS_LIVE_REPLIES } from './config';
+import { getCustomCommandsLiveReplies } from './monitorSettings';
 import { getMultiTwitchDataForChannel } from './twitchMonitor';
 import { recordCommandTestEntry } from './commandMonitorStore';
 import { resolveSharedChatSessionId } from './customCommandHandler';
@@ -84,7 +84,7 @@ export async function executeMultiCommandForTwitch(
   if (!groupInfo) return;
 
   const runtime = _runtime;
-  if (!CUSTOM_COMMANDS_LIVE_REPLIES || !runtime) {
+  if (!getCustomCommandsLiveReplies() || !runtime) {
     console.log(`[Twitch] Preview !multi in ${channel} — would post: ${groupInfo.url}`);
     return;
   }

--- a/src/shoutoutHandler.ts
+++ b/src/shoutoutHandler.ts
@@ -1,4 +1,4 @@
-import { CUSTOM_COMMANDS_LIVE_REPLIES } from './config';
+import { getCustomCommandsLiveReplies } from './monitorSettings';
 import { getUsers, getChannelInfo, getStreams, TwitchChannelInfo, TwitchStream } from './twitchApi';
 import { recordCommandTestEntry } from './commandMonitorStore';
 import { extractCommand } from './commandUtils';
@@ -52,7 +52,7 @@ async function resolveShoutoutData(
 
 async function dispatchShoutout(channel: string, message: string): Promise<void> {
   const runtime = _runtime;
-  if (!CUSTOM_COMMANDS_LIVE_REPLIES || !runtime) {
+  if (!getCustomCommandsLiveReplies() || !runtime) {
     console.log(`[Twitch] Preview !so in ${channel} — would post: ${message}`);
     return;
   }

--- a/src/web/routes/streams.ts
+++ b/src/web/routes/streams.ts
@@ -11,7 +11,7 @@ import {
 } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireManager } from '../middleware';
-import { getMonitorEnabled, setMonitorEnabled } from '../../monitorSettings';
+import { getMonitorEnabled, setAllLive } from '../../monitorSettings';
 import { restartTwitchMonitor, getLiveStates, catchUpDiscordPosts } from '../../twitchMonitor';
 
 const router = Router();
@@ -58,7 +58,7 @@ router.get('/streams', requireManager, csrfProtection, async (req, res) => {
 
 router.post('/streams/toggle', requireManager, csrfProtection, (req, res) => {
   const wasEnabled = getMonitorEnabled();
-  setMonitorEnabled(!wasEnabled);
+  setAllLive(!wasEnabled);
 
   if (!wasEnabled) {
     // Turning ON — post announcements for any currently tracked live streams
@@ -66,7 +66,7 @@ router.post('/streams/toggle', requireManager, csrfProtection, (req, res) => {
       console.error('[Web] TwitchMonitor catch-up error:', err),
     );
   }
-  // Turning OFF — nothing to do; monitor keeps running, Discord posts are silenced
+  // Turning OFF — nothing to do; monitor keeps running, all live outputs are silenced
 
   res.redirect('/admin/streams');
 });

--- a/views/command-monitor.ejs
+++ b/views/command-monitor.ejs
@@ -29,16 +29,6 @@ function htmlAttrJson(value) {
     <section class="section">
       <h2 class="section-title">Command Monitor</h2>
 
-      <div class="card card-spaced">
-        <div class="card-header">
-          <span class="card-icon">🧪</span>
-          <span class="card-label">Preview Only</span>
-        </div>
-        <div class="card-body card-body-muted">
-          This page shows the most recent custom commands and counter commands detected by this bot for monitoring. Replies are currently suppressed in preview mode, and counter trigger previews stay read-only until live responses are enabled.
-        </div>
-      </div>
-
       <div class="card">
         <div class="card-header">
           <span class="card-icon">📜</span>

--- a/views/commands.ejs
+++ b/views/commands.ejs
@@ -32,16 +32,6 @@
       <% } %>
 
       <div class="card card-spaced">
-        <div class="card-header">
-          <span class="card-icon">🛠</span>
-          <span class="card-label">Management Only</span>
-        </div>
-        <div class="card-body card-body-muted">
-          This page manages custom command records and per-user Twitch assignments. Runtime execution in Twitch and Discord bots is not wired yet.
-        </div>
-      </div>
-
-      <div class="card card-spaced">
         <div class="card-header"><span class="card-icon">➕</span><span class="card-label">Add Command</span></div>
         <div class="card-body">
           <form method="POST" action="/admin/commands/add">

--- a/views/counters.ejs
+++ b/views/counters.ejs
@@ -38,16 +38,6 @@
       <% } %>
 
       <div class="card card-spaced">
-        <div class="card-header">
-          <span class="card-icon">🧮</span>
-          <span class="card-label">Management Only</span>
-        </div>
-        <div class="card-body card-body-muted">
-          This page manages counter definitions and current values. Runtime counter execution and yearly scheduler wiring are not enabled yet.
-        </div>
-      </div>
-
-      <div class="card card-spaced">
         <div class="card-header"><span class="card-icon">➕</span><span class="card-label">Add Counter</span></div>
         <div class="card-body">
           <form method="POST" action="/admin/counters/add">

--- a/views/streams.ejs
+++ b/views/streams.ejs
@@ -22,23 +22,23 @@
       </div>
       <% } %>
 
-      <!-- Discord posts toggle -->
+      <!-- Go Live toggle -->
       <div class="card card-spaced">
         <div class="card-header">
-          <span class="card-icon">📡</span>
-          <span class="card-label">Discord Announcements</span>
+          <span class="card-icon"><%= monitorEnabled ? '🟢' : '🔴' %></span>
+          <span class="card-label">Bot Live Mode</span>
           <span class="badge ml-auto <%= monitorEnabled ? 'badge-active' : 'badge-offline' %>">
-            <%= monitorEnabled ? 'Enabled' : 'Disabled' %>
+            <%= monitorEnabled ? 'Live' : 'Shadow Mode' %>
           </span>
         </div>
         <div class="card-body card-body-row">
           <form method="POST" action="/admin/streams/toggle">
             <input type="hidden" name="_csrf" value="<%= csrfToken %>">
             <button type="submit" class="btn <%= monitorEnabled ? 'btn-danger' : '' %>">
-              <%= monitorEnabled ? '⏹ Disable Discord Posts' : '▶ Enable Discord Posts' %>
+              <%= monitorEnabled ? '⏹ Disable Live Mode' : '▶ Go Live' %>
             </button>
           </form>
-          <span class="text-muted-sm">Stream tracking always runs — use <strong>Live Now</strong> below to verify data before enabling posts.</span>
+          <span class="text-muted-sm">Enables Discord announcements, Twitch chat replies, and counter writes. Use <strong>Live Now</strong> below to verify data first.</span>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary

- **Single web toggle** on the Stream Monitor page (`▶ Go Live` / `⏹ Disable Live Mode`) atomically enables/disables all three live outputs: Discord stream announcements, Twitch chat replies, and counter writes
- Moves `CUSTOM_COMMANDS_LIVE_REPLIES` and `COUNTER_LIVE_WRITES` from static env-var constants (required process restart to change) into `monitorSettings.ts` as runtime-toggled file-backed fields alongside `twitchMonitorEnabled`
- Removes stale "Management Only" / "Preview Only" info banners from Commands, Counters, and Command Monitor pages

## Changes

- `src/monitorSettings.ts` — extended interface with `customCommandsLiveReplies` + `counterLiveWrites`; added `getCustomCommandsLiveReplies()`, `getCounterLiveWrites()`, and `setAllLive()`; migrates gracefully from old single-field JSON (new fields default to `false`)
- `src/config.ts` — removed the two shadow-mode env-var constants
- `src/customCommandHandler.ts`, `counterHandler.ts`, `shoutoutHandler.ts`, `multiCommandHandler.ts` — swapped static const imports for runtime getter calls
- `src/web/routes/streams.ts` — toggle route now calls `setAllLive()` instead of `setMonitorEnabled()`
- `views/streams.ejs` — card renamed to "Bot Live Mode" with updated button labels and description
- `views/commands.ejs`, `views/counters.ejs`, `views/command-monitor.ejs` — removed stale shadow-mode notices

## Test plan

- [ ] `npx tsc --noEmit` passes (already verified)
- [ ] With bot running in shadow mode, hit **Go Live** — confirm `monitor-settings.json` writes all three fields `true`
- [ ] Verify a matched Twitch command now posts a real reply; counter trigger increments DB value; a live stream posts to Discord
- [ ] Hit **Disable Live Mode** — confirm all three revert to `false` and outputs are suppressed again
- [ ] Restart process with existing `monitor-settings.json` missing the new fields — confirm it migrates cleanly (defaults to shadow mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live mode settings are now dynamically configurable at runtime instead of static configuration, enabling flexible toggling of custom command replies and counter execution behaviors.
  * Added "Bot Live Mode" toggle to Stream Monitor with clearer status indicators ("Live" vs "Shadow Mode").

* **UI Improvements**
  * Removed informational cards from Command Monitor, Commands, and Counters pages for a cleaner interface.
  * Simplified Stream Monitor controls with consolidated live mode settings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/83)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->