### PR TITLE
Cap DB connection pool queue at 100 (second-pass review fix)

### DIFF
--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -15,7 +15,7 @@ export function getPool(): mysql.Pool {
       bigNumberStrings: true,
       waitForConnections: true,
       connectionLimit: 15,
-      queueLimit: 0,
+      queueLimit: 100,
       connectTimeout: 10_000,
     });
   }


### PR DESCRIPTION
## Summary

- `queueLimit: 0` in mysql2 means **no limit** on waiting connections. Under a traffic spike, this allows the queue to grow unbounded and exhaust memory. Changed to `100`, which is well above any realistic burst for a single-instance bot and causes `getConnection()` to reject immediately once the limit is reached — enabling proper error handling rather than silent unbounded queuing.

## Second-pass review verdict

Three agents reviewed the entire remaining codebase (all web routes, all EJS templates, client-side JS, DB layer, advisory locks, migrations, bot services). The `queueLimit` fix above is the only genuine new finding.

Items investigated and confirmed safe:

| Area | Finding | Verdict |
|------|---------|---------|
| EJS templates | All user data uses `<%=` (HTML-escaped) | ✅ Safe |
| `window.confirm()` in JS | Agent flagged as XSS risk | ✅ False positive — confirm() shows plain text only |
| `data-*` attributes in templates | Agent flagged escaping concern | ✅ False positive — `<%=` already HTML-encodes |
| `dashboard.ejs` JSON in data attribute | `<%-` used with single-quote escape | ✅ Safe — CSP blocks scripts; quoted attribute prevents parser escape |
| `command-monitor.js` `innerHTML` | Used only to clear table (`= ''`) | ✅ Safe |
| Open redirects | All redirects use hardcoded paths or validated enums | ✅ No open redirect |
| `process.env` in logger/server | `LOG_LEVEL` and `NODE_ENV` — standard patterns | ✅ By design |
| `EVENTSUB_TOKEN_SECRET` handling | `maybeDecrypt()` returns null if absent; `saveStreamerToken()` throws | ✅ Already handled |
| Streamdeck key race condition | Denied status enforced at DB level via `IF(status='denied',...)` | ✅ No real race |
| EventSub template interpolation | Event data is Twitch-controlled | ✅ Trusted source |
| Advisory locks / deadlock retry | Proper lock ordering, retry bounded | ✅ Sound |
| Migration files | ALTER TABLE sequence is MySQL limitation, not code issue | ✅ Documented |

## Test plan
- [x] `npx vitest run` — 25/25 pass
- [x] `tsc --project tsconfig.build.json --noEmit` — clean

https://claude.ai/code/session_01GVsGC1GHEKdtfVEsNTGcn9

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVsGC1GHEKdtfVEsNTGcn9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database connection queue configuration to improve stability and connection handling during high-traffic scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->