### PR TITLE
fix: downgrade EventSub 403 auth failures from ERROR to WARN

### DIFF
--- a/src/twitchApiEventSub.ts
+++ b/src/twitchApiEventSub.ts
@@ -111,6 +111,10 @@ export async function createEventSubSubscription(
     }),
   });
   if (res.status === 409) return null;
+  if (res.status === 401 || res.status === 403) {
+    const errBody = await res.text().catch(() => '');
+    throw new TwitchAuthError(`[TwitchAPI] createEventSubSubscription (${type}) failed: ${res.status} ${errBody}`);
+  }
   if (!res.ok) {
     const errBody = await res.text().catch(() => '');
     throw new Error(`[TwitchAPI] createEventSubSubscription (${type}) failed: ${res.status} ${errBody}`);

--- a/src/twitchEventSubSubscriptions.ts
+++ b/src/twitchEventSubSubscriptions.ts
@@ -122,7 +122,18 @@ export async function subscribeAll(sid: string): Promise<number> {
     nextMap.set(uid, { login: streamer.twitch_name ?? '', streamerId: streamer.id, config });
 
     // Create desired subscriptions first so there is never a gap where zero are active
-    const desired = await createSubscriptionsForStreamer(sid, uid, token, config, streamer.twitch_name ?? '');
+    let desired: Set<string>;
+    try {
+      desired = await createSubscriptionsForStreamer(sid, uid, token, config, streamer.twitch_name ?? '');
+    } catch (err) {
+      if (err instanceof TwitchAuthError) {
+        log.warn(`Clearing token for ${streamer.twitch_name ?? uid} — authorization missing, user must reconnect Twitch`);
+        await clearStreamerToken(streamer.id);
+      } else {
+        log.error(`createSubscriptionsForStreamer failed for ${streamer.twitch_name ?? uid}:`, err);
+      }
+      continue;
+    }
     totalSubscriptions += desired.size;
     await deleteStaleSubscriptions(uid, desired, token);
   }
@@ -138,11 +149,8 @@ async function subscribe(sessionId: string, spec: SubSpec, token: string, login:
     const id = await createEventSubSubscription(spec.type, spec.version, spec.condition, sessionId, token);
     if (id !== null) log.info(`Subscribed to ${spec.type} for ${login}`);
   } catch (err) {
-    if (err instanceof TwitchAuthError) {
-      log.warn(`Skipping ${spec.type} for ${login} — authorization missing, user may need to reconnect Twitch`);
-    } else {
-      log.error(`Failed to subscribe to ${spec.type} for ${login}:`, err);
-    }
+    if (err instanceof TwitchAuthError) throw err;
+    log.error(`Failed to subscribe to ${spec.type} for ${login}:`, err);
   }
 }
 

