### PR TITLE
Strengthen graphify usage to reduce token costs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,7 +16,16 @@
         "hooks": [
           {
             "type": "command",
-            "command": "CMD=$(python3 -c \"import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',d).get('command',''))\" 2>/dev/null || true); case \"$CMD\" in *grep*|*rg\\ *|*ripgrep*|*find\\ *|*fd\\ *|*ack\\ *|*ag\\ *)   [ -f graphify-out/graph.json ] &&   echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"graphify: knowledge graph at graphify-out/. For focused questions, run `graphify query \\\"<question>\\\"` (scoped subgraph, usually much smaller than GRAPH_REPORT.md) instead of grepping raw files. Read GRAPH_REPORT.md only for broad architecture context.\"}}'   || true ;; esac"
+            "command": "CMD=$(python3 -c \"import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',d).get('command',''))\" 2>/dev/null || true); case \"$CMD\" in *grep*|*rg\\ *|*ripgrep*|*find\\ *|*fd\\ *|*ack\\ *|*ag\\ *|*cat\\ src*|*cat\\ .*)   [ -f \"$CLAUDE_PROJECT_DIR/graphify-out/graph.json\" ] &&   echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"STOP: do not grep or cat source files to locate code. Use graphify query instead — it returns a scoped subgraph at a fraction of the token cost. Example: graphify query \\\"where is X defined\\\". Only proceed with grep if graphify is unavailable or the question is not about code structure.\"}}'   || true ;; esac"
+          }
+        ]
+      },
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "FILE=$(python3 -c \"import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('file_path',''))\" 2>/dev/null || true); case \"$FILE\" in *.ts|*.js|*.tsx|*.jsx) [ -f \"$CLAUDE_PROJECT_DIR/graphify-out/graph.json\" ] && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"graphify reminder: if you are reading this file to discover its structure, exports, or where something is defined — stop and use graphify query instead (far fewer tokens). Only read the file if you already know the exact location you need to edit or confirm.\"}}' || true ;; esac"
           }
         ]
       },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,14 +1,23 @@
 # BCUK Bot 4 — Claude Code Instructions
 
-## ALWAYS: Codebase Questions → Use Graphify First
+## ALWAYS: Use Graphify — Never Grep or Read to Explore
+
+**Before reading any file or running any search to answer a question about code structure, symbols, or relationships — run graphify query first. This is mandatory.**
 
 ```bash
-graphify query "<question>"
-graphify path "<A>" "<B>"
-graphify explain "<concept>"
+graphify query "where is X defined"           # replaces: grep -r "X" src/
+graphify query "what calls function Y"        # replaces: grep -rn "Y" src/
+graphify query "what does module Z import"    # replaces: reading Z.ts to check imports
+graphify path "src/index.ts" "src/db.ts"     # trace a dependency relationship
+graphify explain "<concept or subsystem>"     # understand how something works
 ```
 
-Use `graphify-out/GRAPH_REPORT.md` for broad architecture review. After changing code run `graphify update .`.
+Rules — no exceptions:
+- **Never run grep / find / rg to locate code** — use `graphify query` instead
+- **Never read a file just to discover what's in it** — query the graph first; read only to confirm or edit a known location
+- **Never read more than one file to answer a structural question** — if you need to read multiple files to understand something, use graphify instead
+- Use `graphify-out/GRAPH_REPORT.md` only for a full architecture overview (read once per session at most, never per question)
+- After changing code: `graphify update .`
 
 ---
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **CLAUDE.md**: Rewrote the graphify section with explicit "never grep/read to explore" rules, concrete before/after examples, and a hard rule against reading multiple files to answer a structural question
- **settings.json (Bash hook)**: Made the existing hook message imperative ("STOP: do not grep") and extended the pattern to also catch `cat src*` and `cat .*` commands
- **settings.json (Read hook)**: Added a new PreToolUse hook on the `Read` tool that fires for `.ts/.js/.tsx/.jsx` files — intercepts exploratory file reads before the file content lands in context, redirecting Claude to `graphify query` instead

## Why

Graphify was installed but Claude was defaulting to its trained habits (grep, Read, sequential file exploration). These changes make graphify the path of least resistance by intercepting the tools Claude reaches for first.

## Test plan

- [ ] Ask a codebase question (e.g. "where is mutationQueue defined?") — verify Claude runs `graphify query` rather than grep
- [ ] Ask Claude to read a `.ts` file it hasn't been pointed to — verify the Read hook fires and Claude redirects to graphify
- [ ] Run `grep -r "something" src/` manually in a session — verify the Bash hook fires with the STOP message
- [ ] Confirm targeted reads (editing a known file) still work without excessive hook noise

https://claude.ai/code/session_01GCpWZXd75PvL4tVWCtBeBg
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCpWZXd75PvL4tVWCtBeBg)_