### PR TITLE
refactor: shared safeResolve utility for path traversal checks

### DIFF
--- a/src/pathUtils.ts
+++ b/src/pathUtils.ts
@@ -1,0 +1,13 @@
+import path from 'path';
+
+/**
+ * Resolves `parts` relative to `base` and returns the absolute path, or null
+ * if the result would escape `base` (path traversal guard).
+ */
+export function safeResolve(base: string, ...parts: string[]): string | null {
+  const resolvedBase = path.resolve(base);
+  const target = path.resolve(resolvedBase, ...parts);
+  const rel = path.relative(resolvedBase, target);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) return null;
+  return target;
+}

--- a/src/sfxPlayer.ts
+++ b/src/sfxPlayer.ts
@@ -5,6 +5,7 @@ import fs from 'fs';
 import ffmpegPath from 'ffmpeg-static';
 import { SFX_FOLDER } from './config';
 import { isConnected, startPlayback } from './audioPlayer';
+import { safeResolve } from './pathUtils';
 
 const log = createLogger('SFXPlayer');
 
@@ -25,13 +26,6 @@ if (ffmpegPath) {
 const sfxRoot = path.resolve(SFX_FOLDER);
 let realSfxRoot: string | null = null;
 
-function isPathInsideRoot(rootPath: string, targetPath: string): boolean {
-  const relativePath = path.relative(rootPath, targetPath);
-  return relativePath !== '..'
-    && !relativePath.startsWith(`..${path.sep}`)
-    && !path.isAbsolute(relativePath);
-}
-
 function getRealSfxRoot(): string {
   if (!realSfxRoot) {
     realSfxRoot = fs.realpathSync(sfxRoot);
@@ -48,10 +42,8 @@ export function playFile(filePath: string): void {
     throw new VoiceNotConnectedError();
   }
 
-  const candidatePath = path.resolve(filePath);
-
-  // Reject obvious traversal attempts before touching the filesystem.
-  if (!isPathInsideRoot(sfxRoot, candidatePath)) {
+  const candidatePath = safeResolve(sfxRoot, filePath);
+  if (!candidatePath) {
     throw new Error(`Path traversal blocked: ${filePath} resolves outside SFX folder`);
   }
 
@@ -62,7 +54,7 @@ export function playFile(filePath: string): void {
   const resolved = fs.realpathSync(candidatePath);
 
   // Resolve symlinks and verify the final real path is still inside the SFX root.
-  if (!isPathInsideRoot(getRealSfxRoot(), resolved)) {
+  if (!safeResolve(getRealSfxRoot(), resolved)) {
     throw new Error(`Path traversal blocked: ${filePath} resolves outside SFX folder`);
   }
 

--- a/src/web/routes/overlaySource.ts
+++ b/src/web/routes/overlaySource.ts
@@ -1,8 +1,8 @@
 import { createLogger } from '../../logger';
 import { Router } from 'express';
-import path from 'path';
 import fs from 'fs';
 import { OVERLAY_FOLDER } from '../../config';
+import { safeResolve } from '../../pathUtils';
 
 const log = createLogger('OverlaySource');
 const router = Router();
@@ -82,10 +82,8 @@ router.get('/videos/:streamerId/:filename', (req, res) => {
   if (!/^\d+$/.test(streamerId)) { res.status(400).end(); return; }
   if (!FILENAME_RE.test(filename)) { res.status(400).end(); return; }
 
-  const filePath = path.join(OVERLAY_FOLDER, streamerId, filename);
-  const resolved = path.resolve(filePath);
-  const base = path.resolve(OVERLAY_FOLDER);
-  if (!resolved.startsWith(base + path.sep)) { res.status(400).end(); return; }
+  const resolved = safeResolve(OVERLAY_FOLDER, streamerId, filename);
+  if (!resolved) { res.status(400).end(); return; }
 
   if (!fs.existsSync(resolved)) { res.status(404).end(); return; }
 


### PR DESCRIPTION
Superseded by #197 which consolidates this fix alongside #189 and #190 into a single clean branch using the shared `safeResolve` utility.