### PR TITLE
Add channel points video overlay

### DIFF
--- a/migrations/overlay_videos.sql
+++ b/migrations/overlay_videos.sql
@@ -1,0 +1,26 @@
+CREATE TABLE overlay_video (
+  id          INT AUTO_INCREMENT PRIMARY KEY,
+  streamer_id INT          NOT NULL,
+  name        VARCHAR(255) NOT NULL,
+  filename    VARCHAR(255) NOT NULL,
+  created_at  TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (streamer_id) REFERENCES streamer(id) ON DELETE CASCADE
+);
+
+CREATE TABLE overlay_reward (
+  id               INT          AUTO_INCREMENT PRIMARY KEY,
+  streamer_id      INT          NOT NULL,
+  twitch_reward_id VARCHAR(255) NOT NULL,
+  UNIQUE KEY uq_reward (streamer_id, twitch_reward_id),
+  FOREIGN KEY (streamer_id) REFERENCES streamer(id) ON DELETE CASCADE
+);
+
+-- One reward can trigger multiple videos (weighted random, same pattern as SFX).
+CREATE TABLE overlay_reward_video (
+  reward_id INT NOT NULL,
+  video_id  INT NOT NULL,
+  weight    INT NOT NULL DEFAULT 1,
+  PRIMARY KEY (reward_id, video_id),
+  FOREIGN KEY (reward_id) REFERENCES overlay_reward(id) ON DELETE CASCADE,
+  FOREIGN KEY (video_id)  REFERENCES overlay_video(id)  ON DELETE CASCADE
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@discordjs/voice": "^0.19.2",
+        "@types/multer": "^2.1.0",
         "discord.js": "^14.26.4",
         "dotenv": "^17.4.2",
         "ejs": "^5.0.2",
@@ -20,6 +21,7 @@
         "helmet": "^8.2.0",
         "libsodium-wrappers": "^0.8.4",
         "mediaplex": "^1.0.0",
+        "multer": "^2.1.1",
         "mysql2": "^3.22.3",
         "tiktok-live-connector": "2.3.0-beta1",
         "tmi.js": "^1.8.5",
@@ -1019,7 +1021,6 @@
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -1041,7 +1042,6 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1072,7 +1072,6 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -1128,7 +1127,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
       "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -1157,8 +1155,16 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/multer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz",
+      "integrity": "sha512-zYZb0+nJhOHtPpGDb3vqPjwpdeGlGC157VpkqNQL+UU2qwoacoQ7MpsAmUptI/0Oa127X32JzWDqQVEXp2RcIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "24.12.4",
@@ -1173,21 +1179,18 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
       "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
       "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1197,7 +1200,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
       "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
@@ -1425,6 +1427,12 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -1503,6 +1511,17 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/byte-counter": {
       "version": "0.1.0",
@@ -3394,6 +3413,47 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/multer/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mysql2": {
       "version": "3.22.3",
       "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.22.3.tgz",
@@ -4097,6 +4157,14 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@discordjs/voice": "^0.19.2",
+    "@types/multer": "^2.1.0",
     "discord.js": "^14.26.4",
     "dotenv": "^17.4.2",
     "ejs": "^5.0.2",
@@ -22,6 +23,7 @@
     "helmet": "^8.2.0",
     "libsodium-wrappers": "^0.8.4",
     "mediaplex": "^1.0.0",
+    "multer": "^2.1.1",
     "mysql2": "^3.22.3",
     "tiktok-live-connector": "2.3.0-beta1",
     "tmi.js": "^1.8.5",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "@discordjs/voice": "^0.19.2",
-    "@types/multer": "^2.1.0",
     "discord.js": "^14.26.4",
     "dotenv": "^17.4.2",
     "ejs": "^5.0.2",
@@ -35,6 +34,7 @@
   },
   "devDependencies": {
     "@types/ejs": "^3.1.5",
+    "@types/multer": "^2.1.0",
     "@types/express": "^5.0.6",
     "@types/express-mysql-session": "^3.0.8",
     "@types/express-session": "^1.19.0",

--- a/public/overlay-source.js
+++ b/public/overlay-source.js
@@ -1,0 +1,61 @@
+(function () {
+  const script = document.currentScript;
+  const login = script ? script.dataset.login : '';
+  if (!login) return;
+
+  const queue = [];
+  let playing = false;
+
+  function playNext() {
+    if (playing || queue.length === 0) return;
+    const videoUrl = queue.shift();
+    playing = true;
+
+    const v = document.createElement('video');
+    v.src = videoUrl;
+    v.autoplay = true;
+    v.playsInline = true;
+    v.style.cssText = 'position:absolute;top:0;left:0;width:100%;height:100%;';
+
+    v.addEventListener('ended', () => {
+      v.remove();
+      playing = false;
+      playNext();
+    });
+
+    v.addEventListener('error', () => {
+      v.remove();
+      playing = false;
+      playNext();
+    });
+
+    document.body.appendChild(v);
+  }
+
+  function connect() {
+    const es = new EventSource('/overlay/' + login + '/events');
+
+    es.onmessage = function (e) {
+      try {
+        const data = JSON.parse(e.data);
+        if (data.video) {
+          queue.push(data.video);
+          playNext();
+        }
+      } catch (_) {}
+    };
+
+    es.onerror = function () {
+      es.close();
+      // Reconnect with exponential backoff (2s → 4s → 8s → cap 30s)
+      const delay = Math.min(30000, (connect.retryMs = (connect.retryMs || 1000) * 2));
+      setTimeout(connect, delay);
+    };
+
+    es.onopen = function () {
+      connect.retryMs = 1000;
+    };
+  }
+
+  connect();
+})();

--- a/src/commandRouter.test.ts
+++ b/src/commandRouter.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SfxTrigger, SfxFile } from './db';
 
 vi.mock('./config', () => ({
   SFX_FOLDER: '/sfx',
@@ -47,8 +48,8 @@ beforeEach(() => {
   vi.spyOn(Date, 'now').mockReturnValue(mockNow);
 });
 
-const TRIGGER = { id: 42, trigger_command: '!ding' };
-const FILES = [{ file: 'ding.mp3', weight: 1 }];
+const TRIGGER: SfxTrigger = { id: 42n, trigger_command: '!ding', category_id: null, hidden: false, description: null };
+const FILES: SfxFile[] = [{ id: 1, trigger_id: 42n, file: 'ding.mp3', trigger_command: null, weight: 1, hidden: false, category_id: null }];
 
 describe('handleCommand', () => {
   it('does nothing for an unrecognised command', async () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -37,6 +37,7 @@ export const DB_PASSWORD = require_env('DB_PASSWORD');
 export const DB_NAME = require_env('DB_NAME');
 
 export const SFX_FOLDER = process.env.SFX_FOLDER ?? './sfx';
+export const OVERLAY_FOLDER = process.env.OVERLAY_FOLDER ?? './overlay-videos';
 const _COOLDOWN = parseInt(process.env.GLOBAL_COOLDOWN_MS ?? '3000', 10);
 if (Number.isNaN(_COOLDOWN)) throw new Error('Invalid GLOBAL_COOLDOWN_MS: must be a number');
 export const GLOBAL_COOLDOWN_MS = _COOLDOWN;

--- a/src/db.ts
+++ b/src/db.ts
@@ -92,6 +92,15 @@ export type { DbStreamerEventSub, EventSubConfig } from './db/eventSub';
 export type { SfxTrigger, SfxFile, SfxTriggerRow, PublicSfxTrigger } from './db/sfx';
 export { findTrigger, findSoundFiles, getAllSfxTriggers, getPublicSfxTriggers } from './db/sfx';
 
+// ─── Overlay videos ─────────────────────────────────────────────────────────
+
+export type { OverlayVideo, OverlayReward, OverlayRewardWithVideos, OverlayWeightedVideo } from './db/overlayVideos';
+export {
+  getVideosForStreamer, addVideo, getVideoById, deleteVideo,
+  getRewardsForStreamer, upsertReward, setRewardVideos, deleteReward,
+  getVideosForReward,
+} from './db/overlayVideos';
+
 // ─── Streamdeck API keys ─────────────────────────────────────────────────────
 
 export type { StreamdeckKeyRow } from './db/streamdeckKeys';

--- a/src/db/overlayVideos.ts
+++ b/src/db/overlayVideos.ts
@@ -1,0 +1,186 @@
+import mysql from 'mysql2/promise';
+import { getPool } from './pool';
+
+export interface OverlayVideo {
+  id: number;
+  streamer_id: number;
+  name: string;
+  filename: string;
+  created_at: Date;
+}
+
+export interface OverlayReward {
+  id: number;
+  streamer_id: number;
+  twitch_reward_id: string;
+}
+
+export interface OverlayRewardWithVideos extends OverlayReward {
+  videos: Array<{ video_id: number; weight: number; name: string; filename: string }>;
+}
+
+export interface OverlayWeightedVideo {
+  file: string;
+  weight: number;
+}
+
+function mapVideo(r: mysql.RowDataPacket): OverlayVideo {
+  return {
+    id: r.id,
+    streamer_id: r.streamer_id,
+    name: r.name,
+    filename: r.filename,
+    created_at: r.created_at,
+  };
+}
+
+export async function getVideosForStreamer(streamerId: number): Promise<OverlayVideo[]> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT id, streamer_id, name, filename, created_at
+     FROM overlay_video
+     WHERE streamer_id = ?
+     ORDER BY created_at DESC`,
+    [streamerId],
+  );
+  return rows.map(mapVideo);
+}
+
+export async function addVideo(streamerId: number, name: string, filename: string): Promise<number> {
+  const [result] = await getPool().execute<mysql.ResultSetHeader>(
+    `INSERT INTO overlay_video (streamer_id, name, filename) VALUES (?, ?, ?)`,
+    [streamerId, name, filename],
+  );
+  return result.insertId;
+}
+
+export async function getVideoById(videoId: number, streamerId: number): Promise<OverlayVideo | null> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT id, streamer_id, name, filename, created_at
+     FROM overlay_video
+     WHERE id = ? AND streamer_id = ?`,
+    [videoId, streamerId],
+  );
+  return rows.length === 0 ? null : mapVideo(rows[0]);
+}
+
+export async function deleteVideo(videoId: number, streamerId: number): Promise<string | null> {
+  const conn = await getPool().getConnection();
+  try {
+    await conn.beginTransaction();
+    const [rows] = await conn.execute<mysql.RowDataPacket[]>(
+      `SELECT filename FROM overlay_video WHERE id = ? AND streamer_id = ?`,
+      [videoId, streamerId],
+    );
+    if (rows.length === 0) {
+      await conn.rollback();
+      return null;
+    }
+    const filename: string = rows[0].filename;
+    await conn.execute(`DELETE FROM overlay_video WHERE id = ? AND streamer_id = ?`, [videoId, streamerId]);
+    await conn.commit();
+    return filename;
+  } catch (err) {
+    await conn.rollback().catch(() => {});
+    throw err;
+  } finally {
+    conn.release();
+  }
+}
+
+export async function getRewardsForStreamer(streamerId: number): Promise<OverlayRewardWithVideos[]> {
+  const [rewardRows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT r.id, r.streamer_id, r.twitch_reward_id,
+            rv.video_id, rv.weight, v.name, v.filename
+     FROM overlay_reward r
+     LEFT JOIN overlay_reward_video rv ON rv.reward_id = r.id
+     LEFT JOIN overlay_video v ON v.id = rv.video_id
+     WHERE r.streamer_id = ?
+     ORDER BY r.id, rv.video_id`,
+    [streamerId],
+  );
+
+  const rewardMap = new Map<number, OverlayRewardWithVideos>();
+  for (const row of rewardRows) {
+    if (!rewardMap.has(row.id)) {
+      rewardMap.set(row.id, {
+        id: row.id,
+        streamer_id: row.streamer_id,
+        twitch_reward_id: row.twitch_reward_id,
+        videos: [],
+      });
+    }
+    if (row.video_id != null) {
+      rewardMap.get(row.id)!.videos.push({
+        video_id: row.video_id,
+        weight: row.weight,
+        name: row.name,
+        filename: row.filename,
+      });
+    }
+  }
+  return Array.from(rewardMap.values());
+}
+
+export async function upsertReward(streamerId: number, twitchRewardId: string): Promise<number> {
+  const [result] = await getPool().execute<mysql.ResultSetHeader>(
+    `INSERT INTO overlay_reward (streamer_id, twitch_reward_id) VALUES (?, ?)
+     ON DUPLICATE KEY UPDATE id=LAST_INSERT_ID(id)`,
+    [streamerId, twitchRewardId],
+  );
+  return result.insertId;
+}
+
+export async function setRewardVideos(
+  rewardId: number,
+  streamerId: number,
+  videos: Array<{ videoId: number; weight: number }>,
+): Promise<void> {
+  const conn = await getPool().getConnection();
+  try {
+    await conn.beginTransaction();
+    // Verify reward belongs to this streamer
+    const [check] = await conn.execute<mysql.RowDataPacket[]>(
+      `SELECT id FROM overlay_reward WHERE id = ? AND streamer_id = ?`,
+      [rewardId, streamerId],
+    );
+    if (check.length === 0) {
+      await conn.rollback();
+      return;
+    }
+    await conn.execute(`DELETE FROM overlay_reward_video WHERE reward_id = ?`, [rewardId]);
+    for (const v of videos) {
+      await conn.execute(
+        `INSERT INTO overlay_reward_video (reward_id, video_id, weight) VALUES (?, ?, ?)`,
+        [rewardId, v.videoId, Math.max(1, v.weight)],
+      );
+    }
+    await conn.commit();
+  } catch (err) {
+    await conn.rollback().catch(() => {});
+    throw err;
+  } finally {
+    conn.release();
+  }
+}
+
+export async function deleteReward(rewardId: number, streamerId: number): Promise<void> {
+  await getPool().execute(
+    `DELETE FROM overlay_reward WHERE id = ? AND streamer_id = ?`,
+    [rewardId, streamerId],
+  );
+}
+
+export async function getVideosForReward(
+  twitchRewardId: string,
+  streamerId: number,
+): Promise<OverlayWeightedVideo[]> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT v.filename, rv.weight
+     FROM overlay_reward r
+     JOIN overlay_reward_video rv ON rv.reward_id = r.id
+     JOIN overlay_video v ON v.id = rv.video_id
+     WHERE r.twitch_reward_id = ? AND r.streamer_id = ?`,
+    [twitchRewardId, streamerId],
+  );
+  return rows.map((r) => ({ file: r.filename, weight: r.weight }));
+}

--- a/src/db/overlayVideos.ts
+++ b/src/db/overlayVideos.ts
@@ -76,7 +76,13 @@ export async function deleteVideo(videoId: number, streamerId: number): Promise<
       return null;
     }
     const filename: string = rows[0].filename;
-    await conn.execute(`DELETE FROM overlay_video WHERE id = ? AND streamer_id = ?`, [videoId, streamerId]);
+    const [del] = await conn.execute<mysql.ResultSetHeader>(
+      `DELETE FROM overlay_video WHERE id = ? AND streamer_id = ?`, [videoId, streamerId],
+    );
+    if (del.affectedRows === 0) {
+      await conn.rollback();
+      return null;
+    }
     await conn.commit();
     return filename;
   } catch (err) {

--- a/src/db/overlayVideos.ts
+++ b/src/db/overlayVideos.ts
@@ -149,10 +149,16 @@ export async function setRewardVideos(
     }
     await conn.execute(`DELETE FROM overlay_reward_video WHERE reward_id = ?`, [rewardId]);
     for (const v of videos) {
-      await conn.execute(
-        `INSERT INTO overlay_reward_video (reward_id, video_id, weight) VALUES (?, ?, ?)`,
-        [rewardId, v.videoId, Math.max(1, v.weight)],
+      const [insert] = await conn.execute<mysql.ResultSetHeader>(
+        `INSERT INTO overlay_reward_video (reward_id, video_id, weight)
+         SELECT ?, ov.id, ?
+         FROM overlay_video ov
+         WHERE ov.id = ? AND ov.streamer_id = ?`,
+        [rewardId, Math.max(1, v.weight), v.videoId, streamerId],
       );
+      if (insert.affectedRows !== 1) {
+        throw new Error(`Video ${v.videoId} does not belong to streamer ${streamerId}`);
+      }
     }
     await conn.commit();
   } catch (err) {

--- a/src/soundSelector.ts
+++ b/src/soundSelector.ts
@@ -1,11 +1,6 @@
-import { SfxFile } from './db';
+export interface WeightedFile { file: string; weight: number }
 
-/**
- * Pick a sound file using weighted-random selection.
- * Files with a higher `weight` value are more likely to be chosen.
- * Falls back to uniform random if all weights are 0 or equal.
- */
-export function pickWeightedRandom(files: SfxFile[]): string {
+export function pickWeightedRandom(files: WeightedFile[]): string {
   if (files.length === 0) throw new Error('No files to pick from');
   if (files.length === 1) return files[0].file;
 

--- a/src/twitchEventSubHandler.ts
+++ b/src/twitchEventSubHandler.ts
@@ -1,5 +1,12 @@
 import { sayInChannel } from './twitchBot';
 import { EventSubConfig } from './db/eventSub';
+import { getVideosForReward } from './db/overlayVideos';
+import { pushOverlayEvent } from './web/routes/overlaySource';
+import { pickWeightedRandom } from './soundSelector';
+import { OVERLAY_FOLDER } from './config';
+import { createLogger } from './logger';
+
+const log = createLogger('EventSubHandler');
 
 export interface FollowEvent {
   user_login: string;
@@ -38,6 +45,15 @@ export interface RaidEvent {
   from_broadcaster_user_name: string;
   to_broadcaster_user_login: string;
   viewers: number;
+}
+
+export interface RedemptionEvent {
+  id: string;
+  user_login: string;
+  user_name: string;
+  broadcaster_user_login: string;
+  reward: { id: string; title: string };
+  user_input: string;
 }
 
 function fill(template: string, vars: Record<string, string>): string {
@@ -103,4 +119,19 @@ export async function handleRaid(login: string, event: RaidEvent, config: EventS
     viewers: String(event.viewers),
   });
   await sayInChannel(login, msg);
+}
+
+export async function handleRedemption(
+  login: string,
+  event: RedemptionEvent,
+  _config: EventSubConfig,
+  streamerId: number,
+): Promise<void> {
+  const videos = await getVideosForReward(event.reward.id, streamerId);
+  if (videos.length === 0) return;
+
+  const filename = pickWeightedRandom(videos);
+  const videoPath = `/overlay/videos/${streamerId}/${filename}`;
+  pushOverlayEvent(login, videoPath);
+  log.info(`Overlay triggered for ${login}: reward="${event.reward.title}" video=${filename}`);
 }

--- a/src/twitchEventSubHandler.ts
+++ b/src/twitchEventSubHandler.ts
@@ -3,7 +3,6 @@ import { EventSubConfig } from './db/eventSub';
 import { getVideosForReward } from './db/overlayVideos';
 import { pushOverlayEvent } from './web/routes/overlaySource';
 import { pickWeightedRandom } from './soundSelector';
-import { OVERLAY_FOLDER } from './config';
 import { createLogger } from './logger';
 
 const log = createLogger('EventSubHandler');

--- a/src/twitchEventSubSubscriptions.ts
+++ b/src/twitchEventSubSubscriptions.ts
@@ -85,9 +85,9 @@ async function createSubscriptionsForStreamer(
     await subscribe(sid, { type: 'channel.raid', version: '1', condition: { to_broadcaster_user_id: uid } }, token, name);
   }
 
-  // Always subscribe to channel points redemptions when a broadcaster token is available.
-  // The handler filters by reward ID against configured overlay assignments.
-  if (token) {
+  // Subscribe to channel points redemptions when a broadcaster token and config are available.
+  // Gated on config to keep subscription and dispatch aligned (dispatchNotification early-exits without config).
+  if (config && token) {
     desired.add('channel.channel_points_custom_reward_redemption');
     await subscribe(sid, {
       type: 'channel.channel_points_custom_reward_redemption',

--- a/src/twitchEventSubSubscriptions.ts
+++ b/src/twitchEventSubSubscriptions.ts
@@ -4,8 +4,8 @@ import { getUsers } from './twitchApi';
 import { TwitchAuthError, refreshUserToken, createEventSubSubscription, listEventSubSubscriptions, deleteEventSubSubscription } from './twitchApiEventSub';
 import { getActiveChannels } from './twitchBot';
 import {
-  handleFollow, handleSub, handleResub, handleGiftSub, handleRaid,
-  FollowEvent, SubEvent, ResubEvent, GiftSubEvent, RaidEvent,
+  handleFollow, handleSub, handleResub, handleGiftSub, handleRaid, handleRedemption,
+  FollowEvent, SubEvent, ResubEvent, GiftSubEvent, RaidEvent, RedemptionEvent,
 } from './twitchEventSubHandler';
 
 const log = createLogger('EventSub');
@@ -20,13 +20,14 @@ const streamerMap = new Map<string, StreamerInfo>();
 
 // Maps EventSub notification types to their handler functions.
 // Using Map instead of a plain object prevents prototype-chain lookup on user-controlled keys.
-type NotificationHandler = (login: string, event: unknown, config: EventSubConfig) => Promise<void>;
+type NotificationHandler = (login: string, event: unknown, config: EventSubConfig, streamerId: number) => Promise<void>;
 const notificationHandlers = new Map<string, NotificationHandler>([
-  ['channel.follow',               (l, e, c) => handleFollow(l, e as FollowEvent, c)],
-  ['channel.subscribe',            (l, e, c) => handleSub(l, e as SubEvent, c)],
-  ['channel.subscription.message', (l, e, c) => handleResub(l, e as ResubEvent, c)],
-  ['channel.subscription.gift',    (l, e, c) => handleGiftSub(l, e as GiftSubEvent, c)],
-  ['channel.raid',                 (l, e, c) => handleRaid(l, e as RaidEvent, c)],
+  ['channel.follow',                                   (l, e, c) => handleFollow(l, e as FollowEvent, c)],
+  ['channel.subscribe',                                (l, e, c) => handleSub(l, e as SubEvent, c)],
+  ['channel.subscription.message',                     (l, e, c) => handleResub(l, e as ResubEvent, c)],
+  ['channel.subscription.gift',                        (l, e, c) => handleGiftSub(l, e as GiftSubEvent, c)],
+  ['channel.raid',                                     (l, e, c) => handleRaid(l, e as RaidEvent, c)],
+  ['channel.channel_points_custom_reward_redemption',  (l, e, c, sid) => handleRedemption(l, e as RedemptionEvent, c, sid)],
 ]);
 
 async function deleteStaleSubscriptions(uid: string, desired: Set<string>, userToken: string | null): Promise<void> {
@@ -82,6 +83,17 @@ async function createSubscriptionsForStreamer(
   if (config?.raid_enabled && token) {
     desired.add('channel.raid');
     await subscribe(sid, { type: 'channel.raid', version: '1', condition: { to_broadcaster_user_id: uid } }, token, name);
+  }
+
+  // Always subscribe to channel points redemptions when a broadcaster token is available.
+  // The handler filters by reward ID against configured overlay assignments.
+  if (token) {
+    desired.add('channel.channel_points_custom_reward_redemption');
+    await subscribe(sid, {
+      type: 'channel.channel_points_custom_reward_redemption',
+      version: '1',
+      condition: { broadcaster_user_id: uid },
+    }, token, name);
   }
 
   return desired;
@@ -175,7 +187,7 @@ export function dispatchNotification(type: string, event: Record<string, unknown
     log.warn(`Invalid EventSub handler for type: ${type}`);
     return;
   }
-  handler(info.login, event, info.config)
+  handler(info.login, event, info.config, info.streamerId)
     .catch((err) => log.error(`${type} handler error:`, err));
 }
 

--- a/src/web/routes/overlayAdmin.ts
+++ b/src/web/routes/overlayAdmin.ts
@@ -59,8 +59,8 @@ router.get('/settings', requireAuth, csrfProtection, async (req, res) => {
         streamer: null,
         videos: [],
         rewards: [],
-        error: null,
-        success: null,
+        error: req.query.error as string | undefined ?? null,
+        success: req.query.success as string | undefined ?? null,
       });
     }
 
@@ -126,7 +126,7 @@ router.post('/settings/videos/:id/delete', requireAuth, csrfProtection, async (r
     const filename = await deleteVideo(videoId, streamer.id);
     if (filename) {
       const filePath = path.join(OVERLAY_FOLDER, String(streamer.id), filename);
-      fs.rmSync(filePath, { force: true });
+      await fs.promises.rm(filePath, { force: true });
     }
 
     res.redirect('/overlay/settings?success=video_deleted');

--- a/src/web/routes/overlayAdmin.ts
+++ b/src/web/routes/overlayAdmin.ts
@@ -97,10 +97,15 @@ router.post('/settings/videos/upload', requireAuth, upload.single('video'), csrf
     const filename = `${randomUUID()}.${ext}`;
 
     const dir = path.join(OVERLAY_FOLDER, String(streamer.id));
-    fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(path.join(dir, filename), req.file.buffer);
-
-    await addVideo(streamer.id, name, filename);
+    await fs.promises.mkdir(dir, { recursive: true });
+    const fullPath = path.join(dir, filename);
+    await fs.promises.writeFile(fullPath, req.file.buffer);
+    try {
+      await addVideo(streamer.id, name, filename);
+    } catch (e) {
+      await fs.promises.rm(fullPath, { force: true });
+      throw e;
+    }
     log.info(`Overlay video uploaded for ${streamer.twitch_name}: ${filename}`);
     res.redirect('/overlay/settings?success=video_uploaded');
   } catch (err) {
@@ -145,7 +150,6 @@ router.post('/settings/rewards', requireAuth, csrfProtection, async (req, res) =
     }
 
     const videoIds = toStringArray(body.video_ids).map(Number).filter((n) => Number.isInteger(n) && n > 0);
-    const weights  = toStringArray(body.weights).map(Number).map((n) => (Number.isFinite(n) && n >= 1 ? Math.floor(n) : 1));
 
     if (videoIds.length === 0) return res.redirect('/overlay/settings?error=no_videos_selected');
 
@@ -153,7 +157,11 @@ router.post('/settings/rewards', requireAuth, csrfProtection, async (req, res) =
     await setRewardVideos(
       rewardId,
       streamer.id,
-      videoIds.map((videoId, i) => ({ videoId, weight: weights[i] ?? 1 })),
+      videoIds.map((videoId) => {
+        const raw = body[`weight_${videoId}`];
+        const n = Number(Array.isArray(raw) ? raw[0] : raw);
+        return { videoId, weight: Number.isFinite(n) && n >= 1 ? Math.floor(n) : 1 };
+      }),
     );
 
     res.redirect('/overlay/settings?success=reward_saved');

--- a/src/web/routes/overlayAdmin.ts
+++ b/src/web/routes/overlayAdmin.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '../../logger';
 import { Router } from 'express';
+import type { Request, Response } from 'express';
 import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
@@ -7,6 +8,7 @@ import { randomUUID } from 'crypto';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
 import { getStreamerByDiscordId } from '../../db';
+import type { DbStreamerEventSub } from '../../db';
 import {
   getVideosForStreamer, addVideo, deleteVideo,
   getRewardsForStreamer, upsertReward, setRewardVideos, deleteReward,
@@ -27,6 +29,22 @@ const upload = multer({
     cb(null, allowed.includes(file.mimetype));
   },
 });
+
+/** Resolves the streamer for the logged-in user, or redirects and returns null. */
+async function requireStreamer(req: Request, res: Response): Promise<DbStreamerEventSub | null> {
+  const streamer = await getStreamerByDiscordId(req.session.user!.discordId);
+  if (!streamer) {
+    res.redirect('/overlay/settings?error=not_a_streamer');
+    return null;
+  }
+  return streamer;
+}
+
+/** Normalises a form field that may arrive as a single string or an array of strings. */
+function toStringArray(value: string | string[] | undefined): string[] {
+  if (Array.isArray(value)) return value;
+  return value ? [value] : [];
+}
 
 // GET /overlay/settings
 router.get('/settings', requireAuth, csrfProtection, async (req, res) => {
@@ -69,9 +87,8 @@ router.get('/settings', requireAuth, csrfProtection, async (req, res) => {
 // POST /overlay/settings/videos/upload
 router.post('/settings/videos/upload', requireAuth, upload.single('video'), csrfProtection, async (req, res) => {
   try {
-    const discordId = req.session.user!.discordId;
-    const streamer = await getStreamerByDiscordId(discordId);
-    if (!streamer) return res.redirect('/overlay/settings?error=not_a_streamer');
+    const streamer = await requireStreamer(req, res);
+    if (!streamer) return;
 
     if (!req.file) return res.redirect('/overlay/settings?error=invalid_file');
 
@@ -95,9 +112,8 @@ router.post('/settings/videos/upload', requireAuth, upload.single('video'), csrf
 // POST /overlay/settings/videos/:id/delete
 router.post('/settings/videos/:id/delete', requireAuth, csrfProtection, async (req, res) => {
   try {
-    const discordId = req.session.user!.discordId;
-    const streamer = await getStreamerByDiscordId(discordId);
-    if (!streamer) return res.redirect('/overlay/settings?error=not_a_streamer');
+    const streamer = await requireStreamer(req, res);
+    if (!streamer) return;
 
     const videoId = parsePositiveIntId(req.params.id);
     if (videoId === null) return res.redirect('/overlay/settings?error=invalid_id');
@@ -118,25 +134,18 @@ router.post('/settings/videos/:id/delete', requireAuth, csrfProtection, async (r
 // POST /overlay/settings/rewards — create or update a reward assignment
 router.post('/settings/rewards', requireAuth, csrfProtection, async (req, res) => {
   try {
-    const discordId = req.session.user!.discordId;
-    const streamer = await getStreamerByDiscordId(discordId);
-    if (!streamer) return res.redirect('/overlay/settings?error=not_a_streamer');
+    const streamer = await requireStreamer(req, res);
+    if (!streamer) return;
 
     const body = req.body as Record<string, string | string[] | undefined>;
     const twitchRewardId = (typeof body.twitch_reward_id === 'string' ? body.twitch_reward_id : '').trim();
 
-    // Basic UUID format validation for the Twitch reward ID
     if (!/^[0-9a-f-]{36}$/i.test(twitchRewardId)) {
       return res.redirect('/overlay/settings?error=invalid_reward_id');
     }
 
-    const videoIds = (Array.isArray(body.video_ids) ? body.video_ids : body.video_ids ? [body.video_ids] : [])
-      .map(Number)
-      .filter((n) => Number.isInteger(n) && n > 0);
-
-    const weights = (Array.isArray(body.weights) ? body.weights : body.weights ? [body.weights] : [])
-      .map(Number)
-      .map((n) => (Number.isFinite(n) && n >= 1 ? Math.floor(n) : 1));
+    const videoIds = toStringArray(body.video_ids).map(Number).filter((n) => Number.isInteger(n) && n > 0);
+    const weights  = toStringArray(body.weights).map(Number).map((n) => (Number.isFinite(n) && n >= 1 ? Math.floor(n) : 1));
 
     if (videoIds.length === 0) return res.redirect('/overlay/settings?error=no_videos_selected');
 
@@ -157,9 +166,8 @@ router.post('/settings/rewards', requireAuth, csrfProtection, async (req, res) =
 // POST /overlay/settings/rewards/:id/delete
 router.post('/settings/rewards/:id/delete', requireAuth, csrfProtection, async (req, res) => {
   try {
-    const discordId = req.session.user!.discordId;
-    const streamer = await getStreamerByDiscordId(discordId);
-    if (!streamer) return res.redirect('/overlay/settings?error=not_a_streamer');
+    const streamer = await requireStreamer(req, res);
+    if (!streamer) return;
 
     const rewardId = parsePositiveIntId(req.params.id);
     if (rewardId === null) return res.redirect('/overlay/settings?error=invalid_id');

--- a/src/web/routes/overlayAdmin.ts
+++ b/src/web/routes/overlayAdmin.ts
@@ -1,0 +1,175 @@
+import { createLogger } from '../../logger';
+import { Router } from 'express';
+import multer from 'multer';
+import path from 'path';
+import fs from 'fs';
+import { randomUUID } from 'crypto';
+import { csrfProtection } from '../csrf';
+import { requireAuth } from '../middleware';
+import { getStreamerByDiscordId } from '../../db';
+import {
+  getVideosForStreamer, addVideo, deleteVideo,
+  getRewardsForStreamer, upsertReward, setRewardVideos, deleteReward,
+} from '../../db';
+import { OVERLAY_FOLDER } from '../../config';
+import { parsePositiveIntId } from './shared';
+
+const log = createLogger('OverlayAdmin');
+const router = Router();
+
+const MAX_FILE_BYTES = parseInt(process.env.OVERLAY_MAX_FILE_MB ?? '100', 10) * 1024 * 1024;
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: MAX_FILE_BYTES },
+  fileFilter: (_req, file, cb) => {
+    const allowed = ['video/webm', 'video/mp4'];
+    cb(null, allowed.includes(file.mimetype));
+  },
+});
+
+// GET /overlay/settings
+router.get('/settings', requireAuth, csrfProtection, async (req, res) => {
+  try {
+    const discordId = req.session.user!.discordId;
+    const streamer = await getStreamerByDiscordId(discordId);
+
+    if (!streamer) {
+      return res.render('overlayAdmin', {
+        user: req.session.user,
+        csrfToken: req.csrfToken(),
+        streamer: null,
+        videos: [],
+        rewards: [],
+        error: null,
+        success: null,
+      });
+    }
+
+    const [videos, rewards] = await Promise.all([
+      getVideosForStreamer(streamer.id),
+      getRewardsForStreamer(streamer.id),
+    ]);
+
+    res.render('overlayAdmin', {
+      user: req.session.user,
+      csrfToken: req.csrfToken(),
+      streamer,
+      videos,
+      rewards,
+      error: req.query.error as string | undefined ?? null,
+      success: req.query.success as string | undefined ?? null,
+    });
+  } catch (err) {
+    log.error('Overlay settings page error:', err);
+    res.status(500).render('error', { message: 'Failed to load overlay settings.', user: req.session.user ?? null, csrfToken: '' });
+  }
+});
+
+// POST /overlay/settings/videos/upload
+router.post('/settings/videos/upload', requireAuth, upload.single('video'), csrfProtection, async (req, res) => {
+  try {
+    const discordId = req.session.user!.discordId;
+    const streamer = await getStreamerByDiscordId(discordId);
+    if (!streamer) return res.redirect('/overlay/settings?error=not_a_streamer');
+
+    if (!req.file) return res.redirect('/overlay/settings?error=invalid_file');
+
+    const name = (req.body?.name as string | undefined ?? '').trim().slice(0, 100) || req.file.originalname;
+    const ext = req.file.mimetype === 'video/webm' ? 'webm' : 'mp4';
+    const filename = `${randomUUID()}.${ext}`;
+
+    const dir = path.join(OVERLAY_FOLDER, String(streamer.id));
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, filename), req.file.buffer);
+
+    await addVideo(streamer.id, name, filename);
+    log.info(`Overlay video uploaded for ${streamer.twitch_name}: ${filename}`);
+    res.redirect('/overlay/settings?success=video_uploaded');
+  } catch (err) {
+    log.error('Overlay video upload error:', err);
+    res.redirect('/overlay/settings?error=upload_failed');
+  }
+});
+
+// POST /overlay/settings/videos/:id/delete
+router.post('/settings/videos/:id/delete', requireAuth, csrfProtection, async (req, res) => {
+  try {
+    const discordId = req.session.user!.discordId;
+    const streamer = await getStreamerByDiscordId(discordId);
+    if (!streamer) return res.redirect('/overlay/settings?error=not_a_streamer');
+
+    const videoId = parsePositiveIntId(req.params.id);
+    if (videoId === null) return res.redirect('/overlay/settings?error=invalid_id');
+
+    const filename = await deleteVideo(videoId, streamer.id);
+    if (filename) {
+      const filePath = path.join(OVERLAY_FOLDER, String(streamer.id), filename);
+      fs.rmSync(filePath, { force: true });
+    }
+
+    res.redirect('/overlay/settings?success=video_deleted');
+  } catch (err) {
+    log.error('Overlay video delete error:', err);
+    res.redirect('/overlay/settings?error=delete_failed');
+  }
+});
+
+// POST /overlay/settings/rewards — create or update a reward assignment
+router.post('/settings/rewards', requireAuth, csrfProtection, async (req, res) => {
+  try {
+    const discordId = req.session.user!.discordId;
+    const streamer = await getStreamerByDiscordId(discordId);
+    if (!streamer) return res.redirect('/overlay/settings?error=not_a_streamer');
+
+    const body = req.body as Record<string, string | string[] | undefined>;
+    const twitchRewardId = (typeof body.twitch_reward_id === 'string' ? body.twitch_reward_id : '').trim();
+
+    // Basic UUID format validation for the Twitch reward ID
+    if (!/^[0-9a-f-]{36}$/i.test(twitchRewardId)) {
+      return res.redirect('/overlay/settings?error=invalid_reward_id');
+    }
+
+    const videoIds = (Array.isArray(body.video_ids) ? body.video_ids : body.video_ids ? [body.video_ids] : [])
+      .map(Number)
+      .filter((n) => Number.isInteger(n) && n > 0);
+
+    const weights = (Array.isArray(body.weights) ? body.weights : body.weights ? [body.weights] : [])
+      .map(Number)
+      .map((n) => (Number.isFinite(n) && n >= 1 ? Math.floor(n) : 1));
+
+    if (videoIds.length === 0) return res.redirect('/overlay/settings?error=no_videos_selected');
+
+    const rewardId = await upsertReward(streamer.id, twitchRewardId);
+    await setRewardVideos(
+      rewardId,
+      streamer.id,
+      videoIds.map((videoId, i) => ({ videoId, weight: weights[i] ?? 1 })),
+    );
+
+    res.redirect('/overlay/settings?success=reward_saved');
+  } catch (err) {
+    log.error('Overlay reward save error:', err);
+    res.redirect('/overlay/settings?error=save_failed');
+  }
+});
+
+// POST /overlay/settings/rewards/:id/delete
+router.post('/settings/rewards/:id/delete', requireAuth, csrfProtection, async (req, res) => {
+  try {
+    const discordId = req.session.user!.discordId;
+    const streamer = await getStreamerByDiscordId(discordId);
+    if (!streamer) return res.redirect('/overlay/settings?error=not_a_streamer');
+
+    const rewardId = parsePositiveIntId(req.params.id);
+    if (rewardId === null) return res.redirect('/overlay/settings?error=invalid_id');
+
+    await deleteReward(rewardId, streamer.id);
+    res.redirect('/overlay/settings?success=reward_deleted');
+  } catch (err) {
+    log.error('Overlay reward delete error:', err);
+    res.redirect('/overlay/settings?error=delete_failed');
+  }
+});
+
+export default router;

--- a/src/web/routes/overlaySource.ts
+++ b/src/web/routes/overlaySource.ts
@@ -1,0 +1,86 @@
+import { createLogger } from '../../logger';
+import { Router } from 'express';
+import path from 'path';
+import fs from 'fs';
+import { OVERLAY_FOLDER } from '../../config';
+
+const log = createLogger('OverlaySource');
+const router = Router();
+
+const LOGIN_RE = /^[a-zA-Z0-9_]{1,25}$/;
+const FILENAME_RE = /^[\w-]+\.(webm|mp4)$/i;
+
+// In-memory map of active SSE connections keyed by Twitch channel login (lowercase).
+const connections = new Map<string, Set<import('express').Response>>();
+
+/** Push a video URL to all browser sources connected for this channel. */
+export function pushOverlayEvent(login: string, videoPath: string): void {
+  const clients = connections.get(login.toLowerCase());
+  if (!clients || clients.size === 0) return;
+  const payload = JSON.stringify({ video: videoPath });
+  for (const res of clients) {
+    try {
+      res.write(`data: ${payload}\n\n`);
+    } catch {
+      // Client disconnected — will be cleaned up by the close handler
+    }
+  }
+  log.info(`Pushed overlay event to ${clients.size} client(s) for ${login}`);
+}
+
+// GET /overlay/:login — browser source HTML page (no auth, opened by OBS)
+router.get('/:login', (req, res) => {
+  const { login } = req.params;
+  if (!LOGIN_RE.test(login)) { res.status(400).end(); return; }
+  res.render('overlaySource', { login: login.toLowerCase() });
+});
+
+// GET /overlay/:login/events — SSE endpoint
+router.get('/:login/events', (req, res) => {
+  const { login } = req.params;
+  if (!LOGIN_RE.test(login)) { res.status(400).end(); return; }
+  const key = login.toLowerCase();
+
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no'); // disable Nginx buffering if behind proxy
+  res.flushHeaders();
+
+  res.write(': connected\n\n');
+
+  if (!connections.has(key)) connections.set(key, new Set());
+  connections.get(key)!.add(res);
+
+  const keepalive = setInterval(() => {
+    try {
+      res.write(': ping\n\n');
+    } catch {
+      clearInterval(keepalive);
+    }
+  }, 25_000);
+
+  req.on('close', () => {
+    clearInterval(keepalive);
+    connections.get(key)?.delete(res);
+  });
+});
+
+// GET /overlay/videos/:streamerId/:filename — serve video files (no auth)
+router.get('/videos/:streamerId/:filename', (req, res) => {
+  const { streamerId, filename } = req.params;
+
+  if (!/^\d+$/.test(streamerId)) { res.status(400).end(); return; }
+  if (!FILENAME_RE.test(filename)) { res.status(400).end(); return; }
+
+  const filePath = path.join(OVERLAY_FOLDER, streamerId, filename);
+  const resolved = path.resolve(filePath);
+  const base = path.resolve(OVERLAY_FOLDER);
+  if (!resolved.startsWith(base + path.sep)) { res.status(400).end(); return; }
+
+  if (!fs.existsSync(resolved)) { res.status(404).end(); return; }
+
+  res.sendFile(resolved);
+});
+
+export default router;

--- a/src/web/routes/overlaySource.ts
+++ b/src/web/routes/overlaySource.ts
@@ -9,36 +9,42 @@ const router = Router();
 
 const LOGIN_RE = /^[a-zA-Z0-9_]{1,25}$/;
 const FILENAME_RE = /^[\w-]+\.(webm|mp4)$/i;
+// Words reserved for admin routes — must not be treated as channel logins.
+const RESERVED_LOGINS = new Set(['settings', 'videos']);
 
 // In-memory map of active SSE connections keyed by Twitch channel login (lowercase).
 const connections = new Map<string, Set<import('express').Response>>();
 
 /** Push a video URL to all browser sources connected for this channel. */
 export function pushOverlayEvent(login: string, videoPath: string): void {
-  const clients = connections.get(login.toLowerCase());
+  const key = login.toLowerCase();
+  const clients = connections.get(key);
   if (!clients || clients.size === 0) return;
   const payload = JSON.stringify({ video: videoPath });
+  const dead: import('express').Response[] = [];
   for (const res of clients) {
     try {
       res.write(`data: ${payload}\n\n`);
     } catch {
-      // Client disconnected — will be cleaned up by the close handler
+      dead.push(res);
     }
   }
+  for (const res of dead) clients.delete(res);
+  if (clients.size === 0) connections.delete(key);
   log.info(`Pushed overlay event to ${clients.size} client(s) for ${login}`);
 }
 
 // GET /overlay/:login — browser source HTML page (no auth, opened by OBS)
-router.get('/:login', (req, res) => {
+router.get('/:login', (req, res, next) => {
   const { login } = req.params;
-  if (!LOGIN_RE.test(login)) { res.status(400).end(); return; }
+  if (!LOGIN_RE.test(login) || RESERVED_LOGINS.has(login.toLowerCase())) { next(); return; }
   res.render('overlaySource', { login: login.toLowerCase() });
 });
 
 // GET /overlay/:login/events — SSE endpoint
-router.get('/:login/events', (req, res) => {
+router.get('/:login/events', (req, res, next) => {
   const { login } = req.params;
-  if (!LOGIN_RE.test(login)) { res.status(400).end(); return; }
+  if (!LOGIN_RE.test(login) || RESERVED_LOGINS.has(login.toLowerCase())) { next(); return; }
   const key = login.toLowerCase();
 
   res.setHeader('Content-Type', 'text/event-stream');
@@ -62,7 +68,10 @@ router.get('/:login/events', (req, res) => {
 
   req.on('close', () => {
     clearInterval(keepalive);
-    connections.get(key)?.delete(res);
+    const clients = connections.get(key);
+    if (!clients) return;
+    clients.delete(res);
+    if (clients.size === 0) connections.delete(key);
   });
 });
 

--- a/src/web/routes/userSettings.ts
+++ b/src/web/routes/userSettings.ts
@@ -10,7 +10,7 @@ import { TWITCH_CLIENT_ID, TWITCH_EVENTSUB_REDIRECT_URI, EVENTSUB_TOKEN_SECRET }
 const log = createLogger('Web');
 const router = Router();
 
-const TWITCH_OAUTH_SCOPE = 'moderator:read:followers channel:read:subscriptions';
+const TWITCH_OAUTH_SCOPE = 'moderator:read:followers channel:read:subscriptions channel:read:redemptions';
 
 const KNOWN_ERRORS = new Set([
   'no_streamer_record',

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -26,6 +26,8 @@ import commandMonitorRouter from './routes/commandMonitor';
 import streamdeckRouter from './routes/streamdeck';
 import streamdeckKeysRouter from './routes/streamdeckKeys';
 import userSettingsRouter from './routes/userSettings';
+import overlaySourceRouter from './routes/overlaySource';
+import overlayAdminRouter from './routes/overlayAdmin';
 import { requireAuth } from './middleware';
 import { ensureSessionCsrfToken } from './csrf';
 
@@ -44,6 +46,7 @@ app.use(
         styleSrc: ["'self'", "'unsafe-inline'"],
         imgSrc: ["'self'", 'data:', 'https://cdn.discordapp.com', 'https://static-cdn.jtvnw.net'],
         connectSrc: ["'self'"],
+        mediaSrc: ["'self'"],
         objectSrc: ["'none'"],
         baseUri: ["'self'"],
         frameAncestors: ["'none'"],
@@ -148,6 +151,8 @@ app.use('/admin', requireAuth, adminRouter);
 app.use('/admin', requireAuth, streamsRouter);
 app.use('/admin', requireAuth, eventsubAdminRouter);
 app.use('/user/settings', requireAuth, userSettingsRouter);
+app.use('/overlay', overlaySourceRouter);
+app.use('/overlay', requireAuth, overlayAdminRouter);
 app.use('/admin', requireAuth, commandsRouter);
 app.use('/admin', requireAuth, countersRouter);
 app.use('/admin', requireAuth, commandMonitorRouter);

--- a/views/overlayAdmin.ejs
+++ b/views/overlayAdmin.ejs
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BCUK Bot — Overlay</title>
+  <link rel="stylesheet" href="/style.css">
+  <%- include('partials/pwa-head') %>
+</head>
+<body>
+  <%- include('partials/nav') %>
+
+  <main class="container">
+
+    <% if (error) { %>
+    <div class="card card-alert-danger">
+      <% const errorMessages = {
+        not_a_streamer:   'You are not configured as a monitored streamer.',
+        invalid_file:     'No valid file was uploaded. Accepted formats: WebM, MP4.',
+        upload_failed:    'Upload failed — please try again.',
+        delete_failed:    'Delete failed — please try again.',
+        invalid_reward_id:'Invalid reward ID format. Paste the UUID from your Twitch dashboard.',
+        no_videos_selected:'Select at least one video to assign to the reward.',
+        save_failed:      'Failed to save — please try again.',
+        invalid_id:       'Invalid request.',
+      }; %>
+      <%= errorMessages[error] ?? `An error occurred (${error}).` %>
+    </div>
+    <% } %>
+
+    <% if (success) { %>
+    <div class="card card-alert-success">
+      <% const successMessages = {
+        video_uploaded: 'Video uploaded successfully.',
+        video_deleted:  'Video deleted.',
+        reward_saved:   'Reward assignment saved.',
+        reward_deleted: 'Reward assignment removed.',
+      }; %>
+      <%= successMessages[success] ?? 'Done.' %>
+    </div>
+    <% } %>
+
+    <% if (!streamer) { %>
+    <section class="section">
+      <div class="card">
+        <div class="card-body">
+          <p class="hint">You are not configured as a monitored streamer. Contact a Manager or Admin.</p>
+        </div>
+      </div>
+    </section>
+    <% } else { %>
+
+    <!-- ── Browser Source URL ──────────────────────────────────────── -->
+    <section class="section">
+      <h2 class="section-title">OBS Browser Source</h2>
+      <div class="card">
+        <div class="card-body">
+          <p class="hint hint-compact">Add this URL as a Browser Source in OBS (1920×1080, transparent background):</p>
+          <% const login = streamer.twitch_name ? streamer.twitch_name.toLowerCase() : ''; %>
+          <code class="mono" style="display:block;margin-top:0.4rem;user-select:all;">/overlay/<%= login %></code>
+          <p class="hint" style="margin-top:0.5rem;">In OBS: Sources → Add → Browser → check "Local file" OFF, paste the full URL including your domain.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── Video Library ──────────────────────────────────────────── -->
+    <section class="section">
+      <h2 class="section-title">Video Library</h2>
+
+      <div class="card card-spaced">
+        <div class="card-body">
+          <form method="POST" action="/overlay/settings/videos/upload" enctype="multipart/form-data">
+            <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+            <div class="form-row-wrap" style="align-items:flex-end;">
+              <div style="flex:1;">
+                <label class="hint hint-compact" for="video-name">Name</label>
+                <input id="video-name" class="input" type="text" name="name" maxlength="100" placeholder="e.g. Confetti Explosion">
+              </div>
+              <div style="flex:1;">
+                <label class="hint hint-compact" for="video-file">Video file (WebM or MP4)</label>
+                <input id="video-file" class="input" type="file" name="video" accept="video/webm,video/mp4" required>
+              </div>
+              <div>
+                <button type="submit" class="btn">Upload</button>
+              </div>
+            </div>
+            <p class="hint" style="margin-top:0.4rem;">WebM with alpha channel recommended for transparent overlays. Max <%= process.env.OVERLAY_MAX_FILE_MB || '100' %> MB.</p>
+          </form>
+        </div>
+      </div>
+
+      <% if (videos.length === 0) { %>
+      <div class="card">
+        <div class="card-body">
+          <p class="hint">No videos uploaded yet.</p>
+        </div>
+      </div>
+      <% } else { %>
+      <div class="card">
+        <div class="card-body">
+          <table class="table" style="width:100%;">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>File</th>
+                <th>Uploaded</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              <% for (const v of videos) { %>
+              <tr>
+                <td><%= v.name %></td>
+                <td class="mono" style="font-size:0.8em;"><%= v.filename %></td>
+                <td><%= new Date(v.created_at).toLocaleDateString() %></td>
+                <td>
+                  <form method="POST" action="/overlay/settings/videos/<%= v.id %>/delete" style="margin:0;">
+                    <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                    <button type="submit" class="btn btn-ghost btn-sm"
+                      onclick="return confirm('Delete this video? Any reward assignments using it will be removed.')">
+                      Delete
+                    </button>
+                  </form>
+                </td>
+              </tr>
+              <% } %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <% } %>
+    </section>
+
+    <!-- ── Reward Assignments ─────────────────────────────────────── -->
+    <section class="section">
+      <h2 class="section-title">Reward Assignments</h2>
+      <p class="hint" style="margin-bottom:0.75rem;">
+        Find your reward ID in your Twitch dashboard under <strong>Channel Points → Manage Rewards</strong>.
+        Each reward can have multiple videos assigned — one will be picked at random (weighted) when redeemed.
+      </p>
+
+      <% if (videos.length === 0) { %>
+      <div class="card">
+        <div class="card-body">
+          <p class="hint">Upload at least one video before creating a reward assignment.</p>
+        </div>
+      </div>
+      <% } else { %>
+
+      <div class="card card-spaced">
+        <div class="card-body">
+          <form method="POST" action="/overlay/settings/rewards" id="reward-form">
+            <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+            <div style="margin-bottom:0.75rem;">
+              <label class="hint hint-compact" for="reward-id">Twitch Reward ID (UUID)</label>
+              <input id="reward-id" class="input" type="text" name="twitch_reward_id"
+                pattern="[0-9a-fA-F\-]{36}" maxlength="36" required
+                placeholder="e.g. 12345678-abcd-1234-abcd-1234567890ab">
+            </div>
+            <p class="hint hint-compact">Videos &amp; weights (higher weight = more likely):</p>
+            <div id="video-assignments" style="margin-top:0.4rem;">
+              <% for (const v of videos) { %>
+              <div class="form-row-wrap" style="margin-bottom:0.4rem;align-items:center;">
+                <label style="flex:3;display:flex;align-items:center;gap:0.5rem;">
+                  <input type="checkbox" name="video_ids" value="<%= v.id %>">
+                  <%= v.name %>
+                </label>
+                <div style="flex:1;display:flex;align-items:center;gap:0.4rem;">
+                  <span class="hint hint-compact" style="white-space:nowrap;">Weight</span>
+                  <input class="input" type="number" name="weights" value="1" min="1" max="100" style="width:5rem;">
+                </div>
+              </div>
+              <% } %>
+            </div>
+            <div class="button-row-wrap" style="margin-top:0.75rem;">
+              <button type="submit" class="btn">Save Assignment</button>
+            </div>
+          </form>
+        </div>
+      </div>
+
+      <% } %>
+
+      <!-- Existing assignments -->
+      <% if (rewards.length > 0) { %>
+      <% for (const r of rewards) { %>
+      <div class="card card-spaced">
+        <div class="card-body">
+          <div class="form-row-wrap" style="align-items:center;justify-content:space-between;">
+            <div>
+              <p class="hint hint-compact">Reward ID</p>
+              <code class="mono"><%= r.twitch_reward_id %></code>
+            </div>
+            <form method="POST" action="/overlay/settings/rewards/<%= r.id %>/delete" style="margin:0;">
+              <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+              <button type="submit" class="btn btn-ghost btn-sm"
+                onclick="return confirm('Remove this reward assignment?')">
+                Remove
+              </button>
+            </form>
+          </div>
+          <% if (r.videos.length > 0) { %>
+          <table class="table" style="width:100%;margin-top:0.75rem;">
+            <thead>
+              <tr><th>Video</th><th>Weight</th></tr>
+            </thead>
+            <tbody>
+              <% for (const v of r.videos) { %>
+              <tr>
+                <td><%= v.name %></td>
+                <td><%= v.weight %></td>
+              </tr>
+              <% } %>
+            </tbody>
+          </table>
+          <% } else { %>
+          <p class="hint" style="margin-top:0.5rem;">No videos assigned.</p>
+          <% } %>
+        </div>
+      </div>
+      <% } %>
+      <% } %>
+    </section>
+
+    <% } %>
+
+  </main>
+
+  <%- include('partials/pwa-register') %>
+</body>
+</html>

--- a/views/overlayAdmin.ejs
+++ b/views/overlayAdmin.ejs
@@ -167,7 +167,7 @@
                 </label>
                 <div style="flex:1;display:flex;align-items:center;gap:0.4rem;">
                   <span class="hint hint-compact" style="white-space:nowrap;">Weight</span>
-                  <input class="input" type="number" name="weights" value="1" min="1" max="100" style="width:5rem;">
+                  <input class="input" type="number" name="weight_<%= v.id %>" value="1" min="1" max="100" style="width:5rem;">
                 </div>
               </div>
               <% } %>

--- a/views/overlaySource.ejs
+++ b/views/overlaySource.ejs
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { background: transparent; overflow: hidden; width: 1920px; height: 1080px; }
+    video { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
+  </style>
+</head>
+<body>
+  <script src="/overlay-source.js" data-login="<%= login %>"></script>
+</body>
+</html>

--- a/views/partials/nav.ejs
+++ b/views/partials/nav.ejs
@@ -29,6 +29,7 @@
       </div>
       <% } %>
       <% if (user) { %>
+      <a href="/overlay/settings" class="nav-item">Overlay</a>
       <a href="/user/settings" class="nav-item">Settings</a>
       <% } %>
     </div>


### PR DESCRIPTION
## Summary

- Streamers upload WebM/MP4 videos via a new **Overlay** settings page (`/overlay/settings`)
- Each video can be assigned to one or more Twitch channel points reward IDs, with weights for random selection (same system as SFX)
- When a viewer redeems, the bot picks a video (weighted random), pushes it to connected browser sources via SSE, and it plays then removes itself
- OBS browser source URL: `/overlay/{twitch_login}` — transparent background, 1920×1080

## What's new

- `migrations/overlay_videos.sql` — three new tables: `overlay_video`, `overlay_reward`, `overlay_reward_video`
- `src/db/overlayVideos.ts` — DB layer (CRUD for videos and reward assignments)
- `src/web/routes/overlayAdmin.ts` — settings page + file upload (multer, memoryStorage)
- `src/web/routes/overlaySource.ts` — browser source HTML, SSE endpoint, video file serving
- `views/overlayAdmin.ejs` + `views/overlaySource.ejs` — templates
- `public/overlay-source.js` — client-side SSE consumer with queue + reconnect backoff
- Subscribes to `channel.channel_points_custom_reward_redemption` EventSub for all streamers with a connected OAuth token
- Adds `channel:read:redemptions` to the Twitch OAuth scope

## Test plan

- [ ] Run `migrations/overlay_videos.sql` against the database
- [ ] `npm install` (adds `multer`)
- [ ] Re-authorise Twitch on `/user/settings` to grant the new `channel:read:redemptions` scope
- [ ] Upload a WebM with alpha channel via `/overlay/settings`
- [ ] Assign it to a Twitch reward ID (paste UUID from Twitch dashboard)
- [ ] Open `/overlay/{login}` in a browser — should be transparent/blank
- [ ] Redeem the reward on Twitch — video should play and disappear

https://claude.ai/code/session_01UQni3pXHUoZzTjEFN62Mbn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQni3pXHUoZzTjEFN62Mbn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full overlay video system: upload/manage videos, assign them to channel point rewards, and play them in OBS via a browser source.
  * Reward-triggered playback with weighted random selection and real-time delivery to overlay pages.
  * Admin UI for overlay settings and a public overlay playback page; “Overlay” link added to the navbar.

* **Chores**
  * Server endpoints, storage, SSE delivery, OAuth scope, and CSP/media-src updates to support overlays.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->