### PR TITLE
fix: eliminate MaxListeners warnings on startup

### DIFF
--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -23,35 +23,34 @@ const consoleFormat = format.combine(
   }),
 );
 
-const sharedTransports = [
-  new DailyRotateFile({
-    dirname: LOG_DIR,
-    filename: 'combined-%DATE%.log',
-    datePattern: 'YYYY-MM-DD',
-    maxSize: '20m',
-    maxFiles: '14d',
-    zippedArchive: true,
-    format: fileFormat,
-  }),
-  new DailyRotateFile({
-    dirname: LOG_DIR,
-    filename: 'error-%DATE%.log',
-    datePattern: 'YYYY-MM-DD',
-    level: 'error',
-    maxSize: '20m',
-    maxFiles: '14d',
-    zippedArchive: true,
-    format: fileFormat,
-  }),
-  new transports.Console({
-    format: consoleFormat,
-  }),
-];
+const rootLogger = winstonCreateLogger({
+  level: LOG_LEVEL,
+  transports: [
+    new DailyRotateFile({
+      dirname: LOG_DIR,
+      filename: 'combined-%DATE%.log',
+      datePattern: 'YYYY-MM-DD',
+      maxSize: '20m',
+      maxFiles: '14d',
+      zippedArchive: true,
+      format: fileFormat,
+    }),
+    new DailyRotateFile({
+      dirname: LOG_DIR,
+      filename: 'error-%DATE%.log',
+      datePattern: 'YYYY-MM-DD',
+      level: 'error',
+      maxSize: '20m',
+      maxFiles: '14d',
+      zippedArchive: true,
+      format: fileFormat,
+    }),
+    new transports.Console({
+      format: consoleFormat,
+    }),
+  ],
+});
 
 export function createLogger(module: string) {
-  return winstonCreateLogger({
-    level: LOG_LEVEL,
-    defaultMeta: { label: module },
-    transports: sharedTransports,
-  });
+  return rootLogger.child({ label: module });
 }


### PR DESCRIPTION
## Summary

- `createLogger()` was sharing the same `DailyRotateFile` and `Console` transport instances across every Winston logger created. Winston registers event listeners on each transport per logger instance, so after ~10 loggers the transports exceeded their `MaxListeners` limit (10 for `DailyRotateFile`, 30 for `Console`).
- Fix: create a single `rootLogger` with the transports, and have `createLogger(module)` return `rootLogger.child({ label: module })` instead of a new top-level logger.

## Test plan

- [ ] Run `npm test` — all 552 tests pass
- [ ] Start the bot and confirm no `MaxListenersExceededWarning` lines on startup

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jce2sF5NHkuSpTny9GxQjx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized logging infrastructure for improved efficiency and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->