### PR TITLE
fix(streamdeck): security hardening on API key management

### DIFF
--- a/src/db/streamdeckKeys.ts
+++ b/src/db/streamdeckKeys.ts
@@ -29,6 +29,11 @@ export async function requestApiKey(
   discordId: string,
   accessLevel: number,
 ): Promise<{ plain: string; status: 'pending' | 'approved' }> {
+  const existing = await getApiKeyStatus(discordId);
+  if (existing?.status === 'denied') {
+    throw new Error('API key request rejected: previous request was denied');
+  }
+
   const plain = randomBytes(32).toString('hex');
   const hash = createHash('sha256').update(plain).digest('hex');
   const status = accessLevel >= AccessLevel.MANAGER ? 'approved' : 'pending';

--- a/src/db/streamdeckKeys.ts
+++ b/src/db/streamdeckKeys.ts
@@ -1,12 +1,11 @@
-import { randomBytes, createHash } from 'crypto';
+import { randomBytes, createHash, timingSafeEqual } from 'crypto';
 import mysql from 'mysql2/promise';
 import { getPool } from './pool';
 import { AccessLevel } from './users';
 
 export interface StreamdeckKeyRow {
   discord_id: string;
-  key_hash: string;
-  status: 'pending' | 'approved' | 'revoked';
+  status: 'pending' | 'approved' | 'revoked' | 'denied';
   requested_at: Date;
   approved_at: Date | null;
   approved_by: string | null;
@@ -17,8 +16,7 @@ export interface StreamdeckKeyRow {
 function mapRow(r: mysql.RowDataPacket): StreamdeckKeyRow {
   return {
     discord_id: String(r.discord_id),
-    key_hash: String(r.key_hash),
-    status: r.status as 'pending' | 'approved' | 'revoked',
+    status: r.status as StreamdeckKeyRow['status'],
     requested_at: r.requested_at,
     approved_at: r.approved_at ?? null,
     approved_by: r.approved_by ?? null,
@@ -61,12 +59,16 @@ export async function findApprovedKeyByHash(hash: string): Promise<StreamdeckKey
      WHERE key_hash = ? AND status = 'approved'`,
     [hash],
   );
-  return rows.length === 0 ? null : mapRow(rows[0]);
+  if (rows.length === 0) return null;
+  const stored = Buffer.from(String(rows[0].key_hash), 'hex');
+  const incoming = Buffer.from(hash, 'hex');
+  if (stored.length !== incoming.length || !timingSafeEqual(stored, incoming)) return null;
+  return mapRow(rows[0]);
 }
 
 export async function getApiKeyStatus(discordId: string): Promise<StreamdeckKeyRow | null> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    `SELECT discord_id, key_hash, status, requested_at, approved_at, approved_by
+    `SELECT discord_id, status, requested_at, approved_at, approved_by
      FROM streamdeck_api_keys
      WHERE discord_id = ?`,
     [discordId],
@@ -85,7 +87,7 @@ export async function approveApiKey(discordId: string, approvedBy: string): Prom
 
 export async function denyApiKey(discordId: string): Promise<void> {
   await getPool().execute(
-    'DELETE FROM streamdeck_api_keys WHERE discord_id = ? AND status = \'pending\'',
+    `UPDATE streamdeck_api_keys SET status = 'denied' WHERE discord_id = ? AND status = 'pending'`,
     [discordId],
   );
 }
@@ -99,7 +101,7 @@ export async function revokeApiKey(discordId: string): Promise<void> {
 
 export async function getPendingRequests(): Promise<StreamdeckKeyRow[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    `SELECT k.discord_id, k.key_hash, k.status, k.requested_at, k.approved_at, k.approved_by,
+    `SELECT k.discord_id, k.status, k.requested_at, k.approved_at, k.approved_by,
             u.discord_name AS user_name, NULL AS approver_name
      FROM streamdeck_api_keys k
      LEFT JOIN \`user\` u ON u.discord_id = k.discord_id
@@ -111,7 +113,7 @@ export async function getPendingRequests(): Promise<StreamdeckKeyRow[]> {
 
 export async function getAllApiKeys(): Promise<StreamdeckKeyRow[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    `SELECT k.discord_id, k.key_hash, k.status, k.requested_at, k.approved_at, k.approved_by,
+    `SELECT k.discord_id, k.status, k.requested_at, k.approved_at, k.approved_by,
             u.discord_name AS user_name, a.discord_name AS approver_name
      FROM streamdeck_api_keys k
      LEFT JOIN \`user\` u ON u.discord_id = k.discord_id

--- a/src/db/streamdeckKeys.ts
+++ b/src/db/streamdeckKeys.ts
@@ -46,13 +46,18 @@ export async function requestApiKey(
        (discord_id, key_hash, status, requested_at, approved_at, approved_by)
      VALUES (?, ?, ?, ?, ?, ?) AS new_row
      ON DUPLICATE KEY UPDATE
-       key_hash     = new_row.key_hash,
-       status       = new_row.status,
-       requested_at = new_row.requested_at,
-       approved_at  = new_row.approved_at,
-       approved_by  = new_row.approved_by`,
+       key_hash     = IF(status = 'denied', key_hash,     new_row.key_hash),
+       status       = IF(status = 'denied', status,       new_row.status),
+       requested_at = IF(status = 'denied', requested_at, new_row.requested_at),
+       approved_at  = IF(status = 'denied', approved_at,  new_row.approved_at),
+       approved_by  = IF(status = 'denied', approved_by,  new_row.approved_by)`,
     [discordId, hash, status, now, approvedAt, approvedBy],
   );
+
+  const after = await getApiKeyStatus(discordId);
+  if (after?.status === 'denied') {
+    throw new Error('API key request rejected: previous request was denied');
+  }
 
   return { plain, status };
 }

--- a/views/streamdeck-keys-admin.ejs
+++ b/views/streamdeck-keys-admin.ejs
@@ -102,6 +102,8 @@
                   <span class="badge badge-active">Active</span>
                   <% } else if (row.status === 'pending') { %>
                   <span class="badge badge-hidden">Pending</span>
+                  <% } else if (row.status === 'denied') { %>
+                  <span class="badge badge-offline">Denied</span>
                   <% } else { %>
                   <span class="badge badge-offline">Revoked</span>
                   <% } %>


### PR DESCRIPTION
## Summary

- **Remove `key_hash` from public interface** — `StreamdeckKeyRow` no longer exposes the hash; non-auth queries no longer `SELECT key_hash`. The hash stays internal to `findApprovedKeyByHash`.
- **Constant-time comparison** — `findApprovedKeyByHash` now uses `timingSafeEqual` as defence-in-depth after the SQL lookup.
- **Audit trail on deny** — `denyApiKey` now issues `UPDATE status = 'denied'` instead of `DELETE`, preserving a full history of all key requests. A "Denied" badge has been added to the admin UI.

## Test plan

- [ ] Approve a pending key request — confirm it still works and the key authenticates correctly
- [ ] Deny a pending key request — confirm the row now shows as **Denied** in the All Keys table rather than disappearing
- [ ] Revoke an approved key — confirm it still shows as **Revoked** as before
- [ ] Confirm the Streamdeck SFX endpoint still accepts valid Bearer tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API keys now support a "Denied" status; denied requests are preserved and shown with a distinct "Denied" badge in the admin dashboard.
* **Behavior Changes**
  * New requests are blocked if an existing request for the same account is in "Denied" state; denying a request updates its status instead of removing it.
* **Security**
  * Key lookup uses a safer verification method to reduce timing-based information leaks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->