### PR TITLE
tests: commandMonitorStore cap/ordering and commandLocks pure functions

### DIFF
--- a/src/commandMonitorStore.test.ts
+++ b/src/commandMonitorStore.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+let recordCommandTestEntry: (typeof import('./commandMonitorStore.js'))['recordCommandTestEntry'];
+let getRecentCommandTestEntries: (typeof import('./commandMonitorStore.js'))['getRecentCommandTestEntries'];
+
+beforeEach(async () => {
+  vi.resetModules();
+  ({ recordCommandTestEntry, getRecentCommandTestEntries } = await import('./commandMonitorStore.js'));
+});
+
+const makeEntry = (command = '!test') => ({
+  source: 'twitch' as const,
+  command,
+  response: 'response',
+  channel: 'channel1',
+  user: 'user1',
+});
+
+describe('recordCommandTestEntry', () => {
+  it('prepends — newest entry is at index 0', () => {
+    recordCommandTestEntry(makeEntry('!first'));
+    recordCommandTestEntry(makeEntry('!second'));
+
+    const entries = getRecentCommandTestEntries();
+    expect(entries[0].command).toBe('!second');
+    expect(entries[1].command).toBe('!first');
+  });
+
+  it('assigns monotonically increasing IDs starting at 1', () => {
+    recordCommandTestEntry(makeEntry('!a'));
+    recordCommandTestEntry(makeEntry('!b'));
+    recordCommandTestEntry(makeEntry('!c'));
+
+    const entries = getRecentCommandTestEntries();
+    // Newest first, so IDs are 3, 2, 1
+    expect(entries[0].id).toBe(3);
+    expect(entries[1].id).toBe(2);
+    expect(entries[2].id).toBe(1);
+  });
+
+  it('caps the list at 30 entries when 31 are added', () => {
+    for (let i = 1; i <= 31; i++) {
+      recordCommandTestEntry(makeEntry(`!cmd${i}`));
+    }
+
+    const entries = getRecentCommandTestEntries();
+    expect(entries).toHaveLength(30);
+  });
+
+  it('drops the oldest entry (original first) when the cap is exceeded', () => {
+    for (let i = 1; i <= 31; i++) {
+      recordCommandTestEntry(makeEntry(`!cmd${i}`));
+    }
+
+    const entries = getRecentCommandTestEntries();
+    // !cmd1 was added first and should have been dropped
+    const commands = entries.map((e) => e.command);
+    expect(commands).not.toContain('!cmd1');
+    expect(commands).toContain('!cmd31');
+  });
+});
+
+describe('getRecentCommandTestEntries', () => {
+  it('returns entries newest-first', () => {
+    recordCommandTestEntry(makeEntry('!alpha'));
+    recordCommandTestEntry(makeEntry('!beta'));
+    recordCommandTestEntry(makeEntry('!gamma'));
+
+    const entries = getRecentCommandTestEntries();
+    expect(entries.map((e) => e.command)).toEqual(['!gamma', '!beta', '!alpha']);
+  });
+
+  it('returns copies — mutating the returned array does not affect internal state', () => {
+    recordCommandTestEntry(makeEntry('!original'));
+
+    const first = getRecentCommandTestEntries();
+    first.splice(0, first.length); // clear the returned array
+
+    const second = getRecentCommandTestEntries();
+    expect(second).toHaveLength(1);
+    expect(second[0].command).toBe('!original');
+  });
+
+  it('returns Date instances for createdAt', () => {
+    recordCommandTestEntry(makeEntry('!timetest'));
+
+    const entries = getRecentCommandTestEntries();
+    expect(entries[0].createdAt).toBeInstanceOf(Date);
+  });
+});

