### PR TITLE
Add qlty pre-commit quality check hook

### DIFF
--- a/.claude/hooks/pre-commit-quality-check.sh
+++ b/.claude/hooks/pre-commit-quality-check.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -uo pipefail
+
+INPUT=$(cat)
+CMD=$(python3 -c "import json,sys; d=json.loads(sys.argv[1]); print(d.get('tool_input',d).get('command',''))" "$INPUT" 2>/dev/null || true)
+
+case "$CMD" in
+  *git\ commit*) ;;
+  *) exit 0 ;;
+esac
+
+if ! command -v qlty &>/dev/null; then
+  exit 0
+fi
+
+STAGED=$(git diff --cached --name-only 2>/dev/null || true)
+if [ -z "$STAGED" ]; then
+  exit 0
+fi
+
+QLTY_OUTPUT=$(qlty check --no-progress $STAGED 2>&1)
+QLTY_EXIT=$?
+
+if [ "$QLTY_EXIT" -ne 0 ]; then
+  python3 -c "
+import json, sys
+output = sys.argv[1]
+print(json.dumps({
+  'decision': 'block',
+  'reason': 'qlty found issues in staged files — fix them before committing:\n' + output
+}))
+" "$QLTY_OUTPUT"
+  exit 0
+fi
+
+exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -7,3 +7,7 @@ fi
 
 cd "$CLAUDE_PROJECT_DIR"
 npm install
+
+if ! command -v qlty &>/dev/null; then
+  curl -fsSL https://qlty.sh/install.sh | bash
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,15 @@
             "command": "CMD=$(python3 -c \"import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',d).get('command',''))\" 2>/dev/null || true); case \"$CMD\" in *grep*|*rg\\ *|*ripgrep*|*find\\ *|*fd\\ *|*ack\\ *|*ag\\ *)   [ -f graphify-out/graph.json ] &&   echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"graphify: knowledge graph at graphify-out/. For focused questions, run `graphify query \\\"<question>\\\"` (scoped subgraph, usually much smaller than GRAPH_REPORT.md) instead of grepping raw files. Read GRAPH_REPORT.md only for broad architecture context.\"}}'   || true ;; esac"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre-commit-quality-check.sh"
+          }
+        ]
       }
     ]
   },
@@ -44,7 +53,8 @@
       "Bash(grep -n * public*)",
       "Bash(grep -rn * migrations*)",
       "Bash(grep -r * migrations*)",
-      "Bash(grep -n * migrations*)"
+      "Bash(grep -n * migrations*)",
+      "Bash(qlty check*)"
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,10 @@ npm run test:watch # re-run on file change (dev)
 Tests live alongside source as `*.test.ts` files (e.g. `src/commandRouter.test.ts`, `src/db/lookupCache.test.ts`).
 
 ### No linter / formatter
-There is **no ESLint or Prettier** configured. `.qlty/` is a CI-only security/smell scanner — do not attempt to run `eslint` or `prettier` locally.
+There is **no ESLint or Prettier** configured. Do not attempt to run `eslint` or `prettier` locally.
+
+### Code quality (qlty)
+`.qlty/qlty.toml` configures three plugins: **trufflehog** (secret detection), **ripgrep** (code smells), and **osv-scanner** (dependency vulnerabilities). A pre-commit hook (`.claude/hooks/pre-commit-quality-check.sh`) runs `qlty check` on staged files automatically before every `git commit`. If qlty finds issues the commit is **blocked** — fix the reported findings before retrying. The goal is to avoid introducing new smells. In cloud sessions, qlty is installed automatically by `.claude/hooks/session-start.sh` if not already available.
 
 ### TypeScript / import style
 - `tsconfig.json` — used by `ts-node` (dev); includes test files


### PR DESCRIPTION
## Summary

- Adds `.claude/hooks/pre-commit-quality-check.sh` — runs `qlty check` on staged files before every `git commit`; if qlty finds any issues the commit is **blocked** so new smells, secrets, or vulnerabilities cannot land unreviewed
- Updates `.claude/hooks/session-start.sh` — installs the qlty CLI at session start in cloud environments where it isn't already available
- Updates `.claude/settings.json` — wires in the new PreToolUse hook and adds `Bash(qlty check*)` to the allow list
- Updates `CLAUDE.md` — documents the new local qlty behaviour and the cloud-install step

## Test plan

- [ ] Stage a file with a deliberate smell/secret placeholder and attempt `git commit` via Claude — confirm the commit is blocked and qlty output appears in the conversation
- [ ] Stage a clean file and attempt `git commit` — confirm qlty exits 0 and the commit proceeds
- [ ] In a fresh cloud session, verify `qlty` is on PATH after `session-start.sh` runs

https://claude.ai/code/session_01JZd9G512WFXFh3VpUeqdH5

---
_Generated by [Claude Code](https://claude.ai/code/session_01JZd9G512WFXFh3VpUeqdH5)_