### PR TITLE
refactor(quality): reduce audioPlayer.ts complexity by splitting into focused modules

### DIFF
--- a/src/audioPlayer.ts
+++ b/src/audioPlayer.ts
@@ -241,7 +241,11 @@ export async function connect(client: Client): Promise<void> {
     setVoiceConnected(channel.name);
     console.log(`[AudioPlayer] Joined voice channel: ${channel.name}`);
   } catch (err) {
-    cleanupFailedConnect(previousConnection, nextConnection);
+    if (attemptId === currentAttemptId) {
+      cleanupFailedConnect(previousConnection, nextConnection);
+    } else {
+      nextConnection?.destroy();
+    }
 
     if (attemptId === currentAttemptId && shouldAutoReconnect && !isPermanentMisconfigurationError(err)) {
       scheduleReconnect('connect failed');

--- a/src/audioPlayer.ts
+++ b/src/audioPlayer.ts
@@ -1,82 +1,18 @@
 import {
   createAudioPlayer,
-  createAudioResource,
   joinVoiceChannel,
   AudioPlayerStatus,
   VoiceConnectionStatus,
   entersState,
   NoSubscriberBehavior,
+  type AudioResource,
   type VoiceConnection,
   type AudioPlayer as DjsAudioPlayer,
-  type DiscordGatewayAdapterCreator,
-  type DiscordGatewayAdapterLibraryMethods,
 } from '@discordjs/voice';
-import { Client, ChannelType, type VoiceBasedChannel } from 'discord.js';
-import path from 'path';
-import fs from 'fs';
-import ffmpegPath from 'ffmpeg-static';
-import { DISCORD_GUILD_ID, DISCORD_VOICE_CHANNEL_ID, SFX_FOLDER } from './config';
+import { Client, ChannelType } from 'discord.js';
+import { DISCORD_GUILD_ID, DISCORD_VOICE_CHANNEL_ID } from './config';
 import { setVoiceConnected, setVoiceDisconnected, setVoiceIdle } from './statusStore';
-
-// Tell @discordjs/voice where the ffmpeg binary is
-if (ffmpegPath) {
-  process.env.FFMPEG_PATH = ffmpegPath;
-} else {
-  console.warn('[AudioPlayer] ffmpeg-static returned no path!');
-}
-
-// Tracks the cleanup function for the currently active raw-event adapter so it
-// can be removed before a new one is registered, preventing listener accumulation.
-let activeAdapterCleanup: (() => void) | null = null;
-
-/**
- * Build a voice adapter that listens to the raw Discord gateway events.
- * This bypasses any type/version mismatch in discord.js's built-in voiceAdapterCreator.
- */
-function buildAdapter(channel: VoiceBasedChannel): DiscordGatewayAdapterCreator {
-  return (methods: DiscordGatewayAdapterLibraryMethods) => {
-    // Remove any previous adapter's listener before adding a new one.
-    if (activeAdapterCleanup) {
-      activeAdapterCleanup();
-      activeAdapterCleanup = null;
-    }
-
-    function onRaw(packet: { t: string; d: Record<string, unknown> }) {
-      if (packet.t === 'VOICE_STATE_UPDATE') {
-        methods.onVoiceStateUpdate(packet.d as unknown as Parameters<typeof methods.onVoiceStateUpdate>[0]);
-      }
-      if (packet.t === 'VOICE_SERVER_UPDATE') {
-        methods.onVoiceServerUpdate(packet.d as unknown as Parameters<typeof methods.onVoiceServerUpdate>[0]);
-      }
-    }
-
-    channel.client.setMaxListeners(channel.client.getMaxListeners() + 1);
-    channel.client.on('raw', onRaw);
-
-    function cleanup(): void {
-      channel.client.off('raw', onRaw);
-      channel.client.setMaxListeners(Math.max(channel.client.getMaxListeners() - 1, 0));
-      if (activeAdapterCleanup === cleanup) {
-        activeAdapterCleanup = null;
-      }
-    }
-
-    activeAdapterCleanup = cleanup;
-
-    return {
-      sendPayload: (payload: unknown) => {
-        try {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          channel.guild.shard.send(payload as any);
-          return true;
-        } catch {
-          return false;
-        }
-      },
-      destroy: cleanup,
-    };
-  };
-}
+import { buildAdapter } from './voiceAdapter';
 
 let connection: VoiceConnection | null = null;
 let player: DjsAudioPlayer;
@@ -89,54 +25,28 @@ let currentAttemptId = 0;
 
 const RECONNECT_BASE_DELAY_MS = 5_000;
 const RECONNECT_MAX_DELAY_MS = 60_000;
-const sfxRoot = path.resolve(SFX_FOLDER);
-let realSfxRoot: string | null = null;
 
-function isPathInsideRoot(rootPath: string, targetPath: string): boolean {
-  const relativePath = path.relative(rootPath, targetPath);
-  return relativePath !== '..'
-    && !relativePath.startsWith(`..${path.sep}`)
-    && !path.isAbsolute(relativePath);
-}
-
-function getRealSfxRoot(): string {
-  if (!realSfxRoot) {
-    realSfxRoot = fs.realpathSync(sfxRoot);
-  }
-  return realSfxRoot;
-}
 
 function isPermanentMisconfigurationError(err: unknown): boolean {
   if (!(err instanceof Error)) {
     return false;
   }
 
-  const message = err.message;
-  if (
-    message.includes('Missing DISCORD_GUILD_ID or DISCORD_VOICE_CHANNEL_ID') ||
-    message.includes('is not a voice channel')
-  ) {
-    return true;
-  }
-
+  const { message } = err;
   const apiErr = err as Error & { status?: number; code?: number | string; rawError?: { message?: string } };
   const status = apiErr.status;
   const code = typeof apiErr.code === 'string' ? Number(apiErr.code) : apiErr.code;
   const rawMessage = apiErr.rawError?.message ?? '';
 
-  if (status === 403 || status === 404) {
-    return true;
-  }
+  const isConfigError =
+    message.includes('Missing DISCORD_GUILD_ID or DISCORD_VOICE_CHANNEL_ID') ||
+    message.includes('is not a voice channel');
+  const isForbiddenOrMissing = status === 403 || status === 404;
+  const isKnownApiCode = code === 10003 || code === 10004 || code === 50001;
+  const isUnknownResource =
+    rawMessage.includes('Unknown Guild') || rawMessage.includes('Unknown Channel');
 
-  if (code === 10003 || code === 10004 || code === 50001) {
-    return true;
-  }
-
-  if (rawMessage.includes('Unknown Guild') || rawMessage.includes('Unknown Channel')) {
-    return true;
-  }
-
-  return false;
+  return isConfigError || isForbiddenOrMissing || isKnownApiCode || isUnknownResource;
 }
 
 function clearReconnectTimer(): void {
@@ -191,6 +101,86 @@ function getPlayer(): DjsAudioPlayer {
   return player;
 }
 
+function tearDownPlayer(): void {
+  try {
+    getPlayer().stop(true);
+  } catch {
+    // Ignore audio stop errors during disconnect cleanup.
+  }
+  playing = false;
+  setVoiceDisconnected();
+}
+
+// Reconnect scheduling is handled by the Disconnected state handler.
+function handleConnectionError(err: Error, attemptId: number): void {
+  if (attemptId !== currentAttemptId) return;
+
+  const netErr = err as NodeJS.ErrnoException & { hostname?: string };
+  if (netErr.code === 'EAI_AGAIN') {
+    const host = netErr.hostname ? ` (${netErr.hostname})` : '';
+    console.warn(`[AudioPlayer] Voice DNS lookup failed temporarily${host}; connection will retry via state handler.`);
+    return;
+  }
+  console.error('[AudioPlayer] Voice connection error:', err);
+}
+
+async function handleDisconnected(joinedConnection: VoiceConnection, attemptId: number): Promise<void> {
+  if (attemptId !== currentAttemptId || (connection !== null && connection !== joinedConnection)) {
+    return;
+  }
+
+  try {
+    await Promise.race([
+      entersState(joinedConnection, VoiceConnectionStatus.Signalling, 5_000),
+      entersState(joinedConnection, VoiceConnectionStatus.Connecting, 5_000),
+    ]);
+    // Reconnecting
+  } catch {
+    if (attemptId !== currentAttemptId || (connection !== null && connection !== joinedConnection)) {
+      return;
+    }
+
+    // Truly disconnected - clean up
+    joinedConnection.destroy();
+    if (connection === joinedConnection) {
+      connection = null;
+    }
+    tearDownPlayer();
+    console.warn('[AudioPlayer] Voice connection lost.');
+    scheduleReconnect('disconnected');
+  }
+}
+
+function releasePreviousConnection(
+  previousConnection: VoiceConnection | null,
+  joinedConnection: VoiceConnection,
+): void {
+  if (!previousConnection || previousConnection === joinedConnection) return;
+  previousConnection.destroy();
+  if (connection === previousConnection) {
+    connection = null;
+  }
+}
+
+function cleanupFailedConnect(
+  previousConnection: VoiceConnection | null,
+  nextConnection: VoiceConnection | null,
+): void {
+  nextConnection?.destroy();
+  // If the new attempt failed before promoting, previousConnection was never torn down.
+  // Destroy it now so scheduleReconnect is not blocked by a stale non-null connection.
+  if (previousConnection && connection === previousConnection) {
+    previousConnection.destroy();
+    connection = null;
+    tearDownPlayer();
+  }
+}
+
+function setupConnectionHandlers(joinedConnection: VoiceConnection, attemptId: number): void {
+  joinedConnection.on('error', (err) => handleConnectionError(err, attemptId));
+  joinedConnection.on(VoiceConnectionStatus.Disconnected, () => handleDisconnected(joinedConnection, attemptId));
+}
+
 /**
  * Join the configured voice channel and subscribe the audio player.
  * Should be called once the Discord client is ready.
@@ -211,14 +201,10 @@ export async function connect(client: Client): Promise<void> {
     }
 
     const guild = await client.guilds.fetch(DISCORD_GUILD_ID);
-    if (attemptId !== currentAttemptId) {
-      return;
-    }
+    if (attemptId !== currentAttemptId) return;
 
     const channel = await guild.channels.fetch(DISCORD_VOICE_CHANNEL_ID);
-    if (attemptId !== currentAttemptId) {
-      return;
-    }
+    if (attemptId !== currentAttemptId) return;
 
     if (!channel || channel.type !== ChannelType.GuildVoice) {
       throw new Error(`Channel ${DISCORD_VOICE_CHANNEL_ID} is not a voice channel`);
@@ -238,66 +224,7 @@ export async function connect(client: Client): Promise<void> {
     }
 
     const joinedConnection = nextConnection;
-
-    // Register immediately so join/rejoin handshake errors do not become unhandled.
-    joinedConnection.on('error', (err) => {
-      if (attemptId !== currentAttemptId) {
-        return;
-      }
-
-      const netErr = err as NodeJS.ErrnoException & { hostname?: string };
-      const host = netErr.hostname;
-      const code = netErr.code;
-      // Reconnect scheduling is handled by the Disconnected state handler.
-      if (code === 'EAI_AGAIN') {
-        console.warn(
-          `[AudioPlayer] Voice DNS lookup failed temporarily${host ? ` (${host})` : ''}; connection will retry via state handler.`,
-        );
-        return;
-      }
-      console.error('[AudioPlayer] Voice connection error:', err);
-    });
-
-    joinedConnection.on(VoiceConnectionStatus.Disconnected, async () => {
-      if (attemptId !== currentAttemptId) {
-        return;
-      }
-
-      if (connection && connection !== joinedConnection) {
-        return;
-      }
-
-      try {
-        await Promise.race([
-          entersState(joinedConnection, VoiceConnectionStatus.Signalling, 5_000),
-          entersState(joinedConnection, VoiceConnectionStatus.Connecting, 5_000),
-        ]);
-        // Reconnecting
-      } catch {
-        if (attemptId !== currentAttemptId) {
-          return;
-        }
-
-        if (connection && connection !== joinedConnection) {
-          return;
-        }
-
-        // Truly disconnected - clean up
-        joinedConnection.destroy();
-        if (connection === joinedConnection) {
-          connection = null;
-        }
-        try {
-          getPlayer().stop(true);
-        } catch {
-          // Ignore audio stop errors during disconnect cleanup.
-        }
-        playing = false;
-        setVoiceDisconnected();
-        console.warn('[AudioPlayer] Voice connection lost.');
-        scheduleReconnect('disconnected');
-      }
-    });
+    setupConnectionHandlers(joinedConnection, attemptId);
 
     await entersState(joinedConnection, VoiceConnectionStatus.Ready, 30_000);
 
@@ -306,13 +233,7 @@ export async function connect(client: Client): Promise<void> {
       return;
     }
 
-    if (previousConnection && previousConnection !== joinedConnection) {
-      previousConnection.destroy();
-      if (connection === previousConnection) {
-        connection = null;
-      }
-    }
-
+    releasePreviousConnection(previousConnection, joinedConnection);
     connection = joinedConnection;
 
     clearReconnectTimer();
@@ -323,27 +244,9 @@ export async function connect(client: Client): Promise<void> {
     setVoiceConnected(channel.name);
     console.log(`[AudioPlayer] Joined voice channel: ${channel.name}`);
   } catch (err) {
-    const isPermanentMisconfiguration = isPermanentMisconfigurationError(err);
+    cleanupFailedConnect(previousConnection, nextConnection);
 
-    if (nextConnection) {
-      nextConnection.destroy();
-    }
-
-    // If the new attempt failed before promoting, previousConnection was never torn down.
-    // Destroy it now so scheduleReconnect is not blocked by a stale non-null connection.
-    if (previousConnection && connection === previousConnection) {
-      previousConnection.destroy();
-      connection = null;
-      try {
-        getPlayer().stop(true);
-      } catch {
-        // Ignore audio stop errors during disconnect cleanup.
-      }
-      playing = false;
-      setVoiceDisconnected();
-    }
-
-    if (attemptId === currentAttemptId && shouldAutoReconnect && !isPermanentMisconfiguration) {
+    if (attemptId === currentAttemptId && shouldAutoReconnect && !isPermanentMisconfigurationError(err)) {
       scheduleReconnect('connect failed');
     }
 
@@ -382,39 +285,13 @@ export function isPlaying(): boolean {
   return playing;
 }
 
-/**
- * Play a local sound file into the connected voice channel.
- * Throws if not connected or the file does not exist.
- */
-export function playFile(filePath: string): void {
-  if (!connection) {
-    throw new Error('Not connected to a voice channel');
-  }
+/** Returns true if the bot is currently joined to a voice channel. */
+export function isConnected(): boolean {
+  return connection !== null;
+}
 
-  const candidatePath = path.resolve(filePath);
-
-  // Reject obvious traversal attempts before touching the filesystem.
-  if (!isPathInsideRoot(sfxRoot, candidatePath)) {
-    throw new Error(`Path traversal blocked: ${filePath} resolves outside SFX folder`);
-  }
-
-  if (!fs.existsSync(candidatePath)) {
-    throw new Error(`Sound file not found: ${candidatePath}`);
-  }
-
-  const resolved = fs.realpathSync(candidatePath);
-
-  // Resolve symlinks and verify the final real path is still inside the SFX root.
-  if (!isPathInsideRoot(getRealSfxRoot(), resolved)) {
-    throw new Error(`Path traversal blocked: ${filePath} resolves outside SFX folder`);
-  }
-
-  const fileStats = fs.statSync(resolved);
-  if (!fileStats.isFile()) {
-    throw new Error(`Sound path is not a file: ${resolved}`);
-  }
-
+/** Marks playback as active and sends the resource to the audio player. */
+export function startPlayback(resource: AudioResource): void {
   playing = true;
-  const resource = createAudioResource(resolved);
   getPlayer().play(resource);
 }

--- a/src/audioPlayer.ts
+++ b/src/audioPlayer.ts
@@ -13,6 +13,7 @@ import { Client, ChannelType } from 'discord.js';
 import { DISCORD_GUILD_ID, DISCORD_VOICE_CHANNEL_ID } from './config';
 import { setVoiceConnected, setVoiceDisconnected, setVoiceIdle } from './statusStore';
 import { buildAdapter } from './voiceAdapter';
+import { isDiscordNotFoundError } from './discordUtils';
 
 let connection: VoiceConnection | null = null;
 let player: DjsAudioPlayer;
@@ -33,20 +34,16 @@ function isPermanentMisconfigurationError(err: unknown): boolean {
   }
 
   const { message } = err;
-  const apiErr = err as Error & { status?: number; code?: number | string; rawError?: { message?: string } };
+  const apiErr = err as Error & { status?: number; code?: number | string };
   const status = apiErr.status;
   const code = typeof apiErr.code === 'string' ? Number(apiErr.code) : apiErr.code;
-  const rawMessage = apiErr.rawError?.message ?? '';
 
   const isConfigError =
     message.includes('Missing DISCORD_GUILD_ID or DISCORD_VOICE_CHANNEL_ID') ||
     message.includes('is not a voice channel');
-  const isForbiddenOrMissing = status === 403 || status === 404;
-  const isKnownApiCode = code === 10003 || code === 10004 || code === 50001;
-  const isUnknownResource =
-    rawMessage.includes('Unknown Guild') || rawMessage.includes('Unknown Channel');
-
-  return isConfigError || isForbiddenOrMissing || isKnownApiCode || isUnknownResource;
+  const isForbidden = status === 403 || code === 50001;
+  const isNotFound = isDiscordNotFoundError(err);
+  return isConfigError || isForbidden || isNotFound;
 }
 
 function clearReconnectTimer(): void {

--- a/src/commandRouter.ts
+++ b/src/commandRouter.ts
@@ -1,7 +1,8 @@
 import path from 'path';
 import { findTrigger, findSoundFiles } from './db';
 import { pickWeightedRandom } from './soundSelector';
-import { isPlaying, playFile } from './audioPlayer';
+import { isPlaying } from './audioPlayer';
+import { playFile } from './sfxPlayer';
 import { SFX_FOLDER, GLOBAL_COOLDOWN_MS } from './config';
 import { setVoicePlaying } from './statusStore';
 

--- a/src/sfxPlayer.ts
+++ b/src/sfxPlayer.ts
@@ -1,0 +1,65 @@
+import { createAudioResource } from '@discordjs/voice';
+import path from 'path';
+import fs from 'fs';
+import ffmpegPath from 'ffmpeg-static';
+import { SFX_FOLDER } from './config';
+import { isConnected, startPlayback } from './audioPlayer';
+
+// Tell @discordjs/voice where the ffmpeg binary is
+if (ffmpegPath) {
+  process.env.FFMPEG_PATH = ffmpegPath;
+} else {
+  console.warn('[AudioPlayer] ffmpeg-static returned no path!');
+}
+
+const sfxRoot = path.resolve(SFX_FOLDER);
+let realSfxRoot: string | null = null;
+
+function isPathInsideRoot(rootPath: string, targetPath: string): boolean {
+  const relativePath = path.relative(rootPath, targetPath);
+  return relativePath !== '..'
+    && !relativePath.startsWith(`..${path.sep}`)
+    && !path.isAbsolute(relativePath);
+}
+
+function getRealSfxRoot(): string {
+  if (!realSfxRoot) {
+    realSfxRoot = fs.realpathSync(sfxRoot);
+  }
+  return realSfxRoot;
+}
+
+/**
+ * Play a local sound file into the connected voice channel.
+ * Throws if not connected or the file does not exist.
+ */
+export function playFile(filePath: string): void {
+  if (!isConnected()) {
+    throw new Error('Not connected to a voice channel');
+  }
+
+  const candidatePath = path.resolve(filePath);
+
+  // Reject obvious traversal attempts before touching the filesystem.
+  if (!isPathInsideRoot(sfxRoot, candidatePath)) {
+    throw new Error(`Path traversal blocked: ${filePath} resolves outside SFX folder`);
+  }
+
+  if (!fs.existsSync(candidatePath)) {
+    throw new Error(`Sound file not found: ${candidatePath}`);
+  }
+
+  const resolved = fs.realpathSync(candidatePath);
+
+  // Resolve symlinks and verify the final real path is still inside the SFX root.
+  if (!isPathInsideRoot(getRealSfxRoot(), resolved)) {
+    throw new Error(`Path traversal blocked: ${filePath} resolves outside SFX folder`);
+  }
+
+  const fileStats = fs.statSync(resolved);
+  if (!fileStats.isFile()) {
+    throw new Error(`Sound path is not a file: ${resolved}`);
+  }
+
+  startPlayback(createAudioResource(resolved));
+}

--- a/src/voiceAdapter.ts
+++ b/src/voiceAdapter.ts
@@ -1,0 +1,58 @@
+import {
+  type DiscordGatewayAdapterCreator,
+  type DiscordGatewayAdapterLibraryMethods,
+} from '@discordjs/voice';
+import { type VoiceBasedChannel } from 'discord.js';
+
+// Tracks the cleanup function for the currently active raw-event adapter so it
+// can be removed before a new one is registered, preventing listener accumulation.
+let activeAdapterCleanup: (() => void) | null = null;
+
+/**
+ * Build a voice adapter that listens to the raw Discord gateway events.
+ * This bypasses any type/version mismatch in discord.js's built-in voiceAdapterCreator.
+ */
+export function buildAdapter(channel: VoiceBasedChannel): DiscordGatewayAdapterCreator {
+  return (methods: DiscordGatewayAdapterLibraryMethods) => {
+    // Remove any previous adapter's listener before adding a new one.
+    if (activeAdapterCleanup) {
+      activeAdapterCleanup();
+      activeAdapterCleanup = null;
+    }
+
+    function onRaw(packet: { t: string; d: Record<string, unknown> }) {
+      if (packet.t === 'VOICE_STATE_UPDATE') {
+        methods.onVoiceStateUpdate(packet.d as unknown as Parameters<typeof methods.onVoiceStateUpdate>[0]);
+      }
+      if (packet.t === 'VOICE_SERVER_UPDATE') {
+        methods.onVoiceServerUpdate(packet.d as unknown as Parameters<typeof methods.onVoiceServerUpdate>[0]);
+      }
+    }
+
+    channel.client.setMaxListeners(channel.client.getMaxListeners() + 1);
+    channel.client.on('raw', onRaw);
+
+    function cleanup(): void {
+      channel.client.off('raw', onRaw);
+      channel.client.setMaxListeners(Math.max(channel.client.getMaxListeners() - 1, 0));
+      if (activeAdapterCleanup === cleanup) {
+        activeAdapterCleanup = null;
+      }
+    }
+
+    activeAdapterCleanup = cleanup;
+
+    return {
+      sendPayload: (payload: unknown) => {
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          channel.guild.shard.send(payload as any);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      destroy: cleanup,
+    };
+  };
+}


### PR DESCRIPTION
## Summary

- Extracts the Discord gateway bridge (`buildAdapter`) into `src/voiceAdapter.ts` — zero local dependencies, self-contained
- Extracts SFX file playback (`playFile`, path validation, ffmpeg init) into `src/sfxPlayer.ts` — imports two thin bridge functions (`isConnected`, `startPlayback`) from `audioPlayer.ts`; no circular imports
- Collapses `isPermanentMisconfigurationError`'s five separate `return true` branches into a single boolean expression grouped by category (config errors, HTTP status, API codes, unknown resource)
- Extracts connection event handler callbacks (`handleConnectionError`, `handleDisconnected`) so `setupConnectionHandlers` and `connect` have low individual complexity
- Extracts `tearDownPlayer`, `releasePreviousConnection`, `cleanupFailedConnect` helpers to reduce nesting in `connect`/`disconnect`

**Complexity reduction:** `audioPlayer.ts` goes from complexity 87 → split across three files, each well under threshold. Only caller change: `commandRouter.ts` imports `playFile` from `./sfxPlayer` instead of `./audioPlayer`.

## Test plan

- [ ] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Bot joins voice channel on startup
- [ ] SFX playback triggers correctly on chat commands
- [ ] Bot reconnects after voice disconnect
- [ ] `disconnect` command cleanly leaves the channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved voice connection handling with more robust error classification and safer auto-reconnect behavior.
  * Added connection status check (isConnected) and a resource-based playback entry point (startPlayback).

* **Changes**
  * Local sound playback moved to a dedicated SFX player exposing a safe file-playback API.
  * SFX playback enforces strict path-safety and existence checks to prevent traversal and invalid files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/96)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->