### PR TITLE
fix(admin): fail fast on DB lock contention and show browser error

### DIFF
--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -105,12 +105,23 @@ export async function upsertUserRecord(
           }
           return normalizedChannelName;
         })();
-  await getPool().execute(
-    `INSERT INTO \`user\` (discord_id, discord_name, access_level, twitch_name, is_twitch_bot_enabled)
-     VALUES (?, ?, ?, ?, 0) AS new_user
-     ON DUPLICATE KEY UPDATE discord_name = new_user.discord_name, access_level = new_user.access_level, twitch_name = IF(?, new_user.twitch_name, \`user\`.twitch_name)`,
-    [discordId, trimmedDiscordName, accessLevel, normalizedTwitchName, twitchNameProvided ? 1 : 0],
-  );
+  // Use a dedicated connection with a short lock-wait timeout so callers see a
+  // fast error rather than a 50-second browser hang when row-level lock contention
+  // occurs (e.g. a concurrent command-assignment transaction holding an FK share
+  // lock on the same user row).
+  const connection = await getPool().getConnection();
+  try {
+    await connection.execute('SET SESSION innodb_lock_wait_timeout = 5');
+    await connection.execute(
+      `INSERT INTO \`user\` (discord_id, discord_name, access_level, twitch_name, is_twitch_bot_enabled)
+       VALUES (?, ?, ?, ?, 0) AS new_user
+       ON DUPLICATE KEY UPDATE discord_name = new_user.discord_name, access_level = new_user.access_level, twitch_name = IF(?, new_user.twitch_name, \`user\`.twitch_name)`,
+      [discordId, trimmedDiscordName, accessLevel, normalizedTwitchName, twitchNameProvided ? 1 : 0],
+    );
+  } finally {
+    try { await connection.execute('SET SESSION innodb_lock_wait_timeout = DEFAULT'); } catch { /* best-effort reset */ }
+    connection.release();
+  }
   return twitchNameProvided;
 }
 

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -74,6 +74,18 @@ export async function getAllUsers(): Promise<DbUser[]> {
   return rows.map(mapUser);
 }
 
+// Short timeout so callers fail fast instead of hanging 50s under lock contention.
+async function withShortLockTimeout<T>(fn: (conn: mysql.PoolConnection) => Promise<T>): Promise<T> {
+  const connection = await getPool().getConnection();
+  try {
+    await connection.execute('SET SESSION innodb_lock_wait_timeout = 5');
+    return await fn(connection);
+  } finally {
+    try { await connection.execute('SET SESSION innodb_lock_wait_timeout = DEFAULT'); } catch {}
+    connection.release();
+  }
+}
+
 /**
  * Upserts a user record. Returns true when the twitchName field was included in the
  * call (even if null), so the caller can decide whether to invalidate any caches that
@@ -105,23 +117,12 @@ export async function upsertUserRecord(
           }
           return normalizedChannelName;
         })();
-  // Use a dedicated connection with a short lock-wait timeout so callers see a
-  // fast error rather than a 50-second browser hang when row-level lock contention
-  // occurs (e.g. a concurrent command-assignment transaction holding an FK share
-  // lock on the same user row).
-  const connection = await getPool().getConnection();
-  try {
-    await connection.execute('SET SESSION innodb_lock_wait_timeout = 5');
-    await connection.execute(
-      `INSERT INTO \`user\` (discord_id, discord_name, access_level, twitch_name, is_twitch_bot_enabled)
-       VALUES (?, ?, ?, ?, 0) AS new_user
-       ON DUPLICATE KEY UPDATE discord_name = new_user.discord_name, access_level = new_user.access_level, twitch_name = IF(?, new_user.twitch_name, \`user\`.twitch_name)`,
-      [discordId, trimmedDiscordName, accessLevel, normalizedTwitchName, twitchNameProvided ? 1 : 0],
-    );
-  } finally {
-    try { await connection.execute('SET SESSION innodb_lock_wait_timeout = DEFAULT'); } catch { /* best-effort reset */ }
-    connection.release();
-  }
+  await withShortLockTimeout((conn) => conn.execute(
+    `INSERT INTO \`user\` (discord_id, discord_name, access_level, twitch_name, is_twitch_bot_enabled)
+     VALUES (?, ?, ?, ?, 0) AS new_user
+     ON DUPLICATE KEY UPDATE discord_name = new_user.discord_name, access_level = new_user.access_level, twitch_name = IF(?, new_user.twitch_name, \`user\`.twitch_name)`,
+    [discordId, trimmedDiscordName, accessLevel, normalizedTwitchName, twitchNameProvided ? 1 : 0],
+  ));
   return twitchNameProvided;
 }
 
