### PR TITLE
fix(db): replace dynamic SQL column name with pre-computed allowlist; extract fromBit helper

### DIFF
--- a/src/db/counters.ts
+++ b/src/db/counters.ts
@@ -7,6 +7,16 @@ import {
 } from './commandLocks';
 import type { SqlExecutor } from './commandLocks';
 import { assertNotReservedCommand } from './reservedCommands';
+import { fromBit } from './utils';
+
+// ─── Archive column allowlist ─────────────────────────────────────────────────
+// MySQL does not support parameterised column names. Rather than building the
+// name dynamically from a validated integer at call-time, we pre-compute every
+// valid mapping here so the string that reaches the SQL template is always
+// drawn from a fixed, auditable set.
+const ARCHIVE_YEAR_COLUMNS = new Map<number, string>(
+  Array.from({ length: 2100 - 2020 + 1 }, (_, i) => [2020 + i, `value${2020 + i}`] as [number, string]),
+);
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -51,7 +61,7 @@ function mapCounter(row: mysql.RowDataPacket): DbCounter {
     check_command: row.check_command,
     message: row.message,
     increment_message: row.increment_message,
-    reset_yearly: Buffer.isBuffer(row.reset_yearly) ? row.reset_yearly[0] === 1 : row.reset_yearly == 1,
+    reset_yearly: fromBit(row.reset_yearly),
     current_value: row.current_value,
   };
 }
@@ -324,12 +334,10 @@ export async function incrementCounter(id: number): Promise<number> {
 }
 
 export async function archiveAndResetYearlyCounters(year: number): Promise<number> {
-  if (!Number.isInteger(year) || year < 2020 || year > 2100) {
+  const columnName = ARCHIVE_YEAR_COLUMNS.get(year);
+  if (!columnName) {
     throw new Error(`[DB] Invalid archive year: ${year}`);
   }
-  // MySQL doesn't support parameterised column names, so the name is built from
-  // `year` which is validated to a safe integer in [2020, 2100] above.
-  const columnName = `value${year}`;
   const [result] = await getPool().execute<mysql.ResultSetHeader>(
     `UPDATE counter SET \`${columnName}\` = current_value, current_value = 0 WHERE reset_yearly = 1 AND \`${columnName}\` IS NULL`,
   );

--- a/src/db/utils.ts
+++ b/src/db/utils.ts
@@ -1,0 +1,5 @@
+/** Converts a MySQL BIT(1) column value (Buffer, number, or boolean) to a boolean. */
+export function fromBit(value: unknown): boolean {
+  if (Buffer.isBuffer(value)) return value[0] === 1;
+  return value == 1;
+}


### PR DESCRIPTION
## Summary

- **H1 – Dynamic SQL column name in `archiveAndResetYearlyCounters`**: The archive column name was constructed by string-interpolating a validated integer into a backtick SQL identifier. While the `[2020, 2100]` range check was sound, any dynamic column name in SQL is a latent injection risk if the validation is ever loosened or bypassed. Replaced with `ARCHIVE_YEAR_COLUMNS`, a `Map<number, string>` pre-computed at module load time for every valid year. The column name reaching the SQL template is now always drawn from this fixed, auditable set — `Map.get()` returns `undefined` for any value not in the map, which is caught and thrown as an error.

- **L3 – Repeated buffer-to-boolean pattern**: Extracted a shared `fromBit(value: unknown): boolean` helper into `src/db/utils.ts` and replaced the inline `Buffer.isBuffer(x) ? x[0] === 1 : x == 1` expression in `counters.ts`.

## Test plan

- [ ] `npm run build` — zero TypeScript errors
- [ ] `npm test` — all tests pass
- [ ] Verify `archiveAndResetYearlyCounters(2025)` hits the correct `value2025` column
- [ ] Verify `archiveAndResetYearlyCounters(1999)` throws `Invalid archive year`


---
_Generated by [Claude Code](https://claude.ai/code/session_01MfLwzp7Ne76U68cq4tdo9b)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved database query handling logic for better code maintainability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->