### PR TITLE
refactor(twitchBot): reduce startTwitchBot complexity by extracting event handlers

### DIFF
--- a/src/twitchBot.test.ts
+++ b/src/twitchBot.test.ts
@@ -1,0 +1,483 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ─── Hoisted state (available inside vi.mock factories) ───────────────────────
+
+const { mockClient, registeredHandlers } = vi.hoisted(() => {
+  const handlers: Record<string, (...args: any[]) => any> = {};
+  const client = {
+    on: vi.fn(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    getChannels: vi.fn(),
+    join: vi.fn(),
+    part: vi.fn(),
+    say: vi.fn(),
+    channels: [] as string[],
+  };
+  return { mockClient: client, registeredHandlers: handlers };
+});
+
+// ─── Module mocks (must precede imports) ─────────────────────────────────────
+
+// Must use a regular function (not an arrow) so `new tmi.Client()` works.
+vi.mock('tmi.js', () => ({
+  default: {
+    Client: vi.fn(function MockTmiClient() { return mockClient; }),
+  },
+}));
+
+vi.mock('./logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock('./config', () => ({
+  TWITCH_USERNAME: 'testbot',
+  TWITCH_OAUTH_TOKEN: 'oauth:test',
+}));
+
+vi.mock('./db', () => ({
+  getTwitchEnabledChannels: vi.fn(),
+}));
+
+vi.mock('./twitchApi', () => ({
+  getUsers: vi.fn(),
+}));
+
+vi.mock('./statusStore', () => ({
+  setTwitchChannel: vi.fn(),
+}));
+
+vi.mock('./commandRouter', () => ({
+  handleCommand: vi.fn(),
+}));
+
+vi.mock('./customCommandHandler', () => ({
+  executeCustomCommandForTwitch: vi.fn(),
+}));
+
+vi.mock('./counterHandler', () => ({
+  executeCounterCommandForTwitch: vi.fn(),
+}));
+
+vi.mock('./multiCommandHandler', () => ({
+  executeMultiCommandForTwitch: vi.fn(),
+}));
+
+vi.mock('./shoutoutHandler', () => ({
+  executeShoutoutForTwitch: vi.fn(),
+}));
+
+vi.mock('./countdownHandler', () => ({
+  executeCountdownForTwitch: vi.fn(),
+}));
+
+// ─── Imports (after mocks) ────────────────────────────────────────────────────
+
+import {
+  startTwitchBot,
+  stopTwitchBot,
+  joinTwitchChannel,
+  partTwitchChannel,
+  sayInChannel,
+  getActiveChannels,
+  getActiveChannelUserIds,
+  setChannelJoinedHook,
+} from './twitchBot';
+import { getTwitchEnabledChannels } from './db';
+import { getUsers } from './twitchApi';
+import { setTwitchChannel } from './statusStore';
+import { executeCustomCommandForTwitch } from './customCommandHandler';
+import { executeCounterCommandForTwitch } from './counterHandler';
+import { executeMultiCommandForTwitch } from './multiCommandHandler';
+import { executeShoutoutForTwitch } from './shoutoutHandler';
+import { handleCommand } from './commandRouter';
+import { executeCountdownForTwitch } from './countdownHandler';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function resetMockClient(): void {
+  // Re-apply default implementations after vi.clearAllMocks() wipes call history
+  // but preserves implementations — some tests override join/part/etc., so we
+  // explicitly restore defaults here each time.
+  mockClient.on.mockImplementation((event: string, handler: (...args: any[]) => any) => {
+    registeredHandlers[event] = handler;
+  });
+  mockClient.connect.mockResolvedValue(undefined);
+  mockClient.disconnect.mockResolvedValue(undefined);
+  mockClient.getChannels.mockReturnValue([]);
+  mockClient.join.mockResolvedValue(undefined);
+  mockClient.part.mockResolvedValue(undefined);
+  mockClient.say.mockResolvedValue(undefined);
+}
+
+/** Start the bot with an empty channel list and simulate a successful connection. */
+async function connectBot(): Promise<void> {
+  vi.mocked(getTwitchEnabledChannels).mockResolvedValue([]);
+  vi.mocked(getUsers).mockResolvedValue([]);
+  await startTwitchBot();
+  // Simulate the IRC server acknowledging the connection.
+  registeredHandlers['connected']('irc.twitch.tv', 6667);
+  // Let reconcileJoinedChannels and queued microtasks settle.
+  await Promise.resolve();
+}
+
+function makeTags(overrides: Record<string, any> = {}): any {
+  return { mod: false, badges: null, ...overrides };
+}
+
+// ─── Lifecycle ────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetMockClient();
+  for (const key of Object.keys(registeredHandlers)) delete registeredHandlers[key];
+  vi.useFakeTimers();
+});
+
+afterEach(async () => {
+  await stopTwitchBot();
+  vi.useRealTimers();
+});
+
+// ─── handleTwitchMessage ─────────────────────────────────────────────────────
+
+describe('handleTwitchMessage', () => {
+  beforeEach(async () => {
+    await connectBot();
+    vi.mocked(getUsers).mockResolvedValue([]);
+    await joinTwitchChannel('streamer');
+    // Reset call history so only message-dispatch calls are visible to assertions.
+    vi.clearAllMocks();
+    resetMockClient();
+  });
+
+  function sendMessage(
+    channel: string,
+    msgTags: Record<string, any>,
+    message: string,
+    self = false,
+  ): void {
+    registeredHandlers['message'](channel, msgTags, message, self);
+  }
+
+  it('ignores self-messages', () => {
+    sendMessage('#streamer', makeTags(), 'hello', true);
+    expect(executeCustomCommandForTwitch).not.toHaveBeenCalled();
+  });
+
+  it('ignores messages for an invalid channel name', () => {
+    sendMessage('!!bad', makeTags(), 'hello');
+    expect(executeCustomCommandForTwitch).not.toHaveBeenCalled();
+  });
+
+  it('ignores messages for channels not in activeChannels', () => {
+    sendMessage('#otherchan', makeTags(), 'hello');
+    expect(executeCustomCommandForTwitch).not.toHaveBeenCalled();
+  });
+
+  it('ignores shared-chat messages that originated in a different channel', () => {
+    sendMessage('#streamer', makeTags({ 'room-id': '111', 'source-room-id': '999' }), 'hello');
+    expect(executeCustomCommandForTwitch).not.toHaveBeenCalled();
+  });
+
+  it('processes messages when source-room-id matches room-id', () => {
+    vi.mocked(executeCustomCommandForTwitch).mockResolvedValue(undefined);
+    sendMessage('#streamer', makeTags({ 'room-id': '111', 'source-room-id': '111' }), 'hello');
+    expect(executeCustomCommandForTwitch).toHaveBeenCalledWith('streamer', 'hello', null);
+  });
+
+  it('dispatches all six executors for a normal message', () => {
+    vi.mocked(executeCustomCommandForTwitch).mockResolvedValue(undefined);
+    vi.mocked(executeCounterCommandForTwitch).mockResolvedValue(undefined);
+    vi.mocked(executeMultiCommandForTwitch).mockResolvedValue(undefined);
+    vi.mocked(executeShoutoutForTwitch).mockResolvedValue(undefined);
+    vi.mocked(handleCommand).mockResolvedValue(undefined);
+    vi.mocked(executeCountdownForTwitch).mockResolvedValue(undefined);
+
+    sendMessage('#streamer', makeTags({ 'display-name': 'Alice' }), '!cmd');
+
+    expect(executeCustomCommandForTwitch).toHaveBeenCalledOnce();
+    expect(executeCounterCommandForTwitch).toHaveBeenCalledOnce();
+    expect(executeMultiCommandForTwitch).toHaveBeenCalledOnce();
+    expect(executeShoutoutForTwitch).toHaveBeenCalledOnce();
+    expect(handleCommand).toHaveBeenCalledOnce();
+    expect(executeCountdownForTwitch).toHaveBeenCalledOnce();
+  });
+
+  it('passes the normalized channel and message to executors', () => {
+    vi.mocked(executeCustomCommandForTwitch).mockResolvedValue(undefined);
+    sendMessage('#STREAMER', makeTags({ 'display-name': 'Alice' }), '!clap');
+    expect(executeCustomCommandForTwitch).toHaveBeenCalledWith('streamer', '!clap', 'Alice');
+  });
+
+  it('falls back to username when display-name is absent', () => {
+    vi.mocked(executeCustomCommandForTwitch).mockResolvedValue(undefined);
+    sendMessage('#streamer', makeTags({ username: 'alice' }), '!hi');
+    expect(executeCustomCommandForTwitch).toHaveBeenCalledWith('streamer', '!hi', 'alice');
+  });
+
+  it('passes null displayName when neither display-name nor username is present', () => {
+    vi.mocked(executeCustomCommandForTwitch).mockResolvedValue(undefined);
+    sendMessage('#streamer', makeTags(), '!hi');
+    expect(executeCustomCommandForTwitch).toHaveBeenCalledWith('streamer', '!hi', null);
+  });
+
+  it('detects isMod=true from the mod tag', () => {
+    vi.mocked(executeShoutoutForTwitch).mockResolvedValue(undefined);
+    sendMessage('#streamer', makeTags({ mod: true }), '!so alice');
+    expect(executeShoutoutForTwitch).toHaveBeenCalledWith('streamer', '!so alice', null, true);
+  });
+
+  it('detects isMod=true from the broadcaster badge', () => {
+    vi.mocked(executeShoutoutForTwitch).mockResolvedValue(undefined);
+    sendMessage('#streamer', makeTags({ badges: { broadcaster: '1' } }), '!so alice');
+    expect(executeShoutoutForTwitch).toHaveBeenCalledWith('streamer', '!so alice', null, true);
+  });
+
+  it('passes isMod=false when neither mod nor broadcaster badge is set', () => {
+    vi.mocked(executeShoutoutForTwitch).mockResolvedValue(undefined);
+    sendMessage('#streamer', makeTags({ mod: false, badges: {} }), '!so alice');
+    expect(executeShoutoutForTwitch).toHaveBeenCalledWith('streamer', '!so alice', null, false);
+  });
+});
+
+// ─── joinTwitchChannel ────────────────────────────────────────────────────────
+
+describe('joinTwitchChannel', () => {
+  it('throws for an invalid channel name', async () => {
+    await connectBot();
+    await expect(joinTwitchChannel('!!bad')).rejects.toThrow('Invalid channel name');
+  });
+
+  it('queues the channel locally when the client is not yet connected', async () => {
+    // startTwitchBot assigns client but 'connected' stays false until the event fires.
+    vi.mocked(getTwitchEnabledChannels).mockResolvedValue([]);
+    vi.mocked(getUsers).mockResolvedValue([]);
+    await startTwitchBot();
+
+    await joinTwitchChannel('streamer');
+
+    expect(getActiveChannels().has('streamer')).toBe(true);
+    expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('streamer', false);
+    expect(mockClient.join).not.toHaveBeenCalled();
+  });
+
+  it('syncs state without calling client.join when already joined in tmi.js', async () => {
+    await connectBot();
+    mockClient.getChannels.mockReturnValue(['#streamer']);
+
+    await joinTwitchChannel('streamer');
+
+    expect(mockClient.join).not.toHaveBeenCalled();
+    expect(getActiveChannels().has('streamer')).toBe(true);
+    expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('streamer', true);
+  });
+
+  it('calls client.join and marks the channel connected on success', async () => {
+    await connectBot();
+    vi.mocked(getUsers).mockResolvedValue([]);
+
+    await joinTwitchChannel('streamer');
+
+    expect(mockClient.join).toHaveBeenCalledWith('streamer');
+    expect(getActiveChannels().has('streamer')).toBe(true);
+    expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('streamer', true);
+  });
+
+  it('caches the channel user ID after a successful join', async () => {
+    await connectBot();
+    vi.mocked(getUsers).mockResolvedValue([{ login: 'streamer', id: 'uid42' } as any]);
+
+    await joinTwitchChannel('streamer');
+    await Promise.resolve(); // flush the fire-and-forget getUsers promise
+
+    expect(getActiveChannelUserIds().get('streamer')).toBe('uid42');
+  });
+
+  it('rolls back activeChannels and status when client.join throws', async () => {
+    await connectBot();
+    mockClient.join.mockRejectedValue(new Error('join failed'));
+
+    await expect(joinTwitchChannel('streamer')).rejects.toThrow('join failed');
+
+    expect(getActiveChannels().has('streamer')).toBe(false);
+    expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('streamer', false);
+  });
+
+  it('invokes the channelJoined hook after a successful join', async () => {
+    await connectBot();
+    const hook = vi.fn();
+    setChannelJoinedHook(hook);
+
+    await joinTwitchChannel('streamer');
+
+    expect(hook).toHaveBeenCalledWith('streamer');
+  });
+
+  it('normalizes the channel name before joining', async () => {
+    await connectBot();
+
+    await joinTwitchChannel('#STREAMER');
+
+    expect(mockClient.join).toHaveBeenCalledWith('streamer');
+    expect(getActiveChannels().has('streamer')).toBe(true);
+  });
+});
+
+// ─── partTwitchChannel ───────────────────────────────────────────────────────
+
+describe('partTwitchChannel', () => {
+  it('does nothing for an invalid channel name', async () => {
+    await connectBot();
+    await partTwitchChannel('!!bad');
+    expect(mockClient.part).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the channel is neither active nor tmi-joined', async () => {
+    await connectBot();
+    await partTwitchChannel('streamer');
+    expect(mockClient.part).not.toHaveBeenCalled();
+    expect(vi.mocked(setTwitchChannel)).not.toHaveBeenCalledWith('streamer', false);
+  });
+
+  it('removes local state only when the client is not connected', async () => {
+    // start without firing 'connected' so connected=false
+    vi.mocked(getTwitchEnabledChannels).mockResolvedValue([]);
+    vi.mocked(getUsers).mockResolvedValue([]);
+    await startTwitchBot();
+    await joinTwitchChannel('streamer'); // queued into activeChannels
+
+    await partTwitchChannel('streamer');
+
+    expect(getActiveChannels().has('streamer')).toBe(false);
+    expect(mockClient.part).not.toHaveBeenCalled();
+  });
+
+  it('calls client.part when the channel is active and tmi-joined', async () => {
+    await connectBot();
+    vi.mocked(getUsers).mockResolvedValue([]);
+    await joinTwitchChannel('streamer');
+    mockClient.getChannels.mockReturnValue(['#streamer']);
+
+    await partTwitchChannel('streamer');
+
+    expect(mockClient.part).toHaveBeenCalledWith('streamer');
+    expect(getActiveChannels().has('streamer')).toBe(false);
+    expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('streamer', false);
+  });
+
+  it('removes from activeChannels without calling part when not tmi-joined', async () => {
+    await connectBot();
+    vi.mocked(getUsers).mockResolvedValue([]);
+    await joinTwitchChannel('streamer');
+    mockClient.getChannels.mockReturnValue([]); // tmi.js reports no joined channels
+
+    await partTwitchChannel('streamer');
+
+    expect(mockClient.part).not.toHaveBeenCalled();
+    expect(getActiveChannels().has('streamer')).toBe(false);
+  });
+
+  it('re-throws when client.part fails (state already cleaned up)', async () => {
+    await connectBot();
+    vi.mocked(getUsers).mockResolvedValue([]);
+    await joinTwitchChannel('streamer');
+    mockClient.getChannels.mockReturnValue(['#streamer']);
+    mockClient.part.mockRejectedValue(new Error('part failed'));
+
+    await expect(partTwitchChannel('streamer')).rejects.toThrow('part failed');
+    expect(getActiveChannels().has('streamer')).toBe(false);
+  });
+});
+
+// ─── sayInChannel ────────────────────────────────────────────────────────────
+
+describe('sayInChannel', () => {
+  it('throws for an invalid channel name', async () => {
+    await connectBot();
+    await expect(sayInChannel('!!bad', 'hi')).rejects.toThrow('Invalid channel name');
+  });
+
+  it('throws when not connected', async () => {
+    // No startTwitchBot call — client is null.
+    await expect(sayInChannel('streamer', 'hi')).rejects.toThrow('not connected');
+  });
+
+  it('delegates to client.say with the normalized channel', async () => {
+    await connectBot();
+    await sayInChannel('#STREAMER', 'hello!');
+    expect(mockClient.say).toHaveBeenCalledWith('streamer', 'hello!');
+  });
+});
+
+// ─── startTwitchBot / initializeActiveChannels ────────────────────────────────
+
+describe('startTwitchBot', () => {
+  it('populates activeChannels from the DB on startup', async () => {
+    vi.mocked(getTwitchEnabledChannels).mockResolvedValue(['streamer', 'other1234']);
+    vi.mocked(getUsers).mockResolvedValue([]);
+    await startTwitchBot();
+
+    expect(getActiveChannels().has('streamer')).toBe(true);
+    expect(getActiveChannels().has('other1234')).toBe(true);
+  });
+
+  it('skips DB entries with invalid channel names', async () => {
+    vi.mocked(getTwitchEnabledChannels).mockResolvedValue(['!!bad', 'streamer']);
+    vi.mocked(getUsers).mockResolvedValue([]);
+    await startTwitchBot();
+
+    expect(getActiveChannels().has('streamer')).toBe(true);
+    expect(getActiveChannels().size).toBe(1);
+  });
+
+  it('caches user IDs for channels loaded at startup', async () => {
+    vi.mocked(getTwitchEnabledChannels).mockResolvedValue(['streamer']);
+    vi.mocked(getUsers).mockResolvedValue([{ login: 'streamer', id: 'uid99' } as any]);
+    await startTwitchBot();
+
+    expect(getActiveChannelUserIds().get('streamer')).toBe('uid99');
+  });
+
+  it('does not call getUsers when there are no active channels', async () => {
+    vi.mocked(getTwitchEnabledChannels).mockResolvedValue([]);
+    await startTwitchBot();
+
+    expect(getUsers).not.toHaveBeenCalled();
+  });
+
+  it('re-throws when client.connect fails', async () => {
+    vi.mocked(getTwitchEnabledChannels).mockResolvedValue([]);
+    mockClient.connect.mockRejectedValue(new Error('connection refused'));
+
+    await expect(startTwitchBot()).rejects.toThrow('connection refused');
+  });
+});
+
+// ─── stopTwitchBot ────────────────────────────────────────────────────────────
+
+describe('stopTwitchBot', () => {
+  it('clears active channels and user IDs', async () => {
+    vi.mocked(getTwitchEnabledChannels).mockResolvedValue(['streamer']);
+    vi.mocked(getUsers).mockResolvedValue([{ login: 'streamer', id: 'u1' } as any]);
+    await startTwitchBot();
+
+    await stopTwitchBot();
+
+    expect(getActiveChannels().size).toBe(0);
+    expect(getActiveChannelUserIds().size).toBe(0);
+  });
+
+  it('calls client.disconnect', async () => {
+    await connectBot();
+
+    await stopTwitchBot();
+
+    expect(mockClient.disconnect).toHaveBeenCalledOnce();
+  });
+
+  it('is a no-op when the client was never started', async () => {
+    await stopTwitchBot();
+    expect(mockClient.disconnect).not.toHaveBeenCalled();
+  });
+});

