### PR TITLE
fix(config): remove dotenv override:true; add dev migration note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A multi-platform community bot connecting Twitch, Discord, and TikTok Live. Feat
 - Node.js, MySQL
 - `.env` file with credentials for each platform
 
+> **Dev environment note:** The `.env` file is the single source of truth for local configuration. dotenv only fills variables that are not already set in the environment — it does **not** override them. If you have any of the bot's variables exported in your shell profile (e.g. `~/.bashrc`, `~/.zshrc`), un-export or remove those entries so the `.env` values are used instead.
+
 ## Usage
 
 ```bash

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 import dotenv from 'dotenv';
-dotenv.config({ override: true });
+dotenv.config();
 
 function require_env(name: string): string {
   const value = process.env[name];


### PR DESCRIPTION
## Summary

- Remove `override: true` from `dotenv.config()` in `config.ts` — this flag silently clobbers environment variables already set by the shell or hosting platform, meaning a leftover `.env` file in production could override the authoritative deployment config without any warning
- Add a note to `README.md` explaining the conventional dotenv behaviour (`.env` fills gaps; OS/shell vars win) and what dev machines need to do

## Dev machine migration required

If you have any of the bot's variables exported in your shell profile (`~/.bashrc`, `~/.zshrc`, etc.) **in addition to** in `.env`, you need to reconcile them before merging this. The `.env` value will no longer win.

**Action:** Ensure `.env` is your single source of truth for local dev config, and un-export or remove any conflicting variables from your shell profile.

## Test plan

- [ ] `npm test` passes (23/23)
- [ ] Start the bot locally without any conflicting shell-level exports — confirm it still reads config correctly from `.env`
- [ ] Confirm that a shell-exported variable (e.g. `export DB_HOST=wronghost`) now takes precedence over the `.env` value

https://claude.ai/code/session_01GXGUicTx3A3BxpoPF3Ladf

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXGUicTx3A3BxpoPF3Ladf)_