### PR TITLE
Fix multi-twitch custom commands broadcasting to all channels when offline

### DIFF
--- a/src/customCommandHandler.ts
+++ b/src/customCommandHandler.ts
@@ -7,6 +7,7 @@ import { recordCommandTestEntry } from './commandMonitorStore';
 import { getSharedChatSession } from './twitchApi';
 import { extractCommand } from './commandUtils';
 import { isDiscordNotFoundError } from './discordUtils';
+import { getMultiTwitchDataForChannel } from './twitchMonitor';
 
 // ─── Twitch runtime (registered from index.ts before startTwitchBot) ─────────
 //
@@ -99,7 +100,16 @@ async function broadcastToActiveChannels(sourceChannel: string, command: string,
 
   // Only send to channels where the command is registered (in-memory cache lookup)
   const registrationResults = await Promise.all(candidates.map((ch) => getCustomCommandForTwitchChannel(ch, command)));
-  const targets = candidates.filter((_, i) => registrationResults[i] !== null);
+  const registered = candidates.filter((_, i) => registrationResults[i] !== null);
+
+  // Restrict to the active multi-twitch group. When the source channel is not in an
+  // active group (e.g. offline), fall back to the source channel only so the command
+  // does not broadcast to unrelated channels.
+  const groupInfo = getMultiTwitchDataForChannel(sourceChannel);
+  const groupParticipantSet = groupInfo ? new Set(groupInfo.participants) : null;
+  const targets = registered.filter((ch) =>
+    ch === sourceChannel || (groupParticipantSet !== null && groupParticipantSet.has(ch)),
+  );
 
   // Pre-resolve all session IDs in parallel to avoid serial Helix calls per channel
   const userIds = [...new Set(targets.map((ch) => loginUserIds.get(ch)).filter((id): id is string => id !== undefined))];


### PR DESCRIPTION
## Summary

- Custom commands with `is_multi_twitch = true` were broadcasting to **every** channel the bot is joined in, regardless of whether an active multi-twitch session existed for the source channel
- When the triggering streamer is offline (or not in an active multi group), the command now falls back to sending only to the source channel
- When an active group exists, only the group's live participants receive the broadcast — matching the behaviour of the built-in `!multi` command

## Root cause

`broadcastToActiveChannels` in `customCommandHandler.ts` was sending to all channels where the command was registered. Because `registerMultiTwitchCandidates` registers the command for *every* active Twitch channel at cache-build time, this meant all channels always received it.

The built-in `!multi` handler correctly calls `getMultiTwitchDataForChannel()` first and scopes delivery to the active group's participants. The custom-command broadcast path had no equivalent check.

## Fix

Added a `getMultiTwitchDataForChannel(sourceChannel)` call inside `broadcastToActiveChannels`. The target list is now filtered to:
- The source channel only (when no active group)
- The group's live participants (when an active group exists)

## Test plan

- [ ] Trigger a `is_multi_twitch` custom command while offline — confirm response only appears in the triggering channel
- [ ] Trigger the same command while live and in an active multi-twitch group — confirm it broadcasts to all group participants
- [ ] Trigger the command while live but with no active multi group — confirm it only goes to the source channel

https://claude.ai/code/session_01W9uiECiwMEdxTAebmoLXVD

---
_Generated by [Claude Code](https://claude.ai/code/session_01W9uiECiwMEdxTAebmoLXVD)_