### PR TITLE
Fix: treat absent expires_in as non-expiring Twitch token

### DIFF
--- a/src/db/eventSub.ts
+++ b/src/db/eventSub.ts
@@ -114,7 +114,7 @@ export async function saveStreamerToken(
   twitchUserId: string,
   accessToken: string,
   refreshToken: string,
-  expiryMs: number,
+  expiryMs: number | null,
 ): Promise<void> {
   if (!EVENTSUB_TOKEN_SECRET) throw new Error('EVENTSUB_TOKEN_SECRET is not configured — refusing to persist plaintext OAuth tokens');
   const storedAccess = encryptToken(accessToken, EVENTSUB_TOKEN_SECRET);

--- a/src/twitchApiEventSub.ts
+++ b/src/twitchApiEventSub.ts
@@ -12,7 +12,7 @@ export class TwitchAuthError extends Error {
 export interface OAuthTokens {
   access_token: string;
   refresh_token: string;
-  expires_in: number;
+  expires_in?: number;
 }
 
 export async function exchangeCode(code: string, redirectUri: string): Promise<OAuthTokens> {

--- a/src/twitchEventSubSubscriptions.ts
+++ b/src/twitchEventSubSubscriptions.ts
@@ -125,8 +125,8 @@ async function subscribe(sessionId: string, spec: SubSpec, token: string, login:
 async function maybeRefreshToken(streamer: DbStreamerEventSub): Promise<string | null> {
   if (!streamer.eventsub_access_token) return null;
 
-  const needsRefresh = !streamer.eventsub_token_expiry
-    || Date.now() > streamer.eventsub_token_expiry - BUFFER_MS;
+  const needsRefresh = streamer.eventsub_token_expiry != null
+    && Date.now() > streamer.eventsub_token_expiry - BUFFER_MS;
 
   if (!needsRefresh) return streamer.eventsub_access_token;
 
@@ -137,7 +137,7 @@ async function maybeRefreshToken(streamer: DbStreamerEventSub): Promise<string |
 
   try {
     const tokens = await refreshUserToken(streamer.eventsub_refresh_token);
-    const expiryMs = Date.now() + tokens.expires_in * 1000 - 60_000;
+    const expiryMs = tokens.expires_in != null ? Date.now() + tokens.expires_in * 1000 - 60_000 : null;
     await saveStreamerToken(streamer.id, streamer.twitch_user_id!, tokens.access_token, tokens.refresh_token, expiryMs);
     log.info(`Token refreshed for ${streamer.twitch_name ?? 'unknown'}`);
     return tokens.access_token;

--- a/src/web/routes/eventsubCallback.ts
+++ b/src/web/routes/eventsubCallback.ts
@@ -52,8 +52,7 @@ router.get('/twitch/eventsub/callback', async (req, res) => {
       return res.redirect(`/user/settings?error=eventsub_wrong_account&expected=${encodeURIComponent(streamer.twitch_name ?? '')}`);
     }
 
-    const expiryMs = Date.now() + tokens.expires_in * 1000 - 60_000;
-    log.info(`EventSub token expiry debug — expires_in=${tokens.expires_in} Date.now()=${Date.now()} expiryMs=${expiryMs}`);
+    const expiryMs = tokens.expires_in != null ? Date.now() + tokens.expires_in * 1000 - 60_000 : null;
     await saveStreamerToken(streamerId, twitchUser.id, tokens.access_token, tokens.refresh_token, expiryMs);
     await initEventConfig(streamerId);
     reloadEventSubSubscriptions();


### PR DESCRIPTION
## Summary

- Twitch omits `expires_in` from OAuth token responses when a token has no expiry, causing `NaN` to be stored in `eventsub_token_expiry`
- `expires_in` is now optional in the `OAuthTokens` interface
- When absent, `NULL` is stored in the DB instead of `NaN`
- The refresh logic now treats `NULL` expiry as non-expiring — the token is never needlessly refreshed

## One-time DB fix

Run this to clear any existing bad values from before this fix:

```sql
UPDATE streamer SET eventsub_token_expiry = NULL WHERE eventsub_token_expiry < 0;
```

## Test plan

- [ ] Connect a Twitch account and verify `eventsub_token_expiry` is `NULL` in the DB (when Twitch omits `expires_in`)
- [ ] Confirm the bot does not attempt unnecessary token refreshes for that streamer
- [ ] Confirm tokens with a real `expires_in` still store a correct positive expiry and are refreshed normally when near expiry

https://claude.ai/code/session_01DNxum6CCm7pacZXJEjxNiM

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNxum6CCm7pacZXJEjxNiM)_