### PR TITLE
fix(shutdown): gracefully disconnect Twitch bot on SIGINT/SIGTERM

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import 'mediaplex'; // Must be imported first to register as Opus provider
 import { getPool, closePool } from './db';
-import { startTwitchBot, sayInChannel, getActiveChannels, getActiveChannelUserIds } from './twitchBot';
+import { startTwitchBot, stopTwitchBot, sayInChannel, getActiveChannels, getActiveChannelUserIds } from './twitchBot';
 import { startDiscordBot, stopDiscordBot } from './discordBot';
 import { startTikTokBot, stopTikTokBot } from './tiktokBot';
 import { startTwitchMonitor, stopTwitchMonitor } from './twitchMonitor';
@@ -17,6 +17,7 @@ async function shutdown(signal: string): Promise<void> {
   stopCounterScheduler();
   await stopTwitchMonitor();
   stopTikTokBot();
+  await stopTwitchBot();
   stopDiscordBot();
   disconnect();
   await closePool();

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -281,3 +281,18 @@ export async function partTwitchChannel(channel: string): Promise<void> {
     }
   });
 }
+
+export async function stopTwitchBot(): Promise<void> {
+  connected = false;
+  activeChannels.clear();
+  activeChannelUserIds.clear();
+  if (client) {
+    try {
+      await client.disconnect();
+    } catch (err) {
+      console.warn('[Twitch] Error during disconnect:', err);
+    }
+    client = null;
+  }
+  console.log('[Twitch] Disconnected.');
+}


### PR DESCRIPTION
## Summary

- Export `stopTwitchBot()` from `twitchBot.ts` — calls `client.disconnect()` (tmi.js graceful part), clears `activeChannels`, `activeChannelUserIds`, and `connected`
- Wire it into `shutdown()` in `index.ts` alongside the existing `stopDiscordBot()` / `stopTikTokBot()` calls

Previously the tmi.js client was abandoned on process exit rather than cleanly parted, which could leave the bot appearing in channels briefly after shutdown.

## Test plan

- [ ] `npm test` passes (23/23)
- [ ] Send `SIGINT` to the running bot — confirm `[Twitch] Disconnected.` appears in logs before process exits

https://claude.ai/code/session_01GXGUicTx3A3BxpoPF3Ladf

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXGUicTx3A3BxpoPF3Ladf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Twitch bot shutdown behavior to ensure proper disconnection and cleanup of active connections during application termination.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->