### PR TITLE
Consolidate streamer/user tables and add self-service settings page

### DIFF
--- a/DATABASE-SCHEMA.md
+++ b/DATABASE-SCHEMA.md
@@ -120,16 +120,46 @@ Stores configuration for Twitch announcement groups.
 
 ## `streamer`
 
-Stores monitored Twitch streamers and their current Discord post state.
+Stores monitored Twitch streamers and their current Discord post state. Each row maps a Discord user to a stream announcement group. The Twitch channel name is read from the linked `user` row (`user.twitch_name`) rather than stored redundantly.
 
 | Column | Type | Notes |
 | --- | --- | --- |
 | `id` | `INT` PK | Streamer row identifier |
-| `name` | `VARCHAR(...)` | Lowercase Twitch username |
+| `discord_id` | `BIGINT` UNIQUE | FK to `user.discord_id`; one row per user |
 | `group_id` | `INT` | FK to `stream_group.id` |
 | `discord_message_id` | `VARCHAR(20)` nullable | ID of the last announcement message |
 | `discord_channel_id` | `BIGINT` nullable | Channel where the last message was posted |
 | `live_game` | `VARCHAR(255)` nullable | Last seen live game |
+| `twitch_user_id` | `VARCHAR(50)` nullable | Twitch numeric user ID (used for EventSub) |
+| `eventsub_access_token` | `TEXT` nullable | AES-256-GCM encrypted Twitch broadcaster OAuth access token |
+| `eventsub_refresh_token` | `TEXT` nullable | AES-256-GCM encrypted refresh token |
+| `eventsub_token_expiry` | `BIGINT` nullable | Token expiry as Unix milliseconds |
+
+Expected constraints:
+
+- `UNIQUE KEY uq_streamer_discord_id (discord_id)` — enforces one stream group per user.
+- `FOREIGN KEY (discord_id) REFERENCES user(discord_id) ON DELETE CASCADE` — removing a user automatically removes their streamer row.
+- `FOREIGN KEY (group_id) REFERENCES stream_group(id)` — group must exist.
+
+Apply `migrations/consolidate_streamer_user.sql` to migrate from the previous schema (which stored `name VARCHAR` instead of `discord_id BIGINT`).
+
+## `streamer_event_config`
+
+Per-streamer EventSub notification message configuration. Applied once the streamer has connected their Twitch OAuth token.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `streamer_id` | `INT` PK | FK to `streamer.id` ON DELETE CASCADE |
+| `follow_enabled` | `TINYINT(1)` | Whether follow notifications are sent |
+| `follow_message` | `VARCHAR(500)` | Message template for follows |
+| `sub_enabled` | `TINYINT(1)` | Whether sub/resub/giftsub notifications are sent |
+| `sub_message` | `VARCHAR(500)` | New sub message template |
+| `resub_message` | `VARCHAR(500)` | Resub message template |
+| `giftsub_message` | `VARCHAR(500)` | Gift sub message template |
+| `raid_enabled` | `TINYINT(1)` | Whether raid notifications are sent |
+| `raid_message` | `VARCHAR(500)` | Raid message template |
+
+Created by `migrations/twitch_eventsub.sql`.
 
 ## `custom_command`
 

--- a/migrations/consolidate_streamer_user.sql
+++ b/migrations/consolidate_streamer_user.sql
@@ -4,10 +4,26 @@
 -- name-based join (streamer.name = user.twitch_name) with an explicit FK
 -- (streamer.discord_id → user.discord_id) and enforces one group per streamer.
 --
--- Run in order; check the verification query between steps 3 and 4.
+-- Run in order. If an error occurs inside the transaction, issue ROLLBACK
+-- before resolving the issue and re-running from START TRANSACTION.
 
 -- Step 1: Add discord_id column (nullable while backfilling)
 ALTER TABLE streamer ADD COLUMN discord_id BIGINT NULL;
+
+-- Temporary guard procedure — SIGNALs an error if any streamer rows have no
+-- matching user after the backfill. Dropped after use.
+DROP PROCEDURE IF EXISTS _migration_check_nulls;
+DELIMITER //
+CREATE PROCEDURE _migration_check_nulls()
+BEGIN
+  DECLARE cnt INT;
+  SELECT COUNT(*) INTO cnt FROM streamer WHERE discord_id IS NULL;
+  IF cnt > 0 THEN
+    SIGNAL SQLSTATE '45000'
+      SET MESSAGE_TEXT = 'Migration aborted: some streamer rows have no matching user. Run: SELECT name FROM streamer WHERE discord_id IS NULL — resolve the missing users, then re-run from START TRANSACTION.';
+  END IF;
+END//
+DELIMITER ;
 
 -- Steps 2–4 are DML and run inside a transaction so a partial failure is
 -- cleanly recoverable. (ALTER TABLE in steps 5–6 auto-commits and cannot
@@ -19,18 +35,59 @@ UPDATE streamer s
 JOIN `user` u ON LOWER(u.twitch_name) = LOWER(s.name)
 SET s.discord_id = u.discord_id;
 
--- Step 3: Verify — the following query must return 0 rows before proceeding.
---         If it returns rows, ROLLBACK and resolve missing users first.
--- SELECT name FROM streamer WHERE discord_id IS NULL;
+-- Step 3: Guard — abort if any rows were not matched.
+--         If this signals, issue ROLLBACK before resolving the missing users.
+CALL _migration_check_nulls();
 
--- Step 4: Deduplicate rows for any streamer that appears in multiple groups.
---         This keeps the row with the lowest id. Audit duplicates first:
---   SELECT discord_id, COUNT(*), GROUP_CONCAT(group_id) AS groups
+-- Step 4: Deduplicate rows for any discord_id that appears in multiple groups,
+--         preserving EventSub credentials and config.
+--
+--         Survivor selection (via window function):
+--           • Credentialed rows (twitch_user_id IS NOT NULL) rank first.
+--           • Among ties, the lower group_id wins (more senior group assignment).
+--
+--         Audit before running:
+--   SELECT discord_id, COUNT(*), GROUP_CONCAT(id ORDER BY id) AS ids,
+--          GROUP_CONCAT(group_id ORDER BY id) AS groups
 --   FROM streamer GROUP BY discord_id HAVING COUNT(*) > 1;
-DELETE s1 FROM streamer s1
-INNER JOIN streamer s2 ON s2.discord_id = s1.discord_id AND s2.id < s1.id;
+
+-- 4a: Identify the survivor id per duplicate discord_id.
+CREATE TEMPORARY TABLE _survivor AS
+WITH ranked AS (
+  SELECT id, discord_id,
+    ROW_NUMBER() OVER (
+      PARTITION BY discord_id
+      ORDER BY (twitch_user_id IS NULL), group_id ASC
+    ) AS rn
+  FROM streamer
+)
+SELECT discord_id, id AS survivor_id
+FROM ranked
+WHERE rn = 1
+  AND discord_id IN (
+    SELECT discord_id FROM streamer GROUP BY discord_id HAVING COUNT(*) > 1
+  );
+
+-- 4b: Reassociate streamer_event_config from a non-survivor to the survivor
+--     when the survivor has no existing config (ON DELETE CASCADE removes the rest).
+UPDATE streamer_event_config sec
+JOIN streamer s ON s.id = sec.streamer_id
+JOIN _survivor sv ON sv.discord_id = s.discord_id AND s.id != sv.survivor_id
+SET sec.streamer_id = sv.survivor_id
+WHERE NOT EXISTS (
+  SELECT 1 FROM streamer_event_config e WHERE e.streamer_id = sv.survivor_id
+);
+
+-- 4c: Delete non-survivor rows; cascade removes any remaining orphan configs.
+DELETE s FROM streamer s
+JOIN _survivor sv ON sv.discord_id = s.discord_id
+WHERE s.id != sv.survivor_id;
+
+DROP TEMPORARY TABLE _survivor;
 
 COMMIT;
+
+DROP PROCEDURE IF EXISTS _migration_check_nulls;
 
 -- Step 5: Apply NOT NULL, UNIQUE and FK constraints
 ALTER TABLE streamer MODIFY COLUMN discord_id BIGINT NOT NULL;

--- a/migrations/consolidate_streamer_user.sql
+++ b/migrations/consolidate_streamer_user.sql
@@ -28,6 +28,7 @@ DELIMITER ;
 -- Steps 2–4 are DML and run inside a transaction so a partial failure is
 -- cleanly recoverable. (ALTER TABLE in steps 5–6 auto-commits and cannot
 -- be made transactional in MySQL.)
+SET SQL_SAFE_UPDATES = 0;
 START TRANSACTION;
 
 -- Step 2: Backfill discord_id via the Twitch name match
@@ -95,6 +96,7 @@ DROP TEMPORARY TABLE _survivor;
 
 COMMIT;
 
+SET SQL_SAFE_UPDATES = 1;
 DROP PROCEDURE IF EXISTS _migration_check_nulls;
 
 -- Step 5: Apply NOT NULL, UNIQUE and FK constraints

--- a/migrations/consolidate_streamer_user.sql
+++ b/migrations/consolidate_streamer_user.sql
@@ -68,15 +68,23 @@ WHERE rn = 1
     SELECT discord_id FROM streamer GROUP BY discord_id HAVING COUNT(*) > 1
   );
 
--- 4b: Reassociate streamer_event_config from a non-survivor to the survivor
---     when the survivor has no existing config (ON DELETE CASCADE removes the rest).
+-- 4b: Reassociate one non-survivor streamer_event_config to the survivor when
+--     the survivor has no config of its own. Using a derived table with MIN()
+--     and GROUP BY survivor_id ensures exactly one source row is selected per
+--     survivor, preventing a PRIMARY KEY conflict if multiple non-survivors
+--     each have a config. The CASCADE in step 4c drops the rest.
 UPDATE streamer_event_config sec
-JOIN streamer s ON s.id = sec.streamer_id
-JOIN _survivor sv ON sv.discord_id = s.discord_id AND s.id != sv.survivor_id
-SET sec.streamer_id = sv.survivor_id
-WHERE NOT EXISTS (
-  SELECT 1 FROM streamer_event_config e WHERE e.streamer_id = sv.survivor_id
-);
+JOIN (
+  SELECT MIN(sec2.streamer_id) AS src_id, sv.survivor_id
+  FROM streamer_event_config sec2
+  JOIN streamer s ON s.id = sec2.streamer_id
+  JOIN _survivor sv ON sv.discord_id = s.discord_id AND s.id != sv.survivor_id
+  WHERE NOT EXISTS (
+    SELECT 1 FROM streamer_event_config e WHERE e.streamer_id = sv.survivor_id
+  )
+  GROUP BY sv.survivor_id
+) chosen ON chosen.src_id = sec.streamer_id
+SET sec.streamer_id = chosen.survivor_id;
 
 -- 4c: Delete non-survivor rows; cascade removes any remaining orphan configs.
 DELETE s FROM streamer s

--- a/migrations/consolidate_streamer_user.sql
+++ b/migrations/consolidate_streamer_user.sql
@@ -1,0 +1,41 @@
+-- Migration: consolidate_streamer_user
+-- Replaces the implicit name-join between `streamer` and `user` with an
+-- explicit FK, drops the redundant `streamer.name` column, and enforces
+-- one-group-per-streamer via a UNIQUE constraint.
+--
+-- Run this BEFORE deploying the matching application code.
+--
+-- STEP 0 — audit duplicates (run first, resolve manually if rows returned):
+--   SELECT discord_id, COUNT(*), GROUP_CONCAT(group_id) c
+--     FROM (SELECT s.id, u.discord_id, s.group_id
+--             FROM streamer s
+--             JOIN `user` u ON LOWER(u.twitch_name) = LOWER(s.name)) x
+--    GROUP BY discord_id HAVING COUNT(*) > 1;
+--
+-- STEP 1: add discord_id (nullable while backfilling)
+ALTER TABLE streamer ADD COLUMN discord_id BIGINT NULL;
+
+-- STEP 2: backfill from `user` via Twitch name match
+UPDATE streamer s
+  JOIN `user` u ON LOWER(u.twitch_name) = LOWER(s.name)
+  SET s.discord_id = u.discord_id;
+
+-- STEP 3: verify no unmatched rows remain before continuing:
+--   SELECT name FROM streamer WHERE discord_id IS NULL;
+-- Any rows here have no matching user account — resolve them before step 4.
+
+-- STEP 4: deduplicate multi-group rows — keeps the row with the lowest id.
+-- Review and adjust manually if you want to preserve a specific group_id.
+DELETE s1 FROM streamer s1
+  INNER JOIN streamer s2
+          ON s2.discord_id = s1.discord_id
+         AND s2.id < s1.id;
+
+-- STEP 5: enforce NOT NULL, add UNIQUE key, add FK
+ALTER TABLE streamer MODIFY COLUMN discord_id BIGINT NOT NULL;
+ALTER TABLE streamer ADD UNIQUE KEY uq_streamer_discord_id (discord_id);
+ALTER TABLE streamer ADD CONSTRAINT fk_streamer_user
+  FOREIGN KEY (discord_id) REFERENCES `user`(discord_id) ON DELETE CASCADE;
+
+-- STEP 6: drop the now-redundant name column
+ALTER TABLE streamer DROP COLUMN name;