--- a/src/db/commandLocks.test.ts
+++ b/src/db/commandLocks.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../logger', () => ({ createLogger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn() }) }));
+vi.mock('./pool', () => ({ getPool: vi.fn() }));
+vi.mock('mysql2/promise', () => ({ default: {} }));
+vi.mock('./commandStringUtils', () => ({
+  CommandConflictError: class CommandConflictError extends Error {
+    constructor(cmds: string[]) {
+      super(String(cmds));
+    }
+  },
+  normalizeCommandInputs: vi.fn(),
+  buildInClausePlaceholders: vi.fn(),
+}));
+
+import { isDeadlockError, getCommandWriteLockName } from './commandLocks';
+
+describe('isDeadlockError', () => {
+  it('returns true when code is ER_LOCK_DEADLOCK', () => {
+    expect(isDeadlockError({ code: 'ER_LOCK_DEADLOCK' })).toBe(true);
+  });
+
+  it('returns true when errno is 1213', () => {
+    expect(isDeadlockError({ errno: 1213 })).toBe(true);
+  });
+
+  it('returns true when both code and errno indicate a deadlock', () => {
+    expect(isDeadlockError({ code: 'ER_LOCK_DEADLOCK', errno: 1213 })).toBe(true);
+  });
+
+  it('returns false for a different error code', () => {
+    expect(isDeadlockError({ code: 'ER_OTHER' })).toBe(false);
+  });
+
+  it('returns false for an empty object', () => {
+    expect(isDeadlockError({})).toBe(false);
+  });
+
+  it('throws when passed null (cannot read properties of null)', () => {
+    expect(() => isDeadlockError(null)).toThrow();
+  });
+
+  it('throws when passed undefined (cannot read properties of undefined)', () => {
+    expect(() => isDeadlockError(undefined)).toThrow();
+  });
+
+  it('returns false for a plain string', () => {
+    expect(isDeadlockError('ER_LOCK_DEADLOCK')).toBe(false);
+  });
+});
+
+describe('getCommandWriteLockName', () => {
+  it('returns a string that starts with bcuk_cmd_', () => {
+    const lockName = getCommandWriteLockName('!test');
+    expect(lockName.startsWith('bcuk_cmd_')).toBe(true);
+  });
+
+  it('is deterministic — same input always returns the same string', () => {
+    const first = getCommandWriteLockName('!clap');
+    const second = getCommandWriteLockName('!clap');
+    expect(first).toBe(second);
+  });
+
+  it('total length is at most 64 characters (MySQL named lock limit)', () => {
+    const lockName = getCommandWriteLockName('!some-very-long-command-trigger-string');
+    expect(lockName.length).toBeLessThanOrEqual(64);
+  });
+
+  it('different commands produce different lock names', () => {
+    const a = getCommandWriteLockName('!clap');
+    const b = getCommandWriteLockName('!hug');
+    expect(a).not.toBe(b);
+  });
+
+  it('the hash portion after bcuk_cmd_ is exactly 48 hex characters', () => {
+    const lockName = getCommandWriteLockName('!test');
+    const prefix = 'bcuk_cmd_';
+    const hashPart = lockName.slice(prefix.length);
+    expect(hashPart).toHaveLength(48);
+    expect(hashPart).toMatch(/^[0-9a-f]{48}$/);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds tests for `commandMonitorStore`: 30-entry cap behaviour, monotonic ID assignment, newest-first ordering, and copy-on-read (mutating the returned array does not affect internal state), plus `Date` instance checks on `createdAt`
- Adds tests for `isDeadlockError`: both the `code: 'ER_LOCK_DEADLOCK'` path and the `errno: 1213` path, plus false-returning cases for unrelated codes and empty objects
- Adds tests for `getCommandWriteLockName`: determinism (same input → same output), `bcuk_cmd_` prefix, total length ≤ 64 characters (MySQL named lock limit), uniqueness across different commands, and exactly 48 hex characters in the hash portion

## Notes

- `commandMonitorStore.test.ts` uses `vi.resetModules()` + dynamic re-import in `beforeEach` to get a fresh module-level state for each test
- `commandLocks.test.ts` mocks `../logger`, `./pool`, `mysql2/promise`, and `./commandStringUtils` so no real DB connection is required
- `null`/`undefined` inputs to `isDeadlockError` throw (the source performs a property access without a null guard) — tests assert the throw rather than a false return

## Test plan

- [ ] `npx tsc --noEmit` passes (pre-existing errors in other test files are unrelated to this PR)
- [ ] `npm test` → all 173 tests pass

https://claude.ai/code/session_01UkRhQ4XwWkiCjp6mgf8QGN

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkRhQ4XwWkiCjp6mgf8QGN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated test coverage for command monitoring and database lock management systems to improve reliability assurance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->