### PR TITLE
test: security-critical coverage + fix null Twitch name clear bug

### DIFF
--- a/src/commandRouter.test.ts
+++ b/src/commandRouter.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./config', () => ({
+  SFX_FOLDER: '/sfx',
+  GLOBAL_COOLDOWN_MS: 3_000,
+}));
+
+vi.mock('./db', () => ({
+  findTrigger: vi.fn(),
+  findSoundFiles: vi.fn(),
+}));
+
+vi.mock('./audioPlayer', () => ({
+  isPlaying: vi.fn(),
+}));
+
+vi.mock('./sfxPlayer', () => ({
+  playFile: vi.fn(),
+}));
+
+vi.mock('./soundSelector', () => ({
+  pickWeightedRandom: vi.fn(),
+}));
+
+vi.mock('./statusStore', () => ({
+  setVoicePlaying: vi.fn(),
+}));
+
+import { handleCommand } from './commandRouter';
+import { findTrigger, findSoundFiles } from './db';
+import { isPlaying } from './audioPlayer';
+import { playFile } from './sfxPlayer';
+import { pickWeightedRandom } from './soundSelector';
+import { setVoicePlaying } from './statusStore';
+
+// Base time far in the future so `Date.now() - 0` always exceeds GLOBAL_COOLDOWN_MS
+// at the start of each test. Each beforeEach adds enough to expire any previous play.
+const COOLDOWN_MS = 3_000;
+let mockNow = 1_000_000_000_000;
+
+beforeEach(() => {
+  mockNow += COOLDOWN_MS + 1_000;
+  vi.spyOn(Date, 'now').mockReturnValue(mockNow);
+  vi.clearAllMocks();
+  vi.spyOn(Date, 'now').mockReturnValue(mockNow);
+});
+
+const TRIGGER = { id: 42, trigger_command: '!ding' };
+const FILES = [{ filename: 'ding.mp3', weight: 1 }];
+
+describe('handleCommand', () => {
+  it('does nothing for an unrecognised command', async () => {
+    vi.mocked(isPlaying).mockReturnValue(false);
+    vi.mocked(findTrigger).mockResolvedValue(null);
+
+    await handleCommand('!unknown', 'twitch');
+
+    expect(vi.mocked(playFile)).not.toHaveBeenCalled();
+  });
+
+  it('ignores the command while audio is already playing', async () => {
+    vi.mocked(isPlaying).mockReturnValue(true);
+
+    await handleCommand('!ding', 'twitch');
+
+    expect(vi.mocked(findTrigger)).not.toHaveBeenCalled();
+    expect(vi.mocked(playFile)).not.toHaveBeenCalled();
+  });
+
+  it('ignores the command while the global cooldown is active', async () => {
+    // First call plays successfully and sets lastPlayedAt = mockNow
+    vi.mocked(isPlaying).mockReturnValue(false);
+    vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
+    vi.mocked(findSoundFiles).mockResolvedValue(FILES);
+    vi.mocked(pickWeightedRandom).mockReturnValue('ding.mp3');
+
+    await handleCommand('!ding', 'twitch');
+    expect(vi.mocked(playFile)).toHaveBeenCalledTimes(1);
+
+    // Second call at the same timestamp — cooldown has not elapsed
+    vi.clearAllMocks();
+    vi.spyOn(Date, 'now').mockReturnValue(mockNow);
+
+    await handleCommand('!ding', 'twitch');
+
+    expect(vi.mocked(findTrigger)).not.toHaveBeenCalled();
+    expect(vi.mocked(playFile)).not.toHaveBeenCalled();
+  });
+
+  it('plays the correct file and updates status for a known command', async () => {
+    vi.mocked(isPlaying).mockReturnValue(false);
+    vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
+    vi.mocked(findSoundFiles).mockResolvedValue(FILES);
+    vi.mocked(pickWeightedRandom).mockReturnValue('ding.mp3');
+
+    await handleCommand('!ding discord', 'discord');
+
+    expect(vi.mocked(findTrigger)).toHaveBeenCalledWith('!ding');
+    expect(vi.mocked(playFile)).toHaveBeenCalledWith('/sfx/ding.mp3');
+    expect(vi.mocked(setVoicePlaying)).toHaveBeenCalledWith('ding.mp3', '!ding', 'discord');
+  });
+});

