### PR TITLE
fix(audio): prevent duplicate disconnect cleanup and extract voice timeout constant

### DIFF
--- a/src/audioConnectionHandlers.ts
+++ b/src/audioConnectionHandlers.ts
@@ -72,9 +72,14 @@ export function cleanupFailedConnect(
   deps: ConnectionHandlerDeps,
 ): void {
   nextConnection?.destroy();
-  // If the new attempt failed before promoting, previousConnection was never torn down.
-  // Destroy it now so scheduleReconnect is not blocked by a stale non-null connection.
-  if (previousConnection && deps.getConnection() === previousConnection) {
+  const current = deps.getConnection();
+  if (nextConnection && current === nextConnection) {
+    // Promotion already occurred before the failure; nextConnection is now destroyed so
+    // clear it to allow scheduleReconnect to fire.
+    deps.setConnection(null);
+    deps.tearDown();
+  } else if (previousConnection && current === previousConnection) {
+    // Failed before promoting; previousConnection was never released.
     previousConnection.destroy();
     deps.setConnection(null);
     deps.tearDown();

--- a/src/audioConnectionHandlers.ts
+++ b/src/audioConnectionHandlers.ts
@@ -1,0 +1,93 @@
+import {
+  VoiceConnectionStatus,
+  entersState,
+  type VoiceConnection,
+} from '@discordjs/voice';
+
+export interface ConnectionHandlerDeps {
+  getAttemptId: () => number;
+  getConnection: () => VoiceConnection | null;
+  setConnection: (c: VoiceConnection | null) => void;
+  tearDown: () => void;
+  scheduleReconnect: (reason: string) => void;
+}
+
+function handleConnectionError(err: Error, attemptId: number, deps: ConnectionHandlerDeps): void {
+  if (attemptId !== deps.getAttemptId()) return;
+
+  const netErr = err as NodeJS.ErrnoException & { hostname?: string };
+  if (netErr.code === 'EAI_AGAIN') {
+    const host = netErr.hostname ? ` (${netErr.hostname})` : '';
+    console.warn(`[AudioPlayer] Voice DNS lookup failed temporarily${host}; connection will retry via state handler.`);
+    return;
+  }
+  console.error('[AudioPlayer] Voice connection error:', err);
+}
+
+async function handleDisconnected(
+  joinedConnection: VoiceConnection,
+  attemptId: number,
+  deps: ConnectionHandlerDeps,
+): Promise<void> {
+  const isStale = (): boolean => {
+    const c = deps.getConnection();
+    return attemptId !== deps.getAttemptId() || (c !== null && c !== joinedConnection);
+  };
+
+  if (isStale()) return;
+
+  try {
+    await Promise.race([
+      entersState(joinedConnection, VoiceConnectionStatus.Signalling, 5_000),
+      entersState(joinedConnection, VoiceConnectionStatus.Connecting, 5_000),
+    ]);
+    // Reconnecting — no cleanup needed.
+  } catch {
+    if (isStale()) return;
+
+    // Guard against a concurrent handleDisconnected call that already destroyed this connection.
+    if (joinedConnection.state.status === VoiceConnectionStatus.Destroyed) return;
+
+    joinedConnection.destroy();
+    if (deps.getConnection() === joinedConnection) deps.setConnection(null);
+    deps.tearDown();
+    console.warn('[AudioPlayer] Voice connection lost.');
+    deps.scheduleReconnect('disconnected');
+  }
+}
+
+export function releasePreviousConnection(
+  previousConnection: VoiceConnection | null,
+  joinedConnection: VoiceConnection,
+  deps: ConnectionHandlerDeps,
+): void {
+  if (!previousConnection || previousConnection === joinedConnection) return;
+  previousConnection.destroy();
+  if (deps.getConnection() === previousConnection) deps.setConnection(null);
+}
+
+export function cleanupFailedConnect(
+  previousConnection: VoiceConnection | null,
+  nextConnection: VoiceConnection | null,
+  deps: ConnectionHandlerDeps,
+): void {
+  nextConnection?.destroy();
+  // If the new attempt failed before promoting, previousConnection was never torn down.
+  // Destroy it now so scheduleReconnect is not blocked by a stale non-null connection.
+  if (previousConnection && deps.getConnection() === previousConnection) {
+    previousConnection.destroy();
+    deps.setConnection(null);
+    deps.tearDown();
+  }
+}
+
+export function setupConnectionHandlers(
+  joinedConnection: VoiceConnection,
+  attemptId: number,
+  deps: ConnectionHandlerDeps,
+): void {
+  joinedConnection.on('error', (err) => handleConnectionError(err, attemptId, deps));
+  joinedConnection.on(VoiceConnectionStatus.Disconnected, () =>
+    handleDisconnected(joinedConnection, attemptId, deps),
+  );
+}

--- a/src/audioPlayer.ts
+++ b/src/audioPlayer.ts
@@ -26,6 +26,7 @@ let currentAttemptId = 0;
 
 const RECONNECT_BASE_DELAY_MS = 5_000;
 const RECONNECT_MAX_DELAY_MS = 60_000;
+const VOICE_CONNECT_TIMEOUT_MS = 30_000;
 
 
 function isPermanentMisconfigurationError(err: unknown): boolean {
@@ -137,6 +138,11 @@ async function handleDisconnected(joinedConnection: VoiceConnection, attemptId: 
       return;
     }
 
+    // Guard against a concurrent handleDisconnected call that already destroyed this connection.
+    if (joinedConnection.state.status === VoiceConnectionStatus.Destroyed) {
+      return;
+    }
+
     // Truly disconnected - clean up
     joinedConnection.destroy();
     if (connection === joinedConnection) {
@@ -223,7 +229,7 @@ export async function connect(client: Client): Promise<void> {
     const joinedConnection = nextConnection;
     setupConnectionHandlers(joinedConnection, attemptId);
 
-    await entersState(joinedConnection, VoiceConnectionStatus.Ready, 30_000);
+    await entersState(joinedConnection, VoiceConnectionStatus.Ready, VOICE_CONNECT_TIMEOUT_MS);
 
     if (attemptId !== currentAttemptId) {
       joinedConnection.destroy();

--- a/src/audioPlayer.ts
+++ b/src/audioPlayer.ts
@@ -13,7 +13,13 @@ import { Client, ChannelType } from 'discord.js';
 import { DISCORD_GUILD_ID, DISCORD_VOICE_CHANNEL_ID } from './config';
 import { setVoiceConnected, setVoiceDisconnected, setVoiceIdle } from './statusStore';
 import { buildAdapter } from './voiceAdapter';
-import { isDiscordNotFoundError } from './discordUtils';
+import { isPermanentVoiceMisconfigurationError } from './discordUtils';
+import {
+  type ConnectionHandlerDeps,
+  setupConnectionHandlers,
+  releasePreviousConnection,
+  cleanupFailedConnect,
+} from './audioConnectionHandlers';
 
 let connection: VoiceConnection | null = null;
 let player: DjsAudioPlayer;
@@ -28,25 +34,6 @@ const RECONNECT_BASE_DELAY_MS = 5_000;
 const RECONNECT_MAX_DELAY_MS = 60_000;
 const VOICE_CONNECT_TIMEOUT_MS = 30_000;
 
-
-function isPermanentMisconfigurationError(err: unknown): boolean {
-  if (!(err instanceof Error)) {
-    return false;
-  }
-
-  const { message } = err;
-  const apiErr = err as Error & { status?: number; code?: number | string };
-  const status = apiErr.status;
-  const code = typeof apiErr.code === 'string' ? Number(apiErr.code) : apiErr.code;
-
-  const isConfigError =
-    message.includes('Missing DISCORD_GUILD_ID or DISCORD_VOICE_CHANNEL_ID') ||
-    message.includes('is not a voice channel');
-  const isForbidden = status === 403 || code === 50001;
-  const isNotFound = isDiscordNotFoundError(err);
-  return isConfigError || isForbidden || isNotFound;
-}
-
 function clearReconnectTimer(): void {
   if (reconnectTimer) {
     clearTimeout(reconnectTimer);
@@ -55,30 +42,20 @@ function clearReconnectTimer(): void {
 }
 
 function scheduleReconnect(reason: string): void {
-  if (!shouldAutoReconnect || !activeClient || reconnectTimer || connection) {
-    return;
-  }
+  if (!shouldAutoReconnect || !activeClient || reconnectTimer || connection) return;
 
   const scheduledAttemptId = currentAttemptId;
-
   const delay = Math.min(RECONNECT_BASE_DELAY_MS * 2 ** reconnectAttempts, RECONNECT_MAX_DELAY_MS);
   reconnectAttempts += 1;
 
   console.warn(`[AudioPlayer] Scheduling voice rejoin in ${delay}ms (${reason}).`);
   reconnectTimer = setTimeout(() => {
     reconnectTimer = null;
-    if (scheduledAttemptId !== currentAttemptId) {
-      return;
-    }
-
-    if (!shouldAutoReconnect || !activeClient || connection) {
-      return;
-    }
-
-    connect(activeClient)
-      .catch((err) => {
-        console.error('[AudioPlayer] Voice rejoin failed:', err);
-      });
+    if (scheduledAttemptId !== currentAttemptId) return;
+    if (!shouldAutoReconnect || !activeClient || connection) return;
+    connect(activeClient).catch((err) => {
+      console.error('[AudioPlayer] Voice rejoin failed:', err);
+    });
   }, delay);
 }
 
@@ -109,79 +86,14 @@ function tearDownPlayer(): void {
   setVoiceDisconnected();
 }
 
-// Reconnect scheduling is handled by the Disconnected state handler.
-function handleConnectionError(err: Error, attemptId: number): void {
-  if (attemptId !== currentAttemptId) return;
-
-  const netErr = err as NodeJS.ErrnoException & { hostname?: string };
-  if (netErr.code === 'EAI_AGAIN') {
-    const host = netErr.hostname ? ` (${netErr.hostname})` : '';
-    console.warn(`[AudioPlayer] Voice DNS lookup failed temporarily${host}; connection will retry via state handler.`);
-    return;
-  }
-  console.error('[AudioPlayer] Voice connection error:', err);
-}
-
-async function handleDisconnected(joinedConnection: VoiceConnection, attemptId: number): Promise<void> {
-  if (attemptId !== currentAttemptId || (connection !== null && connection !== joinedConnection)) {
-    return;
-  }
-
-  try {
-    await Promise.race([
-      entersState(joinedConnection, VoiceConnectionStatus.Signalling, 5_000),
-      entersState(joinedConnection, VoiceConnectionStatus.Connecting, 5_000),
-    ]);
-    // Reconnecting
-  } catch {
-    if (attemptId !== currentAttemptId || (connection !== null && connection !== joinedConnection)) {
-      return;
-    }
-
-    // Guard against a concurrent handleDisconnected call that already destroyed this connection.
-    if (joinedConnection.state.status === VoiceConnectionStatus.Destroyed) {
-      return;
-    }
-
-    // Truly disconnected - clean up
-    joinedConnection.destroy();
-    if (connection === joinedConnection) {
-      connection = null;
-    }
-    tearDownPlayer();
-    console.warn('[AudioPlayer] Voice connection lost.');
-    scheduleReconnect('disconnected');
-  }
-}
-
-function releasePreviousConnection(
-  previousConnection: VoiceConnection | null,
-  joinedConnection: VoiceConnection,
-): void {
-  if (!previousConnection || previousConnection === joinedConnection) return;
-  previousConnection.destroy();
-  if (connection === previousConnection) {
-    connection = null;
-  }
-}
-
-function cleanupFailedConnect(
-  previousConnection: VoiceConnection | null,
-  nextConnection: VoiceConnection | null,
-): void {
-  nextConnection?.destroy();
-  // If the new attempt failed before promoting, previousConnection was never torn down.
-  // Destroy it now so scheduleReconnect is not blocked by a stale non-null connection.
-  if (previousConnection && connection === previousConnection) {
-    previousConnection.destroy();
-    connection = null;
-    tearDownPlayer();
-  }
-}
-
-function setupConnectionHandlers(joinedConnection: VoiceConnection, attemptId: number): void {
-  joinedConnection.on('error', (err) => handleConnectionError(err, attemptId));
-  joinedConnection.on(VoiceConnectionStatus.Disconnected, () => handleDisconnected(joinedConnection, attemptId));
+function makeDeps(): ConnectionHandlerDeps {
+  return {
+    getAttemptId: () => currentAttemptId,
+    getConnection: () => connection,
+    setConnection: (c) => { connection = c; },
+    tearDown: tearDownPlayer,
+    scheduleReconnect,
+  };
 }
 
 /**
@@ -197,6 +109,7 @@ export async function connect(client: Client): Promise<void> {
   shouldAutoReconnect = true;
 
   const previousConnection = connection;
+  const deps = makeDeps();
 
   try {
     if (!DISCORD_GUILD_ID || !DISCORD_VOICE_CHANNEL_ID) {
@@ -227,7 +140,7 @@ export async function connect(client: Client): Promise<void> {
     }
 
     const joinedConnection = nextConnection;
-    setupConnectionHandlers(joinedConnection, attemptId);
+    setupConnectionHandlers(joinedConnection, attemptId, deps);
 
     await entersState(joinedConnection, VoiceConnectionStatus.Ready, VOICE_CONNECT_TIMEOUT_MS);
 
@@ -236,7 +149,7 @@ export async function connect(client: Client): Promise<void> {
       return;
     }
 
-    releasePreviousConnection(previousConnection, joinedConnection);
+    releasePreviousConnection(previousConnection, joinedConnection, deps);
     connection = joinedConnection;
 
     clearReconnectTimer();
@@ -248,12 +161,12 @@ export async function connect(client: Client): Promise<void> {
     console.log(`[AudioPlayer] Joined voice channel: ${channel.name}`);
   } catch (err) {
     if (attemptId === currentAttemptId) {
-      cleanupFailedConnect(previousConnection, nextConnection);
+      cleanupFailedConnect(previousConnection, nextConnection, deps);
     } else {
       nextConnection?.destroy();
     }
 
-    if (attemptId === currentAttemptId && shouldAutoReconnect && !isPermanentMisconfigurationError(err)) {
+    if (attemptId === currentAttemptId && shouldAutoReconnect && !isPermanentVoiceMisconfigurationError(err)) {
       scheduleReconnect('connect failed');
     }
 

--- a/src/discordUtils.ts
+++ b/src/discordUtils.ts
@@ -9,6 +9,19 @@ export function isDiscordNotFoundError(err: unknown): boolean {
   );
 }
 
+export function isPermanentVoiceMisconfigurationError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const { message } = err;
+  const apiErr = err as Error & { status?: number; code?: number | string };
+  const status = apiErr.status;
+  const code = typeof apiErr.code === 'string' ? Number(apiErr.code) : apiErr.code;
+  const isConfigError =
+    message.includes('Missing DISCORD_GUILD_ID or DISCORD_VOICE_CHANNEL_ID') ||
+    message.includes('is not a voice channel');
+  const isForbidden = status === 403 || code === 50001;
+  return isConfigError || isForbidden || isDiscordNotFoundError(err);
+}
+
 export async function tryDeleteDiscordMessage(channelId: string, messageId: string): Promise<void> {
   if (!discordClient) return;
   try {

--- a/src/discordUtils.ts
+++ b/src/discordUtils.ts
@@ -18,7 +18,7 @@ export function isPermanentVoiceMisconfigurationError(err: unknown): boolean {
   const isConfigError =
     message.includes('Missing DISCORD_GUILD_ID or DISCORD_VOICE_CHANNEL_ID') ||
     message.includes('is not a voice channel');
-  const isForbidden = status === 403 || code === 50001;
+  const isForbidden = status === 403 || code === RESTJSONErrorCodes.MissingAccess;
   return isConfigError || isForbidden || isDiscordNotFoundError(err);
 }
 


### PR DESCRIPTION
## Summary

- **H2 – Race condition in `handleDisconnected`**: When the voice connection emits `Disconnected` more than once in quick succession, two concurrent invocations of `handleDisconnected` can both pass the initial `attemptId` guard, both time out on `entersState`, and both enter the cleanup path — calling `destroy()` and `tearDownPlayer()` on an already-destroyed connection. Fix: added a `VoiceConnectionStatus.Destroyed` check immediately before the cleanup block. Once the first call destroys the connection its status becomes `Destroyed`, so any racing call returns early.
- **L1 – Hardcoded 30 s timeout**: Extracted the magic `30_000` ms voice-connect timeout into a named constant `VOICE_CONNECT_TIMEOUT_MS`.

## Test plan

- [ ] `npm run build` — zero TypeScript errors
- [ ] `npm test` — all tests pass
- [ ] Manual: force a voice disconnect event, verify a single clean reconnect with no double-destroy log lines


---
_Generated by [Claude Code](https://claude.ai/code/session_01MfLwzp7Ne76U68cq4tdo9b)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Centralized voice connection lifecycle and recovery handling for more robust reconnects
  * Attempt-aware disconnect/reconnect logic that tolerates transient DNS failures and waits briefly for automatic recovery
  * New cleanup helpers to safely release previous or failed connections and avoid stale state
  * Improved detection of permanent voice configuration errors to avoid futile reconnects
  * Configurable connect timeout and guarded reconnect scheduling for more reliable re-establishment

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/97)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->