### PR TITLE
fix: reduce noisy transient error logs for EventSub and TwitchMonitor

### DIFF
--- a/src/twitch/eventsub/twitchEventSubConnection.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.ts
@@ -37,7 +37,7 @@ export function buildReconnectUrl(reconnectUrl: string): string | null {
     username: !parsed.username,
     password: !parsed.password,
     port: validPorts.has(parsed.port),
-    pathname: parsed.pathname === '/ws',
+    pathname: parsed.pathname.replace(/\/$/, '') === '/ws',
   };
   const failed = Object.entries(checkResults).filter(([, v]) => !v).map(([k]) => k);
   if (failed.length > 0) {
@@ -124,7 +124,7 @@ export class StreamerConnection {
     socket.addEventListener('open', () => this.onOpen());
     socket.addEventListener('message', (ev: MessageEvent) => this.onMessage(ev));
     socket.addEventListener('close', (ev: CloseEvent) => this.onClose(ev, socket));
-    socket.addEventListener('error', () => { log.error(`[${this.name}] WebSocket error`); });
+    socket.addEventListener('error', () => { log.warn(`[${this.name}] WebSocket error`); });
     this.ws = socket;
   }
 
@@ -195,7 +195,7 @@ export class StreamerConnection {
 
   private handleSessionReconnect(reconnectUrl: string): void {
     const safeUrl = buildReconnectUrl(reconnectUrl);
-    if (!safeUrl) { log.error(`[${this.name}] Invalid reconnect URL — ignoring`); return; }
+    if (!safeUrl) { log.error(`[${this.name}] Invalid reconnect URL — reconnecting`); this.scheduleReconnect(); return; }
     const oldSocket = this.ws;
     this.isReconnecting = true;
     log.info(`[${this.name}] Session reconnect — connecting to new session`);

--- a/src/twitch/twitchApi.ts
+++ b/src/twitch/twitchApi.ts
@@ -58,10 +58,23 @@ function chunks<T>(arr: T[], size: number): T[][] {
 
 const HELIX_MAX_RETRIES = 3;
 
-async function fetchHelixWithRetry(url: string, headers: Record<string, string>): Promise<Response> {
-  let res = await twitchFetch(url, { headers });
+const NETWORK_RETRY_DELAYS_MS = [2_000, 4_000];
 
-  for (let attempt = 1; attempt <= HELIX_MAX_RETRIES && res.status === 429; attempt++) {
+async function fetchHelixWithRetry(url: string, headers: Record<string, string>): Promise<Response> {
+  let res: Response;
+  for (let attempt = 0; ; attempt++) {
+    try {
+      res = await twitchFetch(url, { headers });
+      break;
+    } catch (err) {
+      if (attempt >= NETWORK_RETRY_DELAYS_MS.length) throw err;
+      const wait = NETWORK_RETRY_DELAYS_MS[attempt];
+      log.warn(`Network error (attempt ${attempt + 1}), retrying in ${wait}ms`);
+      await new Promise<void>((r) => setTimeout(r, wait));
+    }
+  }
+
+  for (let attempt = 1; attempt <= HELIX_MAX_RETRIES && res!.status === 429; attempt++) {
     const resetHeader = res.headers.get('ratelimit-reset');
     const parsedReset = resetHeader ? Number(resetHeader) : NaN;
     const resetAt = Number.isFinite(parsedReset) ? parsedReset * 1000 : Date.now() + 5_000;
@@ -71,7 +84,7 @@ async function fetchHelixWithRetry(url: string, headers: Record<string, string>)
     res = await twitchFetch(url, { headers });
   }
 
-  return res;
+  return res!;
 }
 
 export interface TwitchUser {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **EventSub WebSocket error log**: Downgraded from `ERROR` to `WARN` — the `error` event always precedes a `close` event which already has the code/reason; logging both at ERROR level was misleading
- **EventSub invalid reconnect URL**: Loosened `buildReconnectUrl` pathname check to accept a trailing slash (`/ws/`), fixing silent rejection when Twitch sends a reconnect URL with a trailing slash. Also falls back to `scheduleReconnect()` immediately on rejection rather than waiting for Twitch's 4004 grace-expiry close
- **TwitchMonitor `fetch failed`**: Added 2-attempt network-error retry (2s then 4s delay) inside `fetchHelixWithRetry` so transient TCP/DNS blips don't immediately surface as `[ERROR] Poll error`

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] `npm test` passes (552 tests)
- [ ] Observe logs after deploy — transient disconnects should show `[WARN]` not `[ERROR]`
- [ ] If a `session_reconnect` occurs, confirm "Session reconnect — connecting to new session" appears instead of "Invalid reconnect URL"

https://claude.ai/code/session_01S3WgJjzfHF8s7iMjy1AovG
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S3WgJjzfHF8s7iMjy1AovG)_