### PR TITLE
fix(twitchApi): coalesce concurrent token requests and use AbortSignal.timeout

### DIFF
--- a/src/twitchApi.ts
+++ b/src/twitchApi.ts
@@ -2,22 +2,15 @@ import { TWITCH_CLIENT_ID, TWITCH_CLIENT_SECRET } from './config';
 
 const FETCH_TIMEOUT_MS = 10_000;
 
-async function twitchFetch(url: string, init?: RequestInit): Promise<Response> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-  try {
-    return await fetch(url, { ...init, signal: controller.signal });
-  } finally {
-    clearTimeout(timer);
-  }
+function twitchFetch(url: string, init?: RequestInit): Promise<Response> {
+  return fetch(url, { ...init, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
 }
 
 let cachedAppToken: string | null = null;
 let appTokenExpiry = 0;
+let tokenRefreshPromise: Promise<string> | null = null;
 
-async function getAppToken(): Promise<string> {
-  if (cachedAppToken && Date.now() < appTokenExpiry) return cachedAppToken;
-
+async function fetchNewAppToken(): Promise<string> {
   const body = new URLSearchParams({
     client_id: TWITCH_CLIENT_ID,
     client_secret: TWITCH_CLIENT_SECRET,
@@ -37,6 +30,14 @@ async function getAppToken(): Promise<string> {
   // Expire 60 s early to avoid edge cases
   appTokenExpiry = Date.now() + (data.expires_in - 60) * 1000;
   return cachedAppToken;
+}
+
+async function getAppToken(): Promise<string> {
+  if (cachedAppToken && Date.now() < appTokenExpiry) return cachedAppToken;
+  if (!tokenRefreshPromise) {
+    tokenRefreshPromise = fetchNewAppToken().finally(() => { tokenRefreshPromise = null; });
+  }
+  return tokenRefreshPromise;
 }
 
 function authHeaders(token: string): Record<string, string> {


### PR DESCRIPTION
## Summary

Two robustness improvements to `src/twitchApi.ts`:

**1. Token request coalescing**
Concurrent `getAppToken()` calls while the cache is empty previously each issued a separate `client_credentials` OAuth request to Twitch. The second response would silently overwrite the first. Now a shared `tokenRefreshPromise` is set for the duration of the in-flight request — all concurrent callers await the same promise and receive the same token. The promise reference is cleared in `.finally()` so the next stale-cache access starts a fresh fetch.

**2. Timeout consistency**
`twitchFetch` used a manual `setTimeout + AbortController` approach (pre-Node-17 pattern). Replaced with `AbortSignal.timeout(FETCH_TIMEOUT_MS)`, which is simpler and consistent with the pattern already used in `auth.ts`.

## Test plan

- [ ] `npm test` passes
- [ ] Bot connects to Twitch normally; Twitch stream monitor polls successfully

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvtuNXzcQApZ16UApPj5Ym)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized Twitch OAuth token fetching with improved timeout handling and concurrency safety to prevent duplicate refresh requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->