### PR TITLE
Log failing check for EventSub reconnect URL validation

### DIFF
--- a/src/twitchEventSub.ts
+++ b/src/twitchEventSub.ts
@@ -194,24 +194,25 @@ function buildReconnectUrl(reconnectUrl: string): string | null {
   let parsed: URL;
   try { parsed = new URL(reconnectUrl); } catch { return null; }
   const validPorts = new Set(['', '443']);
-  const checks = [
-    parsed.protocol === 'wss:',
-    parsed.hostname === 'eventsub.wss.twitch.tv',
-    !parsed.username,
-    !parsed.password,
-    validPorts.has(parsed.port),
-    parsed.pathname === '/ws',
-  ];
-  if (!checks.every(Boolean)) return null;
+  const checkResults = {
+    protocol: parsed.protocol === 'wss:',
+    hostname: parsed.hostname === 'eventsub.wss.twitch.tv',
+    username: !parsed.username,
+    password: !parsed.password,
+    port: validPorts.has(parsed.port),
+    pathname: parsed.pathname === '/ws',
+  };
+  const failed = Object.entries(checkResults).filter(([, v]) => !v).map(([k]) => k);
+  if (failed.length > 0) {
+    log.error(`Invalid reconnect URL — failed checks: ${failed.join(', ')} — url: ${reconnectUrl}`);
+    return null;
+  }
   return reconnectUrl;
 }
 
 function handleSessionReconnect(reconnectUrl: string): void {
   const safeUrl = buildReconnectUrl(reconnectUrl);
-  if (!safeUrl) {
-    log.error('Invalid reconnect URL — ignoring');
-    return;
-  }
+  if (!safeUrl) return;
   const oldSocket = ws;
   isReconnecting = true;
   log.info('Session reconnect — connecting to new session');


### PR DESCRIPTION
Superseded by #194, which includes this fix (applied in commit 9d67bfa).