### PR TITLE
Fix ambiguous command_id in assign query; add user assignment to create form

### DIFF
--- a/src/db/commandConflicts.ts
+++ b/src/db/commandConflicts.ts
@@ -208,7 +208,7 @@ export async function insertUserCommandAssignment(
     `INSERT INTO twitch_user_commands (command_id, discord_id)
      VALUES (?, ?) AS new_row
      ON DUPLICATE KEY UPDATE
-       command_id = command_id`,
+       command_id = new_row.command_id`,
     [commandId, discordId],
   );
 }

--- a/src/db/customCommands.ts
+++ b/src/db/customCommands.ts
@@ -369,13 +369,13 @@ export async function addCustomCommand(
   output: string,
   isDiscordEnabled: boolean,
   isMultiTwitch: boolean,
-): Promise<void> {
+): Promise<number> {
   const normalizedTriggerString = requireTrimmedString(triggerString, 'trigger_string').toLowerCase();
   const normalizedOutput = requireTrimmedString(output, 'output');
 
   assertNotReservedCommand(normalizedTriggerString);
 
-  await runSerializedCommandWrite(
+  const commandId = await runSerializedCommandWrite(
     normalizedTriggerString,
     undefined,
     async (connection) => {
@@ -387,16 +387,20 @@ export async function addCustomCommand(
         await assertMultiTwitchTriggerAvailable(connection, normalizedTriggerString);
       }
 
-      await connection.execute(
+      const [result] = await connection.execute<mysql.ResultSetHeader>(
         `INSERT INTO custom_command (trigger_string, output, is_discord_enabled, is_multi_twitch)
          VALUES (?, ?, ?, ?)`,
         [normalizedTriggerString, normalizedOutput, isDiscordEnabled ? 1 : 0, isMultiTwitch ? 1 : 0],
       );
+
+      return result.insertId;
     },
     { includeCustomCommandTable: false, includeCounterTable: true },
   );
 
   invalidateCustomCommandLookupCache();
+
+  return commandId;
 }
 
 export async function updateCustomCommand(

--- a/src/web/routes/commands.ts
+++ b/src/web/routes/commands.ts
@@ -113,8 +113,9 @@ router.post('/commands/add', requireManager, csrfProtection, async (req, res) =>
     return res.redirect('/admin/commands?error=missing_fields');
   }
 
+  let commandId: number;
   try {
-    await addCustomCommand(normalizedTriggerString, normalizedOutput, isDiscordEnabled, isMultiTwitch);
+    commandId = await addCustomCommand(normalizedTriggerString, normalizedOutput, isDiscordEnabled, isMultiTwitch);
   } catch (err) {
     if (err instanceof ReservedCommandError) {
       return res.redirect('/admin/commands?error=reserved_command');
@@ -126,6 +127,25 @@ router.post('/commands/add', requireManager, csrfProtection, async (req, res) =>
 
     log.error('Add custom command error:', err);
     return res.redirect('/admin/commands?error=add_failed');
+  }
+
+  const rawDiscordIds = req.body.discord_ids;
+  const discordIds: string[] = (Array.isArray(rawDiscordIds) ? rawDiscordIds : rawDiscordIds ? [rawDiscordIds] : [])
+    .map((id: string) => normalizeDiscordId(id))
+    .filter((id): id is string => id !== null);
+
+  for (const discordId of discordIds) {
+    try {
+      const user = await findUser(discordId);
+      if (!user || !user.twitch_name) continue;
+      await assignUserToCommand(commandId, discordId);
+    } catch (err) {
+      if (err instanceof CommandConflictError || isMysqlDuplicateEntryError(err)) {
+        return res.redirect('/admin/commands?error=command_taken');
+      }
+      log.error('Assign user during command creation error:', err);
+      return res.redirect('/admin/commands?error=assign_failed');
+    }
   }
 
   res.redirect('/admin/commands');

--- a/views/commands.ejs
+++ b/views/commands.ejs
@@ -53,6 +53,17 @@
               <p class="hint hint-compact">Reply text to send when the trigger matches.</p>
               <textarea id="output" class="input stream-textarea" name="output" rows="3" placeholder="Hello chat!" required></textarea>
             </div>
+            <% if (assignableUsers.length > 0) { %>
+            <div class="form-section-gap">
+              <label for="add-discord-ids" class="form-label">Assign Twitch Users <span class="muted">(optional)</span></label>
+              <select id="add-discord-ids" class="input" name="discord_ids" multiple size="<%= Math.min(assignableUsers.length, 5) %>">
+                <% assignableUsers.forEach(function(u) { %>
+                  <option value="<%= u.discord_id %>"><%= u.discord_name || u.discord_id %> (<%= u.twitch_name %>)</option>
+                <% }) %>
+              </select>
+              <p class="hint hint-compact">Hold Ctrl / Cmd to select multiple users.</p>
+            </div>
+            <% } %>
             <button type="submit" class="btn">Add Command</button>
           </form>
         </div>


### PR DESCRIPTION
## Summary

- **Fix SQL ambiguity error** (`Column 'command_id' in field list is ambiguous`): the `ON DUPLICATE KEY UPDATE` clause in `insertUserCommandAssignment` used `command_id = command_id`, which MySQL cannot resolve. Changed to `command_id = new_row.command_id` using the row alias already defined in the `VALUES ... AS new_row` clause.
- **Return new command ID from `addCustomCommand`**: changed return type from `void` to `number` (the `insertId`) so callers can reference the newly created row.
- **Accept user assignments on the create form**: the `/commands/add` route now reads an optional `discord_ids[]` field and calls `assignUserToCommand` for each valid entry after creation, matching the existing assign-endpoint logic.
- **Add user multi-select to the create form**: the Add Command panel in `commands.ejs` now shows an optional multi-select for Twitch-eligible users (hidden when no eligible users exist), with a hint to Ctrl/Cmd-click for multiple selections.

## Test plan

- [ ] Create a command without selecting any users — should behave as before
- [ ] Create a command with one or more users selected — users should appear in the Assigned Twitch Users column immediately
- [ ] Edit an existing command and assign a user via the edit panel — the previous SQL error should no longer occur
- [ ] Edit an existing command and unassign a user — should continue to work
- [ ] Attempt to assign a user whose trigger would conflict — should redirect with `command_taken` error

https://claude.ai/code/session_01URjWsuQBdWffHqSo3tajH5

---
_Generated by [Claude Code](https://claude.ai/code/session_01URjWsuQBdWffHqSo3tajH5)_