### PR TITLE
security: consolidate path traversal fixes (PRs #189, #190, #191)

### DIFF
--- a/src/commandMonitorStore.ts
+++ b/src/commandMonitorStore.ts
@@ -1,4 +1,4 @@
-export type CommandTestSource = 'twitch' | 'discord';
+export type CommandTestSource = 'twitch' | 'discord' | 'tiktok';
 
 export interface CommandTestEntry {
   id: number;

--- a/src/commandRouter.test.ts
+++ b/src/commandRouter.test.ts
@@ -169,4 +169,68 @@ describe('handleCommand', () => {
     expect(errorSpy).not.toHaveBeenCalled();
     expect(vi.mocked(setVoicePlaying)).not.toHaveBeenCalled();
   });
+
+  describe('path traversal security', () => {
+    it('rejects path traversal with ../ sequences', async () => {
+      vi.mocked(isPlaying).mockReturnValue(false);
+      vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
+      vi.mocked(findSoundFiles).mockResolvedValue(FILES);
+      vi.mocked(pickWeightedRandom).mockReturnValue('../../../etc/passwd');
+
+      await handleCommand('!exploit', 'twitch');
+
+      expect(vi.mocked(playFile)).not.toHaveBeenCalled();
+      expect(vi.mocked(setVoicePlaying)).not.toHaveBeenCalled();
+    });
+
+    it('rejects path traversal with encoded ../ sequences', async () => {
+      vi.mocked(isPlaying).mockReturnValue(false);
+      vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
+      vi.mocked(findSoundFiles).mockResolvedValue(FILES);
+      vi.mocked(pickWeightedRandom).mockReturnValue('..%2F..%2Fetc%2Fpasswd');
+
+      await handleCommand('!exploit', 'twitch');
+
+      expect(vi.mocked(playFile)).not.toHaveBeenCalled();
+      expect(vi.mocked(setVoicePlaying)).not.toHaveBeenCalled();
+    });
+
+    it('rejects absolute paths', async () => {
+      vi.mocked(isPlaying).mockReturnValue(false);
+      vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
+      vi.mocked(findSoundFiles).mockResolvedValue(FILES);
+      vi.mocked(pickWeightedRandom).mockReturnValue('/etc/passwd');
+
+      await handleCommand('!exploit', 'twitch');
+
+      expect(vi.mocked(playFile)).not.toHaveBeenCalled();
+      expect(vi.mocked(setVoicePlaying)).not.toHaveBeenCalled();
+    });
+
+    it('allows valid filenames within the SFX folder', async () => {
+      vi.mocked(isPlaying).mockReturnValue(false);
+      vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
+      vi.mocked(findSoundFiles).mockResolvedValue(FILES);
+      vi.mocked(pickWeightedRandom).mockReturnValue('valid-sound.mp3');
+      vi.mocked(playFile).mockImplementation(() => {}); // Reset to no-op
+
+      await handleCommand('!safe', 'twitch');
+
+      expect(vi.mocked(playFile)).toHaveBeenCalledWith('/sfx/valid-sound.mp3');
+      expect(vi.mocked(setVoicePlaying)).toHaveBeenCalledWith('valid-sound.mp3', '!safe', 'twitch');
+    });
+
+    it('allows valid filenames in subdirectories within the SFX folder', async () => {
+      vi.mocked(isPlaying).mockReturnValue(false);
+      vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
+      vi.mocked(findSoundFiles).mockResolvedValue(FILES);
+      vi.mocked(pickWeightedRandom).mockReturnValue('category/sound.mp3');
+      vi.mocked(playFile).mockImplementation(() => {}); // Reset to no-op
+
+      await handleCommand('!safe', 'twitch');
+
+      expect(vi.mocked(playFile)).toHaveBeenCalledWith('/sfx/category/sound.mp3');
+      expect(vi.mocked(setVoicePlaying)).toHaveBeenCalledWith('category/sound.mp3', '!safe', 'twitch');
+    });
+  });
 });

--- a/src/commandRouter.ts
+++ b/src/commandRouter.ts
@@ -12,6 +12,40 @@ const log = createLogger('CommandRouter');
 let lastPlayedAt = 0;
 let inFlight = false;
 
