### PR TITLE
feat(voice): add voice channel selection for dashboard and Stream Deck

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -124,60 +124,61 @@ function applyStatus(status) {
 let consecutiveFailures = 0;
 const STALE_THRESHOLD = 3;
 
+let voiceChannelPollTimer = null;
+
 async function loadVoiceChannels() {
+  clearTimeout(voiceChannelPollTimer);
   const select = document.getElementById('voice-channel-select');
   if (!select) return;
 
+  let nextPollMs = 30000;
   try {
     const res = await fetch('/api/voice/channels');
     if (!res.ok) {
       select.innerHTML = '<option value="">Failed to load channels</option>';
       select.disabled = true;
-      return;
-    }
+    } else {
+      const data = await res.json();
+      if (data.ok && Array.isArray(data.channels)) {
+        const currentSelected = select.value;
+        select.innerHTML = '';
 
-    const data = await res.json();
-    if (!data.ok || !Array.isArray(data.channels)) return;
+        if (data.channels.length === 0) {
+          const option = document.createElement('option');
+          option.value = '';
+          option.textContent = 'No voice channels available';
+          option.disabled = true;
+          select.appendChild(option);
+          select.disabled = true;
+          nextPollMs = 5000;
+        } else {
+          select.disabled = false;
+          for (const channel of data.channels) {
+            const option = document.createElement('option');
+            option.value = channel.id;
+            option.textContent = channel.name;
+            select.appendChild(option);
+          }
 
-    const currentSelected = select.value;
-    select.innerHTML = '';
-
-    if (data.channels.length === 0) {
-      const option = document.createElement('option');
-      option.value = '';
-      option.textContent = 'No voice channels available';
-      option.disabled = true;
-      select.appendChild(option);
-      select.disabled = true;
-      return;
-    }
-
-    select.disabled = false;
-    for (const channel of data.channels) {
-      const option = document.createElement('option');
-      option.value = channel.id;
-      option.textContent = channel.name;
-      select.appendChild(option);
-    }
-
-    if (currentSelected) {
-      select.value = currentSelected;
-    }
-    const restored = currentSelected && select.value === currentSelected;
-    if (!restored) {
-      if (data.currentChannelId) {
-        select.value = data.currentChannelId;
-      } else if (data.defaultChannelId) {
-        select.value = data.defaultChannelId;
+          if (currentSelected) {
+            select.value = currentSelected;
+          }
+          const restored = currentSelected && select.value === currentSelected;
+          if (!restored) {
+            if (data.currentChannelId) {
+              select.value = data.currentChannelId;
+            } else if (data.defaultChannelId) {
+              select.value = data.defaultChannelId;
+            }
+          }
+        }
       }
     }
   } catch (_) {
-    const select = document.getElementById('voice-channel-select');
-    if (select) {
-      select.innerHTML = '<option value="">Failed to load channels</option>';
-      select.disabled = true;
-    }
+    select.innerHTML = '<option value="">Failed to load channels</option>';
+    select.disabled = true;
   }
+  voiceChannelPollTimer = setTimeout(loadVoiceChannels, nextPollMs);
 }
 
 async function fetchStatus() {
@@ -214,7 +215,6 @@ if (initialStatusRaw) {
 fetchStatus();
 loadVoiceChannels();
 setInterval(fetchStatus, 5000);
-setInterval(loadVoiceChannels, 30000);
 
 /* ── Rejoin Voice button ─────────────────────────────────── */
 

--- a/public/app.js
+++ b/public/app.js
@@ -140,7 +140,10 @@ function restoreVoiceSelection(select, previousValue, data) {
 }
 
 function applyVoiceChannelData(select, data) {
-  if (!data.ok || !Array.isArray(data.channels)) return 30000;
+  if (!data.ok || !Array.isArray(data.channels)) {
+    setSelectError(select);
+    return 5000;
+  }
   const previousValue = select.value;
   select.innerHTML = '';
 
@@ -174,11 +177,13 @@ async function loadVoiceChannels() {
     const res = await fetch('/api/voice/channels');
     if (!res.ok) {
       setSelectError(select);
+      nextPollMs = 5000;
     } else {
       nextPollMs = applyVoiceChannelData(select, await res.json());
     }
   } catch (_) {
     setSelectError(select);
+    nextPollMs = 5000;
   }
   voiceChannelPollTimer = setTimeout(loadVoiceChannels, nextPollMs);
 }

--- a/public/app.js
+++ b/public/app.js
@@ -104,7 +104,7 @@ function applyStatus(status) {
 
   // Keep the rejoin/leave button label in sync with connection state
   const voiceBtn = document.getElementById('btn-rejoin-voice');
-  if (voiceBtn) {
+  if (voiceBtn && !voiceBtn.disabled) {
     voiceBtn.textContent = voiceOn ? 'Leave Voice' : 'Join Voice';
   }
 

--- a/public/app.js
+++ b/public/app.js
@@ -172,7 +172,7 @@ async function loadVoiceChannels() {
   clearTimeout(voiceChannelPollTimer);
   const select = document.getElementById('voice-channel-select');
   if (!select) return;
-  let nextPollMs = 30000;
+  let nextPollMs;
   try {
     const res = await fetch('/api/voice/channels');
     if (!res.ok) {

--- a/public/app.js
+++ b/public/app.js
@@ -126,57 +126,59 @@ const STALE_THRESHOLD = 3;
 
 let voiceChannelPollTimer = null;
 
+function setSelectError(select) {
+  select.innerHTML = '<option value="">Failed to load channels</option>';
+  select.disabled = true;
+}
+
+function restoreVoiceSelection(select, previousValue, data) {
+  if (previousValue) select.value = previousValue;
+  const restored = previousValue && select.value === previousValue;
+  if (restored) return;
+  if (data.currentChannelId) select.value = data.currentChannelId;
+  else if (data.defaultChannelId) select.value = data.defaultChannelId;
+}
+
+function applyVoiceChannelData(select, data) {
+  if (!data.ok || !Array.isArray(data.channels)) return 30000;
+  const previousValue = select.value;
+  select.innerHTML = '';
+
+  if (data.channels.length === 0) {
+    const opt = document.createElement('option');
+    opt.value = '';
+    opt.textContent = 'No voice channels available';
+    opt.disabled = true;
+    select.appendChild(opt);
+    select.disabled = true;
+    return 5000;
+  }
+
+  select.disabled = false;
+  for (const ch of data.channels) {
+    const opt = document.createElement('option');
+    opt.value = ch.id;
+    opt.textContent = ch.name;
+    select.appendChild(opt);
+  }
+  restoreVoiceSelection(select, previousValue, data);
+  return 30000;
+}
+
 async function loadVoiceChannels() {
   clearTimeout(voiceChannelPollTimer);
   const select = document.getElementById('voice-channel-select');
   if (!select) return;
-
   let nextPollMs = 30000;
   try {
     const res = await fetch('/api/voice/channels');
     if (!res.ok) {
-      select.innerHTML = '<option value="">Failed to load channels</option>';
-      select.disabled = true;
+      setSelectError(select);
     } else {
-      const data = await res.json();
-      if (data.ok && Array.isArray(data.channels)) {
-        const currentSelected = select.value;
-        select.innerHTML = '';
-
-        if (data.channels.length === 0) {
-          const option = document.createElement('option');
-          option.value = '';
-          option.textContent = 'No voice channels available';
-          option.disabled = true;
-          select.appendChild(option);
-          select.disabled = true;
-          nextPollMs = 5000;
-        } else {
-          select.disabled = false;
-          for (const channel of data.channels) {
-            const option = document.createElement('option');
-            option.value = channel.id;
-            option.textContent = channel.name;
-            select.appendChild(option);
-          }
-
-          if (currentSelected) {
-            select.value = currentSelected;
-          }
-          const restored = currentSelected && select.value === currentSelected;
-          if (!restored) {
-            if (data.currentChannelId) {
-              select.value = data.currentChannelId;
-            } else if (data.defaultChannelId) {
-              select.value = data.defaultChannelId;
-            }
-          }
-        }
-      }
+      nextPollMs = applyVoiceChannelData(select, await res.json());
     }
   } catch (_) {
-    select.innerHTML = '<option value="">Failed to load channels</option>';
-    select.disabled = true;
+    setSelectError(select);
   }
   voiceChannelPollTimer = setTimeout(loadVoiceChannels, nextPollMs);
 }

--- a/public/app.js
+++ b/public/app.js
@@ -163,13 +163,12 @@ async function loadVoiceChannels() {
     if (currentSelected) {
       select.value = currentSelected;
     }
-    if (!select.value) {
+    const restored = currentSelected && select.value === currentSelected;
+    if (!restored) {
       if (data.currentChannelId) {
         select.value = data.currentChannelId;
       } else if (data.defaultChannelId) {
         select.value = data.defaultChannelId;
-      } else if (data.channels.length > 0) {
-        select.value = data.channels[0].id;
       }
     }
   } catch (_) {

--- a/public/app.js
+++ b/public/app.js
@@ -104,7 +104,7 @@ function applyStatus(status) {
 
   // Keep the rejoin/leave button label in sync with connection state
   const voiceBtn = document.getElementById('btn-rejoin-voice');
-  if (voiceBtn && !voiceBtn.disabled) {
+  if (voiceBtn) {
     voiceBtn.textContent = voiceOn ? 'Leave Voice' : 'Join Voice';
   }
 

--- a/src/web/routes/streamdeck.ts
+++ b/src/web/routes/streamdeck.ts
@@ -77,7 +77,7 @@ router.post('/sfx', requireApiKey, async (req, res) => {
   }
 });
 
-router.get('/voice/channels', requireApiKey, async (_req, res) => {
+router.get('/voice/channels', async (_req, res) => {
   try {
     const channels = await getAvailableVoiceChannels(DISCORD_GUILD_ID);
     res.json({ ok: true, channels });

--- a/src/web/routes/streamdeck.ts
+++ b/src/web/routes/streamdeck.ts
@@ -110,4 +110,9 @@ router.post('/voice/join', requireApiKey, async (req, res) => {
   }
 });
 
+router.post('/voice/leave', requireApiKey, (_req, res) => {
+  disconnect();
+  res.json({ ok: true });
+});
+
 export default router;

--- a/src/web/routes/streamdeck.ts
+++ b/src/web/routes/streamdeck.ts
@@ -77,7 +77,7 @@ router.post('/sfx', requireApiKey, async (req, res) => {
   }
 });
 
-router.get('/voice/channels', async (_req, res) => {
+router.get('/voice/channels', requireApiKey, async (_req, res) => {
   try {
     const channels = await getAvailableVoiceChannels(DISCORD_GUILD_ID);
     res.json({ ok: true, channels });

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -73,7 +73,7 @@ const generalLimiter = rateLimit({
   keyGenerator: ipKey,
   // Skip authenticated users (session already proves identity) and the Streamdeck API
   // which has its own limiter. This prevents panel pollers from exhausting the budget.
-  skip: (req) => req.path.startsWith('/api/streamdeck') || !!req.session?.user,
+  skip: (req) => req.path.startsWith('/api/streamdeck') || req.path.startsWith('/streamdeck') || !!req.session?.user,
 });
 // Tighter limit for auth endpoints to protect against OAuth quota exhaustion
 const authLimiter = rateLimit({
@@ -140,6 +140,7 @@ app.use('/auth', authLimiter, authRouter);
 // EventSub OAuth callback — must be outside requireAuth (Twitch redirects here without session)
 app.use('/auth', authLimiter, eventsubCallbackRouter);
 app.use('/api/streamdeck', streamdeckLimiter, streamdeckRouter);
+app.use('/streamdeck', streamdeckLimiter, streamdeckRouter);
 app.use('/', sfxPublicRouter);
 app.use('/api', requireAuth, apiRouter);
 app.use('/', requireAuth, streamdeckKeysRouter);

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -73,7 +73,7 @@ const generalLimiter = rateLimit({
   keyGenerator: ipKey,
   // Skip authenticated users (session already proves identity) and the Streamdeck API
   // which has its own limiter. This prevents panel pollers from exhausting the budget.
-  skip: (req) => req.path.startsWith('/api/streamdeck') || req.path.startsWith('/streamdeck') || !!req.session?.user,
+  skip: (req) => req.path.startsWith('/api/streamdeck') || !!req.session?.user,
 });
 // Tighter limit for auth endpoints to protect against OAuth quota exhaustion
 const authLimiter = rateLimit({
@@ -140,7 +140,6 @@ app.use('/auth', authLimiter, authRouter);
 // EventSub OAuth callback — must be outside requireAuth (Twitch redirects here without session)
 app.use('/auth', authLimiter, eventsubCallbackRouter);
 app.use('/api/streamdeck', streamdeckLimiter, streamdeckRouter);
-app.use('/streamdeck', streamdeckLimiter, streamdeckRouter);
 app.use('/', sfxPublicRouter);
 app.use('/api', requireAuth, apiRouter);
 app.use('/', requireAuth, streamdeckKeysRouter);


### PR DESCRIPTION
## Summary

- **Dashboard**: adds a voice channel dropdown left of the Join button, pre-selected to the configured default channel. Polls every 5 s while channels are unavailable (Discord client starting up), backing off to 30 s once loaded.
- **Web API**: new `GET /api/voice/channels` (returns channels + `defaultChannelId` + `currentChannelId`); `POST /api/voice/join` accepts optional `channelId` body field.
- **Stream Deck API** (`/api/streamdeck/`):
  - `GET /voice/channels` — list available voice channels (requires API key)
  - `POST /voice/join` — join a specific channel by ID (requires API key)
  - `POST /voice/leave` — leave the current channel (requires API key)
- **Backend**: `connect()` accepts optional `channelId`; auto-reconnect preserves the user-selected channel via `targetChannelId`; `currentChannelId` is cleared on disconnect/teardown; `getCurrentChannelId()` exported.

## Bug fixes included

- Auto-reconnect now rejoins the user-selected channel rather than always falling back to the env-var default
- `isPermanentVoiceMisconfigurationError` updated to match the new error message, preventing infinite reconnect loops on misconfiguration
- `getAvailableVoiceChannels` re-throws Discord API errors so routes return `{ ok: false }` instead of a misleading empty channel list
- Dropdown defaults correctly to configured channel on load (browser auto-selects first option, bypassing `!select.value` check — fixed with `restored` flag)
- Status poll no longer clobbers in-progress button label; label is set explicitly on success
- Non-ok HTTP responses from the channels endpoint now show an error state on the dropdown instead of leaving it stale
- `loadVoiceChannels` self-schedules with adaptive interval (5 s when empty, 30 s when loaded)

## Test Plan

- [ ] Load dashboard — dropdown shows all voice channels, default pre-selected
- [ ] Select a different channel and click Join — bot joins that channel
- [ ] Bot drops connection — auto-reconnect rejoins the same channel, not the default
- [ ] `GET /api/voice/channels` returns `channels`, `defaultChannelId`, `currentChannelId`
- [ ] `POST /api/voice/join` with no `channelId` joins configured default
- [ ] Stream Deck `GET /api/streamdeck/voice/channels` returns channel list
- [ ] Stream Deck `POST /api/streamdeck/voice/join` joins specified channel
- [ ] Stream Deck `POST /api/streamdeck/voice/leave` disconnects bot

https://claude.ai/code/session_01Fa3TCsg7sBBBciQ2rphYis

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fa3TCsg7sBBBciQ2rphYis)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to leave voice connections via API endpoint.
  * Voice channels now load when the application starts.

* **Improvements**
  * Enhanced voice channel polling with adaptive frequency based on results.
  * Improved error handling and automatic selection restoration for voice channels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->