--- a/migrations/consolidate_streamer_user.sql
+++ b/migrations/consolidate_streamer_user.sql
@@ -20,7 +20,7 @@ BEGIN
   SELECT COUNT(*) INTO cnt FROM streamer WHERE discord_id IS NULL;
   IF cnt > 0 THEN
     SIGNAL SQLSTATE '45000'
-      SET MESSAGE_TEXT = 'Migration aborted: some streamer rows have no matching user. Run: SELECT name FROM streamer WHERE discord_id IS NULL — resolve the missing users, then re-run from START TRANSACTION.';
+      SET MESSAGE_TEXT = 'Aborted: unmatched streamer rows. Check: SELECT name FROM streamer WHERE discord_id IS NULL then re-run from START TRANSACTION.';
   END IF;
 END//
 DELIMITER ;

--- a/migrations/consolidate_streamer_user.sql
+++ b/migrations/consolidate_streamer_user.sql
@@ -9,12 +9,18 @@
 -- Step 1: Add discord_id column (nullable while backfilling)
 ALTER TABLE streamer ADD COLUMN discord_id BIGINT NULL;
 
+-- Steps 2–4 are DML and run inside a transaction so a partial failure is
+-- cleanly recoverable. (ALTER TABLE in steps 5–6 auto-commits and cannot
+-- be made transactional in MySQL.)
+START TRANSACTION;
+
 -- Step 2: Backfill discord_id via the Twitch name match
 UPDATE streamer s
 JOIN `user` u ON LOWER(u.twitch_name) = LOWER(s.name)
 SET s.discord_id = u.discord_id;
 
--- Step 3: Verify — the following query must return 0 rows before proceeding
+-- Step 3: Verify — the following query must return 0 rows before proceeding.
+--         If it returns rows, ROLLBACK and resolve missing users first.
 -- SELECT name FROM streamer WHERE discord_id IS NULL;
 
 -- Step 4: Deduplicate rows for any streamer that appears in multiple groups.
@@ -23,6 +29,8 @@ SET s.discord_id = u.discord_id;
 --   FROM streamer GROUP BY discord_id HAVING COUNT(*) > 1;
 DELETE s1 FROM streamer s1
 INNER JOIN streamer s2 ON s2.discord_id = s1.discord_id AND s2.id < s1.id;
+
+COMMIT;
 
 -- Step 5: Apply NOT NULL, UNIQUE and FK constraints
 ALTER TABLE streamer MODIFY COLUMN discord_id BIGINT NOT NULL;

--- a/migrations/consolidate_streamer_user.sql
+++ b/migrations/consolidate_streamer_user.sql
@@ -1,41 +1,34 @@
--- Migration: consolidate_streamer_user
--- Replaces the implicit name-join between `streamer` and `user` with an
--- explicit FK, drops the redundant `streamer.name` column, and enforces
--- one-group-per-streamer via a UNIQUE constraint.
+-- Migration: consolidate streamer and user tables
 --
--- Run this BEFORE deploying the matching application code.
+-- Every streamer is a Discord user. This migration replaces the implicit
+-- name-based join (streamer.name = user.twitch_name) with an explicit FK
+-- (streamer.discord_id → user.discord_id) and enforces one group per streamer.
 --
--- STEP 0 — audit duplicates (run first, resolve manually if rows returned):
---   SELECT discord_id, COUNT(*), GROUP_CONCAT(group_id) c
---     FROM (SELECT s.id, u.discord_id, s.group_id
---             FROM streamer s
---             JOIN `user` u ON LOWER(u.twitch_name) = LOWER(s.name)) x
---    GROUP BY discord_id HAVING COUNT(*) > 1;
---
--- STEP 1: add discord_id (nullable while backfilling)
+-- Run in order; check the verification query between steps 3 and 4.
+
+-- Step 1: Add discord_id column (nullable while backfilling)
 ALTER TABLE streamer ADD COLUMN discord_id BIGINT NULL;
 
--- STEP 2: backfill from `user` via Twitch name match
+-- Step 2: Backfill discord_id via the Twitch name match
 UPDATE streamer s
-  JOIN `user` u ON LOWER(u.twitch_name) = LOWER(s.name)
-  SET s.discord_id = u.discord_id;
+JOIN `user` u ON LOWER(u.twitch_name) = LOWER(s.name)
+SET s.discord_id = u.discord_id;
 
--- STEP 3: verify no unmatched rows remain before continuing:
---   SELECT name FROM streamer WHERE discord_id IS NULL;
--- Any rows here have no matching user account — resolve them before step 4.
+-- Step 3: Verify — the following query must return 0 rows before proceeding
+-- SELECT name FROM streamer WHERE discord_id IS NULL;
 
--- STEP 4: deduplicate multi-group rows — keeps the row with the lowest id.
--- Review and adjust manually if you want to preserve a specific group_id.
+-- Step 4: Deduplicate rows for any streamer that appears in multiple groups.
+--         This keeps the row with the lowest id. Audit duplicates first:
+--   SELECT discord_id, COUNT(*), GROUP_CONCAT(group_id) AS groups
+--   FROM streamer GROUP BY discord_id HAVING COUNT(*) > 1;
 DELETE s1 FROM streamer s1
-  INNER JOIN streamer s2
-          ON s2.discord_id = s1.discord_id
-         AND s2.id < s1.id;
+INNER JOIN streamer s2 ON s2.discord_id = s1.discord_id AND s2.id < s1.id;
 
--- STEP 5: enforce NOT NULL, add UNIQUE key, add FK
+-- Step 5: Apply NOT NULL, UNIQUE and FK constraints
 ALTER TABLE streamer MODIFY COLUMN discord_id BIGINT NOT NULL;
 ALTER TABLE streamer ADD UNIQUE KEY uq_streamer_discord_id (discord_id);
 ALTER TABLE streamer ADD CONSTRAINT fk_streamer_user
   FOREIGN KEY (discord_id) REFERENCES `user`(discord_id) ON DELETE CASCADE;
 
--- STEP 6: drop the now-redundant name column
+-- Step 6: Drop the now-redundant name column
 ALTER TABLE streamer DROP COLUMN name;

--- a/migrations/twitch_eventsub.sql
+++ b/migrations/twitch_eventsub.sql
@@ -14,11 +14,11 @@ CREATE TABLE streamer_event_config (
   follow_message      VARCHAR(500) NOT NULL DEFAULT 'Thanks {display_name} for the follow!',
   -- Subs/resubs/gifts (requires broadcaster OAuth)
   sub_enabled         TINYINT(1) NOT NULL DEFAULT 0,
-  sub_message         VARCHAR(500) NOT NULL DEFAULT 'Thanks {display_name} for subscribing! (Tier {tier_name})',
-  resub_message       VARCHAR(500) NOT NULL DEFAULT 'Thanks {display_name} for {months} months! (Tier {tier_name})',
+  sub_message         VARCHAR(500) NOT NULL DEFAULT 'Thanks {display_name} for subscribing! (Tier {tier})',
+  resub_message       VARCHAR(500) NOT NULL DEFAULT 'Thanks {display_name} for {months} months! (Tier {tier})',
   giftsub_message     VARCHAR(500) NOT NULL DEFAULT '{gifter_display} gifted {count} sub(s) to the community!',
   -- Raids (app token — no OAuth needed)
   raid_enabled        TINYINT(1) NOT NULL DEFAULT 0,
-  raid_message        VARCHAR(500) NOT NULL DEFAULT 'Welcome raiders from {from_channel}! Thank you for the {viewers} person raid!',
+  raid_message        VARCHAR(500) NOT NULL DEFAULT 'Welcome raiders from {from_display}! Thank you for the {viewers} person raid!',
   FOREIGN KEY (streamer_id) REFERENCES streamer(id) ON DELETE CASCADE
 );

--- a/public/streams-eventsub.js
+++ b/public/streams-eventsub.js
@@ -1,7 +1,0 @@
-document.querySelectorAll('.btn-toggle-eventsub').forEach(function(btn) {
-  btn.addEventListener('click', function() {
-    var id = btn.getAttribute('data-streamer-id');
-    var row = document.getElementById('eventsub-' + id);
-    if (row) row.classList.toggle('is-hidden');
-  });
-});

--- a/src/db.ts
+++ b/src/db.ts
@@ -82,7 +82,8 @@ export type {
 // ─── EventSub ────────────────────────────────────────────────────────────────
 
 export {
-  getAllEventSubStreamers, saveStreamerToken, clearStreamerToken, saveEventConfig,
+  getAllEventSubStreamers, getStreamerByDiscordId,
+  saveStreamerToken, clearStreamerToken, saveEventConfig,
 } from './db/eventSub';
 export type { DbStreamerEventSub, EventSubConfig } from './db/eventSub';
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -82,7 +82,7 @@ export type {
 // ─── EventSub ────────────────────────────────────────────────────────────────
 
 export {
-  getAllEventSubStreamers, getStreamerByDiscordId,
+  getAllEventSubStreamers, getStreamerByDiscordId, getStreamerById,
   saveStreamerToken, clearStreamerToken, saveEventConfig,
 } from './db/eventSub';
 export type { DbStreamerEventSub, EventSubConfig } from './db/eventSub';

--- a/src/db/eventSub.ts
+++ b/src/db/eventSub.ts
@@ -16,7 +16,8 @@ export interface EventSubConfig {
 
 export interface DbStreamerEventSub {
   id: number;
-  name: string;
+  discord_id: string;
+  twitch_name: string | null;
   twitch_user_id: string | null;
   eventsub_access_token: string | null;
   eventsub_refresh_token: string | null;
@@ -51,27 +52,49 @@ function maybeDecrypt(value: string | null): string | null {
   }
 }
 
-export async function getAllEventSubStreamers(): Promise<DbStreamerEventSub[]> {
-  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    `SELECT s.id, s.name, s.twitch_user_id,
-            s.eventsub_access_token, s.eventsub_refresh_token, s.eventsub_token_expiry,
-            c.follow_enabled, c.follow_message,
-            c.sub_enabled, c.sub_message, c.resub_message, c.giftsub_message,
-            c.raid_enabled, c.raid_message
-     FROM streamer s
-     INNER JOIN \`user\` u ON u.twitch_name = s.name AND u.is_twitch_bot_enabled = 1
-     LEFT JOIN streamer_event_config c ON c.streamer_id = s.id
-     ORDER BY s.name`,
-  );
-  return rows.map((r) => ({
+function mapStreamerEventSub(r: mysql.RowDataPacket): DbStreamerEventSub {
+  return {
     id: r.id,
-    name: r.name,
+    discord_id: String(r.discord_id),
+    twitch_name: r.twitch_name ?? null,
     twitch_user_id: r.twitch_user_id ?? null,
     eventsub_access_token: maybeDecrypt(r.eventsub_access_token ?? null),
     eventsub_refresh_token: maybeDecrypt(r.eventsub_refresh_token ?? null),
     eventsub_token_expiry: r.eventsub_token_expiry != null ? Number(r.eventsub_token_expiry) : null,
     config: r.follow_enabled != null ? mapConfig(r) : null,
-  }));
+  };
+}
+
+const EVENT_SUB_SELECT = `
+  s.id, s.discord_id, u.twitch_name,
+  s.twitch_user_id,
+  s.eventsub_access_token, s.eventsub_refresh_token, s.eventsub_token_expiry,
+  c.follow_enabled, c.follow_message,
+  c.sub_enabled, c.sub_message, c.resub_message, c.giftsub_message,
+  c.raid_enabled, c.raid_message`;
+
+export async function getAllEventSubStreamers(): Promise<DbStreamerEventSub[]> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT ${EVENT_SUB_SELECT}
+     FROM streamer s
+     JOIN \`user\` u ON u.discord_id = s.discord_id
+     LEFT JOIN streamer_event_config c ON c.streamer_id = s.id
+     WHERE u.is_twitch_bot_enabled = 1
+     ORDER BY u.twitch_name`,
+  );
+  return rows.map(mapStreamerEventSub);
+}
+
+export async function getStreamerByDiscordId(discordId: string): Promise<DbStreamerEventSub | null> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT ${EVENT_SUB_SELECT}
+     FROM streamer s
+     JOIN \`user\` u ON u.discord_id = s.discord_id
+     LEFT JOIN streamer_event_config c ON c.streamer_id = s.id
+     WHERE s.discord_id = ?`,
+    [discordId],
+  );
+  return rows.length === 0 ? null : mapStreamerEventSub(rows[0]);
 }
 
 export async function saveStreamerToken(

--- a/src/db/eventSub.ts
+++ b/src/db/eventSub.ts
@@ -97,6 +97,18 @@ export async function getStreamerByDiscordId(discordId: string): Promise<DbStrea
   return rows.length === 0 ? null : mapStreamerEventSub(rows[0]);
 }
 