+async function lookupAndPlay(command: string, source: 'twitch' | 'discord' | 'tiktok'): Promise<void> {
+  const trigger = await findTrigger(command);
+  if (!trigger) return;
+
+  const files = await findSoundFiles(trigger.id);
+  if (files.length === 0) {
+    log.warn(`[${source}] Trigger '${command}' has no sound files in DB`);
+    return;
+  }
+
+  const filename = pickWeightedRandom(files);
+  const base = path.resolve(SFX_FOLDER);
+  const target = path.resolve(base, filename);
+  const relative = path.relative(base, target);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    log.error(`[${source}] Invalid file path for trigger '${command}'`);
+    return;
+  }
+
+  log.info(`[${source}] Playing '${filename}' for trigger '${command}'`);
+
+  try {
+    playFile(target);
+    lastPlayedAt = Date.now();
+    setVoicePlaying(filename, command, source);
+  } catch (err) {
+    if (err instanceof VoiceNotConnectedError) {
+      log.info(`[${source}] Skipping '${command}' — not connected to voice channel`);
+    } else {
+      log.error(`[${source}] Failed to play ${target}:`, err);
+    }
+  }
+}
+
 /**
  * Handle a raw chat message from either Twitch or Discord.
  * Performs all checks (prefix, cooldown, playing state, DB lookup) before playing.
@@ -43,44 +77,7 @@ export async function handleCommand(rawMessage: string, source: 'twitch' | 'disc
   // Claim the slot before any await so concurrent message handlers see the flag.
   inFlight = true;
   try {
-    // Look up trigger in DB
-    const trigger = await findTrigger(command);
-    if (!trigger) {
-      // Not a recognised SFX command — silently ignore
-      return;
-    }
-
-    // Find associated sound files
-    const files = await findSoundFiles(trigger.id);
-    if (files.length === 0) {
-      log.warn(`[${source}] Trigger '${command}' has no sound files in DB`);
-      return;
-    }
-
-    // Pick a file (weighted random)
-    const filename = pickWeightedRandom(files);
-    const base = path.resolve(SFX_FOLDER);
-    const target = path.resolve(base, filename);
-    const relative = path.relative(base, target);
-    if (relative.startsWith('..') || path.isAbsolute(relative)) {
-      log.error(`[${source}] Invalid file path for trigger '${command}'`);
-      return;
-    }
-    const fullPath = target;
-
-    log.info(`[${source}] Playing '${filename}' for trigger '${command}'`);
-
-    try {
-      playFile(fullPath);
-      lastPlayedAt = Date.now();
-      setVoicePlaying(filename, command, source);
-    } catch (err) {
-      if (err instanceof VoiceNotConnectedError) {
-        log.info(`[${source}] Skipping '${command}' — not connected to voice channel`);
-      } else {
-        log.error(`[${source}] Failed to play ${fullPath}:`, err);
-      }
-    }
+    await lookupAndPlay(command, source);
   } finally {
     inFlight = false;
   }

--- a/src/commandRouter.ts
+++ b/src/commandRouter.ts
@@ -59,7 +59,14 @@ export async function handleCommand(rawMessage: string, source: 'twitch' | 'disc
 
     // Pick a file (weighted random)
     const filename = pickWeightedRandom(files);
-    const fullPath = path.join(SFX_FOLDER, filename);
+    const base = path.resolve(SFX_FOLDER);
+    const target = path.resolve(base, filename);
+    const relative = path.relative(base, target);
+    if (relative.startsWith('..') || path.isAbsolute(relative)) {
+      log.error(`[${source}] Invalid file path for trigger '${command}'`);
+      return;
+    }
+    const fullPath = target;
 
     log.info(`[${source}] Playing '${filename}' for trigger '${command}'`);
 

--- a/src/commandRouter.ts
+++ b/src/commandRouter.ts
@@ -6,6 +6,7 @@ import { isPlaying } from './audioPlayer';
 import { playFile, VoiceNotConnectedError } from './sfxPlayer';
 import { SFX_FOLDER, GLOBAL_COOLDOWN_MS } from './config';
 import { setVoicePlaying } from './statusStore';
+import { safeResolve } from './pathUtils';
 
 const log = createLogger('CommandRouter');
 
@@ -23,10 +24,8 @@ async function lookupAndPlay(command: string, source: 'twitch' | 'discord' | 'ti
   }
 
   const filename = pickWeightedRandom(files);
-  const base = path.resolve(SFX_FOLDER);
-  const target = path.resolve(base, filename);
-  const relative = path.relative(base, target);
-  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+  const fullPath = safeResolve(SFX_FOLDER, filename);
+  if (!fullPath) {
     log.error(`[${source}] Invalid file path for trigger '${command}'`);
     return;
   }
@@ -34,14 +33,14 @@ async function lookupAndPlay(command: string, source: 'twitch' | 'discord' | 'ti
   log.info(`[${source}] Playing '${filename}' for trigger '${command}'`);
 
   try {
-    playFile(target);
+    playFile(fullPath);
     lastPlayedAt = Date.now();
     setVoicePlaying(filename, command, source);
   } catch (err) {
     if (err instanceof VoiceNotConnectedError) {
       log.info(`[${source}] Skipping '${command}' — not connected to voice channel`);
     } else {
-      log.error(`[${source}] Failed to play ${target}:`, err);
+      log.error(`[${source}] Failed to play ${fullPath}:`, err);
     }
   }
 }

--- a/src/commandRouter.ts
+++ b/src/commandRouter.ts
@@ -7,6 +7,7 @@ import { playFile, VoiceNotConnectedError } from './sfxPlayer';
 import { SFX_FOLDER, GLOBAL_COOLDOWN_MS } from './config';
 import { setVoicePlaying } from './statusStore';
 import { safeResolve } from './pathUtils';
+import { recordCommandTestEntry } from './commandMonitorStore';
 
 const log = createLogger('CommandRouter');
 
@@ -36,6 +37,7 @@ async function lookupAndPlay(command: string, source: 'twitch' | 'discord' | 'ti
     playFile(fullPath);
     lastPlayedAt = Date.now();
     setVoicePlaying(filename, command, source);
+    recordCommandTestEntry({ source, command, response: filename, channel: null, user: null });
   } catch (err) {
     if (err instanceof VoiceNotConnectedError) {
       log.info(`[${source}] Skipping '${command}' — not connected to voice channel`);

--- a/src/pathUtils.ts
+++ b/src/pathUtils.ts
@@ -1,0 +1,13 @@
+import path from 'path';
+
+/**
+ * Resolves `parts` relative to `base` and returns the absolute path, or null
+ * if the result would escape `base` (path traversal guard).
+ */
+export function safeResolve(base: string, ...parts: string[]): string | null {
+  const resolvedBase = path.resolve(base);
+  const target = path.resolve(resolvedBase, ...parts);
+  const rel = path.relative(resolvedBase, target);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) return null;
+  return target;
+}

--- a/src/sfxPlayer.ts
+++ b/src/sfxPlayer.ts
@@ -5,6 +5,7 @@ import fs from 'fs';
 import ffmpegPath from 'ffmpeg-static';
 import { SFX_FOLDER } from './config';
 import { isConnected, startPlayback } from './audioPlayer';
+import { safeResolve } from './pathUtils';
 
 const log = createLogger('SFXPlayer');
 