--- a/src/sfxPlayer.test.ts
+++ b/src/sfxPlayer.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./config', () => ({ SFX_FOLDER: '/sfx' }));
+
+vi.mock('./audioPlayer', () => ({
+  isConnected: vi.fn(),
+  startPlayback: vi.fn(),
+}));
+
+vi.mock('@discordjs/voice', () => ({
+  createAudioResource: vi.fn((p: string) => ({ resourcePath: p })),
+}));
+
+vi.mock('ffmpeg-static', () => ({ default: null }));
+
+vi.mock('fs', () => ({
+  default: {
+    existsSync: vi.fn(),
+    realpathSync: vi.fn(),
+    statSync: vi.fn(),
+  },
+}));
+
+import { playFile, VoiceNotConnectedError } from './sfxPlayer';
+import { isConnected, startPlayback } from './audioPlayer';
+import { createAudioResource } from '@discordjs/voice';
+import fs from 'fs';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: realpathSync is an identity function (no symlinks)
+  vi.mocked(fs.realpathSync).mockImplementation((p) => p as string);
+});
+
+describe('playFile', () => {
+  it('throws VoiceNotConnectedError when not connected to a voice channel', () => {
+    vi.mocked(isConnected).mockReturnValue(false);
+    expect(() => playFile('/sfx/ding.mp3')).toThrow(VoiceNotConnectedError);
+  });
+
+  it('blocks a path that resolves outside the SFX folder', () => {
+    vi.mocked(isConnected).mockReturnValue(true);
+    expect(() => playFile('/etc/passwd')).toThrow('Path traversal blocked');
+  });
+
+  it('blocks a symlink whose real path resolves outside the SFX folder', () => {
+    vi.mocked(isConnected).mockReturnValue(true);
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    // Symlink inside /sfx points to a file outside /sfx
+    vi.mocked(fs.realpathSync).mockImplementation((p) =>
+      String(p) === '/sfx' ? '/sfx' : '/etc/passwd',
+    );
+    expect(() => playFile('/sfx/evil.mp3')).toThrow('Path traversal blocked');
+  });
+
+  it('starts playback for a valid file inside the SFX folder', () => {
+    vi.mocked(isConnected).mockReturnValue(true);
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.statSync).mockReturnValue({ isFile: () => true } as ReturnType<typeof fs.statSync>);
+
+    playFile('/sfx/ding.mp3');
+
+    expect(vi.mocked(createAudioResource)).toHaveBeenCalledWith('/sfx/ding.mp3');
+    expect(vi.mocked(startPlayback)).toHaveBeenCalledOnce();
+  });
+});

