### PR TITLE
feat(commands): per-user coloured badges with mobile wrapping fix

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -328,6 +328,9 @@ textarea.input, .stream-textarea { width: 100%; resize: vertical; font-family: v
   .table-scroll .table td.command-output-cell {
     white-space: normal; overflow-wrap: anywhere; max-width: 180px;
   }
+  .table-scroll .table td.assigned-users-cell {
+    white-space: normal; max-width: 160px;
+  }
 
   /* Section header: stack title + search vertically */
   .section-header { flex-wrap: wrap; gap: .5rem; }

--- a/views/commands.ejs
+++ b/views/commands.ejs
@@ -83,17 +83,30 @@
               </tr>
             </thead>
             <tbody>
+              <%
+              function assignedUserStyle(discordId, isSelf) {
+                let h = 5381;
+                for (let i = 0; i < discordId.length; i++) {
+                  h = ((h << 5) + h) ^ discordId.charCodeAt(i);
+                  h >>>= 0;
+                }
+                const hue = h % 360;
+                if (isSelf) return `color:hsl(${hue},90%,78%);background:hsla(${hue},90%,78%,0.22)`;
+                return `color:hsl(${hue},65%,60%);background:hsla(${hue},65%,60%,0.12)`;
+              }
+              %>
               <% commands.forEach(function(command) { %>
               <tr class="sfx-row">
                 <td class="mono"><strong><%= command.trigger_string %></strong></td>
                 <td class="command-output-cell"><%= command.output %></td>
                 <td><span class="badge <%= command.is_discord_enabled ? 'badge-active' : 'badge-offline' %>"><%= command.is_discord_enabled ? 'Enabled' : 'Off' %></span></td>
                 <td><span class="badge <%= command.is_multi_twitch ? 'badge-active' : 'badge-offline' %>"><%= command.is_multi_twitch ? 'Enabled' : 'Off' %></span></td>
-                <td>
+                <td class="assigned-users-cell">
                   <% if (command.assigned_users.length > 0) { %>
                     <div class="badge-list-wrap">
                       <% command.assigned_users.forEach(function(assignedUser) { %>
-                        <span class="badge <%= assignedUser.is_twitch_bot_enabled ? 'badge-online' : 'badge-offline' %>">
+                        <% const isSelf = user && assignedUser.discord_id === user.discordId; %>
+                        <span class="badge" style="<%= assignedUserStyle(assignedUser.discord_id, isSelf) %>">
                           <%= assignedUser.discord_name || assignedUser.discord_id %>
                           <% if (assignedUser.twitch_name) { %>
                             (<%= assignedUser.twitch_name %>)


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Each assigned user badge in the custom commands table now gets a deterministic colour derived from a hash of their `discord_id`, so the same user always gets the same colour
- The currently logged-in user's badge is rendered noticeably brighter (higher saturation/lightness) to stand out from the rest
- On mobile, the "Assigned Twitch Users" column now wraps badges across multiple lines rather than forcing everything onto one long horizontal line

## Test plan

- [ ] Visit `/admin/commands` — confirm each assigned user badge has a distinct colour
- [ ] Confirm the logged-in user's badge is visibly brighter than others
- [ ] Reload the page — confirm colours are stable (same user = same colour every time)
- [ ] Resize browser to < 640px — confirm the assigned users column wraps badges vertically instead of stretching the table horizontally

https://claude.ai/code/session_01B3hZntRXw6utXThJRyXyeC
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B3hZntRXw6utXThJRyXyeC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced mobile responsiveness and layout optimization for assigned user displays within scrollable tables, improving text wrapping and space usage.
  * Redesigned user badge styling with distinct colors for each user and improved visual highlighting for the current user.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->