### PR TITLE
security(csrf): eliminate token-length timing side-channel

### DIFF
--- a/src/web/csrf.ts
+++ b/src/web/csrf.ts
@@ -42,12 +42,14 @@ export const csrfProtection: RequestHandler = (req, _res, next) => {
 
   const submittedBuffer = Buffer.from(submittedToken);
   const sessionBuffer = Buffer.from(sessionToken);
+  const sameLength = submittedBuffer.length === sessionBuffer.length;
   const len = Math.max(submittedBuffer.length, sessionBuffer.length);
   const a = Buffer.alloc(len);
   const b = Buffer.alloc(len);
   submittedBuffer.copy(a);
   sessionBuffer.copy(b);
-  if (!crypto.timingSafeEqual(a, b)) {
+  const sameValue = crypto.timingSafeEqual(a, b);
+  if (!sameLength || !sameValue) {
     next(createCsrfError());
     return;
   }

--- a/src/web/csrf.ts
+++ b/src/web/csrf.ts
@@ -42,10 +42,12 @@ export const csrfProtection: RequestHandler = (req, _res, next) => {
 
   const submittedBuffer = Buffer.from(submittedToken);
   const sessionBuffer = Buffer.from(sessionToken);
-  if (
-    submittedBuffer.length !== sessionBuffer.length
-    || !crypto.timingSafeEqual(submittedBuffer, sessionBuffer)
-  ) {
+  const len = Math.max(submittedBuffer.length, sessionBuffer.length);
+  const a = Buffer.alloc(len);
+  const b = Buffer.alloc(len);
+  submittedBuffer.copy(a);
+  sessionBuffer.copy(b);
+  if (!crypto.timingSafeEqual(a, b)) {
     next(createCsrfError());
     return;
   }


### PR DESCRIPTION
## Summary

- Pads both the submitted and session CSRF token buffers to the same length before calling `timingSafeEqual`, so comparison time is constant regardless of the submitted token length
- Previously, a mismatched length caused an early return before `timingSafeEqual` ran, which technically leaked whether the submitted length matched the expected 64 chars
- Not practically exploitable (token length is visible in every page's HTML source), but eliminates the code smell

## Test plan

- [ ] `npm run build` passes
- [ ] `npm test` passes (all 10 tests green)
- [ ] Submit a form with a tampered CSRF token — still gets 403

https://claude.ai/code/session_01ANDPuF742D3LehPef6rJVP

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANDPuF742D3LehPef6rJVP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Strengthened CSRF token validation to use a timing-safe comparison that handles differing token lengths without leaking timing information, while preserving prior length-based rejection rules to maintain strict validation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->