--- a/src/web/routes/adminUserMutations.test.ts
+++ b/src/web/routes/adminUserMutations.test.ts
@@ -25,7 +25,6 @@ import {
 } from './adminUserMutations';
 import {
   findUser,
-  findUserByTwitchName,
   upsertUser,
   removeUser,
   updateTwitchBotEnabled,

--- a/src/web/routes/adminUserMutations.test.ts
+++ b/src/web/routes/adminUserMutations.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../db', () => ({
+  findUser: vi.fn(),
+  findUserByTwitchName: vi.fn(),
+  upsertUser: vi.fn(),
+  removeUser: vi.fn(),
+  updateTwitchBotEnabled: vi.fn(),
+  getTwitchEnabledChannels: vi.fn(),
+}));
+
+vi.mock('../../twitchBot', () => ({
+  joinTwitchChannel: vi.fn(),
+  partTwitchChannel: vi.fn(),
+}));
+
+vi.mock('../../twitchChannelName', () => ({
+  normalizeTwitchChannelName: vi.fn((name: string | null) => name?.toLowerCase() ?? null),
+}));
+
+import {
+  addOrUpdateUserMutation,
+  removeUserMutation,
+  toggleTwitchMutation,
+} from './adminUserMutations';
+import {
+  findUser,
+  findUserByTwitchName,
+  upsertUser,
+  removeUser,
+  updateTwitchBotEnabled,
+  getTwitchEnabledChannels,
+} from '../../db';
+import { joinTwitchChannel, partTwitchChannel } from '../../twitchBot';
+
+type MockDbUser = {
+  discord_id: string;
+  discord_name: string;
+  access_level: number;
+  twitch_name: string | null;
+  is_twitch_bot_enabled: boolean;
+};
+
+const BASE_USER: MockDbUser = {
+  discord_id: '111',
+  discord_name: 'TestUser',
+  access_level: 0,
+  twitch_name: null,
+  is_twitch_bot_enabled: false,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(upsertUser).mockResolvedValue(undefined);
+  vi.mocked(updateTwitchBotEnabled).mockResolvedValue(undefined);
+  vi.mocked(removeUser).mockResolvedValue(undefined);
+  vi.mocked(joinTwitchChannel).mockResolvedValue(undefined);
+  vi.mocked(partTwitchChannel).mockResolvedValue(undefined);
+  vi.mocked(getTwitchEnabledChannels).mockResolvedValue([]);
+});
+
+describe('addOrUpdateUserMutation — shouldClearTwitchName', () => {
+  it('passes null (not empty string) to upsertUser when clearing the Twitch name', async () => {
+    vi.mocked(findUser)
+      .mockResolvedValueOnce(null) // no pre-existing user
+      .mockResolvedValueOnce({ ...BASE_USER, twitch_name: null } as any);
+
+    await addOrUpdateUserMutation({
+      discordId: '111',
+      discordName: 'TestUser',
+      level: 0,
+      normalizedTwitchName: null,
+      shouldClearTwitchName: true,
+    });
+
+    expect(vi.mocked(upsertUser)).toHaveBeenCalledWith('111', 'TestUser', 0, null);
+  });
+});
+
+describe('addOrUpdateUserMutation — handleClearTwitchChannel rollback', () => {
+  it('calls upsertUser with the previous channel name when partTwitchChannel throws', async () => {
+    const existingUser: MockDbUser = {
+      ...BASE_USER,
+      twitch_name: 'streamerchan',
+      is_twitch_bot_enabled: true,
+    };
+
+    vi.mocked(findUser)
+      .mockResolvedValueOnce(existingUser as any) // existing state
+      .mockResolvedValueOnce({ ...existingUser, twitch_name: null } as any); // after upsert
+
+    vi.mocked(partTwitchChannel).mockRejectedValue(new Error('Part failed'));
+
+    await expect(
+      addOrUpdateUserMutation({
+        discordId: '111',
+        discordName: 'TestUser',
+        level: 0,
+        normalizedTwitchName: null,
+        shouldClearTwitchName: true,
+      }),
+    ).rejects.toThrow('Part failed');
+
+    const upsertCalls = vi.mocked(upsertUser).mock.calls;
+    // First call: the main upsert (null to clear); second call: rollback (restores channel)
+    expect(upsertCalls.length).toBeGreaterThanOrEqual(2);
+    const rollbackCall = upsertCalls[upsertCalls.length - 1];
+    expect(rollbackCall[3]).toBe('streamerchan');
+  });
+});
+
+describe('addOrUpdateUserMutation — handleChangeTwitchChannel rollback', () => {
+  it('calls upsertUser with null when previousChannel was null and joinTwitchChannel throws', async () => {
+    const existingUser: MockDbUser = {
+      ...BASE_USER,
+      twitch_name: null,
+      is_twitch_bot_enabled: true,
+    };
+    const afterUpsert: MockDbUser = {
+      ...BASE_USER,
+      twitch_name: 'newchan',
+      is_twitch_bot_enabled: true,
+    };
+
+    vi.mocked(findUser)
+      .mockResolvedValueOnce(existingUser as any)
+      .mockResolvedValueOnce(afterUpsert as any);
+
+    // newchan is in the enabled list so joinTwitchChannel is called
+    vi.mocked(getTwitchEnabledChannels).mockResolvedValue(['newchan']);
+    vi.mocked(joinTwitchChannel).mockRejectedValue(new Error('Join failed'));
+
+    await expect(
+      addOrUpdateUserMutation({
+        discordId: '111',
+        discordName: 'TestUser',
+        level: 0,
+        normalizedTwitchName: 'newchan',
+        shouldClearTwitchName: false,
+      }),
+    ).rejects.toThrow('Join failed');
+
+    const upsertCalls = vi.mocked(upsertUser).mock.calls;
+    const rollbackCall = upsertCalls[upsertCalls.length - 1];
+    // previousChannel was null — rollback must use null, not ''
+    expect(rollbackCall[3]).toBeNull();
+  });
+});
+
+describe('removeUserMutation — rollback on partTwitchChannel failure', () => {
+  it('re-inserts the user when partTwitchChannel throws during removal', async () => {
+    const existingUser: MockDbUser = {
+      ...BASE_USER,
+      twitch_name: 'streamerchan',
+      is_twitch_bot_enabled: true,
+    };
+
+    vi.mocked(findUser).mockResolvedValue(existingUser as any);
+    vi.mocked(partTwitchChannel).mockRejectedValue(new Error('Part failed'));
+
+    await expect(removeUserMutation('111')).rejects.toThrow('Part failed');
+
+    expect(vi.mocked(upsertUser)).toHaveBeenCalledWith(
+      existingUser.discord_id,
+      existingUser.discord_name,
+      existingUser.access_level,
+      existingUser.twitch_name,
+    );
+    expect(vi.mocked(updateTwitchBotEnabled)).toHaveBeenCalledWith(
+      existingUser.discord_id,
+      existingUser.is_twitch_bot_enabled,
+    );
+  });
+});
+
+describe('toggleTwitchMutation — rollback on join/part failure', () => {
+  it('reverts updateTwitchBotEnabled when joinTwitchChannel throws', async () => {
+    const user: MockDbUser = {
+      ...BASE_USER,
+      twitch_name: 'streamerchan',
+      is_twitch_bot_enabled: false,
+    };
+
+    vi.mocked(findUser).mockResolvedValue(user as any);
+    vi.mocked(getTwitchEnabledChannels).mockResolvedValue(['streamerchan']);
+    vi.mocked(joinTwitchChannel).mockRejectedValue(new Error('Join failed'));
+
+    await expect(toggleTwitchMutation('111', true)).rejects.toThrow('Join failed');
+
+    expect(vi.mocked(updateTwitchBotEnabled)).toHaveBeenNthCalledWith(1, '111', true);
+    expect(vi.mocked(updateTwitchBotEnabled)).toHaveBeenNthCalledWith(2, '111', false);
+  });
+});

