### PR TITLE
fix: code and security review — input validation, concurrency, and EventSub bugs

### DIFF
--- a/src/db/customCommands.ts
+++ b/src/db/customCommands.ts
@@ -175,8 +175,10 @@ export async function updateCustomCommand(
 
 export async function removeCustomCommand(commandId: number): Promise<void> {
   const connection = await getPool().getConnection();
+  const lockName = `bcuk_cmdid_${commandId}`;
 
   try {
+    await acquireNamedLock(connection, lockName);
     await connection.beginTransaction();
     await connection.execute(
       'DELETE FROM twitch_user_commands WHERE command_id = ?',
@@ -196,6 +198,7 @@ export async function removeCustomCommand(commandId: number): Promise<void> {
     await connection.rollback();
     throw error;
   } finally {
+    await releaseNamedLock(connection, lockName);
     connection.release();
   }
 }

--- a/src/twitch/eventsub/twitchEventSubConnection.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.ts
@@ -106,7 +106,7 @@ export class StreamerConnection {
 
   private async doReload(): Promise<void> {
     if (!this.ws || !this.sessionId) {
-      if (!this.stopped) { this.connect(); }
+      if (!this.stopped && !this.reconnectTimer) { this.connect(); }
       return;
     }
     const count = await subscribeForStreamer(this.sessionId, this.currentData);
@@ -204,6 +204,7 @@ export class StreamerConnection {
   }
 
   private scheduleReconnect(): void {
+    if (this.reconnectTimer) { clearTimeout(this.reconnectTimer); }
     const delay = Math.min(RECONNECT_BACKOFF_MAX_MS, 1_000 * Math.pow(2, this.reconnectAttempts));
     this.reconnectAttempts++;
     log.info(`[${this.name}] Reconnecting in ${delay}ms (attempt ${this.reconnectAttempts})`);

--- a/src/web/routes/api.ts
+++ b/src/web/routes/api.ts
@@ -7,6 +7,7 @@ import { getDiscordClient } from '../../discord/discordBot';
 import { csrfProtection } from '../csrf';
 import { getAvailableVoiceChannels } from '../../discord/discordUtils';
 import { DISCORD_GUILD_ID, DISCORD_VOICE_CHANNEL_ID } from '../../shared/config';
+import { normalizeDiscordId } from './shared';
 
 const log = createLogger('API');
 const router = Router();
@@ -41,12 +42,16 @@ router.post('/voice/join', requireMod, csrfProtection, async (req, res) => {
   }
   try {
     const { channelId } = req.body as { channelId?: unknown };
+    if (channelId !== undefined && typeof channelId !== 'string') {
+      res.status(400).json({ ok: false, error: 'channelId must be a string' });
+      return;
+    }
     const trimmedChannelId = typeof channelId === 'string' ? channelId.trim() : '';
-    if (trimmedChannelId && !/^\d{17,20}$/.test(trimmedChannelId)) {
+    if (trimmedChannelId && !normalizeDiscordId(trimmedChannelId)) {
       res.status(400).json({ ok: false, error: 'Invalid channel ID' });
       return;
     }
-    const resolvedChannelId = trimmedChannelId ? trimmedChannelId : undefined;
+    const resolvedChannelId = trimmedChannelId || undefined;
 
     disconnect();
     await connect(discordClient, resolvedChannelId);

--- a/src/web/routes/api.ts
+++ b/src/web/routes/api.ts
@@ -42,6 +42,10 @@ router.post('/voice/join', requireMod, csrfProtection, async (req, res) => {
   try {
     const { channelId } = req.body as { channelId?: unknown };
     const trimmedChannelId = typeof channelId === 'string' ? channelId.trim() : '';
+    if (trimmedChannelId && !/^\d{17,20}$/.test(trimmedChannelId)) {
+      res.status(400).json({ ok: false, error: 'Invalid channel ID' });
+      return;
+    }
     const resolvedChannelId = trimmedChannelId ? trimmedChannelId : undefined;
 
     disconnect();

--- a/src/web/routes/commandMutations.ts
+++ b/src/web/routes/commandMutations.ts
@@ -67,6 +67,8 @@ router.post('/commands/add', requireMod, csrfProtection, async (req, res) => {
       if (!user || !user.twitch_name) continue;
       await assignUserToCommand(commandId, discordId);
     } catch (err) {
+      // Roll back the newly created command so it doesn't get stuck partially assigned.
+      try { await removeCustomCommand(commandId); } catch (cleanupErr) { log.error('Cleanup after failed assign error:', cleanupErr); }
       if (err instanceof CommandConflictError || isMysqlDuplicateEntryError(err)) {
         return res.redirect('/commands?error=command_taken');
       }

--- a/src/web/routes/commandMutations.ts
+++ b/src/web/routes/commandMutations.ts
@@ -36,6 +36,29 @@ function handleCommandWriteError(err: unknown, res: Response): boolean {
   return false;
 }
 
+/** Assigns users to a newly created command.  On any failure, deletes the command
+ *  to avoid leaving it in a partially-assigned state.  Returns an error code, or
+ *  null on success. */
+async function assignUsersToNewCommand(commandId: number, discordIds: string[]): Promise<string | null> {
+  for (const discordId of discordIds) {
+    try {
+      const user = await findUser(discordId);
+      if (!user || !user.twitch_name) continue;
+      await assignUserToCommand(commandId, discordId);
+    } catch (err) {
+      try {
+        await removeCustomCommand(commandId);
+      } catch (cleanupErr) {
+        log.error('Cleanup after failed assign error:', cleanupErr);
+      }
+      if (err instanceof CommandConflictError || isMysqlDuplicateEntryError(err)) return 'command_taken';
+      log.error('Assign user during command creation error:', err);
+      return 'assign_failed';
+    }
+  }
+  return null;
+}
+
 router.post('/commands/add', requireMod, csrfProtection, async (req, res) => {
   const { trigger_string, output } = req.body as Record<string, string | undefined>;
   const isDiscordEnabled = req.body.is_discord_enabled === 'on';
@@ -61,21 +84,8 @@ router.post('/commands/add', requireMod, csrfProtection, async (req, res) => {
     .map((id: string) => normalizeDiscordId(id))
     .filter((id): id is string => id !== null);
 
-  for (const discordId of discordIds) {
-    try {
-      const user = await findUser(discordId);
-      if (!user || !user.twitch_name) continue;
-      await assignUserToCommand(commandId, discordId);
-    } catch (err) {
-      // Roll back the newly created command so it doesn't get stuck partially assigned.
-      try { await removeCustomCommand(commandId); } catch (cleanupErr) { log.error('Cleanup after failed assign error:', cleanupErr); }
-      if (err instanceof CommandConflictError || isMysqlDuplicateEntryError(err)) {
-        return res.redirect('/commands?error=command_taken');
-      }
-      log.error('Assign user during command creation error:', err);
-      return res.redirect('/commands?error=assign_failed');
-    }
-  }
+  const assignError = await assignUsersToNewCommand(commandId, discordIds);
+  if (assignError) return res.redirect(`/commands?error=${assignError}`);
 
   res.redirect('/commands');
 });

--- a/src/web/routes/overlaySource.ts
+++ b/src/web/routes/overlaySource.ts
@@ -63,6 +63,11 @@ router.get('/:login/events', (req, res, next) => {
       res.write(': ping\n\n');
     } catch {
       clearInterval(keepalive);
+      const clients = connections.get(key);
+      if (clients) {
+        clients.delete(res);
+        if (clients.size === 0) connections.delete(key);
+      }
     }
   }, 25_000);
 

--- a/src/web/routes/overlaySource.ts
+++ b/src/web/routes/overlaySource.ts
@@ -76,7 +76,7 @@ router.get('/:login/events', (req, res, next) => {
 });
 
 // GET /overlay/videos/:streamerId/:filename — serve video files (no auth)
-router.get('/videos/:streamerId/:filename', (req, res) => {
+router.get('/videos/:streamerId/:filename', async (req, res) => {
   const { streamerId, filename } = req.params;
 
   if (!/^\d+$/.test(streamerId)) { res.status(400).end(); return; }
@@ -85,7 +85,12 @@ router.get('/videos/:streamerId/:filename', (req, res) => {
   const resolved = safeResolve(OVERLAY_FOLDER, streamerId, filename);
   if (!resolved) { res.status(400).end(); return; }
 
-  if (!fs.existsSync(resolved)) { res.status(404).end(); return; }
+  try {
+    await fs.promises.access(resolved);
+  } catch {
+    res.status(404).end();
+    return;
+  }
 
   res.sendFile(resolved);
 });

--- a/src/web/routes/streamdeck.ts
+++ b/src/web/routes/streamdeck.ts
@@ -93,6 +93,10 @@ router.post('/voice/join', requireApiKey, async (req, res) => {
     res.status(400).json({ ok: false, error: 'Missing or invalid "channelId" field' });
     return;
   }
+  if (!/^\d{17,20}$/.test(channelId.trim())) {
+    res.status(400).json({ ok: false, error: 'Missing or invalid "channelId" field' });
+    return;
+  }
 
   const discordClient = getDiscordClient();
   if (!discordClient) {

--- a/src/web/routes/streamdeck.ts
+++ b/src/web/routes/streamdeck.ts
@@ -10,6 +10,7 @@ import { requireApiKey } from '../middleware';
 import { getAvailableVoiceChannels } from '../../discord/discordUtils';
 import { connect, disconnect } from '../../audio/audioPlayer';
 import { getDiscordClient } from '../../discord/discordBot';
+import { normalizeDiscordId } from './shared';
 
 const log = createLogger('Streamdeck');
 const router = Router();
@@ -89,11 +90,12 @@ router.get('/voice/channels', requireApiKey, async (_req, res) => {
 
 router.post('/voice/join', requireApiKey, async (req, res) => {
   const { channelId } = req.body as { channelId?: unknown };
-  if (typeof channelId !== 'string' || !channelId.trim()) {
+  if (typeof channelId !== 'string') {
     res.status(400).json({ ok: false, error: 'Missing or invalid "channelId" field' });
     return;
   }
-  if (!/^\d{17,20}$/.test(channelId.trim())) {
+  const normalizedChannelId = normalizeDiscordId(channelId);
+  if (!normalizedChannelId) {
     res.status(400).json({ ok: false, error: 'Missing or invalid "channelId" field' });
     return;
   }
@@ -106,7 +108,7 @@ router.post('/voice/join', requireApiKey, async (req, res) => {
 
   try {
     disconnect();
-    await connect(discordClient, channelId.trim());
+    await connect(discordClient, normalizedChannelId);
     res.json({ ok: true });
   } catch (err) {
     log.error('Voice join failed:', err);


### PR DESCRIPTION
## Summary

Full code and security review of the project. No critical security vulnerabilities found. Seven concrete fixes applied across two commits.

### Commit 1 — Security / input validation fixes

- **`overlaySource.ts`** — replace synchronous `fs.existsSync` with `await fs.promises.access`; the sync call blocked the Node.js event loop on every video file request
- **`api.ts`** — validate user-supplied `channelId` is a Discord snowflake (17–20 digits) before calling the Discord API
- **`streamdeck.ts`** — same snowflake validation for the Streamdeck voice-join endpoint

### Commit 2 — Bug fixes found during code review

- **`twitchEventSubConnection.ts` — `scheduleReconnect` timer overwrite**: `scheduleReconnect` now clears any existing timer before scheduling a new one. Without this, if called twice (e.g. URL validation failure + close event), the old timer fires too, opening a duplicate WebSocket connection.
- **`twitchEventSubConnection.ts` — `doReload` double-connect race**: `doReload` no longer calls `connect()` when `reconnectTimer` is already pending. Previously, a `reload()` arriving while the backoff timer was counting down would open a second connection that then raced with the timer.
- **`customCommands.ts` — `removeCustomCommand` missing named lock**: `removeCustomCommand` now acquires the same `bcuk_cmdid_N` lock held by `assignUserToCommand`. Without this, a concurrent assign+remove could produce an FK violation or leave orphaned `twitch_user_commands` rows.
- **`commandMutations.ts` — partial command creation on assignment failure**: `/commands/add` now deletes the newly created command if any user assignment fails mid-loop, so the command is never left in a permanently partially-assigned state.

## Security findings — No Critical/High Issues

| Concern | Status |
|---|---|
| SQL injection | ✅ All queries use parameterised placeholders |
| XSS | ✅ EJS uses `<%= %>` auto-escaping everywhere |
| CSRF | ✅ Timing-safe token comparison; all mutation routes protected |
| Session fixation | ✅ `session.regenerate()` called on login |
| Path traversal | ✅ `safeResolve()` used consistently for all file I/O |
| Open redirects | ✅ All redirects go to hardcoded paths |
| OAuth state forgery | ✅ Cryptographically random state params verified in session |
| Token storage | ✅ AES-256-GCM with random IV |
| Session cookie | ✅ `httpOnly`, `secure` (prod), `sameSite: lax`, 24h TTL |
| Rate limiting | ✅ Three tiers (general/auth/streamdeck) |
| API key storage | ✅ SHA-256 hash only; `timingSafeEqual` for comparison |
| CSP | ✅ Strict: `defaultSrc: self`, `scriptSrc: self`, `objectSrc: none`, `frameAncestors: none` |

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 552/552 passing

https://claude.ai/code/session_01XTRsvAXWjbMD9GxntfuGo9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented redundant reconnects during recovery to improve connection stability
  * Ensured concurrent deletions are serialized to avoid partial failures
  * Reject invalid voice channel requests early with proper validation
  * Cleaned up overlay event connections and return 404 for missing videos
  * Prevented incomplete command creations by improving assignment error handling

* **Improvements**
  * Streamlined voice join flow to use normalized channel IDs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->