### PR TITLE
fix(db): add deadlock retry logic to command write transactions

### DIFF
--- a/src/db/commandConflicts.ts
+++ b/src/db/commandConflicts.ts
@@ -1,0 +1,260 @@
+import mysql from 'mysql2/promise';
+import { normalizeTwitchChannelName } from '../twitchChannelName';
+import { type SqlExecutor, CommandConflictError } from './commandStringUtils';
+import {
+  acquireNamedLock,
+  releaseNamedLock,
+  getCommandWriteLockName,
+  isDeadlockError,
+  MAX_DEADLOCK_RETRIES,
+} from './commandLocks';
+
+// ─── Conflict assertions ──────────────────────────────────────────────────────
+
+export async function assertDiscordTriggerAvailable(
+  triggerString: string,
+  executor: SqlExecutor,
+  excludeCommandId?: number,
+): Promise<void> {
+  let sql =
+    `SELECT command_id
+     FROM custom_command
+     WHERE trigger_string = ?
+       AND is_discord_enabled = 1`;
+  const params: Array<string | number> = [triggerString];
+
+  if (excludeCommandId !== undefined) {
+    sql += ' AND command_id <> ?';
+    params.push(excludeCommandId);
+  }
+
+  sql += ' LIMIT 1';
+
+  const [conflictRows] = await executor.execute<mysql.RowDataPacket[]>(sql, params);
+  if (conflictRows.length > 0) {
+    throw new CommandConflictError([triggerString]);
+  }
+}
+
+async function hasMultiTwitchTriggerConflict(
+  executor: SqlExecutor,
+  triggerString: string,
+  excludeCommandId?: number,
+): Promise<boolean> {
+  const wherePrefix = excludeCommandId !== undefined
+    ? 'WHERE c.command_id <> ? AND c.trigger_string = ?'
+    : 'WHERE c.trigger_string = ?';
+  const params: Array<string | number> = excludeCommandId !== undefined
+    ? [excludeCommandId, triggerString]
+    : [triggerString];
+
+  const [conflictRows] = await executor.execute<mysql.RowDataPacket[]>(
+    `SELECT c.command_id
+     FROM custom_command c
+     LEFT JOIN twitch_user_commands tuc ON tuc.command_id = c.command_id
+     LEFT JOIN \`user\` u ON u.discord_id = tuc.discord_id
+     ${wherePrefix}
+       AND (
+         c.is_multi_twitch = 1
+         OR (
+           u.twitch_name IS NOT NULL
+           AND u.is_twitch_bot_enabled = 1
+         )
+       )
+     LIMIT 1`,
+    params,
+  );
+
+  return conflictRows.length > 0;
+}
+
+export async function assertMultiTwitchTriggerAvailable(
+  executor: SqlExecutor,
+  triggerString: string,
+  excludeCommandId?: number,
+): Promise<void> {
+  if (await hasMultiTwitchTriggerConflict(executor, triggerString, excludeCommandId)) {
+    throw new CommandConflictError([triggerString]);
+  }
+}
+
+async function hasSingleTwitchAssignmentOverlap(
+  executor: SqlExecutor,
+  commandId: number,
+  triggerString: string,
+): Promise<boolean> {
+  const [overlapRows] = await executor.execute<mysql.RowDataPacket[]>(
+    `SELECT other.command_id
+     FROM twitch_user_commands current_tuc
+     JOIN \`user\` current_u ON current_u.discord_id = current_tuc.discord_id
+     JOIN custom_command other
+       ON other.command_id <> ?
+      AND other.trigger_string = ?
+     LEFT JOIN twitch_user_commands other_tuc ON other_tuc.command_id = other.command_id
+     LEFT JOIN \`user\` other_u ON other_u.discord_id = other_tuc.discord_id
+     WHERE current_tuc.command_id = ?
+       AND current_u.twitch_name IS NOT NULL
+       AND current_u.is_twitch_bot_enabled = 1
+       AND (
+         other.is_multi_twitch = 1
+         OR (
+           other_u.twitch_name IS NOT NULL
+           AND other_u.is_twitch_bot_enabled = 1
+           AND LOWER(other_u.twitch_name) = LOWER(current_u.twitch_name)
+         )
+       )
+     LIMIT 1`,
+    [commandId, triggerString, commandId],
+  );
+
+  return overlapRows.length > 0;
+}
+
+export async function assertNoSingleTwitchAssignmentOverlap(
+  executor: SqlExecutor,
+  commandId: number,
+  triggerString: string,
+): Promise<void> {
+  if (await hasSingleTwitchAssignmentOverlap(executor, commandId, triggerString)) {
+    throw new CommandConflictError([triggerString]);
+  }
+}
+
+export async function getCommandTriggerStringById(executor: SqlExecutor, commandId: number): Promise<string> {
+  const [commandRows] = await executor.execute<mysql.RowDataPacket[]>(
+    'SELECT trigger_string FROM custom_command WHERE command_id = ? LIMIT 1',
+    [commandId],
+  );
+  if (commandRows.length === 0) {
+    throw new Error(`Custom command not found: ${commandId}`);
+  }
+
+  return String(commandRows[0].trigger_string).trim().toLowerCase();
+}
+
+interface UserTwitchEligibility {
+  normalizedTwitchName: string | null;
+  isTwitchBotEnabled: boolean;
+}
+
+export async function getUserTwitchEligibility(executor: SqlExecutor, discordId: string): Promise<UserTwitchEligibility> {
+  const [userRows] = await executor.execute<mysql.RowDataPacket[]>(
+    'SELECT twitch_name, is_twitch_bot_enabled FROM `user` WHERE discord_id = ? LIMIT 1',
+    [discordId],
+  );
+  if (userRows.length === 0) {
+    throw new Error(`User not found: ${discordId}`);
+  }
+
+  const twitchName = userRows[0].twitch_name ? String(userRows[0].twitch_name) : null;
+  return {
+    normalizedTwitchName: twitchName ? normalizeTwitchChannelName(twitchName) : null,
+    isTwitchBotEnabled: Buffer.isBuffer(userRows[0].is_twitch_bot_enabled)
+      ? userRows[0].is_twitch_bot_enabled[0] === 1
+      : userRows[0].is_twitch_bot_enabled == 1,
+  };
+}
+
+async function hasTwitchChannelTriggerConflict(
+  executor: SqlExecutor,
+  commandId: number,
+  triggerString: string,
+  normalizedTwitchName: string,
+): Promise<boolean> {
+  const [conflictRows] = await executor.execute<mysql.RowDataPacket[]>(
+    `SELECT c.command_id
+     FROM custom_command c
+     LEFT JOIN twitch_user_commands tuc ON tuc.command_id = c.command_id
+     LEFT JOIN \`user\` u ON u.discord_id = tuc.discord_id
+     WHERE c.command_id <> ?
+       AND c.trigger_string = ?
+       AND (
+         c.is_multi_twitch = 1
+         OR (
+           u.twitch_name IS NOT NULL
+           AND u.is_twitch_bot_enabled = 1
+           AND LOWER(u.twitch_name) = ?
+         )
+       )
+     LIMIT 1`,
+    [commandId, triggerString, normalizedTwitchName],
+  );
+
+  return conflictRows.length > 0;
+}
+
+export async function assertNoTwitchChannelTriggerConflict(
+  executor: SqlExecutor,
+  commandId: number,
+  triggerString: string,
+  normalizedTwitchName: string,
+): Promise<void> {
+  if (await hasTwitchChannelTriggerConflict(executor, commandId, triggerString, normalizedTwitchName)) {
+    throw new CommandConflictError([triggerString]);
+  }
+}
+
+export async function insertUserCommandAssignment(
+  executor: SqlExecutor,
+  commandId: number,
+  discordId: string,
+): Promise<void> {
+  await executor.execute(
+    `INSERT INTO twitch_user_commands (command_id, discord_id)
+     VALUES (?, ?) AS new_row
+     ON DUPLICATE KEY UPDATE
+       command_id = command_id`,
+    [commandId, discordId],
+  );
+}
+
+export async function assignUserToCommandWithinTransaction(
+  connection: mysql.PoolConnection,
+  commandId: number,
+  discordId: string,
+): Promise<void> {
+  // The named lock is session-scoped: acquire it once and release it in the outer finally,
+  // so deadlock retries on the inner transaction still hold the lock between attempts.
+  let lockNameByTrigger: string | null = null;
+
+  try {
+    for (let attempt = 0; attempt < MAX_DEADLOCK_RETRIES; attempt++) {
+      await connection.beginTransaction();
+      try {
+        const normalizedTriggerString = await getCommandTriggerStringById(connection, commandId);
+
+        if (!lockNameByTrigger) {
+          lockNameByTrigger = getCommandWriteLockName(normalizedTriggerString);
+          await acquireNamedLock(connection, lockNameByTrigger);
+        }
+
+        const userEligibility = await getUserTwitchEligibility(connection, discordId);
+        if (userEligibility.normalizedTwitchName && userEligibility.isTwitchBotEnabled) {
+          await assertNoTwitchChannelTriggerConflict(
+            connection,
+            commandId,
+            normalizedTriggerString,
+            userEligibility.normalizedTwitchName,
+          );
+        }
+
+        await insertUserCommandAssignment(connection, commandId, discordId);
+        await connection.commit();
+        return;
+      } catch (error) {
+        await connection.rollback();
+        if (isDeadlockError(error) && attempt < MAX_DEADLOCK_RETRIES - 1) {
+          console.warn(`[DB] Deadlock in assignUserToCommand, retrying (attempt ${attempt + 1}/${MAX_DEADLOCK_RETRIES}).`);
+          continue;
+        }
+        throw error;
+      }
+    }
+
+    throw new Error('[DB] Deadlock retry limit reached in assignUserToCommandWithinTransaction.');
+  } finally {
+    if (lockNameByTrigger) {
+      await releaseNamedLock(connection, lockNameByTrigger);
+    }
+  }
+}

