### PR TITLE
Show Connected/LIVE status on dashboard channel list

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -45,7 +45,7 @@ function renderChannels(container, channelMap) {
   for (const [name, info] of entries) {
     const online = info.connected;
     const ts = online ? info.lastConnectedAt : info.lastDisconnectedAt;
-    const label = online ? 'Online' : 'Offline';
+    const label = online ? 'Connected' : 'Offline';
     const cls = online ? 'badge-online' : 'badge-offline';
     const meta = ts ? relativeTime(ts) : 'Never seen';
 
@@ -65,12 +65,23 @@ function renderChannels(container, channelMap) {
     left.appendChild(channelName);
     left.appendChild(channelMeta);
 
+    const right = document.createElement('div');
+    right.className = 'channel-badges';
+
+    if (info.isLive) {
+      const liveBadge = document.createElement('span');
+      liveBadge.className = 'badge badge-live';
+      liveBadge.textContent = 'LIVE';
+      right.appendChild(liveBadge);
+    }
+
     const badge = document.createElement('span');
     badge.className = `badge ${cls}`;
     badge.textContent = label;
+    right.appendChild(badge);
 
     item.appendChild(left);
-    item.appendChild(badge);
+    item.appendChild(right);
     container.appendChild(item);
   }
 }

--- a/public/app.js
+++ b/public/app.js
@@ -45,7 +45,7 @@ function renderChannels(container, channelMap) {
   for (const [name, info] of entries) {
     const online = info.connected;
     const ts = online ? info.lastConnectedAt : info.lastDisconnectedAt;
-    const label = online ? 'Connected' : 'Offline';
+    const label = online ? 'Connected' : 'Disconnected';
     const cls = online ? 'badge-online' : 'badge-offline';
     const meta = ts ? relativeTime(ts) : 'Never seen';
 
@@ -68,7 +68,7 @@ function renderChannels(container, channelMap) {
     const right = document.createElement('div');
     right.className = 'channel-badges';
 
-    if (info.isLive) {
+    if (online && info.isLive) {
       const liveBadge = document.createElement('span');
       liveBadge.className = 'badge badge-live';
       liveBadge.textContent = 'LIVE';

--- a/public/style.css
+++ b/public/style.css
@@ -101,6 +101,7 @@ a:hover { text-decoration: underline; }
 .channel-item:last-child { border-bottom: none; }
 .channel-name { font-family: var(--mono); font-size: .85rem; }
 .channel-meta { font-size: .75rem; color: var(--muted); margin-top: .15rem; }
+.channel-badges { display: flex; gap: .35rem; align-items: center; flex-shrink: 0; }
 
 /* ── Badges ────────────────────────────────────────────── */
 .badge           { display: inline-block; padding: .15em .55em; border-radius: 99px; font-size: .75rem; font-weight: 600; white-space: nowrap; }
@@ -108,6 +109,7 @@ a:hover { text-decoration: underline; }
 .badge-hidden    { background: rgba(234,179,8,.15);  color: #ca8a04; }
 .badge-online    { background: rgba(34,197,94,.15);  color: var(--success); }
 .badge-offline   { background: rgba(239,68,68,.15);  color: var(--danger); }
+.badge-live      { background: #ef4444; color: #fff; animation: pulse 1.5s ease-in-out infinite; }
 .level-0 { background: rgba(113,113,122,.2); color: var(--muted); }
 .level-1 { background: rgba(59,130,246,.2);  color: #60a5fa; }
 .level-2 { background: rgba(245,158,11,.2);  color: var(--warning); }

--- a/src/statusStore.ts
+++ b/src/statusStore.ts
@@ -69,7 +69,7 @@ function updateChannel(map: Map<string, ChannelStatus>, key: string, connected: 
 }
 
 export function setTwitchChannel(channel: string, connected: boolean): void {
-  updateChannel(state.twitch, channel.replace(/^#/, ''), connected);
+  updateChannel(state.twitch, channel.toLowerCase().replace(/^#/, ''), connected);
 }
 
 export function setTikTokChannel(username: string, connected: boolean): void {

--- a/src/statusStore.ts
+++ b/src/statusStore.ts
@@ -2,6 +2,7 @@ export interface ChannelStatus {
   connected: boolean;
   lastConnectedAt: Date | null;
   lastDisconnectedAt: Date | null;
+  isLive: boolean;
 }
 
 const state = {
@@ -59,6 +60,7 @@ function updateChannel(map: Map<string, ChannelStatus>, key: string, connected: 
     connected: false,
     lastConnectedAt: null,
     lastDisconnectedAt: null,
+    isLive: false,
   };
   if (connected && !existing.connected) existing.lastConnectedAt = new Date();
   if (!connected && existing.connected) existing.lastDisconnectedAt = new Date();
@@ -72,6 +74,12 @@ export function setTwitchChannel(channel: string, connected: boolean): void {
 
 export function setTikTokChannel(username: string, connected: boolean): void {
   updateChannel(state.tiktok, username, connected);
+}
+
+export function setTwitchChannelLive(login: string, isLive: boolean): void {
+  const key = login.toLowerCase().replace(/^#/, '');
+  const existing = state.twitch.get(key);
+  if (existing) existing.isLive = isLive;
 }
 
 export function getStatus() {

--- a/src/twitchMonitor.ts
+++ b/src/twitchMonitor.ts
@@ -22,6 +22,7 @@ import {
   cancelOfflineTimersForLogin,
   handleStreamOffline,
 } from './twitchMonitorOffline';
+import { setTwitchChannelLive } from './statusStore';
 import { performStartupLiveCheck } from './twitchMonitorStartup';
 
 const log = createLogger('TwitchMonitor');
@@ -60,6 +61,7 @@ async function handlePollStreamer(
       cancelOfflineTimersForLogin(liveStates, loginKey);
       log.info(`${loginKey} came back — offline timer(s) cancelled`);
     }
+    setTwitchChannelLive(loginKey, true);
     const isNew = !liveStates.has(stateKey);
     if (isNew || (existing && !existing.messageId)) {
       // Went live, or state exists with no Discord message (e.g. Discord wasn't ready at startup)

--- a/src/twitchMonitorOffline.ts
+++ b/src/twitchMonitorOffline.ts
@@ -38,8 +38,8 @@ export async function runOfflineCheck(
     const streams = await getStreams([userId]);
     const isLive = streams.some((s) => s.user_id === userId && s.type === 'live');
     if (!isLive) {
-      await deleteAnnouncement(liveStates, stateKey);
       setTwitchChannelLive(key, false);
+      await deleteAnnouncement(liveStates, stateKey);
       log.info(`${login} confirmed offline — announcement removed`);
     }
   } finally {

--- a/src/twitchMonitorOffline.ts
+++ b/src/twitchMonitorOffline.ts
@@ -4,6 +4,7 @@ import { getStreams } from './twitchApi';
 const log = createLogger('TwitchMonitor');
 import { LiveState } from './twitchMonitorTypes';
 import { deleteAnnouncement } from './twitchMonitorAnnouncements';
+import { setTwitchChannelLive } from './statusStore';
 
 const OFFLINE_GRACE_MS = 5 * 60 * 1000;
 
@@ -38,6 +39,7 @@ export async function runOfflineCheck(
     const isLive = streams.some((s) => s.user_id === userId && s.type === 'live');
     if (!isLive) {
       await deleteAnnouncement(liveStates, stateKey);
+      setTwitchChannelLive(key, false);
       log.info(`${login} confirmed offline — announcement removed`);
     }
   } finally {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Replaces the ambiguous **"Online"** label on the dashboard Channels section with **"Connected"**, making it clear the badge reflects the bot's IRC connection — not whether the streamer is live on Twitch
- Adds a pulsing red **LIVE** badge next to any Twitch channel where the streamer is currently broadcasting, tracked automatically via the existing 60-second Twitch monitor poll cycle
- No new API calls or DB queries — live state is derived from data the bot already fetches

## Changes

| File | What changed |
|------|-------------|
| `src/statusStore.ts` | Added `isLive: boolean` to `ChannelStatus`; added `setTwitchChannelLive()` setter |
| `src/twitchMonitor.ts` | Calls `setTwitchChannelLive(login, true)` when a stream is detected live |
| `src/twitchMonitorOffline.ts` | Calls `setTwitchChannelLive(login, false)` after the grace period confirms the stream is offline |
| `public/app.js` | Renders "Connected"/"Offline" labels and an optional LIVE badge per channel |
| `public/style.css` | Adds `.badge-live` (solid red, pulsing animation) and `.channel-badges` flex wrapper |

## Test plan

- [ ] Dashboard Channels section shows **Connected** (not "Online") for bot-joined channels
- [ ] When a monitored streamer goes live, the red **LIVE** badge appears next to their channel within ~60 seconds
- [ ] After the streamer ends their stream (plus the 5-minute grace period), the LIVE badge disappears
- [ ] Channels that are Offline still show the red **Offline** badge with no LIVE badge
- [ ] TikTok channels are unaffected (no LIVE badge logic for TikTok)

https://claude.ai/code/session_01Tkn8TmfHXDWxmjZt9qcC2k
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tkn8TmfHXDWxmjZt9qcC2k)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a LIVE badge with pulsing animation for active channels

* **UI/UX Improvements**
  * Status labels now read "Connected"/"Disconnected" instead of "Online"/"Offline"
  * Reorganized badge layout on channel items for clearer alignment
  * Adjusted offline badge color to the danger accent for stronger contrast

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->