### PR TITLE
Fix EventSub: per-streamer WebSocket connections + auth/reconnect improvements

### DIFF
--- a/src/twitchEventSub.ts
+++ b/src/twitchEventSub.ts
@@ -62,91 +62,108 @@ function buildReconnectUrl(reconnectUrl: string): string | null {
 
 // ─── Per-streamer connection ──────────────────────────────────────────────────
 
-function createStreamerConnection(data: StreamerEventSubData) {
-  const { uid, name } = data;
-  let currentData = data;
+class StreamerConnection {
+  readonly uid: string;
+  private readonly name: string;
+  private currentData: StreamerEventSubData;
 
-  let ws: WebSocket | null = null;
-  let sessionId: string | null = null;
-  let keepaliveTimeoutSecs = 10;
-  let keepaliveTimer: ReturnType<typeof setTimeout> | null = null;
-  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-  let reconnectAttempts = 0;
-  let isReconnecting = false;
-  let stopped = false;
-  let reloadChain: Promise<void> = Promise.resolve();
+  private ws: WebSocket | null = null;
+  private sessionId: string | null = null;
+  private keepaliveTimeoutSecs = 10;
+  private keepaliveTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectAttempts = 0;
+  private isReconnecting = false;
+  private stopped = false;
+  private reloadChain: Promise<void> = Promise.resolve();
 
-  function clearKeepaliveTimer() {
-    if (keepaliveTimer) { clearTimeout(keepaliveTimer); keepaliveTimer = null; }
+  constructor(data: StreamerEventSubData) {
+    this.uid = data.uid;
+    this.name = data.name;
+    this.currentData = data;
   }
 
-  function resetKeepaliveTimer() {
-    clearKeepaliveTimer();
-    keepaliveTimer = setTimeout(() => {
-      log.warn(`[${name}] Keepalive timeout — reconnecting`);
-      ws?.close(4000, 'keepalive timeout');
-    }, (keepaliveTimeoutSecs + 10) * 1_000);
+  start(): void {
+    this.stopped = false;
+    this.connect();
   }
 
-  function scheduleReconnect() {
-    const delay = Math.min(RECONNECT_BACKOFF_MAX_MS, 1_000 * Math.pow(2, reconnectAttempts));
-    reconnectAttempts++;
-    log.info(`[${name}] Reconnecting in ${delay}ms (attempt ${reconnectAttempts})`);
-    reconnectTimer = setTimeout(() => {
-      reconnectTimer = null;
-      connect();
-    }, delay);
+  stop(): void {
+    this.stopped = true;
+    this.isReconnecting = false;
+    this.sessionId = null;
+    this.clearKeepaliveTimer();
+    if (this.reconnectTimer) { clearTimeout(this.reconnectTimer); this.reconnectTimer = null; }
+    this.ws?.close(1000, 'shutdown');
+    this.ws = null;
+    removeStreamerFromMap(this.uid);
   }
 
-  function handleSessionReconnect(reconnectUrl: string) {
-    const safeUrl = buildReconnectUrl(reconnectUrl);
-    if (!safeUrl) {
-      log.error(`[${name}] Invalid reconnect URL — ignoring`);
+  reload(newData: StreamerEventSubData): void {
+    this.currentData = newData;
+    this.reloadChain = this.reloadChain
+      .then(() => this.doReload())
+      .catch((err) => { log.error(`[${this.name}] EventSub reload error:`, err); });
+  }
+
+  private async doReload(): Promise<void> {
+    if (!this.ws || !this.sessionId) {
+      if (!this.stopped) { this.stopped = false; this.connect(); }
       return;
     }
-    const oldSocket = ws;
-    isReconnecting = true;
-    log.info(`[${name}] Session reconnect — connecting to new session`);
-    connect(safeUrl);
-    setTimeout(() => { oldSocket?.close(1000, 'reconnect'); }, 5_000);
+    const count = await subscribeForStreamer(this.sessionId, this.currentData);
+    if (count === 0) {
+      log.info(`[${this.name}] No subscriptions after reload — disconnecting`);
+      this.stop();
+    }
   }
 
-  function handleMessage(msg: EventSubMessage) {
+  private connect(url: string = EVENTSUB_WS_URL): void {
+    if (this.stopped) return;
+    const socket = new WebSocket(url);
+    socket.addEventListener('open', () => this.onOpen());
+    socket.addEventListener('message', (ev: MessageEvent) => this.onMessage(ev));
+    socket.addEventListener('close', (ev: CloseEvent) => this.onClose(ev, socket));
+    socket.addEventListener('error', () => { log.error(`[${this.name}] WebSocket error`); });
+    this.ws = socket;
+  }
+
+  private onOpen(): void {
+    log.info(`[${this.name}] WebSocket connected`);
+    this.reconnectAttempts = 0;
+    this.resetKeepaliveTimer();
+  }
+
+  private onMessage(ev: MessageEvent): void {
+    try {
+      const msg = JSON.parse(ev.data as string) as EventSubMessage;
+      this.handleMessage(msg);
+    } catch (err) {
+      log.error(`[${this.name}] Message parse error:`, err);
+    }
+  }
+
+  private onClose(ev: CloseEvent, socket: WebSocket): void {
+    if (this.ws !== socket) return; // old socket closed during session migration — ignore
+    log.warn(`[${this.name}] WebSocket closed: ${ev.code} ${ev.reason}`);
+    this.clearKeepaliveTimer();
+    if (!this.stopped) {
+      this.isReconnecting = false;
+      this.scheduleReconnect();
+    }
+  }
+
+  private handleMessage(msg: EventSubMessage): void {
     const { message_type, message_id, message_timestamp } = msg.metadata;
-
-    if (isStale(message_timestamp)) {
-      log.warn(`[${name}] Stale message (${message_type}) — ignoring`);
-      return;
-    }
-    if (isDuplicate(message_id)) {
-      log.warn(`[${name}] Duplicate message (${message_type}) — ignoring`);
-      return;
-    }
-
-    resetKeepaliveTimer();
+    if (isStale(message_timestamp)) { log.warn(`[${this.name}] Stale message (${message_type}) — ignoring`); return; }
+    if (isDuplicate(message_id)) { log.warn(`[${this.name}] Duplicate message (${message_type}) — ignoring`); return; }
+    this.resetKeepaliveTimer();
 
     if (message_type === 'session_welcome') {
-      const session = msg.payload.session!;
-      sessionId = session.id;
-      keepaliveTimeoutSecs = session.keepalive_timeout_seconds;
-      resetKeepaliveTimer();
-      if (isReconnecting) {
-        isReconnecting = false;
-        log.info(`[${name}] Reconnected — session ${sessionId}`);
-      } else {
-        log.info(`[${name}] Session established: ${sessionId}`);
-        subscribeForStreamer(sessionId, currentData)
-          .then((count) => {
-            if (count === 0) {
-              log.info(`[${name}] No subscriptions — disconnecting`);
-              stop();
-            }
-          })
-          .catch((err) => log.error(`[${name}] Subscribe error:`, err));
-      }
+      this.onSessionWelcome(msg);
     } else if (message_type === 'session_reconnect') {
       const reconnectUrl = msg.payload.session?.reconnect_url;
-      if (reconnectUrl) handleSessionReconnect(reconnectUrl);
+      if (reconnectUrl) this.handleSessionReconnect(reconnectUrl);
     } else if (message_type === 'notification') {
       const sub = msg.payload.subscription;
       const event = msg.payload.event;
@@ -158,85 +175,54 @@ function createStreamerConnection(data: StreamerEventSubData) {
     // session_keepalive: timer already reset above
   }
 
-  function connect(url: string = EVENTSUB_WS_URL) {
-    if (stopped) return;
-
-    const socket = new WebSocket(url);
-
-    socket.addEventListener('open', () => {
-      log.info(`[${name}] WebSocket connected`);
-      reconnectAttempts = 0;
-      resetKeepaliveTimer();
-    });
-
-    socket.addEventListener('message', (ev: MessageEvent) => {
-      try {
-        const msg = JSON.parse(ev.data as string) as EventSubMessage;
-        handleMessage(msg);
-      } catch (err) {
-        log.error(`[${name}] Message parse error:`, err);
-      }
-    });
-
-    socket.addEventListener('close', (ev: CloseEvent) => {
-      if (ws !== socket) return; // old socket closed during session migration — ignore
-      log.warn(`[${name}] WebSocket closed: ${ev.code} ${ev.reason}`);
-      clearKeepaliveTimer();
-      if (!stopped) {
-        isReconnecting = false;
-        scheduleReconnect();
-      }
-    });
-
-    socket.addEventListener('error', () => {
-      log.error(`[${name}] WebSocket error`);
-    });
-
-    ws = socket;
+  private onSessionWelcome(msg: EventSubMessage): void {
+    const session = msg.payload.session!;
+    this.sessionId = session.id;
+    this.keepaliveTimeoutSecs = session.keepalive_timeout_seconds;
+    this.resetKeepaliveTimer();
+    if (this.isReconnecting) {
+      this.isReconnecting = false;
+      log.info(`[${this.name}] Reconnected — session ${this.sessionId}`);
+      return;
+    }
+    log.info(`[${this.name}] Session established: ${this.sessionId}`);
+    subscribeForStreamer(this.sessionId, this.currentData)
+      .then((count) => { if (count === 0) { log.info(`[${this.name}] No subscriptions — disconnecting`); this.stop(); } })
+      .catch((err) => log.error(`[${this.name}] Subscribe error:`, err));
   }
 
-  function stop() {
-    stopped = true;
-    isReconnecting = false;
-    sessionId = null;
-    clearKeepaliveTimer();
-    if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
-    ws?.close(1000, 'shutdown');
-    ws = null;
-    removeStreamerFromMap(uid);
+  private handleSessionReconnect(reconnectUrl: string): void {
+    const safeUrl = buildReconnectUrl(reconnectUrl);
+    if (!safeUrl) { log.error(`[${this.name}] Invalid reconnect URL — ignoring`); return; }
+    const oldSocket = this.ws;
+    this.isReconnecting = true;
+    log.info(`[${this.name}] Session reconnect — connecting to new session`);
+    this.connect(safeUrl);
+    setTimeout(() => { oldSocket?.close(1000, 'reconnect'); }, 5_000);
   }
 
-  function reload(newData: StreamerEventSubData) {
-    currentData = newData;
-    reloadChain = reloadChain
-      .then(async () => {
-        if (!ws || !sessionId) {
-          if (!stopped) {
-            stopped = false;
-            connect();
-          }
-          return;
-        }
-        const count = await subscribeForStreamer(sessionId, currentData);
-        if (count === 0) {
-          log.info(`[${name}] No subscriptions after reload — disconnecting`);
-          stop();
-        }
-      })
-      .catch((err) => { log.error(`[${name}] EventSub reload error:`, err); });
+  private scheduleReconnect(): void {
+    const delay = Math.min(RECONNECT_BACKOFF_MAX_MS, 1_000 * Math.pow(2, this.reconnectAttempts));
+    this.reconnectAttempts++;
+    log.info(`[${this.name}] Reconnecting in ${delay}ms (attempt ${this.reconnectAttempts})`);
+    this.reconnectTimer = setTimeout(() => { this.reconnectTimer = null; this.connect(); }, delay);
   }
 
-  function start() {
-    stopped = false;
-    connect();
+  private clearKeepaliveTimer(): void {
+    if (this.keepaliveTimer) { clearTimeout(this.keepaliveTimer); this.keepaliveTimer = null; }
   }
 
-  return { uid, start, stop, reload, isStopped: () => stopped };
+  private resetKeepaliveTimer(): void {
+    this.clearKeepaliveTimer();
+    this.keepaliveTimer = setTimeout(() => {
+      log.warn(`[${this.name}] Keepalive timeout — reconnecting`);
+      this.ws?.close(4000, 'keepalive timeout');
+    }, (this.keepaliveTimeoutSecs + 10) * 1_000);
+  }
 }
 
 // ─── Global connection map ────────────────────────────────────────────────────
 
-type StreamerConnection = ReturnType<typeof createStreamerConnection>;
 const connections = new Map<string, StreamerConnection>();
 let globalStopped = false;
 
@@ -252,7 +238,7 @@ export function startEventSub(): void {
       const streamers = await loadStreamersForEventSub();
       for (const data of streamers) {
         if (!connections.has(data.uid)) {
-          const conn = createStreamerConnection(data);
+          const conn = new StreamerConnection(data);
           connections.set(data.uid, conn);
           conn.start();
         }
@@ -276,10 +262,7 @@ export function reloadEventSubSubscriptions(): void {
 
       // Stop and remove connections for streamers no longer present
       for (const [uid, conn] of connections) {
-        if (!newUids.has(uid)) {
-          conn.stop();
-          connections.delete(uid);
-        }
+        if (!newUids.has(uid)) { conn.stop(); connections.delete(uid); }
       }
 
       // Reload existing or start new connections
@@ -288,7 +271,7 @@ export function reloadEventSubSubscriptions(): void {
         if (existing) {
           existing.reload(data);
         } else {
-          const conn = createStreamerConnection(data);
+          const conn = new StreamerConnection(data);
           connections.set(data.uid, conn);
           conn.start();
         }

--- a/src/twitchEventSub.ts
+++ b/src/twitchEventSub.ts
@@ -54,6 +54,7 @@ async function doReload(): Promise<void> {
       existing.reload(data);
     } else {
       const conn = new StreamerConnection(data);
+      conn.setSelfStopCallback((uid) => { connections.delete(uid); });
       connections.set(data.uid, conn);
       conn.start();
     }

--- a/src/twitchEventSub.ts
+++ b/src/twitchEventSub.ts
@@ -54,7 +54,10 @@ function buildReconnectUrl(reconnectUrl: string): string | null {
     parsed.pathname === '/ws',
   ];
   if (!checks.every(Boolean)) return null;
-  return reconnectUrl;
+  // Reconstruct from validated components so taint analysis sees a clean value
+  const safe = new URL('wss://eventsub.wss.twitch.tv/ws');
+  safe.search = parsed.search;
+  return safe.href;
 }
 
 // ─── Per-streamer connection ──────────────────────────────────────────────────

--- a/src/twitchEventSub.ts
+++ b/src/twitchEventSub.ts
@@ -1,235 +1,12 @@
 import { createLogger } from './logger';
-import { loadStreamersForEventSub, subscribeForStreamer, removeStreamerFromMap, dispatchNotification, handleRevocation, StreamerEventSubData } from './twitchEventSubSubscriptions';
+import { loadStreamersForEventSub, StreamerEventSubData } from './twitchEventSubSubscriptions';
+import { StreamerConnection } from './twitchEventSubConnection';
 
 const log = createLogger('EventSub');
 
-const EVENTSUB_WS_URL = 'wss://eventsub.wss.twitch.tv/ws';
-const RECONNECT_BACKOFF_MAX_MS = 30_000;
-const MESSAGE_TTL_MS = 10 * 60 * 1000;
-
-interface EventSubMetadata {
-  message_type: string;
-  message_id: string;
-  message_timestamp: string;
-}
-
-interface EventSubMessage {
-  metadata: EventSubMetadata;
-  payload: {
-    session?: { id: string; keepalive_timeout_seconds: number; reconnect_url?: string | null };
-    subscription?: { type: string; status: string; condition: Record<string, string> };
-    event?: Record<string, unknown>;
-  };
-}
-
-// TTL-based dedup: messageId → expiry timestamp (shared across all per-streamer connections)
-const seenMessageIds = new Map<string, number>();
-
-function isDuplicate(messageId: string): boolean {
-  const now = Date.now();
-  for (const [id, expiry] of seenMessageIds) {
-    if (now > expiry) seenMessageIds.delete(id);
-  }
-  if (seenMessageIds.has(messageId)) return true;
-  seenMessageIds.set(messageId, now + MESSAGE_TTL_MS);
-  return false;
-}
-
-function isStale(timestamp: string): boolean {
-  const ts = Date.parse(timestamp);
-  return !Number.isFinite(ts) || Date.now() - ts > MESSAGE_TTL_MS;
-}
-
-/** Validates the Twitch-supplied reconnect URL against a strict allowlist. */
-function buildReconnectUrl(reconnectUrl: string): string | null {
-  let parsed: URL;
-  try { parsed = new URL(reconnectUrl); } catch { return null; }
-  const validPorts = new Set(['', '443']);
-  const checks = [
-    parsed.protocol === 'wss:',
-    parsed.hostname === 'eventsub.wss.twitch.tv',
-    !parsed.username,
-    !parsed.password,
-    validPorts.has(parsed.port),
-    parsed.pathname === '/ws',
-  ];
-  if (!checks.every(Boolean)) return null;
-  // Reconstruct from validated components so taint analysis sees a clean value
-  const safe = new URL('wss://eventsub.wss.twitch.tv/ws');
-  safe.search = parsed.search;
-  return safe.href;
-}
-
-// ─── Per-streamer connection ──────────────────────────────────────────────────
-
-class StreamerConnection {
-  readonly uid: string;
-  private readonly name: string;
-  private currentData: StreamerEventSubData;
-
-  private ws: WebSocket | null = null;
-  private sessionId: string | null = null;
-  private keepaliveTimeoutSecs = 10;
-  private keepaliveTimer: ReturnType<typeof setTimeout> | null = null;
-  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-  private reconnectAttempts = 0;
-  private isReconnecting = false;
-  private stopped = false;
-  private reloadChain: Promise<void> = Promise.resolve();
-
-  constructor(data: StreamerEventSubData) {
-    this.uid = data.uid;
-    this.name = data.name;
-    this.currentData = data;
-  }
-
-  start(): void {
-    this.stopped = false;
-    this.connect();
-  }
-
-  stop(): void {
-    this.stopped = true;
-    this.isReconnecting = false;
-    this.sessionId = null;
-    this.clearKeepaliveTimer();
-    if (this.reconnectTimer) { clearTimeout(this.reconnectTimer); this.reconnectTimer = null; }
-    this.ws?.close(1000, 'shutdown');
-    this.ws = null;
-    removeStreamerFromMap(this.uid);
-  }
-
-  reload(newData: StreamerEventSubData): void {
-    this.currentData = newData;
-    this.reloadChain = this.reloadChain
-      .then(() => this.doReload())
-      .catch((err) => { log.error(`[${this.name}] EventSub reload error:`, err); });
-  }
-
-  private async doReload(): Promise<void> {
-    if (!this.ws || !this.sessionId) {
-      if (!this.stopped) { this.stopped = false; this.connect(); }
-      return;
-    }
-    const count = await subscribeForStreamer(this.sessionId, this.currentData);
-    if (count === 0) {
-      log.info(`[${this.name}] No subscriptions after reload — disconnecting`);
-      this.stop();
-    }
-  }
-
-  private connect(url: string = EVENTSUB_WS_URL): void {
-    if (this.stopped) return;
-    const socket = new WebSocket(url);
-    socket.addEventListener('open', () => this.onOpen());
-    socket.addEventListener('message', (ev: MessageEvent) => this.onMessage(ev));
-    socket.addEventListener('close', (ev: CloseEvent) => this.onClose(ev, socket));
-    socket.addEventListener('error', () => { log.error(`[${this.name}] WebSocket error`); });
-    this.ws = socket;
-  }
-
-  private onOpen(): void {
-    log.info(`[${this.name}] WebSocket connected`);
-    this.reconnectAttempts = 0;
-    this.resetKeepaliveTimer();
-  }
-
-  private onMessage(ev: MessageEvent): void {
-    try {
-      const msg = JSON.parse(ev.data as string) as EventSubMessage;
-      this.handleMessage(msg);
-    } catch (err) {
-      log.error(`[${this.name}] Message parse error:`, err);
-    }
-  }
-
-  private onClose(ev: CloseEvent, socket: WebSocket): void {
-    if (this.ws !== socket) return; // old socket closed during session migration — ignore
-    log.warn(`[${this.name}] WebSocket closed: ${ev.code} ${ev.reason}`);
-    this.clearKeepaliveTimer();
-    if (!this.stopped) {
-      this.isReconnecting = false;
-      this.scheduleReconnect();
-    }
-  }
-
-  private handleMessage(msg: EventSubMessage): void {
-    const { message_type, message_id, message_timestamp } = msg.metadata;
-    if (isStale(message_timestamp)) { log.warn(`[${this.name}] Stale message (${message_type}) — ignoring`); return; }
-    if (isDuplicate(message_id)) { log.warn(`[${this.name}] Duplicate message (${message_type}) — ignoring`); return; }
-    this.resetKeepaliveTimer();
-
-    if (message_type === 'session_welcome') {
-      this.onSessionWelcome(msg);
-    } else if (message_type === 'session_reconnect') {
-      const reconnectUrl = msg.payload.session?.reconnect_url;
-      if (reconnectUrl) this.handleSessionReconnect(reconnectUrl);
-    } else if (message_type === 'notification') {
-      const sub = msg.payload.subscription;
-      const event = msg.payload.event;
-      if (sub && event) dispatchNotification(sub.type, event, sub.condition);
-    } else if (message_type === 'revocation') {
-      const sub = msg.payload.subscription;
-      if (sub) handleRevocation(sub);
-    }
-    // session_keepalive: timer already reset above
-  }
-
-  private onSessionWelcome(msg: EventSubMessage): void {
-    const session = msg.payload.session!;
-    this.sessionId = session.id;
-    this.keepaliveTimeoutSecs = session.keepalive_timeout_seconds;
-    this.resetKeepaliveTimer();
-    if (this.isReconnecting) {
-      this.isReconnecting = false;
-      log.info(`[${this.name}] Reconnected — session ${this.sessionId}`);
-      return;
-    }
-    log.info(`[${this.name}] Session established: ${this.sessionId}`);
-    subscribeForStreamer(this.sessionId, this.currentData)
-      .then((count) => { if (count === 0) { log.info(`[${this.name}] No subscriptions — disconnecting`); this.stop(); } })
-      .catch((err) => log.error(`[${this.name}] Subscribe error:`, err));
-  }
-
-  private handleSessionReconnect(reconnectUrl: string): void {
-    const safeUrl = buildReconnectUrl(reconnectUrl);
-    if (!safeUrl) { log.error(`[${this.name}] Invalid reconnect URL — ignoring`); return; }
-    const oldSocket = this.ws;
-    this.isReconnecting = true;
-    log.info(`[${this.name}] Session reconnect — connecting to new session`);
-    this.connect(safeUrl);
-    setTimeout(() => { oldSocket?.close(1000, 'reconnect'); }, 5_000);
-  }
-
-  private scheduleReconnect(): void {
-    const delay = Math.min(RECONNECT_BACKOFF_MAX_MS, 1_000 * Math.pow(2, this.reconnectAttempts));
-    this.reconnectAttempts++;
-    log.info(`[${this.name}] Reconnecting in ${delay}ms (attempt ${this.reconnectAttempts})`);
-    this.reconnectTimer = setTimeout(() => { this.reconnectTimer = null; this.connect(); }, delay);
-  }
-
-  private clearKeepaliveTimer(): void {
-    if (this.keepaliveTimer) { clearTimeout(this.keepaliveTimer); this.keepaliveTimer = null; }
-  }
-
-  private resetKeepaliveTimer(): void {
-    this.clearKeepaliveTimer();
-    this.keepaliveTimer = setTimeout(() => {
-      log.warn(`[${this.name}] Keepalive timeout — reconnecting`);
-      this.ws?.close(4000, 'keepalive timeout');
-    }, (this.keepaliveTimeoutSecs + 10) * 1_000);
-  }
-}
-
-// ─── Global connection map ────────────────────────────────────────────────────
-
 const connections = new Map<string, StreamerConnection>();
 let globalStopped = false;
-
-// Serialise top-level reloads
 let topReloadChain: Promise<void> = Promise.resolve();
-
-// ─── Public API ───────────────────────────────────────────────────────────────
 
 export function startEventSub(): void {
   globalStopped = false;
@@ -256,26 +33,26 @@ export function stopEventSub(): void {
 export function reloadEventSubSubscriptions(): void {
   if (globalStopped) return;
   topReloadChain = topReloadChain
-    .then(async () => {
-      const streamers = await loadStreamersForEventSub();
-      const newUids = new Set(streamers.map((s) => s.uid));
-
-      // Stop and remove connections for streamers no longer present
-      for (const [uid, conn] of connections) {
-        if (!newUids.has(uid)) { conn.stop(); connections.delete(uid); }
-      }
-
-      // Reload existing or start new connections
-      for (const data of streamers) {
-        const existing = connections.get(data.uid);
-        if (existing) {
-          existing.reload(data);
-        } else {
-          const conn = new StreamerConnection(data);
-          connections.set(data.uid, conn);
-          conn.start();
-        }
-      }
-    })
+    .then(() => doReload())
     .catch((err) => { log.error('EventSub reload error:', err); });
+}
+
+async function doReload(): Promise<void> {
+  const streamers = await loadStreamersForEventSub();
+  const newUids = new Set(streamers.map((s: StreamerEventSubData) => s.uid));
+
+  for (const [uid, conn] of connections) {
+    if (!newUids.has(uid)) { conn.stop(); connections.delete(uid); }
+  }
+
+  for (const data of streamers) {
+    const existing = connections.get(data.uid);
+    if (existing) {
+      existing.reload(data);
+    } else {
+      const conn = new StreamerConnection(data);
+      connections.set(data.uid, conn);
+      conn.start();
+    }
+  }
 }

--- a/src/twitchEventSub.ts
+++ b/src/twitchEventSub.ts
@@ -1,5 +1,5 @@
 import { createLogger } from './logger';
-import { subscribeAll, dispatchNotification, handleRevocation } from './twitchEventSubSubscriptions';
+import { loadStreamersForEventSub, subscribeForStreamer, removeStreamerFromMap, dispatchNotification, handleRevocation, StreamerEventSubData } from './twitchEventSubSubscriptions';
 
 const log = createLogger('EventSub');
 
@@ -22,7 +22,7 @@ interface EventSubMessage {
   };
 }
 
-// TTL-based dedup: messageId → expiry timestamp
+// TTL-based dedup: messageId → expiry timestamp (shared across all per-streamer connections)
 const seenMessageIds = new Map<string, number>();
 
 function isDuplicate(messageId: string): boolean {
@@ -40,156 +40,7 @@ function isStale(timestamp: string): boolean {
   return !Number.isFinite(ts) || Date.now() - ts > MESSAGE_TTL_MS;
 }
 
-let ws: WebSocket | null = null;
-let sessionId: string | null = null;
-let keepaliveTimeoutSecs = 10;
-let keepaliveTimer: ReturnType<typeof setTimeout> | null = null;
-let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-let reconnectAttempts = 0;
-let stopped = false;
-let isReconnecting = false;
-
-// Serialise subscription reloads so concurrent calls don't interleave
-let reloadChain: Promise<void> = Promise.resolve();
-
-// ─── Public API ───────────────────────────────────────────────────────────────
-
-export function startEventSub(): void {
-  stopped = false;
-  connect();
-}
-
-export function stopEventSub(): void {
-  stopped = true;
-  isReconnecting = false;
-  sessionId = null;
-  clearKeepaliveTimer();
-  if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
-  ws?.close(1000, 'shutdown');
-  ws = null;
-}
-
-/** Closes the connection without setting stopped=true, so reloadEventSubSubscriptions can restart. */
-function disconnectNoSubscriptions(): void {
-  log.info('No EventSub subscriptions configured — disconnecting until next reload');
-  clearKeepaliveTimer();
-  if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
-  ws?.close(1000, 'no subscriptions');
-  ws = null;
-  sessionId = null;
-}
-
-export function reloadEventSubSubscriptions(): void {
-  reloadChain = reloadChain
-    .then(async () => {
-      if (!ws || !sessionId) {
-        // Not connected — may have auto-disconnected due to no subscriptions; restart if not user-stopped
-        if (!stopped) startEventSub();
-        return;
-      }
-      const count = await subscribeAll(sessionId);
-      if (count === 0) disconnectNoSubscriptions();
-    })
-    .catch((err) => { log.error('EventSub reload error:', err); });
-}
-
-// ─── WebSocket connection ─────────────────────────────────────────────────────
-
-function connect(url: string = EVENTSUB_WS_URL): void {
-  if (stopped) return;
-
-  const socket = new WebSocket(url);
-
-  socket.addEventListener('open', () => {
-    log.info('WebSocket connected');
-    reconnectAttempts = 0;
-    resetKeepaliveTimer();
-  });
-
-  socket.addEventListener('message', (ev: MessageEvent) => {
-    try {
-      const msg = JSON.parse(ev.data as string) as EventSubMessage;
-      handleMessage(msg);
-    } catch (err) {
-      log.error('Message parse error:', err);
-    }
-  });
-
-  socket.addEventListener('close', (ev: CloseEvent) => {
-    if (ws !== socket) return; // old socket closed during session migration — ignore
-    log.warn(`WebSocket closed: ${ev.code} ${ev.reason}`);
-    clearKeepaliveTimer();
-    if (!stopped) {
-      // Clear isReconnecting so the next connect() performs a full subscribeAll().
-      // This handles the case where the replacement socket dies before session_welcome.
-      isReconnecting = false;
-      scheduleReconnect();
-    }
-  });
-
-  socket.addEventListener('error', () => {
-    log.error('WebSocket error');
-  });
-
-  ws = socket;
-}
-
-function scheduleReconnect(): void {
-  const delay = Math.min(RECONNECT_BACKOFF_MAX_MS, 1_000 * Math.pow(2, reconnectAttempts));
-  reconnectAttempts++;
-  log.info(`Reconnecting in ${delay}ms (attempt ${reconnectAttempts})`);
-  reconnectTimer = setTimeout(() => {
-    reconnectTimer = null;
-    connect();
-  }, delay);
-}
-
-function handleMessage(msg: EventSubMessage): void {
-  const { message_type, message_id, message_timestamp } = msg.metadata;
-
-  if (isStale(message_timestamp)) {
-    log.warn(`Stale message (${message_type}) — ignoring`);
-    return;
-  }
-  if (isDuplicate(message_id)) {
-    log.warn(`Duplicate message (${message_type}) — ignoring`);
-    return;
-  }
-
-  resetKeepaliveTimer();
-
-  if (message_type === 'session_welcome') {
-    const session = msg.payload.session!;
-    sessionId = session.id;
-    keepaliveTimeoutSecs = session.keepalive_timeout_seconds;
-    resetKeepaliveTimer();
-    if (isReconnecting) {
-      isReconnecting = false;
-      log.info(`Reconnected — session ${sessionId}`);
-    } else {
-      log.info(`Session established: ${sessionId}`);
-      subscribeAll(sessionId)
-        .then((count) => { if (count === 0) disconnectNoSubscriptions(); })
-        .catch((err) => log.error('Subscribe error:', err));
-    }
-  } else if (message_type === 'session_reconnect') {
-    const reconnectUrl = msg.payload.session?.reconnect_url;
-    if (reconnectUrl) handleSessionReconnect(reconnectUrl);
-  } else if (message_type === 'notification') {
-    const sub = msg.payload.subscription;
-    const event = msg.payload.event;
-    if (sub && event) dispatchNotification(sub.type, event, sub.condition);
-  } else if (message_type === 'revocation') {
-    const sub = msg.payload.subscription;
-    if (sub) handleRevocation(sub);
-  }
-  // session_keepalive: timer already reset above
-}
-
-/** Validates the Twitch-supplied reconnect URL against a strict allowlist and
- *  returns the original URL if valid, or null if any component is unexpected.
- *  The allowlist (protocol, hostname, port, pathname) ensures the connection
- *  cannot be redirected to an arbitrary server. */
+/** Validates the Twitch-supplied reconnect URL against a strict allowlist. */
 function buildReconnectUrl(reconnectUrl: string): string | null {
   let parsed: URL;
   try { parsed = new URL(reconnectUrl); } catch { return null; }
@@ -206,28 +57,239 @@ function buildReconnectUrl(reconnectUrl: string): string | null {
   return reconnectUrl;
 }
 
-function handleSessionReconnect(reconnectUrl: string): void {
-  const safeUrl = buildReconnectUrl(reconnectUrl);
-  if (!safeUrl) {
-    log.error('Invalid reconnect URL — ignoring');
-    return;
+// ─── Per-streamer connection ──────────────────────────────────────────────────
+
+function createStreamerConnection(data: StreamerEventSubData) {
+  const { uid, name } = data;
+  let currentData = data;
+
+  let ws: WebSocket | null = null;
+  let sessionId: string | null = null;
+  let keepaliveTimeoutSecs = 10;
+  let keepaliveTimer: ReturnType<typeof setTimeout> | null = null;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let reconnectAttempts = 0;
+  let isReconnecting = false;
+  let stopped = false;
+  let reloadChain: Promise<void> = Promise.resolve();
+
+  function clearKeepaliveTimer() {
+    if (keepaliveTimer) { clearTimeout(keepaliveTimer); keepaliveTimer = null; }
   }
-  const oldSocket = ws;
-  isReconnecting = true;
-  log.info('Session reconnect — connecting to new session');
-  connect(safeUrl);
-  // Close the old socket after the new one has time to establish
-  setTimeout(() => { oldSocket?.close(1000, 'reconnect'); }, 5_000);
+
+  function resetKeepaliveTimer() {
+    clearKeepaliveTimer();
+    keepaliveTimer = setTimeout(() => {
+      log.warn(`[${name}] Keepalive timeout — reconnecting`);
+      ws?.close(4000, 'keepalive timeout');
+    }, (keepaliveTimeoutSecs + 10) * 1_000);
+  }
+
+  function scheduleReconnect() {
+    const delay = Math.min(RECONNECT_BACKOFF_MAX_MS, 1_000 * Math.pow(2, reconnectAttempts));
+    reconnectAttempts++;
+    log.info(`[${name}] Reconnecting in ${delay}ms (attempt ${reconnectAttempts})`);
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null;
+      connect();
+    }, delay);
+  }
+
+  function handleSessionReconnect(reconnectUrl: string) {
+    const safeUrl = buildReconnectUrl(reconnectUrl);
+    if (!safeUrl) {
+      log.error(`[${name}] Invalid reconnect URL — ignoring`);
+      return;
+    }
+    const oldSocket = ws;
+    isReconnecting = true;
+    log.info(`[${name}] Session reconnect — connecting to new session`);
+    connect(safeUrl);
+    setTimeout(() => { oldSocket?.close(1000, 'reconnect'); }, 5_000);
+  }
+
+  function handleMessage(msg: EventSubMessage) {
+    const { message_type, message_id, message_timestamp } = msg.metadata;
+
+    if (isStale(message_timestamp)) {
+      log.warn(`[${name}] Stale message (${message_type}) — ignoring`);
+      return;
+    }
+    if (isDuplicate(message_id)) {
+      log.warn(`[${name}] Duplicate message (${message_type}) — ignoring`);
+      return;
+    }
+
+    resetKeepaliveTimer();
+
+    if (message_type === 'session_welcome') {
+      const session = msg.payload.session!;
+      sessionId = session.id;
+      keepaliveTimeoutSecs = session.keepalive_timeout_seconds;
+      resetKeepaliveTimer();
+      if (isReconnecting) {
+        isReconnecting = false;
+        log.info(`[${name}] Reconnected — session ${sessionId}`);
+      } else {
+        log.info(`[${name}] Session established: ${sessionId}`);
+        subscribeForStreamer(sessionId, currentData)
+          .then((count) => {
+            if (count === 0) {
+              log.info(`[${name}] No subscriptions — disconnecting`);
+              stop();
+            }
+          })
+          .catch((err) => log.error(`[${name}] Subscribe error:`, err));
+      }
+    } else if (message_type === 'session_reconnect') {
+      const reconnectUrl = msg.payload.session?.reconnect_url;
+      if (reconnectUrl) handleSessionReconnect(reconnectUrl);
+    } else if (message_type === 'notification') {
+      const sub = msg.payload.subscription;
+      const event = msg.payload.event;
+      if (sub && event) dispatchNotification(sub.type, event, sub.condition);
+    } else if (message_type === 'revocation') {
+      const sub = msg.payload.subscription;
+      if (sub) handleRevocation(sub);
+    }
+    // session_keepalive: timer already reset above
+  }
+
+  function connect(url: string = EVENTSUB_WS_URL) {
+    if (stopped) return;
+
+    const socket = new WebSocket(url);
+
+    socket.addEventListener('open', () => {
+      log.info(`[${name}] WebSocket connected`);
+      reconnectAttempts = 0;
+      resetKeepaliveTimer();
+    });
+
+    socket.addEventListener('message', (ev: MessageEvent) => {
+      try {
+        const msg = JSON.parse(ev.data as string) as EventSubMessage;
+        handleMessage(msg);
+      } catch (err) {
+        log.error(`[${name}] Message parse error:`, err);
+      }
+    });
+
+    socket.addEventListener('close', (ev: CloseEvent) => {
+      if (ws !== socket) return; // old socket closed during session migration — ignore
+      log.warn(`[${name}] WebSocket closed: ${ev.code} ${ev.reason}`);
+      clearKeepaliveTimer();
+      if (!stopped) {
+        isReconnecting = false;
+        scheduleReconnect();
+      }
+    });
+
+    socket.addEventListener('error', () => {
+      log.error(`[${name}] WebSocket error`);
+    });
+
+    ws = socket;
+  }
+
+  function stop() {
+    stopped = true;
+    isReconnecting = false;
+    sessionId = null;
+    clearKeepaliveTimer();
+    if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
+    ws?.close(1000, 'shutdown');
+    ws = null;
+    removeStreamerFromMap(uid);
+  }
+
+  function reload(newData: StreamerEventSubData) {
+    currentData = newData;
+    reloadChain = reloadChain
+      .then(async () => {
+        if (!ws || !sessionId) {
+          if (!stopped) {
+            stopped = false;
+            connect();
+          }
+          return;
+        }
+        const count = await subscribeForStreamer(sessionId, currentData);
+        if (count === 0) {
+          log.info(`[${name}] No subscriptions after reload — disconnecting`);
+          stop();
+        }
+      })
+      .catch((err) => { log.error(`[${name}] EventSub reload error:`, err); });
+  }
+
+  function start() {
+    stopped = false;
+    connect();
+  }
+
+  return { uid, start, stop, reload, isStopped: () => stopped };
 }
 
-function resetKeepaliveTimer(): void {
-  clearKeepaliveTimer();
-  keepaliveTimer = setTimeout(() => {
-    log.warn('Keepalive timeout — reconnecting');
-    ws?.close(4000, 'keepalive timeout');
-  }, (keepaliveTimeoutSecs + 10) * 1_000);
+// ─── Global connection map ────────────────────────────────────────────────────
+
+type StreamerConnection = ReturnType<typeof createStreamerConnection>;
+const connections = new Map<string, StreamerConnection>();
+let globalStopped = false;
+
+// Serialise top-level reloads
+let topReloadChain: Promise<void> = Promise.resolve();
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+export function startEventSub(): void {
+  globalStopped = false;
+  topReloadChain = topReloadChain
+    .then(async () => {
+      const streamers = await loadStreamersForEventSub();
+      for (const data of streamers) {
+        if (!connections.has(data.uid)) {
+          const conn = createStreamerConnection(data);
+          connections.set(data.uid, conn);
+          conn.start();
+        }
+      }
+    })
+    .catch((err) => { log.error('EventSub start error:', err); });
 }
 
-function clearKeepaliveTimer(): void {
-  if (keepaliveTimer) { clearTimeout(keepaliveTimer); keepaliveTimer = null; }
+export function stopEventSub(): void {
+  globalStopped = true;
+  for (const conn of connections.values()) conn.stop();
+  connections.clear();
+}
+
+export function reloadEventSubSubscriptions(): void {
+  if (globalStopped) return;
+  topReloadChain = topReloadChain
+    .then(async () => {
+      const streamers = await loadStreamersForEventSub();
+      const newUids = new Set(streamers.map((s) => s.uid));
+
+      // Stop and remove connections for streamers no longer present
+      for (const [uid, conn] of connections) {
+        if (!newUids.has(uid)) {
+          conn.stop();
+          connections.delete(uid);
+        }
+      }
+
+      // Reload existing or start new connections
+      for (const data of streamers) {
+        const existing = connections.get(data.uid);
+        if (existing) {
+          existing.reload(data);
+        } else {
+          const conn = createStreamerConnection(data);
+          connections.set(data.uid, conn);
+          conn.start();
+        }
+      }
+    })
+    .catch((err) => { log.error('EventSub reload error:', err); });
 }

--- a/src/twitchEventSub.ts
+++ b/src/twitchEventSub.ts
@@ -13,9 +13,11 @@ export function startEventSub(): void {
   topReloadChain = topReloadChain
     .then(async () => {
       const streamers = await loadStreamersForEventSub();
+      if (globalStopped) return;
       for (const data of streamers) {
         if (!connections.has(data.uid)) {
           const conn = new StreamerConnection(data);
+          conn.setSelfStopCallback((uid) => { connections.delete(uid); });
           connections.set(data.uid, conn);
           conn.start();
         }
@@ -39,6 +41,7 @@ export function reloadEventSubSubscriptions(): void {
 
 async function doReload(): Promise<void> {
   const streamers = await loadStreamersForEventSub();
+  if (globalStopped) return;
   const newUids = new Set(streamers.map((s: StreamerEventSubData) => s.uid));
 
   for (const [uid, conn] of connections) {

--- a/src/twitchEventSubConnection.test.ts
+++ b/src/twitchEventSubConnection.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('./logger', () => ({ createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }));
+vi.mock('./twitchEventSubSubscriptions', () => ({
+  subscribeForStreamer: vi.fn().mockResolvedValue(1),
+  removeStreamerFromMap: vi.fn(),
+  dispatchNotification: vi.fn(),
+  handleRevocation: vi.fn(),
+}));
+
+import {
+  buildReconnectUrl,
+  isDuplicate,
+  isStale,
+  MESSAGE_TTL_MS,
+  StreamerConnection,
+  EventSubMessage,
+} from './twitchEventSubConnection';
+import {
+  subscribeForStreamer,
+  dispatchNotification,
+  handleRevocation,
+} from './twitchEventSubSubscriptions';
+
+// ---------------------------------------------------------------------------
+// buildReconnectUrl
+// ---------------------------------------------------------------------------
+describe('buildReconnectUrl', () => {
+  it('returns a cleaned URL for a valid Twitch reconnect URL', () => {
+    const result = buildReconnectUrl('wss://eventsub.wss.twitch.tv/ws');
+    expect(result).toBe('wss://eventsub.wss.twitch.tv/ws');
+  });
+
+  it('preserves query parameters from the original URL', () => {
+    const result = buildReconnectUrl('wss://eventsub.wss.twitch.tv/ws?foo=bar&baz=1');
+    expect(result).toContain('foo=bar');
+    expect(result).toContain('baz=1');
+  });
+
+  it('returns null for wrong protocol (http)', () => {
+    expect(buildReconnectUrl('http://eventsub.wss.twitch.tv/ws')).toBeNull();
+  });
+
+  it('returns null for wrong protocol (ws)', () => {
+    expect(buildReconnectUrl('ws://eventsub.wss.twitch.tv/ws')).toBeNull();
+  });
+
+  it('returns null for wrong hostname', () => {
+    expect(buildReconnectUrl('wss://evil.example.com/ws')).toBeNull();
+  });
+
+  it('returns null when credentials are present (username)', () => {
+    expect(buildReconnectUrl('wss://user@eventsub.wss.twitch.tv/ws')).toBeNull();
+  });
+
+  it('returns null when credentials are present (password)', () => {
+    expect(buildReconnectUrl('wss://user:pass@eventsub.wss.twitch.tv/ws')).toBeNull();
+  });
+
+  it('returns null for an invalid (non-443) port', () => {
+    expect(buildReconnectUrl('wss://eventsub.wss.twitch.tv:8080/ws')).toBeNull();
+  });
+
+  it('accepts port 443 explicitly', () => {
+    const result = buildReconnectUrl('wss://eventsub.wss.twitch.tv:443/ws');
+    expect(result).not.toBeNull();
+  });
+
+  it('returns null for wrong path', () => {
+    expect(buildReconnectUrl('wss://eventsub.wss.twitch.tv/other')).toBeNull();
+  });
+
+  it('returns null for a malformed string', () => {
+    expect(buildReconnectUrl('not a url')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isDuplicate
+// ---------------------------------------------------------------------------
+describe('isDuplicate', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns false on first call with a new message ID', () => {
+    expect(isDuplicate('msg-unique-1')).toBe(false);
+  });
+
+  it('returns true on second call with the same message ID', () => {
+    isDuplicate('msg-dup-1');
+    expect(isDuplicate('msg-dup-1')).toBe(true);
+  });
+
+  it('returns false again after TTL has expired', () => {
+    isDuplicate('msg-expired-1');
+    vi.advanceTimersByTime(MESSAGE_TTL_MS + 1);
+    expect(isDuplicate('msg-expired-1')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isStale
+// ---------------------------------------------------------------------------
+describe('isStale', () => {
+  it('returns false for a recent timestamp', () => {
+    const recent = new Date().toISOString();
+    expect(isStale(recent)).toBe(false);
+  });
+
+  it('returns true for a timestamp older than MESSAGE_TTL_MS', () => {
+    const old = new Date(Date.now() - MESSAGE_TTL_MS - 1000).toISOString();
+    expect(isStale(old)).toBe(true);
+  });
+
+  it('returns true for an unparseable timestamp', () => {
+    expect(isStale('not-a-date')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// StreamerConnection.handleMessage
+// ---------------------------------------------------------------------------
+
+function makeMsg(overrides: Partial<EventSubMessage> & { message_type: string; message_id?: string; message_timestamp?: string }): EventSubMessage {
+  return {
+    metadata: {
+      message_type: overrides.message_type,
+      message_id: overrides.message_id ?? `id-${Math.random()}`,
+      message_timestamp: overrides.message_timestamp ?? new Date().toISOString(),
+    },
+    payload: overrides.payload ?? {},
+  };
+}
+
+function makeStreamerData() {
+  return { uid: 'uid-123', token: 'token-abc', name: 'streamer', config: null, streamerId: 1 };
+}
+
+function makeWelcomeMsg(sessionId = 'sess-1', msgId?: string): EventSubMessage {
+  return makeMsg({
+    message_type: 'session_welcome',
+    message_id: msgId ?? `welcome-${Math.random()}`,
+    payload: { session: { id: sessionId, keepalive_timeout_seconds: 10 } },
+  });
+}
+
+// Suppress WebSocket construction in tests — we test handleMessage directly.
+class MockWebSocket {
+  addEventListener = vi.fn();
+  close = vi.fn();
+}
+
+vi.stubGlobal('WebSocket', MockWebSocket);
+
+describe('StreamerConnection.handleMessage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(subscribeForStreamer).mockResolvedValue(1);
+  });
+
+  it('session_welcome (non-reconnecting): sets sessionId and calls subscribeForStreamer', async () => {
+    const conn = new StreamerConnection(makeStreamerData());
+    await conn.handleMessage(makeWelcomeMsg('sess-abc'));
+    expect(subscribeForStreamer).toHaveBeenCalledWith('sess-abc', expect.objectContaining({ uid: 'uid-123' }));
+  });
+
+  it('session_welcome (non-reconnecting): calls onSelfStop when subscribeForStreamer returns 0', async () => {
+    vi.mocked(subscribeForStreamer).mockResolvedValue(0);
+    const conn = new StreamerConnection(makeStreamerData());
+    const onSelfStop = vi.fn();
+    conn.setSelfStopCallback(onSelfStop);
+    await conn.handleMessage(makeWelcomeMsg('sess-zero'));
+    // Wait for the promise inside to settle
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onSelfStop).toHaveBeenCalledWith('uid-123');
+  });
+
+  it('session_welcome when isReconnecting: does NOT call subscribeForStreamer', async () => {
+    const conn = new StreamerConnection(makeStreamerData());
+    // Set isReconnecting via the private field accessor trick (cast to any)
+    (conn as any).isReconnecting = true;
+    await conn.handleMessage(makeWelcomeMsg('sess-reconnect'));
+    expect(subscribeForStreamer).not.toHaveBeenCalled();
+  });
+
+  it('notification: calls dispatchNotification', () => {
+    const conn = new StreamerConnection(makeStreamerData());
+    const msg = makeMsg({
+      message_type: 'notification',
+      payload: {
+        subscription: { type: 'channel.follow', status: 'enabled', condition: { broadcaster_user_id: 'uid-123' } },
+        event: { user_login: 'follower' },
+      },
+    });
+    conn.handleMessage(msg);
+    expect(dispatchNotification).toHaveBeenCalledWith(
+      'channel.follow',
+      { user_login: 'follower' },
+      { broadcaster_user_id: 'uid-123' },
+    );
+  });
+
+  it('revocation: calls handleRevocation', () => {
+    const conn = new StreamerConnection(makeStreamerData());
+    const sub = { type: 'channel.follow', status: 'authorization_revoked', condition: { broadcaster_user_id: 'uid-123' } };
+    const msg = makeMsg({ message_type: 'revocation', payload: { subscription: sub } });
+    conn.handleMessage(msg);
+    expect(handleRevocation).toHaveBeenCalledWith(sub);
+  });
+
+  it('stale message: ignored — no dispatch', () => {
+    const conn = new StreamerConnection(makeStreamerData());
+    const oldTs = new Date(Date.now() - MESSAGE_TTL_MS - 1000).toISOString();
+    const msg = makeMsg({
+      message_type: 'notification',
+      message_timestamp: oldTs,
+      payload: {
+        subscription: { type: 'channel.follow', status: 'enabled', condition: {} },
+        event: {},
+      },
+    });
+    conn.handleMessage(msg);
+    expect(dispatchNotification).not.toHaveBeenCalled();
+  });
+
+  it('duplicate message: ignored after the first', () => {
+    const conn = new StreamerConnection(makeStreamerData());
+    const msgId = `dup-test-${Math.random()}`;
+    const msg1 = makeMsg({
+      message_type: 'notification',
+      message_id: msgId,
+      payload: {
+        subscription: { type: 'channel.follow', status: 'enabled', condition: {} },
+        event: {},
+      },
+    });
+    const msg2 = { ...msg1, metadata: { ...msg1.metadata } }; // same id
+
+    conn.handleMessage(msg1);
+    conn.handleMessage(msg2);
+    expect(dispatchNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('session_keepalive: no dispatch, no error', () => {
+    const conn = new StreamerConnection(makeStreamerData());
+    const msg = makeMsg({ message_type: 'session_keepalive', payload: {} });
+    expect(() => conn.handleMessage(msg)).not.toThrow();
+    expect(dispatchNotification).not.toHaveBeenCalled();
+    expect(handleRevocation).not.toHaveBeenCalled();
+  });
+});

--- a/src/twitchEventSubConnection.test.ts
+++ b/src/twitchEventSubConnection.test.ts
@@ -175,16 +175,17 @@ describe('StreamerConnection.handleMessage', () => {
     const onSelfStop = vi.fn();
     conn.setSelfStopCallback(onSelfStop);
     await conn.handleMessage(makeWelcomeMsg('sess-zero'));
-    // Wait for the promise inside to settle
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(onSelfStop).toHaveBeenCalledWith('uid-123');
+    await vi.waitFor(() => expect(onSelfStop).toHaveBeenCalledWith('uid-123'));
   });
 
   it('session_welcome when isReconnecting: does NOT call subscribeForStreamer', async () => {
     const conn = new StreamerConnection(makeStreamerData());
-    // Set isReconnecting via the private field accessor trick (cast to any)
-    (conn as any).isReconnecting = true;
+    // Transition to reconnecting state via a session_reconnect message (public API)
+    const reconnectMsg = makeMsg({
+      message_type: 'session_reconnect',
+      payload: { session: { id: 'sess-old', keepalive_timeout_seconds: 10, reconnect_url: 'wss://eventsub.wss.twitch.tv/ws?session_id=new' } },
+    });
+    conn.handleMessage(reconnectMsg);
     await conn.handleMessage(makeWelcomeMsg('sess-reconnect'));
     expect(subscribeForStreamer).not.toHaveBeenCalled();
   });

--- a/src/twitchEventSubConnection.ts
+++ b/src/twitchEventSubConnection.ts
@@ -50,6 +50,7 @@ export class StreamerConnection {
   readonly uid: string;
   private readonly name: string;
   private currentData: StreamerEventSubData;
+  private onSelfStop: ((uid: string) => void) | null = null;
 
   private ws: WebSocket | null = null;
   private sessionId: string | null = null;
@@ -65,6 +66,11 @@ export class StreamerConnection {
     this.uid = data.uid;
     this.name = data.name;
     this.currentData = data;
+  }
+
+  /** Register a callback invoked when this connection stops itself due to zero subscriptions. */
+  setSelfStopCallback(cb: (uid: string) => void): void {
+    this.onSelfStop = cb;
   }
 
   start(): void {
@@ -99,6 +105,7 @@ export class StreamerConnection {
     if (count === 0) {
       log.info(`[${this.name}] No subscriptions after reload — disconnecting`);
       this.stop();
+      this.onSelfStop?.(this.uid);
     }
   }
 
@@ -131,6 +138,8 @@ export class StreamerConnection {
     if (this.ws !== socket) return; // old socket closed during session migration — ignore
     log.warn(`[${this.name}] WebSocket closed: ${ev.code} ${ev.reason}`);
     this.clearKeepaliveTimer();
+    this.ws = null;
+    this.sessionId = null;
     if (!this.stopped) {
       this.isReconnecting = false;
       this.scheduleReconnect();
@@ -171,7 +180,7 @@ export class StreamerConnection {
     }
     log.info(`[${this.name}] Session established: ${this.sessionId}`);
     subscribeForStreamer(this.sessionId, this.currentData)
-      .then((count) => { if (count === 0) { log.info(`[${this.name}] No subscriptions — disconnecting`); this.stop(); } })
+      .then((count) => { if (count === 0) { log.info(`[${this.name}] No subscriptions — disconnecting`); this.stop(); this.onSelfStop?.(this.uid); } })
       .catch((err) => log.error(`[${this.name}] Subscribe error:`, err));
   }
 

--- a/src/twitchEventSubConnection.ts
+++ b/src/twitchEventSubConnection.ts
@@ -27,15 +27,19 @@ export function buildReconnectUrl(reconnectUrl: string): string | null {
   let parsed: URL;
   try { parsed = new URL(reconnectUrl); } catch { return null; }
   const validPorts = new Set(['', '443']);
-  const checks = [
-    parsed.protocol === 'wss:',
-    parsed.hostname === 'eventsub.wss.twitch.tv',
-    !parsed.username,
-    !parsed.password,
-    validPorts.has(parsed.port),
-    parsed.pathname === '/ws',
-  ];
-  if (!checks.every(Boolean)) return null;
+  const checkResults = {
+    protocol: parsed.protocol === 'wss:',
+    hostname: parsed.hostname === 'eventsub.wss.twitch.tv',
+    username: !parsed.username,
+    password: !parsed.password,
+    port: validPorts.has(parsed.port),
+    pathname: parsed.pathname === '/ws',
+  };
+  const failed = Object.entries(checkResults).filter(([, v]) => !v).map(([k]) => k);
+  if (failed.length > 0) {
+    log.error(`Invalid reconnect URL — failed checks: ${failed.join(', ')} — url: ${reconnectUrl}`);
+    return null;
+  }
   // Reconstruct from validated components so taint analysis sees a clean value
   const safe = new URL('wss://eventsub.wss.twitch.tv/ws');
   safe.search = parsed.search;

--- a/src/twitchEventSubConnection.ts
+++ b/src/twitchEventSubConnection.ts
@@ -1,0 +1,220 @@
+import { createLogger } from './logger';
+import { subscribeForStreamer, removeStreamerFromMap, dispatchNotification, handleRevocation, StreamerEventSubData } from './twitchEventSubSubscriptions';
+
+const log = createLogger('EventSub');
+
+export const EVENTSUB_WS_URL = 'wss://eventsub.wss.twitch.tv/ws';
+const RECONNECT_BACKOFF_MAX_MS = 30_000;
+export const MESSAGE_TTL_MS = 10 * 60 * 1000;
+
+export interface EventSubMetadata {
+  message_type: string;
+  message_id: string;
+  message_timestamp: string;
+}
+
+export interface EventSubMessage {
+  metadata: EventSubMetadata;
+  payload: {
+    session?: { id: string; keepalive_timeout_seconds: number; reconnect_url?: string | null };
+    subscription?: { type: string; status: string; condition: Record<string, string> };
+    event?: Record<string, unknown>;
+  };
+}
+
+/** Validates the Twitch-supplied reconnect URL against a strict allowlist. */
+export function buildReconnectUrl(reconnectUrl: string): string | null {
+  let parsed: URL;
+  try { parsed = new URL(reconnectUrl); } catch { return null; }
+  const validPorts = new Set(['', '443']);
+  const checks = [
+    parsed.protocol === 'wss:',
+    parsed.hostname === 'eventsub.wss.twitch.tv',
+    !parsed.username,
+    !parsed.password,
+    validPorts.has(parsed.port),
+    parsed.pathname === '/ws',
+  ];
+  if (!checks.every(Boolean)) return null;
+  // Reconstruct from validated components so taint analysis sees a clean value
+  const safe = new URL('wss://eventsub.wss.twitch.tv/ws');
+  safe.search = parsed.search;
+  return safe.href;
+}
+
+export class StreamerConnection {
+  readonly uid: string;
+  private readonly name: string;
+  private currentData: StreamerEventSubData;
+
+  private ws: WebSocket | null = null;
+  private sessionId: string | null = null;
+  private keepaliveTimeoutSecs = 10;
+  private keepaliveTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectAttempts = 0;
+  private isReconnecting = false;
+  private stopped = false;
+  private reloadChain: Promise<void> = Promise.resolve();
+
+  constructor(data: StreamerEventSubData) {
+    this.uid = data.uid;
+    this.name = data.name;
+    this.currentData = data;
+  }
+
+  start(): void {
+    this.stopped = false;
+    this.connect();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.isReconnecting = false;
+    this.sessionId = null;
+    this.clearKeepaliveTimer();
+    if (this.reconnectTimer) { clearTimeout(this.reconnectTimer); this.reconnectTimer = null; }
+    this.ws?.close(1000, 'shutdown');
+    this.ws = null;
+    removeStreamerFromMap(this.uid);
+  }
+
+  reload(newData: StreamerEventSubData): void {
+    this.currentData = newData;
+    this.reloadChain = this.reloadChain
+      .then(() => this.doReload())
+      .catch((err) => { log.error(`[${this.name}] EventSub reload error:`, err); });
+  }
+
+  private async doReload(): Promise<void> {
+    if (!this.ws || !this.sessionId) {
+      if (!this.stopped) { this.stopped = false; this.connect(); }
+      return;
+    }
+    const count = await subscribeForStreamer(this.sessionId, this.currentData);
+    if (count === 0) {
+      log.info(`[${this.name}] No subscriptions after reload — disconnecting`);
+      this.stop();
+    }
+  }
+
+  connect(url: string = EVENTSUB_WS_URL): void {
+    if (this.stopped) return;
+    const socket = new WebSocket(url);
+    socket.addEventListener('open', () => this.onOpen());
+    socket.addEventListener('message', (ev: MessageEvent) => this.onMessage(ev));
+    socket.addEventListener('close', (ev: CloseEvent) => this.onClose(ev, socket));
+    socket.addEventListener('error', () => { log.error(`[${this.name}] WebSocket error`); });
+    this.ws = socket;
+  }
+
+  private onOpen(): void {
+    log.info(`[${this.name}] WebSocket connected`);
+    this.reconnectAttempts = 0;
+    this.resetKeepaliveTimer();
+  }
+
+  private onMessage(ev: MessageEvent): void {
+    try {
+      const msg = JSON.parse(ev.data as string) as EventSubMessage;
+      this.handleMessage(msg);
+    } catch (err) {
+      log.error(`[${this.name}] Message parse error:`, err);
+    }
+  }
+
+  private onClose(ev: CloseEvent, socket: WebSocket): void {
+    if (this.ws !== socket) return; // old socket closed during session migration — ignore
+    log.warn(`[${this.name}] WebSocket closed: ${ev.code} ${ev.reason}`);
+    this.clearKeepaliveTimer();
+    if (!this.stopped) {
+      this.isReconnecting = false;
+      this.scheduleReconnect();
+    }
+  }
+
+  handleMessage(msg: EventSubMessage): void {
+    const { message_type, message_id, message_timestamp } = msg.metadata;
+    if (isStale(message_timestamp)) { log.warn(`[${this.name}] Stale message (${message_type}) — ignoring`); return; }
+    if (isDuplicate(message_id)) { log.warn(`[${this.name}] Duplicate message (${message_type}) — ignoring`); return; }
+    this.resetKeepaliveTimer();
+
+    if (message_type === 'session_welcome') {
+      this.onSessionWelcome(msg);
+    } else if (message_type === 'session_reconnect') {
+      const reconnectUrl = msg.payload.session?.reconnect_url;
+      if (reconnectUrl) this.handleSessionReconnect(reconnectUrl);
+    } else if (message_type === 'notification') {
+      const sub = msg.payload.subscription;
+      const event = msg.payload.event;
+      if (sub && event) dispatchNotification(sub.type, event, sub.condition);
+    } else if (message_type === 'revocation') {
+      const sub = msg.payload.subscription;
+      if (sub) handleRevocation(sub);
+    }
+    // session_keepalive: timer already reset above
+  }
+
+  private onSessionWelcome(msg: EventSubMessage): void {
+    const session = msg.payload.session!;
+    this.sessionId = session.id;
+    this.keepaliveTimeoutSecs = session.keepalive_timeout_seconds;
+    this.resetKeepaliveTimer();
+    if (this.isReconnecting) {
+      this.isReconnecting = false;
+      log.info(`[${this.name}] Reconnected — session ${this.sessionId}`);
+      return;
+    }
+    log.info(`[${this.name}] Session established: ${this.sessionId}`);
+    subscribeForStreamer(this.sessionId, this.currentData)
+      .then((count) => { if (count === 0) { log.info(`[${this.name}] No subscriptions — disconnecting`); this.stop(); } })
+      .catch((err) => log.error(`[${this.name}] Subscribe error:`, err));
+  }
+
+  private handleSessionReconnect(reconnectUrl: string): void {
+    const safeUrl = buildReconnectUrl(reconnectUrl);
+    if (!safeUrl) { log.error(`[${this.name}] Invalid reconnect URL — ignoring`); return; }
+    const oldSocket = this.ws;
+    this.isReconnecting = true;
+    log.info(`[${this.name}] Session reconnect — connecting to new session`);
+    this.connect(safeUrl);
+    setTimeout(() => { oldSocket?.close(1000, 'reconnect'); }, 5_000);
+  }
+
+  private scheduleReconnect(): void {
+    const delay = Math.min(RECONNECT_BACKOFF_MAX_MS, 1_000 * Math.pow(2, this.reconnectAttempts));
+    this.reconnectAttempts++;
+    log.info(`[${this.name}] Reconnecting in ${delay}ms (attempt ${this.reconnectAttempts})`);
+    this.reconnectTimer = setTimeout(() => { this.reconnectTimer = null; this.connect(); }, delay);
+  }
+
+  private clearKeepaliveTimer(): void {
+    if (this.keepaliveTimer) { clearTimeout(this.keepaliveTimer); this.keepaliveTimer = null; }
+  }
+
+  private resetKeepaliveTimer(): void {
+    this.clearKeepaliveTimer();
+    this.keepaliveTimer = setTimeout(() => {
+      log.warn(`[${this.name}] Keepalive timeout — reconnecting`);
+      this.ws?.close(4000, 'keepalive timeout');
+    }, (this.keepaliveTimeoutSecs + 10) * 1_000);
+  }
+}
+
+// TTL-based dedup: messageId → expiry timestamp (shared across all per-streamer connections)
+const seenMessageIds = new Map<string, number>();
+
+export function isDuplicate(messageId: string): boolean {
+  const now = Date.now();
+  for (const [id, expiry] of seenMessageIds) {
+    if (now > expiry) seenMessageIds.delete(id);
+  }
+  if (seenMessageIds.has(messageId)) return true;
+  seenMessageIds.set(messageId, now + MESSAGE_TTL_MS);
+  return false;
+}
+
+export function isStale(timestamp: string): boolean {
+  const ts = Date.parse(timestamp);
+  return !Number.isFinite(ts) || Date.now() - ts > MESSAGE_TTL_MS;
+}

--- a/src/twitchEventSubConnection.ts
+++ b/src/twitchEventSubConnection.ts
@@ -3,8 +3,10 @@ import { subscribeForStreamer, removeStreamerFromMap, dispatchNotification, hand
 
 const log = createLogger('EventSub');
 
+/** Default Twitch EventSub WebSocket URL. */
 export const EVENTSUB_WS_URL = 'wss://eventsub.wss.twitch.tv/ws';
 const RECONNECT_BACKOFF_MAX_MS = 30_000;
+/** How long a message ID is remembered for deduplication (ms). */
 export const MESSAGE_TTL_MS = 10 * 60 * 1000;
 
 export interface EventSubMetadata {
@@ -217,6 +219,7 @@ export class StreamerConnection {
 // TTL-based dedup: messageId → expiry timestamp (shared across all per-streamer connections)
 const seenMessageIds = new Map<string, number>();
 
+/** Returns true if messageId has been seen within MESSAGE_TTL_MS; records it otherwise. */
 export function isDuplicate(messageId: string): boolean {
   const now = Date.now();
   for (const [id, expiry] of seenMessageIds) {
@@ -227,6 +230,7 @@ export function isDuplicate(messageId: string): boolean {
   return false;
 }
 
+/** Returns true if the ISO timestamp is older than MESSAGE_TTL_MS or unparseable. */
 export function isStale(timestamp: string): boolean {
   const ts = Date.parse(timestamp);
   return !Number.isFinite(ts) || Date.now() - ts > MESSAGE_TTL_MS;

--- a/src/twitchEventSubConnection.ts
+++ b/src/twitchEventSubConnection.ts
@@ -106,7 +106,7 @@ export class StreamerConnection {
 
   private async doReload(): Promise<void> {
     if (!this.ws || !this.sessionId) {
-      if (!this.stopped) { this.stopped = false; this.connect(); }
+      if (!this.stopped) { this.connect(); }
       return;
     }
     const count = await subscribeForStreamer(this.sessionId, this.currentData);

--- a/src/twitchEventSubConnection.ts
+++ b/src/twitchEventSubConnection.ts
@@ -9,12 +9,14 @@ const RECONNECT_BACKOFF_MAX_MS = 30_000;
 /** How long a message ID is remembered for deduplication (ms). */
 export const MESSAGE_TTL_MS = 10 * 60 * 1000;
 
+/** Metadata fields present on every EventSub WebSocket message. */
 export interface EventSubMetadata {
   message_type: string;
   message_id: string;
   message_timestamp: string;
 }
 
+/** A single EventSub WebSocket message. */
 export interface EventSubMessage {
   metadata: EventSubMetadata;
   payload: {
@@ -48,6 +50,7 @@ export function buildReconnectUrl(reconnectUrl: string): string | null {
   return safe.href;
 }
 
+/** Manages a per-streamer EventSub WebSocket connection with reconnection and keepalive logic. */
 export class StreamerConnection {
   readonly uid: string;
   private readonly name: string;
@@ -75,11 +78,13 @@ export class StreamerConnection {
     this.onSelfStop = cb;
   }
 
+  /** Opens the WebSocket connection for this streamer. */
   start(): void {
     this.stopped = false;
     this.connect();
   }
 
+  /** Closes the connection and removes this streamer from the subscription map. */
   stop(): void {
     this.stopped = true;
     this.isReconnecting = false;
@@ -91,6 +96,7 @@ export class StreamerConnection {
     removeStreamerFromMap(this.uid);
   }
 
+  /** Updates streamer data and re-subscribes on the live session (serialised via reloadChain). */
   reload(newData: StreamerEventSubData): void {
     this.currentData = newData;
     this.reloadChain = this.reloadChain
@@ -111,6 +117,7 @@ export class StreamerConnection {
     }
   }
 
+  /** Opens a new WebSocket to the given URL (defaults to the standard EventSub URL). */
   connect(url: string = EVENTSUB_WS_URL): void {
     if (this.stopped) return;
     const socket = new WebSocket(url);

--- a/src/twitchEventSubSubscriptions.test.ts
+++ b/src/twitchEventSubSubscriptions.test.ts
@@ -30,7 +30,7 @@ import {
   loadStreamersForEventSub,
   subscribeForStreamer,
 } from './twitchEventSubSubscriptions';
-import { getAllEventSubStreamers, clearStreamerToken } from './db';
+import { getAllEventSubStreamers } from './db';
 import { getValidToken, createEventSubSubscription, listEventSubSubscriptions, deleteEventSubSubscription, TwitchAuthError } from './twitchApiEventSub';
 import { getUsers } from './twitchApi';
 import { getActiveChannels } from './twitchBot';

--- a/src/twitchEventSubSubscriptions.test.ts
+++ b/src/twitchEventSubSubscriptions.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./logger', () => ({ createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }));
+vi.mock('./db', () => ({
+  getAllEventSubStreamers: vi.fn(),
+  clearStreamerToken: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('./twitchApi', () => ({ getUsers: vi.fn() }));
+vi.mock('./twitchBot', () => ({ getActiveChannels: vi.fn().mockReturnValue(new Set<string>()) }));
+vi.mock('./twitchChannelName', () => ({ normalizeTwitchChannelName: vi.fn((n: string) => n.toLowerCase()) }));
+vi.mock('./twitchApiEventSub', () => ({
+  createEventSubSubscription: vi.fn().mockResolvedValue('sub-id-1'),
+  listEventSubSubscriptions: vi.fn().mockResolvedValue([]),
+  deleteEventSubSubscription: vi.fn().mockResolvedValue(undefined),
+  getValidToken: vi.fn().mockResolvedValue('token-abc'),
+  TwitchAuthError: class TwitchAuthError extends Error {},
+}));
+vi.mock('./twitchEventSubHandler', () => ({
+  handleFollow: vi.fn(),
+  handleSub: vi.fn(),
+  handleResub: vi.fn(),
+  handleGiftSub: vi.fn(),
+  handleRaid: vi.fn(),
+  handleRedemption: vi.fn(),
+}));
+
+import {
+  hasAuthFailedSubs,
+  clearAuthFailedSubs,
+  loadStreamersForEventSub,
+  subscribeForStreamer,
+} from './twitchEventSubSubscriptions';
+import { getAllEventSubStreamers, clearStreamerToken } from './db';
+import { getValidToken, createEventSubSubscription, listEventSubSubscriptions, deleteEventSubSubscription, TwitchAuthError } from './twitchApiEventSub';
+import { getUsers } from './twitchApi';
+import { getActiveChannels } from './twitchBot';
+
+// ---------------------------------------------------------------------------
+// hasAuthFailedSubs / clearAuthFailedSubs
+// ---------------------------------------------------------------------------
+describe('hasAuthFailedSubs / clearAuthFailedSubs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Clear any auth failures left from previous tests by clearing known logins
+    clearAuthFailedSubs('streamerA');
+    clearAuthFailedSubs('streamerB');
+  });
+
+  it('returns false when no auth failures have been recorded', () => {
+    expect(hasAuthFailedSubs('streamerA')).toBe(false);
+  });
+
+  it('returns true after a subscription fails with TwitchAuthError', async () => {
+    vi.mocked(getActiveChannels).mockReturnValue(new Set(['streamera']));
+    vi.mocked(createEventSubSubscription).mockRejectedValueOnce(new TwitchAuthError('403'));
+
+    // subscribeForStreamer will invoke subscribe internally
+    await subscribeForStreamer('sess-1', {
+      uid: 'uid-A',
+      token: 'token',
+      name: 'streamerA',
+      config: { follow_enabled: true, sub_enabled: false, raid_enabled: false } as any,
+      streamerId: 1,
+    });
+
+    expect(hasAuthFailedSubs('streamerA')).toBe(true);
+  });
+
+  it('clearAuthFailedSubs removes entries for the given login and leaves others intact', async () => {
+    // Seed auth failures for both streamers. Each config (follow_enabled + non-null config)
+    // triggers 2 subscribe calls (follow + channel_points), so mock 4 rejections total.
+    vi.mocked(getActiveChannels).mockReturnValue(new Set(['streamera', 'streamerb']));
+    vi.mocked(createEventSubSubscription)
+      .mockRejectedValue(new TwitchAuthError('403'));
+
+    await subscribeForStreamer('sess-2', {
+      uid: 'uid-A2',
+      token: 'tokenA',
+      name: 'streamerA',
+      config: { follow_enabled: true, sub_enabled: false, raid_enabled: false } as any,
+      streamerId: 2,
+    });
+    await subscribeForStreamer('sess-2', {
+      uid: 'uid-B2',
+      token: 'tokenB',
+      name: 'streamerB',
+      config: { follow_enabled: true, sub_enabled: false, raid_enabled: false } as any,
+      streamerId: 3,
+    });
+
+    expect(hasAuthFailedSubs('streamerA')).toBe(true);
+    expect(hasAuthFailedSubs('streamerB')).toBe(true);
+
+    clearAuthFailedSubs('streamerA');
+
+    expect(hasAuthFailedSubs('streamerA')).toBe(false);
+    expect(hasAuthFailedSubs('streamerB')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadStreamersForEventSub
+// ---------------------------------------------------------------------------
+describe('loadStreamersForEventSub', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the correct shape for streamers with a stored twitch_user_id', async () => {
+    const fakeStreamer = {
+      id: 10,
+      twitch_name: 'someStreamer',
+      twitch_user_id: 'uid-10',
+      config: { follow_enabled: true },
+    };
+    vi.mocked(getAllEventSubStreamers).mockResolvedValue([fakeStreamer] as any);
+    vi.mocked(getValidToken).mockResolvedValue('tok-10');
+
+    const result = await loadStreamersForEventSub();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      uid: 'uid-10',
+      token: 'tok-10',
+      name: 'someStreamer',
+      streamerId: 10,
+    });
+  });
+
+  it('skips streamers where UID cannot be resolved', async () => {
+    const fakeStreamer = {
+      id: 11,
+      twitch_name: 'noUidStreamer',
+      twitch_user_id: null,
+      config: null, // raid_enabled is falsy so resolveBroadcasterId returns null
+    };
+    vi.mocked(getAllEventSubStreamers).mockResolvedValue([fakeStreamer] as any);
+    vi.mocked(getValidToken).mockResolvedValue(null);
+
+    const result = await loadStreamersForEventSub();
+    expect(result).toHaveLength(0);
+  });
+
+  it('falls back to Helix getUsers for raid-only streamers without stored UID', async () => {
+    const fakeStreamer = {
+      id: 12,
+      twitch_name: 'raidOnly',
+      twitch_user_id: null,
+      config: { raid_enabled: true },
+    };
+    vi.mocked(getAllEventSubStreamers).mockResolvedValue([fakeStreamer] as any);
+    vi.mocked(getValidToken).mockResolvedValue('tok-12');
+    vi.mocked(getUsers).mockResolvedValue([{ login: 'raidonly', id: 'uid-raid' }] as any);
+
+    const result = await loadStreamersForEventSub();
+
+    expect(getUsers).toHaveBeenCalledWith(['raidOnly']);
+    expect(result).toHaveLength(1);
+    expect(result[0].uid).toBe('uid-raid');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// subscribeForStreamer
+// ---------------------------------------------------------------------------
+describe('subscribeForStreamer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearAuthFailedSubs('botInChannel');
+    clearAuthFailedSubs('notInChannel');
+  });
+
+  it('returns 0 and skips subscriptions when bot is not in the channel', async () => {
+    vi.mocked(getActiveChannels).mockReturnValue(new Set()); // bot not in any channel
+
+    const count = await subscribeForStreamer('sess-x', {
+      uid: 'uid-x',
+      token: 'tok',
+      name: 'notInChannel',
+      config: { follow_enabled: true, sub_enabled: true, raid_enabled: true } as any,
+      streamerId: 99,
+    });
+
+    expect(count).toBe(0);
+    expect(createEventSubSubscription).not.toHaveBeenCalled();
+  });
+
+  it('calls createEventSubSubscription for enabled subscription types', async () => {
+    vi.mocked(getActiveChannels).mockReturnValue(new Set(['botinchannel']));
+    vi.mocked(createEventSubSubscription).mockResolvedValue('sub-new');
+    vi.mocked(listEventSubSubscriptions).mockResolvedValue([]);
+
+    const count = await subscribeForStreamer('sess-y', {
+      uid: 'uid-y',
+      token: 'tok-y',
+      name: 'botInChannel',
+      config: { follow_enabled: true, sub_enabled: false, raid_enabled: false } as any,
+      streamerId: 20,
+    });
+
+    expect(createEventSubSubscription).toHaveBeenCalled();
+    expect(count).toBeGreaterThan(0);
+  });
+
+  it('calls deleteEventSubSubscription for stale subscriptions', async () => {
+    vi.mocked(getActiveChannels).mockReturnValue(new Set(['botinchannel']));
+    vi.mocked(createEventSubSubscription).mockResolvedValue('sub-new');
+    vi.mocked(listEventSubSubscriptions).mockResolvedValue([
+      { id: 'stale-sub', type: 'channel.subscribe' }, // not in desired set
+    ] as any);
+
+    await subscribeForStreamer('sess-z', {
+      uid: 'uid-z',
+      token: 'tok-z',
+      name: 'botInChannel',
+      config: { follow_enabled: true, sub_enabled: false, raid_enabled: false } as any,
+      streamerId: 21,
+    });
+
+    expect(deleteEventSubSubscription).toHaveBeenCalledWith('stale-sub', 'tok-z');
+  });
+});

--- a/src/twitchEventSubSubscriptions.ts
+++ b/src/twitchEventSubSubscriptions.ts
@@ -123,6 +123,7 @@ async function createSubscriptionsForStreamer(
   return desired;
 }
 
+/** Data bundle passed to a StreamerConnection for setting up EventSub subscriptions. */
 export interface StreamerEventSubData {
   uid: string;
   token: string | null;

--- a/src/twitchEventSubSubscriptions.ts
+++ b/src/twitchEventSubSubscriptions.ts
@@ -114,32 +114,43 @@ async function createSubscriptionsForStreamer(
   return desired;
 }
 
-export async function subscribeAll(sid: string): Promise<number> {
+export interface StreamerEventSubData {
+  uid: string;
+  token: string | null;
+  name: string;
+  config: EventSubConfig | null;
+  streamerId: number;
+}
+
+/** Fetches all streamers from the DB, resolves their broadcaster IDs and valid tokens. */
+export async function loadStreamersForEventSub(): Promise<StreamerEventSubData[]> {
   const streamers = await getAllEventSubStreamers();
-
-  // Build into a temporary map so dispatchNotification/handleRevocation see a
-  // consistent snapshot throughout the async loop, not an empty map mid-reload.
-  const nextMap = new Map<string, StreamerInfo>();
-  let totalSubscriptions = 0;
-
+  const result: StreamerEventSubData[] = [];
   for (const streamer of streamers) {
     const token = await getValidToken(streamer);
     const config = streamer.config;
     const uid = await resolveBroadcasterId(streamer, config);
     if (!uid) continue;
-
-    nextMap.set(uid, { login: streamer.twitch_name ?? '', streamerId: streamer.id, config });
-
-    // Create desired subscriptions first so there is never a gap where zero are active
-    const desired = await createSubscriptionsForStreamer(sid, uid, token, config, streamer.twitch_name ?? '');
-    totalSubscriptions += desired.size;
-    await deleteStaleSubscriptions(uid, desired, token);
+    result.push({ uid, token, name: streamer.twitch_name ?? '', config, streamerId: streamer.id });
   }
+  return result;
+}
 
-  // Atomic swap — old map stays readable until all subscriptions are ready
-  streamerMap.clear();
-  for (const [uid, info] of nextMap) streamerMap.set(uid, info);
-  return totalSubscriptions;
+/** Creates all subscriptions for one streamer on their dedicated session, updates streamerMap,
+ *  and cleans up stale subscriptions. Returns the count of desired subscriptions. */
+export async function subscribeForStreamer(
+  sessionId: string, data: StreamerEventSubData,
+): Promise<number> {
+  const { uid, token, name, config, streamerId } = data;
+  streamerMap.set(uid, { login: name, streamerId, config });
+  const desired = await createSubscriptionsForStreamer(sessionId, uid, token, config, name);
+  await deleteStaleSubscriptions(uid, desired, token);
+  return desired.size;
+}
+
+/** Removes a streamer from the in-memory map (called when their connection is stopped). */
+export function removeStreamerFromMap(uid: string): void {
+  streamerMap.delete(uid);
 }
 
 async function subscribe(sessionId: string, spec: SubSpec, token: string, login: string): Promise<void> {

--- a/src/twitchEventSubSubscriptions.ts
+++ b/src/twitchEventSubSubscriptions.ts
@@ -27,6 +27,11 @@ export function hasAuthFailedSubs(login: string): boolean {
   return false;
 }
 
+export function clearAuthFailedSubs(login: string): void {
+  const prefix = `${login}:`;
+  for (const key of authFailedSubs) if (key.startsWith(prefix)) authFailedSubs.delete(key);
+}
+
 // Maps EventSub notification types to their handler functions.
 // Using Map instead of a plain object prevents prototype-chain lookup on user-controlled keys.
 type NotificationHandler = (login: string, event: unknown, config: EventSubConfig, streamerId: number) => Promise<void>;

--- a/src/twitchEventSubSubscriptions.ts
+++ b/src/twitchEventSubSubscriptions.ts
@@ -13,21 +13,24 @@ import {
 const log = createLogger('EventSub');
 
 
+/** Describes a single EventSub subscription to create. */
 export interface SubSpec { type: string; version: string; condition: Record<string, string> }
 
-// In-memory lookup keyed by Twitch broadcaster user ID
+/** In-memory streamer info keyed by broadcaster user ID. */
 export interface StreamerInfo { login: string; streamerId: number; config: EventSubConfig | null }
 const streamerMap = new Map<string, StreamerInfo>();
 
 // Tracks "login:type:token" triples that failed with 403 — skipped until bot restarts or token changes
 const authFailedSubs = new Set<string>();
 
+/** Returns true if any subscription for the given login has previously failed with a 403. */
 export function hasAuthFailedSubs(login: string): boolean {
   const prefix = `${login}:`;
   for (const key of authFailedSubs) if (key.startsWith(prefix)) return true;
   return false;
 }
 
+/** Clears all auth-failed subscription records for the given login. */
 export function clearAuthFailedSubs(login: string): void {
   const prefix = `${login}:`;
   for (const key of authFailedSubs) if (key.startsWith(prefix)) authFailedSubs.delete(key);
@@ -179,6 +182,7 @@ async function subscribe(sessionId: string, spec: SubSpec, token: string, login:
 }
 
 
+/** Routes an EventSub notification to the appropriate handler based on subscription type. */
 export function dispatchNotification(type: string, event: Record<string, unknown>, condition: Record<string, string>): void {
   const broadcasterId = condition.broadcaster_user_id ?? condition.to_broadcaster_user_id;
   if (!broadcasterId) return;
@@ -201,6 +205,7 @@ export function dispatchNotification(type: string, event: Record<string, unknown
     .catch((err) => log.error(`${type} handler error:`, err));
 }
 
+/** Handles a subscription revocation message, clearing the broadcaster's token if authorisation was revoked. */
 export function handleRevocation(sub: { type: string; status: string; condition: Record<string, string> }): void {
   log.warn(`Subscription revoked: type=${sub.type} status=${sub.status}`);
 

--- a/src/twitchEventSubSubscriptions.ts
+++ b/src/twitchEventSubSubscriptions.ts
@@ -1,5 +1,6 @@
 import { createLogger } from './logger';
-import { getAllEventSubStreamers, clearStreamerToken, DbStreamerEventSub, EventSubConfig } from './db/eventSub';
+import { getAllEventSubStreamers, clearStreamerToken } from './db';
+import type { DbStreamerEventSub, EventSubConfig } from './db/eventSub';
 import { getUsers } from './twitchApi';
 import { getActiveChannels } from './twitchBot';
 import { normalizeTwitchChannelName } from './twitchChannelName';

--- a/src/web/routes/eventsubCallback.ts
+++ b/src/web/routes/eventsubCallback.ts
@@ -4,6 +4,7 @@ import { getStreamerById, saveStreamerToken, initEventConfig } from '../../db';
 import { exchangeCode, getUserFromToken } from '../../twitchApiEventSub';
 import { TWITCH_EVENTSUB_REDIRECT_URI } from '../../config';
 import { reloadEventSubSubscriptions } from '../../twitchEventSub';
+import { clearAuthFailedSubs } from '../../twitchEventSubSubscriptions';
 
 const log = createLogger('Web');
 const router = Router();
@@ -55,6 +56,7 @@ router.get('/twitch/eventsub/callback', async (req, res) => {
     const expiryMs = tokens.expires_in != null ? Date.now() + tokens.expires_in * 1000 - 60_000 : null;
     await saveStreamerToken(streamerId, twitchUser.id, tokens.access_token, tokens.refresh_token, expiryMs);
     await initEventConfig(streamerId);
+    clearAuthFailedSubs(twitchUser.login.toLowerCase());
     reloadEventSubSubscriptions();
     log.info(`EventSub OAuth connected for ${streamer.twitch_name}`);
     res.redirect('/user/settings?success=twitch_connected');


### PR DESCRIPTION
## Summary

- **Root cause fix**: Twitch's WebSocket EventSub transport rejects subscriptions created with different user tokens on the same session ("websocket transport cannot have subscriptions created by different users", 400). Each streamer now gets its own dedicated `StreamerConnection` with its own WebSocket, so all subscriptions on a session use a single user's token.
- **Auth banner fix** (from #193): After a user re-authenticated Twitch, the "Reconnect Twitch" banner persisted because stale `authFailedSubs` entries (keyed by old token) were never cleared. `clearAuthFailedSubs(login)` is now called in the OAuth callback before reloading subscriptions.
- **Reconnect URL logging** (from #192): `buildReconnectUrl` now logs which specific validation check(s) failed and the raw URL at ERROR level, making reconnect URL rejections diagnosable from logs.
- **SSRF fix**: `buildReconnectUrl` reconstructs a clean URL from validated components rather than returning the original tainted string, satisfying CodeQL's taint analysis.

## Changes

- `src/twitchEventSubConnection.ts` *(new)*: `StreamerConnection` class managing a single WebSocket lifecycle (connect, keepalive, reconnect with backoff, session migration). Also contains `buildReconnectUrl`, `isDuplicate`, `isStale`.
- `src/twitchEventSub.ts`: Thin orchestration layer — manages a `Map<uid, StreamerConnection>`, reconciles adds/removes on reload.
- `src/twitchEventSubSubscriptions.ts`: Removed `subscribeAll`. Added `loadStreamersForEventSub()`, `subscribeForStreamer()`, `removeStreamerFromMap()`, and `clearAuthFailedSubs()`.
- `src/web/routes/eventsubCallback.ts`: Calls `clearAuthFailedSubs` on successful re-auth.

## Test plan

- [ ] Multiple streamers each get their own WS connection; no 400 errors on subscription creation
- [ ] Single-streamer setup continues to work
- [ ] Reload correctly adds new streamer connections and removes stale ones
- [ ] After Twitch re-auth, "Reconnect Twitch" banner clears immediately
- [ ] All 464 existing tests pass

https://claude.ai/code/session_01QzYhUGoB2fzsJk6T4EKDUC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-streamer EventSub connection management with serialized start/reload flows and graceful start/stop behavior.
  * OAuth callback now clears prior auth-failure state for the streamer.

* **Bug Fixes**
  * Stronger validation for reconnect URLs, staleness detection, and TTL-based duplicate suppression to reduce false/duplicate events.
  * Improved reconnection and keepalive handling.

* **Tests**
  * Expanded unit tests covering connection lifecycle, message handling, subscription orchestration, and auth-failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->