### PR TITLE
refactor(js): extract confirmSubmit utility and simplify relativeTime

### DIFF
--- a/public/admin.js
+++ b/public/admin.js
@@ -1,12 +1,7 @@
 document.addEventListener('submit', function (event) {
-  var target = event.target;
-  if (!(target instanceof HTMLFormElement)) return;
-  if (!target.classList.contains('js-confirm-remove-user')) return;
-
-  var userName = target.dataset.userName || 'this user';
-  if (!window.confirm('Remove ' + userName + '?')) {
-    event.preventDefault();
-  }
+  confirmSubmit(event, 'js-confirm-remove-user', function (t) {
+    return 'Remove ' + (t.dataset.userName || 'this user') + '?';
+  });
 });
 
 function syncTwitchNameControls(form) {

--- a/public/app.js
+++ b/public/app.js
@@ -2,15 +2,15 @@
 
 function relativeTime(isoString) {
   if (!isoString) return '—';
-  const diff = Date.now() - new Date(isoString).getTime();
-  const s = Math.floor(diff / 1000);
-  if (s < 5)  return 'just now';
-  if (s < 60) return `${s}s ago`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m ago`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h ago`;
-  return `${Math.floor(h / 24)}d ago`;
+  const s = Math.floor((Date.now() - new Date(isoString).getTime()) / 1000);
+  const thresholds = [
+    [5,     'just now'],
+    [60,    `${s}s ago`],
+    [3600,  `${Math.floor(s / 60)}m ago`],
+    [86400, `${Math.floor(s / 3600)}h ago`],
+  ];
+  const match = thresholds.find(([limit]) => s < limit);
+  return match ? match[1] : `${Math.floor(s / 86400)}d ago`;
 }
 
 function setText(id, value) {

--- a/public/counters.js
+++ b/public/counters.js
@@ -23,21 +23,10 @@ document.addEventListener('click', function (event) {
 });
 
 document.addEventListener('submit', function (event) {
-  var target = event.target;
-  if (!(target instanceof HTMLFormElement)) return;
-
-  if (target.classList.contains('js-confirm-remove-counter')) {
-    var triggerString = target.dataset.counterTrigger || 'this counter';
-    if (!window.confirm('Remove counter ' + triggerString + '?')) {
-      event.preventDefault();
-    }
-    return;
-  }
-
-  if (target.classList.contains('js-confirm-reset-counter')) {
-    var resetTriggerString = target.dataset.counterTrigger || 'this counter';
-    if (!window.confirm('Reset current value for ' + resetTriggerString + ' to 0?')) {
-      event.preventDefault();
-    }
-  }
+  if (confirmSubmit(event, 'js-confirm-remove-counter', function (t) {
+    return 'Remove counter ' + (t.dataset.counterTrigger || 'this counter') + '?';
+  })) return;
+  confirmSubmit(event, 'js-confirm-reset-counter', function (t) {
+    return 'Reset current value for ' + (t.dataset.counterTrigger || 'this counter') + ' to 0?';
+  });
 });

--- a/public/streams.js
+++ b/public/streams.js
@@ -331,23 +331,12 @@ document.addEventListener('click', function (event) {
 });
 
 document.addEventListener('submit', function (event) {
-  var target = event.target;
-  if (!(target instanceof HTMLFormElement)) return;
-
-  if (target.classList.contains('js-confirm-remove-group')) {
-    var groupName = target.dataset.groupName || 'this group';
-    if (!window.confirm('Remove group "' + groupName + '" and all its streamers?')) {
-      event.preventDefault();
-    }
-    return;
-  }
-
-  if (target.classList.contains('js-confirm-remove-streamer')) {
-    var streamerName = target.dataset.streamerName || 'this streamer';
-    if (!window.confirm('Remove streamer "' + streamerName + '"?')) {
-      event.preventDefault();
-    }
-  }
+  if (confirmSubmit(event, 'js-confirm-remove-group', function (t) {
+    return 'Remove group "' + (t.dataset.groupName || 'this group') + '" and all its streamers?';
+  })) return;
+  confirmSubmit(event, 'js-confirm-remove-streamer', function (t) {
+    return 'Remove streamer "' + (t.dataset.streamerName || 'this streamer') + '"?';
+  });
 });
 
 var liveNowInflight = false;

--- a/public/utils.js
+++ b/public/utils.js
@@ -1,0 +1,7 @@
+function confirmSubmit(event, className, buildMessage) {
+  var target = event.target;
+  if (!(target instanceof HTMLFormElement)) return false;
+  if (!target.classList.contains(className)) return false;
+  if (!window.confirm(buildMessage(target))) event.preventDefault();
+  return true;
+}

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -157,6 +157,7 @@
     </section>
   </main>
   <%- include('partials/pwa-register') %>
+  <script src="/utils.js"></script>
   <script src="/admin.js"></script>
 </body>
 </html>

--- a/views/counters.ejs
+++ b/views/counters.ejs
@@ -157,6 +157,7 @@
   </main>
 
   <%- include('partials/pwa-register') %>
+  <script src="/utils.js"></script>
   <script src="/counters.js"></script>
 </body>
 </html>

--- a/views/streams.ejs
+++ b/views/streams.ejs
@@ -250,6 +250,7 @@
   </main>
 
   <%- include('partials/pwa-register') %>
+  <script src="/utils.js"></script>
   <script src="/streams.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Extracts duplicated confirm-before-submit boilerplate from `streams.js`, `counters.js`, and `admin.js` into a shared `public/utils.js` helper (`confirmSubmit`)
- Loads `utils.js` before each page script in the relevant views so the helper is available at runtime
- Rewrites `relativeTime` in `app.js` using a threshold lookup table, reducing it from 6 returns to 2 (resolves the too-many-returns code smell)

## Test plan

- [ ] Streams page: confirm dialog appears when removing a group or streamer; cancelling blocks submission
- [ ] Counters page: confirm dialog appears when removing or resetting a counter; cancelling blocks submission
- [ ] Admin page: confirm dialog appears when removing a user; cancelling blocks submission
- [ ] Dashboard status timestamps display correctly (just now / Xs ago / Xm ago / Xh ago / Xd ago)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicate confirmation dialog logic across user management, counter operations, and streaming features into a centralized shared utility function, reducing code duplication and improving consistency throughout the application.
  * Optimized relative time calculation implementation for better performance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/84)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->