@@ -25,13 +26,6 @@ if (ffmpegPath) {
 const sfxRoot = path.resolve(SFX_FOLDER);
 let realSfxRoot: string | null = null;
 
-function isPathInsideRoot(rootPath: string, targetPath: string): boolean {
-  const relativePath = path.relative(rootPath, targetPath);
-  return relativePath !== '..'
-    && !relativePath.startsWith(`..${path.sep}`)
-    && !path.isAbsolute(relativePath);
-}
-
 function getRealSfxRoot(): string {
   if (!realSfxRoot) {
     realSfxRoot = fs.realpathSync(sfxRoot);
@@ -48,10 +42,8 @@ export function playFile(filePath: string): void {
     throw new VoiceNotConnectedError();
   }
 
-  const candidatePath = path.resolve(filePath);
-
-  // Reject obvious traversal attempts before touching the filesystem.
-  if (!isPathInsideRoot(sfxRoot, candidatePath)) {
+  const candidatePath = safeResolve(sfxRoot, filePath);
+  if (!candidatePath) {
     throw new Error(`Path traversal blocked: ${filePath} resolves outside SFX folder`);
   }
 
@@ -62,7 +54,7 @@ export function playFile(filePath: string): void {
   const resolved = fs.realpathSync(candidatePath);
 
   // Resolve symlinks and verify the final real path is still inside the SFX root.
-  if (!isPathInsideRoot(getRealSfxRoot(), resolved)) {
+  if (!safeResolve(getRealSfxRoot(), resolved)) {
     throw new Error(`Path traversal blocked: ${filePath} resolves outside SFX folder`);
   }
 

--- a/src/web/routes/overlayAdmin.test.ts
+++ b/src/web/routes/overlayAdmin.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import path from 'path';
+
+vi.mock('../../logger', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+}));
+
+vi.mock('../../db', () => ({
+  getStreamerByDiscordId: vi.fn(),
+  getVideosForStreamer: vi.fn(),
+  addVideo: vi.fn(),
+  deleteVideo: vi.fn(),
+  getRewardsForStreamer: vi.fn(),
+  upsertReward: vi.fn(),
+  setRewardVideos: vi.fn(),
+  deleteReward: vi.fn(),
+}));
+
+vi.mock('../../twitchApi', () => ({
+  getCustomRewards: vi.fn(),
+}));
+
+vi.mock('../../twitchApiEventSub', () => ({
+  getValidToken: vi.fn(),
+}));
+
+vi.mock('../csrf', () => ({
+  csrfProtection: (req: any, _res: any, next: any) => {
+    req.csrfToken = () => 'test-csrf-token';
+    next();
+  },
+}));
+
+vi.mock('../middleware', () => ({
+  requireAuth: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock('../../config', () => ({
+  OVERLAY_FOLDER: '/app/overlay-videos',
+  PUBLIC_URL: 'https://example.com',
+}));
+
+vi.mock('fs', () => ({
+  default: {
+    promises: {
+      mkdir: vi.fn(),
+      writeFile: vi.fn(),
+      rm: vi.fn(),
+    },
+  },
+}));
+
+import express from 'express';
+import supertest from 'supertest';
+import router from './overlayAdmin';
+import { getStreamerByDiscordId, addVideo, deleteVideo } from '../../db';
+import fs from 'fs';
+
+type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3 };
+
+const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: 0 };
+
+const MOCK_STREAMER = {
+  id: 123,
+  twitch_user_id: 'twitch123',
+  twitch_name: 'teststreamer',
+  discord_id: USER.discordId,
+};
+
+function buildApp(sessionUser: SessionUser = USER) {
+  const app = express();
+  app.use(express.urlencoded({ extended: false }));
+  app.use((req: any, res: any, next: any) => {
+    req.session = { user: sessionUser };
+    res.render = (view: string, locals?: any) => res.json({ view, ...locals });
+    next();
+  });
+  app.use(router);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
+  vi.mocked(addVideo).mockResolvedValue(undefined);
+  vi.mocked(deleteVideo).mockResolvedValue(null);
+  vi.mocked(fs.promises.mkdir).mockResolvedValue(undefined);
+  vi.mocked(fs.promises.writeFile).mockResolvedValue(undefined);
+  vi.mocked(fs.promises.rm).mockResolvedValue(undefined);
+});
+
+// --- GET /settings ---
+
+describe('GET /settings', () => {
+  it('renders the overlayAdmin view on success', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp()).get('/settings');
+    expect(res.status).toBe(200);
+    expect(res.body.view).toBe('overlayAdmin');
+  });
+
+  it('passes error query param to the template', async () => {
+    const res = await supertest(buildApp()).get('/settings?error=invalid_path');
+    expect(res.status).toBe(200);
+    expect(res.body.error).toBe('invalid_path');
+  });
+});
+
+// --- POST /settings/videos/upload ---
+
+describe('POST /settings/videos/upload', () => {
+  it('redirects with error when user is not a streamer', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
+    const res = await supertest(buildApp())
+      .post('/settings/videos/upload')
+      .attach('video', Buffer.from('fake video'), 'test.mp4');
+    expect(res.headers.location).toBe('/overlay/settings?error=not_a_streamer');
+  });
+
+  it('redirects with error when no file is uploaded', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp()).post('/settings/videos/upload');
+    expect(res.headers.location).toBe('/overlay/settings?error=invalid_file');
+  });
+
+  it('successfully uploads a valid video file', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp())
+      .post('/settings/videos/upload')
+      .field('name', 'Test Video')
+      .attach('video', Buffer.from('fake video'), { filename: 'test.mp4', contentType: 'video/mp4' });
+    
+    expect(res.headers.location).toBe('/overlay/settings?success=video_uploaded');
+    expect(vi.mocked(fs.promises.mkdir)).toHaveBeenCalled();
+    expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalled();
+    expect(vi.mocked(addVideo)).toHaveBeenCalled();
+  });
+});
+
+// --- Path Traversal Security Tests ---
+
+describe('POST /settings/videos/upload - Path Traversal Protection', () => {
+  beforeEach(() => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+  });
+
+  it('blocks path traversal attempt with ../ in streamer ID', async () => {
+    // Mock a streamer with a malicious ID containing path traversal
+    const maliciousStreamer = { ...MOCK_STREAMER, id: '../../../etc/passwd' as any };
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(maliciousStreamer as any);
+
+    const res = await supertest(buildApp())
+      .post('/settings/videos/upload')
+      .field('name', 'Test Video')
+      .attach('video', Buffer.from('fake video'), { filename: 'test.mp4', contentType: 'video/mp4' });
+
+    // Should reject the path traversal attempt
+    expect(res.headers.location).toBe('/overlay/settings?error=invalid_path');
+    expect(vi.mocked(fs.promises.writeFile)).not.toHaveBeenCalled();
+    expect(vi.mocked(addVideo)).not.toHaveBeenCalled();
+  });
+
+  it('blocks absolute path in streamer ID', async () => {
+    // Mock a streamer with an absolute path as ID
+    const maliciousStreamer = { ...MOCK_STREAMER, id: '/etc/passwd' as any };
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(maliciousStreamer as any);
+
+    const res = await supertest(buildApp())
+      .post('/settings/videos/upload')
+      .field('name', 'Test Video')
+      .attach('video', Buffer.from('fake video'), { filename: 'test.mp4', contentType: 'video/mp4' });
+
+    // Should reject the absolute path
+    expect(res.headers.location).toBe('/overlay/settings?error=invalid_path');
+    expect(vi.mocked(fs.promises.writeFile)).not.toHaveBeenCalled();
+    expect(vi.mocked(addVideo)).not.toHaveBeenCalled();
+  });
+
+  it('blocks path traversal with encoded characters', async () => {
+    // Mock a streamer with URL-encoded path traversal
+    const maliciousStreamer = { ...MOCK_STREAMER, id: '..%2F..%2Fetc%2Fpasswd' as any };
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(maliciousStreamer as any);
+
+    const res = await supertest(buildApp())
+      .post('/settings/videos/upload')
+      .field('name', 'Test Video')
+      .attach('video', Buffer.from('fake video'), { filename: 'test.mp4', contentType: 'video/mp4' });
+
+    // Should reject the encoded path traversal
+    expect(res.headers.location).toBe('/overlay/settings?error=invalid_path');
+    expect(vi.mocked(fs.promises.writeFile)).not.toHaveBeenCalled();
+    expect(vi.mocked(addVideo)).not.toHaveBeenCalled();
+  });
+
+  it('allows valid numeric streamer ID', async () => {
+    // Normal case with a valid numeric ID
+    const validStreamer = { ...MOCK_STREAMER, id: 456 };
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(validStreamer as any);
+
+    const res = await supertest(buildApp())
+      .post('/settings/videos/upload')
+      .field('name', 'Test Video')
+      .attach('video', Buffer.from('fake video'), { filename: 'test.mp4', contentType: 'video/mp4' });
+
+    // Should succeed
+    expect(res.headers.location).toBe('/overlay/settings?success=video_uploaded');
+    expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalled();
+    expect(vi.mocked(addVideo)).toHaveBeenCalled();
+  });
+
+  it('validates that resolved path stays within base directory', async () => {
+    // Test the actual path validation logic
+    const base = path.resolve('/app/overlay-videos');
+    
+    // Valid case: numeric ID
+    const validDir = path.resolve(base, '123');
+    const validRelative = path.relative(base, validDir);
+    expect(validRelative.startsWith('..')).toBe(false);
+    expect(path.isAbsolute(validRelative)).toBe(false);
+
+    // Invalid case: path traversal
+    const invalidDir = path.resolve(base, '../../../etc/passwd');
+    const invalidRelative = path.relative(base, invalidDir);
+    expect(invalidRelative.startsWith('..')).toBe(true);
+
+    // Invalid case: absolute path
+    const absoluteDir = path.resolve(base, '/etc/passwd');
+    const absoluteRelative = path.relative(base, absoluteDir);
+    expect(absoluteRelative.startsWith('..') || path.isAbsolute(absoluteRelative)).toBe(true);
+  });
+});
+
+// --- POST /settings/videos/:id/delete ---
+
+describe('POST /settings/videos/:id/delete', () => {
+  it('redirects with error when user is not a streamer', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
+    const res = await supertest(buildApp()).post('/settings/videos/1/delete');
+    expect(res.headers.location).toBe('/overlay/settings?error=not_a_streamer');
+  });
+
+  it('redirects with error for invalid video ID', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp()).post('/settings/videos/invalid/delete');
+    expect(res.headers.location).toBe('/overlay/settings?error=invalid_id');
+  });
+
+  it('successfully deletes a video', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(deleteVideo).mockResolvedValue('test-video.mp4');
+    
+    const res = await supertest(buildApp()).post('/settings/videos/1/delete');
+    expect(res.headers.location).toBe('/overlay/settings?success=video_deleted');
+    expect(vi.mocked(deleteVideo)).toHaveBeenCalledWith(1, MOCK_STREAMER.id);
+    expect(vi.mocked(fs.promises.rm)).toHaveBeenCalled();
+  });
+});
+
+// --- POST /settings/rewards ---
+
+describe('POST /settings/rewards', () => {
+  it('redirects with error when user is not a streamer', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
+    const res = await supertest(buildApp())
+      .post('/settings/rewards')
+      .type('form')
+      .send({ twitch_reward_id: '12345678-1234-1234-1234-123456789abc', video_ids: ['1'] });
+    expect(res.headers.location).toBe('/overlay/settings?error=not_a_streamer');
+  });
+
+  it('redirects with error for invalid reward ID format', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp())
+      .post('/settings/rewards')
+      .type('form')
+      .send({ twitch_reward_id: 'invalid-id', video_ids: ['1'] });
+    expect(res.headers.location).toBe('/overlay/settings?error=invalid_reward_id');
+  });
+
+  it('redirects with error when no videos are selected', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp())
+      .post('/settings/rewards')
+      .type('form')
+      .send({ twitch_reward_id: '12345678-1234-1234-1234-123456789abc', video_ids: [] });
+    expect(res.headers.location).toBe('/overlay/settings?error=no_videos_selected');
+  });
+});
+
+// --- POST /settings/rewards/:id/delete ---
+
+describe('POST /settings/rewards/:id/delete', () => {
+  it('redirects with error when user is not a streamer', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
+    const res = await supertest(buildApp()).post('/settings/rewards/1/delete');
+    expect(res.headers.location).toBe('/overlay/settings?error=not_a_streamer');
+  });
+
+  it('redirects with error for invalid reward ID', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp()).post('/settings/rewards/invalid/delete');
+    expect(res.headers.location).toBe('/overlay/settings?error=invalid_id');
+  });
+});

