### PR TITLE
fix(tests): resolve TypeScript errors in test files

### DIFF
--- a/src/counterHandler.test.ts
+++ b/src/counterHandler.test.ts
@@ -111,7 +111,7 @@ describe('executeCounterCommandForDiscord', () => {
   });
 
   it('swallows Discord not-found errors on reply failure', async () => {
-    const { isDiscordNotFoundError } = await import('./discordUtils');
+    const { isDiscordNotFoundError } = await import('./discordUtils.js');
     vi.mocked(isDiscordNotFoundError).mockReturnValue(true);
     vi.mocked(findCounterByCommand).mockResolvedValue(CHECK_COUNTER as any);
     const msg = makeMockMessage('!count');

--- a/src/discordUtils.test.ts
+++ b/src/discordUtils.test.ts
@@ -31,24 +31,28 @@ const MISSING_ACCESS = 50001;
 import { isDiscordNotFoundError, isPermanentVoiceMisconfigurationError } from './discordUtils';
 import { DiscordAPIError } from 'discord.js';
 
+// The mock above replaces DiscordAPIError with a simpler single-arg constructor.
+// Cast here so TypeScript accepts the mock's signature without casting at every call site.
+const MockedDiscordAPIError = DiscordAPIError as unknown as new (opts: { code: number; status: number }) => DiscordAPIError;
+
 describe('isDiscordNotFoundError', () => {
   it('returns true for UnknownMessage code', () => {
-    const err = new DiscordAPIError({ code: UNKNOWN_MESSAGE, status: 200 });
+    const err = new MockedDiscordAPIError({ code: UNKNOWN_MESSAGE, status: 200 });
     expect(isDiscordNotFoundError(err)).toBe(true);
   });
 
   it('returns true for UnknownChannel code', () => {
-    const err = new DiscordAPIError({ code: UNKNOWN_CHANNEL, status: 200 });
+    const err = new MockedDiscordAPIError({ code: UNKNOWN_CHANNEL, status: 200 });
     expect(isDiscordNotFoundError(err)).toBe(true);
   });
 
   it('returns true when status is 404 regardless of code', () => {
-    const err = new DiscordAPIError({ code: 99999, status: 404 });
+    const err = new MockedDiscordAPIError({ code: 99999, status: 404 });
     expect(isDiscordNotFoundError(err)).toBe(true);
   });
 
   it('returns false for unrelated Discord errors', () => {
-    const err = new DiscordAPIError({ code: MISSING_ACCESS, status: 403 });
+    const err = new MockedDiscordAPIError({ code: MISSING_ACCESS, status: 403 });
     expect(isDiscordNotFoundError(err)).toBe(false);
   });
 
@@ -86,7 +90,7 @@ describe('isPermanentVoiceMisconfigurationError', () => {
   });
 
   it('returns true when the inner check is a 404 DiscordAPIError', () => {
-    const err = new DiscordAPIError({ code: UNKNOWN_CHANNEL, status: 200 });
+    const err = new MockedDiscordAPIError({ code: UNKNOWN_CHANNEL, status: 200 });
     expect(isPermanentVoiceMisconfigurationError(err)).toBe(true);
   });
 

--- a/src/multiCommandHandler.test.ts
+++ b/src/multiCommandHandler.test.ts
@@ -95,7 +95,7 @@ describe('executeMultiCommandForTwitch', () => {
   });
 
   it('skips channels that share the same shared-chat session ID', async () => {
-    const { resolveSharedChatSessionId } = await import('./customCommandHandler');
+    const { resolveSharedChatSessionId } = await import('./customCommandHandler.js');
     vi.mocked(resolveSharedChatSessionId).mockResolvedValue('session-xyz');
 
     vi.mocked(getMultiTwitchDataForChannel).mockReturnValue({

--- a/src/web/routes/commands.test.ts
+++ b/src/web/routes/commands.test.ts
@@ -120,7 +120,7 @@ describe('POST /commands/add', () => {
   });
 
   it('5. redirects ?error=command_taken when addCustomCommand throws CommandConflictError', async () => {
-    vi.mocked(addCustomCommand).mockRejectedValue(new CommandConflictError('conflict'));
+    vi.mocked(addCustomCommand).mockRejectedValue(new CommandConflictError(['conflict']));
     const res = await supertest(buildApp())
       .post('/commands/add')
       .type('form')
@@ -183,7 +183,7 @@ describe('POST /commands/update', () => {
   });
 
   it('11. returns 404 when updateCustomCommand throws CommandNotFoundError', async () => {
-    vi.mocked(updateCustomCommand).mockRejectedValue(new CommandNotFoundError('not found'));
+    vi.mocked(updateCustomCommand).mockRejectedValue(new CommandNotFoundError(1));
     const res = await supertest(buildApp())
       .post('/commands/update')
       .type('form')

--- a/src/web/routes/counters.test.ts
+++ b/src/web/routes/counters.test.ts
@@ -150,7 +150,7 @@ describe('POST /counters/add', () => {
   });
 
   it('7. redirects ?error=duplicate_command when addCounter throws CommandConflictError', async () => {
-    vi.mocked(addCounter).mockRejectedValue(new CommandConflictError('conflict'));
+    vi.mocked(addCounter).mockRejectedValue(new CommandConflictError(['conflict']));
     const res = await supertest(buildApp())
       .post('/counters/add')
       .type('form')
@@ -221,7 +221,7 @@ describe('POST /counters/update', () => {
   });
 
   it('14. returns 404 when updateCounter throws CounterNotFoundError', async () => {
-    vi.mocked(updateCounter).mockRejectedValue(new CounterNotFoundError('not found'));
+    vi.mocked(updateCounter).mockRejectedValue(new CounterNotFoundError(1));
     const res = await supertest(buildApp())
       .post('/counters/update')
       .type('form')
@@ -262,7 +262,7 @@ describe('POST /counters/remove', () => {
   });
 
   it('18. returns 404 when removeCounter throws CounterNotFoundError', async () => {
-    vi.mocked(removeCounter).mockRejectedValue(new CounterNotFoundError('not found'));
+    vi.mocked(removeCounter).mockRejectedValue(new CounterNotFoundError(1));
     const res = await supertest(buildApp())
       .post('/counters/remove')
       .type('form')


### PR DESCRIPTION
## Summary

- Add `.js` extensions to dynamic `import()` calls in `counterHandler.test.ts` and `multiCommandHandler.test.ts` (required by `moduleResolution: node16`)
- Fix `CommandConflictError` constructor calls to pass `string[]` instead of `string`
- Fix `CommandNotFoundError` and `CounterNotFoundError` constructor calls to pass `number` instead of `string`
- Add `MockedDiscordAPIError` type cast in `discordUtils.test.ts` so the mock's single-arg `{code, status}` constructor satisfies TypeScript without per-call casts

## Test plan

- [ ] `npx tsc --noEmit` passes with zero errors
- [ ] `npm test` — all 326 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_015pZzKErvonBeksvaeuACrk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure for improved error handling and module import consistency across test suites.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->