### PR TITLE
security(auth): guard avatar URL against non-CDN values

### DIFF
--- a/src/web/routes/auth.ts
+++ b/src/web/routes/auth.ts
@@ -89,12 +89,13 @@ router.get('/discord/callback', async (req, res) => {
     }
 
     // 4. Save to session — regenerate the session ID first to prevent session fixation.
+    const rawAvatar = profile.avatar
+      ? `https://cdn.discordapp.com/avatars/${profile.id}/${profile.avatar}.png`
+      : null;
     const userData = {
       discordId: profile.id,
       discordName: syncedDiscordName,
-      discordAvatar: profile.avatar
-        ? `https://cdn.discordapp.com/avatars/${profile.id}/${profile.avatar}.png`
-        : null,
+      discordAvatar: rawAvatar?.startsWith('https://cdn.discordapp.com/') ? rawAvatar : null,
       accessLevel: dbUser.access_level as 0 | 1 | 2 | 3,
     };
 


### PR DESCRIPTION
## Summary

- Validates that the Discord avatar URL starts with `https://cdn.discordapp.com/` before storing it in the session
- The URL is already constructed server-side from Discord OAuth fields (`profile.id` + `profile.avatar` hash), so this check always passes in practice
- Makes the CDN invariant explicit in code and provides defence-in-depth against future refactors that might take the URL directly from an API response

## Test plan

- [ ] `npm run build` passes
- [ ] `npm test` passes
- [ ] Log in via Discord OAuth — avatar displays correctly in the nav bar
- [ ] Log in with a Discord account that has no avatar — nav still renders without an `<img>` (existing guard: `<% if (user.discordAvatar) { %>`)

https://claude.ai/code/session_01ANDPuF742D3LehPef6rJVP

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANDPuF742D3LehPef6rJVP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced avatar URL validation in authentication to ensure only valid Discord CDN URLs are stored, preventing potential display errors from malformed URLs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->