--- a/src/twitchEventSubSubscriptions.ts
+++ b/src/twitchEventSubSubscriptions.ts
@@ -3,7 +3,7 @@ import { getAllEventSubStreamers, clearStreamerToken, DbStreamerEventSub, EventS
 import { getUsers } from './twitchApi';
 import { getActiveChannels } from './twitchBot';
 import { normalizeTwitchChannelName } from './twitchChannelName';
-import { createEventSubSubscription, listEventSubSubscriptions, deleteEventSubSubscription, getValidToken } from './twitchApiEventSub';
+import { createEventSubSubscription, listEventSubSubscriptions, deleteEventSubSubscription, getValidToken, TwitchAuthError } from './twitchApiEventSub';
 import {
   handleFollow, handleSub, handleResub, handleGiftSub, handleRaid, handleRedemption,
   FollowEvent, SubEvent, ResubEvent, GiftSubEvent, RaidEvent, RedemptionEvent,
@@ -138,7 +138,11 @@ async function subscribe(sessionId: string, spec: SubSpec, token: string, login:
     const id = await createEventSubSubscription(spec.type, spec.version, spec.condition, sessionId, token);
     if (id !== null) log.info(`Subscribed to ${spec.type} for ${login}`);
   } catch (err) {
-    log.error(`Failed to subscribe to ${spec.type} for ${login}:`, err);
+    if (err instanceof TwitchAuthError) {
+      log.warn(`Skipping ${spec.type} for ${login} — authorization missing, user may need to reconnect Twitch`);
+    } else {
+      log.error(`Failed to subscribe to ${spec.type} for ${login}:`, err);
+    }
   }
 }
 

--- a/src/twitchEventSubSubscriptions.ts
+++ b/src/twitchEventSubSubscriptions.ts
@@ -18,7 +18,7 @@ export interface SubSpec { type: string; version: string; condition: Record<stri
 export interface StreamerInfo { login: string; streamerId: number; config: EventSubConfig | null }
 const streamerMap = new Map<string, StreamerInfo>();
 
-// Tracks "login:type" pairs that failed with 403 — silently skipped until bot restarts
+// Tracks "login:type:token" triples that failed with 403 — skipped until bot restarts or token changes
 const authFailedSubs = new Set<string>();
 
 export function hasAuthFailedSubs(login: string): boolean {
@@ -143,11 +143,14 @@ export async function subscribeAll(sid: string): Promise<number> {
 }
 
 async function subscribe(sessionId: string, spec: SubSpec, token: string, login: string): Promise<void> {
-  const skipKey = `${login}:${spec.type}`;
+  const skipKey = `${login}:${spec.type}:${token}`;
   if (authFailedSubs.has(skipKey)) return;
   try {
     const id = await createEventSubSubscription(spec.type, spec.version, spec.condition, sessionId, token);
-    if (id !== null) log.info(`Subscribed to ${spec.type} for ${login}`);
+    if (id !== null) {
+      authFailedSubs.delete(skipKey);
+      log.info(`Subscribed to ${spec.type} for ${login}`);
+    }
   } catch (err) {
     if (err instanceof TwitchAuthError) {
       authFailedSubs.add(skipKey);

--- a/src/twitchEventSubSubscriptions.ts
+++ b/src/twitchEventSubSubscriptions.ts
@@ -18,6 +18,9 @@ export interface SubSpec { type: string; version: string; condition: Record<stri
 export interface StreamerInfo { login: string; streamerId: number; config: EventSubConfig | null }
 const streamerMap = new Map<string, StreamerInfo>();
 
+// Tracks "login:type" pairs that failed with 403 — silently skipped until bot restarts
+const authFailedSubs = new Set<string>();
+
 // Maps EventSub notification types to their handler functions.
 // Using Map instead of a plain object prevents prototype-chain lookup on user-controlled keys.
 type NotificationHandler = (login: string, event: unknown, config: EventSubConfig, streamerId: number) => Promise<void>;
@@ -122,18 +125,7 @@ export async function subscribeAll(sid: string): Promise<number> {
     nextMap.set(uid, { login: streamer.twitch_name ?? '', streamerId: streamer.id, config });
 
     // Create desired subscriptions first so there is never a gap where zero are active
-    let desired: Set<string>;
-    try {
-      desired = await createSubscriptionsForStreamer(sid, uid, token, config, streamer.twitch_name ?? '');
-    } catch (err) {
-      if (err instanceof TwitchAuthError) {
-        log.warn(`Clearing token for ${streamer.twitch_name ?? uid} — authorization missing, user must reconnect Twitch`);
-        await clearStreamerToken(streamer.id);
-      } else {
-        log.error(`createSubscriptionsForStreamer failed for ${streamer.twitch_name ?? uid}:`, err);
-      }
-      continue;
-    }
+    const desired = await createSubscriptionsForStreamer(sid, uid, token, config, streamer.twitch_name ?? '');
     totalSubscriptions += desired.size;
     await deleteStaleSubscriptions(uid, desired, token);
   }
@@ -145,12 +137,18 @@ export async function subscribeAll(sid: string): Promise<number> {
 }
 
 async function subscribe(sessionId: string, spec: SubSpec, token: string, login: string): Promise<void> {
+  const skipKey = `${login}:${spec.type}`;
+  if (authFailedSubs.has(skipKey)) return;
   try {
     const id = await createEventSubSubscription(spec.type, spec.version, spec.condition, sessionId, token);
     if (id !== null) log.info(`Subscribed to ${spec.type} for ${login}`);
   } catch (err) {
-    if (err instanceof TwitchAuthError) throw err;
-    log.error(`Failed to subscribe to ${spec.type} for ${login}:`, err);
+    if (err instanceof TwitchAuthError) {
+      authFailedSubs.add(skipKey);
+      log.warn(`Skipping ${spec.type} for ${login} — authorization missing, user must reconnect Twitch`);
+    } else {
+      log.error(`Failed to subscribe to ${spec.type} for ${login}:`, err);
+    }
   }
 }
 

--- a/src/twitchEventSubSubscriptions.ts
+++ b/src/twitchEventSubSubscriptions.ts
@@ -21,6 +21,12 @@ const streamerMap = new Map<string, StreamerInfo>();
 // Tracks "login:type" pairs that failed with 403 — silently skipped until bot restarts
 const authFailedSubs = new Set<string>();
 
+export function hasAuthFailedSubs(login: string): boolean {
+  const prefix = `${login}:`;
+  for (const key of authFailedSubs) if (key.startsWith(prefix)) return true;
+  return false;
+}
+
 // Maps EventSub notification types to their handler functions.
 // Using Map instead of a plain object prevents prototype-chain lookup on user-controlled keys.
 type NotificationHandler = (login: string, event: unknown, config: EventSubConfig, streamerId: number) => Promise<void>;

--- a/src/web/routes/dashboard.ts
+++ b/src/web/routes/dashboard.ts
@@ -2,6 +2,8 @@ import { createLogger } from '../../logger';
 import { Router } from 'express';
 import { getStatus } from '../../statusStore';
 import { csrfProtection } from '../csrf';
+import { getStreamerByDiscordId } from '../../db';
+import { hasAuthFailedSubs } from '../../twitchEventSubSubscriptions';
 
 const log = createLogger('Web');
 const router = Router();
@@ -9,10 +11,16 @@ const router = Router();
 router.get('/', csrfProtection, async (req, res) => {
   try {
     const status = getStatus();
+    let needsReconnect = false;
+    if (req.session.user) {
+      const streamer = await getStreamerByDiscordId(req.session.user.discordId);
+      needsReconnect = !!(streamer?.eventsub_access_token && streamer.twitch_name && hasAuthFailedSubs(streamer.twitch_name));
+    }
     res.render('dashboard', {
       user: req.session.user,
       status,
       csrfToken: req.csrfToken(),
+      needsReconnect,
     });
   } catch (err) {
     log.error('Dashboard error:', err);

--- a/src/web/routes/userSettings.ts
+++ b/src/web/routes/userSettings.ts
@@ -5,6 +5,7 @@ import { findUser, getStreamerByDiscordId, saveEventConfig, clearStreamerToken, 
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
 import { reloadEventSubSubscriptions } from '../../twitchEventSub';
+import { hasAuthFailedSubs } from '../../twitchEventSubSubscriptions';
 import { TWITCH_CLIENT_ID, TWITCH_EVENTSUB_REDIRECT_URI, EVENTSUB_TOKEN_SECRET } from '../../config';
 
 const log = createLogger('Web');
@@ -62,11 +63,14 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
       ? { ...streamer, eventsub_access_token: null, eventsub_refresh_token: null }
       : null;
 
+    const needsReconnect = isConnected && !!(streamer?.twitch_name) && hasAuthFailedSubs(streamer.twitch_name);
+
     res.render('userSettings', {
       user: req.session.user,
       dbUser,
       streamer: safeStreamer,
       isConnected,
+      needsReconnect,
       csrfToken: req.csrfToken(),
       error: errorKey,
       success: req.query.success as string | undefined,

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -92,7 +92,7 @@
     <div style="background:var(--bg-card);border:1px solid var(--danger);border-radius:var(--radius);max-width:480px;width:100%;padding:2rem;text-align:center;">
       <div style="font-size:2.5rem;margin-bottom:0.75rem;">⚠️</div>
       <h2 style="color:var(--danger);margin-bottom:0.75rem;font-size:1.25rem;">Twitch Reconnection Required</h2>
-      <p style="color:var(--text);margin-bottom:0.5rem;">Your Twitch connection is missing required permissions and some notifications (such as channel point redemptions) are not working.</p>
+      <p style="color:var(--text);margin-bottom:0.5rem;">Your Twitch connection is missing required permissions and some notifications are not working.</p>
       <p style="color:var(--muted);font-size:0.875rem;margin-bottom:1.5rem;">Please reconnect your Twitch account to restore full functionality.</p>
       <div style="display:flex;gap:0.75rem;justify-content:center;flex-wrap:wrap;">
         <a href="/user/settings/twitch-connect" class="btn">Reconnect Twitch</a>

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -86,5 +86,31 @@
 
   <%- include('partials/pwa-register') %>
   <script src="/app.js"></script>
+
+  <% if (needsReconnect) { %>
+  <div id="reconnect-modal" style="position:fixed;inset:0;z-index:9999;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,0.85);padding:1.5rem;">
+    <div style="background:var(--bg-card);border:1px solid var(--danger);border-radius:var(--radius);max-width:480px;width:100%;padding:2rem;text-align:center;">
+      <div style="font-size:2.5rem;margin-bottom:0.75rem;">⚠️</div>
+      <h2 style="color:var(--danger);margin-bottom:0.75rem;font-size:1.25rem;">Twitch Reconnection Required</h2>
+      <p style="color:var(--text);margin-bottom:0.5rem;">Your Twitch connection is missing required permissions and some notifications (such as channel point redemptions) are not working.</p>
+      <p style="color:var(--muted);font-size:0.875rem;margin-bottom:1.5rem;">Please reconnect your Twitch account to restore full functionality.</p>
+      <div style="display:flex;gap:0.75rem;justify-content:center;flex-wrap:wrap;">
+        <a href="/user/settings/twitch-connect" class="btn">Reconnect Twitch</a>
+        <button onclick="dismissReconnectModal()" class="btn btn-ghost">Dismiss</button>
+      </div>
+    </div>
+  </div>
+  <script>
+    (function () {
+      if (sessionStorage.getItem('twitch_reconnect_dismissed')) {
+        document.getElementById('reconnect-modal').style.display = 'none';
+      }
+    })();
+    function dismissReconnectModal() {
+      sessionStorage.setItem('twitch_reconnect_dismissed', '1');
+      document.getElementById('reconnect-modal').style.display = 'none';
+    }
+  </script>
+  <% } %>
 </body>
 </html>

--- a/views/userSettings.ejs
+++ b/views/userSettings.ejs
@@ -67,6 +67,13 @@
       </div>
       <% } else { %>
 
+      <% if (needsReconnect) { %>
+      <div class="card card-alert-danger" style="margin-bottom:0.75rem;">
+        Your Twitch connection is missing required permissions. Please reconnect your Twitch account to restore channel point redemption notifications.
+        <a href="/user/settings/twitch-connect" class="btn btn-sm" style="margin-left:1rem;">Reconnect Twitch</a>
+      </div>
+      <% } %>
+
       <div class="card card-spaced">
         <div class="card-body">
           <div class="form-row-wrap" style="align-items:center;">


### PR DESCRIPTION
## Summary

- A 403 on `createEventSubSubscription` means the user's token is missing the required scope (e.g. `channel:read:redemptions`). This is expected for users with outdated Twitch connections and was spamming the error log on every EventSub reconnect.
- `createEventSubSubscription` now throws `TwitchAuthError` on 401/403 (consistent with how `refreshUserToken` treats auth failures).
- `subscribe()` catches `TwitchAuthError` and emits a single `WARN` instead of `ERROR`, with a clear message directing the user to reconnect Twitch.

## Test plan

- [ ] Confirm `npm test` passes (153 tests, no regressions)
- [ ] Manually verify: a streamer with an outdated token now produces `[WARN] Skipping channel.channel_points_custom_reward_redemption.add for USER — authorization missing, user may need to reconnect Twitch` instead of `[ERROR]` spam

https://claude.ai/code/session_012LzHPiLHGAkAHquDgbF9mM

---
_Generated by [Claude Code](https://claude.ai/code/session_012LzHPiLHGAkAHquDgbF9mM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better detection/handling of Twitch authentication and authorization failures

* **New Features**
  * Dashboard shows reconnect prompt when Twitch permissions/notifications are missing
  * Settings page displays a reconnect alert for affected accounts
  * Reconnection reminders are dismissible and persist across sessions
  * System prevents repeated retry attempts for failed Twitch subscription attempts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->