--- a/src/twitchBot.ts
+++ b/src/twitchBot.ts
@@ -38,6 +38,9 @@ function isChannelJoined(channel: string): boolean {
   return client.getChannels().some((joinedChannel) => normalizeChannel(joinedChannel) === channel);
 }
 
+function fireAndForget(promise: Promise<void>, context: string): void {
+  promise.catch((err) => log.error(`${context}:`, err));
+}
 
 async function partStaleChannel(channel: string): Promise<void> {
   if (activeChannels.has(channel)) {
@@ -97,7 +100,7 @@ async function reconcileJoinedChannels(): Promise<void> {
   }
 }
 
-export async function startTwitchBot(): Promise<void> {
+async function initializeActiveChannels(): Promise<void> {
   const configuredChannels = await getTwitchEnabledChannels();
   for (const ch of configuredChannels) {
     const normalized = normalizeChannel(ch);
@@ -111,16 +114,77 @@ export async function startTwitchBot(): Promise<void> {
 
   if (activeChannels.size === 0) {
     log.warn('No enabled Twitch channels found in DB; connecting with no joined channels.');
+    return;
   }
 
-  if (activeChannels.size > 0) {
-    try {
-      const users = await getUsers([...activeChannels]);
-      for (const u of users) activeChannelUserIds.set(u.login.toLowerCase(), u.id);
-    } catch (err) {
-      log.error('Failed to resolve channel user IDs (shared-chat dedup unavailable):', err);
-    }
+  try {
+    const users = await getUsers([...activeChannels]);
+    for (const u of users) activeChannelUserIds.set(u.login.toLowerCase(), u.id);
+  } catch (err) {
+    log.error('Failed to resolve channel user IDs (shared-chat dedup unavailable):', err);
   }
+}
+
+function handleTwitchMessage(
+  channel: string,
+  tags: tmi.ChatUserstate,
+  message: string,
+  self: boolean,
+): void {
+  try {
+    if (self) return;
+    const normalizedChannel = normalizeChannel(channel);
+    if (!normalizedChannel) return;
+    if (!activeChannels.has(normalizedChannel)) return;
+
+    // In Twitch shared chat, source-room-id differs from room-id when a message
+    // originated in a partner channel and was shared into this one. Skip it entirely
+    // (including SFX command handling) so each message is only processed once, in
+    // its source channel.
+    if (tags['source-room-id'] && tags['source-room-id'] !== tags['room-id']) return;
+
+    const displayName = tags['display-name'] ?? tags.username ?? null;
+    const isMod = tags.mod === true || !!(tags.badges as Record<string, string> | null | undefined)?.broadcaster;
+
+    fireAndForget(executeCustomCommandForTwitch(normalizedChannel, message, displayName), 'Custom command error');
+    fireAndForget(executeCounterCommandForTwitch(normalizedChannel, message, displayName), 'Counter command error');
+    fireAndForget(executeMultiCommandForTwitch(normalizedChannel, message, displayName), 'Multi command error');
+    fireAndForget(executeShoutoutForTwitch(normalizedChannel, message, displayName, isMod), 'Shoutout error');
+    fireAndForget(handleCommand(message, 'twitch'), 'Command handler error');
+    fireAndForget(executeCountdownForTwitch(normalizedChannel, message), 'Countdown error');
+  } catch (err) {
+    log.error('Unexpected error in message handler:', err);
+  }
+}
+
+function onConnected(addr: string, port: number): void {
+  connected = true;
+  log.info(`Connected to ${addr}:${port}`);
+  log.info(`Listening on: ${[...activeChannels].join(', ') || '(none)'}`);
+  // Reset every activeChannels entry via setTwitchChannel to a pessimistic
+  // disconnected state until reconcileJoinedChannels() asynchronously
+  // rechecks the actual joined memberships and corrects the status.
+  activeChannels.forEach((ch) => { setTwitchChannel(ch, false); });
+  void reconcileJoinedChannels().catch((err) => {
+    log.error('Failed to reconcile joined channels:', err);
+  });
+}
+
+function onDisconnected(reason: string): void {
+  connected = false;
+  // Clear tmi.js's confirmed-channel list so it doesn't replay those
+  // channels in its auto-rejoin queue on the next connect. All joining
+  // is handled by reconcileJoinedChannels after 'connected' fires.
+  // tmi.js doesn't expose `channels` in its public types, but it is a real
+  // internal array. Clearing it prevents tmi.js from auto-rejoining stale
+  // channels on the next connect — all joins are handled by reconcileJoinedChannels.
+  (client as any).channels = [];
+  log.warn(`Disconnected: ${reason}`);
+  activeChannels.forEach((ch) => { setTwitchChannel(ch, false); });
+}
+
+export async function startTwitchBot(): Promise<void> {
+  await initializeActiveChannels();
 
   client = new tmi.Client({
     identity: {
@@ -140,76 +204,9 @@ export async function startTwitchBot(): Promise<void> {
     },
   });
 
-  client.on('message', (channel, tags, message, self) => {
-    try {
-      // Don't respond to own messages
-      if (self) return;
-      const normalizedChannel = normalizeChannel(channel);
-      if (!normalizedChannel) return;
-      if (!activeChannels.has(normalizedChannel)) return;
-
-      // In Twitch shared chat, source-room-id differs from room-id when a message
-      // originated in a partner channel and was shared into this one. Skip it entirely
-      // (including SFX command handling) so each message is only processed once, in
-      // its source channel.
-      if (tags['source-room-id'] && tags['source-room-id'] !== tags['room-id']) return;
-
-      const displayName = tags['display-name'] ?? tags.username ?? null;
-      const isMod = tags.mod === true || !!(tags.badges as Record<string, string> | null | undefined)?.broadcaster;
-
-      executeCustomCommandForTwitch(normalizedChannel, message, displayName).catch((err) =>
-        log.error('Custom command error:', err),
-      );
-
-      executeCounterCommandForTwitch(normalizedChannel, message, displayName).catch((err) =>
-        log.error('Counter command error:', err),
-      );
-
-      executeMultiCommandForTwitch(normalizedChannel, message, displayName).catch((err) =>
-        log.error('Multi command error:', err),
-      );
-
-      executeShoutoutForTwitch(normalizedChannel, message, displayName, isMod).catch((err) =>
-        log.error('Shoutout error:', err),
-      );
-
-      handleCommand(message, 'twitch').catch((err) =>
-        log.error('Command handler error:', err),
-      );
-
-      executeCountdownForTwitch(normalizedChannel, message).catch((err) =>
-        log.error('Countdown error:', err),
-      );
-    } catch (err) {
-      log.error('Unexpected error in message handler:', err);
-    }
-  });
-
-  client.on('connected', (addr, port) => {
-    connected = true;
-    log.info(`Connected to ${addr}:${port}`);
-    log.info(`Listening on: ${[...activeChannels].join(', ') || '(none)'}`);
-    // Reset every activeChannels entry via setTwitchChannel to a pessimistic
-    // disconnected state until reconcileJoinedChannels() asynchronously
-    // rechecks the actual joined memberships and corrects the status.
-    activeChannels.forEach((ch) => { setTwitchChannel(ch, false); });
-    void reconcileJoinedChannels().catch((err) => {
-      log.error('Failed to reconcile joined channels:', err);
-    });
-  });
-
-  client.on('disconnected', (reason) => {
-    connected = false;
-    // Clear tmi.js's confirmed-channel list so it doesn't replay those
-    // channels in its auto-rejoin queue on the next connect. All joining
-    // is handled by reconcileJoinedChannels after 'connected' fires.
-    // tmi.js doesn't expose `channels` in its public types, but it is a real
-    // internal array. Clearing it prevents tmi.js from auto-rejoining stale
-    // channels on the next connect — all joins are handled by reconcileJoinedChannels.
-    (client as any).channels = [];
-    log.warn(`Disconnected: ${reason}`);
-    activeChannels.forEach((ch) => { setTwitchChannel(ch, false); });
-  });
+  client.on('message', handleTwitchMessage);
+  client.on('connected', onConnected);
+  client.on('disconnected', onDisconnected);
 
   try {
     await client.connect();


### PR DESCRIPTION
## Summary

- Extracted the inline `message` handler closure into a named `handleTwitchMessage` function, eliminating ~12 decision points from `startTwitchBot`
- Extracted `onConnected` and `onDisconnected` as named top-level functions
- Extracted channel initialisation logic into `initializeActiveChannels`
- Added `fireAndForget` helper to collapse the six repeated `.catch` patterns in the message handler
- `startTwitchBot` now just wires the pieces together (complexity drops from ~25 to ~4)

## Test plan

- [ ] `npx tsc --noEmit` passes with no errors
- [ ] `npm test` — all 363 tests pass
- [ ] Verify Twitch bot still connects, joins/parts channels, and routes messages correctly in a live environment

https://claude.ai/code/session_01K73PVVrkszw9ek9PHoNYVg

---
_Generated by [Claude Code](https://claude.ai/code/session_01K73PVVrkszw9ek9PHoNYVg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for Twitch bot operations, covering message handling with filtering logic, channel join/part operations, message sending functionality, and complete bot lifecycle (startup/shutdown).

* **Refactor**
  * Internal code improvements including better error handling patterns, organized connection event management, and enhanced promise rejection handling for improved system reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Battle-Cattle/BCUK-Bot-4/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->