### PR TITLE
feat(streamdeck): per-user API key system and SFX HTTP endpoint

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,5 +1,5 @@
 const APP_CACHE_PREFIX = 'bcuk-panel-';
-const CACHE_VERSION = 'bcuk-panel-v7';
+const CACHE_VERSION = 'bcuk-panel-v8';
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const RUNTIME_CACHE = `${CACHE_VERSION}-runtime`;
 const RUNTIME_CACHE_MAX_ENTRIES = 50;

--- a/src/db.ts
+++ b/src/db.ts
@@ -83,3 +83,17 @@ export type {
 
 export type { SfxTrigger, SfxFile, SfxTriggerRow } from './db/sfx';
 export { findTrigger, findSoundFiles, getAllSfxTriggers } from './db/sfx';
+
+// ─── Streamdeck API keys ─────────────────────────────────────────────────────
+
+export type { StreamdeckKeyRow } from './db/streamdeckKeys';
+export {
+  requestApiKey,
+  findApprovedKeyByHash,
+  getApiKeyStatus,
+  approveApiKey,
+  denyApiKey,
+  revokeApiKey,
+  getPendingRequests,
+  getAllApiKeys,
+} from './db/streamdeckKeys';

--- a/src/db/streamdeckKeys.ts
+++ b/src/db/streamdeckKeys.ts
@@ -1,0 +1,113 @@
+import { randomBytes, createHash } from 'crypto';
+import mysql from 'mysql2/promise';
+import { getPool } from './pool';
+import { AccessLevel } from './users';
+
+export interface StreamdeckKeyRow {
+  discord_id: string;
+  key_hash: string;
+  status: 'pending' | 'approved' | 'revoked';
+  requested_at: Date;
+  approved_at: Date | null;
+  approved_by: string | null;
+}
+
+function mapRow(r: mysql.RowDataPacket): StreamdeckKeyRow {
+  return {
+    discord_id: String(r.discord_id),
+    key_hash: String(r.key_hash),
+    status: r.status as 'pending' | 'approved' | 'revoked',
+    requested_at: r.requested_at,
+    approved_at: r.approved_at ?? null,
+    approved_by: r.approved_by ?? null,
+  };
+}
+
+export async function requestApiKey(
+  discordId: string,
+  accessLevel: number,
+): Promise<{ plain: string; status: 'pending' | 'approved' }> {
+  const plain = randomBytes(32).toString('hex');
+  const hash = createHash('sha256').update(plain).digest('hex');
+  const status = accessLevel >= AccessLevel.MANAGER ? 'approved' : 'pending';
+  const now = new Date();
+  const approvedAt = status === 'approved' ? now : null;
+  const approvedBy = status === 'approved' ? discordId : null;
+
+  await getPool().execute(
+    `INSERT INTO streamdeck_api_keys
+       (discord_id, key_hash, status, requested_at, approved_at, approved_by)
+     VALUES (?, ?, ?, ?, ?, ?)
+     ON DUPLICATE KEY UPDATE
+       key_hash     = VALUES(key_hash),
+       status       = VALUES(status),
+       requested_at = VALUES(requested_at),
+       approved_at  = VALUES(approved_at),
+       approved_by  = VALUES(approved_by)`,
+    [discordId, hash, status, now, approvedAt, approvedBy],
+  );
+
+  return { plain, status };
+}
+
+export async function findApprovedKeyByHash(hash: string): Promise<StreamdeckKeyRow | null> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT discord_id, key_hash, status, requested_at, approved_at, approved_by
+     FROM streamdeck_api_keys
+     WHERE key_hash = ? AND status = 'approved'`,
+    [hash],
+  );
+  return rows.length === 0 ? null : mapRow(rows[0]);
+}
+
+export async function getApiKeyStatus(discordId: string): Promise<StreamdeckKeyRow | null> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT discord_id, key_hash, status, requested_at, approved_at, approved_by
+     FROM streamdeck_api_keys
+     WHERE discord_id = ?`,
+    [discordId],
+  );
+  return rows.length === 0 ? null : mapRow(rows[0]);
+}
+
+export async function approveApiKey(discordId: string, approvedBy: string): Promise<void> {
+  await getPool().execute(
+    `UPDATE streamdeck_api_keys
+     SET status = 'approved', approved_at = NOW(), approved_by = ?
+     WHERE discord_id = ? AND status = 'pending'`,
+    [approvedBy, discordId],
+  );
+}
+
+export async function denyApiKey(discordId: string): Promise<void> {
+  await getPool().execute(
+    'DELETE FROM streamdeck_api_keys WHERE discord_id = ? AND status = \'pending\'',
+    [discordId],
+  );
+}
+
+export async function revokeApiKey(discordId: string): Promise<void> {
+  await getPool().execute(
+    `UPDATE streamdeck_api_keys SET status = 'revoked' WHERE discord_id = ?`,
+    [discordId],
+  );
+}
+
+export async function getPendingRequests(): Promise<StreamdeckKeyRow[]> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT discord_id, key_hash, status, requested_at, approved_at, approved_by
+     FROM streamdeck_api_keys
+     WHERE status = 'pending'
+     ORDER BY requested_at ASC`,
+  );
+  return rows.map(mapRow);
+}
+
+export async function getAllApiKeys(): Promise<StreamdeckKeyRow[]> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT discord_id, key_hash, status, requested_at, approved_at, approved_by
+     FROM streamdeck_api_keys
+     ORDER BY status ASC, requested_at ASC`,
+  );
+  return rows.map(mapRow);
+}

