### PR TITLE
fix: close SFX race condition, silence VoiceNotConnectedError, fix missing csrfToken in auth error

### DIFF
--- a/src/commandRouter.test.ts
+++ b/src/commandRouter.test.ts
@@ -16,6 +16,9 @@ vi.mock('./audioPlayer', () => ({
 
 vi.mock('./sfxPlayer', () => ({
   playFile: vi.fn(),
+  VoiceNotConnectedError: class VoiceNotConnectedError extends Error {
+    constructor() { super('Not connected to a voice channel'); this.name = 'VoiceNotConnectedError'; }
+  },
 }));
 
 vi.mock('./soundSelector', () => ({
@@ -29,7 +32,7 @@ vi.mock('./statusStore', () => ({
 import { handleCommand } from './commandRouter';
 import { findTrigger, findSoundFiles } from './db';
 import { isPlaying } from './audioPlayer';
-import { playFile } from './sfxPlayer';
+import { playFile, VoiceNotConnectedError } from './sfxPlayer';
 import { pickWeightedRandom } from './soundSelector';
 import { setVoicePlaying } from './statusStore';
 
@@ -40,13 +43,12 @@ let mockNow = 1_000_000_000_000;
 
 beforeEach(() => {
   mockNow += COOLDOWN_MS + 1_000;
-  vi.spyOn(Date, 'now').mockReturnValue(mockNow);
   vi.clearAllMocks();
   vi.spyOn(Date, 'now').mockReturnValue(mockNow);
 });
 
 const TRIGGER = { id: 42, trigger_command: '!ding' };
-const FILES = [{ filename: 'ding.mp3', weight: 1 }];
+const FILES = [{ file: 'ding.mp3', weight: 1 }];
 
 describe('handleCommand', () => {
   it('does nothing for an unrecognised command', async () => {
@@ -98,5 +100,45 @@ describe('handleCommand', () => {
     expect(vi.mocked(findTrigger)).toHaveBeenCalledWith('!ding');
     expect(vi.mocked(playFile)).toHaveBeenCalledWith('/sfx/ding.mp3');
     expect(vi.mocked(setVoicePlaying)).toHaveBeenCalledWith('ding.mp3', '!ding', 'discord');
+  });
+
+  it('blocks a second concurrent call via the inFlight flag', async () => {
+    vi.mocked(isPlaying).mockReturnValue(false);
+
+    // findTrigger resolves immediately for the first call, but the second call
+    // arrives while the first is still awaiting — simulate by running both
+    // handleCommand calls concurrently without awaiting the first.
+    let resolveFirst!: (value: typeof TRIGGER) => void;
+    const firstTriggerPromise = new Promise<typeof TRIGGER>((resolve) => { resolveFirst = resolve; });
+    vi.mocked(findTrigger).mockReturnValueOnce(firstTriggerPromise as ReturnType<typeof findTrigger>);
+
+    const first = handleCommand('!ding', 'twitch');
+
+    // Second call arrives while first is suspended inside findTrigger
+    await handleCommand('!ding', 'twitch');
+    expect(vi.mocked(findTrigger)).toHaveBeenCalledTimes(1); // second was blocked
+
+    // Let the first call complete
+    vi.mocked(findSoundFiles).mockResolvedValue(FILES);
+    vi.mocked(pickWeightedRandom).mockReturnValue('ding.mp3');
+    resolveFirst(TRIGGER);
+    await first;
+
+    expect(vi.mocked(playFile)).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not log an error when not connected to a voice channel', async () => {
+    vi.mocked(isPlaying).mockReturnValue(false);
+    vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
+    vi.mocked(findSoundFiles).mockResolvedValue(FILES);
+    vi.mocked(pickWeightedRandom).mockReturnValue('ding.mp3');
+    vi.mocked(playFile).mockImplementation(() => { throw new VoiceNotConnectedError(); });
+
+    const errorSpy = vi.spyOn(console, 'error');
+
+    await handleCommand('!ding', 'twitch');
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(vi.mocked(setVoicePlaying)).not.toHaveBeenCalled();
   });
 });

--- a/src/commandRouter.ts
+++ b/src/commandRouter.ts
@@ -2,11 +2,12 @@ import path from 'path';
 import { findTrigger, findSoundFiles } from './db';
 import { pickWeightedRandom } from './soundSelector';
 import { isPlaying } from './audioPlayer';
-import { playFile } from './sfxPlayer';
+import { playFile, VoiceNotConnectedError } from './sfxPlayer';
 import { SFX_FOLDER, GLOBAL_COOLDOWN_MS } from './config';
 import { setVoicePlaying } from './statusStore';
 
 let lastPlayedAt = 0;
+let inFlight = false;
 
 /**
  * Handle a raw chat message from either Twitch or Discord.
@@ -30,37 +31,47 @@ export async function handleCommand(rawMessage: string, source: 'twitch' | 'disc
     return;
   }
 
-  // Ignore if already playing
-  if (isPlaying()) {
+  // Ignore if already playing or another handler is mid-lookup
+  if (isPlaying() || inFlight) {
     console.log(`[${source}] Already playing, ignoring '${command}'`);
     return;
   }
 
-  // Look up trigger in DB
-  const trigger = await findTrigger(command);
-  if (!trigger) {
-    // Not a recognised SFX command — silently ignore
-    return;
-  }
-
-  // Find associated sound files
-  const files = await findSoundFiles(trigger.id);
-  if (files.length === 0) {
-    console.warn(`[${source}] Trigger '${command}' has no sound files in DB`);
-    return;
-  }
-
-  // Pick a file (weighted random)
-  const filename = pickWeightedRandom(files);
-  const fullPath = path.join(SFX_FOLDER, filename);
-
-  console.log(`[${source}] Playing '${filename}' for trigger '${command}'`);
-
+  // Claim the slot before any await so concurrent message handlers see the flag.
+  inFlight = true;
   try {
-    playFile(fullPath);
-    lastPlayedAt = Date.now();
-    setVoicePlaying(filename, command, source);
-  } catch (err) {
-    console.error(`[${source}] Failed to play ${fullPath}:`, err);
+    // Look up trigger in DB
+    const trigger = await findTrigger(command);
+    if (!trigger) {
+      // Not a recognised SFX command — silently ignore
+      return;
+    }
+
+    // Find associated sound files
+    const files = await findSoundFiles(trigger.id);
+    if (files.length === 0) {
+      console.warn(`[${source}] Trigger '${command}' has no sound files in DB`);
+      return;
+    }
+
+    // Pick a file (weighted random)
+    const filename = pickWeightedRandom(files);
+    const fullPath = path.join(SFX_FOLDER, filename);
+
+    console.log(`[${source}] Playing '${filename}' for trigger '${command}'`);
+
+    try {
+      playFile(fullPath);
+      lastPlayedAt = Date.now();
+      setVoicePlaying(filename, command, source);
+    } catch (err) {
+      if (err instanceof VoiceNotConnectedError) {
+        console.log(`[${source}] Skipping '${command}' — not connected to voice channel`);
+      } else {
+        console.error(`[${source}] Failed to play ${fullPath}:`, err);
+      }
+    }
+  } finally {
+    inFlight = false;
   }
 }

--- a/src/web/routes/auth.ts
+++ b/src/web/routes/auth.ts
@@ -115,6 +115,7 @@ router.get('/discord/callback', async (req, res) => {
     res.status(500).render('error', {
       message: 'Authentication failed — please try again.',
       user: null,
+      csrfToken: '',
     });
   }
 });


### PR DESCRIPTION
## Summary

Three bugs identified in the code review, all low-risk fixes:

- **Race condition in `commandRouter.ts`** — two near-simultaneous chat messages could both pass the `isPlaying()` / cooldown guards before either set the playing flag, then both call `playFile()`. An `inFlight` boolean is now set immediately after the guards (before the first `await`) and cleared in a `finally` block, closing the window.
- **`VoiceNotConnectedError` logged as `console.error`** — when the bot is not yet in voice (startup, reconnect window) and a command arrives, it logged a noisy error. This is an expected transient state; it now logs at `console.log` level.
- **Missing `csrfToken` in OAuth error render** (`auth.ts`) — the catch-block error render omitted `csrfToken` from its locals, unlike every other error render in the codebase.

Two new test cases are added covering the `inFlight` guard and the `VoiceNotConnectedError` path.

> **Note:** This PR also carries the PR #120 test baseline fixes (`beforeEach` duplicate spy removed, `FILES.filename` → `FILES.file`). Merge PR #120 first and rebase this branch to keep the diff clean.

## Test plan

- [ ] `npm test` passes (25/25 tests green)
- [ ] Trigger an SFX command while the bot is not in voice — no `console.error` output
- [ ] Verify only one sound plays when two chat messages arrive at the same instant

https://claude.ai/code/session_01GXGUicTx3A3BxpoPF3Ladf

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXGUicTx3A3BxpoPF3Ladf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TikTok as a supported command source alongside Twitch and Discord

* **Bug Fixes**
  * Prevented race conditions by implementing concurrency control for command processing
  * Improved error handling for voice connection failures with appropriate skip messages
  * Fixed authentication error page rendering

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->