### PR TITLE
Add public SFX commands list page

### DIFF
--- a/public/sfx-public.js
+++ b/public/sfx-public.js
@@ -57,18 +57,27 @@ function updateSortHeaders() {
   });
 }
 
+function activateSort(th) {
+  const col = th.dataset.col;
+  if (sortCol === col) {
+    sortDir = sortDir === 'asc' ? 'desc' : 'asc';
+  } else {
+    sortCol = col;
+    sortDir = 'asc';
+  }
+  updateSortHeaders();
+  applySort(sortCol);
+  applyFilter();
+}
+
 headers.forEach((th) => {
-  th.addEventListener('click', () => {
-    const col = th.dataset.col;
-    if (sortCol === col) {
-      sortDir = sortDir === 'asc' ? 'desc' : 'asc';
-    } else {
-      sortCol = col;
-      sortDir = 'asc';
+  th.setAttribute('tabindex', '0');
+  th.addEventListener('click', () => activateSort(th));
+  th.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
+      e.preventDefault();
+      activateSort(th);
     }
-    updateSortHeaders();
-    applySort(sortCol);
-    applyFilter();
   });
 });
 

--- a/public/sfx-public.js
+++ b/public/sfx-public.js
@@ -19,9 +19,10 @@ function applyFilter() {
   let visible = 0;
 
   rows.forEach((row) => {
-    const cmd = row.dataset.command || '';
-    const cat = row.dataset.category || '';
-    const match = !query || cmd.includes(query) || cat.includes(query);
+    const cmd  = row.dataset.command || '';
+    const cat  = row.dataset.category || '';
+    const desc = row.dataset.description || '';
+    const match = !query || cmd.includes(query) || cat.includes(query) || desc.includes(query);
     row.style.display = match ? '' : 'none';
     if (match) visible++;
   });

--- a/public/sfx-public.js
+++ b/public/sfx-public.js
@@ -1,0 +1,80 @@
+/* ── SFX public list: search + sort ─────────────────────────────────────── */
+
+const searchInput = document.getElementById('sfx-search');
+const tbody       = document.getElementById('sfx-tbody');
+const noResults   = document.getElementById('no-results');
+const cmdCount    = document.getElementById('cmd-count');
+const headers     = document.querySelectorAll('.th-sortable');
+
+let sortCol = null;   // 'command' | 'category' | null
+let sortDir = 'asc';  // 'asc' | 'desc'
+let query   = '';
+
+function getRows() {
+  return Array.from(tbody.querySelectorAll('tr'));
+}
+
+function applyFilter() {
+  const rows = getRows();
+  let visible = 0;
+
+  rows.forEach((row) => {
+    const cmd = row.dataset.command || '';
+    const cat = row.dataset.category || '';
+    const match = !query || cmd.includes(query) || cat.includes(query);
+    row.style.display = match ? '' : 'none';
+    if (match) visible++;
+  });
+
+  if (noResults) noResults.classList.toggle('is-hidden', visible !== 0);
+  if (cmdCount)  cmdCount.textContent = String(visible);
+}
+
+function applySort(col) {
+  const rows = getRows();
+
+  rows.sort((a, b) => {
+    const av = (col === 'category' ? a.dataset.category : a.dataset.command) || '';
+    const bv = (col === 'category' ? b.dataset.category : b.dataset.command) || '';
+    const cmp = av.localeCompare(bv, undefined, { sensitivity: 'base' });
+    return sortDir === 'asc' ? cmp : -cmp;
+  });
+
+  rows.forEach((row) => tbody.appendChild(row));
+}
+
+function updateSortHeaders() {
+  headers.forEach((th) => {
+    const col = th.dataset.col;
+    const icon = th.querySelector('.sort-icon');
+    if (col === sortCol) {
+      th.setAttribute('aria-sort', sortDir === 'asc' ? 'ascending' : 'descending');
+      if (icon) icon.textContent = sortDir === 'asc' ? '↑' : '↓';
+    } else {
+      th.setAttribute('aria-sort', 'none');
+      if (icon) icon.textContent = '⇅';
+    }
+  });
+}
+
+headers.forEach((th) => {
+  th.addEventListener('click', () => {
+    const col = th.dataset.col;
+    if (sortCol === col) {
+      sortDir = sortDir === 'asc' ? 'desc' : 'asc';
+    } else {
+      sortCol = col;
+      sortDir = 'asc';
+    }
+    updateSortHeaders();
+    applySort(sortCol);
+    applyFilter();
+  });
+});
+
+if (searchInput) {
+  searchInput.addEventListener('input', () => {
+    query = searchInput.value.toLowerCase().trim();
+    applyFilter();
+  });
+}

--- a/public/style.css
+++ b/public/style.css
@@ -132,6 +132,9 @@ a:hover { text-decoration: underline; }
 .table td { padding: .6rem 1rem; border-bottom: 1px solid var(--border); vertical-align: middle; }
 .table tr:last-child td { border-bottom: none; }
 .table tr.row-hidden td { opacity: .5; }
+.th-sortable { cursor: pointer; user-select: none; white-space: nowrap; }
+.th-sortable:hover { color: var(--text); }
+.sort-icon { font-size: .7em; margin-left: .3em; opacity: .6; }
 .table tr.sfx-row:hover td { background: var(--bg-hover); }
 .table tr.live-detail-row td { background: rgba(7, 10, 22, .92); }
 

--- a/src/commandRouter.test.ts
+++ b/src/commandRouter.test.ts
@@ -31,6 +31,7 @@ vi.mock('./statusStore', () => ({
 
 import { handleCommand } from './commandRouter';
 import { findTrigger, findSoundFiles } from './db';
+import type { SfxTrigger, SfxFile } from './db';
 import { isPlaying } from './audioPlayer';
 import { playFile, VoiceNotConnectedError } from './sfxPlayer';
 import { pickWeightedRandom } from './soundSelector';
@@ -47,8 +48,8 @@ beforeEach(() => {
   vi.spyOn(Date, 'now').mockReturnValue(mockNow);
 });
 
-const TRIGGER = { id: 42, trigger_command: '!ding' };
-const FILES = [{ file: 'ding.mp3', weight: 1 }];
+const TRIGGER: SfxTrigger = { id: BigInt(42), trigger_command: '!ding', category_id: null, hidden: false, description: null };
+const FILES: SfxFile[] = [{ id: 1, trigger_id: BigInt(42), file: 'ding.mp3', trigger_command: null, weight: 1, hidden: false, category_id: null }];
 
 describe('handleCommand', () => {
   it('does nothing for an unrecognised command', async () => {

--- a/src/commandRouter.test.ts
+++ b/src/commandRouter.test.ts
@@ -31,7 +31,6 @@ vi.mock('./statusStore', () => ({
 
 import { handleCommand } from './commandRouter';
 import { findTrigger, findSoundFiles } from './db';
-import type { SfxTrigger, SfxFile } from './db';
 import { isPlaying } from './audioPlayer';
 import { playFile, VoiceNotConnectedError } from './sfxPlayer';
 import { pickWeightedRandom } from './soundSelector';
@@ -48,8 +47,8 @@ beforeEach(() => {
   vi.spyOn(Date, 'now').mockReturnValue(mockNow);
 });
 
-const TRIGGER: SfxTrigger = { id: BigInt(42), trigger_command: '!ding', category_id: null, hidden: false, description: null };
-const FILES: SfxFile[] = [{ id: 1, trigger_id: BigInt(42), file: 'ding.mp3', trigger_command: null, weight: 1, hidden: false, category_id: null }];
+const TRIGGER = { id: 42, trigger_command: '!ding' };
+const FILES = [{ file: 'ding.mp3', weight: 1 }];
 
 describe('handleCommand', () => {
   it('does nothing for an unrecognised command', async () => {

--- a/src/db.ts
+++ b/src/db.ts
@@ -89,8 +89,8 @@ export type { DbStreamerEventSub, EventSubConfig } from './db/eventSub';
 
 // ─── SFX ────────────────────────────────────────────────────────────────────
 
-export type { SfxTrigger, SfxFile, SfxTriggerRow } from './db/sfx';
-export { findTrigger, findSoundFiles, getAllSfxTriggers } from './db/sfx';
+export type { SfxTrigger, SfxFile, SfxTriggerRow, PublicSfxTrigger } from './db/sfx';
+export { findTrigger, findSoundFiles, getAllSfxTriggers, getPublicSfxTriggers } from './db/sfx';
 
 // ─── Streamdeck API keys ─────────────────────────────────────────────────────
 

--- a/src/db/sfx.ts
+++ b/src/db/sfx.ts
@@ -76,6 +76,25 @@ export async function findSoundFiles(triggerId: bigint): Promise<SfxFile[]> {
   }));
 }
 
+export interface PublicSfxTrigger {
+  triggerCommand: string;
+  categoryName: string | null;
+}
+
+export async function getPublicSfxTriggers(): Promise<PublicSfxTrigger[]> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT t.trigger_command AS triggerCommand, c.name AS categoryName
+     FROM sfxtrigger t
+     LEFT JOIN sfxcategory c ON t.category_id = c.id
+     WHERE t.hidden = 0
+     ORDER BY c.name, t.trigger_command`,
+  );
+  return rows.map((r) => ({
+    triggerCommand: r.triggerCommand,
+    categoryName: r.categoryName ?? null,
+  }));
+}
+
 export async function getAllSfxTriggers(): Promise<SfxTriggerRow[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
     `SELECT

--- a/src/db/sfx.ts
+++ b/src/db/sfx.ts
@@ -79,11 +79,12 @@ export async function findSoundFiles(triggerId: bigint): Promise<SfxFile[]> {
 export interface PublicSfxTrigger {
   triggerCommand: string;
   categoryName: string | null;
+  description: string | null;
 }
 
 export async function getPublicSfxTriggers(): Promise<PublicSfxTrigger[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    `SELECT t.trigger_command AS triggerCommand, c.name AS categoryName
+    `SELECT t.trigger_command AS triggerCommand, c.name AS categoryName, t.description
      FROM sfxtrigger t
      LEFT JOIN sfxcategory c ON t.category_id = c.id
      WHERE t.hidden = 0
@@ -92,6 +93,7 @@ export async function getPublicSfxTriggers(): Promise<PublicSfxTrigger[]> {
   return rows.map((r) => ({
     triggerCommand: r.triggerCommand,
     categoryName: r.categoryName ?? null,
+    description: r.description ?? null,
   }));
 }
 

--- a/src/web/routes/sfxPublic.ts
+++ b/src/web/routes/sfxPublic.ts
@@ -1,0 +1,36 @@
+import { createLogger } from '../../logger';
+import { Router } from 'express';
+import { getPublicSfxTriggers } from '../../db';
+import type { PublicSfxTrigger } from '../../db';
+
+const log = createLogger('Web');
+const router = Router();
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+let cache: { data: PublicSfxTrigger[]; expiresAt: number } | null = null;
+
+async function getCachedData(): Promise<PublicSfxTrigger[]> {
+  if (cache && Date.now() < cache.expiresAt) return cache.data;
+  const data = await getPublicSfxTriggers();
+  cache = { data, expiresAt: Date.now() + CACHE_TTL_MS };
+  return data;
+}
+
+router.get('/sfx-list', async (req, res) => {
+  try {
+    const triggers = await getCachedData();
+    res.render('sfx-public', {
+      user: req.session.user ?? null,
+      triggers,
+    });
+  } catch (err) {
+    log.error('Public SFX list error:', err);
+    res.status(500).render('error', {
+      message: 'Failed to load SFX list.',
+      user: req.session.user ?? null,
+      csrfToken: '',
+    });
+  }
+});
+
+export default router;

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -18,6 +18,7 @@ import dashboardRouter from './routes/dashboard';
 import adminRouter from './routes/admin';
 import apiRouter from './routes/api';
 import sfxRouter from './routes/sfx';
+import sfxPublicRouter from './routes/sfxPublic';
 import streamsRouter from './routes/streams';
 import commandsRouter from './routes/commands';
 import countersRouter from './routes/counters';
@@ -129,6 +130,7 @@ app.use('/auth', authLimiter, authRouter);
 // EventSub OAuth callback — must be outside requireAuth (Twitch redirects here without session)
 app.use('/auth', authLimiter, eventsubCallbackRouter);
 app.use('/api/streamdeck', streamdeckLimiter, streamdeckRouter);
+app.use('/', sfxPublicRouter);
 app.use('/api', requireAuth, apiRouter);
 app.use('/', requireAuth, streamdeckKeysRouter);
 app.use('/', requireAuth, sfxRouter);

--- a/views/sfx-public.ejs
+++ b/views/sfx-public.ejs
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BCUK Bot — SFX Commands</title>
+  <link rel="stylesheet" href="/style.css">
+  <%- include('partials/pwa-head') %>
+</head>
+<body>
+  <nav class="navbar">
+    <a href="/sfx-list" class="navbar-brand">🤖 BCUK Bot</a>
+  </nav>
+
+  <main class="container">
+
+    <section class="section">
+      <div class="section-header">
+        <h2 class="section-title">SFX Commands (<span id="cmd-count"><%= triggers.length %></span>)</h2>
+        <label for="sfx-search" style="position:absolute;left:-10000px;width:1px;height:1px;overflow:hidden;">Filter SFX commands</label>
+        <input type="search" id="sfx-search" class="search-input" placeholder="Search commands…">
+      </div>
+
+      <div class="card">
+        <div class="table-scroll">
+          <table class="table" id="sfx-table" aria-label="SFX commands">
+            <thead>
+              <tr>
+                <th scope="col" class="th-sortable" data-col="command" aria-sort="none">
+                  Command <span class="sort-icon" aria-hidden="true">⇅</span>
+                </th>
+                <th scope="col" class="th-sortable" data-col="category" aria-sort="none">
+                  Category <span class="sort-icon" aria-hidden="true">⇅</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody id="sfx-tbody">
+              <% triggers.forEach(function(t) { %>
+              <tr data-command="<%= t.triggerCommand.toLowerCase() %>" data-category="<%= (t.categoryName || '').toLowerCase() %>">
+                <td class="mono"><%= t.triggerCommand %></td>
+                <td><% if (t.categoryName) { %><%= t.categoryName %><% } else { %><em class="muted">—</em><% } %></td>
+              </tr>
+              <% }) %>
+            </tbody>
+          </table>
+        </div>
+        <div id="no-results" class="empty-msg empty-msg-padded is-hidden">No commands match your search.</div>
+      </div>
+    </section>
+
+  </main>
+
+  <script src="/sfx-public.js"></script>
+</body>
+</html>

--- a/views/sfx-public.ejs
+++ b/views/sfx-public.ejs
@@ -32,13 +32,15 @@
                 <th scope="col" class="th-sortable" data-col="category" aria-sort="none">
                   Category <span class="sort-icon" aria-hidden="true">⇅</span>
                 </th>
+                <th scope="col">Description</th>
               </tr>
             </thead>
             <tbody id="sfx-tbody">
               <% triggers.forEach(function(t) { %>
-              <tr data-command="<%= t.triggerCommand.toLowerCase() %>" data-category="<%= (t.categoryName || '').toLowerCase() %>">
+              <tr data-command="<%= t.triggerCommand.toLowerCase() %>" data-category="<%= (t.categoryName || '').toLowerCase() %>" data-description="<%= (t.description || '').toLowerCase() %>">
                 <td class="mono"><%= t.triggerCommand %></td>
                 <td><% if (t.categoryName) { %><%= t.categoryName %><% } else { %><em class="muted">—</em><% } %></td>
+                <td><% if (t.description) { %><%= t.description %><% } else { %><em class="muted">—</em><% } %></td>
               </tr>
               <% }) %>
             </tbody>

--- a/views/sfx-public.ejs
+++ b/views/sfx-public.ejs
@@ -50,6 +50,7 @@
 
   </main>
 
+  <%- include('partials/pwa-register') %>
   <script src="/sfx-public.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Adds a public (no login required) page at `/sfx-list` showing all non-hidden SFX commands and their categories
- Server-side in-memory cache (5 min TTL) means the DB is only queried occasionally — burst traffic from viewers won't hammer the database
- All data is embedded in the initial HTML response as server-rendered rows; search and column sorting are fully client-side with zero extra requests after page load
- Hidden triggers are excluded at the query level (`WHERE hidden = 0`)

## Test plan

- [ ] Visit `/sfx-list` without being logged in — page loads with no redirect to login
- [ ] Confirm only non-hidden commands appear
- [ ] Search box filters by command name and category in real time
- [ ] Clicking "Command" or "Category" column headers sorts ascending then descending on repeated clicks; sort icon updates accordingly
- [ ] Visiting the page multiple times within 5 minutes doesn't fire repeated DB queries (cache is working)
- [ ] Existing authenticated `/sfx` page is unaffected

https://claude.ai/code/session_01C51mdTV2KSAPJnHouvn9dy

---
_Generated by [Claude Code](https://claude.ai/code/session_01C51mdTV2KSAPJnHouvn9dy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New public Sound Effects (SFX) commands reference page accessible without signing in
  * Real-time search filtering across commands, categories, and descriptions with live result count
  * Clickable sortable table columns with visual sort indicators and accessible sort state
  * No-results feedback message and improved responsive client-side interactions for browsing commands

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->