### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/src/discordBot.ts
+++ b/src/discordBot.ts
@@ -1,6 +1,5 @@
 import { Client, GatewayIntentBits, Guild } from 'discord.js';
 import { DISCORD_TOKEN, DISCORD_GUILD_ID } from './config';
-import { connect } from './audioPlayer';
 import { handleCommand } from './commandRouter';
 import { executeCustomCommandForDiscord } from './customCommandHandler';
 import { executeCounterCommandForDiscord } from './counterHandler';


### PR DESCRIPTION
Remove the unused `connect` import from `src/discordBot.ts`.

- **General fix approach:** delete imports that are not referenced in the module.
- **Best fix for this case:** remove line 3 (`import { connect } from './audioPlayer';`) and leave all other logic unchanged.
- **Where to change:** top import block in `src/discordBot.ts`.
- **What is needed:** no new methods, no new definitions, no new dependencies.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._