### PR TITLE
fix: install qlty via GitHub releases instead of blocked install script

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -9,5 +9,10 @@ cd "$CLAUDE_PROJECT_DIR"
 npm install
 
 if ! command -v qlty &>/dev/null; then
-  curl -fsSL https://qlty.sh/install.sh | bash
+  QLTY_VERSION=$(curl -fsSL -I "https://github.com/qltysh/qlty/releases/latest" | grep -i location | grep -oP 'v[\d.]+' | head -1)
+  curl -fsSL "https://github.com/qltysh/qlty/releases/download/${QLTY_VERSION}/qlty-x86_64-unknown-linux-gnu.tar.xz" -o /tmp/qlty.tar.xz
+  tar -xJf /tmp/qlty.tar.xz -C /tmp
+  mv /tmp/qlty-x86_64-unknown-linux-gnu/qlty /root/.local/bin/qlty
+  chmod +x /root/.local/bin/qlty
+  rm -rf /tmp/qlty.tar.xz /tmp/qlty-x86_64-unknown-linux-gnu
 fi


### PR DESCRIPTION
## Summary

- `qlty.sh/install.sh` returns 403 in the remote container environment, so `qlty` was never installed by the SessionStart hook
- Updated `session-start.sh` to resolve the latest qlty version via a GitHub redirect, then download and extract the `x86_64-unknown-linux-gnu` tarball directly from GitHub releases
- Installs the binary to `/root/.local/bin/` which is already on PATH

## Test plan

- [ ] Start a new remote Claude Code session on this repo — qlty should be available after session start (`which qlty` returns a path)
- [ ] Attempt a `git commit` with staged changes — pre-commit quality gate should fire and run `qlty check`

https://claude.ai/code/session_012CwXuE2A6dFHNHMX5QxgzY

---
_Generated by [Claude Code](https://claude.ai/code/session_012CwXuE2A6dFHNHMX5QxgzY)_