### PR TITLE
Gate EventSub subscriptions on channel membership

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 import 'mediaplex'; // Must be imported first to register as Opus provider
 import { getPool, closePool } from './db';
-import { startTwitchBot, stopTwitchBot, sayInChannel, getActiveChannels, getActiveChannelUserIds } from './twitchBot';
+import { startTwitchBot, stopTwitchBot, sayInChannel, getActiveChannels, getActiveChannelUserIds, setChannelJoinedHook } from './twitchBot';
 import { startDiscordBot, stopDiscordBot } from './discordBot';
 import { startTikTokBot, stopTikTokBot } from './tiktokBot';
 import { startTwitchMonitor, stopTwitchMonitor } from './twitchMonitor';
-import { startEventSub, stopEventSub } from './twitchEventSub';
+import { startEventSub, stopEventSub, reloadEventSubSubscriptions } from './twitchEventSub';
 import { startWebPanel } from './web/server';
 import { disconnect } from './audioPlayer';
 import { registerTwitchChatRuntime } from './customCommandHandler';
@@ -62,6 +62,7 @@ async function main(): Promise<void> {
 
   startDiscordBot();
   await startTwitchBot();
+  setChannelJoinedHook(() => reloadEventSubSubscriptions());
   await startTikTokBot();
   startWebPanel();
   startCounterScheduler();

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,9 +60,9 @@ async function main(): Promise<void> {
   registerShoutoutRuntime({ send: sayInChannel });
   registerCountdownTwitchRuntime({ send: sayInChannel });
 
+  setChannelJoinedHook(() => reloadEventSubSubscriptions());
   startDiscordBot();
   await startTwitchBot();
-  setChannelJoinedHook(() => reloadEventSubSubscriptions());
   await startTikTokBot();
   startWebPanel();
   startCounterScheduler();

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -66,7 +66,7 @@ async function joinMissingChannel(channel: string): Promise<void> {
   await client.join(channel);
   await new Promise<void>((resolve) => { setTimeout(resolve, JOIN_THROTTLE_MS); });
   setTwitchChannel(channel, true);
-  _onChannelJoined?.(channel);
+  try { _onChannelJoined?.(channel); } catch (err) { log.error('Channel joined hook error:', err); }
   log.info(`Joined queued channel after reconnect: ${channel}`);
 }
 
@@ -252,7 +252,6 @@ export async function joinTwitchChannel(channel: string): Promise<void> {
     try {
       await client.join(normalized);
       setTwitchChannel(normalized, true);
-      _onChannelJoined?.(normalized);
       getUsers([normalized])
         .then(([u]) => { if (u) activeChannelUserIds.set(normalized, u.id); })
         .catch((err) => { log.warn(`Failed to cache user ID for channel ${normalized}:`, err); });
@@ -263,6 +262,7 @@ export async function joinTwitchChannel(channel: string): Promise<void> {
       log.error(`Failed to join channel ${normalized}:`, err);
       throw err;
     }
+    try { _onChannelJoined?.(normalized); } catch (err) { log.error('Channel joined hook error:', err); }
   });
 }
 

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -18,6 +18,11 @@ const log = createLogger('Twitch');
 let client: tmi.Client | null = null;
 let connected = false;
 const activeChannels = new Set<string>();
+let _onChannelJoined: ((channel: string) => void) | null = null;
+
+export function setChannelJoinedHook(fn: (channel: string) => void): void {
+  _onChannelJoined = fn;
+}
 const activeChannelUserIds = new Map<string, string>();
 const membershipMutationQueue = createMutationQueue();
 // Twitch rate-limits JOIN to 20 per 10 s (2/s). 600 ms ≈ 1.67/s, ~83% of the ceiling.
@@ -61,6 +66,7 @@ async function joinMissingChannel(channel: string): Promise<void> {
   await client.join(channel);
   await new Promise<void>((resolve) => { setTimeout(resolve, JOIN_THROTTLE_MS); });
   setTwitchChannel(channel, true);
+  _onChannelJoined?.(channel);
   log.info(`Joined queued channel after reconnect: ${channel}`);
 }
 

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -252,6 +252,7 @@ export async function joinTwitchChannel(channel: string): Promise<void> {
     try {
       await client.join(normalized);
       setTwitchChannel(normalized, true);
+      _onChannelJoined?.(normalized);
       getUsers([normalized])
         .then(([u]) => { if (u) activeChannelUserIds.set(normalized, u.id); })
         .catch((err) => { log.warn(`Failed to cache user ID for channel ${normalized}:`, err); });

--- a/src/twitchEventSubSubscriptions.ts
+++ b/src/twitchEventSubSubscriptions.ts
@@ -2,6 +2,7 @@ import { createLogger } from './logger';
 import { getAllEventSubStreamers, clearStreamerToken, DbStreamerEventSub, EventSubConfig } from './db/eventSub';
 import { getUsers } from './twitchApi';
 import { getActiveChannels } from './twitchBot';
+import { normalizeTwitchChannelName } from './twitchChannelName';
 import { createEventSubSubscription, listEventSubSubscriptions, deleteEventSubSubscription, getValidToken } from './twitchApiEventSub';
 import {
   handleFollow, handleSub, handleResub, handleGiftSub, handleRaid, handleRedemption,
@@ -60,7 +61,8 @@ async function resolveBroadcasterId(streamer: DbStreamerEventSub, config: EventS
 async function createSubscriptionsForStreamer(
   sid: string, uid: string, token: string | null, config: EventSubConfig | null, name: string,
 ): Promise<Set<string>> {
-  if (!getActiveChannels().has(name)) {
+  const normalizedName = normalizeTwitchChannelName(name) ?? name.toLowerCase();
+  if (!getActiveChannels().has(normalizedName)) {
     log.info(`Skipping EventSub subscriptions for ${name} — bot not in channel`);
     return new Set();
   }

--- a/src/twitchEventSubSubscriptions.ts
+++ b/src/twitchEventSubSubscriptions.ts
@@ -111,6 +111,7 @@ export async function subscribeAll(sid: string): Promise<number> {
   // Build into a temporary map so dispatchNotification/handleRevocation see a
   // consistent snapshot throughout the async loop, not an empty map mid-reload.
   const nextMap = new Map<string, StreamerInfo>();
+  let totalSubscriptions = 0;
 
   for (const streamer of streamers) {
     const token = await getValidToken(streamer);
@@ -122,13 +123,14 @@ export async function subscribeAll(sid: string): Promise<number> {
 
     // Create desired subscriptions first so there is never a gap where zero are active
     const desired = await createSubscriptionsForStreamer(sid, uid, token, config, streamer.twitch_name ?? '');
+    totalSubscriptions += desired.size;
     await deleteStaleSubscriptions(uid, desired, token);
   }
 
   // Atomic swap — old map stays readable until all subscriptions are ready
   streamerMap.clear();
   for (const [uid, info] of nextMap) streamerMap.set(uid, info);
-  return streamerMap.size;
+  return totalSubscriptions;
 }
 
 async function subscribe(sessionId: string, spec: SubSpec, token: string, login: string): Promise<void> {

--- a/src/twitchEventSubSubscriptions.ts
+++ b/src/twitchEventSubSubscriptions.ts
@@ -1,6 +1,7 @@
 import { createLogger } from './logger';
 import { getAllEventSubStreamers, clearStreamerToken, DbStreamerEventSub, EventSubConfig } from './db/eventSub';
 import { getUsers } from './twitchApi';
+import { getActiveChannels } from './twitchBot';
 import { createEventSubSubscription, listEventSubSubscriptions, deleteEventSubSubscription, getValidToken } from './twitchApiEventSub';
 import {
   handleFollow, handleSub, handleResub, handleGiftSub, handleRaid, handleRedemption,
@@ -59,6 +60,11 @@ async function resolveBroadcasterId(streamer: DbStreamerEventSub, config: EventS
 async function createSubscriptionsForStreamer(
   sid: string, uid: string, token: string | null, config: EventSubConfig | null, name: string,
 ): Promise<Set<string>> {
+  if (!getActiveChannels().has(name)) {
+    log.info(`Skipping EventSub subscriptions for ${name} — bot not in channel`);
+    return new Set();
+  }
+
   const desired = new Set<string>();
 
   if (config?.follow_enabled && token) {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `setChannelJoinedHook()` to `twitchBot.ts` so `index.ts` can register a callback without creating a circular dependency between the bot and EventSub modules
- Calls the hook in `joinMissingChannel()` after each channel is successfully joined, covering both startup reconcile and runtime channel additions
- Registers the hook in `index.ts` to trigger `reloadEventSubSubscriptions()` per channel join — subscriptions come up one channel at a time as the bot joins, rather than all-at-once or before any channel is ready
- Adds a `getActiveChannels()` guard at the top of `createSubscriptionsForStreamer()` so `subscribeAll()` never creates subscriptions for channels the bot hasn't joined yet

## Test plan

- [ ] `npm test` passes (25/25)
- [ ] On startup with multiple configured channels, confirm logs show each "Joined queued channel" entry followed promptly by EventSub subscription log lines for that channel, before the next channel joins
- [ ] Dynamically add a channel at runtime; confirm EventSub subscription fires for it immediately after join
- [ ] Disconnect and reconnect the Twitch bot; confirm subscriptions are re-established only for channels that rejoin

https://claude.ai/code/session_015R1cAAEmbNw9CGg8aiUhsi
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015R1cAAEmbNw9CGg8aiUhsi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event subscriptions now refresh automatically when the bot joins a channel, enabling streamer notifications immediately.

* **Bug Fixes**
  * Stops creating event subscriptions for channels the bot isn't present in, reducing stale subscriptions and improving notification accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->