### PR TITLE
Group nav items into dropdowns; fix mobile table wrapping

### DIFF
--- a/public/navbar.js
+++ b/public/navbar.js
@@ -20,6 +20,7 @@
     var open = nav.classList.toggle('nav-open');
     toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
     collapse.setAttribute('aria-hidden', open ? 'false' : 'true');
+    if (!open) closeAllGroups();
   });
 
   document.addEventListener('click', function (e) {

--- a/public/navbar.js
+++ b/public/navbar.js
@@ -31,15 +31,49 @@
   });
 
   document.addEventListener('keydown', function (e) {
-    if (e.key === 'Escape' && nav.classList.contains('nav-open')) {
-      nav.classList.remove('nav-open');
-      toggle.setAttribute('aria-expanded', 'false');
-      collapse.setAttribute('aria-hidden', 'true');
-      toggle.focus();
+    if (e.key === 'Escape') {
+      if (nav.classList.contains('nav-open')) {
+        nav.classList.remove('nav-open');
+        toggle.setAttribute('aria-expanded', 'false');
+        collapse.setAttribute('aria-hidden', 'true');
+        toggle.focus();
+      }
+      closeAllGroups();
     }
   });
 
   mql.addEventListener('change', function (e) {
     syncToViewport(e.matches);
+  });
+
+  /* ── Nav group dropdowns ────────────────────────────────── */
+  var groups = Array.prototype.slice.call(document.querySelectorAll('.nav-group'));
+
+  function closeAllGroups(except) {
+    groups.forEach(function (g) {
+      if (g !== except) {
+        g.classList.remove('open');
+        var lbl = g.querySelector('.nav-group-label');
+        if (lbl) lbl.setAttribute('aria-expanded', 'false');
+      }
+    });
+  }
+
+  groups.forEach(function (group) {
+    var label = group.querySelector('.nav-group-label');
+    if (!label) return;
+
+    label.addEventListener('click', function (e) {
+      e.stopPropagation();
+      var opening = !group.classList.contains('open');
+      closeAllGroups(opening ? group : null);
+      group.classList.toggle('open', opening);
+      label.setAttribute('aria-expanded', opening ? 'true' : 'false');
+    });
+  });
+
+  /* Close open groups when clicking outside the navbar. */
+  document.addEventListener('click', function (e) {
+    if (!nav.contains(e.target)) closeAllGroups();
   });
 }());

--- a/public/style.css
+++ b/public/style.css
@@ -31,13 +31,36 @@ a:hover { text-decoration: underline; }
 }
 .navbar-brand    { font-size: 1.1rem; font-weight: 700; color: var(--text); gap: .5rem; display:flex; align-items:center; }
 .navbar-collapse { display: flex; flex: 1; align-items: center; }
-.navbar-menu     { display: flex; gap: .25rem; flex: 1; }
+.navbar-menu     { display: flex; gap: .25rem; flex: 1; align-items: center; }
 .navbar-end      { display: flex; align-items: center; gap: .75rem; margin-left: auto; }
 .navbar-toggle   { display: none; }
 .nav-item { color: var(--muted); padding: .4rem .75rem; border-radius: 6px; transition: background .15s, color .15s; }
 .nav-item:hover { background: var(--bg-hover); color: var(--text); text-decoration: none; }
 .avatar { width: 28px; height: 28px; border-radius: 50%; }
 .username { color: var(--text); font-weight: 600; }
+
+/* Nav groups (dropdown) */
+.nav-group { position: relative; }
+.nav-group-label {
+  display: flex; align-items: center; gap: .3rem;
+  color: var(--muted); padding: .4rem .75rem; border-radius: 6px;
+  background: transparent; border: none; cursor: pointer;
+  font-size: inherit; font-family: inherit;
+  transition: background .15s, color .15s;
+}
+.nav-group-label:hover,
+.nav-group.open .nav-group-label { background: var(--bg-hover); color: var(--text); }
+.nav-caret { font-size: .7em; transition: transform .2s; line-height: 1; }
+.nav-group.open .nav-caret { transform: rotate(180deg); }
+.nav-group-items {
+  display: none; flex-direction: column;
+  position: absolute; top: calc(100% + .35rem); left: 0;
+  background: var(--bg-card); border: 1px solid var(--border); border-radius: 8px;
+  padding: .3rem; min-width: 175px; z-index: 200;
+  box-shadow: 0 6px 20px rgba(0,0,0,.45);
+}
+.nav-group.open .nav-group-items { display: flex; }
+.nav-group-items .nav-item { border-radius: 6px; white-space: nowrap; }
 
 /* ── Container ─────────────────────────────────────────── */
 .container { max-width: 1280px; margin: 0 auto; padding: 1.5rem; }
@@ -274,7 +297,7 @@ textarea.input, .stream-textarea { width: 100%; resize: vertical; font-family: v
     padding: .5rem 1rem;
   }
   .navbar.nav-open .navbar-collapse { display: flex; }
