### PR TITLE
tests: web route validation for /counters and /commands (supertest)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,9 +34,11 @@
         "@types/express-session": "^1.19.0",
         "@types/multer": "^2.1.0",
         "@types/node": "^24.12.4",
+        "@types/supertest": "^7.2.0",
         "@types/tmi.js": "^1.8.6",
         "@types/ws": "^8.18.1",
         "@vitest/coverage-v8": "^4.1.7",
+        "supertest": "^7.2.2",
         "ts-node": "^10.9.2",
         "typescript": "^6.0.3",
         "vitest": "^4.1.7"
@@ -446,6 +448,19 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.130.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
@@ -454,6 +469,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1110,6 +1135,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1223,6 +1255,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/multer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.1.0.tgz",
@@ -1275,6 +1314,30 @@
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.10",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.10.tgz",
+      "integrity": "sha512-nbt4IWXABhW0jGmmpRzCFNlbmwCTzZ2gTUsNIr+X+ItdqPms+PAJZbWsNzpS2USqXjcoNLQcO6nXo60zcPQiIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz",
+      "integrity": "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
       }
     },
     "node_modules/@types/tmi.js": {
@@ -1539,6 +1602,13 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1811,6 +1881,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
@@ -1872,6 +1952,13 @@
       "engines": {
         "node": ">=6.6.0"
       }
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -1947,6 +2034,17 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/diff": {
@@ -2359,6 +2457,13 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2469,6 +2574,24 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -3581,6 +3704,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -4402,6 +4548,42 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -41,9 +41,11 @@
     "@types/express-session": "^1.19.0",
     "@types/multer": "^2.1.0",
     "@types/node": "^24.12.4",
+    "@types/supertest": "^7.2.0",
     "@types/tmi.js": "^1.8.6",
     "@types/ws": "^8.18.1",
     "@vitest/coverage-v8": "^4.1.7",
+    "supertest": "^7.2.2",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.3",
     "vitest": "^4.1.7"

--- a/src/web/routes/commands.test.ts
+++ b/src/web/routes/commands.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../db', () => {
+  class CommandConflictError extends Error {}
+  class CommandNotFoundError extends Error {}
+  class ReservedCommandError extends Error {}
+  return {
+    getAllCustomCommandsWithAssignments: vi.fn().mockResolvedValue([]),
+    getAllUsers: vi.fn().mockResolvedValue([]),
+    addCustomCommand: vi.fn().mockResolvedValue(1),
+    updateCustomCommand: vi.fn().mockResolvedValue(undefined),
+    removeCustomCommand: vi.fn().mockResolvedValue(undefined),
+    assignUserToCommand: vi.fn().mockResolvedValue(undefined),
+    unassignUserFromCommand: vi.fn().mockResolvedValue(undefined),
+    findUser: vi.fn().mockResolvedValue(null),
+    CommandConflictError,
+    CommandNotFoundError,
+    ReservedCommandError,
+    isMysqlDuplicateEntryError: vi.fn().mockReturnValue(false),
+  };
+});
+
+vi.mock('../csrf', () => ({
+  csrfProtection: (req: any, res: any, next: any) => {
+    req.csrfToken = () => 'test-csrf-token';
+    next();
+  },
+}));
+
+vi.mock('../middleware', () => ({
+  requireAuth: (_req: any, _res: any, next: any) => next(),
+  requireMod: (_req: any, _res: any, next: any) => next(),
+  requireManager: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock('../../logger', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+}));
+
+import express from 'express';
+import supertest from 'supertest';
+import router from './commands';
+import {
+  addCustomCommand,
+  updateCustomCommand,
+  removeCustomCommand,
+  assignUserToCommand,
+  unassignUserFromCommand,
+  findUser,
+  isMysqlDuplicateEntryError,
+  CommandConflictError,
+  CommandNotFoundError,
+  ReservedCommandError,
+} from '../../db';
+
+function buildApp() {
+  const app = express();
+  app.use(express.urlencoded({ extended: false }));
+  app.use((_req: any, res: any, next: any) => {
+    res.render = (view: string) => res.send(`rendered:${view}`);
+    next();
+  });
+  app.use((req: any, _res: any, next: any) => {
+    req.session = { user: { discord_id: '1', discord_name: 'TestUser', access_level: 2 } };
+    next();
+  });
+  app.use(router);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(addCustomCommand).mockResolvedValue(1);
+  vi.mocked(updateCustomCommand).mockResolvedValue(undefined);
+  vi.mocked(removeCustomCommand).mockResolvedValue(undefined);
+  vi.mocked(assignUserToCommand).mockResolvedValue(undefined);
+  vi.mocked(unassignUserFromCommand).mockResolvedValue(undefined);
+  vi.mocked(findUser).mockResolvedValue(null);
+  vi.mocked(isMysqlDuplicateEntryError).mockReturnValue(false);
+});
+
+// --- POST /commands/add ---
+
+describe('POST /commands/add', () => {
+  it('1. redirects ?error=missing_fields when trigger_string is absent', async () => {
+    const res = await supertest(buildApp())
+      .post('/commands/add')
+      .type('form')
+      .send({ output: 'Hello!' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/commands?error=missing_fields');
+  });
+
+  it('2. redirects ?error=missing_fields when output is absent', async () => {
+    const res = await supertest(buildApp())
+      .post('/commands/add')
+      .type('form')
+      .send({ trigger_string: '!hello' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/commands?error=missing_fields');
+  });
+
+  it('3. redirects ?error=missing_fields when trigger_string contains whitespace', async () => {
+    const res = await supertest(buildApp())
+      .post('/commands/add')
+      .type('form')
+      .send({ trigger_string: '!hello world', output: 'Hello!' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/commands?error=missing_fields');
+  });
+
+  it('4. redirects ?error=reserved_command when addCustomCommand throws ReservedCommandError', async () => {
+    vi.mocked(addCustomCommand).mockRejectedValue(new ReservedCommandError('reserved'));
+    const res = await supertest(buildApp())
+      .post('/commands/add')
+      .type('form')
+      .send({ trigger_string: '!hello', output: 'Hello!' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/commands?error=reserved_command');
+  });
+
+  it('5. redirects ?error=command_taken when addCustomCommand throws CommandConflictError', async () => {
+    vi.mocked(addCustomCommand).mockRejectedValue(new CommandConflictError('conflict'));
+    const res = await supertest(buildApp())
+      .post('/commands/add')
+      .type('form')
+      .send({ trigger_string: '!hello', output: 'Hello!' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/commands?error=command_taken');
+  });
+
+  it('6. redirects /commands when valid and no discord_ids', async () => {
+    const res = await supertest(buildApp())
+      .post('/commands/add')
+      .type('form')
+      .send({ trigger_string: '!hello', output: 'Hello!' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/commands');
+  });
+
+  it('7. skips assignment and redirects /commands when user has no twitch_name', async () => {
+    vi.mocked(findUser).mockResolvedValue({ discord_id: '99', twitch_name: null } as any);
+    const res = await supertest(buildApp())
+      .post('/commands/add')
+      .type('form')
+      .send({ trigger_string: '!hello', output: 'Hello!', discord_ids: '99' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/commands');
+    expect(vi.mocked(assignUserToCommand)).not.toHaveBeenCalled();
+  });
+
+  it('8. calls assignUserToCommand and redirects /commands when user has twitch_name', async () => {
+    vi.mocked(findUser).mockResolvedValue({ discord_id: '99', twitch_name: 'streamer' } as any);
+    const res = await supertest(buildApp())
+      .post('/commands/add')
+      .type('form')
+      .send({ trigger_string: '!hello', output: 'Hello!', discord_ids: '99' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/commands');
+    expect(vi.mocked(assignUserToCommand)).toHaveBeenCalledWith(1, '99');
+  });
+});
+
+// --- POST /commands/update ---
+
+describe('POST /commands/update', () => {
+  it('9. redirects ?error=missing_fields when trigger_string is absent', async () => {
+    const res = await supertest(buildApp())
+      .post('/commands/update')
+      .type('form')
+      .send({ command_id: '1', output: 'Hello!' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/commands?error=missing_fields');
+  });
+
+  it('10. redirects ?error=invalid_id when command_id is non-numeric', async () => {
+    const res = await supertest(buildApp())
+      .post('/commands/update')
+      .type('form')
+      .send({ command_id: 'abc', trigger_string: '!hello', output: 'Hello!' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/commands?error=invalid_id');
+  });
+
+  it('11. returns 404 when updateCustomCommand throws CommandNotFoundError', async () => {
+    vi.mocked(updateCustomCommand).mockRejectedValue(new CommandNotFoundError('not found'));
+    const res = await supertest(buildApp())
+      .post('/commands/update')
+      .type('form')
+      .send({ command_id: '1', trigger_string: '!hello', output: 'Hello!' });
+    expect(res.status).toBe(404);
+  });
+
+  it('12. redirects ?error=reserved_command when updateCustomCommand throws ReservedCommandError', async () => {
+    vi.mocked(updateCustomCommand).mockRejectedValue(new ReservedCommandError('reserved'));
+    const res = await supertest(buildApp())
+      .post('/commands/update')
+      .type('form')
+      .send({ command_id: '1', trigger_string: '!hello', output: 'Hello!' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/commands?error=reserved_command');
+  });
+
+  it('13. redirects /commands on valid update', async () => {
+    const res = await supertest(buildApp())
+      .post('/commands/update')
+      .type('form')
+      .send({ command_id: '1', trigger_string: '!hello', output: 'Hello!' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/commands');
+  });
+});
+
+// --- POST /commands/remove ---
+
+describe('POST /commands/remove', () => {
+  it('14. redirects ?error=invalid_id when command_id is non-numeric', async () => {
+    const res = await supertest(buildApp())
+      .post('/commands/remove')
+      .type('form')
+      .send({ command_id: 'notanumber' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/commands?error=invalid_id');
+  });
+
+  it('15. redirects /commands on valid remove', async () => {
+    const res = await supertest(buildApp())
+      .post('/commands/remove')
+      .type('form')
+      .send({ command_id: '3' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/commands');
+  });
+});
+
+// --- POST /commands/assign ---
+
+describe('POST /commands/assign', () => {
+  it('16. redirects ?error=missing_fields when fields are absent', async () => {
+    const res = await supertest(buildApp())
+      .post('/commands/assign')
+      .type('form')
+      .send({});
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/commands?error=missing_fields');
+  });
+
+  it('17. redirects ?error=invalid_assignment_user when user not found or has no twitch_name', async () => {
+    vi.mocked(findUser).mockResolvedValue(null);
+    const res = await supertest(buildApp())
+      .post('/commands/assign')
+      .type('form')
+      .send({ command_id: '1', discord_id: '99' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/commands?error=invalid_assignment_user');
+  });
+
+  it('17b. redirects ?error=invalid_assignment_user when user exists but has no twitch_name', async () => {
+    vi.mocked(findUser).mockResolvedValue({ discord_id: '99', twitch_name: null } as any);
+    const res = await supertest(buildApp())
+      .post('/commands/assign')
+      .type('form')
+      .send({ command_id: '1', discord_id: '99' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/commands?error=invalid_assignment_user');
+  });
+
+  it('18. redirects /commands on valid assign', async () => {
+    vi.mocked(findUser).mockResolvedValue({ discord_id: '99', twitch_name: 'streamer' } as any);
+    const res = await supertest(buildApp())
+      .post('/commands/assign')
+      .type('form')
+      .send({ command_id: '1', discord_id: '99' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/commands');
+    expect(vi.mocked(assignUserToCommand)).toHaveBeenCalledWith(1, '99');
+  });
+});
+
+// --- POST /commands/unassign ---
+
+describe('POST /commands/unassign', () => {
+  it('19. redirects ?error=missing_fields when fields are absent', async () => {
+    const res = await supertest(buildApp())
+      .post('/commands/unassign')
+      .type('form')
+      .send({});
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/commands?error=missing_fields');
+  });
+
+  it('20. redirects /commands on valid unassign', async () => {
+    const res = await supertest(buildApp())
+      .post('/commands/unassign')
+      .type('form')
+      .send({ command_id: '1', discord_id: '99' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/commands');
+    expect(vi.mocked(unassignUserFromCommand)).toHaveBeenCalledWith(1, '99');
+  });
+});

--- a/src/web/routes/counters.test.ts
+++ b/src/web/routes/counters.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../db', () => {
+  class CommandConflictError extends Error {}
+  class CounterNotFoundError extends Error {}
+  class ReservedCommandError extends Error {}
+  return {
+    getAllCounters: vi.fn().mockResolvedValue([]),
+    addCounter: vi.fn().mockResolvedValue(undefined),
+    updateCounter: vi.fn().mockResolvedValue(undefined),
+    removeCounter: vi.fn().mockResolvedValue(undefined),
+    resetCounterCurrentValue: vi.fn().mockResolvedValue(undefined),
+    isCounterCommandTaken: vi.fn().mockResolvedValue(false),
+    CommandConflictError,
+    CounterNotFoundError,
+    ReservedCommandError,
+    isMysqlDuplicateEntryError: vi.fn().mockReturnValue(false),
+  };
+});
+
+vi.mock('../csrf', () => ({
+  csrfProtection: (req: any, res: any, next: any) => {
+    req.csrfToken = () => 'test-csrf-token';
+    next();
+  },
+}));
+
+vi.mock('../middleware', () => ({
+  requireAuth: (_req: any, _res: any, next: any) => next(),
+  requireMod: (_req: any, _res: any, next: any) => next(),
+  requireManager: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock('../../logger', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+}));
+
+import express from 'express';
+import supertest from 'supertest';
+import router from './counters';
+import {
+  addCounter,
+  updateCounter,
+  removeCounter,
+  resetCounterCurrentValue,
+  isCounterCommandTaken,
+  isMysqlDuplicateEntryError,
+  CommandConflictError,
+  CounterNotFoundError,
+  ReservedCommandError,
+} from '../../db';
+
+function buildApp() {
+  const app = express();
+  app.use(express.urlencoded({ extended: false }));
+  app.use((_req: any, res: any, next: any) => {
+    res.render = (view: string) => res.send(`rendered:${view}`);
+    next();
+  });
+  app.use((req: any, _res: any, next: any) => {
+    req.session = { user: { discord_id: '1', discord_name: 'TestUser', access_level: 2 } };
+    next();
+  });
+  app.use(router);
+  return app;
+}
+
+const VALID_ADD = {
+  trigger_command: '!hits',
+  check_command: '!count',
+  message: 'Count: %d',
+  increment_message: 'Now %d!',
+};
+
+const VALID_UPDATE = {
+  id: '42',
+  trigger_command: '!hits',
+  check_command: '!count',
+  message: 'Count: %d',
+  increment_message: 'Now %d!',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(addCounter).mockResolvedValue(undefined);
+  vi.mocked(updateCounter).mockResolvedValue(undefined);
+  vi.mocked(removeCounter).mockResolvedValue(undefined);
+  vi.mocked(resetCounterCurrentValue).mockResolvedValue(undefined);
+  vi.mocked(isCounterCommandTaken).mockResolvedValue(false);
+  vi.mocked(isMysqlDuplicateEntryError).mockReturnValue(false);
+});
+
+// --- POST /counters/add ---
+
+describe('POST /counters/add', () => {
+  it('1. redirects ?error=missing_fields when trigger_command is absent', async () => {
+    const res = await supertest(buildApp())
+      .post('/counters/add')
+      .type('form')
+      .send({ check_command: '!count', message: 'Count: %d', increment_message: 'Now %d!' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/counters?error=missing_fields');
+  });
+
+  it('2. redirects ?error=missing_fields when check_command is absent', async () => {
+    const res = await supertest(buildApp())
+      .post('/counters/add')
+      .type('form')
+      .send({ trigger_command: '!hits', message: 'Count: %d', increment_message: 'Now %d!' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/counters?error=missing_fields');
+  });
+
+  it('3. redirects ?error=same_commands when trigger_command === check_command', async () => {
+    const res = await supertest(buildApp())
+      .post('/counters/add')
+      .type('form')
+      .send({ trigger_command: '!hits', check_command: '!hits', message: 'Count: %d', increment_message: 'Now %d!' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/counters?error=same_commands');
+  });
+
+  it('4. redirects ?error=missing_fields when trigger_command contains whitespace', async () => {
+    const res = await supertest(buildApp())
+      .post('/counters/add')
+      .type('form')
+      .send({ ...VALID_ADD, trigger_command: '!hi there' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/counters?error=missing_fields');
+  });
+
+  it('5. redirects ?error=duplicate_command when isCounterCommandTaken returns true', async () => {
+    vi.mocked(isCounterCommandTaken).mockResolvedValue(true);
+    const res = await supertest(buildApp())
+      .post('/counters/add')
+      .type('form')
+      .send(VALID_ADD);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/counters?error=duplicate_command');
+  });
+
+  it('6. redirects ?error=reserved_command when addCounter throws ReservedCommandError', async () => {
+    vi.mocked(addCounter).mockRejectedValue(new ReservedCommandError('reserved'));
+    const res = await supertest(buildApp())
+      .post('/counters/add')
+      .type('form')
+      .send(VALID_ADD);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/counters?error=reserved_command');
+  });
+
+  it('7. redirects ?error=duplicate_command when addCounter throws CommandConflictError', async () => {
+    vi.mocked(addCounter).mockRejectedValue(new CommandConflictError('conflict'));
+    const res = await supertest(buildApp())
+      .post('/counters/add')
+      .type('form')
+      .send(VALID_ADD);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/counters?error=duplicate_command');
+  });
+
+  it('8. redirects ?error=duplicate_command when isMysqlDuplicateEntryError returns true', async () => {
+    vi.mocked(addCounter).mockRejectedValue(new Error('ER_DUP_ENTRY'));
+    vi.mocked(isMysqlDuplicateEntryError).mockReturnValue(true);
+    const res = await supertest(buildApp())
+      .post('/counters/add')
+      .type('form')
+      .send(VALID_ADD);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/counters?error=duplicate_command');
+  });
+
+  it('9. redirects ?error=add_failed when addCounter throws unknown error', async () => {
+    vi.mocked(addCounter).mockRejectedValue(new Error('unknown db error'));
+    const res = await supertest(buildApp())
+      .post('/counters/add')
+      .type('form')
+      .send(VALID_ADD);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/counters?error=add_failed');
+  });
+
+  it('10. redirects /counters on valid form data', async () => {
+    const res = await supertest(buildApp())
+      .post('/counters/add')
+      .type('form')
+      .send(VALID_ADD);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/counters');
+  });
+});
+
+// --- POST /counters/update ---
+
+describe('POST /counters/update', () => {
+  it('11. redirects ?error=missing_fields when required fields are absent', async () => {
+    const res = await supertest(buildApp())
+      .post('/counters/update')
+      .type('form')
+      .send({ id: '42' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/counters?error=missing_fields');
+  });
+
+  it('12. redirects ?error=invalid_id when id is non-numeric', async () => {
+    const res = await supertest(buildApp())
+      .post('/counters/update')
+      .type('form')
+      .send({ ...VALID_UPDATE, id: 'abc' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/counters?error=invalid_id');
+  });
+
+  it('13. redirects ?error=same_commands when trigger_command === check_command', async () => {
+    const res = await supertest(buildApp())
+      .post('/counters/update')
+      .type('form')
+      .send({ ...VALID_UPDATE, trigger_command: '!same', check_command: '!same' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/counters?error=same_commands');
+  });
+
+  it('14. returns 404 when updateCounter throws CounterNotFoundError', async () => {
+    vi.mocked(updateCounter).mockRejectedValue(new CounterNotFoundError('not found'));
+    const res = await supertest(buildApp())
+      .post('/counters/update')
+      .type('form')
+      .send(VALID_UPDATE);
+    expect(res.status).toBe(404);
+  });
+
+  it('15. redirects ?error=reserved_command when updateCounter throws ReservedCommandError', async () => {
+    vi.mocked(updateCounter).mockRejectedValue(new ReservedCommandError('reserved'));
+    const res = await supertest(buildApp())
+      .post('/counters/update')
+      .type('form')
+      .send(VALID_UPDATE);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/counters?error=reserved_command');
+  });
+
+  it('16. redirects /counters on valid update', async () => {
+    const res = await supertest(buildApp())
+      .post('/counters/update')
+      .type('form')
+      .send(VALID_UPDATE);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/counters');
+  });
+});
+
+// --- POST /counters/remove ---
+
+describe('POST /counters/remove', () => {
+  it('17. redirects ?error=invalid_id when id is non-numeric', async () => {
+    const res = await supertest(buildApp())
+      .post('/counters/remove')
+      .type('form')
+      .send({ id: 'notanumber' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/counters?error=invalid_id');
+  });
+
+  it('18. returns 404 when removeCounter throws CounterNotFoundError', async () => {
+    vi.mocked(removeCounter).mockRejectedValue(new CounterNotFoundError('not found'));
+    const res = await supertest(buildApp())
+      .post('/counters/remove')
+      .type('form')
+      .send({ id: '5' });
+    expect(res.status).toBe(404);
+  });
+
+  it('19. redirects /counters on valid remove', async () => {
+    const res = await supertest(buildApp())
+      .post('/counters/remove')
+      .type('form')
+      .send({ id: '5' });
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/counters');
+  });
+});
+
+// --- POST /counters/reset/:id ---
+
+describe('POST /counters/reset/:id', () => {
+  it('20. redirects ?error=invalid_id when :id is non-numeric', async () => {
+    const res = await supertest(buildApp())
+      .post('/counters/reset/notanumber');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/counters?error=invalid_id');
+  });
+
+  it('21. redirects /counters?reset=1 on valid reset', async () => {
+    const res = await supertest(buildApp())
+      .post('/counters/reset/7');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/counters?reset=1');
+  });
+});


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `supertest` and `@types/supertest` as dev dependencies for HTTP-level route testing
- Adds `src/web/routes/counters.test.ts` — 21 tests covering all POST routes (`/counters/add`, `/counters/update`, `/counters/remove`, `/counters/reset/:id`): missing-field validation, single-token command validation, same-command rejection, duplicate-command detection via `isCounterCommandTaken` and `isMysqlDuplicateEntryError`, DB error class propagation (`ReservedCommandError`, `CommandConflictError`, `CounterNotFoundError`), and redirect destinations
- Adds `src/web/routes/commands.test.ts` — 20 tests covering all POST routes (`/commands/add`, `/commands/update`, `/commands/remove`, `/commands/assign`, `/commands/unassign`): field validation, whitespace-in-trigger rejection, error class propagation (`ReservedCommandError`, `CommandConflictError`, `CommandNotFoundError`), user-assignment logic (skips when no `twitch_name`, calls `assignUserToCommand` when `twitch_name` present), and redirect destinations

## Test plan

- [ ] `npx tsc --noEmit` passes with no errors in the new test files
- [ ] `npm test` — all 195 tests pass (41 new tests across the two new files)
- [ ] Confirm each mock factory uses a `vi.mock(path, factory)` form with classes defined inside the factory to avoid hoisting issues
- [ ] Confirm `res.render` mock uses `res.send(...)` (not `res.status(200).send(...)`) so that 404 responses from `res.status(404).render(...)` preserve their status code

https://claude.ai/code/session_01UkRhQ4XwWkiCjp6mgf8QGN
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkRhQ4XwWkiCjp6mgf8QGN)_