### PR TITLE
Route tmi.js internal logs through Winston logger

### DIFF
--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -118,13 +118,11 @@ export async function startTwitchBot(): Promise<void> {
       password: TWITCH_OAUTH_TOKEN,
     },
     channels: [...activeChannels],
-    options: {
-      debug: false,
-      logger: {
-        info: (msg: string) => log.info(msg),
-        warn: (msg: string) => log.warn(msg),
-        error: (msg: string) => log.error(msg),
-      },
+    options: { debug: false },
+    logger: {
+      info: (msg: string) => log.info(msg),
+      warn: (msg: string) => log.warn(msg),
+      error: (msg: string) => log.error(msg),
     },
     connection: {
       reconnect: true,

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -118,7 +118,14 @@ export async function startTwitchBot(): Promise<void> {
       password: TWITCH_OAUTH_TOKEN,
     },
     channels: [...activeChannels],
-    options: { debug: false },
+    options: {
+      debug: false,
+      logger: {
+        info: (msg: string) => log.info(msg),
+        warn: (msg: string) => log.warn(msg),
+        error: (msg: string) => log.error(msg),
+      },
+    },
     connection: {
       reconnect: true,
       secure: true,


### PR DESCRIPTION
## Summary

- `tmi.js` has its own built-in logger that defaults to `console`, meaning its error-level messages (e.g. `"No response from Twitch."`) were bypassing Winston and printing raw to stdout
- The `[HH:MM] error:` timestamp format visible on startup is tmi.js's own log format, not our app's
- These messages fire on ping timeout / reconnect cycles — they're not fatal, but were invisible to our log files
- Fix: pass a custom `logger` object via `options.logger` to route all tmi.js internal output through the existing Winston `Twitch` logger

## Test plan

- [ ] Start the bot and confirm `"No response from Twitch."` messages now appear in `logs/combined-*.log` with the `[Twitch]` label instead of printing raw to stdout
- [ ] Verify no raw `[HH:MM] error:` lines appear on stdout from tmi.js

https://claude.ai/code/session_01NA9t11be1WWdCbFkszYE31

---
_Generated by [Claude Code](https://claude.ai/code/session_01NA9t11be1WWdCbFkszYE31)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced logging integration for Twitch bot operations to provide better visibility into system behavior and improve debugging capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->