### PR TITLE
fix: skip general rate limiter for authenticated web panel users

### DIFF
--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -97,7 +97,9 @@ app.use(express.urlencoded({ extended: false }));
 app.use(express.json());
 
 // Session
-if (isProduction) app.set('trust proxy', 1);
+// Always trust exactly one proxy hop (Caddy). Without this, req.ip resolves to
+// Caddy's loopback address and all users share a single rate-limit bucket.
+app.set('trust proxy', 1);
 const sessionStore = new (MySQLStore(session))({
   host: DB_HOST,
   port: DB_PORT,

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -70,7 +70,9 @@ const generalLimiter = rateLimit({
   standardHeaders: 'draft-8',
   legacyHeaders: false,
   keyGenerator: ipKey,
-  skip: (req) => req.path.startsWith('/api/streamdeck'),
+  // Skip authenticated users (session already proves identity) and the Streamdeck API
+  // which has its own limiter. This prevents panel pollers from exhausting the budget.
+  skip: (req) => req.path.startsWith('/api/streamdeck') || !!req.session?.user,
 });
 // Tighter limit for auth endpoints to protect against OAuth quota exhaustion
 const authLimiter = rateLimit({
@@ -90,8 +92,6 @@ const streamdeckLimiter = rateLimit({
   keyGenerator: ipKey,
   message: 'Too many requests, please try again shortly.',
 });
-app.use(generalLimiter);
-
 // Body parsers
 app.use(express.urlencoded({ extended: false }));
 app.use(express.json());
@@ -117,6 +117,9 @@ app.use(
     cookie: { secure: isProduction, httpOnly: true, sameSite: 'lax', maxAge: 24 * 60 * 60 * 1000 },
   }),
 );
+
+// General rate limiter — placed after session so authenticated users can be skipped
+app.use(generalLimiter);
 
 app.use((req, res, next) => {
   res.locals.user = req.session.user ?? null;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- The general rate limiter (100 req / 15 min) was being tripped by the web panel's own background pollers running in an authenticated session
- `/api/status` (every 5s), `/admin/command-monitor/recent` (every 5s), and `/admin/streams/live` (every 15s) together generate ~420 requests per 15 minutes — well over the limit
- Moves `generalLimiter` registration to after session middleware so `req.session` is available, then adds an authenticated-user skip so the limiter only applies to unauthenticated traffic (login page, OAuth flow)

## Test plan

- [ ] Log in to the web panel and leave it open for 15+ minutes — no "Too many requests" errors should appear
- [ ] Confirm the command monitor, status indicator, and streams page all continue polling normally
- [ ] Confirm the login page still works and is rate-limited for unauthenticated requests
- [ ] Confirm `/auth/*` routes still hit the `authLimiter` (10 req/60s) independently

https://claude.ai/code/session_01VLydKBiaZV1JCjudUK59Hh
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLydKBiaZV1JCjudUK59Hh)_