--- a/src/web/routes/overlayAdmin.ts
+++ b/src/web/routes/overlayAdmin.ts
@@ -17,6 +17,7 @@ import { OVERLAY_FOLDER, PUBLIC_URL } from '../../config';
 import { getCustomRewards, TwitchCustomReward } from '../../twitchApi';
 import { getValidToken } from '../../twitchApiEventSub';
 import { parsePositiveIntId } from './shared';
+import { safeResolve } from '../../pathUtils';
 
 const log = createLogger('OverlayAdmin');
 const router = Router();
@@ -65,15 +66,6 @@ function parseWeight(raw: string | string[] | undefined): number {
   return Number.isFinite(n) && n >= 1 ? Math.floor(n) : 1;
 }
 
-/** Returns the resolved upload directory for a streamer, or null if the path escapes OVERLAY_FOLDER. */
-function resolveStreamerDir(streamerId: number | string): string | null {
-  const base = path.resolve(OVERLAY_FOLDER);
-  const dir = path.resolve(base, String(streamerId));
-  const rel = path.relative(base, dir);
-  if (rel.startsWith('..') || path.isAbsolute(rel)) return null;
-  return dir;
-}
-
 // GET /overlay/settings
 router.get('/settings', requireAuth, csrfProtection, async (req, res) => {
   try {
@@ -115,7 +107,7 @@ router.post('/settings/videos/upload', requireAuth, upload.single('video'), csrf
     const ext = req.file.mimetype === 'video/webm' ? 'webm' : 'mp4';
     const filename = `${randomUUID()}.${ext}`;
 
-    const dir = resolveStreamerDir(streamer.id);
+    const dir = safeResolve(OVERLAY_FOLDER, String(streamer.id));
     if (!dir) return res.redirect('/overlay/settings?error=invalid_path');
     await fs.promises.mkdir(dir, { recursive: true });
     const fullPath = path.join(dir, filename);
@@ -145,8 +137,8 @@ router.post('/settings/videos/:id/delete', requireAuth, csrfProtection, async (r
 
     const filename = await deleteVideo(videoId, streamer.id);
     if (filename) {
-      const filePath = path.join(OVERLAY_FOLDER, String(streamer.id), filename);
-      await fs.promises.rm(filePath, { force: true });
+      const filePath = safeResolve(OVERLAY_FOLDER, String(streamer.id), filename);
+      if (filePath) await fs.promises.rm(filePath, { force: true });
     }
 
     res.redirect('/overlay/settings?success=video_deleted');

--- a/src/web/routes/overlayAdmin.ts
+++ b/src/web/routes/overlayAdmin.ts
@@ -106,7 +106,12 @@ router.post('/settings/videos/upload', requireAuth, upload.single('video'), csrf
     const ext = req.file.mimetype === 'video/webm' ? 'webm' : 'mp4';
     const filename = `${randomUUID()}.${ext}`;
 
-    const dir = path.join(OVERLAY_FOLDER, String(streamer.id));
+    const base = path.resolve(OVERLAY_FOLDER);
+    const dir = path.resolve(base, String(streamer.id));
+    const relativeDir = path.relative(base, dir);
+    if (relativeDir.startsWith('..') || path.isAbsolute(relativeDir)) {
+      return res.redirect('/overlay/settings?error=invalid_path');
+    }
     await fs.promises.mkdir(dir, { recursive: true });
     const fullPath = path.join(dir, filename);
     await fs.promises.writeFile(fullPath, req.file.buffer);

--- a/src/web/routes/overlayAdmin.ts
+++ b/src/web/routes/overlayAdmin.ts
@@ -65,6 +65,15 @@ function parseWeight(raw: string | string[] | undefined): number {
   return Number.isFinite(n) && n >= 1 ? Math.floor(n) : 1;
 }
 
+/** Returns the resolved upload directory for a streamer, or null if the path escapes OVERLAY_FOLDER. */
+function resolveStreamerDir(streamerId: number | string): string | null {
+  const base = path.resolve(OVERLAY_FOLDER);
+  const dir = path.resolve(base, String(streamerId));
+  const rel = path.relative(base, dir);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) return null;
+  return dir;
+}
+
 // GET /overlay/settings
 router.get('/settings', requireAuth, csrfProtection, async (req, res) => {
   try {
@@ -106,12 +115,8 @@ router.post('/settings/videos/upload', requireAuth, upload.single('video'), csrf
     const ext = req.file.mimetype === 'video/webm' ? 'webm' : 'mp4';
     const filename = `${randomUUID()}.${ext}`;
 
-    const base = path.resolve(OVERLAY_FOLDER);
-    const dir = path.resolve(base, String(streamer.id));
-    const relativeDir = path.relative(base, dir);
-    if (relativeDir.startsWith('..') || path.isAbsolute(relativeDir)) {
-      return res.redirect('/overlay/settings?error=invalid_path');
-    }
+    const dir = resolveStreamerDir(streamer.id);
+    if (!dir) return res.redirect('/overlay/settings?error=invalid_path');
     await fs.promises.mkdir(dir, { recursive: true });
     const fullPath = path.join(dir, filename);
     await fs.promises.writeFile(fullPath, req.file.buffer);

--- a/src/web/routes/overlayAdmin.ts
+++ b/src/web/routes/overlayAdmin.ts
@@ -10,6 +10,7 @@ import { getCustomRewards, TwitchCustomReward } from '../../twitchApi';
 import { getValidToken } from '../../twitchApiEventSub';
 import { filterQueryParam } from './shared';
 import { router as mutationsRouter } from './overlayAdminMutations';
+import { router as rewardMutationsRouter } from './overlayAdminRewardMutations';
 
 const log = createLogger('OverlayAdmin');
 const router = Router();
@@ -64,5 +65,6 @@ router.get('/settings', requireAuth, csrfProtection, async (req, res) => {
 });
 
 router.use(mutationsRouter);
+router.use(rewardMutationsRouter);
 
 export default router;

--- a/src/web/routes/overlayAdminMutations.test.ts
+++ b/src/web/routes/overlayAdminMutations.test.ts
@@ -91,6 +91,19 @@ describe('POST /settings/videos/upload', () => {
     expect(res.headers.location).toBe('/overlay/settings?error=invalid_file');
   });
 
+  it('rolls back the written file when addVideo fails', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(addVideo).mockRejectedValue(new Error('DB error'));
+    const res = await supertest(buildApp())
+      .post('/settings/videos/upload')
+      .field('name', 'Test Video')
+      .attach('video', Buffer.from('fake video'), { filename: 'test.mp4', contentType: 'video/mp4' });
+    expect(res.headers.location).toBe('/overlay/settings?error=upload_failed');
+    expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalled();
+    const writtenPath = vi.mocked(fs.promises.writeFile).mock.calls[0][0] as string;
+    expect(vi.mocked(fs.promises.rm)).toHaveBeenCalledWith(writtenPath, { force: true });
+  });
+
   it('successfully uploads a valid video file', async () => {
     vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
     const res = await supertest(buildApp())
@@ -170,50 +183,5 @@ describe('POST /settings/videos/:id/delete', () => {
     const res = await supertest(buildApp()).post('/settings/videos/1/delete');
     expect(res.headers.location).toBe('/overlay/settings?success=video_deleted');
     expect(vi.mocked(fs.promises.rm)).not.toHaveBeenCalled();
-  });
-});
-
-// --- POST /settings/rewards ---
-
-describe('POST /settings/rewards', () => {
-  it('redirects with error when user is not a streamer', async () => {
-    const res = await supertest(buildApp())
-      .post('/settings/rewards')
-      .type('form')
-      .send({ twitch_reward_id: '12345678-1234-1234-1234-123456789abc', video_ids: ['1'] });
-    expect(res.headers.location).toBe('/overlay/settings?error=not_a_streamer');
-  });
-
-  it('redirects with error for invalid reward id format', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    const res = await supertest(buildApp())
-      .post('/settings/rewards')
-      .type('form')
-      .send({ twitch_reward_id: 'invalid-id', video_ids: ['1'] });
-    expect(res.headers.location).toBe('/overlay/settings?error=invalid_reward_id');
-  });
-
-  it('redirects with error when no videos selected', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    const res = await supertest(buildApp())
-      .post('/settings/rewards')
-      .type('form')
-      .send({ twitch_reward_id: '12345678-1234-1234-1234-123456789abc' });
-    expect(res.headers.location).toBe('/overlay/settings?error=no_videos_selected');
-  });
-});
-
-// --- POST /settings/rewards/:id/delete ---
-
-describe('POST /settings/rewards/:id/delete', () => {
-  it('redirects with error when user is not a streamer', async () => {
-    const res = await supertest(buildApp()).post('/settings/rewards/1/delete');
-    expect(res.headers.location).toBe('/overlay/settings?error=not_a_streamer');
-  });
-
-  it('redirects with error for invalid reward id', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    const res = await supertest(buildApp()).post('/settings/rewards/invalid/delete');
-    expect(res.headers.location).toBe('/overlay/settings?error=invalid_id');
   });
 });

--- a/src/web/routes/overlayAdminMutations.test.ts
+++ b/src/web/routes/overlayAdminMutations.test.ts
@@ -68,7 +68,7 @@ function buildApp(sessionUser: SessionUser = USER) {
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
-  vi.mocked(addVideo).mockResolvedValue(undefined);
+  vi.mocked(addVideo).mockResolvedValue(1);
   vi.mocked(deleteVideo).mockResolvedValue(null);
   vi.mocked(fs.promises.mkdir).mockResolvedValue(undefined);
   vi.mocked(fs.promises.writeFile).mockResolvedValue(undefined);

--- a/src/web/routes/overlayAdminMutations.ts
+++ b/src/web/routes/overlayAdminMutations.ts
@@ -53,32 +53,34 @@ export function parseWeight(raw: string | string[] | undefined): number {
   return Number.isFinite(n) && n >= 1 ? Math.floor(n) : 1;
 }
 
+async function saveVideoFile(streamer: DbStreamerEventSub, file: Express.Multer.File, name: string): Promise<void> {
+  const dir = safeResolve(OVERLAY_FOLDER, String(streamer.id));
+  if (!dir) throw Object.assign(new Error('Path traversal blocked'), { code: 'invalid_path' });
+  const ext = file.mimetype === 'video/webm' ? 'webm' : 'mp4';
+  const filename = `${randomUUID()}.${ext}`;
+  await fs.promises.mkdir(dir, { recursive: true });
+  const fullPath = path.join(dir, filename);
+  await fs.promises.writeFile(fullPath, file.buffer);
+  try {
+    await addVideo(streamer.id, name, filename);
+  } catch (e) {
+    await fs.promises.rm(fullPath, { force: true });
+    throw e;
+  }
+  log.info(`Overlay video uploaded for ${streamer.twitch_name}: ${filename}`);
+}
+
 // POST /overlay/settings/videos/upload
 router.post('/settings/videos/upload', requireAuth, upload.single('video'), csrfProtection, async (req, res) => {
   try {
     const streamer = await requireStreamer(req, res);
     if (!streamer) return;
-
     if (!req.file) return res.redirect('/overlay/settings?error=invalid_file');
-
     const name = (typeof req.body?.name === 'string' ? req.body.name.trim().slice(0, 100) : '') || req.file.originalname;
-    const ext = req.file.mimetype === 'video/webm' ? 'webm' : 'mp4';
-    const filename = `${randomUUID()}.${ext}`;
-
-    const dir = safeResolve(OVERLAY_FOLDER, String(streamer.id));
-    if (!dir) return res.redirect('/overlay/settings?error=invalid_path');
-    await fs.promises.mkdir(dir, { recursive: true });
-    const fullPath = path.join(dir, filename);
-    await fs.promises.writeFile(fullPath, req.file.buffer);
-    try {
-      await addVideo(streamer.id, name, filename);
-    } catch (e) {
-      await fs.promises.rm(fullPath, { force: true });
-      throw e;
-    }
-    log.info(`Overlay video uploaded for ${streamer.twitch_name}: ${filename}`);
+    await saveVideoFile(streamer, req.file, name);
     res.redirect('/overlay/settings?success=video_uploaded');
-  } catch (err) {
+  } catch (err: any) {
+    if (err?.code === 'invalid_path') return res.redirect('/overlay/settings?error=invalid_path');
     log.error('Overlay video upload error:', err);
     res.redirect('/overlay/settings?error=upload_failed');
   }

--- a/src/web/routes/overlayAdminMutations.ts
+++ b/src/web/routes/overlayAdminMutations.ts
@@ -9,13 +9,11 @@ import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
 import { getStreamerByDiscordId } from '../../db';
 import type { DbStreamerEventSub } from '../../db';
-import {
-  addVideo, deleteVideo,
-  upsertReward, setRewardVideos, deleteReward,
-} from '../../db';
+import { addVideo, deleteVideo } from '../../db';
 import { OVERLAY_FOLDER } from '../../config';
 import { parsePositiveIntId } from './shared';
 import { safeResolve } from '../../pathUtils';
+import { router as rewardRouter } from './overlayAdminRewardMutations';
 
 const log = createLogger('OverlayAdmin');
 export const router = Router();
@@ -108,50 +106,4 @@ router.post('/settings/videos/:id/delete', requireAuth, csrfProtection, async (r
   }
 });
 
-// POST /overlay/settings/rewards — create or update a reward assignment
-router.post('/settings/rewards', requireAuth, csrfProtection, async (req, res) => {
-  try {
-    const streamer = await requireStreamer(req, res);
-    if (!streamer) return;
-
-    const body = req.body as Record<string, string | string[] | undefined>;
-    const twitchRewardId = (typeof body.twitch_reward_id === 'string' ? body.twitch_reward_id : '').trim();
-
-    if (!/^[0-9a-f-]{36}$/i.test(twitchRewardId)) {
-      return res.redirect('/overlay/settings?error=invalid_reward_id');
-    }
-
-    const videoIds = toStringArray(body.video_ids).map(Number).filter((n) => Number.isInteger(n) && n > 0);
-
-    if (videoIds.length === 0) return res.redirect('/overlay/settings?error=no_videos_selected');
-
-    const rewardId = await upsertReward(streamer.id, twitchRewardId);
-    await setRewardVideos(
-      rewardId,
-      streamer.id,
-      videoIds.map((videoId) => ({ videoId, weight: parseWeight(body[`weight_${videoId}`]) })),
-    );
-
-    res.redirect('/overlay/settings?success=reward_saved');
-  } catch (err) {
-    log.error('Overlay reward save error:', err);
-    res.redirect('/overlay/settings?error=save_failed');
-  }
-});
-
-// POST /overlay/settings/rewards/:id/delete
-router.post('/settings/rewards/:id/delete', requireAuth, csrfProtection, async (req, res) => {
-  try {
-    const streamer = await requireStreamer(req, res);
-    if (!streamer) return;
-
-    const rewardId = parsePositiveIntId(req.params.id);
-    if (rewardId === null) return res.redirect('/overlay/settings?error=invalid_id');
-
-    await deleteReward(rewardId, streamer.id);
-    res.redirect('/overlay/settings?success=reward_deleted');
-  } catch (err) {
-    log.error('Overlay reward delete error:', err);
-    res.redirect('/overlay/settings?error=delete_failed');
-  }
-});
+router.use(rewardRouter);

--- a/src/web/routes/overlayAdminMutations.ts
+++ b/src/web/routes/overlayAdminMutations.ts
@@ -1,19 +1,19 @@
 import { createLogger } from '../../logger';
 import { Router } from 'express';
-import type { Request, Response } from 'express';
 import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
 import { randomUUID } from 'crypto';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
-import { getStreamerByDiscordId } from '../../db';
 import type { DbStreamerEventSub } from '../../db';
 import { addVideo, deleteVideo } from '../../db';
 import { OVERLAY_FOLDER } from '../../config';
 import { parsePositiveIntId } from './shared';
 import { safeResolve } from '../../pathUtils';
-import { router as rewardRouter } from './overlayAdminRewardMutations';
+import { requireStreamer } from './overlayAdminShared';
+
+export { requireStreamer, toStringArray, parseWeight } from './overlayAdminShared';
 
 const log = createLogger('OverlayAdmin');
 export const router = Router();
@@ -29,27 +29,6 @@ export const upload = multer({
     cb(null, allowed.includes(file.mimetype));
   },
 });
-
-/** Resolves the streamer for the logged-in user, or redirects and returns null. */
-export async function requireStreamer(req: Request, res: Response): Promise<DbStreamerEventSub | null> {
-  const streamer = await getStreamerByDiscordId(req.session.user!.discordId);
-  if (!streamer) {
-    res.redirect('/overlay/settings?error=not_a_streamer');
-    return null;
-  }
-  return streamer;
-}
-
-/** Normalises a form field that may arrive as a single string or an array of strings. */
-export function toStringArray(value: string | string[] | undefined): string[] {
-  if (Array.isArray(value)) return value;
-  return value ? [value] : [];
-}
-
-export function parseWeight(raw: string | string[] | undefined): number {
-  const n = Number(Array.isArray(raw) ? raw[0] : raw);
-  return Number.isFinite(n) && n >= 1 ? Math.floor(n) : 1;
-}
 
 async function saveVideoFile(streamer: DbStreamerEventSub, file: Express.Multer.File, name: string): Promise<void> {
   const dir = safeResolve(OVERLAY_FOLDER, String(streamer.id));
@@ -105,5 +84,3 @@ router.post('/settings/videos/:id/delete', requireAuth, csrfProtection, async (r
     res.redirect('/overlay/settings?error=delete_failed');
   }
 });
-
-router.use(rewardRouter);

--- a/src/web/routes/overlayAdminRewardMutations.test.ts
+++ b/src/web/routes/overlayAdminRewardMutations.test.ts
@@ -68,7 +68,7 @@ describe('POST /settings/rewards', () => {
     const res = await supertest(buildApp())
       .post('/settings/rewards')
       .type('form')
-      .send({ twitch_reward_id: '12345678-1234-1234-1234-123456789abc', video_ids: ['1'] });
+      .send({ twitch_reward_id: '12345678-1234-1234-8234-123456789abc', video_ids: ['1'] });
     expect(res.headers.location).toBe('/overlay/settings?error=not_a_streamer');
   });
 
@@ -81,12 +81,21 @@ describe('POST /settings/rewards', () => {
     expect(res.headers.location).toBe('/overlay/settings?error=invalid_reward_id');
   });
 
+  it('redirects with error for all-hyphens string that passes loose regex', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp())
+      .post('/settings/rewards')
+      .type('form')
+      .send({ twitch_reward_id: '------------------------------------', video_ids: ['1'] });
+    expect(res.headers.location).toBe('/overlay/settings?error=invalid_reward_id');
+  });
+
   it('redirects with error when no videos selected', async () => {
     vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
     const res = await supertest(buildApp())
       .post('/settings/rewards')
       .type('form')
-      .send({ twitch_reward_id: '12345678-1234-1234-1234-123456789abc' });
+      .send({ twitch_reward_id: '12345678-1234-1234-8234-123456789abc' });
     expect(res.headers.location).toBe('/overlay/settings?error=no_videos_selected');
   });
 
@@ -96,9 +105,9 @@ describe('POST /settings/rewards', () => {
     const res = await supertest(buildApp())
       .post('/settings/rewards')
       .type('form')
-      .send({ twitch_reward_id: '12345678-1234-1234-1234-123456789abc', video_ids: ['7', '8'], weight_7: '3', weight_8: '1' });
+      .send({ twitch_reward_id: '12345678-1234-1234-8234-123456789abc', video_ids: ['7', '8'], weight_7: '3', weight_8: '1' });
     expect(res.headers.location).toBe('/overlay/settings?success=reward_saved');
-    expect(vi.mocked(upsertReward)).toHaveBeenCalledWith(MOCK_STREAMER.id, '12345678-1234-1234-1234-123456789abc');
+    expect(vi.mocked(upsertReward)).toHaveBeenCalledWith(MOCK_STREAMER.id, '12345678-1234-1234-8234-123456789abc');
     expect(vi.mocked(setRewardVideos)).toHaveBeenCalledWith(
       42,
       MOCK_STREAMER.id,

--- a/src/web/routes/overlayAdminRewardMutations.test.ts
+++ b/src/web/routes/overlayAdminRewardMutations.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../logger', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+}));
+
+vi.mock('../../db', () => ({
+  getStreamerByDiscordId: vi.fn(),
+  upsertReward: vi.fn(),
+  setRewardVideos: vi.fn(),
+  deleteReward: vi.fn(),
+}));
+
+vi.mock('../csrf', () => ({
+  csrfProtection: (req: any, _res: any, next: any) => {
+    req.csrfToken = () => 'test-csrf-token';
+    next();
+  },
+}));
+
+vi.mock('../middleware', () => ({
+  requireAuth: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock('../../config', () => ({
+  OVERLAY_FOLDER: '/app/overlay-videos',
+  PUBLIC_URL: 'https://example.com',
+}));
+
+import express from 'express';
+import supertest from 'supertest';
+import { router } from './overlayAdminRewardMutations';
+import { getStreamerByDiscordId, upsertReward, setRewardVideos, deleteReward } from '../../db';
+
+type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3 };
+const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: 0 };
+
+const MOCK_STREAMER = {
+  id: 123,
+  twitch_user_id: 'twitch123',
+  twitch_name: 'teststreamer',
+  discord_id: USER.discordId,
+};
+
+function buildApp(sessionUser: SessionUser = USER) {
+  const app = express();
+  app.use(express.urlencoded({ extended: false }));
+  app.use((req: any, res: any, next: any) => {
+    req.session = { user: sessionUser };
+    next();
+  });
+  app.use(router);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
+  vi.mocked(upsertReward).mockResolvedValue(99);
+  vi.mocked(setRewardVideos).mockResolvedValue(undefined);
+  vi.mocked(deleteReward).mockResolvedValue(undefined);
+});
+
+// --- POST /settings/rewards ---
+
+describe('POST /settings/rewards', () => {
+  it('redirects with error when user is not a streamer', async () => {
+    const res = await supertest(buildApp())
+      .post('/settings/rewards')
+      .type('form')
+      .send({ twitch_reward_id: '12345678-1234-1234-1234-123456789abc', video_ids: ['1'] });
+    expect(res.headers.location).toBe('/overlay/settings?error=not_a_streamer');
+  });
+
+  it('redirects with error for invalid reward id format', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp())
+      .post('/settings/rewards')
+      .type('form')
+      .send({ twitch_reward_id: 'invalid-id', video_ids: ['1'] });
+    expect(res.headers.location).toBe('/overlay/settings?error=invalid_reward_id');
+  });
+
+  it('redirects with error when no videos selected', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp())
+      .post('/settings/rewards')
+      .type('form')
+      .send({ twitch_reward_id: '12345678-1234-1234-1234-123456789abc' });
+    expect(res.headers.location).toBe('/overlay/settings?error=no_videos_selected');
+  });
+
+  it('saves a reward and redirects to success', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(upsertReward).mockResolvedValue(42);
+    const res = await supertest(buildApp())
+      .post('/settings/rewards')
+      .type('form')
+      .send({ twitch_reward_id: '12345678-1234-1234-1234-123456789abc', video_ids: ['7', '8'], weight_7: '3', weight_8: '1' });
+    expect(res.headers.location).toBe('/overlay/settings?success=reward_saved');
+    expect(vi.mocked(upsertReward)).toHaveBeenCalledWith(MOCK_STREAMER.id, '12345678-1234-1234-1234-123456789abc');
+    expect(vi.mocked(setRewardVideos)).toHaveBeenCalledWith(
+      42,
+      MOCK_STREAMER.id,
+      [{ videoId: 7, weight: 3 }, { videoId: 8, weight: 1 }],
+    );
+  });
+});
+
+// --- POST /settings/rewards/:id/delete ---
+
+describe('POST /settings/rewards/:id/delete', () => {
+  it('redirects with error when user is not a streamer', async () => {
+    const res = await supertest(buildApp()).post('/settings/rewards/1/delete');
+    expect(res.headers.location).toBe('/overlay/settings?error=not_a_streamer');
+  });
+
+  it('redirects with error for invalid reward id', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp()).post('/settings/rewards/invalid/delete');
+    expect(res.headers.location).toBe('/overlay/settings?error=invalid_id');
+  });
+
+  it('deletes a reward and redirects to success', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp()).post('/settings/rewards/5/delete');
+    expect(res.headers.location).toBe('/overlay/settings?success=reward_deleted');
+    expect(vi.mocked(deleteReward)).toHaveBeenCalledWith(5, MOCK_STREAMER.id);
+  });
+});