@@ -147,22 +148,25 @@ export async function getTwitchEnabledChannels(): Promise<string[]> {
 }
 
 export async function setTwitchBotEnabledRecord(discordId: string, enabled: boolean): Promise<void> {
-  await getPool().execute(
+  await withShortLockTimeout((conn) => conn.execute(
     'UPDATE `user` SET is_twitch_bot_enabled = ? WHERE discord_id = ?',
     [enabled ? 1 : 0, discordId],
-  );
+  ));
 }
 
 export async function updateAccessLevel(discordId: string, accessLevel: number): Promise<void> {
   if (!(Object.values(AccessLevel) as number[]).includes(accessLevel)) {
     throw new Error(`Invalid accessLevel: ${accessLevel}`);
   }
-  await getPool().execute(
+  await withShortLockTimeout((conn) => conn.execute(
     'UPDATE `user` SET access_level = ? WHERE discord_id = ?',
     [accessLevel, discordId],
-  );
+  ));
 }
 
 export async function removeUserRecord(discordId: string): Promise<void> {
-  await getPool().execute('DELETE FROM `user` WHERE discord_id = ?', [discordId]);
+  await withShortLockTimeout((conn) => conn.execute(
+    'DELETE FROM `user` WHERE discord_id = ?',
+    [discordId],
+  ));
 }

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -1,6 +1,9 @@
 import mysql from 'mysql2/promise';
 import { normalizeTwitchChannelName } from '../twitchChannelName';
 import { getPool } from './pool';
