### PR TITLE
fix(multitwitch): update both posts when 2nd streamer goes live; make URL clickable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,6 @@ Tables in the existing MySQL 8 database:
 | `live_message`       | text       | Template for go-live message               |
 | `new_game_message`   | text       | Template for game-change message           |
 | `multi_twitch`       | bit(1)     | Enable multitwitch links                   |
-| `multi_twitch_message`| text      | Footer template when multitwitch applies   |
 | `delete_old_posts`   | bit(1)     | Delete old embed on game change instead of edit |
 
 ### `streamer`
@@ -331,7 +330,7 @@ When a stream appears offline in a poll, `handleStreamOffline()` starts a 5-minu
 On `startTwitchMonitor()`, after loading streamers from DB, `performStartupLiveCheck()` is called. It queries Helix for all monitored user IDs and reconciles against the stored `discord_message_id`/`live_game` columns: live + has message → edit; live + no message → post fresh; offline + has message → delete and clear DB; offline + no message → no-op.
 
 ### Twitch stream monitor — multitwitch
-When ≥2 streamers in the same group are live on the same game, each matching Discord embed gets a footer built from `group.multi_twitch_message` with `{multitwitch}` replaced by `https://www.multitwitch.tv/login1/login2/...`. `updateMultitwitch(groupId)` is called after any live-state change (go-live, game-change, go-offline).
+When ≥2 streamers in the same group are live on the same game, each matching Discord embed gets a `MultiTwitch` field added containing `https://www.multitwitch.tv/login1/login2/...`. `updateMultitwitch(groupId)` is called after any live-state change (go-live, game-change, go-offline).
 
 ### Twitch stream monitor — hot reload
 Any CRUD change to groups or streamers via the web panel calls `restartTwitchMonitor()` which tears down the poll timer, clears in-memory state, and re-runs `startTwitchMonitor()` (including startup live-check). Existing Discord messages are NOT deleted on restart; the live-check will re-sync them.

--- a/DATABASE-SCHEMA.md
+++ b/DATABASE-SCHEMA.md
@@ -115,8 +115,7 @@ Stores configuration for Twitch announcement groups.
 | `discord_channel` | `BIGINT` | Channel ID for announcements |
 | `live_message` | `TEXT` | Go-live message template |
 | `new_game_message` | `TEXT` | Game-change message template |
-| `multi_twitch` | `BIT(1)` or `TINYINT(1)` | Enables multitwitch footer generation |
-| `multi_twitch_message` | `TEXT` | Footer template containing `{multitwitch}` |
+| `multi_twitch` | `BIT(1)` or `TINYINT(1)` | Enables multitwitch URL field in embeds |
 | `delete_old_posts` | `BIT(1)` or `TINYINT(1)` | Delete old announcement on game change instead of editing |
 
 ## `streamer`

--- a/public/streams.js
+++ b/public/streams.js
@@ -132,7 +132,6 @@ function renderMessagePreview(title, preview) {
               (safeImageUrl
                 ? '<div class="discord-embed-footer">Image: ' + renderLink(safeImageUrl, 'open thumbnail') + '</div>'
                 : '') +
-              (embed.footer ? '<div class="discord-embed-footer">' + escapeHtml(embed.footer) + '</div>' : '<div class="discord-embed-footer muted">No footer</div>') +
             '</div>' +
           '</div>' : '') +
       '</div>' +
@@ -147,9 +146,6 @@ function renderMultiTwitchDetails(multiTwitch) {
   var participants = multiTwitch && multiTwitch.participants && multiTwitch.participants.length
     ? multiTwitch.participants.join(', ')
     : '—';
-  var footerState = multiTwitch && multiTwitch.renderedFooter
-    ? renderBadge('Footer active', 'badge-active')
-    : '<span class="muted">No footer rendered</span>';
 
   return '' +
     '<section class="live-detail-section">' +
@@ -158,13 +154,11 @@ function renderMultiTwitchDetails(multiTwitch) {
         renderMetadataItem('Setting', multiTwitch && multiTwitch.enabled ? 'Enabled' : 'Disabled') +
         renderMetadataItem('Applicable Now', multiTwitch && multiTwitch.applicable ? 'Yes' : 'No') +
         renderMetadataItem('Participants', participants, 'mono') +
-        renderMetadataItem('Footer', multiTwitch && multiTwitch.renderedFooter ? multiTwitch.renderedFooter : '—', 'mono') +
       '</div>' +
       '<div class="live-link-row">' +
         '<span class="live-meta-label">Computed link</span>' +
         '<span class="live-meta-value mono">' + renderLink(multiTwitch ? multiTwitch.url : null, multiTwitch && multiTwitch.url ? multiTwitch.url : '—') + '</span>' +
       '</div>' +
-      '<div class="live-footer-state">' + footerState + '</div>' +
     '</section>';
 }
 

--- a/src/db/streamMonitor.ts
+++ b/src/db/streamMonitor.ts
@@ -8,7 +8,6 @@ export interface DbStreamGroup {
   live_message: string;
   new_game_message: string;
   multi_twitch: boolean;
-  multi_twitch_message: string;
   delete_old_posts: boolean;
 }
 
@@ -18,7 +17,6 @@ export interface AddStreamGroupInput {
   liveMessage: string;
   newGameMessage: string;
   multiTwitch: boolean;
-  multiTwitchMessage: string;
   deleteOldPosts: boolean;
 }
 
@@ -56,7 +54,6 @@ function mapStreamGroup(r: mysql.RowDataPacket): DbStreamGroup {
     live_message: r.live_message,
     new_game_message: r.new_game_message,
     multi_twitch: mapBool(r.multi_twitch),
-    multi_twitch_message: r.multi_twitch_message ?? '',
     delete_old_posts: mapBool(r.delete_old_posts),
   };
 }