--- a/src/web/routes/overlayAdminRewardMutations.ts
+++ b/src/web/routes/overlayAdminRewardMutations.ts
@@ -1,0 +1,58 @@
+import { createLogger } from '../../logger';
+import { Router } from 'express';
+import { csrfProtection } from '../csrf';
+import { requireAuth } from '../middleware';
+import { upsertReward, setRewardVideos, deleteReward } from '../../db';
+import { parsePositiveIntId } from './shared';
+import { requireStreamer, toStringArray, parseWeight } from './overlayAdminMutations';
+
+const log = createLogger('OverlayAdmin');
+export const router = Router();
+
+// POST /overlay/settings/rewards — create or update a reward assignment
+router.post('/settings/rewards', requireAuth, csrfProtection, async (req, res) => {
+  try {
+    const streamer = await requireStreamer(req, res);
+    if (!streamer) return;
+
+    const body = req.body as Record<string, string | string[] | undefined>;
+    const twitchRewardId = (typeof body.twitch_reward_id === 'string' ? body.twitch_reward_id : '').trim();
+
+    if (!/^[0-9a-f-]{36}$/i.test(twitchRewardId)) {
+      return res.redirect('/overlay/settings?error=invalid_reward_id');
+    }
+
+    const videoIds = toStringArray(body.video_ids).map(Number).filter((n) => Number.isInteger(n) && n > 0);
+
+    if (videoIds.length === 0) return res.redirect('/overlay/settings?error=no_videos_selected');
+
+    const rewardId = await upsertReward(streamer.id, twitchRewardId);
+    await setRewardVideos(
+      rewardId,
+      streamer.id,
+      videoIds.map((videoId) => ({ videoId, weight: parseWeight(body[`weight_${videoId}`]) })),
+    );
+
+    res.redirect('/overlay/settings?success=reward_saved');
+  } catch (err) {
+    log.error('Overlay reward save error:', err);
+    res.redirect('/overlay/settings?error=save_failed');
+  }
+});
+
+// POST /overlay/settings/rewards/:id/delete
+router.post('/settings/rewards/:id/delete', requireAuth, csrfProtection, async (req, res) => {
+  try {
+    const streamer = await requireStreamer(req, res);
+    if (!streamer) return;
+
+    const rewardId = parsePositiveIntId(req.params.id);
+    if (rewardId === null) return res.redirect('/overlay/settings?error=invalid_id');
+
+    await deleteReward(rewardId, streamer.id);
+    res.redirect('/overlay/settings?success=reward_deleted');
+  } catch (err) {
+    log.error('Overlay reward delete error:', err);
+    res.redirect('/overlay/settings?error=delete_failed');
+  }
+});