+import { createLogger } from '../logger';
+
+const log = createLogger('DB');
 
 export const AccessLevel = {
   USER: 0,
@@ -81,7 +84,9 @@ async function withShortLockTimeout<T>(fn: (conn: mysql.PoolConnection) => Promi
     await connection.execute('SET SESSION innodb_lock_wait_timeout = 5');
     return await fn(connection);
   } finally {
-    try { await connection.execute('SET SESSION innodb_lock_wait_timeout = DEFAULT'); } catch {}
+    try { await connection.execute('SET SESSION innodb_lock_wait_timeout = DEFAULT'); } catch (e) {
+      log.warn('connection.execute: failed to reset innodb_lock_wait_timeout to DEFAULT:', e);
+    }
     connection.release();
   }
 }

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -15,6 +15,7 @@ import adminRefreshRouter, { refreshState } from './adminRefresh';
 import {
   DuplicateTwitchNameError,
   isDuplicateTwitchNameDbError,
+  isLockWaitTimeoutDbError,
   addOrUpdateUserMutation,
   removeUserMutation,
   toggleTwitchMutation,
@@ -24,7 +25,7 @@ const log = createLogger('Web');
 const router = Router();
 router.use(adminRefreshRouter);
 
-const KNOWN_ERRORS = new Set(['add_failed', 'duplicate_twitch_name', 'update_failed', 'remove_failed', 'toggle_failed']);
+const KNOWN_ERRORS = new Set(['add_failed', 'duplicate_twitch_name', 'db_busy', 'update_failed', 'remove_failed', 'toggle_failed']);
 // Twitch membership changes are serialized per user in-process because this bot
 // currently runs as a single web instance. If that changes, move this lock into
 // shared storage or a DB transaction/row lock before scaling out.
@@ -88,6 +89,9 @@ router.post('/users/add', requireAdmin, csrfProtection, async (req, res) => {
     if (err instanceof DuplicateTwitchNameError || isDuplicateTwitchNameDbError(err)) {
       return res.redirect('/admin/users?error=duplicate_twitch_name');
     }
+    if (isLockWaitTimeoutDbError(err)) {
+      return res.redirect('/admin/users?error=db_busy');
+    }
     return res.redirect('/admin/users?error=add_failed');
   }
   res.redirect('/admin/users');
@@ -112,6 +116,7 @@ router.post('/users/update', requireAdmin, csrfProtection, async (req, res) => {
     await userMutationQueue.run(trimmedDiscordId, () => updateAccessLevel(trimmedDiscordId, level));
   } catch (err) {
     log.error('Update access level error:', err);
+    if (isLockWaitTimeoutDbError(err)) return res.redirect('/admin/users?error=db_busy');
     return res.redirect('/admin/users?error=update_failed');
   }
   res.redirect('/admin/users');
@@ -133,6 +138,7 @@ router.post('/users/remove', requireAdmin, csrfProtection, async (req, res) => {
     await userMutationQueue.run(trimmedDiscordId, () => removeUserMutation(trimmedDiscordId));
   } catch (err) {
     log.error('Remove user error:', err);
+    if (isLockWaitTimeoutDbError(err)) return res.redirect('/admin/users?error=db_busy');
     return res.redirect('/admin/users?error=remove_failed');
   }
   res.redirect('/admin/users');
@@ -163,6 +169,7 @@ router.post('/users/toggle-twitch', requireManager, csrfProtection, async (req, 
     await userMutationQueue.run(trimmedDiscordId, () => toggleTwitchMutation(trimmedDiscordId, nextEnabled));
   } catch (err) {
     log.error('Toggle twitch user error:', err);
+    if (isLockWaitTimeoutDbError(err)) return res.redirect('/admin/users?error=db_busy');
     return res.redirect('/admin/users?error=toggle_failed');
   }
   res.redirect('/admin/users');

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -86,7 +86,7 @@ router.post('/users/add', requireAdmin, csrfProtection, async (req, res) => {
     }));
   } catch (err) {
     if (isLockWaitTimeoutDbError(err)) {
-      log.warn('Add user DB lock timeout');
+      log.warn('Add user DB lock timeout', err);
       return res.redirect('/admin/users?error=db_busy');
     }
     log.error('Add user error:', err);
@@ -117,7 +117,7 @@ router.post('/users/update', requireAdmin, csrfProtection, async (req, res) => {
     await userMutationQueue.run(trimmedDiscordId, () => updateAccessLevel(trimmedDiscordId, level));
   } catch (err) {
     if (isLockWaitTimeoutDbError(err)) {
-      log.warn('Update access level DB lock timeout');
+      log.warn('Update access level DB lock timeout', err);
       return res.redirect('/admin/users?error=db_busy');
     }
     log.error('Update access level error:', err);
@@ -142,7 +142,7 @@ router.post('/users/remove', requireAdmin, csrfProtection, async (req, res) => {
     await userMutationQueue.run(trimmedDiscordId, () => removeUserMutation(trimmedDiscordId));
   } catch (err) {
     if (isLockWaitTimeoutDbError(err)) {
-      log.warn('Remove user DB lock timeout');
+      log.warn('Remove user DB lock timeout', err);
       return res.redirect('/admin/users?error=db_busy');
     }
     log.error('Remove user error:', err);
@@ -176,7 +176,7 @@ router.post('/users/toggle-twitch', requireManager, csrfProtection, async (req, 
     await userMutationQueue.run(trimmedDiscordId, () => toggleTwitchMutation(trimmedDiscordId, nextEnabled));
   } catch (err) {
     if (isLockWaitTimeoutDbError(err)) {
-      log.warn('Toggle Twitch DB lock timeout');
+      log.warn('Toggle Twitch DB lock timeout', err);
       return res.redirect('/admin/users?error=db_busy');
     }
     log.error('Toggle twitch user error:', err);

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -85,12 +85,13 @@ router.post('/users/add', requireAdmin, csrfProtection, async (req, res) => {
       shouldClearTwitchName,
     }));
   } catch (err) {
+    if (isLockWaitTimeoutDbError(err)) {
+      log.warn('Add user DB lock timeout');
+      return res.redirect('/admin/users?error=db_busy');
+    }
     log.error('Add user error:', err);
     if (err instanceof DuplicateTwitchNameError || isDuplicateTwitchNameDbError(err)) {
       return res.redirect('/admin/users?error=duplicate_twitch_name');
-    }
-    if (isLockWaitTimeoutDbError(err)) {
-      return res.redirect('/admin/users?error=db_busy');
     }
     return res.redirect('/admin/users?error=add_failed');
   }
@@ -115,8 +116,11 @@ router.post('/users/update', requireAdmin, csrfProtection, async (req, res) => {
   try {
     await userMutationQueue.run(trimmedDiscordId, () => updateAccessLevel(trimmedDiscordId, level));
   } catch (err) {
+    if (isLockWaitTimeoutDbError(err)) {
+      log.warn('Update access level DB lock timeout');
+      return res.redirect('/admin/users?error=db_busy');
+    }
     log.error('Update access level error:', err);
-    if (isLockWaitTimeoutDbError(err)) return res.redirect('/admin/users?error=db_busy');
     return res.redirect('/admin/users?error=update_failed');
   }
   res.redirect('/admin/users');
@@ -137,8 +141,11 @@ router.post('/users/remove', requireAdmin, csrfProtection, async (req, res) => {
   try {
     await userMutationQueue.run(trimmedDiscordId, () => removeUserMutation(trimmedDiscordId));
   } catch (err) {
+    if (isLockWaitTimeoutDbError(err)) {
+      log.warn('Remove user DB lock timeout');
+      return res.redirect('/admin/users?error=db_busy');
+    }
     log.error('Remove user error:', err);
-    if (isLockWaitTimeoutDbError(err)) return res.redirect('/admin/users?error=db_busy');
     return res.redirect('/admin/users?error=remove_failed');
   }
   res.redirect('/admin/users');
@@ -168,8 +175,11 @@ router.post('/users/toggle-twitch', requireManager, csrfProtection, async (req, 
   try {
     await userMutationQueue.run(trimmedDiscordId, () => toggleTwitchMutation(trimmedDiscordId, nextEnabled));
   } catch (err) {
+    if (isLockWaitTimeoutDbError(err)) {
+      log.warn('Toggle Twitch DB lock timeout');
+      return res.redirect('/admin/users?error=db_busy');
+    }
     log.error('Toggle twitch user error:', err);
-    if (isLockWaitTimeoutDbError(err)) return res.redirect('/admin/users?error=db_busy');
     return res.redirect('/admin/users?error=toggle_failed');
   }
   res.redirect('/admin/users');

--- a/src/web/routes/adminUserMutations.ts
+++ b/src/web/routes/adminUserMutations.ts
@@ -20,6 +20,12 @@ export class DuplicateTwitchNameError extends Error {
   }
 }
 
+export function isLockWaitTimeoutDbError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const dbError = error as { errno?: number; code?: string };
+  return dbError.errno === 1205 || dbError.code === 'ER_LOCK_WAIT_TIMEOUT';
+}
+
 export function isDuplicateTwitchNameDbError(error: unknown): boolean {
   if (!error || typeof error !== 'object') {
     return false;

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -16,7 +16,11 @@
 
       <% if (error) { %>
       <div class="card card-alert-danger" role="alert" aria-live="assertive" aria-atomic="true">
-        <span class="text-danger">&#9888; <%= error === 'duplicate_twitch_name' ? 'Twitch name is already assigned to another user.' : 'Operation failed: ' + error.replace(/_/g, ' ') %></span>
+        <span class="text-danger">&#9888; <%=
+          error === 'duplicate_twitch_name' ? 'Twitch name is already assigned to another user.' :
+          error === 'db_busy' ? 'Database is busy — please try again in a moment.' :
+          'Operation failed: ' + error.replace(/_/g, ' ')
+        %></span>
       </div>
       <% } %>
 


### PR DESCRIPTION
## Summary

- The user table upsert was hitting MySQL's 50-second `innodb_lock_wait_timeout` when another transaction held a row-level lock (e.g. FK shared lock from a concurrent `twitch_user_commands` insert via `assignUserToCommand`). The browser would hang for the full 50 seconds before the caught error redirected to the error page.
- Sets a 5-second session-level `innodb_lock_wait_timeout` for the `upsertUserRecord` connection, then resets it to `DEFAULT` before returning the connection to the pool — so the error surfaces in ~5 seconds instead of ~50.
- Adds `isLockWaitTimeoutDbError` (MySQL errno 1205 / `ER_LOCK_WAIT_TIMEOUT`) and uses it in all four admin mutation routes (add, update, remove, toggle) to redirect to a new `db_busy` error code.
- Shows **"Database is busy — please try again in a moment."** in the admin panel for `db_busy` instead of the generic "Operation failed" text.

## Test plan

- [ ] Add a user normally — should succeed as before
- [ ] Simulate lock contention (e.g. run a long transaction on the `user` table) and try to add a user — should fail in ~5 seconds with "Database is busy — please try again in a moment." instead of hanging for 50 seconds
- [ ] Verify the same message appears for update access level, remove user, and toggle Twitch bot under lock contention
- [ ] Confirm the `db_busy` query param is sanitised by `KNOWN_ERRORS` (already handled — set was updated)

https://claude.ai/code/session_01WeMHqU3eEHMKr6hVMqwB1p

---
_Generated by [Claude Code](https://claude.ai/code/session_01WeMHqU3eEHMKr6hVMqwB1p)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Admin operations for user management and Twitch bot configuration now detect and communicate database resource constraints through clear "database busy" error messages, improving visibility during high-load scenarios.

* **Style**
  * Improved formatting of error alert messages in the admin interface for better readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->