### PR TITLE
fix(admin): pass null instead of empty string in Twitch rollback paths

### DIFF
--- a/src/web/routes/adminUserMutations.ts
+++ b/src/web/routes/adminUserMutations.ts
@@ -42,7 +42,7 @@ async function handleClearTwitchChannel(
     }
   } catch (err) {
     try {
-      await upsertUser(discordId, discordName, level, previousChannel ?? '');
+      await upsertUser(discordId, discordName, level, previousChannel ?? null);
       await updateTwitchBotEnabled(discordId, wasBotEnabled);
     } catch (rollbackErr) {
       console.error('[Web] Add user clear Twitch rollback failed:', rollbackErr);
@@ -83,7 +83,7 @@ async function handleChangeTwitchChannel({
     }
   } catch (err) {
     try {
-      await upsertUser(discordId, discordName, level, previousChannel ?? '');
+      await upsertUser(discordId, discordName, level, previousChannel ?? null);
       await updateTwitchBotEnabled(discordId, wasBotEnabled);
 
       const rollbackEnabledChannels = await getTwitchEnabledChannels();
@@ -180,7 +180,7 @@ export async function removeUserMutation(discordId: string): Promise<void> {
         existingUser.discord_id,
         existingUser.discord_name?.trim() ?? '',
         existingUser.access_level as AccessLevelValue,
-        existingUser.twitch_name,
+        existingUser.twitch_name ?? null,
       );
       await updateTwitchBotEnabled(existingUser.discord_id, existingUser.is_twitch_bot_enabled);
     } catch (rollbackErr) {


### PR DESCRIPTION
## Summary

Three rollback callsites in `adminUserMutations.ts` were passing `previousChannel ?? ''` as the `twitchName` argument to `upsertUser`. When `previousChannel` is `null`, the empty string `''` reaches `upsertUserRecord` in `users.ts`, which treats a non-`null` value as an explicit name, trims it, and throws `Invalid twitchName:` — masking the original error entirely and leaving DB state unrecovered.

**Affected callsites:**
- `handleClearTwitchChannel` rollback (line 45) — `previousChannel ?? ''` → `previousChannel ?? null`
- `handleChangeTwitchChannel` rollback (line 87) — same
- `removeUserMutation` rollback (line 180) — `existingUser.twitch_name` can be `undefined` from the DB row; now explicitly `?? null`

`upsertUserRecord` already handles `null` correctly (line 94 of `users.ts` short-circuits the normalization path).

## Test plan

- [ ] `npm test` passes
- [ ] Trace the rollback path for a user with `twitch_name = NULL` and `is_twitch_bot_enabled = true`: when `partTwitchChannel` throws, the rollback should now complete without a secondary throw

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvtuNXzcQApZ16UApPj5Ym)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data consistency handling during error recovery scenarios for Twitch channel management operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->