### PR TITLE
Save default EventSub config on Twitch account connect

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -83,7 +83,7 @@ export type {
 
 export {
   getAllEventSubStreamers, getStreamerByDiscordId, getStreamerById,
-  saveStreamerToken, clearStreamerToken, saveEventConfig,
+  saveStreamerToken, clearStreamerToken, initEventConfig, saveEventConfig,
 } from './db/eventSub';
 export type { DbStreamerEventSub, EventSubConfig } from './db/eventSub';
 

--- a/src/db/eventSub.ts
+++ b/src/db/eventSub.ts
@@ -136,6 +136,34 @@ export async function clearStreamerToken(streamerId: number): Promise<void> {
   );
 }
 
+const DEFAULT_EVENT_CONFIG: EventSubConfig = {
+  follow_enabled: false,
+  follow_message: 'Thanks {display_name} for the follow!',
+  sub_enabled: false,
+  sub_message: 'Thanks {display_name} for subscribing! (Tier {tier})',
+  resub_message: 'Thanks {display_name} for {months} months! (Tier {tier})',
+  giftsub_message: '{gifter_display} gifted {count} sub(s) to the community!',
+  raid_enabled: false,
+  raid_message: 'Welcome raiders from {from_display}! Thank you for the {viewers} person raid!',
+};
+
+export async function initEventConfig(streamerId: number): Promise<void> {
+  const c = DEFAULT_EVENT_CONFIG;
+  await getPool().execute(
+    `INSERT IGNORE INTO streamer_event_config
+       (streamer_id, follow_enabled, follow_message,
+        sub_enabled, sub_message, resub_message, giftsub_message,
+        raid_enabled, raid_message)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      streamerId,
+      c.follow_enabled ? 1 : 0, c.follow_message,
+      c.sub_enabled ? 1 : 0, c.sub_message, c.resub_message, c.giftsub_message,
+      c.raid_enabled ? 1 : 0, c.raid_message,
+    ],
+  );
+}
+
 export async function saveEventConfig(streamerId: number, config: EventSubConfig): Promise<void> {
   await getPool().execute(
     `INSERT INTO streamer_event_config

--- a/src/web/routes/eventsubCallback.ts
+++ b/src/web/routes/eventsubCallback.ts
@@ -53,6 +53,7 @@ router.get('/twitch/eventsub/callback', async (req, res) => {
     }
 
     const expiryMs = Date.now() + tokens.expires_in * 1000 - 60_000;
+    log.info(`EventSub token expiry debug — expires_in=${tokens.expires_in} Date.now()=${Date.now()} expiryMs=${expiryMs}`);
     await saveStreamerToken(streamerId, twitchUser.id, tokens.access_token, tokens.refresh_token, expiryMs);
     await initEventConfig(streamerId);
     reloadEventSubSubscriptions();

--- a/src/web/routes/eventsubCallback.ts
+++ b/src/web/routes/eventsubCallback.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '../../logger';
 import { Router } from 'express';
-import { getStreamerById, saveStreamerToken } from '../../db';
+import { getStreamerById, saveStreamerToken, initEventConfig } from '../../db';
 import { exchangeCode, getUserFromToken } from '../../twitchApiEventSub';
 import { TWITCH_EVENTSUB_REDIRECT_URI } from '../../config';
 import { reloadEventSubSubscriptions } from '../../twitchEventSub';
@@ -54,6 +54,7 @@ router.get('/twitch/eventsub/callback', async (req, res) => {
 
     const expiryMs = Date.now() + tokens.expires_in * 1000 - 60_000;
     await saveStreamerToken(streamerId, twitchUser.id, tokens.access_token, tokens.refresh_token, expiryMs);
+    await initEventConfig(streamerId);
     reloadEventSubSubscriptions();
     log.info(`EventSub OAuth connected for ${streamer.twitch_name}`);
     res.redirect('/user/settings?success=twitch_connected');


### PR DESCRIPTION
## Summary

- Added `initEventConfig(streamerId)` to `src/db/eventSub.ts` — uses `INSERT IGNORE` to create a default `streamer_event_config` row only if one doesn't already exist
- Exported the new function from `src/db.ts`
- Called `initEventConfig` in the Twitch OAuth callback (`src/web/routes/eventsubCallback.ts`) immediately after saving the streamer's tokens

## Behaviour

- **First connect:** default config row is inserted (all events disabled, stock message templates)
- **Reconnect:** `INSERT IGNORE` is a no-op, so existing settings are never overwritten
- Defaults match the SQL schema defaults and the fallback values already used by the settings page

## Test plan

- [ ] Connect a Twitch account for a streamer with no existing config — verify a `streamer_event_config` row is created with all-disabled flags and default messages
- [ ] Disconnect and reconnect the same account — verify the existing config row is unchanged
- [ ] Confirm the settings page loads without errors and shows the saved defaults

https://claude.ai/code/session_01DNxum6CCm7pacZXJEjxNiM

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNxum6CCm7pacZXJEjxNiM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streamers' event subscription configurations are now automatically initialized with default settings when connecting their Twitch account.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->