### PR TITLE
test: fix cross-platform path assertions in sfxPlayer and commandRouter tests

### DIFF
--- a/src/audio/sfxPlayer.test.ts
+++ b/src/audio/sfxPlayer.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import path from 'path';
 
 vi.mock('../shared/config', () => ({ SFX_FOLDER: '/sfx' }));
+
+// Resolved once here so all assertions and mocks use the same OS-specific form.
+// On Linux: '/sfx'; on Windows: 'C:\sfx' (or whichever drive is current).
+const SFX_ROOT = path.resolve('/sfx');
 
 vi.mock('./audioPlayer', () => ({
   isConnected: vi.fn(),
@@ -35,22 +40,23 @@ beforeEach(() => {
 describe('playFile', () => {
   it('throws VoiceNotConnectedError when not connected to a voice channel', () => {
     vi.mocked(isConnected).mockReturnValue(false);
-    expect(() => playFile('/sfx/ding.mp3')).toThrow(VoiceNotConnectedError);
+    expect(() => playFile(path.join(SFX_ROOT, 'ding.mp3'))).toThrow(VoiceNotConnectedError);
   });
 
   it('blocks a path that resolves outside the SFX folder', () => {
     vi.mocked(isConnected).mockReturnValue(true);
-    expect(() => playFile('/etc/passwd')).toThrow('Path traversal blocked');
+    expect(() => playFile(path.resolve('/etc/passwd'))).toThrow('Path traversal blocked');
   });
 
   it('blocks a symlink whose real path resolves outside the SFX folder', () => {
     vi.mocked(isConnected).mockReturnValue(true);
     vi.mocked(fs.existsSync).mockReturnValue(true);
-    // Symlink inside /sfx points to a file outside /sfx
+    const outsidePath = path.resolve('/etc/passwd');
+    // Symlink inside SFX_ROOT points to a file outside it
     vi.mocked(fs.realpathSync).mockImplementation((p) =>
-      String(p) === '/sfx' ? '/sfx' : '/etc/passwd',
+      String(p) === SFX_ROOT ? SFX_ROOT : outsidePath,
     );
-    expect(() => playFile('/sfx/evil.mp3')).toThrow('Path traversal blocked');
+    expect(() => playFile(path.join(SFX_ROOT, 'evil.mp3'))).toThrow('Path traversal blocked');
   });
 
   it('starts playback for a valid file inside the SFX folder', () => {
@@ -58,9 +64,10 @@ describe('playFile', () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.statSync).mockReturnValue({ isFile: () => true } as ReturnType<typeof fs.statSync>);
 
-    playFile('/sfx/ding.mp3');
+    const filePath = path.join(SFX_ROOT, 'ding.mp3');
+    playFile(filePath);
 
-    expect(vi.mocked(createAudioResource)).toHaveBeenCalledWith('/sfx/ding.mp3');
+    expect(vi.mocked(createAudioResource)).toHaveBeenCalledWith(filePath);
     expect(vi.mocked(startPlayback)).toHaveBeenCalledOnce();
   });
 
@@ -68,7 +75,7 @@ describe('playFile', () => {
     vi.mocked(isConnected).mockReturnValue(true);
     vi.mocked(fs.existsSync).mockReturnValue(false);
 
-    expect(() => playFile('/sfx/missing.mp3')).toThrow('Sound file not found');
+    expect(() => playFile(path.join(SFX_ROOT, 'missing.mp3'))).toThrow('Sound file not found');
   });
 
   it('throws when the resolved path is a directory, not a file', () => {
@@ -76,6 +83,6 @@ describe('playFile', () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.statSync).mockReturnValue({ isFile: () => false } as ReturnType<typeof fs.statSync>);
 
-    expect(() => playFile('/sfx/notafile')).toThrow('Sound path is not a file');
+    expect(() => playFile(path.join(SFX_ROOT, 'notafile'))).toThrow('Sound path is not a file');
   });
 });

--- a/src/commands/commandRouter.test.ts
+++ b/src/commands/commandRouter.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import path from 'path';
 import type { SfxTrigger, SfxFile } from '../db';
+
+const SFX_ROOT = path.resolve('/sfx');
 
 vi.mock('../shared/config', () => ({
   SFX_FOLDER: '/sfx',
@@ -99,7 +102,7 @@ describe('handleCommand', () => {
     await handleCommand('!ding discord', 'discord');
 
     expect(vi.mocked(findTrigger)).toHaveBeenCalledWith('!ding');
-    expect(vi.mocked(playFile)).toHaveBeenCalledWith('/sfx/ding.mp3');
+    expect(vi.mocked(playFile)).toHaveBeenCalledWith(path.join(SFX_ROOT, 'ding.mp3'));
     expect(vi.mocked(setVoicePlaying)).toHaveBeenCalledWith('ding.mp3', '!ding', 'discord');
   });
 
@@ -216,7 +219,7 @@ describe('handleCommand', () => {
 
       await handleCommand('!safe', 'twitch');
 
-      expect(vi.mocked(playFile)).toHaveBeenCalledWith('/sfx/valid-sound.mp3');
+      expect(vi.mocked(playFile)).toHaveBeenCalledWith(path.join(SFX_ROOT, 'valid-sound.mp3'));
       expect(vi.mocked(setVoicePlaying)).toHaveBeenCalledWith('valid-sound.mp3', '!safe', 'twitch');
     });
 
@@ -229,7 +232,7 @@ describe('handleCommand', () => {
 
       await handleCommand('!safe', 'twitch');
 
-      expect(vi.mocked(playFile)).toHaveBeenCalledWith('/sfx/category/sound.mp3');
+      expect(vi.mocked(playFile)).toHaveBeenCalledWith(path.join(SFX_ROOT, 'category', 'sound.mp3'));
       expect(vi.mocked(setVoicePlaying)).toHaveBeenCalledWith('category/sound.mp3', '!safe', 'twitch');
     });
   });


### PR DESCRIPTION
## Summary

- Hardcoded POSIX paths like `/sfx/ding.mp3` in test assertions fail on Windows because `path.resolve('/sfx')` produces a drive-prefixed path (e.g. `F:\sfx`)
- Added a `SFX_ROOT = path.resolve('/sfx')` constant in both test files and replaced all hardcoded expected paths with `path.join(SFX_ROOT, ...)` calls
- Also fixed the symlink mock in `sfxPlayer.test.ts` to compare against the OS-resolved root rather than the literal string `'/sfx'`

## Test plan

- [ ] Run `npm test` on Windows — all 6 previously failing tests in `sfxPlayer.test.ts` and `commandRouter.test.ts` should now pass
- [ ] Run `npm test` on Linux — all 552 tests continue to pass

https://claude.ai/code/session_01N8jf4DqoPNgbkn5Mp9xm5M

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8jf4DqoPNgbkn5Mp9xm5M)_