### PR TITLE
fix(reliability): multi-retry on Twitch 429, larger DB pool, parallel streamer polling

### DIFF
--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -14,7 +14,7 @@ export function getPool(): mysql.Pool {
       supportBigNumbers: true,
       bigNumberStrings: true,
       waitForConnections: true,
-      connectionLimit: 5,
+      connectionLimit: 15,
       queueLimit: 0,
       connectTimeout: 10_000,
     });

--- a/src/twitchApi.ts
+++ b/src/twitchApi.ts
@@ -53,15 +53,21 @@ function chunks<T>(arr: T[], size: number): T[][] {
   return result;
 }
 
+const HELIX_MAX_RETRIES = 3;
+
 async function fetchHelixWithRetry(url: string, headers: Record<string, string>): Promise<Response> {
-  const res = await twitchFetch(url, { headers });
-  if (res.status !== 429) return res;
-  const resetHeader = res.headers.get('ratelimit-reset');
-  const resetAt = resetHeader ? Number(resetHeader) * 1000 : Date.now() + 5000;
-  const wait = Math.max(0, resetAt - Date.now());
-  console.warn(`[TwitchAPI] Rate limited. Retrying after ${wait}ms`);
-  await new Promise<void>((r) => setTimeout(r, wait));
-  return twitchFetch(url, { headers });
+  let res = await twitchFetch(url, { headers });
+
+  for (let attempt = 1; attempt < HELIX_MAX_RETRIES && res.status === 429; attempt++) {
+    const resetHeader = res.headers.get('ratelimit-reset');
+    const resetAt = resetHeader ? Number(resetHeader) * 1000 : Date.now() + 5_000;
+    const wait = Math.max(0, resetAt - Date.now());
+    console.warn(`[TwitchAPI] Rate limited (attempt ${attempt}/${HELIX_MAX_RETRIES - 1}). Retrying after ${wait}ms`);
+    await new Promise<void>((r) => setTimeout(r, wait));
+    res = await twitchFetch(url, { headers });
+  }
+
+  return res;
 }
 
 export interface TwitchUser {

--- a/src/twitchApi.ts
+++ b/src/twitchApi.ts
@@ -58,11 +58,12 @@ const HELIX_MAX_RETRIES = 3;
 async function fetchHelixWithRetry(url: string, headers: Record<string, string>): Promise<Response> {
   let res = await twitchFetch(url, { headers });
 
-  for (let attempt = 1; attempt < HELIX_MAX_RETRIES && res.status === 429; attempt++) {
+  for (let attempt = 1; attempt <= HELIX_MAX_RETRIES && res.status === 429; attempt++) {
     const resetHeader = res.headers.get('ratelimit-reset');
-    const resetAt = resetHeader ? Number(resetHeader) * 1000 : Date.now() + 5_000;
+    const parsedReset = resetHeader ? Number(resetHeader) : NaN;
+    const resetAt = Number.isFinite(parsedReset) ? parsedReset * 1000 : Date.now() + 5_000;
     const wait = Math.max(0, resetAt - Date.now());
-    console.warn(`[TwitchAPI] Rate limited (attempt ${attempt}/${HELIX_MAX_RETRIES - 1}). Retrying after ${wait}ms`);
+    console.warn(`[TwitchAPI] Rate limited (attempt ${attempt}/${HELIX_MAX_RETRIES}). Retrying after ${wait}ms`);
     await new Promise<void>((r) => setTimeout(r, wait));
     res = await twitchFetch(url, { headers });
   }

--- a/src/twitchMonitor.ts
+++ b/src/twitchMonitor.ts
@@ -90,8 +90,13 @@ async function pollStreams(): Promise<void> {
         liveStreams.filter((s) => s.type === 'live').map((s) => [s.user_id, s]),
       );
 
-      for (const streamer of streamersData) {
-        await handlePollStreamer(streamer, liveByUserId);
+      const results = await Promise.allSettled(
+        streamersData.map((streamer) => handlePollStreamer(streamer, liveByUserId)),
+      );
+      for (const result of results) {
+        if (result.status === 'rejected') {
+          console.error('[TwitchMonitor] Error handling streamer poll:', result.reason);
+        }
       }
     } catch (err) {
       console.error('[TwitchMonitor] Poll error:', err);

--- a/src/twitchMonitor.ts
+++ b/src/twitchMonitor.ts
@@ -90,8 +90,23 @@ async function pollStreams(): Promise<void> {
         liveStreams.filter((s) => s.type === 'live').map((s) => [s.user_id, s]),
       );
 
+      // Group streamer rows by login so that rows sharing a login (same streamer,
+      // different groups) are processed sequentially — avoiding races on the
+      // shared login-scoped offline-timer state. Different logins run in parallel.
+      const byLogin = new Map<string, DbStreamerFull[]>();
+      for (const streamer of streamersData) {
+        const key = streamer.name.toLowerCase();
+        const group = byLogin.get(key);
+        if (group) group.push(streamer);
+        else byLogin.set(key, [streamer]);
+      }
+
       const results = await Promise.allSettled(
-        streamersData.map((streamer) => handlePollStreamer(streamer, liveByUserId)),
+        Array.from(byLogin.values()).map(async (group) => {
+          for (const streamer of group) {
+            await handlePollStreamer(streamer, liveByUserId);
+          }
+        }),
       );
       for (const result of results) {
         if (result.status === 'rejected') {

--- a/src/twitchMonitor.ts
+++ b/src/twitchMonitor.ts
@@ -77,6 +77,34 @@ async function handlePollStreamer(
   }
 }
 
+async function dispatchStreamerPolls(
+  streamers: DbStreamerFull[],
+  liveByUserId: Map<string, TwitchStream>,
+): Promise<void> {
+  // Group rows by login so same-login rows are serialized (shared offline-timer
+  // state); different logins run in parallel via Promise.allSettled.
+  const byLogin = new Map<string, DbStreamerFull[]>();
+  for (const streamer of streamers) {
+    const key = streamer.name.toLowerCase();
+    const existing = byLogin.get(key);
+    if (existing) existing.push(streamer);
+    else byLogin.set(key, [streamer]);
+  }
+
+  const results = await Promise.allSettled(
+    Array.from(byLogin.values()).map(async (group) => {
+      for (const streamer of group) {
+        await handlePollStreamer(streamer, liveByUserId);
+      }
+    }),
+  );
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      console.error('[TwitchMonitor] Error handling streamer poll:', result.reason);
+    }
+  }
+}
+
 async function pollStreams(): Promise<void> {
   if (pollRunning || streamersData.length === 0) return;
   pollRunning = true;
@@ -89,30 +117,7 @@ async function pollStreams(): Promise<void> {
       const liveByUserId = new Map(
         liveStreams.filter((s) => s.type === 'live').map((s) => [s.user_id, s]),
       );
-
-      // Group streamer rows by login so that rows sharing a login (same streamer,
-      // different groups) are processed sequentially — avoiding races on the
-      // shared login-scoped offline-timer state. Different logins run in parallel.
-      const byLogin = new Map<string, DbStreamerFull[]>();
-      for (const streamer of streamersData) {
-        const key = streamer.name.toLowerCase();
-        const group = byLogin.get(key);
-        if (group) group.push(streamer);
-        else byLogin.set(key, [streamer]);
-      }
-
-      const results = await Promise.allSettled(
-        Array.from(byLogin.values()).map(async (group) => {
-          for (const streamer of group) {
-            await handlePollStreamer(streamer, liveByUserId);
-          }
-        }),
-      );
-      for (const result of results) {
-        if (result.status === 'rejected') {
-          console.error('[TwitchMonitor] Error handling streamer poll:', result.reason);
-        }
-      }
+      await dispatchStreamerPolls(streamersData, liveByUserId);
     } catch (err) {
       console.error('[TwitchMonitor] Poll error:', err);
     } finally {

--- a/src/twitchMonitor.ts
+++ b/src/twitchMonitor.ts
@@ -91,18 +91,20 @@ async function dispatchStreamerPolls(
     else byLogin.set(key, [streamer]);
   }
 
-  const results = await Promise.allSettled(
+  await Promise.allSettled(
     Array.from(byLogin.values()).map(async (group) => {
       for (const streamer of group) {
-        await handlePollStreamer(streamer, liveByUserId);
+        try {
+          await handlePollStreamer(streamer, liveByUserId);
+        } catch (err) {
+          console.error(
+            `[TwitchMonitor] Error handling streamer poll for ${streamer.name} in group ${streamer.group.name}:`,
+            err,
+          );
+        }
       }
     }),
   );
-  for (const result of results) {
-    if (result.status === 'rejected') {
-      console.error('[TwitchMonitor] Error handling streamer poll:', result.reason);
-    }
-  }
 }
 
 async function pollStreams(): Promise<void> {


### PR DESCRIPTION
## Summary

Three independent reliability improvements from the code review:

- **`twitchApi.ts`** — `fetchHelixWithRetry` previously gave up after a single retry. A second 429 or a mis-estimated reset window would propagate as an error to the poll loop. It now retries up to `HELIX_MAX_RETRIES` (3) times before giving up.
- **`db/pool.ts`** — `connectionLimit` was 5, shared across web requests, named-lock writes, counter increments, and the Twitch monitor. Under any concurrent load the pool would queue requests unnecessarily. Raised to 15.
- **`twitchMonitor.ts`** — streamers were polled sequentially inside a `for…await` loop, so a slow Discord announcement for one streamer delayed all subsequent ones. Replaced with `Promise.allSettled` so all streamers are polled concurrently and a single failure is isolated.

## Test plan

- [ ] `npm test` passes (23/23)
- [ ] Start bot with several monitored streamers — confirm all go-live announcements post without serial delay
- [ ] Confirm rate-limited Twitch API calls retry (observable in logs)

https://claude.ai/code/session_01GXGUicTx3A3BxpoPF3Ladf

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXGUicTx3A3BxpoPF3Ladf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience to Twitch API rate limits with adaptive retries, backoff timing and retry logging.
* **Performance**
  * Increased database connection capacity to allow more concurrent requests.
  * Implemented concurrent streamer polling to process multiple streams in parallel while preserving per-stream sequencing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->