--- a/src/db/streamdeckKeys.ts
+++ b/src/db/streamdeckKeys.ts
@@ -37,13 +37,13 @@ export async function requestApiKey(
   await getPool().execute(
     `INSERT INTO streamdeck_api_keys
        (discord_id, key_hash, status, requested_at, approved_at, approved_by)
-     VALUES (?, ?, ?, ?, ?, ?)
+     VALUES (?, ?, ?, ?, ?, ?) AS new_row
      ON DUPLICATE KEY UPDATE
-       key_hash     = VALUES(key_hash),
-       status       = VALUES(status),
-       requested_at = VALUES(requested_at),
-       approved_at  = VALUES(approved_at),
-       approved_by  = VALUES(approved_by)`,
+       key_hash     = new_row.key_hash,
+       status       = new_row.status,
+       requested_at = new_row.requested_at,
+       approved_at  = new_row.approved_at,
+       approved_by  = new_row.approved_by`,
     [discordId, hash, status, now, approvedAt, approvedBy],
   );
 

--- a/src/sfxPlayer.ts
+++ b/src/sfxPlayer.ts
@@ -5,6 +5,13 @@ import ffmpegPath from 'ffmpeg-static';
 import { SFX_FOLDER } from './config';
 import { isConnected, startPlayback } from './audioPlayer';
 
+export class VoiceNotConnectedError extends Error {
+  constructor() {
+    super('Not connected to a voice channel');
+    this.name = 'VoiceNotConnectedError';
+  }
+}
+
 // Tell @discordjs/voice where the ffmpeg binary is
 if (ffmpegPath) {
   process.env.FFMPEG_PATH = ffmpegPath;
@@ -35,7 +42,7 @@ function getRealSfxRoot(): string {
  */
 export function playFile(filePath: string): void {
   if (!isConnected()) {
-    throw new Error('Not connected to a voice channel');
+    throw new VoiceNotConnectedError();
   }
 
   const candidatePath = path.resolve(filePath);

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -19,6 +19,7 @@ declare module 'express-session' {
 declare module 'express-serve-static-core' {
   interface Request {
     csrfToken(): string;
+    apiKeyOwner?: string;
   }
 }
 

--- a/src/web/middleware.ts
+++ b/src/web/middleware.ts
@@ -53,6 +53,7 @@ export async function requireApiKey(req: Request, res: Response, next: NextFunct
       res.status(401).json({ ok: false, error: 'Unauthorized' });
       return;
     }
+    req.apiKeyOwner = row.discord_id;
     next();
   } catch {
     res.status(500).json({ ok: false, error: 'Internal server error' });

--- a/src/web/middleware.ts
+++ b/src/web/middleware.ts
@@ -1,6 +1,7 @@
+import { createHash } from 'crypto';
 import { Request, Response, NextFunction } from 'express';
 import { ensureSessionCsrfToken } from './csrf';
-import { AccessLevel } from '../db';
+import { AccessLevel, findApprovedKeyByHash } from '../db';
 
 export function requireAuth(req: Request, res: Response, next: NextFunction): void {
   if (req.session.user) {
@@ -35,6 +36,26 @@ export function requireMod(req: Request, res: Response, next: NextFunction): voi
         user: req.session.user ?? null,
         csrfToken: req.session?.user ? ensureSessionCsrfToken(req) : '',
       });
+  }
+}
+
+export async function requireApiKey(req: Request, res: Response, next: NextFunction): Promise<void> {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : '';
+  if (!token) {
+    res.status(401).json({ ok: false, error: 'Unauthorized' });
+    return;
+  }
+  const hash = createHash('sha256').update(token).digest('hex');
+  try {
+    const row = await findApprovedKeyByHash(hash);
+    if (!row) {
+      res.status(401).json({ ok: false, error: 'Unauthorized' });
+      return;
+    }
+    next();
+  } catch {
+    res.status(500).json({ ok: false, error: 'Internal server error' });
   }
 }
 

--- a/src/web/routes/streamdeck.ts
+++ b/src/web/routes/streamdeck.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { Router } from 'express';
 import { findTrigger, findSoundFiles, getAllSfxTriggers } from '../../db';
 import { pickWeightedRandom } from '../../soundSelector';
-import { playFile } from '../../sfxPlayer';
+import { playFile, VoiceNotConnectedError } from '../../sfxPlayer';
 import { setVoicePlaying } from '../../statusStore';
 import { SFX_FOLDER } from '../../config';
 import { requireApiKey } from '../middleware';
@@ -60,11 +60,10 @@ router.post('/sfx', requireApiKey, async (req, res) => {
   try {
     playFile(fullPath);
     setVoicePlaying(filename, normalizedCommand, 'streamdeck');
-    console.log(`[Streamdeck] Playing '${filename}' for trigger '${normalizedCommand}'`);
+    console.log(`[Streamdeck] Playing '${filename}' for trigger '${normalizedCommand}' (owner: ${req.apiKeyOwner})`);
     res.json({ ok: true, file: filename });
   } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    if (message.includes('Not connected')) {
+    if (err instanceof VoiceNotConnectedError) {
       res.status(503).json({ ok: false, error: 'Bot is not connected to a voice channel' });
     } else {
       console.error(`[Streamdeck] Failed to play ${fullPath}:`, err);

--- a/src/web/routes/streamdeck.ts
+++ b/src/web/routes/streamdeck.ts
@@ -60,7 +60,7 @@ router.post('/sfx', requireApiKey, async (req, res) => {
   try {
     playFile(fullPath);
     setVoicePlaying(filename, normalizedCommand, 'streamdeck');
-    console.log(`[Streamdeck] Playing '${filename}' for trigger '${normalizedCommand}' (owner: ${req.apiKeyOwner})`);
+    console.log(`[Streamdeck] Playing '${filename}' for trigger '${normalizedCommand}'`);
     res.json({ ok: true, file: filename });
   } catch (err: unknown) {
     if (err instanceof VoiceNotConnectedError) {

--- a/src/web/routes/streamdeck.ts
+++ b/src/web/routes/streamdeck.ts
@@ -1,0 +1,76 @@
+import path from 'path';
+import { Router } from 'express';
+import { findTrigger, findSoundFiles, getAllSfxTriggers } from '../../db';
+import { pickWeightedRandom } from '../../soundSelector';
+import { playFile } from '../../sfxPlayer';
+import { setVoicePlaying } from '../../statusStore';
+import { SFX_FOLDER } from '../../config';
+import { requireApiKey } from '../middleware';
+
+const router = Router();
+
+router.get('/sfx', requireApiKey, async (_req, res) => {
+  try {
+    const triggers = await getAllSfxTriggers();
+    res.json({ ok: true, triggers });
+  } catch (err) {
+    console.error('[Streamdeck] Failed to list triggers:', err);
+    res.status(500).json({ ok: false, error: 'Failed to fetch triggers' });
+  }
+});
+
+router.post('/sfx', requireApiKey, async (req, res) => {
+  const { command } = req.body as { command?: unknown };
+  if (typeof command !== 'string' || !command.trim()) {
+    res.status(400).json({ ok: false, error: 'Missing or invalid "command" field' });
+    return;
+  }
+
+  const normalizedCommand = command.trim().toLowerCase();
+
+  let trigger;
+  try {
+    trigger = await findTrigger(normalizedCommand);
+  } catch (err) {
+    console.error('[Streamdeck] DB error looking up trigger:', err);
+    res.status(500).json({ ok: false, error: 'Database error' });
+    return;
+  }
+  if (!trigger) {
+    res.status(404).json({ ok: false, error: 'Unknown command' });
+    return;
+  }
+
+  let files;
+  try {
+    files = await findSoundFiles(trigger.id);
+  } catch (err) {
+    console.error('[Streamdeck] DB error fetching sound files:', err);
+    res.status(500).json({ ok: false, error: 'Database error' });
+    return;
+  }
+  if (files.length === 0) {
+    res.status(404).json({ ok: false, error: 'No sound files for this command' });
+    return;
+  }
+
+  const filename = pickWeightedRandom(files);
+  const fullPath = path.join(SFX_FOLDER, filename);
+
+  try {
+    playFile(fullPath);
+    setVoicePlaying(filename, normalizedCommand, 'streamdeck');
+    console.log(`[Streamdeck] Playing '${filename}' for trigger '${normalizedCommand}'`);
+    res.json({ ok: true, file: filename });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.includes('Not connected')) {
+      res.status(503).json({ ok: false, error: 'Bot is not connected to a voice channel' });
+    } else {
+      console.error(`[Streamdeck] Failed to play ${fullPath}:`, err);
+      res.status(500).json({ ok: false, error: 'Failed to play sound' });
+    }
+  }
+});
+
+export default router;

--- a/src/web/routes/streamdeckKeys.ts
+++ b/src/web/routes/streamdeckKeys.ts
@@ -1,0 +1,134 @@
+import { Router } from 'express';
+import {
+  requestApiKey,
+  getApiKeyStatus,
+  revokeApiKey,
+  approveApiKey,
+  denyApiKey,
+  getAllApiKeys,
+  getPendingRequests,
+} from '../../db';
+import { csrfProtection } from '../csrf';
+import { requireAdmin } from '../middleware';
+
+const router = Router();
+
+// ─── User routes (any authenticated user) ────────────────────────────────────
+
+router.get('/streamdeck-key', csrfProtection, async (req, res) => {
+  try {
+    const keyRow = await getApiKeyStatus(req.session.user!.discordId);
+    res.render('streamdeck-keys', {
+      user: req.session.user,
+      csrfToken: req.csrfToken(),
+      keyRow,
+      newKey: null,
+      error: null,
+    });
+  } catch (err) {
+    console.error('[Web] Streamdeck key page error:', err);
+    res.status(500).render('error', {
+      message: 'Failed to load Streamdeck key status.',
+      user: req.session.user ?? null,
+      csrfToken: '',
+    });
+  }
+});
+
+router.post('/streamdeck-key/request', csrfProtection, async (req, res) => {
+  try {
+    const { plain, status } = await requestApiKey(
+      req.session.user!.discordId,
+      req.session.user!.accessLevel,
+    );
+    const keyRow = await getApiKeyStatus(req.session.user!.discordId);
+    res.render('streamdeck-keys', {
+      user: req.session.user,
+      csrfToken: req.csrfToken(),
+      keyRow,
+      newKey: plain,
+      error: null,
+    });
+  } catch (err) {
+    console.error('[Web] Streamdeck key request error:', err);
+    res.status(500).render('error', {
+      message: 'Failed to generate API key.',
+      user: req.session.user ?? null,
+      csrfToken: '',
+    });
+  }
+});
+
+router.post('/streamdeck-key/revoke', csrfProtection, async (req, res) => {
+  try {
+    await revokeApiKey(req.session.user!.discordId);
+    res.redirect('/streamdeck-key');
+  } catch (err) {
+    console.error('[Web] Streamdeck key revoke error:', err);
+    res.status(500).render('error', {
+      message: 'Failed to revoke API key.',
+      user: req.session.user ?? null,
+      csrfToken: '',
+    });
+  }
+});
+
+// ─── Admin routes ─────────────────────────────────────────────────────────────
+
+router.get('/admin/streamdeck-keys', requireAdmin, csrfProtection, async (req, res) => {
+  try {
+    const [pending, all] = await Promise.all([getPendingRequests(), getAllApiKeys()]);
+    res.render('streamdeck-keys-admin', {
+      user: req.session.user,
+      csrfToken: req.csrfToken(),
+      pending,
+      all,
+      error: null,
+    });
+  } catch (err) {
+    console.error('[Web] Streamdeck admin keys error:', err);
+    res.status(500).render('error', {
+      message: 'Failed to load Streamdeck key management.',
+      user: req.session.user ?? null,
+      csrfToken: '',
+    });
+  }
+});
+
+router.post('/admin/streamdeck-keys/approve', requireAdmin, csrfProtection, async (req, res) => {
+  const { discord_id } = req.body as { discord_id?: string };
+  if (!discord_id?.trim()) return res.redirect('/admin/streamdeck-keys');
+  try {
+    await approveApiKey(discord_id.trim(), req.session.user!.discordId);
+    res.redirect('/admin/streamdeck-keys');
+  } catch (err) {
+    console.error('[Web] Streamdeck key approve error:', err);
+    res.redirect('/admin/streamdeck-keys?error=approve_failed');
+  }
+});
+
+router.post('/admin/streamdeck-keys/deny', requireAdmin, csrfProtection, async (req, res) => {
+  const { discord_id } = req.body as { discord_id?: string };
+  if (!discord_id?.trim()) return res.redirect('/admin/streamdeck-keys');
+  try {
+    await denyApiKey(discord_id.trim());
+    res.redirect('/admin/streamdeck-keys');
+  } catch (err) {
+    console.error('[Web] Streamdeck key deny error:', err);
+    res.redirect('/admin/streamdeck-keys?error=deny_failed');
+  }
+});
+
+router.post('/admin/streamdeck-keys/revoke', requireAdmin, csrfProtection, async (req, res) => {
+  const { discord_id } = req.body as { discord_id?: string };
+  if (!discord_id?.trim()) return res.redirect('/admin/streamdeck-keys');
+  try {
+    await revokeApiKey(discord_id.trim());
+    res.redirect('/admin/streamdeck-keys');
+  } catch (err) {
+    console.error('[Web] Streamdeck key admin revoke error:', err);
+    res.redirect('/admin/streamdeck-keys?error=revoke_failed');
+  }
+});
+
+export default router;

--- a/src/web/routes/streamdeckKeys.ts
+++ b/src/web/routes/streamdeckKeys.ts
@@ -37,7 +37,7 @@ router.get('/streamdeck-key', csrfProtection, async (req, res) => {
 
 router.post('/streamdeck-key/request', csrfProtection, async (req, res) => {
   try {
-    const { plain, status } = await requestApiKey(
+    const { plain } = await requestApiKey(
       req.session.user!.discordId,
       req.session.user!.accessLevel,
     );

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -16,6 +16,8 @@ import streamsRouter from './routes/streams';
 import commandsRouter from './routes/commands';
 import countersRouter from './routes/counters';
 import commandMonitorRouter from './routes/commandMonitor';
+import streamdeckRouter from './routes/streamdeck';
+import streamdeckKeysRouter from './routes/streamdeckKeys';
 import { requireAuth } from './middleware';
 import { ensureSessionCsrfToken } from './csrf';
 
@@ -86,7 +88,9 @@ app.use((req, res, next) => {
 
 // Routes
 app.use('/auth', authRouter);
+app.use('/api/streamdeck', streamdeckRouter);
 app.use('/api', requireAuth, apiRouter);
+app.use('/', requireAuth, streamdeckKeysRouter);
 app.use('/', requireAuth, sfxRouter);
 app.use('/admin', requireAuth, adminRouter);
 app.use('/admin', requireAuth, streamsRouter);

--- a/views/partials/nav.ejs
+++ b/views/partials/nav.ejs
@@ -5,12 +5,16 @@
     <div class="navbar-menu">
       <a href="/" class="nav-item">Dashboard</a>
       <a href="/sfx" class="nav-item">SFX</a>
+      <a href="/streamdeck-key" class="nav-item">Streamdeck Key</a>
       <% if (user && user.accessLevel >= 2) { %>
       <a href="/admin/commands" class="nav-item">Commands</a>
       <a href="/admin/counters" class="nav-item">Counters</a>
       <a href="/admin/command-monitor" class="nav-item">Command Monitor</a>
       <a href="/admin/streams" class="nav-item">Streams</a>
       <a href="/admin/users" class="nav-item">Users</a>
+      <% } %>
+      <% if (user && user.accessLevel >= 3) { %>
+      <a href="/admin/streamdeck-keys" class="nav-item">Streamdeck Keys</a>
       <% } %>
     </div>
     <div class="navbar-end">

--- a/views/streamdeck-keys-admin.ejs
+++ b/views/streamdeck-keys-admin.ejs
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BCUK Bot — Streamdeck Keys</title>
+  <link rel="stylesheet" href="/style.css">
+  <%- include('partials/pwa-head') %>
+</head>
+<body>
+  <%- include('partials/nav') %>
+
+  <main class="container">
+    <section class="section">
+      <h2 class="section-title">Streamdeck API Keys</h2>
+
+      <% if (error) { %>
+      <div class="card card-alert-danger" role="alert" aria-live="assertive">
+        <span class="text-danger">&#9888; Operation failed. Please try again.</span>
+      </div>
+      <% } %>
+
+      <!-- Pending requests -->
+      <div class="card card-spaced">
+        <div class="card-header">
+          <span class="card-icon">&#9203;</span>
+          <span class="card-label">Pending Requests (<%= pending.length %>)</span>
+        </div>
+
+        <% if (pending.length === 0) { %>
+        <p class="muted">No pending requests.</p>
+        <% } else { %>
+        <div class="table-scroll">
+          <table class="table" aria-label="Pending API key requests">
+            <thead>
+              <tr>
+                <th scope="col">Discord ID</th>
+                <th scope="col">Requested</th>
+                <th scope="col">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% pending.forEach(function(row) { %>
+              <tr>
+                <td class="mono"><%= row.discord_id %></td>
+                <td><%= row.requested_at.toLocaleString() %></td>
+                <td>
+                  <div style="display:flex;gap:.4rem;flex-wrap:wrap;">
+                    <form method="POST" action="/admin/streamdeck-keys/approve" class="inline-form-sm">
+                      <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                      <input type="hidden" name="discord_id" value="<%= row.discord_id %>">
+                      <button type="submit" class="btn btn-sm">Approve</button>
+                    </form>
+                    <form method="POST" action="/admin/streamdeck-keys/deny" class="inline-form-sm">
+                      <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                      <input type="hidden" name="discord_id" value="<%= row.discord_id %>">
+                      <button type="submit" class="btn btn-sm btn-ghost" onclick="return confirm('Deny this request? The user will need to request again.')">Deny</button>
+                    </form>
+                  </div>
+                </td>
+              </tr>
+              <% }); %>
+            </tbody>
+          </table>
+        </div>
+        <% } %>
+      </div>
+
+      <!-- All keys -->
+      <div class="card card-spaced">
+        <div class="card-header">
+          <span class="card-icon">&#128273;</span>
+          <span class="card-label">All Keys (<%= all.length %>)</span>
+        </div>
+
+        <% if (all.length === 0) { %>
+        <p class="muted">No keys have been requested yet.</p>
+        <% } else { %>
+        <div class="table-scroll">
+          <table class="table" aria-label="All Streamdeck API keys">
+            <thead>
+              <tr>
+                <th scope="col">Discord ID</th>
+                <th scope="col">Status</th>
+                <th scope="col">Requested</th>
+                <th scope="col">Approved By</th>
+                <th scope="col">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% all.forEach(function(row) { %>
+              <tr>
+                <td class="mono"><%= row.discord_id %></td>
+                <td>
+                  <% if (row.status === 'approved') { %>
+                  <span class="badge badge-active">Active</span>
+                  <% } else if (row.status === 'pending') { %>
+                  <span class="badge badge-hidden">Pending</span>
+                  <% } else { %>
+                  <span class="badge badge-offline">Revoked</span>
+                  <% } %>
+                </td>
+                <td><%= row.requested_at.toLocaleDateString() %></td>
+                <td>
+                  <% if (row.approved_by) { %>
+                  <span class="mono muted" style="font-size:.8rem;"><%= row.approved_by %></span>
+                  <% } else { %>
+                  <em class="muted">—</em>
+                  <% } %>
+                </td>
+                <td>
+                  <% if (row.status === 'pending') { %>
+                  <div style="display:flex;gap:.4rem;flex-wrap:wrap;">
+                    <form method="POST" action="/admin/streamdeck-keys/approve" class="inline-form-sm">
+                      <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                      <input type="hidden" name="discord_id" value="<%= row.discord_id %>">
+                      <button type="submit" class="btn btn-sm">Approve</button>
+                    </form>
+                    <form method="POST" action="/admin/streamdeck-keys/deny" class="inline-form-sm">
+                      <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                      <input type="hidden" name="discord_id" value="<%= row.discord_id %>">
+                      <button type="submit" class="btn btn-sm btn-ghost" onclick="return confirm('Deny this request?')">Deny</button>
+                    </form>
+                  </div>
+                  <% } else if (row.status === 'approved') { %>
+                  <form method="POST" action="/admin/streamdeck-keys/revoke" class="inline-form-sm">
+                    <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                    <input type="hidden" name="discord_id" value="<%= row.discord_id %>">
+                    <button type="submit" class="btn btn-sm btn-ghost" onclick="return confirm('Revoke this key? It will stop working immediately.')">Revoke</button>
+                  </form>
+                  <% } else { %>
+                  <em class="muted">—</em>
+                  <% } %>
+                </td>
+              </tr>
+              <% }); %>
+            </tbody>
+          </table>
+        </div>
+        <% } %>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/views/streamdeck-keys-admin.ejs
+++ b/views/streamdeck-keys-admin.ejs
@@ -141,5 +141,6 @@
       </div>
     </section>
   </main>
+  <%- include('partials/pwa-register') %>
 </body>
 </html>

--- a/views/streamdeck-keys.ejs
+++ b/views/streamdeck-keys.ejs
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BCUK Bot — Streamdeck API Key</title>
+  <link rel="stylesheet" href="/style.css">
+  <%- include('partials/pwa-head') %>
+</head>
+<body>
+  <%- include('partials/nav') %>
+
+  <main class="container">
+    <section class="section">
+      <h2 class="section-title">Streamdeck API Key</h2>
+
+      <% if (newKey) { %>
+      <div class="card card-alert-success" role="alert">
+        <p><strong>&#10003; Your API key has been generated.</strong> Copy it now — it will not be shown again.</p>
+        <div style="margin-top:.75rem;display:flex;gap:.5rem;align-items:center;flex-wrap:wrap;">
+          <code class="mono" id="new-key" style="font-size:.85rem;word-break:break-all;flex:1;min-width:0;"><%= newKey %></code>
+          <button type="button" class="btn btn-sm" onclick="copyKey()">Copy</button>
+        </div>
+        <% if (keyRow && keyRow.status === 'pending') { %>
+        <p style="margin-top:.75rem;" class="muted">Your key is pending admin approval. It will become active once an Admin approves your request.</p>
+        <% } %>
+      </div>
+      <script>
+        function copyKey() {
+          const key = document.getElementById('new-key').textContent;
+          navigator.clipboard.writeText(key).then(() => {
+            const btn = event.target;
+            btn.textContent = 'Copied!';
+            setTimeout(() => { btn.textContent = 'Copy'; }, 2000);
+          }).catch(() => { alert('Could not copy automatically — please copy the key manually.'); });
+        }
+      </script>
+      <% } %>
+
+      <div class="card card-spaced">
+        <div class="card-header">
+          <span class="card-icon">&#128273;</span>
+          <span class="card-label">Key Status</span>
+        </div>
+
+        <% if (!keyRow) { %>
+        <p>You do not have an API key yet.</p>
+        <% if (user.accessLevel >= 2) { %>
+        <p class="muted">As a Manager or above, your key will be approved immediately.</p>
+        <% } else { %>
+        <p class="muted">Your request will be reviewed by an Admin before the key becomes active.</p>
+        <% } %>
+        <form method="POST" action="/streamdeck-key/request" style="margin-top:1rem;">
+          <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+          <button type="submit" class="btn">Request API Key</button>
+        </form>
+
+        <% } else if (keyRow.status === 'pending') { %>
+        <div style="display:flex;align-items:center;gap:.75rem;flex-wrap:wrap;margin-bottom:1rem;">
+          <span class="badge badge-hidden">Pending Approval</span>
+          <span class="muted" style="font-size:.85rem;">Requested <%= keyRow.requested_at.toLocaleDateString() %></span>
+        </div>
+        <p>Your key is waiting for Admin approval. You will need to come back to this page after it is approved to see no further action is needed — the key you already copied will become active.</p>
+        <p class="muted" style="margin-top:.5rem;">Want to cancel and start over? Requesting a new key will replace the pending one.</p>
+        <form method="POST" action="/streamdeck-key/request" style="margin-top:1rem;">
+          <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+          <button type="submit" class="btn btn-sm">Generate New Key (replaces pending)</button>
+        </form>
+
+        <% } else if (keyRow.status === 'approved') { %>
+        <div style="display:flex;align-items:center;gap:.75rem;flex-wrap:wrap;margin-bottom:1rem;">
+          <span class="badge badge-active">Active</span>
+          <span class="muted" style="font-size:.85rem;">Approved <%= keyRow.approved_at ? keyRow.approved_at.toLocaleDateString() : '' %></span>
+        </div>
+        <p>Your API key is active. Use it in your Streamdeck configuration with the header:</p>
+        <pre style="background:var(--surface);padding:.75rem 1rem;border-radius:6px;font-size:.82rem;overflow-x:auto;margin:.75rem 0;">Authorization: Bearer &lt;your-key&gt;</pre>
+        <p class="muted">If you have lost your key, you can generate a new one. The old key will immediately stop working.</p>
+        <div style="display:flex;gap:.5rem;flex-wrap:wrap;margin-top:1rem;">
+          <form method="POST" action="/streamdeck-key/request">
+            <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+            <button type="submit" class="btn btn-sm">Generate New Key</button>
+          </form>
+          <form method="POST" action="/streamdeck-key/revoke">
+            <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+            <button type="submit" class="btn btn-sm btn-ghost" onclick="return confirm('Revoke your API key? It will stop working immediately.')">Revoke Key</button>
+          </form>
+        </div>
+
+        <% } else if (keyRow.status === 'revoked') { %>
+        <div style="display:flex;align-items:center;gap:.75rem;flex-wrap:wrap;margin-bottom:1rem;">
+          <span class="badge badge-offline">Revoked</span>
+        </div>
+        <p>Your API key has been revoked and is no longer active. You can request a new one.</p>
+        <% if (user.accessLevel >= 2) { %>
+        <p class="muted">As a Manager or above, your new key will be approved immediately.</p>
+        <% } else { %>
+        <p class="muted">A new request will need Admin approval.</p>
+        <% } %>
+        <form method="POST" action="/streamdeck-key/request" style="margin-top:1rem;">
+          <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+          <button type="submit" class="btn">Request New API Key</button>
+        </form>
+        <% } %>
+      </div>
+
+      <div class="card card-spaced">
+        <div class="card-header">
+          <span class="card-icon">&#128221;</span>
+          <span class="card-label">How to Use</span>
+        </div>
+        <p>Send HTTP requests to the bot to trigger sound effects:</p>
+        <pre style="background:var(--surface);padding:.75rem 1rem;border-radius:6px;font-size:.82rem;overflow-x:auto;margin:.75rem 0;">POST /api/streamdeck/sfx
+Authorization: Bearer &lt;your-key&gt;
+Content-Type: application/json
+
+{ "command": "!boom" }</pre>
+        <p>You can also list all available commands:</p>
+        <pre style="background:var(--surface);padding:.75rem 1rem;border-radius:6px;font-size:.82rem;overflow-x:auto;margin:.75rem 0;">GET /api/streamdeck/sfx
+Authorization: Bearer &lt;your-key&gt;</pre>
+        <p class="muted">Streamdeck triggers are not subject to the chat cooldown and will interrupt any currently playing sound.</p>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/views/streamdeck-keys.ejs
+++ b/views/streamdeck-keys.ejs
@@ -121,5 +121,6 @@ Authorization: Bearer &lt;your-key&gt;</pre>
       </div>
     </section>
   </main>
+  <%- include('partials/pwa-register') %>
 </body>
 </html>

--- a/views/streamdeck-keys.ejs
+++ b/views/streamdeck-keys.ejs
@@ -19,17 +19,17 @@
         <p><strong>&#10003; Your API key has been generated.</strong> Copy it now — it will not be shown again.</p>
         <div style="margin-top:.75rem;display:flex;gap:.5rem;align-items:center;flex-wrap:wrap;">
           <code class="mono" id="new-key" style="font-size:.85rem;word-break:break-all;flex:1;min-width:0;"><%= newKey %></code>
-          <button type="button" class="btn btn-sm" onclick="copyKey()">Copy</button>
+          <button type="button" class="btn btn-sm" onclick="copyKey(event)">Copy</button>
         </div>
         <% if (keyRow && keyRow.status === 'pending') { %>
         <p style="margin-top:.75rem;" class="muted">Your key is pending admin approval. It will become active once an Admin approves your request.</p>
         <% } %>
       </div>
       <script>
-        function copyKey() {
+        function copyKey(event) {
           const key = document.getElementById('new-key').textContent;
           navigator.clipboard.writeText(key).then(() => {
-            const btn = event.target;
+            const btn = event.currentTarget;
             btn.textContent = 'Copied!';
             setTimeout(() => { btn.textContent = 'Copy'; }, 2000);
           }).catch(() => { alert('Could not copy automatically — please copy the key manually.'); });
@@ -60,7 +60,7 @@
           <span class="badge badge-hidden">Pending Approval</span>
           <span class="muted" style="font-size:.85rem;">Requested <%= keyRow.requested_at.toLocaleDateString() %></span>
         </div>
-        <p>Your key is waiting for Admin approval. You will need to come back to this page after it is approved to see no further action is needed — the key you already copied will become active.</p>
+        <p>Your key is awaiting Admin approval. No further action is needed — the key you already copied will become active automatically once an Admin approves your request. Refresh this page to check the current status.</p>
         <p class="muted" style="margin-top:.5rem;">Want to cancel and start over? Requesting a new key will replace the pending one.</p>
         <form method="POST" action="/streamdeck-key/request" style="margin-top:1rem;">
           <input type="hidden" name="_csrf" value="<%= csrfToken %>">


### PR DESCRIPTION
## Summary

- Adds `POST /api/streamdeck/sfx` to trigger sound effects by command name — no chat cooldown, interrupts any currently playing audio
- Adds `GET /api/streamdeck/sfx` to list all available trigger commands (useful for Streamdeck plugin setup)
- Introduces a per-user API key system backed by a new `streamdeck_api_keys` database table — keys are SHA-256 hashed at rest and validated on every request
- Managers and Admins are auto-approved on key request; Mods and Users require Admin approval
- Adds web panel pages: `/streamdeck-key` (user self-service) and `/admin/streamdeck-keys` (Admin approval queue)

## Database migration required

Apply the following before deploying:

```sql
CREATE TABLE streamdeck_api_keys (
  discord_id   VARCHAR(64)  NOT NULL,
  key_hash     CHAR(64)     NOT NULL,
  status       ENUM('pending','approved','revoked') NOT NULL DEFAULT 'pending',
  requested_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
  approved_at  DATETIME     NULL,
  approved_by  VARCHAR(64)  NULL,
  PRIMARY KEY (discord_id)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
```

## Test plan

- [x] Apply DB migration and start bot with `npm run dev`
- [ ] Log in as User/Mod → request key → confirm "Pending" shown, plain key visible once
- [ ] Log in as Admin → `/admin/streamdeck-keys` → approve → confirm status changes to Active
- [ ] `curl -X POST -H "Authorization: Bearer <key>" -H "Content-Type: application/json" -d '{"command":"!boom"}' http://localhost:3000/api/streamdeck/sfx` → confirm `200` and audio plays in Discord
- [ ] Send a second POST while audio is playing → confirm it interrupts and plays the new sound
- [ ] Wrong/missing key → confirm `401`; revoked key → confirm `401`
- [ ] Unknown command → confirm `404`; bot disconnected → confirm `503`
- [ ] Log in as Manager → request key → confirm immediate Active status

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API key-based authorization for Streamdeck integration (middleware-protected API)
  * User dashboard to request, view, copy, replace, and revoke Streamdeck API keys
  * Admin UI to review, approve, deny, and revoke Streamdeck API key requests
  * New SFX endpoints to trigger sound playback via Streamdeck

* **Bug Fixes / Improvements**
  * Distinct error type for "voice not connected" playback failures
  * Updated service worker cache version and keys
  * Navigation shows Streamdeck Keys link for admins

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->