--- a/src/db/commandConflicts.ts
+++ b/src/db/commandConflicts.ts
@@ -149,6 +149,8 @@ export async function getUserTwitchEligibility(executor: SqlExecutor, discordId:
   const twitchName = userRows[0].twitch_name ? String(userRows[0].twitch_name) : null;
   return {
     normalizedTwitchName: twitchName ? normalizeTwitchChannelName(twitchName) : null,
+    // MySQL BIT(1) columns arrive as a single-byte Buffer on some driver configurations
+    // and as a numeric 0/1 on others; check byte 0 in the Buffer path, loose-equality for numeric.
     isTwitchBotEnabled: Buffer.isBuffer(userRows[0].is_twitch_bot_enabled)
       ? userRows[0].is_twitch_bot_enabled[0] === 1
       : userRows[0].is_twitch_bot_enabled == 1,

--- a/src/db/commandConflicts.ts
+++ b/src/db/commandConflicts.ts
@@ -256,7 +256,7 @@ export async function assignUserToCommandWithinTransaction(
     throw new Error('[DB] Deadlock retry limit reached in assignUserToCommandWithinTransaction.');
   } finally {
     if (lockNameByTrigger) {
-      await releaseNamedLock(connection, lockNameByTrigger);
+      try { await releaseNamedLock(connection, lockNameByTrigger); } catch (_) {}
     }
   }
 }

--- a/src/db/commandLocks.ts
+++ b/src/db/commandLocks.ts
@@ -1,40 +1,33 @@
 import { createHash } from 'node:crypto';
 import mysql from 'mysql2/promise';
-import { normalizeTwitchChannelName } from '../twitchChannelName';
 import { getPool } from './pool';
+import {
+  type SqlExecutor,
+  CommandConflictError,
+  normalizeCommandInputs,
+  buildInClausePlaceholders,
+} from './commandStringUtils';
 
-export type SqlExecutor = mysql.Pool | mysql.PoolConnection;
+export type { SqlExecutor } from './commandStringUtils';
+export {
+  requireTrimmedString,
+  normalizeCommandList,
+  normalizeCommandInputs,
+  buildInClausePlaceholders,
+  CommandNotFoundError,
+  CommandConflictError,
+  isMysqlDuplicateEntryError,
+} from './commandStringUtils';
 
 const COMMAND_WRITE_LOCK_TIMEOUT_SECONDS = 10;
 
-// ─── String normalisation ────────────────────────────────────────────────────
+// ─── Deadlock retry ──────────────────────────────────────────────────────────
 
-export function requireTrimmedString(value: string, fieldName: string): string {
-  const normalizedValue = value.trim();
-  if (!normalizedValue) {
-    throw new Error(`Missing ${fieldName}`);
-  }
-  return normalizedValue;
-}
+export const MAX_DEADLOCK_RETRIES = 3;
 
-function normalizeCommand(command: string): string | null {
-  const normalized = command.trim().toLowerCase();
-  return normalized.length > 0 ? normalized : null;
-}
-
-export function normalizeCommandList(commandOrCommands: string | string[]): string[] {
-  const commands = Array.isArray(commandOrCommands) ? commandOrCommands : [commandOrCommands];
-  return commands
-    .map((command) => normalizeCommand(command))
-    .filter((command): command is string => command !== null);
-}
-
-export function normalizeCommandInputs(commandOrCommands: string | string[]): string[] {
-  return Array.from(new Set(normalizeCommandList(commandOrCommands)));
-}
-
-export function buildInClausePlaceholders(count: number): string {
-  return Array.from({ length: count }, () => '?').join(', ');
+export function isDeadlockError(error: unknown): boolean {
+  const err = error as { code?: string; errno?: number };
+  return err.code === 'ER_LOCK_DEADLOCK' || err.errno === 1213;
 }
 
 // ─── Named locks ─────────────────────────────────────────────────────────────
@@ -90,43 +83,6 @@ async function releaseNamedLocks(connection: mysql.PoolConnection, lockNames: st
   for (let index = lockNames.length - 1; index >= 0; index -= 1) {
     await releaseNamedLock(connection, lockNames[index]);
   }
-}
-
-// ─── Deadlock retry ──────────────────────────────────────────────────────────
-
-const MAX_DEADLOCK_RETRIES = 3;
-
-function isDeadlockError(error: unknown): boolean {
-  const err = error as { code?: string; errno?: number };
-  return err.code === 'ER_LOCK_DEADLOCK' || err.errno === 1213;
-}
-
-// ─── Error types ─────────────────────────────────────────────────────────────
-
-export class CommandNotFoundError extends Error {
-  constructor(id: number) {
-    super(`Command not found: ${id}`);
-    this.name = 'CommandNotFoundError';
-  }
-}
-
-export class CommandConflictError extends Error {
-  readonly commands: string[];
-
-  constructor(commands: string[]) {
-    super(`Command already taken: ${commands.join(', ')}`);
-    this.name = 'CommandConflictError';
-    this.commands = commands;
-  }
-}
-
-export function isMysqlDuplicateEntryError(error: unknown): boolean {
-  if (!error || typeof error !== 'object') {
-    return false;
-  }
-
-  const mysqlError = error as { code?: string; errno?: number };
-  return mysqlError.code === 'ER_DUP_ENTRY' || mysqlError.errno === 1062;
 }
 
 // ─── Exists checks ────────────────────────────────────────────────────────────
@@ -208,259 +164,7 @@ export async function isCustomCommandTriggerTaken(triggerString: string, exclude
   return isAnyCommandTakenAcrossTables(triggerString, { excludeCustomCommandId: excludeCommandId });
 }
 
-// ─── Conflict assertions ──────────────────────────────────────────────────────
-
-export async function assertDiscordTriggerAvailable(
-  triggerString: string,
-  executor: SqlExecutor,
-  excludeCommandId?: number,
-): Promise<void> {
-  let sql =
-    `SELECT command_id
-     FROM custom_command
-     WHERE trigger_string = ?
-       AND is_discord_enabled = 1`;
-  const params: Array<string | number> = [triggerString];
-
-  if (excludeCommandId !== undefined) {
-    sql += ' AND command_id <> ?';
-    params.push(excludeCommandId);
-  }
-
-  sql += ' LIMIT 1';
-
-  const [conflictRows] = await executor.execute<mysql.RowDataPacket[]>(sql, params);
-  if (conflictRows.length > 0) {
-    throw new CommandConflictError([triggerString]);
-  }
-}
-
-async function hasMultiTwitchTriggerConflict(
-  executor: SqlExecutor,
-  triggerString: string,
-  excludeCommandId?: number,
-): Promise<boolean> {
-  const wherePrefix = excludeCommandId !== undefined
-    ? 'WHERE c.command_id <> ? AND c.trigger_string = ?'
-    : 'WHERE c.trigger_string = ?';
-  const params: Array<string | number> = excludeCommandId !== undefined
-    ? [excludeCommandId, triggerString]
-    : [triggerString];
-
-  const [conflictRows] = await executor.execute<mysql.RowDataPacket[]>(
-    `SELECT c.command_id
-     FROM custom_command c
-     LEFT JOIN twitch_user_commands tuc ON tuc.command_id = c.command_id
-     LEFT JOIN \`user\` u ON u.discord_id = tuc.discord_id
-     ${wherePrefix}
-       AND (
-         c.is_multi_twitch = 1
-         OR (
-           u.twitch_name IS NOT NULL
-           AND u.is_twitch_bot_enabled = 1
-         )
-       )
-     LIMIT 1`,
-    params,
-  );
-
-  return conflictRows.length > 0;
-}
-
-export async function assertMultiTwitchTriggerAvailable(
-  executor: SqlExecutor,
-  triggerString: string,
-  excludeCommandId?: number,
-): Promise<void> {
-  if (await hasMultiTwitchTriggerConflict(executor, triggerString, excludeCommandId)) {
-    throw new CommandConflictError([triggerString]);
-  }
-}
-
-async function hasSingleTwitchAssignmentOverlap(
-  executor: SqlExecutor,
-  commandId: number,
-  triggerString: string,
-): Promise<boolean> {
-  const [overlapRows] = await executor.execute<mysql.RowDataPacket[]>(
-    `SELECT other.command_id
-     FROM twitch_user_commands current_tuc
-     JOIN \`user\` current_u ON current_u.discord_id = current_tuc.discord_id
-     JOIN custom_command other
-       ON other.command_id <> ?
-      AND other.trigger_string = ?
-     LEFT JOIN twitch_user_commands other_tuc ON other_tuc.command_id = other.command_id
-     LEFT JOIN \`user\` other_u ON other_u.discord_id = other_tuc.discord_id
-     WHERE current_tuc.command_id = ?
-       AND current_u.twitch_name IS NOT NULL
-       AND current_u.is_twitch_bot_enabled = 1
-       AND (
-         other.is_multi_twitch = 1
-         OR (
-           other_u.twitch_name IS NOT NULL
-           AND other_u.is_twitch_bot_enabled = 1
-           AND LOWER(other_u.twitch_name) = LOWER(current_u.twitch_name)
-         )
-       )
-     LIMIT 1`,
-    [commandId, triggerString, commandId],
-  );
-
-  return overlapRows.length > 0;
-}
-
-export async function assertNoSingleTwitchAssignmentOverlap(
-  executor: SqlExecutor,
-  commandId: number,
-  triggerString: string,
-): Promise<void> {
-  if (await hasSingleTwitchAssignmentOverlap(executor, commandId, triggerString)) {
-    throw new CommandConflictError([triggerString]);
-  }
-}
-
-export async function getCommandTriggerStringById(executor: SqlExecutor, commandId: number): Promise<string> {
-  const [commandRows] = await executor.execute<mysql.RowDataPacket[]>(
-    'SELECT trigger_string FROM custom_command WHERE command_id = ? LIMIT 1',
-    [commandId],
-  );
-  if (commandRows.length === 0) {
-    throw new Error(`Custom command not found: ${commandId}`);
-  }
-
-  return String(commandRows[0].trigger_string).trim().toLowerCase();
-}
-
-interface UserTwitchEligibility {
-  normalizedTwitchName: string | null;
-  isTwitchBotEnabled: boolean;
-}
-
-export async function getUserTwitchEligibility(executor: SqlExecutor, discordId: string): Promise<UserTwitchEligibility> {
-  const [userRows] = await executor.execute<mysql.RowDataPacket[]>(
-    'SELECT twitch_name, is_twitch_bot_enabled FROM `user` WHERE discord_id = ? LIMIT 1',
-    [discordId],
-  );
-  if (userRows.length === 0) {
-    throw new Error(`User not found: ${discordId}`);
-  }
-
-  const twitchName = userRows[0].twitch_name ? String(userRows[0].twitch_name) : null;
-  return {
-    normalizedTwitchName: twitchName ? normalizeTwitchChannelName(twitchName) : null,
-    isTwitchBotEnabled: Buffer.isBuffer(userRows[0].is_twitch_bot_enabled)
-      ? userRows[0].is_twitch_bot_enabled[0] === 1
-      : userRows[0].is_twitch_bot_enabled == 1,
-  };
-}
-
-async function hasTwitchChannelTriggerConflict(
-  executor: SqlExecutor,
-  commandId: number,
-  triggerString: string,
-  normalizedTwitchName: string,
-): Promise<boolean> {
-  const [conflictRows] = await executor.execute<mysql.RowDataPacket[]>(
-    `SELECT c.command_id
-     FROM custom_command c
-     LEFT JOIN twitch_user_commands tuc ON tuc.command_id = c.command_id
-     LEFT JOIN \`user\` u ON u.discord_id = tuc.discord_id
-     WHERE c.command_id <> ?
-       AND c.trigger_string = ?
-       AND (
-         c.is_multi_twitch = 1
-         OR (
-           u.twitch_name IS NOT NULL
-           AND u.is_twitch_bot_enabled = 1
-           AND LOWER(u.twitch_name) = ?
-         )
-       )
-     LIMIT 1`,
-    [commandId, triggerString, normalizedTwitchName],
-  );
-
-  return conflictRows.length > 0;
-}
-
-export async function assertNoTwitchChannelTriggerConflict(
-  executor: SqlExecutor,
-  commandId: number,
-  triggerString: string,
-  normalizedTwitchName: string,
-): Promise<void> {
-  if (await hasTwitchChannelTriggerConflict(executor, commandId, triggerString, normalizedTwitchName)) {
-    throw new CommandConflictError([triggerString]);
-  }
-}
-
-export async function insertUserCommandAssignment(
-  executor: SqlExecutor,
-  commandId: number,
-  discordId: string,
-): Promise<void> {
-  await executor.execute(
-    `INSERT INTO twitch_user_commands (command_id, discord_id)
-     VALUES (?, ?) AS new_row
-     ON DUPLICATE KEY UPDATE
-       command_id = command_id`,
-    [commandId, discordId],
-  );
-}
-
-export async function assignUserToCommandWithinTransaction(
-  connection: mysql.PoolConnection,
-  commandId: number,
-  discordId: string,
-): Promise<void> {
-  // The named lock is session-scoped: acquire it once and release it in the outer finally,
-  // so deadlock retries on the inner transaction still hold the lock between attempts.
-  let lockNameByTrigger: string | null = null;
-
-  try {
-    for (let attempt = 0; attempt < MAX_DEADLOCK_RETRIES; attempt++) {
-      await connection.beginTransaction();
-      try {
-        // Re-read the current trigger_string inside the transaction.
-        // This read comes from the transaction snapshot. If another transaction updates
-        // the same command's trigger in a tiny concurrent window, the conflict check
-        // below can be conservative until the next cache rebuild.
-        const normalizedTriggerString = await getCommandTriggerStringById(connection, commandId);
-
-        if (!lockNameByTrigger) {
-          lockNameByTrigger = getCommandWriteLockName(normalizedTriggerString);
-          await acquireNamedLock(connection, lockNameByTrigger);
-        }
-
-        const userEligibility = await getUserTwitchEligibility(connection, discordId);
-        if (userEligibility.normalizedTwitchName && userEligibility.isTwitchBotEnabled) {
-          await assertNoTwitchChannelTriggerConflict(
-            connection,
-            commandId,
-            normalizedTriggerString,
-            userEligibility.normalizedTwitchName,
-          );
-        }
-
-        await insertUserCommandAssignment(connection, commandId, discordId);
-        await connection.commit();
-        return;
-      } catch (error) {
-        await connection.rollback();
-        if (isDeadlockError(error) && attempt < MAX_DEADLOCK_RETRIES - 1) {
-          console.warn(`[DB] Deadlock in assignUserToCommand, retrying (attempt ${attempt + 1}/${MAX_DEADLOCK_RETRIES}).`);
-          continue;
-        }
-        throw error;
-      }
-    }
-
-    throw new Error('[DB] Deadlock retry limit reached in assignUserToCommandWithinTransaction.');
-  } finally {
-    if (lockNameByTrigger) {
-      await releaseNamedLock(connection, lockNameByTrigger);
-    }
-  }
-}
+// ─── Serialized write ─────────────────────────────────────────────────────────
 
 export async function commandExists(id: number, executor: SqlExecutor = getPool()): Promise<boolean> {
   const [rows] = await executor.execute<mysql.RowDataPacket[]>(

--- a/src/db/commandLocks.ts
+++ b/src/db/commandLocks.ts
@@ -92,6 +92,15 @@ async function releaseNamedLocks(connection: mysql.PoolConnection, lockNames: st
   }
 }
 
+// ─── Deadlock retry ──────────────────────────────────────────────────────────
+
+const MAX_DEADLOCK_RETRIES = 3;
+
+function isDeadlockError(error: unknown): boolean {
+  const err = error as { code?: string; errno?: number };
+  return err.code === 'ER_LOCK_DEADLOCK' || err.errno === 1213;
+}
+
 // ─── Error types ─────────────────────────────────────────────────────────────
 
 export class CommandNotFoundError extends Error {
@@ -403,35 +412,49 @@ export async function assignUserToCommandWithinTransaction(
   commandId: number,
   discordId: string,
 ): Promise<void> {
-  await connection.beginTransaction();
+  // The named lock is session-scoped: acquire it once and release it in the outer finally,
+  // so deadlock retries on the inner transaction still hold the lock between attempts.
   let lockNameByTrigger: string | null = null;
 
   try {
-    // Re-read the current trigger_string inside the transaction.
-    // This read comes from the transaction snapshot. If another transaction updates
-    // the same command's trigger in a tiny concurrent window, the conflict check
-    // below can be conservative until the next cache rebuild.
-    const normalizedTriggerString = await getCommandTriggerStringById(connection, commandId);
-    lockNameByTrigger = getCommandWriteLockName(normalizedTriggerString);
+    for (let attempt = 0; attempt < MAX_DEADLOCK_RETRIES; attempt++) {
+      await connection.beginTransaction();
+      try {
+        // Re-read the current trigger_string inside the transaction.
+        // This read comes from the transaction snapshot. If another transaction updates
+        // the same command's trigger in a tiny concurrent window, the conflict check
+        // below can be conservative until the next cache rebuild.
+        const normalizedTriggerString = await getCommandTriggerStringById(connection, commandId);
 
-    // Named locks are session-scoped (not transaction-scoped), so this must be released explicitly.
-    await acquireNamedLock(connection, lockNameByTrigger);
+        if (!lockNameByTrigger) {
+          lockNameByTrigger = getCommandWriteLockName(normalizedTriggerString);
+          await acquireNamedLock(connection, lockNameByTrigger);
+        }
 
-    const userEligibility = await getUserTwitchEligibility(connection, discordId);
-    if (userEligibility.normalizedTwitchName && userEligibility.isTwitchBotEnabled) {
-      await assertNoTwitchChannelTriggerConflict(
-        connection,
-        commandId,
-        normalizedTriggerString,
-        userEligibility.normalizedTwitchName,
-      );
+        const userEligibility = await getUserTwitchEligibility(connection, discordId);
+        if (userEligibility.normalizedTwitchName && userEligibility.isTwitchBotEnabled) {
+          await assertNoTwitchChannelTriggerConflict(
+            connection,
+            commandId,
+            normalizedTriggerString,
+            userEligibility.normalizedTwitchName,
+          );
+        }
+
+        await insertUserCommandAssignment(connection, commandId, discordId);
+        await connection.commit();
+        return;
+      } catch (error) {
+        await connection.rollback();
+        if (isDeadlockError(error) && attempt < MAX_DEADLOCK_RETRIES - 1) {
+          console.warn(`[DB] Deadlock in assignUserToCommand, retrying (attempt ${attempt + 1}/${MAX_DEADLOCK_RETRIES}).`);
+          continue;
+        }
+        throw error;
+      }
     }
 
-    await insertUserCommandAssignment(connection, commandId, discordId);
-    await connection.commit();
-  } catch (error) {
-    await connection.rollback();
-    throw error;
+    throw new Error('[DB] Deadlock retry limit reached in assignUserToCommandWithinTransaction.');
   } finally {
     if (lockNameByTrigger) {
       await releaseNamedLock(connection, lockNameByTrigger);
@@ -464,20 +487,27 @@ export async function runSerializedCommandWrite<T>(
     connection = await getPool().getConnection();
     await acquireNamedLocks(connection, lockNames);
 
-    await connection.beginTransaction();
+    for (let attempt = 0; attempt < MAX_DEADLOCK_RETRIES; attempt++) {
+      await connection.beginTransaction();
+      try {
+        if (await isAnyCommandTakenAcrossTables(normalizedCommands, options, connection, checks)) {
+          throw new CommandConflictError(normalizedCommands);
+        }
 
-    try {
-      if (await isAnyCommandTakenAcrossTables(normalizedCommands, options, connection, checks)) {
-        throw new CommandConflictError(normalizedCommands);
+        const result = await writeOperation(connection);
+        await connection.commit();
+        return result;
+      } catch (error) {
+        await connection.rollback();
+        if (isDeadlockError(error) && attempt < MAX_DEADLOCK_RETRIES - 1) {
+          console.warn(`[DB] Deadlock detected, retrying transaction (attempt ${attempt + 1}/${MAX_DEADLOCK_RETRIES}).`);
+          continue;
+        }
+        throw error;
       }
-
-      const result = await writeOperation(connection);
-      await connection.commit();
-      return result;
-    } catch (error) {
-      await connection.rollback();
-      throw error;
     }
+
+    throw new Error('[DB] Deadlock retry limit reached without success.');
   } finally {
     if (connection) {
       try { await releaseNamedLocks(connection, lockNames); } catch (_) {}

--- a/src/db/commandStringUtils.ts
+++ b/src/db/commandStringUtils.ts
@@ -1,0 +1,61 @@
+import mysql from 'mysql2/promise';
+
+export type SqlExecutor = mysql.Pool | mysql.PoolConnection;
+
+// ─── String normalisation ────────────────────────────────────────────────────
+
+export function requireTrimmedString(value: string, fieldName: string): string {
+  const normalizedValue = value.trim();
+  if (!normalizedValue) {
+    throw new Error(`Missing ${fieldName}`);
+  }
+  return normalizedValue;
+}
+
+function normalizeCommand(command: string): string | null {
+  const normalized = command.trim().toLowerCase();
+  return normalized.length > 0 ? normalized : null;
+}
+
+export function normalizeCommandList(commandOrCommands: string | string[]): string[] {
+  const commands = Array.isArray(commandOrCommands) ? commandOrCommands : [commandOrCommands];
+  return commands
+    .map((command) => normalizeCommand(command))
+    .filter((command): command is string => command !== null);
+}
+
+export function normalizeCommandInputs(commandOrCommands: string | string[]): string[] {
+  return Array.from(new Set(normalizeCommandList(commandOrCommands)));
+}
+
+export function buildInClausePlaceholders(count: number): string {
+  return Array.from({ length: count }, () => '?').join(', ');
+}
+
+// ─── Error types ─────────────────────────────────────────────────────────────
+
+export class CommandNotFoundError extends Error {
+  constructor(id: number) {
+    super(`Command not found: ${id}`);
+    this.name = 'CommandNotFoundError';
+  }
+}
+
+export class CommandConflictError extends Error {
+  readonly commands: string[];
+
+  constructor(commands: string[]) {
+    super(`Command already taken: ${commands.join(', ')}`);
+    this.name = 'CommandConflictError';
+    this.commands = commands;
+  }
+}
+
+export function isMysqlDuplicateEntryError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const mysqlError = error as { code?: string; errno?: number };
+  return mysqlError.code === 'ER_DUP_ENTRY' || mysqlError.errno === 1062;
+}

--- a/src/db/counters.ts
+++ b/src/db/counters.ts
@@ -1,11 +1,8 @@
 import mysql from 'mysql2/promise';
 import { getPool } from './pool';
 import { createManagedLookupCache, type RefreshingLookupCache } from './lookupCache';
-import {
-  requireTrimmedString, normalizeCommandList,
-  isAnyCommandTakenAcrossTables, runSerializedCommandWrite,
-} from './commandLocks';
-import type { SqlExecutor } from './commandLocks';
+import { requireTrimmedString, normalizeCommandList, type SqlExecutor } from './commandStringUtils';
+import { isAnyCommandTakenAcrossTables, runSerializedCommandWrite } from './commandLocks';
 import { assertNotReservedCommand } from './reservedCommands';
 
 // ─── Types ───────────────────────────────────────────────────────────────────

--- a/src/db/customCommands.ts
+++ b/src/db/customCommands.ts
@@ -5,14 +5,12 @@ import { createManagedLookupCache, type RefreshingLookupCache } from './lookupCa
 import { AccessLevel, getTwitchEnabledChannels } from './users';
 import type { AccessLevelValue } from './users';
 import { assertNotReservedCommand } from './reservedCommands';
+import { requireTrimmedString, CommandNotFoundError, type SqlExecutor } from './commandStringUtils';
+import { acquireNamedLock, releaseNamedLock, commandExists, runSerializedCommandWrite } from './commandLocks';
 import {
-  requireTrimmedString,
   assertDiscordTriggerAvailable, assertMultiTwitchTriggerAvailable, assertNoSingleTwitchAssignmentOverlap,
-  acquireNamedLock, releaseNamedLock,
-  assignUserToCommandWithinTransaction, commandExists, runSerializedCommandWrite,
-  CommandNotFoundError,
-} from './commandLocks';
-import type { SqlExecutor } from './commandLocks';
+  assignUserToCommandWithinTransaction,
+} from './commandConflicts';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- **H3 – No deadlock retry in `commandLocks.ts`**: MySQL deadlock errors (`ER_LOCK_DEADLOCK` / errno 1213) previously surfaced as unhandled rejections, potentially hanging callers. Both `runSerializedCommandWrite` and `assignUserToCommandWithinTransaction` now retry the inner transaction up to 3 times on deadlock.
  - The advisory named locks are held across retries in `assignUserToCommandWithinTransaction` because they are session-scoped and do not need to be re-acquired after a rollback.
  - Each retry logs a warning so deadlock frequency is observable.
  - Any non-deadlock error is re-thrown immediately without retrying.

## Test plan

- [ ] `npm run build` — zero TypeScript errors
- [ ] `npm test` — all tests pass
- [ ] Verify deadlock path: simulate two concurrent writes to the same command and confirm the retry warning appears rather than an unhandled rejection


---
_Generated by [Claude Code](https://claude.ai/code/session_01MfLwzp7Ne76U68cq4tdo9b)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better detection/prevention of conflicting command assignments (Discord/Twitch), including case-insensitive Twitch name handling and channel-specific checks.
  * Improved transaction reliability with deadlock detection and automatic retry for transient database conflicts.

* **Refactor**
  * Consolidated command normalization, validation, and error handling utilities for consistency.
  * Reorganized command persistence and locking logic for clearer serialization and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->