--- a/src/web/routes/adminUserMutations.ts
+++ b/src/web/routes/adminUserMutations.ts
@@ -125,7 +125,7 @@ export async function addOrUpdateUserMutation({
     ? normalizeTwitchChannelName(existingUser.twitch_name)
     : null;
   const nextTwitchName = shouldClearTwitchName
-    ? ''
+    ? null
     : normalizedTwitchName ?? undefined;
 
   if (normalizedTwitchName) {

--- a/src/web/routes/adminUserMutations.ts
+++ b/src/web/routes/adminUserMutations.ts
@@ -42,7 +42,7 @@ async function handleClearTwitchChannel(
     }
   } catch (err) {
     try {
-      await upsertUser(discordId, discordName, level, previousChannel ?? '');
+      await upsertUser(discordId, discordName, level, previousChannel ?? null);
       await updateTwitchBotEnabled(discordId, wasBotEnabled);
     } catch (rollbackErr) {
       console.error('[Web] Add user clear Twitch rollback failed:', rollbackErr);
@@ -83,7 +83,7 @@ async function handleChangeTwitchChannel({
     }
   } catch (err) {
     try {
-      await upsertUser(discordId, discordName, level, previousChannel ?? '');
+      await upsertUser(discordId, discordName, level, previousChannel ?? null);
       await updateTwitchBotEnabled(discordId, wasBotEnabled);
 
       const rollbackEnabledChannels = await getTwitchEnabledChannels();
@@ -180,7 +180,7 @@ export async function removeUserMutation(discordId: string): Promise<void> {
         existingUser.discord_id,
         existingUser.discord_name?.trim() ?? '',
         existingUser.access_level as AccessLevelValue,
-        existingUser.twitch_name,
+        existingUser.twitch_name ?? null,
       );
       await updateTwitchBotEnabled(existingUser.discord_id, existingUser.is_twitch_bot_enabled);
     } catch (rollbackErr) {


### PR DESCRIPTION
## Summary

- **Bug fix**: `addOrUpdateUserMutation` was passing `''` (empty string) to `upsertUser` when `shouldClearTwitchName` is true. `upsertUserRecord` rejects empty strings and throws, so the clear operation would always fail at the DB layer. Changed to `null`. The same `?? ''` → `?? null` fix is applied to the two rollback paths in `handleClearTwitchChannel` and `handleChangeTwitchChannel` (guards against a `previousChannel = null` rollback calling upsert with an invalid empty string).
- **New tests**: Three test files covering the paths highlighted in the code review.

### New test files

| File | What it covers |
|---|---|
| `src/sfxPlayer.test.ts` | `VoiceNotConnectedError`, path traversal block, symlink traversal block, happy-path playback |
| `src/commandRouter.test.ts` | Unknown command (no-op), already-playing gate, global cooldown window, happy-path play with status update |
| `src/web/routes/adminUserMutations.test.ts` | `shouldClearTwitchName → null` fix, `handleClearTwitchChannel` rollback, `handleChangeTwitchChannel` rollback with `null` previous channel, `removeUserMutation` rollback, `toggleTwitchMutation` rollback |

## Test plan

- [x] `npm test` — 23 tests across 5 files, all green
- [x] `npm run build` — TypeScript compiles cleanly

https://claude.ai/code/session_01JvtuNXzcQApZ16UApPj5Ym

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvtuNXzcQApZ16UApPj5Ym)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test suites for command routing with configuration and playback state validation.
  * Added test coverage for audio file playback including connection verification and path security.
  * Added test coverage for admin user operations including Twitch channel management and rollback scenarios.

* **Bug Fixes**
  * Fixed Twitch channel clearing to properly persist empty channel states across database operations and rollback scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->