### PR TITLE
fix(tiktok): detect permanent channel errors and disable reconnect loop

### DIFF
--- a/src/tiktokBot.ts
+++ b/src/tiktokBot.ts
@@ -41,9 +41,10 @@ export async function startTikTokBot(): Promise<void> {
     }) as unknown as Connection;
     activeConnections.set(username, connection);
     let reconnectScheduled = false;
+    let permanentFailure = false;
 
     function scheduleReconnect(): void {
-      if (reconnectScheduled) return;
+      if (reconnectScheduled || permanentFailure) return;
       reconnectScheduled = true;
       connection.disconnect().catch(() => { /* already disconnected */ });
       // Only take ownership of the map entry and schedule a reconnect when this
@@ -81,6 +82,15 @@ export async function startTikTokBot(): Promise<void> {
 
     connection.on(ControlEvent.ERROR, (err: unknown) => {
       console.error(`[TikTok] Error on @${username}:`, err);
+      // Treat errors that indicate the channel is permanently unavailable as
+      // fatal so that the reconnect loop does not spin forever on a bad username
+      // or a banned/suspended account.
+      const msg = err instanceof Error ? err.message : String(err);
+      if (/not found|does not exist|banned|suspended|unauthorized|forbidden/i.test(msg)) {
+        console.error(`[TikTok] Permanent failure for @${username} — reconnect disabled.`);
+        permanentFailure = true;
+        activeConnections.delete(username);
+      }
     });
 
     connection

--- a/src/tiktokBot.ts
+++ b/src/tiktokBot.ts
@@ -1,5 +1,10 @@
 import type TypedEmitter from 'typed-emitter';
-import type { ClientEventMap, TikTokLiveConnectionState } from 'tiktok-live-connector' with { 'resolution-mode': 'import' };
+import type {
+  ClientEventMap,
+  TikTokLiveConnectionState,
+  WebcastEvent,
+  ControlEvent,
+} from 'tiktok-live-connector' with { 'resolution-mode': 'import' };
 import { TIKTOK_CHANNELS, TIKTOK_SIGN_API_KEY } from './config';
 import { handleCommand } from './commandRouter';
 import { setTikTokChannel } from './statusStore';
@@ -11,10 +16,98 @@ type Connection = TypedEmitter<ClientEventMap> & {
   disconnect(): Promise<void>;
 };
 
+interface TikTokModules {
+  TikTokLiveConnection: new (username: string, options: { signApiKey?: string }) => unknown;
+  WebcastEvent: typeof WebcastEvent;
+  ControlEvent: typeof ControlEvent;
+}
+
 const RECONNECT_DELAY_MS = 30_000;
 
 // Tracks the active connection object per channel to prevent duplicate connections.
 const activeConnections = new Map<string, Connection>();
+
+function connectToChannel(username: string, modules: TikTokModules): void {
+  const { TikTokLiveConnection, WebcastEvent, ControlEvent } = modules;
+
+  const existing = activeConnections.get(username);
+  if (existing) {
+    existing.disconnect().catch(() => { /* already disconnected */ });
+    activeConnections.delete(username);
+  }
+
+  const connection = new TikTokLiveConnection(username, {
+    signApiKey: TIKTOK_SIGN_API_KEY || undefined,
+  }) as unknown as Connection;
+  activeConnections.set(username, connection);
+  let reconnectScheduled = false;
+  let permanentFailure = false;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function scheduleReconnect(): void {
+    if (reconnectScheduled || permanentFailure) return;
+    reconnectScheduled = true;
+    connection.disconnect().catch(() => { /* already disconnected */ });
+    // Only take ownership of the map entry and schedule a reconnect when this
+    // connection is still the active one — a newer connection may have already
+    // replaced it, in which case we must not clobber the map or queue a
+    // redundant reconnect.
+    if (activeConnections.get(username) === connection) {
+      activeConnections.delete(username);
+      reconnectTimer = setTimeout(() => connectToChannel(username, modules), RECONNECT_DELAY_MS);
+    }
+  }
+
+  connection.on(ControlEvent.CONNECTED, () => {
+    console.log(`[TikTok] Connected to @${username}`);
+    setTikTokChannel(username, true);
+  });
+
+  connection.on(WebcastEvent.CHAT, (data) => {
+    handleCommand(data.content, 'tiktok').catch((err) =>
+      console.error(`[TikTok] Command handler error (${username}):`, err),
+    );
+  });
+
+  connection.on(WebcastEvent.STREAM_END, () => {
+    console.log(`[TikTok] Stream ended for @${username}. Will retry in ${RECONNECT_DELAY_MS / 1000}s`);
+    setTikTokChannel(username, false);
+    scheduleReconnect();
+  });
+
+  connection.on(ControlEvent.DISCONNECTED, () => {
+    console.warn(`[TikTok] Disconnected from @${username}. Will retry in ${RECONNECT_DELAY_MS / 1000}s`);
+    setTikTokChannel(username, false);
+    scheduleReconnect();
+  });
+
+  connection.on(ControlEvent.ERROR, (err: unknown) => {
+    console.error(`[TikTok] Error on @${username}:`, err);
+    // Treat errors that indicate the channel is permanently unavailable as
+    // fatal so that the reconnect loop does not spin forever on a bad username
+    // or a banned/suspended account.
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/not found|does not exist|banned|suspended|unauthorized|forbidden/i.test(msg)) {
+      console.error(`[TikTok] Permanent failure for @${username} — reconnect disabled.`);
+      permanentFailure = true;
+      activeConnections.delete(username);
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+    }
+  });
+
+  connection
+    .connect()
+    .then((state) => {
+      console.log(`[TikTok] Joined roomId ${state.roomId} for @${username}`);
+    })
+    .catch((err: Error) => {
+      console.warn(`[TikTok] Could not connect to @${username} (${err.message}). Will retry in ${RECONNECT_DELAY_MS / 1000}s`);
+      scheduleReconnect();
+    });
+}
 
 export async function startTikTokBot(): Promise<void> {
   if (TIKTOK_CHANNELS.length === 0) {
@@ -26,90 +119,9 @@ export async function startTikTokBot(): Promise<void> {
   console.log(`[TikTok] Connecting to channels: ${TIKTOK_CHANNELS.join(', ')}`);
 
   // Dynamic import required because tiktok-live-connector 2.3+ is ESM-only
-  const { TikTokLiveConnection, WebcastEvent, ControlEvent } = await import('tiktok-live-connector');
-
-  function connectToChannel(username: string): void {
-    // Disconnect any existing connection for this channel before creating a new one.
-    const existing = activeConnections.get(username);
-    if (existing) {
-      existing.disconnect().catch(() => { /* already disconnected */ });
-      activeConnections.delete(username);
-    }
-
-    const connection = new TikTokLiveConnection(username, {
-      signApiKey: TIKTOK_SIGN_API_KEY || undefined,
-    }) as unknown as Connection;
-    activeConnections.set(username, connection);
-    let reconnectScheduled = false;
-    let permanentFailure = false;
-    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-
-    function scheduleReconnect(): void {
-      if (reconnectScheduled || permanentFailure) return;
-      reconnectScheduled = true;
-      connection.disconnect().catch(() => { /* already disconnected */ });
-      // Only take ownership of the map entry and schedule a reconnect when this
-      // connection is still the active one — a newer connection may have already
-      // replaced it, in which case we must not clobber the map or queue a
-      // redundant reconnect.
-      if (activeConnections.get(username) === connection) {
-        activeConnections.delete(username);
-        reconnectTimer = setTimeout(() => connectToChannel(username), RECONNECT_DELAY_MS);
-      }
-    }
-
-    connection.on(ControlEvent.CONNECTED, () => {
-      console.log(`[TikTok] Connected to @${username}`);
-      setTikTokChannel(username, true);
-    });
-
-    connection.on(WebcastEvent.CHAT, (data) => {
-      handleCommand(data.content, 'tiktok').catch((err) =>
-        console.error(`[TikTok] Command handler error (${username}):`, err),
-      );
-    });
-
-    connection.on(WebcastEvent.STREAM_END, () => {
-      console.log(`[TikTok] Stream ended for @${username}. Will retry in ${RECONNECT_DELAY_MS / 1000}s`);
-      setTikTokChannel(username, false);
-      scheduleReconnect();
-    });
-
-    connection.on(ControlEvent.DISCONNECTED, () => {
-      console.warn(`[TikTok] Disconnected from @${username}. Will retry in ${RECONNECT_DELAY_MS / 1000}s`);
-      setTikTokChannel(username, false);
-      scheduleReconnect();
-    });
-
-    connection.on(ControlEvent.ERROR, (err: unknown) => {
-      console.error(`[TikTok] Error on @${username}:`, err);
-      // Treat errors that indicate the channel is permanently unavailable as
-      // fatal so that the reconnect loop does not spin forever on a bad username
-      // or a banned/suspended account.
-      const msg = err instanceof Error ? err.message : String(err);
-      if (/not found|does not exist|banned|suspended|unauthorized|forbidden/i.test(msg)) {
-        console.error(`[TikTok] Permanent failure for @${username} — reconnect disabled.`);
-        permanentFailure = true;
-        activeConnections.delete(username);
-        if (reconnectTimer) {
-          clearTimeout(reconnectTimer);
-          reconnectTimer = null;
-        }
-      }
-    });
-
-    connection
-      .connect()
-      .then((state) => {
-        console.log(`[TikTok] Joined roomId ${state.roomId} for @${username}`);
-      })
-      .catch((err: Error) => {
-        console.warn(`[TikTok] Could not connect to @${username} (${err.message}). Will retry in ${RECONNECT_DELAY_MS / 1000}s`);
-        scheduleReconnect();
-      });
-  }
+  const modules = await import('tiktok-live-connector') as unknown as TikTokModules;
 
   for (const username of TIKTOK_CHANNELS) {
-    connectToChannel(username);
+    connectToChannel(username, modules);
   }
 }

--- a/src/tiktokBot.ts
+++ b/src/tiktokBot.ts
@@ -42,6 +42,7 @@ export async function startTikTokBot(): Promise<void> {
     activeConnections.set(username, connection);
     let reconnectScheduled = false;
     let permanentFailure = false;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
     function scheduleReconnect(): void {
       if (reconnectScheduled || permanentFailure) return;
@@ -53,7 +54,7 @@ export async function startTikTokBot(): Promise<void> {
       // redundant reconnect.
       if (activeConnections.get(username) === connection) {
         activeConnections.delete(username);
-        setTimeout(() => connectToChannel(username), RECONNECT_DELAY_MS);
+        reconnectTimer = setTimeout(() => connectToChannel(username), RECONNECT_DELAY_MS);
       }
     }
 
@@ -90,6 +91,10 @@ export async function startTikTokBot(): Promise<void> {
         console.error(`[TikTok] Permanent failure for @${username} — reconnect disabled.`);
         permanentFailure = true;
         activeConnections.delete(username);
+        if (reconnectTimer) {
+          clearTimeout(reconnectTimer);
+          reconnectTimer = null;
+        }
       }
     });
 


### PR DESCRIPTION
## Summary

- **H4 / L2 – `ControlEvent.ERROR` treats all errors as transient**: Previously, `ControlEvent.ERROR` only logged the error. The `DISCONNECTED` event would then fire and call `scheduleReconnect()` regardless of whether the failure was permanent. A banned, suspended, or non-existent TikTok channel would reconnect in a 30 s loop forever.

  Added a `permanentFailure` boolean flag per connection. If the error message matches known permanent-failure patterns (`not found`, `does not exist`, `banned`, `suspended`, `unauthorized`, `forbidden`), the flag is set, `scheduleReconnect()` becomes a no-op, and the entry is removed from `activeConnections` so no future reconnect can be queued.

## Test plan

- [ ] `npm run build` — zero TypeScript errors
- [ ] `npm test` — all tests pass
- [ ] Simulate a permanent error (mock `ControlEvent.ERROR` with message `"Channel not found"`) and verify no reconnect is scheduled
- [ ] Simulate a transient error (connection drop) and verify reconnect still fires after 30 s


---
_Generated by [Claude Code](https://claude.ai/code/session_01MfLwzp7Ne76U68cq4tdo9b)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * TikTok bot now detects permanently unavailable channels (banned, suspended, not found, or unauthorized) and stops further reconnection attempts, clearing any pending reconnects.
  * Improved error handling to recognize and handle these permanent failures, reducing unnecessary reconnect scheduling and system activity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->