### PR TITLE
Fix stale entries in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,6 @@ npm test      # Vitest
 
 - **`mediaplex` must be the first import in `src/index.ts`** — registers the Opus provider. Never reorder.
 - **Import DB functions from `src/db.ts` only**, never `src/db/*` directly. The facade wraps some functions with cache-invalidation side effects (`upsertUser`, `removeUser`, `updateTwitchBotEnabled`).
-- **`boolFromDb()` from `src/db/utils.ts`** for all tinyint/bit columns — MySQL may return a `Buffer`.
 - **BIGINT columns are strings** (`bigNumberStrings: true` on the pool) — never coerce to `Number`.
 - **Blank Twitch names → `NULL`** — `user.twitch_name` has a unique index; empty strings collide.
 - **`mutationQueue`** for concurrent-unsafe DB writes — user mutations serialise through it.
@@ -52,13 +51,11 @@ npm test      # Vitest
 
 ## Design Decisions
 
-**Command matching:** `trigger_command` stores the full prefixed string (e.g. `!clap`). First word is lowercased and queried directly — **no prefix stripping**.
+**Command matching:** `trigger_string` stores the full prefixed string (e.g. `!clap`). First word is lowercased and queried directly — **no prefix stripping**.
 
 **Voice adapter:** `audioPlayer.ts` uses a custom `DiscordGatewayAdapterCreator` via `client.on('raw', ...)`. `guild.voiceAdapterCreator` is unused — discord.js v14 incompatibility.
 
-**Shadow mode:** `CUSTOM_COMMANDS_LIVE_REPLIES=true` enables live replies; `COUNTER_LIVE_WRITES=true` enables counter increments. Both default `false`.
-
-**`customCommands.ts` owns its cache:** Write functions call `invalidateLookupCache()` internally — don't add a second call in `db.ts`.
+**`customCommands.ts` owns its cache:** Write functions call `invalidateCustomCommandLookupCache()` internally — don't add a second call in `db.ts`.
 
 **MySQL 8 upsert:** Row-alias form only: `VALUES (...) AS new_row`. Deprecated `VALUES(col)` not used.
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Remove shadow mode section (`CUSTOM_COMMANDS_LIVE_REPLIES` / `COUNTER_LIVE_WRITES` no longer exist in the codebase)
- Remove `boolFromDb()` invariant (function does not exist anywhere in `src/`)
- Fix column name: `trigger_command` → `trigger_string` for the custom commands table
- Fix function name: `invalidateLookupCache()` → `invalidateCustomCommandLookupCache()`

## Test plan
- [ ] No code changes — documentation only
- [ ] Verify CLAUDE.md reads accurately against the current codebase

https://claude.ai/code/session_01G4kQyeWn4DvCVtchHvuNKU
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4kQyeWn4DvCVtchHvuNKU)_