+export async function getStreamerById(id: number): Promise<DbStreamerEventSub | null> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT ${EVENT_SUB_SELECT}
+     FROM streamer s
+     JOIN \`user\` u ON u.discord_id = s.discord_id
+     LEFT JOIN streamer_event_config c ON c.streamer_id = s.id
+     WHERE s.id = ?`,
+    [id],
+  );
+  return rows.length === 0 ? null : mapStreamerEventSub(rows[0]);
+}
+
 export async function saveStreamerToken(
   streamerId: number,
   twitchUserId: string,

--- a/src/db/streamMonitor.ts
+++ b/src/db/streamMonitor.ts
@@ -27,7 +27,9 @@ export interface UpdateStreamGroupInput extends AddStreamGroupInput {
 /** Flat view used by the admin web panel (streamer + group name only). */
 export interface DbStreamer {
   id: number;
-  name: string;
+  discord_id: string;
+  twitch_name: string | null;
+  discord_name: string | null;
   group_id: number;
   group_name: string;
 }
@@ -35,7 +37,8 @@ export interface DbStreamer {
 /** Full view used by twitchMonitor — includes DB-persisted live state. */
 export interface DbStreamerFull {
   id: number;
-  name: string;
+  discord_id: string;
+  twitch_name: string | null;
   discord_message_id: string | null;
   discord_channel_id: string | null;
   live_game: string | null;
@@ -99,14 +102,19 @@ export async function removeStreamGroup(id: number): Promise<void> {
 
 export async function getAllStreamers(): Promise<DbStreamer[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    `SELECT s.id, s.name, s.group_id, g.name AS group_name
+    `SELECT s.id, s.discord_id, s.group_id,
+            u.twitch_name, u.discord_name,
+            g.name AS group_name
      FROM streamer s
+     JOIN \`user\` u ON u.discord_id = s.discord_id
      JOIN stream_group g ON s.group_id = g.id
-     ORDER BY g.name, s.name`,
+     ORDER BY g.name, u.twitch_name`,
   );
   return rows.map((r) => ({
     id: r.id,
-    name: r.name,
+    discord_id: String(r.discord_id),
+    twitch_name: r.twitch_name ?? null,
+    discord_name: r.discord_name ?? null,
     group_id: r.group_id,
     group_name: r.group_name,
   }));
@@ -114,17 +122,20 @@ export async function getAllStreamers(): Promise<DbStreamer[]> {
 
 export async function getAllStreamersWithGroups(): Promise<DbStreamerFull[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    `SELECT s.id, s.name, s.group_id,
+    `SELECT s.id, s.discord_id, s.group_id,
+            u.twitch_name,
             s.discord_message_id, s.discord_channel_id, s.live_game,
             g.name AS group_name, g.discord_channel, g.live_message, g.new_game_message,
             g.multi_twitch, g.delete_old_posts
      FROM streamer s
+     JOIN \`user\` u ON u.discord_id = s.discord_id
      JOIN stream_group g ON s.group_id = g.id
-     ORDER BY g.id, s.name`,
+     ORDER BY g.id, u.twitch_name`,
   );
   return rows.map((r) => ({
     id: r.id,
-    name: r.name,
+    discord_id: String(r.discord_id),
+    twitch_name: r.twitch_name ?? null,
     discord_message_id: r.discord_message_id ?? null,
     discord_channel_id: r.discord_channel_id !== null && r.discord_channel_id !== undefined ? String(r.discord_channel_id) : null,
     live_game: r.live_game ?? null,
@@ -140,10 +151,10 @@ export async function getAllStreamersWithGroups(): Promise<DbStreamerFull[]> {
   }));
 }
 
-export async function addStreamer(name: string, groupId: number): Promise<void> {
+export async function addStreamer(discordId: string, groupId: number): Promise<void> {
   await getPool().execute(
-    'INSERT INTO streamer (name, group_id) VALUES (?, ?)',
-    [name.toLowerCase().trim(), groupId],
+    'INSERT INTO streamer (discord_id, group_id) VALUES (?, ?)',
+    [discordId, groupId],
   );
 }
 

--- a/src/twitchEventSubSubscriptions.ts
+++ b/src/twitchEventSubSubscriptions.ts
@@ -46,11 +46,12 @@ async function deleteStaleSubscriptions(uid: string, desired: Set<string>, userT
 async function resolveBroadcasterId(streamer: DbStreamerEventSub, config: EventSubConfig | null): Promise<string | null> {
   if (streamer.twitch_user_id) return streamer.twitch_user_id;
   if (!config?.raid_enabled) return null;
+  if (!streamer.twitch_name) return null;
   try {
-    const users = await getUsers([streamer.name]);
+    const users = await getUsers([streamer.twitch_name]);
     return users[0]?.id ?? null;
   } catch (err) {
-    log.error(`Failed to resolve Twitch user ID for ${streamer.name}:`, err);
+    log.error(`Failed to resolve Twitch user ID for ${streamer.twitch_name}:`, err);
     return null;
   }
 }
@@ -99,10 +100,10 @@ export async function subscribeAll(sid: string): Promise<number> {
     const uid = await resolveBroadcasterId(streamer, config);
     if (!uid) continue;
 
-    nextMap.set(uid, { login: streamer.name, streamerId: streamer.id, config });
+    nextMap.set(uid, { login: streamer.twitch_name ?? '', streamerId: streamer.id, config });
 
     // Create desired subscriptions first so there is never a gap where zero are active
-    const desired = await createSubscriptionsForStreamer(sid, uid, token, config, streamer.name);
+    const desired = await createSubscriptionsForStreamer(sid, uid, token, config, streamer.twitch_name ?? '');
     await deleteStaleSubscriptions(uid, desired, token);
   }
 
@@ -130,7 +131,7 @@ async function maybeRefreshToken(streamer: DbStreamerEventSub): Promise<string |
   if (!needsRefresh) return streamer.eventsub_access_token;
 
   if (!streamer.eventsub_refresh_token) {
-    log.warn(`No refresh token for ${streamer.name}`);
+    log.warn(`No refresh token for ${streamer.twitch_name ?? 'unknown'}`);
     return null;
   }
 
@@ -138,14 +139,14 @@ async function maybeRefreshToken(streamer: DbStreamerEventSub): Promise<string |
     const tokens = await refreshUserToken(streamer.eventsub_refresh_token);
     const expiryMs = Date.now() + tokens.expires_in * 1000 - 60_000;
     await saveStreamerToken(streamer.id, streamer.twitch_user_id!, tokens.access_token, tokens.refresh_token, expiryMs);
-    log.info(`Token refreshed for ${streamer.name}`);
+    log.info(`Token refreshed for ${streamer.twitch_name ?? 'unknown'}`);
     return tokens.access_token;
   } catch (err) {
     if (err instanceof TwitchAuthError) {
       await clearStreamerToken(streamer.id);
-      log.error(`Token refresh failed for ${streamer.name} — re-authorization required:`, err);
+      log.error(`Token refresh failed for ${streamer.twitch_name ?? 'unknown'} — re-authorization required:`, err);
     } else {
-      log.error(`Token refresh failed for ${streamer.name} — transient error, will retry on next reload:`, err);
+      log.error(`Token refresh failed for ${streamer.twitch_name ?? 'unknown'} — transient error, will retry on next reload:`, err);
     }
     return null;
   }

--- a/src/twitchMonitor.ts
+++ b/src/twitchMonitor.ts
@@ -45,7 +45,8 @@ async function handlePollStreamer(
   streamer: DbStreamerFull,
   liveByUserId: Map<string, TwitchStream>,
 ): Promise<void> {
-  const loginKey = streamer.name.toLowerCase();
+  const loginKey = streamer.twitch_name?.toLowerCase();
+  if (!loginKey) return;
   const stateKey = String(streamer.id);
   const userId = loginToUserId.get(loginKey);
   if (!userId) return;
@@ -88,7 +89,8 @@ async function dispatchStreamerPolls(
   // state); different logins run in parallel via Promise.allSettled.
   const byLogin = new Map<string, DbStreamerFull[]>();
   for (const streamer of streamers) {
-    const key = streamer.name.toLowerCase();
+    const key = streamer.twitch_name?.toLowerCase() ?? '';
+    if (!key) continue;
     const existing = byLogin.get(key);
     if (existing) existing.push(streamer);
     else byLogin.set(key, [streamer]);
@@ -100,7 +102,7 @@ async function dispatchStreamerPolls(
         try {
           await handlePollStreamer(streamer, liveByUserId);
         } catch (err) {
-          log.error(`Error handling streamer poll for ${streamer.name} in group ${streamer.group.name}:`, err);
+          log.error(`Error handling streamer poll for ${streamer.twitch_name ?? 'unknown'} in group ${streamer.group.name}:`, err);
         }
       }
     }),
@@ -148,7 +150,7 @@ export async function startTwitchMonitor(): Promise<void> {
     log.warn('No streamers configured in DB — nothing to monitor');
   }
 
-  const logins = streamersData.map((s) => s.name);
+  const logins = streamersData.map((s) => s.twitch_name).filter((n): n is string => n !== null);
   const users = await getUsers(logins);
   loginToUserId = new Map(users.map((u) => [u.login.toLowerCase(), u.id]));
 

--- a/src/twitchMonitorStartup.ts
+++ b/src/twitchMonitorStartup.ts
@@ -21,7 +21,7 @@ export async function tryEditStartupMessage(
   try {
     const channel = await discordClient.channels.fetch(streamer.discord_channel_id);
     if (!channel || !channel.isTextBased()) return false;
-    const vars = templateVars(streamer.name, liveStream);
+    const vars = templateVars(liveStream.user_login, liveStream);
     const content = fillTemplate(streamer.group.live_message, vars);
     const embed = buildEmbed(liveStream);
     const message = await channel.messages.fetch(streamer.discord_message_id);
@@ -31,7 +31,7 @@ export async function tryEditStartupMessage(
     return true;
   } catch (err) {
     if (isDiscordNotFoundError(err)) return false;
-    log.error(`Failed to edit startup message for ${streamer.name}:`, err);
+    log.error(`Failed to edit startup message for ${streamer.twitch_name ?? 'unknown'}:`, err);
     throw err;
   }
 }
@@ -101,7 +101,8 @@ export async function performStartupLiveCheck(
   const groupsWithChanges = new Set<number>();
 
   for (const streamer of streamersData) {
-    const userId = loginToUserId.get(streamer.name.toLowerCase());
+    const loginKey = streamer.twitch_name?.toLowerCase();
+    const userId = loginKey ? loginToUserId.get(loginKey) : undefined;
     if (!userId) continue;
 
     const liveStream = liveByUserId.get(userId);

--- a/src/web/routes/eventsubAdmin.ts
+++ b/src/web/routes/eventsubAdmin.ts
@@ -1,58 +1,16 @@
 import { createLogger } from '../../logger';
 import { Router } from 'express';
-import { randomBytes } from 'crypto';
-import {
-  getAllEventSubStreamers,
-  saveEventConfig,
-  clearStreamerToken,
-  getTwitchEnabledChannels,
-  EventSubConfig,
-} from '../../db';
+import { clearStreamerToken } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireAdmin } from '../middleware';
 import { reloadEventSubSubscriptions } from '../../twitchEventSub';
-import { TWITCH_CLIENT_ID, TWITCH_EVENTSUB_REDIRECT_URI, EVENTSUB_TOKEN_SECRET } from '../../config';
 import { parsePositiveIntId } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
 
-const TWITCH_OAUTH_SCOPE = 'moderator:read:followers channel:read:subscriptions';
-
-router.get('/streams/twitch-oauth/:streamerId', requireAdmin, async (req, res) => {
-  const streamerId = parsePositiveIntId(req.params['streamerId']);
-  if (streamerId === null) return res.redirect('/admin/streams?error=invalid_id');
-
-  const streamers = await getAllEventSubStreamers().catch(() => null);
-  const streamer = streamers?.find((s) => s.id === streamerId);
-  if (!streamer) return res.redirect('/admin/streams?error=invalid_id');
-
-  const botEnabled = await getTwitchEnabledChannels().catch(() => [] as string[]);
-  if (!botEnabled.includes(streamer.name.toLowerCase())) {
-    return res.redirect('/admin/streams?error=eventsub_not_bot_enabled');
-  }
-
-  if (!TWITCH_EVENTSUB_REDIRECT_URI || !EVENTSUB_TOKEN_SECRET) {
-    log.error('TWITCH_EVENTSUB_REDIRECT_URI or EVENTSUB_TOKEN_SECRET is not configured');
-    return res.redirect('/admin/streams?error=eventsub_config_failed');
-  }
-
-  const state = randomBytes(16).toString('hex');
-  req.session.eventsubOAuthState = state;
-  req.session.eventsubStreamerId = streamerId;
-
-  const params = new URLSearchParams({
-    client_id: TWITCH_CLIENT_ID,
-    redirect_uri: TWITCH_EVENTSUB_REDIRECT_URI,
-    response_type: 'code',
-    scope: TWITCH_OAUTH_SCOPE,
-    state,
-    force_verify: 'true',
-  });
-
-  res.redirect(`https://id.twitch.tv/oauth2/authorize?${params.toString()}`);
-});
-
+// Admin-only emergency disconnect — e.g. if a streamer's OAuth token is compromised.
+// Normal connect/disconnect flows live in /user/settings.
 router.post('/streams/twitch-disconnect/:streamerId', requireAdmin, csrfProtection, async (req, res) => {
   const streamerId = parsePositiveIntId(req.params.streamerId);
   if (streamerId === null) return res.redirect('/admin/streams?error=invalid_id');
@@ -61,59 +19,9 @@ router.post('/streams/twitch-disconnect/:streamerId', requireAdmin, csrfProtecti
     await clearStreamerToken(streamerId);
     reloadEventSubSubscriptions();
   } catch (err) {
-    log.error('EventSub disconnect error:', err);
+    log.error('EventSub admin disconnect error:', err);
     return res.redirect('/admin/streams?error=eventsub_disconnect_failed');
   }
-  res.redirect('/admin/streams');
-});
-
-router.post('/streams/event-config/:streamerId', requireAdmin, csrfProtection, async (req, res) => {
-  const streamerId = parsePositiveIntId(req.params.streamerId);
-  if (streamerId === null) return res.redirect('/admin/streams?error=invalid_id');
-
-  const botEnabled = await getTwitchEnabledChannels().catch(() => [] as string[]);
-  const streamers = await getAllEventSubStreamers().catch(() => null);
-  const streamer = streamers?.find((s) => s.id === streamerId);
-  if (!streamer || !botEnabled.includes(streamer.name.toLowerCase())) {
-    return res.redirect('/admin/streams?error=eventsub_not_bot_enabled');
-  }
-
-  const body = req.body as Record<string, string | undefined>;
-
-  const MESSAGE_MAX_LENGTH = 500;
-  const messageFields = ['follow_message', 'sub_message', 'resub_message', 'giftsub_message', 'raid_message'] as const;
-  for (const field of messageFields) {
-    const value = (body[field] ?? '').trim();
-    if (value.length > MESSAGE_MAX_LENGTH) {
-      return res.redirect('/admin/streams?error=eventsub_config_failed');
-    }
-  }
-
-  // Follow/sub inputs are disabled in the UI when the streamer is disconnected, so those
-  // keys are absent from the POST body. Fall back to existing config to avoid wiping saved settings.
-  const current = streamer.config;
-  function bodyMsg(key: string, fallback: string): string {
-    return key in body ? ((body[key] ?? '').trim() || fallback) : (current?.[key as keyof EventSubConfig] as string | undefined ?? fallback);
-  }
-  const config: EventSubConfig = {
-    follow_enabled: 'follow_enabled' in body ? body.follow_enabled === 'on' : (current?.follow_enabled ?? false),
-    follow_message: bodyMsg('follow_message', 'Thanks {display_name} for the follow!'),
-    sub_enabled: 'sub_enabled' in body ? body.sub_enabled === 'on' : (current?.sub_enabled ?? false),
-    sub_message: bodyMsg('sub_message', 'Thanks {display_name} for subscribing! (Tier {tier_name})'),
-    resub_message: bodyMsg('resub_message', 'Thanks {display_name} for {months} months! (Tier {tier_name})'),
-    giftsub_message: bodyMsg('giftsub_message', '{gifter_display} gifted {count} sub(s) to the community!'),
-    raid_enabled: body.raid_enabled === 'on',
-    raid_message: bodyMsg('raid_message', 'Welcome raiders from {from_channel}! Thank you for the {viewers} person raid!'),
-  };
-
-  try {
-    await saveEventConfig(streamerId, config);
-    reloadEventSubSubscriptions();
-  } catch (err) {
-    log.error('EventSub config save error:', err);
-    return res.redirect('/admin/streams?error=eventsub_config_failed');
-  }
-
   res.redirect('/admin/streams');
 });
 

--- a/src/web/routes/eventsubCallback.ts
+++ b/src/web/routes/eventsubCallback.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '../../logger';
 import { Router } from 'express';
-import { getAllEventSubStreamers, saveStreamerToken } from '../../db';
+import { getStreamerById, saveStreamerToken } from '../../db';
 import { exchangeCode, getUserFromToken } from '../../twitchApiEventSub';
 import { TWITCH_EVENTSUB_REDIRECT_URI } from '../../config';
 import { reloadEventSubSubscriptions } from '../../twitchEventSub';
@@ -43,8 +43,7 @@ router.get('/twitch/eventsub/callback', async (req, res) => {
     const twitchUser = await getUserFromToken(tokens.access_token);
     if (!twitchUser) return res.redirect('/user/settings?error=eventsub_token_invalid');
 
-    const streamers = await getAllEventSubStreamers();
-    const streamer = streamers.find((s) => s.id === streamerId);
+    const streamer = await getStreamerById(streamerId);
     if (!streamer) return res.redirect('/user/settings?error=invalid_id');
 
     const expectedLogin = streamer.twitch_name?.toLowerCase();

--- a/src/web/routes/eventsubCallback.ts
+++ b/src/web/routes/eventsubCallback.ts
@@ -9,14 +9,14 @@ const log = createLogger('Web');
 const router = Router();
 
 // GET /auth/twitch/eventsub/callback
-// No requireAuth — Twitch redirects here outside the normal admin session flow.
+// No requireAuth — Twitch redirects here outside the normal session flow.
 // CSRF is handled via the session state set during OAuth initiation.
 router.get('/twitch/eventsub/callback', async (req, res) => {
   const { code, state, error } = req.query as Record<string, string | undefined>;
 
   if (error) {
     log.warn(`EventSub OAuth denied: ${error}`);
-    return res.redirect('/admin/streams?error=eventsub_oauth_denied');
+    return res.redirect('/user/settings?error=eventsub_oauth_denied');
   }
 
   const expectedState = req.session.eventsubOAuthState;
@@ -27,39 +27,40 @@ router.get('/twitch/eventsub/callback', async (req, res) => {
   delete req.session.eventsubStreamerId;
 
   if (!code || !state || !expectedState || !streamerId) {
-    return res.redirect('/admin/streams?error=eventsub_oauth_state_mismatch');
+    return res.redirect('/user/settings?error=eventsub_oauth_state_mismatch');
   }
   if (state !== expectedState) {
-    return res.redirect('/admin/streams?error=eventsub_oauth_state_mismatch');
+    return res.redirect('/user/settings?error=eventsub_oauth_state_mismatch');
   }
 
   if (!TWITCH_EVENTSUB_REDIRECT_URI) {
     log.error('TWITCH_EVENTSUB_REDIRECT_URI is not configured');
-    return res.redirect('/admin/streams?error=eventsub_config_failed');
+    return res.redirect('/user/settings?error=eventsub_config_failed');
   }
 
   try {
     const tokens = await exchangeCode(code, TWITCH_EVENTSUB_REDIRECT_URI);
-    const user = await getUserFromToken(tokens.access_token);
-    if (!user) return res.redirect('/admin/streams?error=eventsub_token_invalid');
+    const twitchUser = await getUserFromToken(tokens.access_token);
+    if (!twitchUser) return res.redirect('/user/settings?error=eventsub_token_invalid');
 
     const streamers = await getAllEventSubStreamers();
     const streamer = streamers.find((s) => s.id === streamerId);
-    if (!streamer) return res.redirect('/admin/streams?error=invalid_id');
+    if (!streamer) return res.redirect('/user/settings?error=invalid_id');
 
-    if (user.login.toLowerCase() !== streamer.name.toLowerCase()) {
-      log.warn(`EventSub OAuth mismatch: expected ${streamer.name}, got ${user.login}`);
-      return res.redirect(`/admin/streams?error=eventsub_wrong_account&expected=${encodeURIComponent(streamer.name)}`);
+    const expectedLogin = streamer.twitch_name?.toLowerCase();
+    if (!expectedLogin || twitchUser.login.toLowerCase() !== expectedLogin) {
+      log.warn(`EventSub OAuth mismatch: expected ${streamer.twitch_name ?? 'unknown'}, got ${twitchUser.login}`);
+      return res.redirect(`/user/settings?error=eventsub_wrong_account&expected=${encodeURIComponent(streamer.twitch_name ?? '')}`);
     }
 
     const expiryMs = Date.now() + tokens.expires_in * 1000 - 60_000;
-    await saveStreamerToken(streamerId, user.id, tokens.access_token, tokens.refresh_token, expiryMs);
+    await saveStreamerToken(streamerId, twitchUser.id, tokens.access_token, tokens.refresh_token, expiryMs);
     reloadEventSubSubscriptions();
-    log.info(`EventSub OAuth connected for ${streamer.name}`);
-    res.redirect('/admin/streams?success=twitch_connected');
+    log.info(`EventSub OAuth connected for ${streamer.twitch_name}`);
+    res.redirect('/user/settings?success=twitch_connected');
   } catch (err) {
     log.error('EventSub OAuth callback error:', err);
-    res.redirect('/admin/streams?error=eventsub_config_failed');
+    res.redirect('/user/settings?error=eventsub_config_failed');
   }
 });
 

--- a/src/web/routes/streams.ts
+++ b/src/web/routes/streams.ts
@@ -10,7 +10,7 @@ import {
   removeStreamer,
   removeStreamersByGroup,
   getAllEventSubStreamers,
-  getTwitchEnabledChannels,
+  getAllUsers,
 } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireManager } from '../middleware';
@@ -29,26 +29,18 @@ const KNOWN_ERRORS = new Set([
   'missing_fields', 'invalid_id',
   'add_group_failed', 'update_group_failed', 'remove_group_failed',
   'add_streamer_failed', 'remove_streamer_failed',
-  'eventsub_not_bot_enabled', 'eventsub_config_failed', 'eventsub_disconnect_failed',
-  'eventsub_oauth_denied', 'eventsub_oauth_state_mismatch', 'eventsub_token_invalid',
-  'eventsub_wrong_account',
+  'eventsub_disconnect_failed',
 ]);
 
 export const ERROR_MESSAGES: Record<string, string> = {
-  missing_fields:                'All required fields must be filled in.',
-  invalid_id:                    'Invalid ID — please try again.',
-  add_group_failed:              'Failed to add stream group. Please try again.',
-  update_group_failed:           'Failed to update stream group. Please try again.',
-  remove_group_failed:           'Failed to remove stream group. Please try again.',
-  add_streamer_failed:           'Failed to add streamer. Please try again.',
-  remove_streamer_failed:        'Failed to remove streamer. Please try again.',
-  eventsub_not_bot_enabled:      'Notifications can only be configured for channels with the Twitch bot enabled.',
-  eventsub_config_failed:        'Failed to save notification config. Please try again.',
-  eventsub_disconnect_failed:    'Failed to disconnect Twitch account. Please try again.',
-  eventsub_oauth_denied:         'Twitch authorization was denied.',
-  eventsub_oauth_state_mismatch: 'Authorization failed — please try connecting again.',
-  eventsub_token_invalid:        'Could not verify the Twitch account. Please try again.',
-  eventsub_wrong_account:        'Wrong Twitch account — please authorize with the correct broadcaster account.',
+  missing_fields:             'All required fields must be filled in.',
+  invalid_id:                 'Invalid ID — please try again.',
+  add_group_failed:           'Failed to add stream group. Please try again.',
+  update_group_failed:        'Failed to update stream group. Please try again.',
+  remove_group_failed:        'Failed to remove stream group. Please try again.',
+  add_streamer_failed:        'Failed to add streamer. Please try again.',
+  remove_streamer_failed:     'Failed to remove streamer. Please try again.',
+  eventsub_disconnect_failed: 'Failed to disconnect Twitch account. Please try again.',
 };
 
 function getFriendlyError(key: string): string {
@@ -60,16 +52,22 @@ function getFriendlyError(key: string): string {
 router.get('/streams', requireManager, csrfProtection, async (req, res) => {
   try {
     const isAdmin = (req.session.user?.accessLevel ?? 0) >= AccessLevel.ADMIN;
-    const [groups, streamers, eventSubStreamers, botEnabledChannels] = await Promise.all([
+    const [groups, streamers, eventSubStreamers, allUsers] = await Promise.all([
       getAllStreamGroups(),
       getAllStreamers(),
       isAdmin ? getAllEventSubStreamers() : Promise.resolve([]),
-      isAdmin ? getTwitchEnabledChannels() : Promise.resolve([]),
+      getAllUsers(),
     ]);
 
+    // EventSub status keyed by streamer row id — admin only
     const eventSubById: Record<number, (typeof eventSubStreamers)[0]> = {};
     for (const s of eventSubStreamers) eventSubById[s.id] = s;
-    const botEnabledSet = new Set(botEnabledChannels);
+
+    // Users eligible to be added as streamers: have a Twitch name, not already a streamer
+    const existingStreamerIds = new Set(streamers.map((s) => s.discord_id));
+    const eligibleUsers = allUsers.filter(
+      (u) => u.twitch_name && !existingStreamerIds.has(u.discord_id),
+    );
 
     res.render('streams', {
       user: req.session.user,
@@ -77,14 +75,10 @@ router.get('/streams', requireManager, csrfProtection, async (req, res) => {
       streamers,
       isAdmin,
       eventSubById,
-      botEnabledSet,
+      eligibleUsers,
       csrfToken: req.csrfToken(),
       error: KNOWN_ERRORS.has(req.query.error as string) ? (req.query.error as string) : null,
       success: req.query.success as string | undefined,
-      successExpectedAccount: (() => {
-        const expected = req.query.expected as string | undefined;
-        return expected && botEnabledSet.has(expected) ? expected : undefined;
-      })(),
       getFriendlyError,
     });
   } catch (err) {
@@ -110,17 +104,12 @@ router.post('/streams/groups/add', requireManager, csrfProtection, async (req, r
     return res.redirect('/admin/streams?error=missing_fields');
   }
 
-  const normalizedName = name!.trim();
-  const normalizedDiscordChannel = discord_channel!.trim();
-  const normalizedLiveMessage = live_message!.trim();
-  const normalizedNewGameMessage = new_game_message!.trim();
-
   try {
     await addStreamGroup({
-      name: normalizedName,
-      discordChannel: normalizedDiscordChannel,
-      liveMessage: normalizedLiveMessage,
-      newGameMessage: normalizedNewGameMessage,
+      name: name!.trim(),
+      discordChannel: discord_channel!.trim(),
+      liveMessage: live_message!.trim(),
+      newGameMessage: new_game_message!.trim(),
       multiTwitch: multi_twitch,
       deleteOldPosts: delete_old_posts,
     });
@@ -141,21 +130,16 @@ router.post('/streams/groups/update', requireManager, csrfProtection, async (req
     return res.redirect('/admin/streams?error=missing_fields');
   }
 
-  const normalizedName = name!.trim();
-  const normalizedDiscordChannel = discord_channel!.trim();
-  const normalizedLiveMessage = live_message!.trim();
-  const normalizedNewGameMessage = new_game_message!.trim();
-
   const parsedGroupId = parsePositiveIntId(group_id);
   if (parsedGroupId === null) return res.redirect('/admin/streams?error=invalid_id');
 
   try {
     await updateStreamGroup({
       id: parsedGroupId,
-      name: normalizedName,
-      discordChannel: normalizedDiscordChannel,
-      liveMessage: normalizedLiveMessage,
-      newGameMessage: normalizedNewGameMessage,
+      name: name!.trim(),
+      discordChannel: discord_channel!.trim(),
+      liveMessage: live_message!.trim(),
+      newGameMessage: new_game_message!.trim(),
       multiTwitch: multi_twitch,
       deleteOldPosts: delete_old_posts,
     });
@@ -188,13 +172,13 @@ router.post('/streams/groups/remove', requireManager, csrfProtection, async (req
 // ─── Streamers ────────────────────────────────────────────────────────────────
 
 router.post('/streams/streamers/add', requireManager, csrfProtection, async (req, res) => {
-  const { name, group_id } = req.body as { name?: string; group_id?: string };
-  if (!name || !group_id) return res.redirect('/admin/streams');
+  const { discord_id, group_id } = req.body as { discord_id?: string; group_id?: string };
+  if (!discord_id || !group_id) return res.redirect('/admin/streams?error=missing_fields');
   const parsedGroupId = parsePositiveIntId(group_id);
   if (parsedGroupId === null) return res.redirect('/admin/streams?error=invalid_id');
 
   try {
-    await addStreamer(name.trim(), parsedGroupId);
+    await addStreamer(discord_id.trim(), parsedGroupId);
     triggerRestart();
   } catch (err) {
     log.error('Add streamer error:', err);

--- a/src/web/routes/streams.ts
+++ b/src/web/routes/streams.ts
@@ -11,6 +11,7 @@ import {
   removeStreamersByGroup,
   getAllEventSubStreamers,
   getAllUsers,
+  findUser,
 } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireManager } from '../middleware';
@@ -176,6 +177,9 @@ router.post('/streams/streamers/add', requireManager, csrfProtection, async (req
   if (!discord_id || !group_id) return res.redirect('/admin/streams?error=missing_fields');
   const parsedGroupId = parsePositiveIntId(group_id);
   if (parsedGroupId === null) return res.redirect('/admin/streams?error=invalid_id');
+
+  const user = await findUser(discord_id.trim()).catch(() => null);
+  if (!user?.twitch_name) return res.redirect('/admin/streams?error=missing_fields');
 
   try {
     await addStreamer(discord_id.trim(), parsedGroupId);

--- a/src/web/routes/streams.ts
+++ b/src/web/routes/streams.ts
@@ -178,10 +178,9 @@ router.post('/streams/streamers/add', requireManager, csrfProtection, async (req
   const parsedGroupId = parsePositiveIntId(group_id);
   if (parsedGroupId === null) return res.redirect('/admin/streams?error=invalid_id');
 
-  const user = await findUser(discord_id.trim()).catch(() => null);
-  if (!user?.twitch_name) return res.redirect('/admin/streams?error=missing_fields');
-
   try {
+    const user = await findUser(discord_id.trim());
+    if (!user?.twitch_name) return res.redirect('/admin/streams?error=missing_fields');
     await addStreamer(discord_id.trim(), parsedGroupId);
     triggerRestart();
   } catch (err) {

--- a/src/web/routes/userSettings.ts
+++ b/src/web/routes/userSettings.ts
@@ -1,0 +1,173 @@
+import { createLogger } from '../../logger';
+import { Router } from 'express';
+import { randomBytes } from 'crypto';
+import { findUser, getStreamerByDiscordId, saveEventConfig, clearStreamerToken, EventSubConfig } from '../../db';
+import { csrfProtection } from '../csrf';
+import { requireAuth } from '../middleware';
+import { reloadEventSubSubscriptions } from '../../twitchEventSub';
+import { TWITCH_CLIENT_ID, TWITCH_EVENTSUB_REDIRECT_URI, EVENTSUB_TOKEN_SECRET } from '../../config';
+
+const log = createLogger('Web');
+const router = Router();
+
+const TWITCH_OAUTH_SCOPE = 'moderator:read:followers channel:read:subscriptions';
+
+const KNOWN_ERRORS = new Set([
+  'no_streamer_record',
+  'eventsub_not_bot_enabled',
+  'eventsub_config_failed',
+  'eventsub_disconnect_failed',
+  'eventsub_oauth_denied',
+  'eventsub_oauth_state_mismatch',
+  'eventsub_token_invalid',
+  'eventsub_wrong_account',
+  'invalid_id',
+]);
+
+const ERROR_MESSAGES: Record<string, string> = {
+  no_streamer_record:            'You are not configured as a monitored streamer.',
+  eventsub_not_bot_enabled:      'The Twitch bot must be enabled for your channel before you can configure notifications. Contact a Manager or Admin.',
+  eventsub_config_failed:        'Failed to save notification config. Please try again.',
+  eventsub_disconnect_failed:    'Failed to disconnect Twitch account. Please try again.',
+  eventsub_oauth_denied:         'Twitch authorization was denied.',
+  eventsub_oauth_state_mismatch: 'Authorization failed — please try connecting again.',
+  eventsub_token_invalid:        'Could not verify the Twitch account. Please try again.',
+  eventsub_wrong_account:        'Wrong Twitch account — please authorize with your own broadcaster account.',
+  invalid_id:                    'Invalid request — please try again.',
+};
+
+function getFriendlyError(key: string): string {
+  return ERROR_MESSAGES[key] ?? `An error occurred (${key}).`;
+}
+
+// GET /user/settings
+router.get('/', requireAuth, csrfProtection, async (req, res) => {
+  try {
+    const discordId = req.session.user!.discordId;
+    const [dbUser, streamer] = await Promise.all([
+      findUser(discordId),
+      getStreamerByDiscordId(discordId),
+    ]);
+
+    const errorKey = KNOWN_ERRORS.has(req.query.error as string) ? (req.query.error as string) : null;
+    const expectedAccount = (() => {
+      if (errorKey !== 'eventsub_wrong_account') return undefined;
+      const expected = req.query.expected as string | undefined;
+      return expected && streamer?.twitch_name?.toLowerCase() === expected.toLowerCase() ? expected : undefined;
+    })();
+
+    res.render('userSettings', {
+      user: req.session.user,
+      dbUser,
+      streamer,
+      csrfToken: req.csrfToken(),
+      error: errorKey,
+      success: req.query.success as string | undefined,
+      successExpectedAccount: expectedAccount,
+      getFriendlyError,
+    });
+  } catch (err) {
+    log.error('User settings page error:', err);
+    res.status(500).render('error', { message: 'Failed to load settings page.', user: req.session.user ?? null });
+  }
+});
+
+// GET /user/twitch-connect — initiates Twitch OAuth for the logged-in user
+router.get('/twitch-connect', requireAuth, async (req, res) => {
+  const discordId = req.session.user!.discordId;
+
+  const [dbUser, streamer] = await Promise.all([
+    findUser(discordId).catch(() => null),
+    getStreamerByDiscordId(discordId).catch(() => null),
+  ]);
+
+  if (!streamer) return res.redirect('/user/settings?error=no_streamer_record');
+  if (!dbUser?.is_twitch_bot_enabled) return res.redirect('/user/settings?error=eventsub_not_bot_enabled');
+
+  if (!TWITCH_EVENTSUB_REDIRECT_URI || !EVENTSUB_TOKEN_SECRET) {
+    log.error('TWITCH_EVENTSUB_REDIRECT_URI or EVENTSUB_TOKEN_SECRET is not configured');
+    return res.redirect('/user/settings?error=eventsub_config_failed');
+  }
+
+  const state = randomBytes(16).toString('hex');
+  req.session.eventsubOAuthState = state;
+  req.session.eventsubStreamerId = streamer.id;
+
+  const params = new URLSearchParams({
+    client_id: TWITCH_CLIENT_ID,
+    redirect_uri: TWITCH_EVENTSUB_REDIRECT_URI,
+    response_type: 'code',
+    scope: TWITCH_OAUTH_SCOPE,
+    state,
+    force_verify: 'true',
+  });
+
+  res.redirect(`https://id.twitch.tv/oauth2/authorize?${params.toString()}`);
+});
+
+// POST /user/twitch-disconnect
+router.post('/twitch-disconnect', requireAuth, csrfProtection, async (req, res) => {
+  const discordId = req.session.user!.discordId;
+  const streamer = await getStreamerByDiscordId(discordId).catch(() => null);
+  if (!streamer) return res.redirect('/user/settings?error=no_streamer_record');
+
+  try {
+    await clearStreamerToken(streamer.id);
+    reloadEventSubSubscriptions();
+  } catch (err) {
+    log.error('EventSub disconnect error:', err);
+    return res.redirect('/user/settings?error=eventsub_disconnect_failed');
+  }
+  res.redirect('/user/settings');
+});
+
+// POST /user/eventsub-config
+router.post('/eventsub-config', requireAuth, csrfProtection, async (req, res) => {
+  const discordId = req.session.user!.discordId;
+
+  const [dbUser, streamer] = await Promise.all([
+    findUser(discordId).catch(() => null),
+    getStreamerByDiscordId(discordId).catch(() => null),
+  ]);
+
+  if (!streamer) return res.redirect('/user/settings?error=no_streamer_record');
+  if (!dbUser?.is_twitch_bot_enabled) return res.redirect('/user/settings?error=eventsub_not_bot_enabled');
+
+  const body = req.body as Record<string, string | undefined>;
+
+  const MESSAGE_MAX_LENGTH = 500;
+  const messageFields = ['follow_message', 'sub_message', 'resub_message', 'giftsub_message', 'raid_message'] as const;
+  for (const field of messageFields) {
+    if ((body[field] ?? '').trim().length > MESSAGE_MAX_LENGTH) {
+      return res.redirect('/user/settings?error=eventsub_config_failed');
+    }
+  }
+
+  // Inputs are disabled in the UI when disconnected, so those keys are absent from
+  // the POST body. Fall back to existing config to avoid wiping saved settings.
+  const current = streamer.config;
+  function bodyMsg(key: string, fallback: string): string {
+    return key in body ? ((body[key] ?? '').trim() || fallback) : (current?.[key as keyof EventSubConfig] as string | undefined ?? fallback);
+  }
+  const config: EventSubConfig = {
+    follow_enabled:  'follow_enabled'  in body ? body.follow_enabled  === 'on' : (current?.follow_enabled  ?? false),
+    follow_message:  bodyMsg('follow_message',  'Thanks {display_name} for the follow!'),
+    sub_enabled:     'sub_enabled'     in body ? body.sub_enabled     === 'on' : (current?.sub_enabled     ?? false),
+    sub_message:     bodyMsg('sub_message',     'Thanks {display_name} for subscribing! (Tier {tier_name})'),
+    resub_message:   bodyMsg('resub_message',   'Thanks {display_name} for {months} months! (Tier {tier_name})'),
+    giftsub_message: bodyMsg('giftsub_message', '{gifter_display} gifted {count} sub(s) to the community!'),
+    raid_enabled:    body.raid_enabled === 'on',
+    raid_message:    bodyMsg('raid_message',    'Welcome raiders from {from_channel}! Thank you for the {viewers} person raid!'),
+  };
+
+  try {
+    await saveEventConfig(streamer.id, config);
+    reloadEventSubSubscriptions();
+  } catch (err) {
+    log.error('EventSub config save error:', err);
+    return res.redirect('/user/settings?error=eventsub_config_failed');
+  }
+  res.redirect('/user/settings');
+});
+
+export default router;

--- a/src/web/routes/userSettings.ts
+++ b/src/web/routes/userSettings.ts
@@ -84,8 +84,8 @@ router.get('/twitch-connect', requireAuth, async (req, res) => {
   if (!streamer) return res.redirect('/user/settings?error=no_streamer_record');
   if (!dbUser?.is_twitch_bot_enabled) return res.redirect('/user/settings?error=eventsub_not_bot_enabled');
 
-  if (!TWITCH_EVENTSUB_REDIRECT_URI || !EVENTSUB_TOKEN_SECRET) {
-    log.error('TWITCH_EVENTSUB_REDIRECT_URI or EVENTSUB_TOKEN_SECRET is not configured');
+  if (!TWITCH_CLIENT_ID || !TWITCH_EVENTSUB_REDIRECT_URI || !EVENTSUB_TOKEN_SECRET) {
+    log.error('TWITCH_CLIENT_ID, TWITCH_EVENTSUB_REDIRECT_URI, or EVENTSUB_TOKEN_SECRET is not configured');
     return res.redirect('/user/settings?error=eventsub_config_failed');
   }
 
@@ -156,7 +156,7 @@ router.post('/eventsub-config', requireAuth, csrfProtection, async (req, res) =>
     sub_message:     bodyMsg('sub_message',     'Thanks {display_name} for subscribing! (Tier {tier})'),
     resub_message:   bodyMsg('resub_message',   'Thanks {display_name} for {months} months! (Tier {tier})'),
     giftsub_message: bodyMsg('giftsub_message', '{gifter_display} gifted {count} sub(s) to the community!'),
-    raid_enabled:    body.raid_enabled === 'on',
+    raid_enabled:    'raid_enabled' in body ? body.raid_enabled === 'on' : (current?.raid_enabled ?? false),
     raid_message:    bodyMsg('raid_message',    'Welcome raiders from {from_display}! Thank you for the {viewers} person raid!'),
   };
 

--- a/src/web/routes/userSettings.ts
+++ b/src/web/routes/userSettings.ts
@@ -81,100 +81,105 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
 
 // GET /user/twitch-connect — initiates Twitch OAuth for the logged-in user
 router.get('/twitch-connect', requireAuth, async (req, res) => {
-  const discordId = req.session.user!.discordId;
+  try {
+    const discordId = req.session.user!.discordId;
 
-  const [dbUser, streamer] = await Promise.all([
-    findUser(discordId).catch(() => null),
-    getStreamerByDiscordId(discordId).catch(() => null),
-  ]);
+    const [dbUser, streamer] = await Promise.all([
+      findUser(discordId),
+      getStreamerByDiscordId(discordId),
+    ]);
 
-  if (!streamer) return res.redirect('/user/settings?error=no_streamer_record');
-  if (!dbUser?.is_twitch_bot_enabled) return res.redirect('/user/settings?error=eventsub_not_bot_enabled');
+    if (!streamer) return res.redirect('/user/settings?error=no_streamer_record');
+    if (!dbUser?.is_twitch_bot_enabled) return res.redirect('/user/settings?error=eventsub_not_bot_enabled');
 
-  if (!TWITCH_CLIENT_ID || !TWITCH_EVENTSUB_REDIRECT_URI || !EVENTSUB_TOKEN_SECRET) {
-    log.error('TWITCH_CLIENT_ID, TWITCH_EVENTSUB_REDIRECT_URI, or EVENTSUB_TOKEN_SECRET is not configured');
-    return res.redirect('/user/settings?error=eventsub_config_failed');
+    if (!TWITCH_CLIENT_ID || !TWITCH_EVENTSUB_REDIRECT_URI || !EVENTSUB_TOKEN_SECRET) {
+      log.error('TWITCH_CLIENT_ID, TWITCH_EVENTSUB_REDIRECT_URI, or EVENTSUB_TOKEN_SECRET is not configured');
+      return res.redirect('/user/settings?error=eventsub_config_failed');
+    }
+
+    const state = randomBytes(16).toString('hex');
+    req.session.eventsubOAuthState = state;
+    req.session.eventsubStreamerId = streamer.id;
+
+    const params = new URLSearchParams({
+      client_id: TWITCH_CLIENT_ID,
+      redirect_uri: TWITCH_EVENTSUB_REDIRECT_URI,
+      response_type: 'code',
+      scope: TWITCH_OAUTH_SCOPE,
+      state,
+      force_verify: 'true',
+    });
+
+    res.redirect(`https://id.twitch.tv/oauth2/authorize?${params.toString()}`);
+  } catch (err) {
+    log.error('Twitch connect error:', err);
+    res.redirect('/user/settings?error=eventsub_config_failed');
   }
-
-  const state = randomBytes(16).toString('hex');
-  req.session.eventsubOAuthState = state;
-  req.session.eventsubStreamerId = streamer.id;
-
-  const params = new URLSearchParams({
-    client_id: TWITCH_CLIENT_ID,
-    redirect_uri: TWITCH_EVENTSUB_REDIRECT_URI,
-    response_type: 'code',
-    scope: TWITCH_OAUTH_SCOPE,
-    state,
-    force_verify: 'true',
-  });
-
-  res.redirect(`https://id.twitch.tv/oauth2/authorize?${params.toString()}`);
 });
 
 // POST /user/twitch-disconnect
 router.post('/twitch-disconnect', requireAuth, csrfProtection, async (req, res) => {
-  const discordId = req.session.user!.discordId;
-  const streamer = await getStreamerByDiscordId(discordId).catch(() => null);
-  if (!streamer) return res.redirect('/user/settings?error=no_streamer_record');
-
   try {
+    const discordId = req.session.user!.discordId;
+    const streamer = await getStreamerByDiscordId(discordId);
+    if (!streamer) return res.redirect('/user/settings?error=no_streamer_record');
+
     await clearStreamerToken(streamer.id);
     reloadEventSubSubscriptions();
+    res.redirect('/user/settings');
   } catch (err) {
     log.error('EventSub disconnect error:', err);
-    return res.redirect('/user/settings?error=eventsub_disconnect_failed');
+    res.redirect('/user/settings?error=eventsub_disconnect_failed');
   }
-  res.redirect('/user/settings');
 });
 
 // POST /user/eventsub-config
 router.post('/eventsub-config', requireAuth, csrfProtection, async (req, res) => {
-  const discordId = req.session.user!.discordId;
-
-  const [dbUser, streamer] = await Promise.all([
-    findUser(discordId).catch(() => null),
-    getStreamerByDiscordId(discordId).catch(() => null),
-  ]);
-
-  if (!streamer) return res.redirect('/user/settings?error=no_streamer_record');
-  if (!dbUser?.is_twitch_bot_enabled) return res.redirect('/user/settings?error=eventsub_not_bot_enabled');
-
-  const body = req.body as Record<string, string | undefined>;
-
-  const MESSAGE_MAX_LENGTH = 500;
-  const messageFields = ['follow_message', 'sub_message', 'resub_message', 'giftsub_message', 'raid_message'] as const;
-  for (const field of messageFields) {
-    if ((body[field] ?? '').trim().length > MESSAGE_MAX_LENGTH) {
-      return res.redirect('/user/settings?error=eventsub_config_failed');
-    }
-  }
-
-  // Inputs are disabled in the UI when disconnected, so those keys are absent from
-  // the POST body. Fall back to existing config to avoid wiping saved settings.
-  const current = streamer.config;
-  function bodyMsg(key: string, fallback: string): string {
-    return key in body ? ((body[key] ?? '').trim() || fallback) : (current?.[key as keyof EventSubConfig] as string | undefined ?? fallback);
-  }
-  const config: EventSubConfig = {
-    follow_enabled:  'follow_enabled'  in body ? body.follow_enabled  === 'on' : (current?.follow_enabled  ?? false),
-    follow_message:  bodyMsg('follow_message',  'Thanks {display_name} for the follow!'),
-    sub_enabled:     'sub_enabled'     in body ? body.sub_enabled     === 'on' : (current?.sub_enabled     ?? false),
-    sub_message:     bodyMsg('sub_message',     'Thanks {display_name} for subscribing! (Tier {tier})'),
-    resub_message:   bodyMsg('resub_message',   'Thanks {display_name} for {months} months! (Tier {tier})'),
-    giftsub_message: bodyMsg('giftsub_message', '{gifter_display} gifted {count} sub(s) to the community!'),
-    raid_enabled:    'raid_enabled' in body ? body.raid_enabled === 'on' : (current?.raid_enabled ?? false),
-    raid_message:    bodyMsg('raid_message',    'Welcome raiders from {from_display}! Thank you for the {viewers} person raid!'),
-  };
-
   try {
+    const discordId = req.session.user!.discordId;
+
+    const [dbUser, streamer] = await Promise.all([
+      findUser(discordId),
+      getStreamerByDiscordId(discordId),
+    ]);
+
+    if (!streamer) return res.redirect('/user/settings?error=no_streamer_record');
+    if (!dbUser?.is_twitch_bot_enabled) return res.redirect('/user/settings?error=eventsub_not_bot_enabled');
+
+    const body = req.body as Record<string, string | undefined>;
+
+    const MESSAGE_MAX_LENGTH = 500;
+    const messageFields = ['follow_message', 'sub_message', 'resub_message', 'giftsub_message', 'raid_message'] as const;
+    for (const field of messageFields) {
+      if ((body[field] ?? '').trim().length > MESSAGE_MAX_LENGTH) {
+        return res.redirect('/user/settings?error=eventsub_config_failed');
+      }
+    }
+
+    // Inputs are disabled in the UI when disconnected, so those keys are absent from
+    // the POST body. Fall back to existing config to avoid wiping saved settings.
+    const current = streamer.config;
+    function bodyMsg(key: string, fallback: string): string {
+      return key in body ? ((body[key] ?? '').trim() || fallback) : (current?.[key as keyof EventSubConfig] as string | undefined ?? fallback);
+    }
+    const config: EventSubConfig = {
+      follow_enabled:  'follow_enabled'  in body ? body.follow_enabled  === 'on' : (current?.follow_enabled  ?? false),
+      follow_message:  bodyMsg('follow_message',  'Thanks {display_name} for the follow!'),
+      sub_enabled:     'sub_enabled'     in body ? body.sub_enabled     === 'on' : (current?.sub_enabled     ?? false),
+      sub_message:     bodyMsg('sub_message',     'Thanks {display_name} for subscribing! (Tier {tier})'),
+      resub_message:   bodyMsg('resub_message',   'Thanks {display_name} for {months} months! (Tier {tier})'),
+      giftsub_message: bodyMsg('giftsub_message', '{gifter_display} gifted {count} sub(s) to the community!'),
+      raid_enabled:    'raid_enabled' in body ? body.raid_enabled === 'on' : (current?.raid_enabled ?? false),
+      raid_message:    bodyMsg('raid_message',    'Welcome raiders from {from_display}! Thank you for the {viewers} person raid!'),
+    };
+
     await saveEventConfig(streamer.id, config);
     reloadEventSubSubscriptions();
+    res.redirect('/user/settings');
   } catch (err) {
     log.error('EventSub config save error:', err);
-    return res.redirect('/user/settings?error=eventsub_config_failed');
+    res.redirect('/user/settings?error=eventsub_config_failed');
   }
-  res.redirect('/user/settings');
 });
 
 export default router;

--- a/src/web/routes/userSettings.ts
+++ b/src/web/routes/userSettings.ts
@@ -153,11 +153,11 @@ router.post('/eventsub-config', requireAuth, csrfProtection, async (req, res) =>
     follow_enabled:  'follow_enabled'  in body ? body.follow_enabled  === 'on' : (current?.follow_enabled  ?? false),
     follow_message:  bodyMsg('follow_message',  'Thanks {display_name} for the follow!'),
     sub_enabled:     'sub_enabled'     in body ? body.sub_enabled     === 'on' : (current?.sub_enabled     ?? false),
-    sub_message:     bodyMsg('sub_message',     'Thanks {display_name} for subscribing! (Tier {tier_name})'),
-    resub_message:   bodyMsg('resub_message',   'Thanks {display_name} for {months} months! (Tier {tier_name})'),
+    sub_message:     bodyMsg('sub_message',     'Thanks {display_name} for subscribing! (Tier {tier})'),
+    resub_message:   bodyMsg('resub_message',   'Thanks {display_name} for {months} months! (Tier {tier})'),
     giftsub_message: bodyMsg('giftsub_message', '{gifter_display} gifted {count} sub(s) to the community!'),
     raid_enabled:    body.raid_enabled === 'on',
-    raid_message:    bodyMsg('raid_message',    'Welcome raiders from {from_channel}! Thank you for the {viewers} person raid!'),
+    raid_message:    bodyMsg('raid_message',    'Welcome raiders from {from_display}! Thank you for the {viewers} person raid!'),
   };
 
   try {

--- a/src/web/routes/userSettings.ts
+++ b/src/web/routes/userSettings.ts
@@ -56,10 +56,17 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
       return expected && streamer?.twitch_name?.toLowerCase() === expected.toLowerCase() ? expected : undefined;
     })();
 
+    // Strip decrypted OAuth tokens — the template only needs a boolean.
+    const isConnected = !!(streamer?.eventsub_access_token);
+    const safeStreamer = streamer
+      ? { ...streamer, eventsub_access_token: null, eventsub_refresh_token: null }
+      : null;
+
     res.render('userSettings', {
       user: req.session.user,
       dbUser,
-      streamer,
+      streamer: safeStreamer,
+      isConnected,
       csrfToken: req.csrfToken(),
       error: errorKey,
       success: req.query.success as string | undefined,

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -24,6 +24,7 @@ import countersRouter from './routes/counters';
 import commandMonitorRouter from './routes/commandMonitor';
 import streamdeckRouter from './routes/streamdeck';
 import streamdeckKeysRouter from './routes/streamdeckKeys';
+import userSettingsRouter from './routes/userSettings';
 import { requireAuth } from './middleware';
 import { ensureSessionCsrfToken } from './csrf';
 
@@ -129,6 +130,7 @@ app.use('/', requireAuth, sfxRouter);
 app.use('/admin', requireAuth, adminRouter);
 app.use('/admin', requireAuth, streamsRouter);
 app.use('/admin', requireAuth, eventsubAdminRouter);
+app.use('/user/settings', requireAuth, userSettingsRouter);
 app.use('/admin', requireAuth, commandsRouter);
 app.use('/admin', requireAuth, countersRouter);
 app.use('/admin', requireAuth, commandMonitorRouter);

--- a/views/partials/nav.ejs
+++ b/views/partials/nav.ejs
@@ -6,6 +6,9 @@
       <a href="/" class="nav-item">Dashboard</a>
       <a href="/sfx" class="nav-item">SFX</a>
       <a href="/streamdeck-key" class="nav-item">Streamdeck Key</a>
+      <% if (user) { %>
+      <a href="/user/settings" class="nav-item">Settings</a>
+      <% } %>
       <% if (user && user.accessLevel >= 2) { %>
       <a href="/admin/commands" class="nav-item">Commands</a>
       <a href="/admin/counters" class="nav-item">Counters</a>

--- a/views/streams.ejs
+++ b/views/streams.ejs
@@ -15,13 +15,7 @@
     <% if (error) { %>
     <div class="card card-alert-danger">
       <%= getFriendlyError(error) %>
-      <% if (error === 'eventsub_wrong_account' && successExpectedAccount) { %>
-        Expected account: <strong><%= successExpectedAccount %></strong>
-      <% } %>
     </div>
-    <% } %>
-    <% if (success === 'twitch_connected') { %>
-    <div class="card card-alert-success">Twitch account connected successfully.</div>
     <% } %>
 
     <!-- ── Live Now ─────────────────────────────────────────────────── -->
@@ -161,12 +155,17 @@
     <section class="section">
       <h2 class="section-title">Streamers</h2>
 
-      <% if (groups.length > 0) { %>
+      <% if (groups.length > 0 && eligibleUsers.length > 0) { %>
       <div class="card card-spaced">
         <div class="card-header"><span class="card-icon">➕</span><span class="card-label">Add Streamer</span></div>
         <form method="POST" action="/admin/streams/streamers/add" class="inline-form">
           <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-          <input class="input" type="text" name="name" placeholder="Twitch username (lowercase)" required>
+          <select class="input" name="discord_id" required>
+            <option value="" disabled selected>Select user…</option>
+            <% eligibleUsers.forEach(function(u) { %>
+            <option value="<%= u.discord_id %>"><%= u.discord_name || u.discord_id %> (<%= u.twitch_name %>)</option>
+            <% }) %>
+          </select>
           <select class="input" name="group_id">
             <% groups.forEach(function(g) { %>
             <option value="<%= g.id %>"><%= g.name %></option>
@@ -175,6 +174,12 @@
           <button type="submit" class="btn">Add Streamer</button>
         </form>
       </div>
+      <% } else if (groups.length > 0) { %>
+      <div class="card card-spaced">
+        <div class="card-body">
+          <p class="hint">All users with a Twitch name are already configured as streamers, or no users have a Twitch name set.</p>
+        </div>
+      </div>
       <% } %>
 
       <div class="card">
@@ -182,7 +187,7 @@
         <table class="table" aria-label="Streamers">
           <thead>
             <tr>
-              <th scope="col">Username</th>
+              <th scope="col">Streamer</th>
               <th scope="col">Group</th>
               <th scope="col">Actions</th>
             </tr>
@@ -190,28 +195,30 @@
           <tbody>
             <% streamers.forEach(function(s) {
               const esData = isAdmin ? (eventSubById[s.id] || null) : null;
-              const isBotEnabled = isAdmin && botEnabledSet.has(s.name.toLowerCase());
               const isConnected = !!(esData && esData.eventsub_access_token);
-              const cfg = esData && esData.config;
             %>
             <tr>
               <td class="mono">
-                <%= s.name %>
-                <% if (isAdmin && isBotEnabled) { %>
+                <%= s.twitch_name ?? '–' %>
+                <% if (s.discord_name) { %><br><small class="hint"><%= s.discord_name %></small><% } %>
+                <% if (isAdmin && esData) { %>
                   <% if (isConnected) { %>
-                  <span class="badge badge-active" title="Twitch account connected for notifications">🔔</span>
+                  <span class="badge badge-active" title="EventSub connected">🔔</span>
                   <% } else { %>
-                  <span class="badge" title="Notifications not connected">🔕</span>
+                  <span class="badge" title="EventSub not connected">🔕</span>
                   <% } %>
                 <% } %>
               </td>
               <td><%= s.group_name %></td>
               <td>
                 <div class="actions">
-                  <% if (isAdmin && isBotEnabled) { %>
-                  <button type="button" class="btn btn-sm btn-ghost btn-toggle-eventsub" data-streamer-id="<%= s.id %>">🔔 Notifications</button>
+                  <% if (isAdmin && isConnected) { %>
+                  <form method="POST" action="/admin/streams/twitch-disconnect/<%= s.id %>" class="inline-form-sm">
+                    <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                    <button type="submit" class="btn btn-ghost btn-sm" onclick="return confirm('Disconnect Twitch for <%= s.twitch_name %>?')">Disconnect</button>
+                  </form>
                   <% } %>
-                  <form method="POST" action="/admin/streams/streamers/remove" class="inline-form-sm js-confirm-remove-streamer" data-streamer-name="<%= s.name %>">
+                  <form method="POST" action="/admin/streams/streamers/remove" class="inline-form-sm js-confirm-remove-streamer" data-streamer-name="<%= s.twitch_name ?? s.discord_id %>">
                     <input type="hidden" name="_csrf" value="<%= csrfToken %>">
                     <input type="hidden" name="streamer_id" value="<%= s.id %>">
                     <button type="submit" class="btn btn-danger btn-sm">Remove</button>
@@ -219,66 +226,6 @@
                 </div>
               </td>
             </tr>
-            <% if (isAdmin && isBotEnabled) { %>
-            <tr class="files-row is-hidden" id="eventsub-<%= s.id %>">
-              <td colspan="3">
-                <div class="edit-panel">
-                  <div class="form-row-wrap form-section-gap" style="align-items:center;margin-bottom:0.75rem;">
-                    <strong>Twitch Notifications — <%= s.name %></strong>
-                    <% if (isConnected) { %>
-                    <span class="badge badge-active">✓ Connected</span>
-                    <form method="POST" action="/admin/streams/twitch-disconnect/<%= s.id %>" class="inline-form-sm">
-                      <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-                      <button type="submit" class="btn btn-ghost btn-sm">Disconnect</button>
-                    </form>
-                    <% } else { %>
-                    <span class="badge">⚠ Not connected</span>
-                    <a href="/admin/streams/twitch-oauth/<%= s.id %>" class="btn btn-sm">Connect Twitch</a>
-                    <% } %>
-                  </div>
-                  <form method="POST" action="/admin/streams/event-config/<%= s.id %>">
-                    <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-
-                    <div class="form-subsection-gap">
-                      <label class="input checkbox-input-label">
-                        <input type="checkbox" name="follow_enabled" <%= (cfg && cfg.follow_enabled) ? 'checked' : '' %> <%= !isConnected ? 'disabled' : '' %>>
-                        Follow notifications <% if (!isConnected) { %><span class="hint">(requires Twitch connection)</span><% } %>
-                      </label>
-                      <p class="hint hint-compact">Variables: <code>{username} {display_name}</code></p>
-                      <textarea class="input stream-textarea" name="follow_message" rows="1" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.follow_message) ? cfg.follow_message : 'Thanks {display_name} for the follow!' %></textarea>
-                    </div>
-
-                    <div class="form-subsection-gap">
-                      <label class="input checkbox-input-label">
-                        <input type="checkbox" name="sub_enabled" <%= (cfg && cfg.sub_enabled) ? 'checked' : '' %> <%= !isConnected ? 'disabled' : '' %>>
-                        Sub/resub/gift notifications <% if (!isConnected) { %><span class="hint">(requires Twitch connection)</span><% } %>
-                      </label>
-                      <p class="hint hint-compact">New sub — variables: <code>{username} {display_name} {tier} {tier_name}</code></p>
-                      <textarea class="input stream-textarea" name="sub_message" rows="1" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.sub_message) ? cfg.sub_message : 'Thanks {display_name} for subscribing! (Tier {tier_name})' %></textarea>
-                      <p class="hint hint-compact" style="margin-top:0.4rem;">Resub — variables: <code>{username} {display_name} {tier} {tier_name} {months} {streak}</code></p>
-                      <textarea class="input stream-textarea" name="resub_message" rows="1" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.resub_message) ? cfg.resub_message : 'Thanks {display_name} for {months} months! (Tier {tier_name})' %></textarea>
-                      <p class="hint hint-compact" style="margin-top:0.4rem;">Gift sub — variables: <code>{gifter} {gifter_display} {count} {tier} {tier_name}</code></p>
-                      <textarea class="input stream-textarea" name="giftsub_message" rows="1" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.giftsub_message) ? cfg.giftsub_message : '{gifter_display} gifted {count} sub(s) to the community!' %></textarea>
-                    </div>
-
-                    <div class="form-subsection-gap">
-                      <label class="input checkbox-input-label">
-                        <input type="checkbox" name="raid_enabled" <%= (cfg && cfg.raid_enabled) ? 'checked' : '' %> <%= !isConnected ? 'disabled' : '' %>>
-                        Raid notifications <% if (!isConnected) { %><span class="hint">(requires Twitch connection)</span><% } %>
-                      </label>
-                      <p class="hint hint-compact">Variables: <code>{from_channel} {from_display} {viewers}</code></p>
-                      <textarea class="input stream-textarea" name="raid_message" rows="1" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.raid_message) ? cfg.raid_message : 'Welcome raiders from {from_channel}! Thank you for the {viewers} person raid!' %></textarea>
-                    </div>
-
-                    <div class="button-row-wrap">
-                      <button type="submit" class="btn">Save</button>
-                      <button type="button" class="btn btn-ghost btn-toggle-eventsub" data-streamer-id="<%= s.id %>">Cancel</button>
-                    </div>
-                  </form>
-                </div>
-              </td>
-            </tr>
-            <% } %>
             <% }) %>
             <% if (streamers.length === 0) { %>
             <tr>
@@ -302,7 +249,6 @@
   <%- include('partials/pwa-register') %>
   <script src="/utils.js"></script>
   <script src="/streams-utils.js"></script>
-  <script src="/streams-eventsub.js"></script>
   <script src="/streams-discord.js"></script>
   <script src="/streams-live-detail.js"></script>
   <script src="/streams-live-table.js"></script>

--- a/views/userSettings.ejs
+++ b/views/userSettings.ejs
@@ -78,12 +78,12 @@
               <% } %>
             </div>
             <% if (isConnected) { %>
-            <form method="POST" action="/user/twitch-disconnect" class="inline-form-sm">
+            <form method="POST" action="/user/settings/twitch-disconnect" class="inline-form-sm">
               <input type="hidden" name="_csrf" value="<%= csrfToken %>">
               <button type="submit" class="btn btn-ghost btn-sm">Disconnect Twitch</button>
             </form>
             <% } else { %>
-            <a href="/user/twitch-connect" class="btn btn-sm">Connect Twitch</a>
+            <a href="/user/settings/twitch-connect" class="btn btn-sm">Connect Twitch</a>
             <% } %>
           </div>
         </div>
@@ -91,7 +91,7 @@
 
       <div class="card">
         <div class="card-body">
-          <form method="POST" action="/user/eventsub-config">
+          <form method="POST" action="/user/settings/eventsub-config">
             <input type="hidden" name="_csrf" value="<%= csrfToken %>">
 
             <div class="form-subsection-gap">

--- a/views/userSettings.ejs
+++ b/views/userSettings.ejs
@@ -110,9 +110,9 @@
                 Sub/resub/gift notifications <% if (!isConnected) { %><span class="hint">(requires Twitch connection)</span><% } %>
               </label>
               <p class="hint hint-compact">New sub — variables: <code>{username} {display_name} {tier} {tier_name}</code></p>
-              <textarea class="input stream-textarea" name="sub_message" rows="1" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.sub_message) ? cfg.sub_message : 'Thanks {display_name} for subscribing! (Tier {tier_name})' %></textarea>
+              <textarea class="input stream-textarea" name="sub_message" rows="1" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.sub_message) ? cfg.sub_message : 'Thanks {display_name} for subscribing! (Tier {tier})' %></textarea>
               <p class="hint hint-compact" style="margin-top:0.4rem;">Resub — variables: <code>{username} {display_name} {tier} {tier_name} {months} {streak}</code></p>
-              <textarea class="input stream-textarea" name="resub_message" rows="1" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.resub_message) ? cfg.resub_message : 'Thanks {display_name} for {months} months! (Tier {tier_name})' %></textarea>
+              <textarea class="input stream-textarea" name="resub_message" rows="1" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.resub_message) ? cfg.resub_message : 'Thanks {display_name} for {months} months! (Tier {tier})' %></textarea>
               <p class="hint hint-compact" style="margin-top:0.4rem;">Gift sub — variables: <code>{gifter} {gifter_display} {count} {tier} {tier_name}</code></p>
               <textarea class="input stream-textarea" name="giftsub_message" rows="1" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.giftsub_message) ? cfg.giftsub_message : '{gifter_display} gifted {count} sub(s) to the community!' %></textarea>
             </div>
@@ -123,7 +123,7 @@
                 Raid notifications <% if (!isConnected) { %><span class="hint">(requires Twitch connection)</span><% } %>
               </label>
               <p class="hint hint-compact">Variables: <code>{from_channel} {from_display} {viewers}</code></p>
-              <textarea class="input stream-textarea" name="raid_message" rows="1" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.raid_message) ? cfg.raid_message : 'Welcome raiders from {from_channel}! Thank you for the {viewers} person raid!' %></textarea>
+              <textarea class="input stream-textarea" name="raid_message" rows="1" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.raid_message) ? cfg.raid_message : 'Welcome raiders from {from_display}! Thank you for the {viewers} person raid!' %></textarea>
             </div>
 
             <div class="button-row-wrap">

--- a/views/userSettings.ejs
+++ b/views/userSettings.ejs
@@ -51,7 +51,6 @@
 
     <% if (streamer) { %>
     <%
-      const isConnected = !!(streamer && streamer.eventsub_access_token);
       const isBotEnabled = !!(dbUser && dbUser.is_twitch_bot_enabled);
       const cfg = streamer.config;
     %>

--- a/views/userSettings.ejs
+++ b/views/userSettings.ejs
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BCUK Bot — Settings</title>
+  <link rel="stylesheet" href="/style.css">
+  <%- include('partials/pwa-head') %>
+</head>
+<body>
+  <%- include('partials/nav') %>
+
+  <main class="container">
+
+    <% if (error) { %>
+    <div class="card card-alert-danger">
+      <%= getFriendlyError(error) %>
+      <% if (error === 'eventsub_wrong_account' && successExpectedAccount) { %>
+        Expected account: <strong><%= successExpectedAccount %></strong>
+      <% } %>
+    </div>
+    <% } %>
+    <% if (success === 'twitch_connected') { %>
+    <div class="card card-alert-success">Twitch account connected successfully.</div>
+    <% } %>
+
+    <!-- ── Profile ────────────────────────────────────────────────── -->
+    <section class="section">
+      <h2 class="section-title">Your Profile</h2>
+      <div class="card">
+        <div class="card-body">
+          <div class="form-row-wrap">
+            <% if (user && user.discordAvatar) { %>
+            <img src="<%= user.discordAvatar %>?size=64" class="avatar" style="width:48px;height:48px;border-radius:50%;" alt="">
+            <% } %>
+            <div>
+              <p class="hint hint-compact">Discord</p>
+              <strong><%= dbUser ? (dbUser.discord_name ?? user.discordName) : user.discordName %></strong>
+              <span class="badge level-<%= user.accessLevel %>"><%= ['User','Mod','Manager','Admin'][user.accessLevel] || 'Unknown' %></span>
+            </div>
+            <% if (dbUser && dbUser.twitch_name) { %>
+            <div>
+              <p class="hint hint-compact">Twitch</p>
+              <strong class="mono"><%= dbUser.twitch_name %></strong>
+            </div>
+            <% } %>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <% if (streamer) { %>
+    <%
+      const isConnected = !!(streamer && streamer.eventsub_access_token);
+      const isBotEnabled = !!(dbUser && dbUser.is_twitch_bot_enabled);
+      const cfg = streamer.config;
+    %>
+
+    <!-- ── Twitch Connection ──────────────────────────────────────── -->
+    <section class="section">
+      <h2 class="section-title">Twitch Notifications</h2>
+
+      <% if (!isBotEnabled) { %>
+      <div class="card">
+        <div class="card-body">
+          <p class="hint">The Twitch bot must be enabled for your channel before you can configure notifications. Contact a Manager or Admin.</p>
+        </div>
+      </div>
+      <% } else { %>
+
+      <div class="card card-spaced">
+        <div class="card-body">
+          <div class="form-row-wrap" style="align-items:center;">
+            <div>
+              <% if (isConnected) { %>
+              <span class="badge badge-active">✓ Connected</span>
+              <% } else { %>
+              <span class="badge">⚠ Not connected</span>
+              <% } %>
+            </div>
+            <% if (isConnected) { %>
+            <form method="POST" action="/user/twitch-disconnect" class="inline-form-sm">
+              <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+              <button type="submit" class="btn btn-ghost btn-sm">Disconnect Twitch</button>
+            </form>
+            <% } else { %>
+            <a href="/user/twitch-connect" class="btn btn-sm">Connect Twitch</a>
+            <% } %>
+          </div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-body">
+          <form method="POST" action="/user/eventsub-config">
+            <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+
+            <div class="form-subsection-gap">
+              <label class="input checkbox-input-label">
+                <input type="checkbox" name="follow_enabled" <%= (cfg && cfg.follow_enabled) ? 'checked' : '' %> <%= !isConnected ? 'disabled' : '' %>>
+                Follow notifications <% if (!isConnected) { %><span class="hint">(requires Twitch connection)</span><% } %>
+              </label>
+              <p class="hint hint-compact">Variables: <code>{username} {display_name}</code></p>
+              <textarea class="input stream-textarea" name="follow_message" rows="1" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.follow_message) ? cfg.follow_message : 'Thanks {display_name} for the follow!' %></textarea>
+            </div>
+
+            <div class="form-subsection-gap">
+              <label class="input checkbox-input-label">
+                <input type="checkbox" name="sub_enabled" <%= (cfg && cfg.sub_enabled) ? 'checked' : '' %> <%= !isConnected ? 'disabled' : '' %>>
+                Sub/resub/gift notifications <% if (!isConnected) { %><span class="hint">(requires Twitch connection)</span><% } %>
+              </label>
+              <p class="hint hint-compact">New sub — variables: <code>{username} {display_name} {tier} {tier_name}</code></p>
+              <textarea class="input stream-textarea" name="sub_message" rows="1" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.sub_message) ? cfg.sub_message : 'Thanks {display_name} for subscribing! (Tier {tier_name})' %></textarea>
+              <p class="hint hint-compact" style="margin-top:0.4rem;">Resub — variables: <code>{username} {display_name} {tier} {tier_name} {months} {streak}</code></p>
+              <textarea class="input stream-textarea" name="resub_message" rows="1" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.resub_message) ? cfg.resub_message : 'Thanks {display_name} for {months} months! (Tier {tier_name})' %></textarea>
+              <p class="hint hint-compact" style="margin-top:0.4rem;">Gift sub — variables: <code>{gifter} {gifter_display} {count} {tier} {tier_name}</code></p>
+              <textarea class="input stream-textarea" name="giftsub_message" rows="1" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.giftsub_message) ? cfg.giftsub_message : '{gifter_display} gifted {count} sub(s) to the community!' %></textarea>
+            </div>
+
+            <div class="form-subsection-gap">
+              <label class="input checkbox-input-label">
+                <input type="checkbox" name="raid_enabled" <%= (cfg && cfg.raid_enabled) ? 'checked' : '' %> <%= !isConnected ? 'disabled' : '' %>>
+                Raid notifications <% if (!isConnected) { %><span class="hint">(requires Twitch connection)</span><% } %>
+              </label>
+              <p class="hint hint-compact">Variables: <code>{from_channel} {from_display} {viewers}</code></p>
+              <textarea class="input stream-textarea" name="raid_message" rows="1" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.raid_message) ? cfg.raid_message : 'Welcome raiders from {from_channel}! Thank you for the {viewers} person raid!' %></textarea>
+            </div>
+
+            <div class="button-row-wrap">
+              <button type="submit" class="btn" <%= !isConnected ? 'disabled' : '' %>>Save Settings</button>
+            </div>
+          </form>
+        </div>
+      </div>
+
+      <% } %>
+    </section>
+    <% } %>
+
+  </main>
+
+  <%- include('partials/pwa-register') %>
+</body>
+</html>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Schema consolidation**: Replaces the implicit name-join between `streamer` and `user` with an explicit FK (`streamer.discord_id → user.discord_id`). The redundant `streamer.name` column is dropped — the Twitch login is now read from `user.twitch_name` via the join. A UNIQUE constraint on `streamer.discord_id` enforces one stream group per user.
- **Migration SQL**: `migrations/consolidate_streamer_user.sql` handles the backfill, deduplication, and schema changes. **Run this before deploying the new code.**
- **Self-service settings page** (`/user/settings`): Any logged-in user can now connect their Twitch account and configure EventSub notifications (follows, subs, raids) without needing Manager/Admin access.
- **EventSub access shift**: Previously admin-only; now any user with `is_twitch_bot_enabled = 1` manages their own settings. Admins retain a read-only status badge in the streams admin panel plus an emergency disconnect button.
- **Updated `DATABASE-SCHEMA.md`**: Now reflects the actual current schema including the `streamer_event_config` table and the new `streamer` columns.

## Deployment notes

1. **Run `migrations/consolidate_streamer_user.sql` first** — the new code expects `streamer.discord_id` and no `streamer.name`.
2. **`TWITCH_EVENTSUB_REDIRECT_URI` does not change** — the OAuth callback endpoint is still `GET /auth/twitch/eventsub/callback`. No Twitch Developer Console or `.env` changes needed.
3. **Existing OAuth tokens survive** — stored tokens in `streamer` are unaffected by the migration.
4. **Communicate the flow change to streamers** — the "Connect Twitch" button moves from the admin streams page to each user's `/user/settings` page.

## Test plan

- [ ] Run migration SQL on dev/staging; confirm `SELECT * FROM streamer WHERE discord_id IS NULL` returns no rows before step 5
- [ ] `tsc --noEmit` passes (only pre-existing test-file errors remain)
- [ ] Log in as a non-admin streamer → `/user/settings` shows Twitch connection section
- [ ] Complete Twitch OAuth from `/user/settings` → token saved, success message shown
- [ ] Save EventSub config (follow/sub/raid) from user settings → confirmed in DB
- [ ] Log in as admin → `/admin/streams` shows streamer list with `twitch_name` and status badges
- [ ] Admin emergency disconnect button works
- [ ] Add a new streamer from admin panel (now uses user dropdown instead of text input)
- [ ] Trigger a live stream event → announcements and EventSub notifications fire correctly

https://claude.ai/code/session_01T3BoyKw5i9AiCT3A9siTU8
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T3BoyKw5i9AiCT3A9siTU8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user settings page to manage personal Twitch connection and per-streamer EventSub notification templates; users can connect/disconnect Twitch and save templates.

* **UI Changes**
  * EventSub config moved from admin streams to user settings; admin streams UI simplified (removed per-stream toggles/panels and client-side toggle buttons).
  * Settings link shows only for signed-in users; add-streamer now requires selecting an eligible Discord user.

* **Documentation**
  * Database schema updated to reflect Discord-based streamer mapping and EventSub config.

* **Other**
  * OAuth callback and admin flows now route to the user settings page; updated default notification placeholders for subs/resubs and raids.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->