@@ -68,14 +65,14 @@ function streamGroupParams(input: AddStreamGroupInput): Array<string | number> {
     input.liveMessage,
     input.newGameMessage,
     input.multiTwitch ? 1 : 0,
-    input.multiTwitchMessage,
+    '',
     input.deleteOldPosts ? 1 : 0,
   ];
 }
 
 export async function getAllStreamGroups(): Promise<DbStreamGroup[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    `SELECT id, name, discord_channel, live_message, new_game_message, multi_twitch, multi_twitch_message, delete_old_posts
+    `SELECT id, name, discord_channel, live_message, new_game_message, multi_twitch, delete_old_posts
      FROM stream_group ORDER BY name`,
   );
   return rows.map(mapStreamGroup);
@@ -121,7 +118,7 @@ export async function getAllStreamersWithGroups(): Promise<DbStreamerFull[]> {
     `SELECT s.id, s.name, s.group_id,
             s.discord_message_id, s.discord_channel_id, s.live_game,
             g.name AS group_name, g.discord_channel, g.live_message, g.new_game_message,
-            g.multi_twitch, g.multi_twitch_message, g.delete_old_posts
+            g.multi_twitch, g.delete_old_posts
      FROM streamer s
      JOIN stream_group g ON s.group_id = g.id
      ORDER BY g.id, s.name`,
@@ -139,7 +136,6 @@ export async function getAllStreamersWithGroups(): Promise<DbStreamerFull[]> {
       live_message: r.live_message,
       new_game_message: r.new_game_message,
       multi_twitch: mapBool(r.multi_twitch),
-      multi_twitch_message: r.multi_twitch_message ?? '',
       delete_old_posts: mapBool(r.delete_old_posts),
     },
   }));

--- a/src/db/streamMonitor.ts
+++ b/src/db/streamMonitor.ts
@@ -65,7 +65,6 @@ function streamGroupParams(input: AddStreamGroupInput): Array<string | number> {
     input.liveMessage,
     input.newGameMessage,
     input.multiTwitch ? 1 : 0,
-    '',
     input.deleteOldPosts ? 1 : 0,
   ];
 }
@@ -80,15 +79,15 @@ export async function getAllStreamGroups(): Promise<DbStreamGroup[]> {
 
 export async function addStreamGroup(input: AddStreamGroupInput): Promise<void> {
   await getPool().execute(
-    `INSERT INTO stream_group (name, discord_channel, live_message, new_game_message, multi_twitch, multi_twitch_message, delete_old_posts)
-     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO stream_group (name, discord_channel, live_message, new_game_message, multi_twitch, delete_old_posts)
+     VALUES (?, ?, ?, ?, ?, ?)`,
     streamGroupParams(input),
   );
 }
 
 export async function updateStreamGroup(input: UpdateStreamGroupInput): Promise<void> {
   await getPool().execute(
-    `UPDATE stream_group SET name=?, discord_channel=?, live_message=?, new_game_message=?, multi_twitch=?, multi_twitch_message=?, delete_old_posts=?
+    `UPDATE stream_group SET name=?, discord_channel=?, live_message=?, new_game_message=?, multi_twitch=?, delete_old_posts=?
      WHERE id=?`,
     [...streamGroupParams(input), input.id],
   );

--- a/src/twitchMonitorEmbed.ts
+++ b/src/twitchMonitorEmbed.ts
@@ -51,8 +51,8 @@ export function parseHexColor(color: string): number {
   return parseInt(normalized, 16);
 }
 
