### PR TITLE
Add !321 countdown command for Twitch

### DIFF
--- a/src/countdownHandler.ts
+++ b/src/countdownHandler.ts
@@ -1,0 +1,33 @@
+import { extractCommand } from './commandUtils';
+
+const COUNTDOWN_COMMAND = '!321';
+const STEPS = ['3', '2', '1', 'Go!'];
+const DELAY_MS = 1000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+interface CountdownTwitchRuntime {
+  send: (channel: string, message: string) => Promise<void>;
+}
+let _twitchRuntime: CountdownTwitchRuntime | null = null;
+
+export function registerCountdownTwitchRuntime(runtime: CountdownTwitchRuntime): void {
+  _twitchRuntime = runtime;
+}
+
+export async function executeCountdownForTwitch(channel: string, rawMessage: string): Promise<void> {
+  if (extractCommand(rawMessage) !== COUNTDOWN_COMMAND) return;
+  const runtime = _twitchRuntime;
+  if (!runtime) return;
+  for (let i = 0; i < STEPS.length; i++) {
+    if (i > 0) await sleep(DELAY_MS);
+    try {
+      await runtime.send(channel, STEPS[i]!);
+    } catch (err) {
+      console.error(`[Twitch] Countdown failed at '${STEPS[i]}' in ${channel}:`, err);
+      return;
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { registerTwitchChatRuntime } from './customCommandHandler';
 import { registerCounterTwitchRuntime } from './counterHandler';
 import { registerMultiTwitchRuntime } from './multiCommandHandler';
 import { registerShoutoutRuntime } from './shoutoutHandler';
+import { registerCountdownTwitchRuntime } from './countdownHandler';
 import { startCounterScheduler, stopCounterScheduler } from './counterScheduler';
 
 async function shutdown(signal: string): Promise<void> {
@@ -51,6 +52,7 @@ async function main(): Promise<void> {
   registerCounterTwitchRuntime({ send: sayInChannel });
   registerMultiTwitchRuntime({ send: sayInChannel, getActiveChannels, getLoginUserIds: getActiveChannelUserIds });
   registerShoutoutRuntime({ send: sayInChannel });
+  registerCountdownTwitchRuntime({ send: sayInChannel });
 
   startDiscordBot();
   await startTwitchBot();

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -5,6 +5,7 @@ import { executeCustomCommandForTwitch } from './customCommandHandler';
 import { executeCounterCommandForTwitch } from './counterHandler';
 import { executeMultiCommandForTwitch } from './multiCommandHandler';
 import { executeShoutoutForTwitch } from './shoutoutHandler';
+import { executeCountdownForTwitch } from './countdownHandler';
 import { setTwitchChannel } from './statusStore';
 import { getTwitchEnabledChannels } from './db';
 import { normalizeTwitchChannelName } from './twitchChannelName';
@@ -156,6 +157,10 @@ export async function startTwitchBot(): Promise<void> {
 
       handleCommand(message, 'twitch').catch((err) =>
         console.error('[Twitch] Command handler error:', err),
+      );
+
+      executeCountdownForTwitch(normalizedChannel, message).catch((err) =>
+        console.error('[Twitch] Countdown error:', err),
       );
     } catch (err) {
       console.error('[Twitch] Unexpected error in message handler:', err);


### PR DESCRIPTION
## Summary

- Adds a new `!321` command for Twitch chat
- When triggered, the bot sends "3", "2", "1", "Go!" with a 1-second gap between each message
- Follows the same runtime-injection pattern as existing handlers (`registerCountdownTwitchRuntime` wired in `index.ts`)

## Changes

- `src/countdownHandler.ts` — new file containing the handler logic
- `src/index.ts` — registers the Twitch runtime for the countdown handler
- `src/twitchBot.ts` — hooks `executeCountdownForTwitch` into the message event

## Test plan

- [ ] Send `!321` in a joined Twitch channel and confirm the bot replies with "3", "2", "1", "Go!" ~1 second apart
- [ ] Confirm other commands (`!sfx`, custom commands, counters) are unaffected

https://claude.ai/code/session_01Sn63f55uJefe9i1AopvxMg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added countdown feature for Twitch chat. Users can now trigger a countdown sequence that displays 3, 2, 1, and "Go!" with intervals between each message.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->