### PR TITLE
security: minor hardening from code review

### DIFF
--- a/public/streams-live-poll.js
+++ b/public/streams-live-poll.js
@@ -17,7 +17,7 @@ document.addEventListener('click', function (event) {
     if (!liveKey) return;
     expandedLiveRows[liveKey] = !expandedLiveRows[liveKey];
 
-    var detailRow = document.querySelector('tr.live-detail-row[data-live-key="' + liveKey + '"]');
+    var detailRow = document.querySelector('tr.live-detail-row[data-live-key="' + CSS.escape(liveKey) + '"]');
     if (detailRow instanceof HTMLElement) {
       detailRow.style.display = expandedLiveRows[liveKey] ? 'table-row' : 'none';
     }

--- a/public/streams-live-table.js
+++ b/public/streams-live-table.js
@@ -3,7 +3,7 @@
 var liveItemsByKey = Object.create(null);
 
 function hydrateLivePreviewGrid(liveKey) {
-  var detailRow = document.querySelector('tr.live-detail-row[data-live-key="' + liveKey + '"]');
+  var detailRow = document.querySelector('tr.live-detail-row[data-live-key="' + CSS.escape(liveKey) + '"]');
   if (!(detailRow instanceof HTMLElement)) return;
 
   var grid = detailRow.querySelector('.live-preview-grid');

--- a/src/db/commandConflicts.ts
+++ b/src/db/commandConflicts.ts
@@ -256,7 +256,7 @@ export async function assignUserToCommandWithinTransaction(
     throw new Error('[DB] Deadlock retry limit reached in assignUserToCommandWithinTransaction.');
   } finally {
     if (lockNameByTrigger) {
-      try { await releaseNamedLock(connection, lockNameByTrigger); } catch (_) {}
+      try { await releaseNamedLock(connection, lockNameByTrigger); } catch (err) { console.warn('[DB] Failed to release named lock:', err); }
     }
   }
 }

--- a/src/db/commandLocks.ts
+++ b/src/db/commandLocks.ts
@@ -214,7 +214,7 @@ export async function runSerializedCommandWrite<T>(
     throw new Error('[DB] Deadlock retry limit reached without success.');
   } finally {
     if (connection) {
-      try { await releaseNamedLocks(connection, lockNames); } catch (_) {}
+      try { await releaseNamedLocks(connection, lockNames); } catch (err) { console.warn('[DB] Failed to release named locks:', err); }
       connection.release();
     }
   }

--- a/src/web/routes/streamdeckKeys.ts
+++ b/src/web/routes/streamdeckKeys.ts
@@ -78,6 +78,16 @@ router.post('/streamdeck-key/revoke', csrfProtection, async (req, res) => {
 
 // ─── Admin routes ─────────────────────────────────────────────────────────────
 
+const ADMIN_KNOWN_ERRORS = new Set(['approve_failed', 'deny_failed', 'revoke_failed', 'invalid_discord_id']);
+
+const DISCORD_ID_RE = /^\d{17,20}$/;
+
+function validateDiscordId(discordId: string | undefined): string | null {
+  const trimmed = discordId?.trim();
+  if (!trimmed || !DISCORD_ID_RE.test(trimmed)) return null;
+  return trimmed;
+}
+
 router.get('/admin/streamdeck-keys', requireAdmin, csrfProtection, async (req, res) => {
   try {
     const [pending, all] = await Promise.all([getPendingRequests(), getAllApiKeys()]);
@@ -86,7 +96,7 @@ router.get('/admin/streamdeck-keys', requireAdmin, csrfProtection, async (req, r
       csrfToken: req.csrfToken(),
       pending,
       all,
-      error: null,
+      error: ADMIN_KNOWN_ERRORS.has(req.query.error as string) ? (req.query.error as string) : null,
     });
   } catch (err) {
     console.error('[Web] Streamdeck admin keys error:', err);
@@ -98,13 +108,11 @@ router.get('/admin/streamdeck-keys', requireAdmin, csrfProtection, async (req, r
   }
 });
 
-const DISCORD_ID_RE = /^\d{17,20}$/;
-
 router.post('/admin/streamdeck-keys/approve', requireAdmin, csrfProtection, async (req, res) => {
-  const { discord_id } = req.body as { discord_id?: string };
-  if (!discord_id?.trim() || !DISCORD_ID_RE.test(discord_id.trim())) return res.redirect('/admin/streamdeck-keys');
+  const validId = validateDiscordId((req.body as { discord_id?: string }).discord_id);
+  if (!validId) return res.redirect('/admin/streamdeck-keys?error=invalid_discord_id');
   try {
-    await approveApiKey(discord_id.trim(), req.session.user!.discordId);
+    await approveApiKey(validId, req.session.user!.discordId);
     res.redirect('/admin/streamdeck-keys');
   } catch (err) {
     console.error('[Web] Streamdeck key approve error:', err);
@@ -113,10 +121,10 @@ router.post('/admin/streamdeck-keys/approve', requireAdmin, csrfProtection, asyn
 });
 
 router.post('/admin/streamdeck-keys/deny', requireAdmin, csrfProtection, async (req, res) => {
-  const { discord_id } = req.body as { discord_id?: string };
-  if (!discord_id?.trim() || !DISCORD_ID_RE.test(discord_id.trim())) return res.redirect('/admin/streamdeck-keys');
+  const validId = validateDiscordId((req.body as { discord_id?: string }).discord_id);
+  if (!validId) return res.redirect('/admin/streamdeck-keys?error=invalid_discord_id');
   try {
-    await denyApiKey(discord_id.trim());
+    await denyApiKey(validId);
     res.redirect('/admin/streamdeck-keys');
   } catch (err) {
     console.error('[Web] Streamdeck key deny error:', err);
@@ -125,10 +133,10 @@ router.post('/admin/streamdeck-keys/deny', requireAdmin, csrfProtection, async (
 });
 
 router.post('/admin/streamdeck-keys/revoke', requireAdmin, csrfProtection, async (req, res) => {
-  const { discord_id } = req.body as { discord_id?: string };
-  if (!discord_id?.trim() || !DISCORD_ID_RE.test(discord_id.trim())) return res.redirect('/admin/streamdeck-keys');
+  const validId = validateDiscordId((req.body as { discord_id?: string }).discord_id);
+  if (!validId) return res.redirect('/admin/streamdeck-keys?error=invalid_discord_id');
   try {
-    await revokeApiKey(discord_id.trim());
+    await revokeApiKey(validId);
     res.redirect('/admin/streamdeck-keys');
   } catch (err) {
     console.error('[Web] Streamdeck key admin revoke error:', err);

--- a/src/web/routes/streamdeckKeys.ts
+++ b/src/web/routes/streamdeckKeys.ts
@@ -98,9 +98,11 @@ router.get('/admin/streamdeck-keys', requireAdmin, csrfProtection, async (req, r
   }
 });
 
+const DISCORD_ID_RE = /^\d{17,20}$/;
+
 router.post('/admin/streamdeck-keys/approve', requireAdmin, csrfProtection, async (req, res) => {
   const { discord_id } = req.body as { discord_id?: string };
-  if (!discord_id?.trim()) return res.redirect('/admin/streamdeck-keys');
+  if (!discord_id?.trim() || !DISCORD_ID_RE.test(discord_id.trim())) return res.redirect('/admin/streamdeck-keys');
   try {
     await approveApiKey(discord_id.trim(), req.session.user!.discordId);
     res.redirect('/admin/streamdeck-keys');
@@ -112,7 +114,7 @@ router.post('/admin/streamdeck-keys/approve', requireAdmin, csrfProtection, asyn
 
 router.post('/admin/streamdeck-keys/deny', requireAdmin, csrfProtection, async (req, res) => {
   const { discord_id } = req.body as { discord_id?: string };
-  if (!discord_id?.trim()) return res.redirect('/admin/streamdeck-keys');
+  if (!discord_id?.trim() || !DISCORD_ID_RE.test(discord_id.trim())) return res.redirect('/admin/streamdeck-keys');
   try {
     await denyApiKey(discord_id.trim());
     res.redirect('/admin/streamdeck-keys');
@@ -124,7 +126,7 @@ router.post('/admin/streamdeck-keys/deny', requireAdmin, csrfProtection, async (
 
 router.post('/admin/streamdeck-keys/revoke', requireAdmin, csrfProtection, async (req, res) => {
   const { discord_id } = req.body as { discord_id?: string };
-  if (!discord_id?.trim()) return res.redirect('/admin/streamdeck-keys');
+  if (!discord_id?.trim() || !DISCORD_ID_RE.test(discord_id.trim())) return res.redirect('/admin/streamdeck-keys');
   try {
     await revokeApiKey(discord_id.trim());
     res.redirect('/admin/streamdeck-keys');


### PR DESCRIPTION
## Summary

Three low-severity items identified in the post-merge security review:

- **`CSS.escape()` on `liveKey` in querySelector** (`streams-live-table.js`, `streams-live-poll.js`) — `liveKey` is `streamerId:groupId` from the bot's own API (always numeric), so this can never cause XSS. But if a non-numeric value ever ended up in the DB, the unescaped string could produce an invalid CSS selector and throw a `SyntaxError` breaking the row-toggle UI. `CSS.escape()` is a one-word fix.

- **Discord snowflake format validation** (`src/web/routes/streamdeckKeys.ts`) — The approve/deny/revoke admin endpoints accepted any non-empty string as a Discord ID. Added `/^\d{17,20}$/` check on all three before touching the DB. Parameterised queries already prevented SQL injection; this just stops garbage data from being persisted.

- **Log lock-release failures** (`src/db/commandConflicts.ts`, `src/db/commandLocks.ts`) — The `catch (_) {}` in the finally blocks that call `RELEASE_LOCK` swallowed all errors silently. The underlying query already logs via `console.warn`, but replaced the empty catch with a warn so unexpected failures are visible.

## Test plan

- [ ] `npm run build` passes
- [ ] `npm test` passes
- [ ] Toggle a live stream row on the streams page — detail row expands/collapses as before
- [ ] Attempt to approve/deny/revoke with a non-numeric Discord ID in the form body — silently redirects without DB write

https://claude.ai/code/session_01ANDPuF742D3LehPef6rJVP

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANDPuF742D3LehPef6rJVP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of special characters in live stream keys to prevent display/selection issues.
  * Added stricter Discord ID validation in the admin panel; invalid IDs are rejected and users are returned to the admin page with an error.
  * Improved logging when releasing internal locks fails to make troubleshooting easier.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->