### PR TITLE
Add Qlty code coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,10 @@ jobs:
           name: coverage-report
           path: coverage/coverage-report.txt
           retention-days: 30
+
+      - name: Publish coverage to Qlty
+        if: always()
+        uses: qltysh/qlty-action/coverage@v2
+        with:
+          token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
+          files: coverage/lcov.info

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     include: ['src/**/*.test.ts'],
     coverage: {
       provider: 'v8',
-      reporter: [['text', { file: 'coverage-report.txt' }]],
+      reporter: [['text', { file: 'coverage-report.txt' }], 'lcov'],
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts'],
     },


### PR DESCRIPTION
## Summary

- Adds `lcov` reporter to Vitest coverage config so `coverage/lcov.info` is generated on each test run
- Adds `qltysh/qlty-action/coverage@v2` step to CI to publish coverage to Qlty

## Notes

You'll need to add `QLTY_COVERAGE_TOKEN` as a repository secret in GitHub Settings → Secrets and variables → Actions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQ6NwaRyyp2nRNXWvRYFYQ)_