### PR TITLE
security: add rate limiting to HTTP endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "ejs": "^5.0.2",
         "express": "^5.2.1",
         "express-mysql-session": "^3.0.3",
+        "express-rate-limit": "^8.5.2",
         "express-session": "^1.19.0",
         "ffmpeg-static": "^5.2.0",
         "helmet": "^8.1.0",
@@ -2025,6 +2026,24 @@
         "node": ">= 8.0"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express-session": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.19.0.tgz",
@@ -2469,6 +2488,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "ejs": "^5.0.2",
     "express": "^5.2.1",
     "express-mysql-session": "^3.0.3",
+    "express-rate-limit": "^8.5.2",
     "express-session": "^1.19.0",
     "ffmpeg-static": "^5.2.0",
     "helmet": "^8.1.0",

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -3,6 +3,7 @@ import type { ErrorRequestHandler } from 'express';
 import session from 'express-session';
 import MySQLStore from 'express-mysql-session';
 import helmet from 'helmet';
+import rateLimit from 'express-rate-limit';
 import path from 'path';
 import { WEB_PORT, SESSION_SECRET, DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME } from '../config';
 
@@ -54,6 +55,23 @@ app.set('views', path.join(__dirname, '../../views'));
 // Static assets
 app.use(express.static(path.join(__dirname, '../../public')));
 
+// Rate limiting — applied after static assets so file downloads aren't counted
+const generalLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 100,
+  standardHeaders: 'draft-8',
+  legacyHeaders: false,
+});
+// Tighter limit for auth endpoints to protect against OAuth quota exhaustion
+const authLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 10,
+  standardHeaders: 'draft-8',
+  legacyHeaders: false,
+  message: 'Too many requests, please try again shortly.',
+});
+app.use(generalLimiter);
+
 // Body parsers
 app.use(express.urlencoded({ extended: false }));
 app.use(express.json());
@@ -87,7 +105,7 @@ app.use((req, res, next) => {
 });
 
 // Routes
-app.use('/auth', authRouter);
+app.use('/auth', authLimiter, authRouter);
 app.use('/api/streamdeck', streamdeckRouter);
 app.use('/api', requireAuth, apiRouter);
 app.use('/', requireAuth, streamdeckKeysRouter);

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -61,11 +61,20 @@ const generalLimiter = rateLimit({
   limit: 100,
   standardHeaders: 'draft-8',
   legacyHeaders: false,
+  skip: (req) => req.path.startsWith('/api/streamdeck'),
 });
 // Tighter limit for auth endpoints to protect against OAuth quota exhaustion
 const authLimiter = rateLimit({
   windowMs: 60 * 1000,
   limit: 10,
+  standardHeaders: 'draft-8',
+  legacyHeaders: false,
+  message: 'Too many requests, please try again shortly.',
+});
+// Generous limit for the Streamdeck API — authenticated by API key, used for live button presses
+const streamdeckLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 120,
   standardHeaders: 'draft-8',
   legacyHeaders: false,
   message: 'Too many requests, please try again shortly.',
@@ -106,7 +115,7 @@ app.use((req, res, next) => {
 
 // Routes
 app.use('/auth', authLimiter, authRouter);
-app.use('/api/streamdeck', streamdeckRouter);
+app.use('/api/streamdeck', streamdeckLimiter, streamdeckRouter);
 app.use('/api', requireAuth, apiRouter);
 app.use('/', requireAuth, streamdeckKeysRouter);
 app.use('/', requireAuth, sfxRouter);


### PR DESCRIPTION
## Summary

- Installs `express-rate-limit` v8
- Adds a **general limiter** (100 req / 15 min) applied to all routes after static asset serving, so large file downloads don't eat into the quota
- Adds a **tighter auth limiter** (10 req / min) stacked on top for all `/auth/*` routes, protecting against Discord OAuth quota exhaustion and login spam
- Uses `draft-8` standard headers (`RateLimit-Policy`, `RateLimit`) rather than the deprecated `X-RateLimit-*` headers

## Test plan

- [ ] `npm run build` passes
- [ ] `npm test` passes
- [ ] Hit `/auth/login` 11 times in under a minute — 11th request gets `429 Too Many Requests`
- [ ] Normal browsing of the admin panel is unaffected

https://claude.ai/code/session_01ANDPuF742D3LehPef6rJVP

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANDPuF742D3LehPef6rJVP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Request rate limiting has been implemented across the application to enhance security. Authentication endpoints enforce stricter rate limits.

* **Chores**
  * Added `express-rate-limit` as a new dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->