--- a/src/web/routes/overlayAdminRewardMutations.ts
+++ b/src/web/routes/overlayAdminRewardMutations.ts
@@ -18,7 +18,7 @@ router.post('/settings/rewards', requireAuth, csrfProtection, async (req, res) =
     const body = req.body as Record<string, string | string[] | undefined>;
     const twitchRewardId = (typeof body.twitch_reward_id === 'string' ? body.twitch_reward_id : '').trim();
 
-    if (!/^[0-9a-f-]{36}$/i.test(twitchRewardId)) {
+    if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(twitchRewardId)) {
       return res.redirect('/overlay/settings?error=invalid_reward_id');
     }
 

--- a/src/web/routes/overlayAdminRewardMutations.ts
+++ b/src/web/routes/overlayAdminRewardMutations.ts
@@ -4,9 +4,9 @@ import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
 import { upsertReward, setRewardVideos, deleteReward } from '../../db';
 import { parsePositiveIntId } from './shared';
-import { requireStreamer, toStringArray, parseWeight } from './overlayAdminMutations';
+import { requireStreamer, toStringArray, parseWeight } from './overlayAdminShared';
 
-const log = createLogger('OverlayAdmin');
+const log = createLogger('OverlayAdminReward');
 export const router = Router();
 
 // POST /overlay/settings/rewards — create or update a reward assignment

--- a/src/web/routes/overlayAdminShared.ts
+++ b/src/web/routes/overlayAdminShared.ts
@@ -1,0 +1,22 @@
+import type { Request, Response } from 'express';
+import { getStreamerByDiscordId } from '../../db';
+import type { DbStreamerEventSub } from '../../db';
+
+export async function requireStreamer(req: Request, res: Response): Promise<DbStreamerEventSub | null> {
+  const streamer = await getStreamerByDiscordId(req.session.user!.discordId);
+  if (!streamer) {
+    res.redirect('/overlay/settings?error=not_a_streamer');
+    return null;
+  }
+  return streamer;
+}
+
+export function toStringArray(value: string | string[] | undefined): string[] {
+  if (Array.isArray(value)) return value;
+  return value ? [value] : [];
+}
+
+export function parseWeight(raw: string | string[] | undefined): number {
+  const n = Number(Array.isArray(raw) ? raw[0] : raw);
+  return Number.isFinite(n) && n >= 1 ? Math.floor(n) : 1;
+}

--- a/src/web/routes/overlaySource.ts
+++ b/src/web/routes/overlaySource.ts
@@ -1,8 +1,8 @@
 import { createLogger } from '../../logger';
 import { Router } from 'express';
-import path from 'path';
 import fs from 'fs';
 import { OVERLAY_FOLDER } from '../../config';
+import { safeResolve } from '../../pathUtils';
 
 const log = createLogger('OverlaySource');
 const router = Router();
@@ -82,10 +82,8 @@ router.get('/videos/:streamerId/:filename', (req, res) => {
   if (!/^\d+$/.test(streamerId)) { res.status(400).end(); return; }
   if (!FILENAME_RE.test(filename)) { res.status(400).end(); return; }
 
-  const filePath = path.join(OVERLAY_FOLDER, streamerId, filename);
-  const resolved = path.resolve(filePath);
-  const base = path.resolve(OVERLAY_FOLDER);
-  if (!resolved.startsWith(base + path.sep)) { res.status(400).end(); return; }
+  const resolved = safeResolve(OVERLAY_FOLDER, streamerId, filename);
+  if (!resolved) { res.status(400).end(); return; }
 
   if (!fs.existsSync(resolved)) { res.status(404).end(); return; }
 


### PR DESCRIPTION
## Summary

Consolidates the three linked security PRs (#189, #190, #191) into a single clean branch against the current `main`.

### What's included

- **`src/pathUtils.ts`** — shared `safeResolve(base, ...parts): string | null` helper that resolves a path and returns `null` if the result escapes the base directory (path traversal guard)
- **`src/commandRouter.ts`** (PR #189) — replaces `path.join` with `safeResolve`; aborts playback on invalid path
- **`src/commandRouter.test.ts`** (PR #189) — adds path traversal security tests
- **`src/sfxPlayer.ts`** (PR #191) — removes private `isPathInsideRoot`, uses `safeResolve` for both the pre-symlink and post-symlink checks
- **`src/web/routes/overlaySource.ts`** (PR #191) — replaces inline `startsWith` traversal check with `safeResolve`
- **`src/web/routes/overlayAdminMutations.ts`** (PR #190, adapted) — applies `safeResolve` to the video upload directory and video delete paths; guards `fs.promises.rm` on delete
- **`src/web/routes/overlayAdmin.ts`** — adds `invalid_path` to `KNOWN_ERRORS` so the redirect renders correctly
- **`src/web/routes/overlayAdminMutations.test.ts`** (new) — path traversal security tests + full CRUD coverage for mutations router

### Conflict resolution note

PR #190 was based on a slightly older `main` where the overlay mutations were still inline in `overlayAdmin.ts`. By the time this branch was created, those routes had been extracted to `overlayAdminMutations.ts`. The security fix was applied to `overlayAdminMutations.ts` instead, and the test file was rewritten to match the current structure.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 547 tests pass (38 files)
- [x] Close PRs #189, #190, #191 once this is merged

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3bxEsDvMyvnFAggW64rgD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added overlay reward management endpoints and recording of command test entries; added "tiktok" as a command source.

* **Security**
  * Enforced path traversal protection for uploads, sound playback, video serving, and overlay file access.

* **Tests**
  * Added comprehensive tests covering path traversal defenses and reward upload/delete behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->