### PR TITLE
fix(shutdown): stop TikTok connections and destroy Discord client on exit

### DIFF
--- a/src/discordBot.ts
+++ b/src/discordBot.ts
@@ -92,3 +92,14 @@ export function startDiscordBot(): void {
 
   client.login(DISCORD_TOKEN).catch((err) => console.error('[Discord] Login failed:', err));
 }
+
+export function stopDiscordBot(): void {
+  discordClient = null;
+  cachedGuild = null;
+  try {
+    client?.destroy();
+  } catch (err) {
+    console.error('[Discord] Error destroying client:', err);
+  }
+  console.log('[Discord] Client destroyed.');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import 'mediaplex'; // Must be imported first to register as Opus provider
 import { getPool, closePool } from './db';
 import { startTwitchBot, sayInChannel, getActiveChannels, getActiveChannelUserIds } from './twitchBot';
-import { startDiscordBot } from './discordBot';
-import { startTikTokBot } from './tiktokBot';
+import { startDiscordBot, stopDiscordBot } from './discordBot';
+import { startTikTokBot, stopTikTokBot } from './tiktokBot';
 import { startTwitchMonitor, stopTwitchMonitor } from './twitchMonitor';
 import { startWebPanel } from './web/server';
 import { disconnect } from './audioPlayer';
@@ -16,6 +16,8 @@ async function shutdown(signal: string): Promise<void> {
   console.log(`[Bot] ${signal} received — disconnecting from voice and shutting down.`);
   stopCounterScheduler();
   await stopTwitchMonitor();
+  stopTikTokBot();
+  stopDiscordBot();
   disconnect();
   await closePool();
   process.exit(0);

--- a/src/tiktokBot.ts
+++ b/src/tiktokBot.ts
@@ -59,6 +59,7 @@ function connectToChannel(username: string, modules: TikTokModules): void {
       activeConnections.delete(username);
       reconnectTimer = setTimeout(() => {
         pendingReconnectTimers.delete(reconnectTimer!);
+        if (stopped) return;
         connectToChannel(username, modules);
       }, RECONNECT_DELAY_MS);
       pendingReconnectTimers.add(reconnectTimer);

--- a/src/tiktokBot.ts
+++ b/src/tiktokBot.ts
@@ -26,6 +26,9 @@ const RECONNECT_DELAY_MS = 30_000;
 
 // Tracks the active connection object per channel to prevent duplicate connections.
 const activeConnections = new Map<string, Connection>();
+// Tracks all pending reconnect timers so stopTikTokBot() can cancel them.
+const pendingReconnectTimers = new Set<ReturnType<typeof setTimeout>>();
+let stopped = false;
 
 function connectToChannel(username: string, modules: TikTokModules): void {
   const { TikTokLiveConnection, WebcastEvent, ControlEvent } = modules;
@@ -45,7 +48,7 @@ function connectToChannel(username: string, modules: TikTokModules): void {
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
   function scheduleReconnect(): void {
-    if (reconnectScheduled || permanentFailure) return;
+    if (stopped || reconnectScheduled || permanentFailure) return;
     reconnectScheduled = true;
     connection.disconnect().catch(() => { /* already disconnected */ });
     // Only take ownership of the map entry and schedule a reconnect when this
@@ -54,7 +57,11 @@ function connectToChannel(username: string, modules: TikTokModules): void {
     // redundant reconnect.
     if (activeConnections.get(username) === connection) {
       activeConnections.delete(username);
-      reconnectTimer = setTimeout(() => connectToChannel(username, modules), RECONNECT_DELAY_MS);
+      reconnectTimer = setTimeout(() => {
+        pendingReconnectTimers.delete(reconnectTimer!);
+        connectToChannel(username, modules);
+      }, RECONNECT_DELAY_MS);
+      pendingReconnectTimers.add(reconnectTimer);
     }
   }
 
@@ -92,6 +99,7 @@ function connectToChannel(username: string, modules: TikTokModules): void {
       permanentFailure = true;
       activeConnections.delete(username);
       if (reconnectTimer) {
+        pendingReconnectTimers.delete(reconnectTimer);
         clearTimeout(reconnectTimer);
         reconnectTimer = null;
       }
@@ -110,6 +118,7 @@ function connectToChannel(username: string, modules: TikTokModules): void {
 }
 
 export async function startTikTokBot(): Promise<void> {
+  stopped = false;
   if (TIKTOK_CHANNELS.length === 0) {
     console.log('[TikTok] No TIKTOK_CHANNELS configured — TikTok listener not started.');
     return;
@@ -124,4 +133,18 @@ export async function startTikTokBot(): Promise<void> {
   for (const username of TIKTOK_CHANNELS) {
     connectToChannel(username, modules);
   }
+}
+
+export function stopTikTokBot(): void {
+  stopped = true;
+  for (const [username, conn] of activeConnections) {
+    setTikTokChannel(username, false);
+    conn.disconnect().catch(() => { /* already disconnected */ });
+  }
+  activeConnections.clear();
+  for (const timer of pendingReconnectTimers) {
+    clearTimeout(timer);
+  }
+  pendingReconnectTimers.clear();
+  console.log('[TikTok] Stopped.');
 }


### PR DESCRIPTION
## Summary

- `stopTikTokBot()`: disconnects all active connections, cancels all pending reconnect timers via a module-level `Set`, sets a `stopped` flag so `scheduleReconnect` no longer queues new timers after shutdown is called
- `stopDiscordBot()`: calls `client.destroy()` and resets `discordClient`/`cachedGuild` to null
- `shutdown()` in `index.ts` calls both before `closePool()`

Previously SIGINT/SIGTERM left the Discord WebSocket open and TikTok `setTimeout` reconnect timers in-flight, which prevented a clean process exit.

## Test plan

- [ ] Send SIGINT to a running bot instance; confirm `process.exit(0)` is reached promptly with no dangling handles
- [ ] Optionally run with `node --trace-exits dist/index.js` to observe no async handle leaks
- [ ] `npm test` passes (no regression to existing tests)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvtuNXzcQApZ16UApPj5Ym)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit stop controls for Discord and TikTok bots so they can be cleanly stopped during shutdown.

* **Chores**
  * Improved coordinated shutdown flow to stop Discord, TikTok, and Twitch components, disconnect audio/player, and clean up resources.

* **Bug Fixes**
  * Prevented unwanted reconnect attempts after stop, avoiding lingering connections and timers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->