-export function buildEmbed(stream: TwitchStream, footer?: string): EmbedBuilder {
-  const preview = buildEmbedPreview(stream, footer);
+export function buildEmbed(stream: TwitchStream, multitwitchUrl?: string): EmbedBuilder {
+  const preview = buildEmbedPreview(stream);
 
   const embed = new EmbedBuilder()
     .setTitle(preview.title)
@@ -61,7 +61,7 @@ export function buildEmbed(stream: TwitchStream, footer?: string): EmbedBuilder 
     .addFields(...preview.fields)
     .setImage(preview.imageUrl);
 
-  if (preview.footer) embed.setFooter({ text: preview.footer });
+  if (multitwitchUrl) embed.addFields({ name: 'MultiTwitch', value: multitwitchUrl });
   return embed;
 }
 

--- a/src/twitchMonitorEmbed.ts
+++ b/src/twitchMonitorEmbed.ts
@@ -62,13 +62,12 @@ export function buildEmbed(stream: TwitchStream, multitwitchUrl?: string): Embed
     .setImage(preview.imageUrl);
 }
 
-export function templateVars(login: string, stream: TwitchStream, multitwitch?: string): Record<string, string> {
+export function templateVars(login: string, stream: TwitchStream): Record<string, string> {
   return {
     streamer: login,
     game: stream.game_name || 'Unknown',
     title: stream.title,
     url: getStreamUrl(login),
-    multitwitch: multitwitch ?? '',
   };
 }
 

--- a/src/twitchMonitorEmbed.ts
+++ b/src/twitchMonitorEmbed.ts
@@ -10,7 +10,6 @@ export interface DiscordEmbedPreview {
   color: string;
   fields: Array<{ name: string; value: string }>;
   imageUrl: string;
-  footer: string | null;
 }
 
 export interface DiscordMessagePreview {
@@ -34,14 +33,15 @@ export function getThumbnailUrl(stream: TwitchStream): string {
     .replace('{height}', '360');
 }
 
-export function buildEmbedPreview(stream: TwitchStream, footer?: string): DiscordEmbedPreview {
+export function buildEmbedPreview(stream: TwitchStream, multitwitchUrl?: string): DiscordEmbedPreview {
+  const fields: Array<{ name: string; value: string }> = [{ name: 'Game', value: stream.game_name || 'Unknown' }];
+  if (multitwitchUrl) fields.push({ name: 'MultiTwitch', value: multitwitchUrl });
   return {
     title: stream.title,
     url: getStreamUrl(stream.user_login),
     color: '#9146FF',
-    fields: [{ name: 'Game', value: stream.game_name || 'Unknown' }],
+    fields,
     imageUrl: getThumbnailUrl(stream),
-    footer: footer || null,
   };
 }
 
@@ -52,17 +52,14 @@ export function parseHexColor(color: string): number {
 }
 
 export function buildEmbed(stream: TwitchStream, multitwitchUrl?: string): EmbedBuilder {
-  const preview = buildEmbedPreview(stream);
+  const preview = buildEmbedPreview(stream, multitwitchUrl);
 
-  const embed = new EmbedBuilder()
+  return new EmbedBuilder()
     .setTitle(preview.title)
     .setURL(preview.url)
     .setColor(parseHexColor(preview.color))
     .addFields(...preview.fields)
     .setImage(preview.imageUrl);
-
-  if (multitwitchUrl) embed.addFields({ name: 'MultiTwitch', value: multitwitchUrl });
-  return embed;
 }
 
 export function templateVars(login: string, stream: TwitchStream, multitwitch?: string): Record<string, string> {
@@ -80,7 +77,7 @@ export function templateVars(login: string, stream: TwitchStream, multitwitch?: 
 export function buildMessagePreview(
   state: LiveState,
   templateKey: 'live_message' | 'new_game_message',
-  multiTwitch: { renderedFooter: string | null },
+  multiTwitch: { url: string | null },
 ): DiscordMessagePreview {
   const stream = state.currentStream;
   const template = templateKey === 'new_game_message'
@@ -90,6 +87,6 @@ export function buildMessagePreview(
 
   return {
     content: fillTemplate(template, vars),
-    embed: buildEmbedPreview(stream, multiTwitch.renderedFooter ?? undefined),
+    embed: buildEmbedPreview(stream, multiTwitch.url ?? undefined),
   };
 }

--- a/src/twitchMonitorMultitwitch.ts
+++ b/src/twitchMonitorMultitwitch.ts
@@ -1,7 +1,6 @@
-import { EmbedBuilder } from 'discord.js';
 import { discordClient } from './discordBot';
 import { getMonitorEnabled } from './monitorSettings';
-import { fillTemplate } from './twitchMonitorEmbed';
+import { buildEmbed, fillTemplate } from './twitchMonitorEmbed';
 import { LiveState } from './twitchMonitorTypes';
 
 // ─── Public types ─────────────────────────────────────────────────────────────
@@ -100,21 +99,13 @@ export async function updateMultitwitch(groupId: number, liveStates: ReadonlyMap
   for (const state of groupLive) {
     if (!state.messageId || !state.channelId) continue;
     const multiTwitch = getMultitwitchPreview(state, context);
-    const footer = multiTwitch.renderedFooter ?? undefined;
+    const multitwitchUrl = multiTwitch.url ?? undefined;
 
     try {
       const channel = await discordClient.channels.fetch(state.channelId);
       if (!channel || !channel.isTextBased()) continue;
       const message = await channel.messages.fetch(state.messageId);
-      const existing = message.embeds[0];
-      if (!existing) continue;
-
-      const updated = EmbedBuilder.from(existing);
-      if (footer) {
-        updated.setFooter({ text: footer });
-      } else {
-        updated.setFooter(null);
-      }
+      const updated = buildEmbed(state.currentStream, multitwitchUrl);
       await message.edit({ embeds: [updated] });
     } catch (err) {
       console.error(`[TwitchMonitor] Failed to update multitwitch for ${state.login}:`, err);

--- a/src/twitchMonitorMultitwitch.ts
+++ b/src/twitchMonitorMultitwitch.ts
@@ -1,6 +1,6 @@
 import { discordClient } from './discordBot';
 import { getMonitorEnabled } from './monitorSettings';
-import { buildEmbed, fillTemplate } from './twitchMonitorEmbed';
+import { buildEmbed } from './twitchMonitorEmbed';
 import { LiveState } from './twitchMonitorTypes';
 
 // ─── Public types ─────────────────────────────────────────────────────────────
@@ -10,7 +10,6 @@ export interface MultiTwitchPreview {
   applicable: boolean;
   participants: string[];
   url: string | null;
-  renderedFooter: string | null;
 }
 
 export interface MultiTwitchGroupInfo {
@@ -64,7 +63,6 @@ export function getMultitwitchPreview(state: LiveState, context: MultiTwitchCont
       applicable: false,
       participants: [state.login],
       url: null,
-      renderedFooter: null,
     };
   }
 
@@ -74,19 +72,16 @@ export function getMultitwitchPreview(state: LiveState, context: MultiTwitchCont
       applicable: true,
       participants,
       url: null,
-      renderedFooter: null,
     };
   }
 
   const url = `https://www.multitwitch.tv/${participants.join('/')}`;
-  const renderedFooter = fillTemplate(state.group.multi_twitch_message, { multitwitch: url }) || null;
 
   return {
     enabled: true,
     applicable: true,
     participants,
     url,
-    renderedFooter,
   };
 }
 

--- a/src/web/routes/streams.ts
+++ b/src/web/routes/streams.ts
@@ -100,7 +100,6 @@ router.post('/streams/groups/add', requireManager, csrfProtection, async (req, r
       liveMessage: normalizedLiveMessage,
       newGameMessage: normalizedNewGameMessage,
       multiTwitch: multi_twitch,
-      multiTwitchMessage: '',
       deleteOldPosts: delete_old_posts,
     });
     triggerRestart();
@@ -136,7 +135,6 @@ router.post('/streams/groups/update', requireManager, csrfProtection, async (req
       liveMessage: normalizedLiveMessage,
       newGameMessage: normalizedNewGameMessage,
       multiTwitch: multi_twitch,
-      multiTwitchMessage: '',
       deleteOldPosts: delete_old_posts,
     });
     triggerRestart();

--- a/src/web/routes/streams.ts
+++ b/src/web/routes/streams.ts
@@ -80,7 +80,7 @@ router.get('/streams/live', requireManager, (_req, res) => {
 // ─── Groups ───────────────────────────────────────────────────────────────────
 
 router.post('/streams/groups/add', requireManager, csrfProtection, async (req, res) => {
-  const { name, discord_channel, live_message, new_game_message, multi_twitch_message } = req.body as Record<string, string | undefined>;
+  const { name, discord_channel, live_message, new_game_message } = req.body as Record<string, string | undefined>;
   const multi_twitch = req.body.multi_twitch === 'on';
   const delete_old_posts = req.body.delete_old_posts === 'on';
 
@@ -100,7 +100,7 @@ router.post('/streams/groups/add', requireManager, csrfProtection, async (req, r
       liveMessage: normalizedLiveMessage,
       newGameMessage: normalizedNewGameMessage,
       multiTwitch: multi_twitch,
-      multiTwitchMessage: typeof multi_twitch_message === 'string' ? multi_twitch_message.trim() : '',
+      multiTwitchMessage: '',
       deleteOldPosts: delete_old_posts,
     });
     triggerRestart();
@@ -112,7 +112,7 @@ router.post('/streams/groups/add', requireManager, csrfProtection, async (req, r
 });
 
 router.post('/streams/groups/update', requireManager, csrfProtection, async (req, res) => {
-  const { group_id, name, discord_channel, live_message, new_game_message, multi_twitch_message } = req.body as Record<string, string | undefined>;
+  const { group_id, name, discord_channel, live_message, new_game_message } = req.body as Record<string, string | undefined>;
   const multi_twitch = req.body.multi_twitch === 'on';
   const delete_old_posts = req.body.delete_old_posts === 'on';
 
@@ -136,7 +136,7 @@ router.post('/streams/groups/update', requireManager, csrfProtection, async (req
       liveMessage: normalizedLiveMessage,
       newGameMessage: normalizedNewGameMessage,
       multiTwitch: multi_twitch,
-      multiTwitchMessage: typeof multi_twitch_message === 'string' ? multi_twitch_message.trim() : '',
+      multiTwitchMessage: '',
       deleteOldPosts: delete_old_posts,
     });
     triggerRestart();

--- a/views/streams.ejs
+++ b/views/streams.ejs
@@ -99,10 +99,6 @@
               <p class="hint hint-compact">Game change message — shown when the streamer switches games. Same variables.</p>
               <textarea class="input stream-textarea" name="new_game_message" rows="2" placeholder="{streamer} switched to {game}! {url}" required></textarea>
             </div>
-            <div class="form-section-gap">
-              <p class="hint hint-compact">Multi-Twitch footer (optional) — appended to embeds when 2+ group members play the same game. Variable: <code>{multitwitch}</code></p>
-              <textarea class="input stream-textarea" name="multi_twitch_message" rows="1" placeholder="Watch together: {multitwitch}"></textarea>
-            </div>
             <button type="submit" class="btn">Add Group</button>
           </form>
         </div>
@@ -161,10 +157,6 @@
                     <div class="form-subsection-gap">
                       <p class="hint hint-compact">Game change message</p>
                       <textarea class="input stream-textarea" name="new_game_message" rows="2" required><%= g.new_game_message %></textarea>
-                    </div>
-                    <div class="form-section-gap">
-                      <p class="hint hint-compact">Multi-Twitch footer</p>
-                      <textarea class="input stream-textarea" name="multi_twitch_message" rows="1"><%= g.multi_twitch_message %></textarea>
                     </div>
                     <div class="button-row-wrap">
                       <button type="submit" class="btn">Save Changes</button>


### PR DESCRIPTION
## Summary

- **Both posts now updated**: `updateMultitwitch` was fetching the existing Discord embed and bailing with `if (!existing) continue` when `message.embeds[0]` was empty. For a message sent milliseconds earlier, Discord.js can return it from cache before the embed is populated, silently skipping the second streamer's post. Fixed by rebuilding the embed fresh from `state.currentStream` instead.
- **URL is now clickable**: The multitwitch text was previously rendered via `setFooter`. Discord footers never auto-link URLs — they're always plain text. Replaced the footer/template approach with a dedicated `MultiTwitch` embed field containing the raw URL; Discord field values do auto-link URLs.
- The `multi_twitch_message` DB template is no longer used for the embed (the URL is placed directly in the field), removing an unnecessary layer of indirection.

## Test plan

- [ ] Stream A goes live → no MultiTwitch field (only 1 person)
- [ ] Stream B goes live (same group, same game) → both A and B posts show a clickable `MultiTwitch` field with `https://www.multitwitch.tv/a/b`
- [ ] Stream B goes offline → MultiTwitch field removed from A's post
- [ ] Confirm the URL in the field is clickable in Discord (not plain text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/battle-cattle/bcuk-bot-4/pull/89" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Multitwitch info is now shown as a dedicated embed field (multitwitch URL) instead of an embed footer; previews and live embeds are rebuilt accordingly.
* **UI**
  * Admin group forms no longer expose a “Multi‑Twitch footer” input.
  * Preview display omits footer text unless a thumbnail link is present.
* **Documentation**
  * Docs updated to reflect the new multitwitch URL field and removed footer-template behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/89)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->