### PR TITLE
fix(twitch): eliminate duplicate JOIN race causing "No response from Twitch" errors

### DIFF
--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -20,8 +20,8 @@ let connected = false;
 const activeChannels = new Set<string>();
 const activeChannelUserIds = new Map<string, string>();
 const membershipMutationQueue = createMutationQueue();
-// Conservative throttle between JOIN commands to avoid Twitch IRC rate limits.
-const JOIN_THROTTLE_MS = 300;
+// Twitch rate-limits JOIN to 20 per 10 s (2/s). 600 ms ≈ 1.67/s, ~83% of the ceiling.
+const JOIN_THROTTLE_MS = 600;
 
 function normalizeChannel(channel: string): string | null {
   return normalizeTwitchChannelName(channel);

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -20,8 +20,8 @@ let connected = false;
 const activeChannels = new Set<string>();
 const activeChannelUserIds = new Map<string, string>();
 const membershipMutationQueue = createMutationQueue();
-// Twitch IRC rate-limits JOIN to 50/15 s; 400 ms gives ~37 joins/15 s (~75% of the limit).
-const JOIN_THROTTLE_MS = 400;
+// Conservative throttle between JOIN commands to avoid Twitch IRC rate limits.
+const JOIN_THROTTLE_MS = 300;
 
 function normalizeChannel(channel: string): string | null {
   return normalizeTwitchChannelName(channel);

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -117,7 +117,7 @@ export async function startTwitchBot(): Promise<void> {
       username: TWITCH_USERNAME,
       password: TWITCH_OAUTH_TOKEN,
     },
-    channels: [...activeChannels],
+    channels: [],
     options: { debug: false },
     logger: {
       info: (msg: string) => log.info(msg),
@@ -190,6 +190,10 @@ export async function startTwitchBot(): Promise<void> {
 
   client.on('disconnected', (reason) => {
     connected = false;
+    // Clear tmi.js's confirmed-channel list so it doesn't replay those
+    // channels in its auto-rejoin queue on the next connect. All joining
+    // is handled by reconcileJoinedChannels after 'connected' fires.
+    (client as any).channels = [];
     log.warn(`Disconnected: ${reason}`);
     activeChannels.forEach((ch) => { setTwitchChannel(ch, false); });
   });

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -20,6 +20,8 @@ let connected = false;
 const activeChannels = new Set<string>();
 const activeChannelUserIds = new Map<string, string>();
 const membershipMutationQueue = createMutationQueue();
+// Twitch IRC rate-limits JOIN to 20/10 s for unverified bots; pace reconcile joins safely below that.
+const JOIN_THROTTLE_MS = 300;
 
 function normalizeChannel(channel: string): string | null {
   return normalizeTwitchChannelName(channel);
@@ -56,6 +58,7 @@ async function joinMissingChannel(channel: string): Promise<void> {
     return;
   }
   await client.join(channel);
+  await new Promise<void>((resolve) => { setTimeout(resolve, JOIN_THROTTLE_MS); });
   setTwitchChannel(channel, true);
   log.info(`Joined queued channel after reconnect: ${channel}`);
 }

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -20,8 +20,8 @@ let connected = false;
 const activeChannels = new Set<string>();
 const activeChannelUserIds = new Map<string, string>();
 const membershipMutationQueue = createMutationQueue();
-// Twitch IRC rate-limits JOIN to 20/10 s for unverified bots; pace reconcile joins safely below that.
-const JOIN_THROTTLE_MS = 300;
+// Twitch IRC rate-limits JOIN to 50/15 s; 400 ms gives ~37 joins/15 s (~75% of the limit).
+const JOIN_THROTTLE_MS = 400;
 
 function normalizeChannel(channel: string): string | null {
   return normalizeTwitchChannelName(channel);


### PR DESCRIPTION
## Summary

- **Root cause:** On every connect/reconnect, tmi.js emits `'connected'` and then starts its own throttled JOIN queue (from `opts.channels` + previously confirmed `this.channels`). Our `reconcileJoinedChannels` fires on the same event, sees `getChannels() = []` (tmi.js resets this list before emitting `'connected'`), and races to join all channels first. tmi.js's ~2 s-throttled JOINs then arrive for already-joined channels — Twitch never responds — producing `"No response from Twitch."` errors every startup and reconnect.
- **Fix 1:** Pass `channels: []` to the tmi.Client constructor so tmi.js's constructor join queue is always empty on first connect.
- **Fix 2:** In the `'disconnected'` handler, clear `(client as any).channels = []` so tmi.js cannot replay previously-confirmed channels in its reconnect join queue. `reconcileJoinedChannels` becomes the sole path for all channel joining, with no race.

## Test plan

- [ ] `npm run build` passes with no TypeScript errors
- [ ] On bot startup, each channel appears in exactly one `Executing command: JOIN #X` log entry
- [ ] `Joined queued channel after reconnect: X` appears for each channel
- [ ] Zero `"No response from Twitch."` errors at startup
- [ ] Simulate a reconnect — same clean single-JOIN pattern repeats, no errors

https://claude.ai/code/session_01Vnnqcd9XPy6VfgJFHyFkbq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vnnqcd9XPy6VfgJFHyFkbq)_