-  .navbar-menu { flex-direction: column; gap: 0; width: 100%; }
+  .navbar-menu { flex-direction: column; gap: 0; width: 100%; align-items: stretch; }
   .navbar-end {
     flex-direction: row; flex-wrap: wrap; align-items: center;
     width: 100%; margin-left: 0; gap: .5rem;
@@ -282,12 +305,26 @@ textarea.input, .stream-textarea { width: 100%; resize: vertical; font-family: v
   }
   .nav-item { width: 100%; border-radius: 6px; }
 
+  /* Nav groups: expand inline on mobile */
+  .nav-group { width: 100%; }
+  .nav-group-label { width: 100%; justify-content: space-between; }
+  .nav-group-items {
+    position: static; box-shadow: none;
+    background: transparent; border: none; border-left: 2px solid var(--border);
+    margin: .15rem 0 .15rem .75rem; padding: .2rem 0 .2rem .5rem; min-width: 0;
+  }
+  .nav-group-items .nav-item { white-space: normal; }
+
   /* Tables: allow horizontal scroll within the scroll wrapper */
   .card { overflow: visible; }
   .table-scroll { border-radius: var(--radius); }
   .table-scroll .table { width: max-content; min-width: 100%; }
   .table-scroll .table th,
   .table-scroll .table td { white-space: nowrap; }
+  /* Restore wrapping for long-content cells */
+  .table-scroll .table td.command-output-cell {
+    white-space: normal; overflow-wrap: anywhere; max-width: 180px;
+  }
 
   /* Section header: stack title + search vertically */
   .section-header { flex-wrap: wrap; gap: .5rem; }

--- a/views/partials/nav.ejs
+++ b/views/partials/nav.ejs
@@ -4,20 +4,32 @@
   <div class="navbar-collapse" id="navbar-collapse" aria-hidden="false">
     <div class="navbar-menu">
       <a href="/" class="nav-item">Dashboard</a>
-      <a href="/sfx" class="nav-item">SFX</a>
+      <div class="nav-group">
+        <button class="nav-group-label" aria-haspopup="true" aria-expanded="false">Bot Commands <span class="nav-caret">▾</span></button>
+        <div class="nav-group-items">
+          <a href="/sfx" class="nav-item">SFX</a>
+          <% if (user && user.accessLevel >= 2) { %>
+          <a href="/admin/commands" class="nav-item">Commands</a>
+          <a href="/admin/counters" class="nav-item">Counters</a>
+          <a href="/admin/command-monitor" class="nav-item">Command Monitor</a>
+          <% } %>
+        </div>
+      </div>
       <a href="/streamdeck-key" class="nav-item">Streamdeck Key</a>
+      <% if (user && user.accessLevel >= 2) { %>
+      <div class="nav-group">
+        <button class="nav-group-label" aria-haspopup="true" aria-expanded="false">Admin <span class="nav-caret">▾</span></button>
+        <div class="nav-group-items">
+          <a href="/admin/streams" class="nav-item">Streams</a>
+          <a href="/admin/users" class="nav-item">Users</a>
+          <% if (user.accessLevel >= 3) { %>
+          <a href="/admin/streamdeck-keys" class="nav-item">Streamdeck Keys</a>
+          <% } %>
+        </div>
+      </div>
+      <% } %>
       <% if (user) { %>
       <a href="/user/settings" class="nav-item">Settings</a>
-      <% } %>
-      <% if (user && user.accessLevel >= 2) { %>
-      <a href="/admin/commands" class="nav-item">Commands</a>
-      <a href="/admin/counters" class="nav-item">Counters</a>
-      <a href="/admin/command-monitor" class="nav-item">Command Monitor</a>
-      <a href="/admin/streams" class="nav-item">Streams</a>
-      <a href="/admin/users" class="nav-item">Users</a>
-      <% } %>
-      <% if (user && user.accessLevel >= 3) { %>
-      <a href="/admin/streamdeck-keys" class="nav-item">Streamdeck Keys</a>
       <% } %>
     </div>
     <div class="navbar-end">


### PR DESCRIPTION
## Summary

- **Bot Commands dropdown**: groups SFX, Commands, Counters, and Command Monitor under a single nav label. SFX is always visible; the other three appear for Manager+ users only.
- **Admin dropdown**: groups Streams, Users, and Streamdeck Keys under a single nav label for Manager+ users. Streamdeck Keys remains Admin-only within the group.
- **Standalone items**: Dashboard, Streamdeck Key, and Settings remain as top-level links.
- **Mobile behaviour**: dropdowns expand inline (indented beneath their label) rather than as floating panels, consistent with the existing hamburger menu layout.
- **Mobile table fix**: restores `white-space: normal` for `.command-output-cell` inside the mobile media query, which was being silently overridden by the global `nowrap` rule — fixing long text (e.g. command output, counter messages) spilling into adjacent columns.

## Test plan

- [ ] Desktop: click each group label → dropdown panel appears; click outside or press Escape closes it; clicking a second group closes the first
- [ ] Desktop: hover styles on group labels match the existing `.nav-item` hover
- [ ] Mobile (≤640px): hamburger opens menu; Bot Commands and Admin labels expand inline when tapped
- [ ] User (level 0): sees Dashboard, Bot Commands (SFX only), Streamdeck Key — no Admin group
- [ ] Manager (level 2): sees full Bot Commands group and Admin group (without Streamdeck Keys)
- [ ] Admin (level 3): sees full Bot Commands group and full Admin group (including Streamdeck Keys)
- [ ] Mobile Commands/Counters page: long output text wraps within its column rather than overflowing

https://claude.ai/code/session_017ZKcJodNheVKqqQaCk3ByW

---
_Generated by [Claude Code](https://claude.ai/code/session_017ZKcJodNheVKqqQaCk3ByW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Navigation menu restructured with collapsible dropdown groups for Bot Commands and Admin sections, providing improved organization and accessibility
  * Escape key now closes the navigation menu for enhanced keyboard navigation support

* **Improvements**
  * Mobile navigation layout and styling enhanced for better responsive behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->