### PR TITLE
Fix CodeRabbit config: move path_filters under reviews key

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,5 +1,7 @@
-path_filters:
-  - "!graphify-out/**"
-  - "!.claude/**"
-  - "!CLAUDE.md"
-  - "!AGENTS.md"
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+reviews:
+  path_filters:
+    - "!graphify-out/**"
+    - "!.claude/**"
+    - "!CLAUDE.md"
+    - "!AGENTS.md"


### PR DESCRIPTION
## Summary

- `path_filters` at the top level of `.coderabbit.yaml` is not a valid key per the v2 schema, causing a validation error
- Moved it under `reviews.path_filters` where the schema expects it
- Added the `# yaml-language-server` schema comment for editor auto-completion and validation

## Test plan

- [ ] Confirm CodeRabbit no longer reports an "Unrecognized key: path_filters" validation error on next PR review

https://claude.ai/code/session_01HQHuSfQMTiFefSVBN6hXt7

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQHuSfQMTiFefSVBN6hXt7)_