### PR TITLE
fix(eventsub): disconnect gracefully when no subscriptions; fix migration DEFAULT error

### DIFF
--- a/migrations/twitch_eventsub.sql
+++ b/migrations/twitch_eventsub.sql
@@ -11,14 +11,14 @@ CREATE TABLE streamer_event_config (
   streamer_id         INT PRIMARY KEY,
   -- Follows (requires broadcaster OAuth)
   follow_enabled      TINYINT(1) NOT NULL DEFAULT 0,
-  follow_message      TEXT NOT NULL DEFAULT 'Thanks {display_name} for the follow!',
+  follow_message      VARCHAR(500) NOT NULL DEFAULT 'Thanks {display_name} for the follow!',
   -- Subs/resubs/gifts (requires broadcaster OAuth)
   sub_enabled         TINYINT(1) NOT NULL DEFAULT 0,
-  sub_message         TEXT NOT NULL DEFAULT 'Thanks {display_name} for subscribing! (Tier {tier_name})',
-  resub_message       TEXT NOT NULL DEFAULT 'Thanks {display_name} for {months} months! (Tier {tier_name})',
-  giftsub_message     TEXT NOT NULL DEFAULT '{gifter_display} gifted {count} sub(s) to the community!',
+  sub_message         VARCHAR(500) NOT NULL DEFAULT 'Thanks {display_name} for subscribing! (Tier {tier_name})',
+  resub_message       VARCHAR(500) NOT NULL DEFAULT 'Thanks {display_name} for {months} months! (Tier {tier_name})',
+  giftsub_message     VARCHAR(500) NOT NULL DEFAULT '{gifter_display} gifted {count} sub(s) to the community!',
   -- Raids (app token — no OAuth needed)
   raid_enabled        TINYINT(1) NOT NULL DEFAULT 0,
-  raid_message        TEXT NOT NULL DEFAULT 'Welcome raiders from {from_channel}! Thank you for the {viewers} person raid!',
+  raid_message        VARCHAR(500) NOT NULL DEFAULT 'Welcome raiders from {from_channel}! Thank you for the {viewers} person raid!',
   FOREIGN KEY (streamer_id) REFERENCES streamer(id) ON DELETE CASCADE
 );

--- a/src/twitchEventSub.ts
+++ b/src/twitchEventSub.ts
@@ -69,11 +69,26 @@ export function stopEventSub(): void {
   ws = null;
 }
 
+/** Closes the connection without setting stopped=true, so reloadEventSubSubscriptions can restart. */
+function disconnectNoSubscriptions(): void {
+  log.info('No EventSub subscriptions configured — disconnecting until next reload');
+  clearKeepaliveTimer();
+  if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
+  ws?.close(1000, 'no subscriptions');
+  ws = null;
+  sessionId = null;
+}
+
 export function reloadEventSubSubscriptions(): void {
   reloadChain = reloadChain
     .then(async () => {
-      if (!ws || !sessionId) return;
-      await subscribeAll(sessionId);
+      if (!ws || !sessionId) {
+        // Not connected — may have auto-disconnected due to no subscriptions; restart if not user-stopped
+        if (!stopped) startEventSub();
+        return;
+      }
+      const count = await subscribeAll(sessionId);
+      if (count === 0) disconnectNoSubscriptions();
     })
     .catch((err) => { log.error('EventSub reload error:', err); });
 }
@@ -153,7 +168,9 @@ function handleMessage(msg: EventSubMessage): void {
       log.info(`Reconnected — session ${sessionId}`);
     } else {
       log.info(`Session established: ${sessionId}`);
-      subscribeAll(sessionId).catch((err) => log.error('Subscribe error:', err));
+      subscribeAll(sessionId)
+        .then((count) => { if (count === 0) disconnectNoSubscriptions(); })
+        .catch((err) => log.error('Subscribe error:', err));
     }
   } else if (message_type === 'session_reconnect') {
     const reconnectUrl = msg.payload.session?.reconnect_url;

--- a/src/twitchEventSubSubscriptions.ts
+++ b/src/twitchEventSubSubscriptions.ts
@@ -95,7 +95,7 @@ async function createSubscriptionsForStreamer(
   return desired;
 }
 
-export async function subscribeAll(sid: string): Promise<void> {
+export async function subscribeAll(sid: string): Promise<number> {
   const streamers = await getAllEventSubStreamers();
 
   // Build into a temporary map so dispatchNotification/handleRevocation see a
@@ -118,6 +118,7 @@ export async function subscribeAll(sid: string): Promise<void> {
   // Atomic swap — old map stays readable until all subscriptions are ready
   streamerMap.clear();
   for (const [uid, info] of nextMap) streamerMap.set(uid, info);
+  return streamerMap.size;
 }
 
 async function subscribe(sessionId: string, spec: SubSpec, token: string, login: string): Promise<void> {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **No-subscription spam fix**: when `subscribeAll()` returns 0 streamers, the bot now calls `disconnectNoSubscriptions()` instead of staying connected and getting immediately kicked by Twitch. The connection restarts automatically the next time `reloadEventSubSubscriptions()` is called (e.g. when an admin adds a streamer config).
- **Migration fix**: message columns changed from `TEXT` to `VARCHAR(500)` — MySQL does not allow `DEFAULT` values on `TEXT` columns (Error 1101), so the original migration would fail on a clean install.
- `subscribeAll()` now returns the streamer count so callers can make the disconnect decision.

## Test plan

- [ ] Run `migrations/twitch_eventsub.sql` on a clean DB — confirm no Error 1101
- [ ] Start bot with no streamers configured — confirm WebSocket does **not** keep reconnecting
- [ ] Add a streamer config via admin panel — confirm bot reconnects and subscribes

https://claude.ai/code/session_01TLybAVgM3qiuBuUfkwMhBV
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLybAVgM3qiuBuUfkwMhBV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Twitch EventSub subscription handling with enhanced automatic reconnection when service connectivity is unexpectedly lost, ensuring subscriptions are reestablished.
  * Better management of subscription state cleanup and disconnection logic.

* **Chores**
  * Database schema optimization for notification template column definitions, improving storage efficiency and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->