### PR TITLE
fix: guard rate limiter keyGenerator against undefined req.ip

### DIFF
--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -61,11 +61,14 @@ app.set('views', path.join(__dirname, '../../views'));
 app.use(express.static(path.join(__dirname, '../../public')));
 
 // Rate limiting — applied after static assets so file downloads aren't counted
+const ipKey = (req: express.Request) => req.ip ?? req.socket?.remoteAddress ?? 'unknown';
+
 const generalLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   limit: 100,
   standardHeaders: 'draft-8',
   legacyHeaders: false,
+  keyGenerator: ipKey,
   skip: (req) => req.path.startsWith('/api/streamdeck'),
 });
 // Tighter limit for auth endpoints to protect against OAuth quota exhaustion
@@ -74,6 +77,7 @@ const authLimiter = rateLimit({
   limit: 10,
   standardHeaders: 'draft-8',
   legacyHeaders: false,
+  keyGenerator: ipKey,
   message: 'Too many requests, please try again shortly.',
 });
 // Generous limit for the Streamdeck API — authenticated by API key, used for live button presses
@@ -82,6 +86,7 @@ const streamdeckLimiter = rateLimit({
   limit: 120,
   standardHeaders: 'draft-8',
   legacyHeaders: false,
+  keyGenerator: ipKey,
   message: 'Too many requests, please try again shortly.',
 });
 app.use(generalLimiter);


### PR DESCRIPTION
## Summary

- `standardHeaders: 'draft-8'` in `express-rate-limit` calls `getPartitionKey`, which hashes the client key via Node's `crypto.Hash`
- All three rate limiters relied on the default key (`req.ip`), which can be `undefined` when the server runs behind a proxy without `trust proxy` set, or on Unix-socket connections
- `Hash.update(undefined)` throws `ERR_INVALID_ARG_TYPE`, surfacing as an unhandled error in the web process

## Fix

Added a shared `ipKey` helper that falls back through `req.socket?.remoteAddress` and finally `'unknown'`, ensuring the hash never receives `undefined`. Applied as `keyGenerator` on all three limiters (`generalLimiter`, `authLimiter`, `streamdeckLimiter`).

## Test plan

- [ ] Reproduce: send a request where `req.ip` would be undefined (e.g. non-production env behind a proxy without `trust proxy`) — confirm no crash
- [ ] Confirm rate limiting still works normally for regular requests
- [ ] Check response headers contain `RateLimit-*` draft-8 headers as before

https://claude.ai/code/session_01E9VrrizWJ2Bt1Re8hguVnb

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9VrrizWJ2Bt1Re8hguVnb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rate limiting to use consistent client IP identification across general, authentication, and Streamdeck endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->