### PR TITLE
fix(quality): address GitHub Code Quality findings

### DIFF
--- a/src/twitchMonitor.ts
+++ b/src/twitchMonitor.ts
@@ -1,4 +1,3 @@
-import { discordClient } from './discordBot';
 import { getAllStreamersWithGroups, DbStreamerFull } from './db';
 import { getUsers, getStreams, TwitchStream } from './twitchApi';
 import { LiveState } from './twitchMonitorTypes';
@@ -129,19 +128,8 @@ export async function startTwitchMonitor(): Promise<void> {
   // Startup live-check: sync with any streams that went live/offline while bot was down
   await performStartupLiveCheck(liveStates, loginToUserId, streamersData);
 
-  // Begin polling every 60 s. The in-flight guard prevents a slow poll from
-  // stacking with the next tick if the interval fires before it completes.
-  let polling = false;
-  pollTimer = setInterval(async () => {
-    if (polling) return;
-    polling = true;
-    try {
-      await pollStreams();
-    } catch (err) {
-      console.error('[TwitchMonitor] Poll error:', err);
-    } finally {
-      polling = false;
-    }
+  pollTimer = setInterval(() => {
+    pollStreams().catch((err) => console.error('[TwitchMonitor] Poll error:', err));
   }, POLL_INTERVAL_MS);
   console.log(`[TwitchMonitor] Polling ${loginToUserId.size} streamer(s) every ${POLL_INTERVAL_MS / 1000}s`);
 }

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -40,7 +40,7 @@
             <div class="stat-row"><span class="stat-label">State</span><span class="stat-value" id="voice-state">Idle</span></div>
             <% if (user && user.accessLevel >= 1) { %>
             <div class="stat-row stat-row-top-gap">
-              <button class="btn btn-sm" id="btn-rejoin-voice"><%= status.voice.connected ? 'Leave Voice' : 'Rejoin Voice' %></button>
+              <button class="btn btn-sm" id="btn-rejoin-voice"><%= status.voice.connected ? 'Leave Voice' : 'Join Voice' %></button>
             </div>
             <% } %>
           </div>


### PR DESCRIPTION
## Summary
- Remove unused `discordClient` import in `twitchMonitor.ts` (flagged by GitHub static analysis)
- Remove redundant local `polling` flag in the poll interval; the `pollRunning` guard inside `pollStreams()` is sufficient and already prevents re-entrant polls
- Change voice button label from `'Rejoin Voice'` to `'Join Voice'` when the bot is not connected, so the label accurately reflects the action being taken

## Notes
The first fix was found by GitHub's Code Quality (static analysis). The remaining two were AI-generated suggestions that were reviewed and confirmed as real issues.

## Test plan
- [ ] Bot starts and polls Twitch streams as normal (no regression from polling change)
- [ ] Dashboard voice button shows `Join Voice` when disconnected and `Leave Voice` when connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Voice channel action button now displays "Join Voice" when the voice bot is disconnected (was previously labeled "Rejoin Voice").

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/95)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->