### PR TITLE
fix: pin ws >=8.20.1 to remediate CVE-2026-45736

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "tiktok-live-connector": "2.3.0-beta1",
     "tmi.js": "^1.8.5"
   },
+  "overrides": {
+    "ws": ">=8.20.1"
+  },
   "devDependencies": {
     "@types/ejs": "^3.1.5",
     "@types/express": "^5.0.6",


### PR DESCRIPTION
## Summary

- `ws@8.20.0` is vulnerable to CVE-2026-45736 (GHSA-58qx-3vcg-4xpx)
- `ws` is a transitive dependency pulled in by four packages: `@discordjs/voice`, `@discordjs/ws`, `tiktok-live-connector`, and `tmi.js`
- Adds an `overrides` entry in `package.json` to force all resolved `ws` versions to `>=8.20.1`, preventing any transitive dependency from resolving to the vulnerable version

## Test plan

- [ ] Run `npm audit` — should report 0 vulnerabilities
- [ ] Verify `node_modules/ws/package.json` shows version `8.20.1` or higher
- [ ] Confirm the bot starts and Discord/TikTok/Twitch integrations function normally

https://claude.ai/code/session_01Cw27aT2fBx5WQQjjsMA53z

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cw27aT2fBx5WQQjjsMA53z)_