### PR TITLE
Add comprehensive unit tests for src/db modules [superseded by #206–#209]

### DIFF
--- a/src/db/commandConflicts.test.ts
+++ b/src/db/commandConflicts.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../shared/logger', () => ({ createLogger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn() }) }));
+vi.mock('./pool', () => ({ getPool: vi.fn() }));
+vi.mock('mysql2/promise', () => ({ default: {} }));
+vi.mock('../twitch/twitchChannelName', () => ({
+  normalizeTwitchChannelName: vi.fn((s: string) => (s ? s.toLowerCase() : null)),
+}));
+vi.mock('./commandLocks', () => ({
+  acquireNamedLock: vi.fn().mockResolvedValue(undefined),
+  releaseNamedLock: vi.fn().mockResolvedValue(undefined),
+  getCommandWriteLockName: vi.fn((s: string) => `bcuk_cmd_${s}`),
+  isDeadlockError: vi.fn().mockReturnValue(false),
+  MAX_DEADLOCK_RETRIES: 3,
+}));
+vi.mock('./commandStringUtils', () => ({
+  CommandConflictError: class CommandConflictError extends Error {
+    commands: string[];
+    constructor(cmds: string[]) {
+      super(String(cmds));
+      this.commands = cmds;
+    }
+  },
+}));
+
+import {
+  assertDiscordTriggerAvailable,
+  assertMultiTwitchTriggerAvailable,
+  assertNoSingleTwitchAssignmentOverlap,
+  assertNoTwitchChannelTriggerConflict,
+  getCommandTriggerStringById,
+  getUserTwitchEligibility,
+  insertUserCommandAssignment,
+} from './commandConflicts';
+import { CommandConflictError } from './commandStringUtils';
+import { normalizeTwitchChannelName } from '../twitch/twitchChannelName';
+
+// Cast to any to satisfy SqlExecutor (Pool | PoolConnection) without importing full mysql types
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeExecutor(rows: unknown[] = []): any {
+  return { execute: vi.fn().mockResolvedValue([[...rows], []]) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(normalizeTwitchChannelName).mockImplementation((s: string) => s ? s.toLowerCase() : null);
+});
+
+// ─── assertDiscordTriggerAvailable ───────────────────────────────────────────
+
+describe('assertDiscordTriggerAvailable', () => {
+  it('does not throw when no conflict rows returned', async () => {
+    const exec = makeExecutor([]);
+    await expect(assertDiscordTriggerAvailable('!test', exec)).resolves.not.toThrow();
+  });
+
+  it('throws CommandConflictError when a conflict row is found', async () => {
+    const exec = makeExecutor([{ command_id: 1 }]);
+    await expect(assertDiscordTriggerAvailable('!test', exec)).rejects.toBeInstanceOf(CommandConflictError);
+  });
+
+  it('includes the trigger string in the conflict error', async () => {
+    const exec = makeExecutor([{ command_id: 1 }]);
+    const error = await assertDiscordTriggerAvailable('!test', exec).catch((e) => e);
+    expect(error.commands).toContain('!test');
+  });
+
+  it('adds AND command_id <> ? clause when excludeCommandId is provided', async () => {
+    const exec = makeExecutor([]);
+    await assertDiscordTriggerAvailable('!test', exec, 42);
+    const sql: string = exec.execute.mock.calls[0][0];
+    expect(sql).toContain('command_id <> ?');
+    expect(exec.execute.mock.calls[0][1]).toContain(42);
+  });
+
+  it('does not add exclude clause when excludeCommandId is undefined', async () => {
+    const exec = makeExecutor([]);
+    await assertDiscordTriggerAvailable('!test', exec);
+    const sql: string = exec.execute.mock.calls[0][0];
+    expect(sql).not.toContain('command_id <> ?');
+  });
+});
+
+// ─── assertMultiTwitchTriggerAvailable ───────────────────────────────────────
+
+describe('assertMultiTwitchTriggerAvailable', () => {
+  it('does not throw when no multi-twitch conflict', async () => {
+    const exec = makeExecutor([]);
+    await expect(assertMultiTwitchTriggerAvailable(exec, '!test')).resolves.not.toThrow();
+  });
+
+  it('throws CommandConflictError when a multi-twitch conflict exists', async () => {
+    const exec = makeExecutor([{ command_id: 5 }]);
+    await expect(assertMultiTwitchTriggerAvailable(exec, '!test')).rejects.toBeInstanceOf(CommandConflictError);
+  });
+
+  it('uses exclude clause when excludeCommandId is provided', async () => {
+    const exec = makeExecutor([]);
+    await assertMultiTwitchTriggerAvailable(exec, '!test', 7);
+    const sql: string = exec.execute.mock.calls[0][0];
+    expect(sql).toContain('c.command_id <> ?');
+    expect(exec.execute.mock.calls[0][1]).toContain(7);
+  });
+
+  it('does not use exclude clause when no excludeCommandId', async () => {
+    const exec = makeExecutor([]);
+    await assertMultiTwitchTriggerAvailable(exec, '!test');
+    const sql: string = exec.execute.mock.calls[0][0];
+    expect(sql).not.toContain('c.command_id <> ?');
+  });
+});
+
+// ─── assertNoSingleTwitchAssignmentOverlap ────────────────────────────────────
+
+describe('assertNoSingleTwitchAssignmentOverlap', () => {
+  it('does not throw when no overlap rows returned', async () => {
+    const exec = makeExecutor([]);
+    await expect(assertNoSingleTwitchAssignmentOverlap(exec, 1, '!test')).resolves.not.toThrow();
+  });
+
+  it('throws CommandConflictError when overlap exists', async () => {
+    const exec = makeExecutor([{ command_id: 2 }]);
+    await expect(assertNoSingleTwitchAssignmentOverlap(exec, 1, '!test')).rejects.toBeInstanceOf(CommandConflictError);
+  });
+});
+
+// ─── assertNoTwitchChannelTriggerConflict ─────────────────────────────────────
+
+describe('assertNoTwitchChannelTriggerConflict', () => {
+  it('does not throw when no conflict', async () => {
+    const exec = makeExecutor([]);
+    await expect(assertNoTwitchChannelTriggerConflict(exec, 1, '!test', 'alice')).resolves.not.toThrow();
+  });
+
+  it('throws CommandConflictError when conflict found', async () => {
+    const exec = makeExecutor([{ command_id: 3 }]);
+    await expect(assertNoTwitchChannelTriggerConflict(exec, 1, '!test', 'alice')).rejects.toBeInstanceOf(CommandConflictError);
+  });
+
+  it('passes commandId, triggerString, and normalizedTwitchName to the query', async () => {
+    const exec = makeExecutor([]);
+    await assertNoTwitchChannelTriggerConflict(exec, 10, '!clap', 'alice');
+    const params: unknown[] = exec.execute.mock.calls[0][1];
+    expect(params).toContain(10);
+    expect(params).toContain('!clap');
+    expect(params).toContain('alice');
+  });
+});
+
+// ─── getCommandTriggerStringById ─────────────────────────────────────────────
+
+describe('getCommandTriggerStringById', () => {
+  it('throws when no command found', async () => {
+    const exec = makeExecutor([]);
+    await expect(getCommandTriggerStringById(exec, 99)).rejects.toThrow('Custom command not found: 99');
+  });
+
+  it('returns trimmed lowercase trigger string', async () => {
+    const exec = makeExecutor([{ trigger_string: '  !CLAP  ' }]);
+    const result = await getCommandTriggerStringById(exec, 1);
+    expect(result).toBe('!clap');
+  });
+});
+
+// ─── getUserTwitchEligibility ─────────────────────────────────────────────────
+
+describe('getUserTwitchEligibility', () => {
+  it('throws when user not found', async () => {
+    const exec = makeExecutor([]);
+    await expect(getUserTwitchEligibility(exec, '999')).rejects.toThrow('User not found: 999');
+  });
+
+  it('returns null normalizedTwitchName when twitch_name is null', async () => {
+    const exec = makeExecutor([{ twitch_name: null, is_twitch_bot_enabled: 0 }]);
+    const result = await getUserTwitchEligibility(exec, '1');
+    expect(result.normalizedTwitchName).toBeNull();
+    expect(result.isTwitchBotEnabled).toBe(false);
+  });
+
+  it('normalizes twitch_name through normalizeTwitchChannelName', async () => {
+    vi.mocked(normalizeTwitchChannelName).mockReturnValue('alice');
+    const exec = makeExecutor([{ twitch_name: 'Alice', is_twitch_bot_enabled: 1 }]);
+    const result = await getUserTwitchEligibility(exec, '1');
+    expect(result.normalizedTwitchName).toBe('alice');
+    expect(result.isTwitchBotEnabled).toBe(true);
+  });
+
+  it('handles is_twitch_bot_enabled as a Buffer with value 0x01 → true', async () => {
+    const exec = makeExecutor([{ twitch_name: 'alice', is_twitch_bot_enabled: Buffer.from([1]) }]);
+    const result = await getUserTwitchEligibility(exec, '1');
+    expect(result.isTwitchBotEnabled).toBe(true);
+  });
+
+  it('handles is_twitch_bot_enabled as a Buffer with value 0x00 → false', async () => {
+    const exec = makeExecutor([{ twitch_name: 'alice', is_twitch_bot_enabled: Buffer.from([0]) }]);
+    const result = await getUserTwitchEligibility(exec, '1');
+    expect(result.isTwitchBotEnabled).toBe(false);
+  });
+
+  it('handles is_twitch_bot_enabled as numeric 1 → true', async () => {
+    const exec = makeExecutor([{ twitch_name: 'alice', is_twitch_bot_enabled: 1 }]);
+    const result = await getUserTwitchEligibility(exec, '1');
+    expect(result.isTwitchBotEnabled).toBe(true);
+  });
+
+  it('handles is_twitch_bot_enabled as numeric 0 → false', async () => {
+    const exec = makeExecutor([{ twitch_name: 'alice', is_twitch_bot_enabled: 0 }]);
+    const result = await getUserTwitchEligibility(exec, '1');
+    expect(result.isTwitchBotEnabled).toBe(false);
+  });
+});
+
+// ─── insertUserCommandAssignment ──────────────────────────────────────────────
+
+describe('insertUserCommandAssignment', () => {
+  it('executes an INSERT with commandId and discordId', async () => {
+    const exec = makeExecutor();
+    await insertUserCommandAssignment(exec, 5, 'user123');
+    expect(exec.execute).toHaveBeenCalledOnce();
+    const [sql, params] = exec.execute.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('INSERT INTO twitch_user_commands');
+    expect(params).toContain(5);
+    expect(params).toContain('user123');
+  });
+});

--- a/src/db/commandLocks.test.ts
+++ b/src/db/commandLocks.test.ts
@@ -1,19 +1,24 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../logger', () => ({ createLogger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn() }) }));
+vi.mock('../shared/logger', () => ({ createLogger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn() }) }));
 vi.mock('./pool', () => ({ getPool: vi.fn() }));
 vi.mock('mysql2/promise', () => ({ default: {} }));
 vi.mock('./commandStringUtils', () => ({
   CommandConflictError: class CommandConflictError extends Error {
+    commands: string[];
     constructor(cmds: string[]) {
       super(String(cmds));
+      this.commands = cmds;
     }
   },
-  normalizeCommandInputs: vi.fn(),
-  buildInClausePlaceholders: vi.fn(),
+  normalizeCommandInputs: vi.fn((x: string | string[]) => (Array.isArray(x) ? x : [x]).map((s: string) => s.trim().toLowerCase()).filter(Boolean)),
+  buildInClausePlaceholders: vi.fn((n: number) => Array(n).fill('?').join(',')),
 }));
 
-import { isDeadlockError, getCommandWriteLockName } from './commandLocks';
+import { getPool } from './pool';
+import { isDeadlockError, getCommandWriteLockName, acquireNamedLock, isAnyCommandTakenAcrossTables } from './commandLocks';
+import { CommandConflictError } from './commandStringUtils';
 
 describe('isDeadlockError', () => {
   it('returns true when code is ER_LOCK_DEADLOCK', () => {
@@ -78,5 +83,122 @@ describe('getCommandWriteLockName', () => {
     const hashPart = lockName.slice(prefix.length);
     expect(hashPart).toHaveLength(48);
     expect(hashPart).toMatch(/^[0-9a-f]{48}$/);
+  });
+});
+
+// ─── acquireNamedLock ─────────────────────────────────────────────────────────
+
+describe('acquireNamedLock', () => {
+  function makeConn(lockStatus: unknown) {
+    return { execute: vi.fn().mockResolvedValue([[{ lock_status: lockStatus }], []]) };
+  }
+
+  it('resolves without error when lock_status is the string "1"', async () => {
+    await expect(acquireNamedLock(makeConn('1') as any, 'test_lock')).resolves.not.toThrow();
+  });
+
+  it('resolves without error when lock_status is the number 1', async () => {
+    await expect(acquireNamedLock(makeConn(1) as any, 'test_lock')).resolves.not.toThrow();
+  });
+
+  it('throws a timeout error when lock_status is the string "0"', async () => {
+    await expect(acquireNamedLock(makeConn('0') as any, 'test_lock')).rejects.toThrow('Timed out acquiring command write lock');
+  });
+
+  it('throws a timeout error when lock_status is the number 0', async () => {
+    await expect(acquireNamedLock(makeConn(0) as any, 'test_lock')).rejects.toThrow('Timed out acquiring command write lock');
+  });
+
+  it('throws an internal error when lock_status is null', async () => {
+    await expect(acquireNamedLock(makeConn(null) as any, 'test_lock')).rejects.toThrow('Internal error acquiring command write lock');
+  });
+
+  it('throws an unexpected-result error for an unrecognized lock_status value', async () => {
+    await expect(acquireNamedLock(makeConn('unexpected') as any, 'test_lock')).rejects.toThrow('Unexpected result acquiring command write lock');
+  });
+
+  it('includes the lock name in the error message', async () => {
+    const error = await acquireNamedLock(makeConn('0') as any, 'bcuk_cmd_abc123').catch((e) => e);
+    expect(error.message).toContain('bcuk_cmd_abc123');
+  });
+
+  it('calls GET_LOCK with the lock name and timeout', async () => {
+    const conn = makeConn('1');
+    await acquireNamedLock(conn as any, 'my_lock');
+    const [sql, params] = conn.execute.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('GET_LOCK');
+    expect(params[0]).toBe('my_lock');
+  });
+});
+
+// ─── isAnyCommandTakenAcrossTables ────────────────────────────────────────────
+
+describe('isAnyCommandTakenAcrossTables', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns false immediately for an empty array without querying', async () => {
+    const pool = { execute: vi.fn() };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await isAnyCommandTakenAcrossTables([]);
+    expect(result).toBe(false);
+    expect(pool.execute).not.toHaveBeenCalled();
+  });
+
+  it('returns false when both tables return no rows', async () => {
+    const pool = { execute: vi.fn().mockResolvedValue([[]]  ) };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await isAnyCommandTakenAcrossTables('!test');
+    expect(result).toBe(false);
+  });
+
+  it('returns true when custom_command table returns a row', async () => {
+    const pool = {
+      execute: vi.fn()
+        .mockResolvedValueOnce([[{ '1': 1 }]])  // custom_command hit
+        .mockResolvedValueOnce([[]]),             // counter miss
+    };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await isAnyCommandTakenAcrossTables('!test');
+    expect(result).toBe(true);
+  });
+
+  it('returns true when only counter table returns a row', async () => {
+    const pool = {
+      execute: vi.fn()
+        .mockResolvedValueOnce([[]])               // custom_command miss
+        .mockResolvedValueOnce([[{ '1': 1 }]]),   // counter hit
+    };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await isAnyCommandTakenAcrossTables('!test');
+    expect(result).toBe(true);
+  });
+
+  it('skips custom_command table when includeCustomCommandTable is false', async () => {
+    const pool = { execute: vi.fn().mockResolvedValue([[]]  ) };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await isAnyCommandTakenAcrossTables('!test', undefined, pool as any, { includeCustomCommandTable: false, includeCounterTable: true });
+    const sql: string = pool.execute.mock.calls[0][0];
+    expect(sql).toContain('counter');
+    expect(sql).not.toContain('custom_command');
+  });
+
+  it('skips counter table when includeCounterTable is false', async () => {
+    const pool = { execute: vi.fn().mockResolvedValue([[]]  ) };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await isAnyCommandTakenAcrossTables('!test', undefined, pool as any, { includeCustomCommandTable: true, includeCounterTable: false });
+    expect(pool.execute).toHaveBeenCalledOnce();
+    const sql: string = pool.execute.mock.calls[0][0];
+    expect(sql).toContain('custom_command');
+  });
+
+  it('passes excludeCustomCommandId to custom_command query', async () => {
+    const pool = { execute: vi.fn().mockResolvedValue([[]]  ) };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await isAnyCommandTakenAcrossTables('!test', { excludeCustomCommandId: 7 }, pool as any);
+    const customCmdCall = pool.execute.mock.calls.find((args) => (args[0] as string).includes('custom_command'));
+    expect(customCmdCall).toBeDefined();
+    expect(customCmdCall![1]).toContain(7);
   });
 });

--- a/src/db/counters.test.ts
+++ b/src/db/counters.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./pool', () => ({ getPool: vi.fn() }));
+vi.mock('mysql2/promise', () => ({ default: {} }));
+vi.mock('./commandLocks', () => ({
+  runSerializedCommandWrite: vi.fn(async (_cmds: unknown, _opts: unknown, fn: (conn: unknown) => Promise<unknown>) => fn(mockConnection)),
+}));
+vi.mock('./commandStringUtils', () => ({
+  requireTrimmedString: vi.fn((v: string, _name: string, _max?: number) => {
+    const t = v.trim();
+    if (!t) throw new Error(`${_name} is required`);
+    return t;
+  }),
+  CommandConflictError: class CommandConflictError extends Error {
+    constructor(cmds: string[]) { super(String(cmds)); }
+  },
+}));
+vi.mock('./reservedCommands', () => ({
+  assertNotReservedCommand: vi.fn(),
+}));
+vi.mock('./utils', () => ({
+  fromBit: vi.fn((v: unknown) => (Buffer.isBuffer(v) ? v[0] === 1 : v == 1)),
+}));
+vi.mock('./counterCache', () => ({
+  invalidateCounterLookupCache: vi.fn(),
+}));
+
+// Shared mock connection used by runSerializedCommandWrite
+const mockConnection = {
+  execute: vi.fn(),
+  beginTransaction: vi.fn().mockResolvedValue(undefined),
+  commit: vi.fn().mockResolvedValue(undefined),
+  rollback: vi.fn().mockResolvedValue(undefined),
+  release: vi.fn(),
+};
+
+import { getPool } from './pool';
+import {
+  getAllCounters,
+  addCounter,
+  updateCounter,
+  removeCounter,
+  resetCounterCurrentValue,
+  incrementCounter,
+  archiveAndResetYearlyCounters,
+  CounterNotFoundError,
+} from './counters';
+import { runSerializedCommandWrite } from './commandLocks';
+import { assertNotReservedCommand } from './reservedCommands';
+import { invalidateCounterLookupCache } from './counterCache';
+
+function makePool(rows: unknown[] = [], meta: unknown = {}) {
+  const conn = {
+    execute: vi.fn(),
+    beginTransaction: vi.fn().mockResolvedValue(undefined),
+    commit: vi.fn().mockResolvedValue(undefined),
+    rollback: vi.fn().mockResolvedValue(undefined),
+    release: vi.fn(),
+  };
+  return {
+    execute: vi.fn().mockResolvedValue([[...rows], meta]),
+    getConnection: vi.fn().mockResolvedValue(conn),
+    _conn: conn,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─── CounterNotFoundError ────────────────────────────────────────────────────
+
+describe('CounterNotFoundError', () => {
+  it('has name CounterNotFoundError', () => {
+    const err = new CounterNotFoundError(42);
+    expect(err.name).toBe('CounterNotFoundError');
+  });
+
+  it('includes the id in the message', () => {
+    expect(new CounterNotFoundError(7).message).toContain('7');
+  });
+
+  it('is an instance of Error', () => {
+    expect(new CounterNotFoundError(1)).toBeInstanceOf(Error);
+  });
+});
+
+// ─── getAllCounters ───────────────────────────────────────────────────────────
+
+describe('getAllCounters', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    expect(await getAllCounters()).toEqual([]);
+  });
+
+  it('maps rows via fromBit for reset_yearly', async () => {
+    const rows = [
+      { id: 1, trigger_command: '!hits', check_command: '!checkhits', message: 'msg', increment_message: 'inc', reset_yearly: 1, current_value: 5 },
+      { id: 2, trigger_command: '!deaths', check_command: '!checkdeaths', message: 'm2', increment_message: 'i2', reset_yearly: 0, current_value: 0 },
+    ];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await getAllCounters();
+    expect(result).toHaveLength(2);
+    expect(result[0].reset_yearly).toBe(true);
+    expect(result[1].reset_yearly).toBe(false);
+    expect(result[0].current_value).toBe(5);
+  });
+});
+
+// ─── addCounter ──────────────────────────────────────────────────────────────
+
+describe('addCounter', () => {
+  it('throws when trigger and check command are the same', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    await expect(addCounter('!hits', '!hits', 'msg', 'inc', false)).rejects.toThrow('must be different');
+  });
+
+  it('calls assertNotReservedCommand for both commands', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    mockConnection.execute.mockResolvedValue([{}, []]);
+    await addCounter('!hits', '!checkhits', 'msg', 'inc', false);
+    expect(assertNotReservedCommand).toHaveBeenCalledWith('!hits');
+    expect(assertNotReservedCommand).toHaveBeenCalledWith('!checkhits');
+  });
+
+  it('calls runSerializedCommandWrite with both commands', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    mockConnection.execute.mockResolvedValue([{}, []]);
+    await addCounter('!hits', '!checkhits', 'msg', 'inc', true);
+    expect(runSerializedCommandWrite).toHaveBeenCalledWith(
+      ['!hits', '!checkhits'],
+      undefined,
+      expect.any(Function),
+    );
+  });
+
+  it('invalidates the counter cache after success', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    mockConnection.execute.mockResolvedValue([{}, []]);
+    await addCounter('!hits', '!checkhits', 'msg', 'inc', false);
+    expect(invalidateCounterLookupCache).toHaveBeenCalled();
+  });
+
+  it('throws when trigger and check differ only by case (normalized to same value)', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    await expect(addCounter('!HITS', '!hits', 'msg', 'inc', false)).rejects.toThrow('must be different');
+  });
+});
+
+// ─── updateCounter ────────────────────────────────────────────────────────────
+
+describe('updateCounter', () => {
+  it('throws when trigger and check are the same', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([{ trigger_command: '!old', check_command: '!oldcheck' }]) as any);
+    await expect(updateCounter({ id: 1, triggerCommand: '!hits', checkCommand: '!hits', message: 'm', incrementMessage: 'i', resetYearly: false }))
+      .rejects.toThrow('must be different');
+  });
+
+  it('throws CounterNotFoundError when getCounterCommandsById returns null', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    await expect(updateCounter({ id: 99, triggerCommand: '!hits', checkCommand: '!check', message: 'm', incrementMessage: 'i', resetYearly: false }))
+      .rejects.toBeInstanceOf(CounterNotFoundError);
+  });
+
+  it('calls assertNotReservedCommand for both commands', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([{ trigger_command: '!old', check_command: '!oldcheck' }]) as any);
+    mockConnection.execute.mockResolvedValue([{ affectedRows: 1 }, []]);
+    await updateCounter({ id: 1, triggerCommand: '!new', checkCommand: '!newcheck', message: 'm', incrementMessage: 'i', resetYearly: false });
+    expect(assertNotReservedCommand).toHaveBeenCalledWith('!new');
+    expect(assertNotReservedCommand).toHaveBeenCalledWith('!newcheck');
+  });
+
+  it('invalidates the counter cache after success', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([{ trigger_command: '!old', check_command: '!oldcheck' }]) as any);
+    mockConnection.execute.mockResolvedValue([{ affectedRows: 1 }, []]);
+    await updateCounter({ id: 1, triggerCommand: '!new', checkCommand: '!check', message: 'm', incrementMessage: 'i', resetYearly: false });
+    expect(invalidateCounterLookupCache).toHaveBeenCalled();
+  });
+});
+
+// ─── removeCounter ────────────────────────────────────────────────────────────
+
+describe('removeCounter', () => {
+  it('throws CounterNotFoundError when counter does not exist', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    await expect(removeCounter(99)).rejects.toBeInstanceOf(CounterNotFoundError);
+  });
+
+  it('calls runSerializedCommandWrite with existing commands', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([{ trigger_command: '!hits', check_command: '!checkhits' }]) as any);
+    mockConnection.execute.mockResolvedValue([{ affectedRows: 1 }, []]);
+    await removeCounter(1);
+    expect(runSerializedCommandWrite).toHaveBeenCalledWith(
+      ['!hits', '!checkhits'],
+      { excludeCounterId: 1 },
+      expect.any(Function),
+    );
+  });
+
+  it('invalidates cache after removal', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([{ trigger_command: '!hits', check_command: '!checkhits' }]) as any);
+    mockConnection.execute.mockResolvedValue([{ affectedRows: 1 }, []]);
+    await removeCounter(1);
+    expect(invalidateCounterLookupCache).toHaveBeenCalled();
+  });
+});
+
+// ─── resetCounterCurrentValue ─────────────────────────────────────────────────
+
+describe('resetCounterCurrentValue', () => {
+  it('throws CounterNotFoundError when no rows affected and counter not found', async () => {
+    const pool = makePool();
+    pool.execute
+      .mockResolvedValueOnce([{ affectedRows: 0 }, []])  // UPDATE: ResultSetHeader (affectedRows=0)
+      .mockResolvedValueOnce([[], []]);                    // EXISTS check: no rows
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(resetCounterCurrentValue(99)).rejects.toBeInstanceOf(CounterNotFoundError);
+  });
+
+  it('does not throw when affectedRows > 0', async () => {
+    const pool = makePool();
+    pool.execute.mockResolvedValue([{ affectedRows: 1 }, []]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(resetCounterCurrentValue(1)).resolves.not.toThrow();
+  });
+
+  it('invalidates cache on success', async () => {
+    const pool = makePool();
+    pool.execute.mockResolvedValue([[{ affectedRows: 1 }], []]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await resetCounterCurrentValue(1);
+    expect(invalidateCounterLookupCache).toHaveBeenCalled();
+  });
+});
+
+// ─── incrementCounter ─────────────────────────────────────────────────────────
+
+describe('incrementCounter', () => {
+  it('throws CounterNotFoundError when UPDATE affects 0 rows', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute
+      .mockResolvedValueOnce([{ affectedRows: 0 }, []]);  // UPDATE: ResultSetHeader
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(incrementCounter(99)).rejects.toBeInstanceOf(CounterNotFoundError);
+    expect(conn.rollback).toHaveBeenCalled();
+  });
+
+  it('returns the new current_value on success', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute
+      .mockResolvedValueOnce([{ affectedRows: 1 }, []])       // UPDATE: ResultSetHeader
+      .mockResolvedValueOnce([[{ current_value: 7 }], []]);    // SELECT: rows
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await incrementCounter(1);
+    expect(result).toBe(7);
+    expect(conn.commit).toHaveBeenCalled();
+  });
+
+  it('releases the connection even when it throws', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute.mockRejectedValue(new Error('DB error'));
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(incrementCounter(1)).rejects.toThrow('DB error');
+    expect(conn.release).toHaveBeenCalled();
+  });
+
+  it('invalidates cache on success', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute
+      .mockResolvedValueOnce([[{ affectedRows: 1 }], []])
+      .mockResolvedValueOnce([[{ current_value: 3 }], []]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await incrementCounter(1);
+    expect(invalidateCounterLookupCache).toHaveBeenCalled();
+  });
+});
+
+// ─── archiveAndResetYearlyCounters ────────────────────────────────────────────
+
+describe('archiveAndResetYearlyCounters', () => {
+  it('throws for a year before 2020', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    await expect(archiveAndResetYearlyCounters(2019)).rejects.toThrow('Invalid archive year: 2019');
+  });
+
+  it('throws for a year after 2100', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    await expect(archiveAndResetYearlyCounters(2101)).rejects.toThrow('Invalid archive year: 2101');
+  });
+
+  it('accepts year 2020 (lower boundary)', async () => {
+    const pool = makePool();
+    pool.execute.mockResolvedValue([{ affectedRows: 3 }, []]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(archiveAndResetYearlyCounters(2020)).resolves.toBe(3);
+  });
+
+  it('accepts year 2100 (upper boundary)', async () => {
+    const pool = makePool();
+    pool.execute.mockResolvedValue([{ affectedRows: 0 }, []]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(archiveAndResetYearlyCounters(2100)).resolves.toBe(0);
+  });
+
+  it('returns the number of affected rows', async () => {
+    const pool = makePool();
+    pool.execute.mockResolvedValue([{ affectedRows: 5 }, []]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    expect(await archiveAndResetYearlyCounters(2024)).toBe(5);
+  });
+
+  it('includes the column name for the given year in the SQL', async () => {
+    const pool = makePool();
+    pool.execute.mockResolvedValue([{ affectedRows: 1 }, []]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await archiveAndResetYearlyCounters(2024);
+    const [sql] = pool.execute.mock.calls[0] as [string];
+    expect(sql).toContain('value2024');
+  });
+
+  it('invalidates cache after archiving', async () => {
+    const pool = makePool();
+    pool.execute.mockResolvedValue([{ affectedRows: 2 }, []]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await archiveAndResetYearlyCounters(2025);
+    expect(invalidateCounterLookupCache).toHaveBeenCalled();
+  });
+});

--- a/src/db/eventSub.test.ts
+++ b/src/db/eventSub.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./pool', () => ({ getPool: vi.fn() }));
+vi.mock('mysql2/promise', () => ({ default: {} }));
+// Use a mutable variable so individual tests can temporarily clear the secret.
+let mockSecret: string | undefined = 'a'.repeat(64);
+vi.mock('../shared/config', () => ({
+  get EVENTSUB_TOKEN_SECRET() { return mockSecret; },
+}));
+vi.mock('../shared/crypto', () => ({
+  encryptToken: vi.fn((value: string) => `enc:${value}`),
+  decryptToken: vi.fn((value: string) => value.replace('enc:', '')),
+}));
+
+import { getPool } from './pool';
+import { encryptToken, decryptToken } from '../shared/crypto';
+import {
+  getAllEventSubStreamers,
+  getStreamerByDiscordId,
+  getStreamerById,
+  saveStreamerToken,
+  clearStreamerToken,
+  initEventConfig,
+  saveEventConfig,
+} from './eventSub';
+
+function makePool(rows: unknown[] = []) {
+  return { execute: vi.fn().mockResolvedValue([[...rows], []]) };
+}
+
+function makeRow(overrides: object = {}): Record<string, unknown> {
+  return {
+    id: 1,
+    discord_id: '100',
+    twitch_name: 'alice',
+    twitch_user_id: 'uid1',
+    eventsub_access_token: null,
+    eventsub_refresh_token: null,
+    eventsub_token_expiry: null,
+    follow_enabled: null,  // null → config is null
+    follow_message: null,
+    sub_enabled: null,
+    sub_message: null,
+    resub_message: null,
+    giftsub_message: null,
+    raid_enabled: null,
+    raid_message: null,
+    ...overrides,
+  };
+}
+
+function makeRowWithConfig(overrides: object = {}): Record<string, unknown> {
+  return makeRow({
+    follow_enabled: 1,
+    follow_message: 'Thanks {display_name}!',
+    sub_enabled: 0,
+    sub_message: 'Sub msg',
+    resub_message: 'Resub msg',
+    giftsub_message: 'Gift msg',
+    raid_enabled: 1,
+    raid_message: 'Raid msg',
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(encryptToken).mockImplementation((v: string) => `enc:${v}`);
+  vi.mocked(decryptToken).mockImplementation((v: string) => v.replace('enc:', ''));
+});
+
+// ─── getAllEventSubStreamers ───────────────────────────────────────────────────
+
+describe('getAllEventSubStreamers', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    expect(await getAllEventSubStreamers()).toEqual([]);
+  });
+
+  it('maps a row with no config (follow_enabled=null) to config=null', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([makeRow()]) as any);
+    const [s] = await getAllEventSubStreamers();
+    expect(s.config).toBeNull();
+  });
+
+  it('maps a row with config correctly, including BIT flags', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([makeRowWithConfig()]) as any);
+    const [s] = await getAllEventSubStreamers();
+    expect(s.config).not.toBeNull();
+    expect(s.config!.follow_enabled).toBe(true);
+    expect(s.config!.sub_enabled).toBe(false);
+    expect(s.config!.raid_enabled).toBe(true);
+  });
+
+  it('maps BIT(1) config flags as Buffer correctly', async () => {
+    const row = makeRowWithConfig({ follow_enabled: Buffer.from([1]), sub_enabled: Buffer.from([0]), raid_enabled: Buffer.from([0]) });
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const [s] = await getAllEventSubStreamers();
+    expect(s.config!.follow_enabled).toBe(true);
+    expect(s.config!.sub_enabled).toBe(false);
+    expect(s.config!.raid_enabled).toBe(false);
+  });
+
+  it('decrypts access and refresh tokens via maybeDecrypt', async () => {
+    const row = makeRow({ eventsub_access_token: 'enc:accessabc', eventsub_refresh_token: 'enc:refreshxyz' });
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const [s] = await getAllEventSubStreamers();
+    expect(s.eventsub_access_token).toBe('accessabc');
+    expect(s.eventsub_refresh_token).toBe('refreshxyz');
+  });
+
+  it('returns null tokens when decryptToken throws', async () => {
+    vi.mocked(decryptToken).mockImplementation(() => { throw new Error('Bad decrypt'); });
+    const row = makeRow({ eventsub_access_token: 'corrupted', eventsub_refresh_token: 'bad' });
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const [s] = await getAllEventSubStreamers();
+    expect(s.eventsub_access_token).toBeNull();
+    expect(s.eventsub_refresh_token).toBeNull();
+  });
+
+  it('coerces discord_id to string', async () => {
+    const row = makeRow({ discord_id: 12345n });
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const [s] = await getAllEventSubStreamers();
+    expect(s.discord_id).toBe('12345');
+  });
+
+  it('converts eventsub_token_expiry to Number', async () => {
+    const row = makeRow({ eventsub_token_expiry: '9007199254740993' });
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const [s] = await getAllEventSubStreamers();
+    expect(typeof s.eventsub_token_expiry).toBe('number');
+  });
+
+  it('maps eventsub_token_expiry=null to null', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([makeRow()]) as any);
+    const [s] = await getAllEventSubStreamers();
+    expect(s.eventsub_token_expiry).toBeNull();
+  });
+});
+
+// ─── getStreamerByDiscordId ───────────────────────────────────────────────────
+
+describe('getStreamerByDiscordId', () => {
+  it('returns null when no rows found', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    expect(await getStreamerByDiscordId('999')).toBeNull();
+  });
+
+  it('maps the found row', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([makeRow()]) as any);
+    const result = await getStreamerByDiscordId('100');
+    expect(result!.discord_id).toBe('100');
+  });
+
+  it('queries with the given discordId', async () => {
+    const pool = makePool([]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await getStreamerByDiscordId('abc');
+    expect(pool.execute.mock.calls[0][1]).toContain('abc');
+  });
+});
+
+// ─── getStreamerById ──────────────────────────────────────────────────────────
+
+describe('getStreamerById', () => {
+  it('returns null when no rows found', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    expect(await getStreamerById(999)).toBeNull();
+  });
+
+  it('queries with the given id', async () => {
+    const pool = makePool([]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await getStreamerById(42);
+    expect(pool.execute.mock.calls[0][1]).toContain(42);
+  });
+});
+
+// ─── saveStreamerToken ────────────────────────────────────────────────────────
+
+describe('saveStreamerToken', () => {
+  it('throws when EVENTSUB_TOKEN_SECRET is not configured', async () => {
+    const prev = mockSecret;
+    mockSecret = undefined;
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    await expect(saveStreamerToken(1, 'uid', 'access', 'refresh', null)).rejects.toThrow('EVENTSUB_TOKEN_SECRET');
+    mockSecret = prev;
+  });
+
+  it('encrypts tokens before saving', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await saveStreamerToken(1, 'uid', 'myaccess', 'myrefresh', 1234567890);
+    const params: unknown[] = pool.execute.mock.calls[0][1];
+    expect(params).toContain('enc:myaccess');
+    expect(params).toContain('enc:myrefresh');
+    expect(params).not.toContain('myaccess');
+    expect(params).not.toContain('myrefresh');
+  });
+
+  it('includes twitchUserId, expiryMs, and streamerId in the query params', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await saveStreamerToken(7, 'u123', 'a', 'r', 9999);
+    const params: unknown[] = pool.execute.mock.calls[0][1];
+    expect(params).toContain('u123');
+    expect(params).toContain(9999);
+    expect(params).toContain(7);
+  });
+});
+
+// ─── clearStreamerToken ───────────────────────────────────────────────────────
+
+describe('clearStreamerToken', () => {
+  it('executes UPDATE NULLing token fields for the given streamerId', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await clearStreamerToken(5);
+    const [sql, params] = pool.execute.mock.calls[0] as [string, unknown[]];
+    expect(sql.toLowerCase()).toContain('update');
+    expect(params).toContain(5);
+  });
+});
+
+// ─── initEventConfig ──────────────────────────────────────────────────────────
+
+describe('initEventConfig', () => {
+  it('uses INSERT IGNORE in the SQL', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await initEventConfig(3);
+    const sql: string = pool.execute.mock.calls[0][0];
+    expect(sql.toUpperCase()).toContain('INSERT IGNORE');
+  });
+
+  it('includes the streamerId in the params', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await initEventConfig(42);
+    expect(pool.execute.mock.calls[0][1]).toContain(42);
+  });
+});
+
+// ─── saveEventConfig ──────────────────────────────────────────────────────────
+
+describe('saveEventConfig', () => {
+  const eventConfig: import('./eventSub').EventSubConfig = {
+    follow_enabled: true,
+    follow_message: 'follow!',
+    sub_enabled: false,
+    sub_message: 'sub!',
+    resub_message: 'resub!',
+    giftsub_message: 'gift!',
+    raid_enabled: true,
+    raid_message: 'raid!',
+  };
+
+  it('uses ON DUPLICATE KEY UPDATE in the SQL', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await saveEventConfig(1, eventConfig);
+    const sql: string = pool.execute.mock.calls[0][0];
+    expect(sql.toUpperCase()).toContain('ON DUPLICATE KEY UPDATE');
+  });
+
+  it('converts boolean flags to 1/0 in params', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await saveEventConfig(1, eventConfig);
+    const params: unknown[] = pool.execute.mock.calls[0][1];
+    // follow_enabled=true → 1, sub_enabled=false → 0
+    expect(params).toContain(1);
+    expect(params).toContain(0);
+  });
+
+  it('includes all message strings in params', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await saveEventConfig(1, eventConfig);
+    const params: unknown[] = pool.execute.mock.calls[0][1];
+    expect(params).toContain('follow!');
+    expect(params).toContain('sub!');
+    expect(params).toContain('resub!');
+    expect(params).toContain('gift!');
+    expect(params).toContain('raid!');
+  });
+});

--- a/src/db/overlayVideos.test.ts
+++ b/src/db/overlayVideos.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./pool', () => ({ getPool: vi.fn() }));
+vi.mock('mysql2/promise', () => ({ default: {} }));
+
+import { getPool } from './pool';
+import {
+  getVideosForStreamer,
+  addVideo,
+  getVideoById,
+  deleteVideo,
+  getRewardsForStreamer,
+  upsertReward,
+  setRewardVideos,
+  deleteReward,
+  getVideosForReward,
+} from './overlayVideos';
+
+function makePool(rows: unknown[] = [], meta: unknown = {}) {
+  const conn = {
+    execute: vi.fn(),
+    beginTransaction: vi.fn().mockResolvedValue(undefined),
+    commit: vi.fn().mockResolvedValue(undefined),
+    rollback: vi.fn().mockResolvedValue(undefined),
+    release: vi.fn(),
+  };
+  return {
+    execute: vi.fn().mockResolvedValue([[...rows], meta]),
+    getConnection: vi.fn().mockResolvedValue(conn),
+    _conn: conn,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─── getVideosForStreamer ─────────────────────────────────────────────────────
+
+describe('getVideosForStreamer', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    expect(await getVideosForStreamer(1)).toEqual([]);
+  });
+
+  it('maps rows correctly', async () => {
+    const now = new Date();
+    const rows = [{ id: 10, streamer_id: 1, name: 'Intro', filename: 'intro.mp4', created_at: now }];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const [v] = await getVideosForStreamer(1);
+    expect(v.id).toBe(10);
+    expect(v.name).toBe('Intro');
+    expect(v.filename).toBe('intro.mp4');
+    expect(v.created_at).toBe(now);
+  });
+
+  it('queries with the given streamerId', async () => {
+    const pool = makePool([]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await getVideosForStreamer(42);
+    expect(pool.execute.mock.calls[0][1]).toContain(42);
+  });
+});
+
+// ─── addVideo ────────────────────────────────────────────────────────────────
+
+describe('addVideo', () => {
+  it('returns the insertId from the result', async () => {
+    const pool = makePool();
+    pool.execute.mockResolvedValue([{ insertId: 99 }, []]);  // ResultSetHeader format
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const id = await addVideo(1, 'Clip', 'clip.mp4');
+    expect(id).toBe(99);
+  });
+
+  it('passes streamerId, name, filename to execute', async () => {
+    const pool = makePool();
+    pool.execute.mockResolvedValue([[{ insertId: 1 }], []]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await addVideo(5, 'MyVid', 'vid.mp4');
+    expect(pool.execute.mock.calls[0][1]).toEqual([5, 'MyVid', 'vid.mp4']);
+  });
+});
+
+// ─── getVideoById ─────────────────────────────────────────────────────────────
+
+describe('getVideoById', () => {
+  it('returns null when no rows found', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    expect(await getVideoById(1, 1)).toBeNull();
+  });
+
+  it('maps the found row', async () => {
+    const now = new Date();
+    const row = { id: 5, streamer_id: 2, name: 'Clip', filename: 'clip.mp4', created_at: now };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const v = await getVideoById(5, 2);
+    expect(v!.id).toBe(5);
+    expect(v!.name).toBe('Clip');
+  });
+
+  it('queries with videoId and streamerId', async () => {
+    const pool = makePool([]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await getVideoById(7, 3);
+    expect(pool.execute.mock.calls[0][1]).toEqual([7, 3]);
+  });
+});
+
+// ─── deleteVideo ──────────────────────────────────────────────────────────────
+
+describe('deleteVideo', () => {
+  it('returns null when video not found', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute.mockResolvedValueOnce([[], []]);  // SELECT returns no rows
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await deleteVideo(99, 1);
+    expect(result).toBeNull();
+    expect(conn.rollback).toHaveBeenCalled();
+  });
+
+  it('returns null when DELETE affects 0 rows', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute
+      .mockResolvedValueOnce([[{ filename: 'old.mp4' }], []])  // SELECT: rows
+      .mockResolvedValueOnce([{ affectedRows: 0 }, []]);         // DELETE: ResultSetHeader
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await deleteVideo(1, 1);
+    expect(result).toBeNull();
+    expect(conn.rollback).toHaveBeenCalled();
+  });
+
+  it('returns filename on success', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute
+      .mockResolvedValueOnce([[{ filename: 'clip.mp4' }], []])  // SELECT: rows
+      .mockResolvedValueOnce([{ affectedRows: 1 }, []]);          // DELETE: ResultSetHeader
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await deleteVideo(1, 1);
+    expect(result).toBe('clip.mp4');
+    expect(conn.commit).toHaveBeenCalled();
+  });
+
+  it('releases connection even when an error is thrown', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute.mockRejectedValue(new Error('DB error'));
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(deleteVideo(1, 1)).rejects.toThrow('DB error');
+    expect(conn.release).toHaveBeenCalled();
+  });
+});
+
+// ─── getRewardsForStreamer ─────────────────────────────────────────────────────
+
+describe('getRewardsForStreamer', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    expect(await getRewardsForStreamer(1)).toEqual([]);
+  });
+
+  it('groups videos under their reward', async () => {
+    const rows = [
+      { id: 1, streamer_id: 1, twitch_reward_id: 'rwdA', video_id: 10, weight: 2, name: 'Intro', filename: 'intro.mp4' },
+      { id: 1, streamer_id: 1, twitch_reward_id: 'rwdA', video_id: 11, weight: 1, name: 'Outro', filename: 'outro.mp4' },
+    ];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await getRewardsForStreamer(1);
+    expect(result).toHaveLength(1);
+    expect(result[0].twitch_reward_id).toBe('rwdA');
+    expect(result[0].videos).toHaveLength(2);
+    expect(result[0].videos[0].weight).toBe(2);
+  });
+
+  it('handles multiple rewards', async () => {
+    const rows = [
+      { id: 1, streamer_id: 1, twitch_reward_id: 'rwdA', video_id: 10, weight: 1, name: 'A', filename: 'a.mp4' },
+      { id: 2, streamer_id: 1, twitch_reward_id: 'rwdB', video_id: 20, weight: 3, name: 'B', filename: 'b.mp4' },
+    ];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await getRewardsForStreamer(1);
+    expect(result).toHaveLength(2);
+  });
+
+  it('skips null video_id rows (reward with no videos)', async () => {
+    const rows = [{ id: 1, streamer_id: 1, twitch_reward_id: 'rwdA', video_id: null, weight: null, name: null, filename: null }];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await getRewardsForStreamer(1);
+    expect(result).toHaveLength(1);
+    expect(result[0].videos).toHaveLength(0);
+  });
+});
+
+// ─── upsertReward ─────────────────────────────────────────────────────────────
+
+describe('upsertReward', () => {
+  it('returns the insertId', async () => {
+    const pool = makePool();
+    pool.execute.mockResolvedValue([{ insertId: 5 }, []]);  // ResultSetHeader format
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    expect(await upsertReward(1, 'reward123')).toBe(5);
+  });
+
+  it('passes streamerId and twitchRewardId to execute', async () => {
+    const pool = makePool();
+    pool.execute.mockResolvedValue([[{ insertId: 1 }], []]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await upsertReward(7, 'rewardXYZ');
+    expect(pool.execute.mock.calls[0][1]).toEqual([7, 'rewardXYZ']);
+  });
+});
+
+// ─── setRewardVideos ──────────────────────────────────────────────────────────
+
+describe('setRewardVideos', () => {
+  it('rolls back and returns when reward does not belong to streamer', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute.mockResolvedValueOnce([[], []]);  // ownership check: no rows
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await setRewardVideos(1, 99, [{ videoId: 5, weight: 2 }]);
+    expect(conn.rollback).toHaveBeenCalled();
+    expect(conn.commit).not.toHaveBeenCalled();
+  });
+
+  it('commits when all videos belong to streamer', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute
+      .mockResolvedValueOnce([[{ id: 1 }], []])         // ownership check: rows
+      .mockResolvedValueOnce([{ affectedRows: 1 }, []])  // DELETE: ResultSetHeader
+      .mockResolvedValueOnce([{ affectedRows: 1 }, []]);  // INSERT: ResultSetHeader
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await setRewardVideos(1, 1, [{ videoId: 5, weight: 2 }]);
+    expect(conn.commit).toHaveBeenCalled();
+  });
+
+  it('throws when a video does not belong to the streamer', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute
+      .mockResolvedValueOnce([[{ id: 1 }], []])         // ownership check: rows
+      .mockResolvedValueOnce([{ affectedRows: 1 }, []])  // DELETE: ResultSetHeader
+      .mockResolvedValueOnce([{ affectedRows: 0 }, []]);  // INSERT: affectedRows=0 → wrong streamer
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(setRewardVideos(1, 1, [{ videoId: 999, weight: 1 }])).rejects.toThrow('does not belong to streamer');
+    expect(conn.rollback).toHaveBeenCalled();
+  });
+
+  it('releases connection on error', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute
+      .mockResolvedValueOnce([[{ id: 1 }], []])
+      .mockRejectedValueOnce(new Error('DB crash'));
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(setRewardVideos(1, 1, [])).rejects.toThrow('DB crash');
+    expect(conn.release).toHaveBeenCalled();
+  });
+
+  it('clamps weight to minimum of 1 via Math.max', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute
+      .mockResolvedValueOnce([[{ id: 1 }], []])         // ownership check
+      .mockResolvedValueOnce([{ affectedRows: 1 }, []])  // DELETE
+      .mockResolvedValueOnce([{ affectedRows: 1 }, []]); // INSERT
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await setRewardVideos(1, 1, [{ videoId: 5, weight: 0 }]);
+    const insertParams: unknown[] = conn.execute.mock.calls[2][1];
+    expect(insertParams[1]).toBe(1);  // Math.max(1, 0) = 1
+  });
+});
+
+// ─── deleteReward ─────────────────────────────────────────────────────────────
+
+describe('deleteReward', () => {
+  it('executes DELETE with rewardId and streamerId', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await deleteReward(3, 7);
+    expect(pool.execute.mock.calls[0][1]).toEqual([3, 7]);
+  });
+});
+
+// ─── getVideosForReward ───────────────────────────────────────────────────────
+
+describe('getVideosForReward', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    expect(await getVideosForReward('rwd1', 1)).toEqual([]);
+  });
+
+  it('maps filename and weight', async () => {
+    const rows = [{ filename: 'clip.mp4', weight: 3 }, { filename: 'outro.mp4', weight: 1 }];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await getVideosForReward('rwd1', 1);
+    expect(result[0]).toEqual({ file: 'clip.mp4', weight: 3 });
+    expect(result[1]).toEqual({ file: 'outro.mp4', weight: 1 });
+  });
+
+  it('queries with twitchRewardId and streamerId', async () => {
+    const pool = makePool([]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await getVideosForReward('rwdABC', 5);
+    expect(pool.execute.mock.calls[0][1]).toEqual(['rwdABC', 5]);
+  });
+});

--- a/src/db/sfx.test.ts
+++ b/src/db/sfx.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./pool', () => ({ getPool: vi.fn() }));
+vi.mock('mysql2/promise', () => ({ default: {} }));
+
+import { getPool } from './pool';
+import { findTrigger, findSoundFiles, getPublicSfxTriggers, getAllSfxTriggers } from './sfx';
+
+function makePool(rows: unknown[] = []) {
+  return { execute: vi.fn().mockResolvedValue([[...rows], []]) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─── findTrigger ─────────────────────────────────────────────────────────────
+
+describe('findTrigger', () => {
+  it('returns null when no rows found', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    const result = await findTrigger('!bang');
+    expect(result).toBeNull();
+  });
+
+  it('maps a row with numeric hidden=1 to true', async () => {
+    const row = { id: '1', trigger_command: '!bang', category_id: null, hidden: 1, description: null };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const result = await findTrigger('!bang');
+    expect(result).not.toBeNull();
+    expect(result!.hidden).toBe(true);
+  });
+
+  it('maps a row with numeric hidden=0 to false', async () => {
+    const row = { id: '2', trigger_command: '!clap', category_id: 3, hidden: 0, description: 'Clap sound' };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const result = await findTrigger('!clap');
+    expect(result!.hidden).toBe(false);
+    expect(result!.description).toBe('Clap sound');
+    expect(result!.category_id).toBe(3);
+  });
+
+  it('maps a row with Buffer hidden=0x01 to true', async () => {
+    const row = { id: '3', trigger_command: '!wow', category_id: null, hidden: Buffer.from([1]), description: null };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const result = await findTrigger('!wow');
+    expect(result!.hidden).toBe(true);
+  });
+
+  it('maps a row with Buffer hidden=0x00 to false', async () => {
+    const row = { id: '4', trigger_command: '!ok', category_id: null, hidden: Buffer.from([0]), description: null };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const result = await findTrigger('!ok');
+    expect(result!.hidden).toBe(false);
+  });
+
+  it('converts id to BigInt', async () => {
+    const row = { id: '9007199254740993', trigger_command: '!big', category_id: null, hidden: 0, description: null };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const result = await findTrigger('!big');
+    expect(result!.id).toBe(9007199254740993n);
+  });
+
+  it('lowercases the command string before querying', async () => {
+    const pool = makePool([]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await findTrigger('!BANG');
+    const params: unknown[] = pool.execute.mock.calls[0][1];
+    expect(params[0]).toBe('!bang');
+  });
+});
+
+// ─── findSoundFiles ───────────────────────────────────────────────────────────
+
+describe('findSoundFiles', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    const result = await findSoundFiles(1n);
+    expect(result).toEqual([]);
+  });
+
+  it('maps rows correctly including Buffer hidden flag', async () => {
+    const rows = [
+      { id: 10, trigger_id: '1', file: 'bang.mp3', trigger_command: '!bang', weight: 2, hidden: Buffer.from([0]), category_id: null },
+      { id: 11, trigger_id: '1', file: 'bang2.mp3', trigger_command: '!bang', weight: 1, hidden: 1, category_id: 3 },
+    ];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await findSoundFiles(1n);
+    expect(result).toHaveLength(2);
+    expect(result[0].file).toBe('bang.mp3');
+    expect(result[0].hidden).toBe(false);
+    expect(result[0].trigger_id).toBe(1n);
+    expect(result[1].hidden).toBe(true);
+    expect(result[1].category_id).toBe(3);
+  });
+
+  it('passes triggerId as string to the query', async () => {
+    const pool = makePool([]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await findSoundFiles(42n);
+    const params: unknown[] = pool.execute.mock.calls[0][1];
+    expect(params[0]).toBe('42');
+  });
+});
+
+// ─── getPublicSfxTriggers ─────────────────────────────────────────────────────
+
+describe('getPublicSfxTriggers', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    const result = await getPublicSfxTriggers();
+    expect(result).toEqual([]);
+  });
+
+  it('maps rows with null categoryName and description', async () => {
+    const rows = [{ triggerCommand: '!test', categoryName: null, description: null }];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await getPublicSfxTriggers();
+    expect(result[0]).toEqual({ triggerCommand: '!test', categoryName: null, description: null });
+  });
+
+  it('maps rows with categoryName and description', async () => {
+    const rows = [{ triggerCommand: '!clap', categoryName: 'Reactions', description: 'Clap sound' }];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await getPublicSfxTriggers();
+    expect(result[0]).toEqual({ triggerCommand: '!clap', categoryName: 'Reactions', description: 'Clap sound' });
+  });
+});
+
+// ─── getAllSfxTriggers ────────────────────────────────────────────────────────
+
+describe('getAllSfxTriggers', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    const result = await getAllSfxTriggers();
+    expect(result).toEqual([]);
+  });
+
+  it('groups multiple sound files under the same trigger', async () => {
+    const rows = [
+      { triggerId: '1', triggerCommand: '!bang', description: null, triggerHidden: 0, categoryName: null, sfxId: 10, file: 'a.mp3', weight: 1, sfxHidden: 0 },
+      { triggerId: '1', triggerCommand: '!bang', description: null, triggerHidden: 0, categoryName: null, sfxId: 11, file: 'b.mp3', weight: 2, sfxHidden: 1 },
+    ];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await getAllSfxTriggers();
+    expect(result).toHaveLength(1);
+    expect(result[0].files).toHaveLength(2);
+    expect(result[0].files[0].file).toBe('a.mp3');
+    expect(result[0].files[1].hidden).toBe(true);
+  });
+
+  it('handles multiple distinct triggers', async () => {
+    const rows = [
+      { triggerId: '1', triggerCommand: '!bang', description: null, triggerHidden: 0, categoryName: null, sfxId: 10, file: 'a.mp3', weight: 1, sfxHidden: 0 },
+      { triggerId: '2', triggerCommand: '!clap', description: 'Clap', triggerHidden: 1, categoryName: 'Reactions', sfxId: 20, file: 'c.mp3', weight: 3, sfxHidden: 0 },
+    ];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await getAllSfxTriggers();
+    expect(result).toHaveLength(2);
+    expect(result[1].triggerCommand).toBe('!clap');
+    expect(result[1].hidden).toBe(true);
+    expect(result[1].categoryName).toBe('Reactions');
+  });
+
+  it('skips adding to files array when sfxId is null (trigger with no files)', async () => {
+    const rows = [
+      { triggerId: '1', triggerCommand: '!silent', description: null, triggerHidden: 0, categoryName: null, sfxId: null, file: null, weight: null, sfxHidden: null },
+    ];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await getAllSfxTriggers();
+    expect(result).toHaveLength(1);
+    expect(result[0].files).toHaveLength(0);
+  });
+
+  it('maps triggerHidden as Buffer correctly', async () => {
+    const rows = [
+      { triggerId: '1', triggerCommand: '!test', description: null, triggerHidden: Buffer.from([1]), categoryName: null, sfxId: null, file: null, weight: null, sfxHidden: null },
+    ];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await getAllSfxTriggers();
+    expect(result[0].hidden).toBe(true);
+  });
+});

--- a/src/db/streamMonitor.test.ts
+++ b/src/db/streamMonitor.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./pool', () => ({ getPool: vi.fn() }));
+vi.mock('mysql2/promise', () => ({ default: {} }));
+
+import { getPool } from './pool';
+import {
+  getAllStreamGroups,
+  addStreamGroup,
+  updateStreamGroup,
+  removeStreamGroup,
+  getAllStreamers,
+  getAllStreamersWithGroups,
+  addStreamer,
+  removeStreamer,
+  removeStreamersByGroup,
+  setStreamerLive,
+  clearStreamerLive,
+} from './streamMonitor';
+
+function makePool(rows: unknown[] = []) {
+  return { execute: vi.fn().mockResolvedValue([[...rows], []]) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─── getAllStreamGroups ────────────────────────────────────────────────────────
+
+describe('getAllStreamGroups', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    expect(await getAllStreamGroups()).toEqual([]);
+  });
+
+  it('maps multi_twitch as numeric 1 → true', async () => {
+    const row = { id: 1, name: 'G', discord_channel: '123', live_message: 'live', new_game_message: 'game', multi_twitch: 1, delete_old_posts: 0 };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const [group] = await getAllStreamGroups();
+    expect(group.multi_twitch).toBe(true);
+    expect(group.delete_old_posts).toBe(false);
+  });
+
+  it('maps multi_twitch as Buffer 0x01 → true', async () => {
+    const row = { id: 1, name: 'G', discord_channel: '123', live_message: 'l', new_game_message: 'g', multi_twitch: Buffer.from([1]), delete_old_posts: Buffer.from([0]) };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const [group] = await getAllStreamGroups();
+    expect(group.multi_twitch).toBe(true);
+    expect(group.delete_old_posts).toBe(false);
+  });
+
+  it('coerces discord_channel to string', async () => {
+    const row = { id: 1, name: 'G', discord_channel: 99999n, live_message: 'l', new_game_message: 'g', multi_twitch: 0, delete_old_posts: 0 };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const [group] = await getAllStreamGroups();
+    expect(group.discord_channel).toBe('99999');
+  });
+
+  it('maps multiple rows', async () => {
+    const rows = [
+      { id: 1, name: 'A', discord_channel: '1', live_message: '', new_game_message: '', multi_twitch: 0, delete_old_posts: 0 },
+      { id: 2, name: 'B', discord_channel: '2', live_message: '', new_game_message: '', multi_twitch: 1, delete_old_posts: 1 },
+    ];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await getAllStreamGroups();
+    expect(result).toHaveLength(2);
+    expect(result[1].id).toBe(2);
+    expect(result[1].multi_twitch).toBe(true);
+  });
+});
+
+// ─── addStreamGroup ───────────────────────────────────────────────────────────
+
+describe('addStreamGroup', () => {
+  it('passes multiTwitch=true as 1 and deleteOldPosts=false as 0', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await addStreamGroup({ name: 'G', discordChannel: '123', liveMessage: 'l', newGameMessage: 'g', multiTwitch: true, deleteOldPosts: false });
+    const params: unknown[] = pool.execute.mock.calls[0][1];
+    expect(params).toContain(1);  // multiTwitch
+    expect(params).toContain(0);  // deleteOldPosts
+  });
+
+  it('includes all fields in the INSERT params', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await addStreamGroup({ name: 'MyGroup', discordChannel: 'chan1', liveMessage: 'is live', newGameMessage: 'new game', multiTwitch: false, deleteOldPosts: true });
+    const params: unknown[] = pool.execute.mock.calls[0][1];
+    expect(params).toContain('MyGroup');
+    expect(params).toContain('chan1');
+    expect(params).toContain('is live');
+    expect(params).toContain('new game');
+  });
+});
+
+// ─── updateStreamGroup ────────────────────────────────────────────────────────
+
+describe('updateStreamGroup', () => {
+  it('includes the id as the last WHERE param', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await updateStreamGroup({ id: 42, name: 'G', discordChannel: 'c', liveMessage: 'l', newGameMessage: 'g', multiTwitch: false, deleteOldPosts: false });
+    const params: unknown[] = pool.execute.mock.calls[0][1];
+    expect(params[params.length - 1]).toBe(42);
+  });
+
+  it('uses UPDATE in the SQL', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await updateStreamGroup({ id: 1, name: 'G', discordChannel: 'c', liveMessage: 'l', newGameMessage: 'g', multiTwitch: false, deleteOldPosts: false });
+    expect((pool.execute.mock.calls[0][0] as string).toLowerCase()).toContain('update');
+  });
+});
+
+// ─── removeStreamGroup ────────────────────────────────────────────────────────
+
+describe('removeStreamGroup', () => {
+  it('executes DELETE with the group id', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await removeStreamGroup(7);
+    const params: unknown[] = pool.execute.mock.calls[0][1];
+    expect(params).toContain(7);
+    expect((pool.execute.mock.calls[0][0] as string).toLowerCase()).toContain('delete');
+  });
+});
+
+// ─── getAllStreamers ──────────────────────────────────────────────────────────
+
+describe('getAllStreamers', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    expect(await getAllStreamers()).toEqual([]);
+  });
+
+  it('maps rows and coerces discord_id to string', async () => {
+    const row = { id: 1, discord_id: 123n, group_id: 5, twitch_name: 'alice', discord_name: 'Alice', group_name: 'Group A' };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const [s] = await getAllStreamers();
+    expect(s.discord_id).toBe('123');
+    expect(s.twitch_name).toBe('alice');
+    expect(s.group_name).toBe('Group A');
+  });
+
+  it('maps null twitch_name and discord_name to null', async () => {
+    const row = { id: 2, discord_id: '456', group_id: 1, twitch_name: null, discord_name: null, group_name: 'G' };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const [s] = await getAllStreamers();
+    expect(s.twitch_name).toBeNull();
+    expect(s.discord_name).toBeNull();
+  });
+});
+
+// ─── getAllStreamersWithGroups ─────────────────────────────────────────────────
+
+describe('getAllStreamersWithGroups', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    expect(await getAllStreamersWithGroups()).toEqual([]);
+  });
+
+  it('builds nested group object from flat row', async () => {
+    const row = {
+      id: 1, discord_id: '111', group_id: 2, twitch_name: 'alice',
+      discord_message_id: 'msg1', discord_channel_id: 'chan1', live_game: 'Minecraft',
+      group_name: 'Streamers', discord_channel: 'ch', live_message: 'live', new_game_message: 'newgame',
+      multi_twitch: 1, delete_old_posts: 0,
+    };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const [s] = await getAllStreamersWithGroups();
+    expect(s.live_game).toBe('Minecraft');
+    expect(s.discord_message_id).toBe('msg1');
+    expect(s.group.id).toBe(2);
+    expect(s.group.multi_twitch).toBe(true);
+    expect(s.group.delete_old_posts).toBe(false);
+  });
+
+  it('coerces discord_channel_id to string when set', async () => {
+    const row = {
+      id: 1, discord_id: '1', group_id: 1, twitch_name: 'bob',
+      discord_message_id: null, discord_channel_id: 99999n, live_game: null,
+      group_name: 'G', discord_channel: 'c', live_message: 'l', new_game_message: 'g',
+      multi_twitch: 0, delete_old_posts: 0,
+    };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const [s] = await getAllStreamersWithGroups();
+    expect(s.discord_channel_id).toBe('99999');
+  });
+
+  it('maps null discord_channel_id to null', async () => {
+    const row = {
+      id: 1, discord_id: '1', group_id: 1, twitch_name: 'bob',
+      discord_message_id: null, discord_channel_id: null, live_game: null,
+      group_name: 'G', discord_channel: 'c', live_message: 'l', new_game_message: 'g',
+      multi_twitch: 0, delete_old_posts: 0,
+    };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const [s] = await getAllStreamersWithGroups();
+    expect(s.discord_channel_id).toBeNull();
+  });
+});
+
+// ─── addStreamer / removeStreamer / removeStreamersByGroup ────────────────────
+
+describe('addStreamer', () => {
+  it('inserts with discordId and groupId', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await addStreamer('user1', 3);
+    expect(pool.execute.mock.calls[0][1]).toEqual(['user1', 3]);
+  });
+});
+
+describe('removeStreamer', () => {
+  it('deletes by id', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await removeStreamer(5);
+    expect(pool.execute.mock.calls[0][1]).toContain(5);
+  });
+});
+
+describe('removeStreamersByGroup', () => {
+  it('deletes by group_id', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await removeStreamersByGroup(10);
+    expect(pool.execute.mock.calls[0][1]).toContain(10);
+  });
+});
+
+// ─── setStreamerLive / clearStreamerLive ──────────────────────────────────────
+
+describe('setStreamerLive', () => {
+  it('updates with messageId, channelId, game, and id', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await setStreamerLive(1, 'msg42', 'chan99', 'Fortnite');
+    const params: unknown[] = pool.execute.mock.calls[0][1];
+    expect(params).toContain('msg42');
+    expect(params).toContain('chan99');
+    expect(params).toContain('Fortnite');
+    expect(params).toContain(1);
+  });
+});
+
+describe('clearStreamerLive', () => {
+  it('executes UPDATE with id', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await clearStreamerLive(7);
+    const [sql, params] = pool.execute.mock.calls[0] as [string, unknown[]];
+    expect(sql.toLowerCase()).toContain('update');
+    expect(params).toContain(7);
+  });
+});

--- a/src/db/streamdeckKeys.test.ts
+++ b/src/db/streamdeckKeys.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./pool', () => ({ getPool: vi.fn() }));
+vi.mock('mysql2/promise', () => ({ default: {} }));
+vi.mock('./users', () => ({
+  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
+}));
+
+import { getPool } from './pool';
+import {
+  findApprovedKeyByHash,
+  getApiKeyStatus,
+  approveApiKey,
+  denyApiKey,
+  revokeApiKey,
+  getPendingRequests,
+  getAllApiKeys,
+  requestApiKey,
+} from './streamdeckKeys';
+import { createHash } from 'crypto';
+
+function makePool(rows: unknown[] = []) {
+  return { execute: vi.fn().mockResolvedValue([[...rows], []]) };
+}
+
+function sha256hex(s: string) {
+  return createHash('sha256').update(s).digest('hex');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─── findApprovedKeyByHash ────────────────────────────────────────────────────
+
+describe('findApprovedKeyByHash', () => {
+  it('returns null when no rows found', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    const result = await findApprovedKeyByHash('a'.repeat(64));
+    expect(result).toBeNull();
+  });
+
+  it('returns null when stored hash does not match incoming hash', async () => {
+    const incoming = 'aa'.repeat(32); // 64 hex chars
+    const stored = 'bb'.repeat(32);   // different 64 hex chars
+    const row = { discord_id: '1', key_hash: stored, status: 'approved', requested_at: new Date(), approved_at: null, approved_by: null };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const result = await findApprovedKeyByHash(incoming);
+    expect(result).toBeNull();
+  });
+
+  it('returns the mapped row when hash matches', async () => {
+    const hash = sha256hex('mysecretkey');
+    const row = { discord_id: '42', key_hash: hash, status: 'approved', requested_at: new Date(), approved_at: new Date(), approved_by: '1' };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const result = await findApprovedKeyByHash(hash);
+    expect(result).not.toBeNull();
+    expect(result!.discord_id).toBe('42');
+    expect(result!.status).toBe('approved');
+  });
+
+  it('returns null when stored and incoming hash have different lengths', async () => {
+    const incoming = 'ab'.repeat(32); // 64 chars
+    const stored = 'ab'.repeat(16);   // 32 chars — different length
+    const row = { discord_id: '1', key_hash: stored, status: 'approved', requested_at: new Date(), approved_at: null, approved_by: null };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const result = await findApprovedKeyByHash(incoming);
+    expect(result).toBeNull();
+  });
+});
+
+// ─── getApiKeyStatus ──────────────────────────────────────────────────────────
+
+describe('getApiKeyStatus', () => {
+  it('returns null when no rows found', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    const result = await getApiKeyStatus('999');
+    expect(result).toBeNull();
+  });
+
+  it('maps a row with all fields', async () => {
+    const now = new Date();
+    const row = {
+      discord_id: '123',
+      status: 'pending',
+      requested_at: now,
+      approved_at: null,
+      approved_by: null,
+      user_name: null,
+      approver_name: null,
+    };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const result = await getApiKeyStatus('123');
+    expect(result!.discord_id).toBe('123');
+    expect(result!.status).toBe('pending');
+    expect(result!.requested_at).toBe(now);
+    expect(result!.approved_at).toBeNull();
+    expect(result!.approved_by).toBeNull();
+  });
+
+  it('maps a row with approver info', async () => {
+    const row = {
+      discord_id: '1',
+      status: 'approved',
+      requested_at: new Date(),
+      approved_at: new Date(),
+      approved_by: '99',
+      user_name: 'Alice',
+      approver_name: 'Admin',
+    };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const result = await getApiKeyStatus('1');
+    expect(result!.approved_by).toBe('99');
+    expect(result!.user_name).toBe('Alice');
+    expect(result!.approver_name).toBe('Admin');
+  });
+});
+
+// ─── approveApiKey ────────────────────────────────────────────────────────────
+
+describe('approveApiKey', () => {
+  it('executes UPDATE with approvedBy and discordId', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await approveApiKey('user1', 'admin1');
+    const [sql, params] = pool.execute.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("status = 'approved'");
+    expect(params).toContain('admin1');
+    expect(params).toContain('user1');
+  });
+});
+
+// ─── denyApiKey ───────────────────────────────────────────────────────────────
+
+describe('denyApiKey', () => {
+  it('executes UPDATE setting status to denied', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await denyApiKey('user1');
+    const [sql, params] = pool.execute.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("status = 'denied'");
+    expect(params).toContain('user1');
+  });
+});
+
+// ─── revokeApiKey ─────────────────────────────────────────────────────────────
+
+describe('revokeApiKey', () => {
+  it('executes UPDATE setting status to revoked', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await revokeApiKey('user1');
+    const [sql, params] = pool.execute.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("status = 'revoked'");
+    expect(params).toContain('user1');
+  });
+});
+
+// ─── getPendingRequests ───────────────────────────────────────────────────────
+
+describe('getPendingRequests', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    const result = await getPendingRequests();
+    expect(result).toEqual([]);
+  });
+
+  it('maps pending rows', async () => {
+    const row = { discord_id: '1', status: 'pending', requested_at: new Date(), approved_at: null, approved_by: null, user_name: 'Alice', approver_name: null };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const result = await getPendingRequests();
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe('pending');
+    expect(result[0].user_name).toBe('Alice');
+  });
+});
+
+// ─── getAllApiKeys ────────────────────────────────────────────────────────────
+
+describe('getAllApiKeys', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    const result = await getAllApiKeys();
+    expect(result).toEqual([]);
+  });
+
+  it('maps multiple rows with different statuses', async () => {
+    const rows = [
+      { discord_id: '1', status: 'approved', requested_at: new Date(), approved_at: new Date(), approved_by: '2', user_name: 'Alice', approver_name: 'Admin' },
+      { discord_id: '3', status: 'revoked', requested_at: new Date(), approved_at: null, approved_by: null, user_name: 'Bob', approver_name: null },
+    ];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await getAllApiKeys();
+    expect(result).toHaveLength(2);
+    expect(result[0].status).toBe('approved');
+    expect(result[1].status).toBe('revoked');
+  });
+});
+
+// ─── requestApiKey ────────────────────────────────────────────────────────────
+
+describe('requestApiKey', () => {
+  it('throws when existing status is denied', async () => {
+    const row = { discord_id: '1', status: 'denied', requested_at: new Date(), approved_at: null, approved_by: null, user_name: null, approver_name: null };
+    const pool = makePool([row]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(requestApiKey('1', 0)).rejects.toThrow('denied');
+  });
+
+  it('returns status=approved for MANAGER access level (2)', async () => {
+    // First call returns null (no existing row), second returns approved row
+    const pool = {
+      execute: vi.fn()
+        .mockResolvedValueOnce([[]])    // getApiKeyStatus initial
+        .mockResolvedValueOnce([[]])    // INSERT
+        .mockResolvedValueOnce([[{     // getApiKeyStatus after insert
+          discord_id: '1', status: 'approved', requested_at: new Date(), approved_at: new Date(), approved_by: '1', user_name: null, approver_name: null,
+        }]]),
+    };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await requestApiKey('1', 2);
+    expect(result.status).toBe('approved');
+    expect(result.plain).toHaveLength(64); // 32 bytes as hex
+  });
+
+  it('returns status=pending for USER access level (0)', async () => {
+    const pool = {
+      execute: vi.fn()
+        .mockResolvedValueOnce([[]])   // getApiKeyStatus initial
+        .mockResolvedValueOnce([[]])   // INSERT
+        .mockResolvedValueOnce([[{    // getApiKeyStatus after insert
+          discord_id: '1', status: 'pending', requested_at: new Date(), approved_at: null, approved_by: null, user_name: null, approver_name: null,
+        }]]),
+    };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await requestApiKey('1', 0);
+    expect(result.status).toBe('pending');
+  });
+
+  it('generates a 64-character hex plain key', async () => {
+    const pool = {
+      execute: vi.fn()
+        .mockResolvedValueOnce([[]])
+        .mockResolvedValueOnce([[]])
+        .mockResolvedValueOnce([[{
+          discord_id: '1', status: 'pending', requested_at: new Date(), approved_at: null, approved_by: null, user_name: null, approver_name: null,
+        }]]),
+    };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await requestApiKey('1', 1);
+    expect(result.plain).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/src/db/users.test.ts
+++ b/src/db/users.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../shared/logger', () => ({ createLogger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn() }) }));
+vi.mock('./pool', () => ({ getPool: vi.fn() }));
+vi.mock('mysql2/promise', () => ({ default: {} }));
+vi.mock('../twitch/twitchChannelName', () => ({
+  normalizeTwitchChannelName: vi.fn((s: string) => (s ? s.toLowerCase() : null)),
+}));
+
+import { getPool } from './pool';
+import {
+  findUser,
+  findUserByTwitchName,
+  getAllUsers,
+  upsertUserRecord,
+  updateDiscordName,
+  getTwitchEnabledChannels,
+  setTwitchBotEnabledRecord,
+  updateAccessLevel,
+  removeUserRecord,
+  AccessLevel,
+} from './users';
+import { normalizeTwitchChannelName } from '../twitch/twitchChannelName';
+
+function makeConnection(executeResult: unknown = [[], []]) {
+  return {
+    execute: vi.fn().mockResolvedValue(executeResult),
+    release: vi.fn(),
+  };
+}
+
+function makePool(executeResult: unknown = [[], []], connectionExecuteResult?: unknown) {
+  const conn = makeConnection(connectionExecuteResult ?? [[], []]);
+  return {
+    execute: vi.fn().mockResolvedValue(executeResult),
+    getConnection: vi.fn().mockResolvedValue(conn),
+    _conn: conn,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(normalizeTwitchChannelName).mockImplementation((s: string) => (s ? s.toLowerCase() : null));
+});
+
+// ─── findUser ────────────────────────────────────────────────────────────────
+
+describe('findUser', () => {
+  it('returns null when no rows found', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([[]]  ) as any);
+    const result = await findUser('123');
+    expect(result).toBeNull();
+  });
+
+  it('maps a row with numeric is_twitch_bot_enabled = 1 to true', async () => {
+    const row = { discord_id: '123', discord_name: 'Alice', is_twitch_bot_enabled: 1, twitch_name: 'alice', access_level: 0 };
+    vi.mocked(getPool).mockReturnValue(makePool([[row]]) as any);
+    const user = await findUser('123');
+    expect(user).not.toBeNull();
+    expect(user!.is_twitch_bot_enabled).toBe(true);
+    expect(user!.discord_id).toBe('123');
+  });
+
+  it('maps a row with numeric is_twitch_bot_enabled = 0 to false', async () => {
+    const row = { discord_id: '456', discord_name: 'Bob', is_twitch_bot_enabled: 0, twitch_name: null, access_level: 1 };
+    vi.mocked(getPool).mockReturnValue(makePool([[row]]) as any);
+    const user = await findUser('456');
+    expect(user!.is_twitch_bot_enabled).toBe(false);
+  });
+
+  it('maps a row with Buffer is_twitch_bot_enabled 0x01 to true', async () => {
+    const row = { discord_id: '789', discord_name: 'Carol', is_twitch_bot_enabled: Buffer.from([1]), twitch_name: 'carol', access_level: 2 };
+    vi.mocked(getPool).mockReturnValue(makePool([[row]]) as any);
+    const user = await findUser('789');
+    expect(user!.is_twitch_bot_enabled).toBe(true);
+  });
+
+  it('maps a row with Buffer is_twitch_bot_enabled 0x00 to false', async () => {
+    const row = { discord_id: '789', discord_name: 'Carol', is_twitch_bot_enabled: Buffer.from([0]), twitch_name: 'carol', access_level: 2 };
+    vi.mocked(getPool).mockReturnValue(makePool([[row]]) as any);
+    const user = await findUser('789');
+    expect(user!.is_twitch_bot_enabled).toBe(false);
+  });
+
+  it('coerces discord_id to string', async () => {
+    const row = { discord_id: 999n, discord_name: 'Bigint', is_twitch_bot_enabled: 0, twitch_name: null, access_level: 0 };
+    vi.mocked(getPool).mockReturnValue(makePool([[row]]) as any);
+    const user = await findUser('999');
+    expect(user!.discord_id).toBe('999');
+  });
+});
+
+// ─── findUserByTwitchName ─────────────────────────────────────────────────────
+
+describe('findUserByTwitchName', () => {
+  it('returns null when normalizeTwitchChannelName returns null (blank/invalid name)', async () => {
+    vi.mocked(normalizeTwitchChannelName).mockReturnValue(null);
+    const pool = makePool([[]]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await findUserByTwitchName('');
+    expect(result).toBeNull();
+    expect(pool.execute).not.toHaveBeenCalled();
+  });
+
+  it('returns null when query returns no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([[]]) as any);
+    const result = await findUserByTwitchName('alice');
+    expect(result).toBeNull();
+  });
+
+  it('maps a found row correctly', async () => {
+    const row = { discord_id: '111', discord_name: 'Alice', is_twitch_bot_enabled: 1, twitch_name: 'alice', access_level: 0 };
+    vi.mocked(getPool).mockReturnValue(makePool([[row]]) as any);
+    const result = await findUserByTwitchName('alice');
+    expect(result!.discord_id).toBe('111');
+  });
+
+  it('uses an exclude query when excludeDiscordId is provided', async () => {
+    const pool = makePool([[]]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await findUserByTwitchName('alice', '999');
+    const sql: string = vi.mocked(pool.execute).mock.calls[0][0] as string;
+    expect(sql).toContain('discord_id <> ?');
+  });
+
+  it('does not use an exclude clause when no excludeDiscordId provided', async () => {
+    const pool = makePool([[]]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await findUserByTwitchName('alice');
+    const sql: string = vi.mocked(pool.execute).mock.calls[0][0] as string;
+    expect(sql).not.toContain('discord_id <> ?');
+  });
+});
+
+// ─── getAllUsers ──────────────────────────────────────────────────────────────
+
+describe('getAllUsers', () => {
+  it('returns an empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([[]]) as any);
+    const result = await getAllUsers();
+    expect(result).toEqual([]);
+  });
+
+  it('maps multiple rows', async () => {
+    const rows = [
+      { discord_id: '1', discord_name: 'A', is_twitch_bot_enabled: 0, twitch_name: null, access_level: 3 },
+      { discord_id: '2', discord_name: 'B', is_twitch_bot_enabled: 1, twitch_name: 'b', access_level: 0 },
+    ];
+    vi.mocked(getPool).mockReturnValue(makePool([rows]) as any);
+    const result = await getAllUsers();
+    expect(result).toHaveLength(2);
+    expect(result[0].discord_id).toBe('1');
+    expect(result[1].is_twitch_bot_enabled).toBe(true);
+  });
+});
+
+// ─── upsertUserRecord ─────────────────────────────────────────────────────────
+
+describe('upsertUserRecord', () => {
+  it('throws for an invalid access level', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    await expect(upsertUserRecord('1', 'Alice', 99)).rejects.toThrow('Invalid accessLevel: 99');
+  });
+
+  it('accepts all valid access levels', async () => {
+    for (const level of Object.values(AccessLevel)) {
+      const pool = makePool();
+      vi.mocked(getPool).mockReturnValue(pool as any);
+      await expect(upsertUserRecord('1', 'Alice', level)).resolves.not.toThrow();
+    }
+  });
+
+  it('returns true when twitchName is provided (even if null)', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    const result = await upsertUserRecord('1', 'Alice', 0, null);
+    expect(result).toBe(true);
+  });
+
+  it('returns false when twitchName is not provided (undefined)', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    const result = await upsertUserRecord('1', 'Alice', 0);
+    expect(result).toBe(false);
+  });
+
+  it('throws when twitchName is an empty string', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    await expect(upsertUserRecord('1', 'Alice', 0, '')).rejects.toThrow('Invalid twitchName');
+  });
+
+  it('throws when twitchName is whitespace-only', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    await expect(upsertUserRecord('1', 'Alice', 0, '   ')).rejects.toThrow('Invalid twitchName');
+  });
+
+  it('throws when normalizeTwitchChannelName returns null for twitchName', async () => {
+    vi.mocked(normalizeTwitchChannelName).mockReturnValue(null);
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    await expect(upsertUserRecord('1', 'Alice', 0, 'invalid!')).rejects.toThrow('Invalid twitchName');
+  });
+
+  it('trims discordName and passes null when blank', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await upsertUserRecord('1', '   ', 0);
+    const params = pool._conn.execute.mock.calls[1][1] as unknown[];
+    expect(params[1]).toBeNull();
+  });
+});
+
+// ─── updateDiscordName ────────────────────────────────────────────────────────
+
+describe('updateDiscordName', () => {
+  it('passes trimmed name to the query', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await updateDiscordName('1', '  Alice  ');
+    expect(pool.execute).toHaveBeenCalledWith(expect.any(String), ['Alice', '1']);
+  });
+
+  it('passes null when name is blank after trimming', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await updateDiscordName('1', '   ');
+    expect(pool.execute).toHaveBeenCalledWith(expect.any(String), [null, '1']);
+  });
+});
+
+// ─── getTwitchEnabledChannels ─────────────────────────────────────────────────
+
+describe('getTwitchEnabledChannels', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([[]]) as any);
+    const result = await getTwitchEnabledChannels();
+    expect(result).toEqual([]);
+  });
+
+  it('maps twitch_name through normalizeTwitchChannelName', async () => {
+    vi.mocked(normalizeTwitchChannelName).mockImplementation((s) => `normalized_${s}`);
+    const rows = [{ twitch_name: 'Alice' }, { twitch_name: 'Bob' }];
+    vi.mocked(getPool).mockReturnValue(makePool([rows]) as any);
+    const result = await getTwitchEnabledChannels();
+    expect(result).toEqual(['normalized_Alice', 'normalized_Bob']);
+  });
+
+  it('filters out entries where normalizeTwitchChannelName returns null', async () => {
+    vi.mocked(normalizeTwitchChannelName).mockReturnValueOnce('alice').mockReturnValueOnce(null);
+    const rows = [{ twitch_name: 'alice' }, { twitch_name: 'bad!' }];
+    vi.mocked(getPool).mockReturnValue(makePool([rows]) as any);
+    const result = await getTwitchEnabledChannels();
+    expect(result).toEqual(['alice']);
+  });
+});
+
+// ─── updateAccessLevel ────────────────────────────────────────────────────────
+
+describe('updateAccessLevel', () => {
+  it('throws for an invalid access level', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    await expect(updateAccessLevel('1', 5)).rejects.toThrow('Invalid accessLevel: 5');
+  });
+
+  it('accepts all valid access levels', async () => {
+    for (const level of Object.values(AccessLevel)) {
+      vi.mocked(getPool).mockReturnValue(makePool() as any);
+      await expect(updateAccessLevel('1', level)).resolves.not.toThrow();
+    }
+  });
+});
+
+// ─── setTwitchBotEnabledRecord ────────────────────────────────────────────────
+
+describe('setTwitchBotEnabledRecord', () => {
+  it('passes 1 when enabled=true', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await setTwitchBotEnabledRecord('1', true);
+    const params = pool._conn.execute.mock.calls[1][1] as unknown[];
+    expect(params[0]).toBe(1);
+  });
+
+  it('passes 0 when enabled=false', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await setTwitchBotEnabledRecord('1', false);
+    const params = pool._conn.execute.mock.calls[1][1] as unknown[];
+    expect(params[0]).toBe(0);
+  });
+});
+
+// ─── removeUserRecord ─────────────────────────────────────────────────────────
+
+describe('removeUserRecord', () => {
+  it('executes a DELETE with the discord_id', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await removeUserRecord('42');
+    const sql: string = pool._conn.execute.mock.calls[1][0] as string;
+    expect(sql).toContain('DELETE FROM');
+    const params = pool._conn.execute.mock.calls[1][1] as unknown[];
+    expect(params).toContain('42');
+  });
+});
+
+// ─── AccessLevel constant ─────────────────────────────────────────────────────
+
+describe('AccessLevel', () => {
+  it('has USER=0, MOD=1, MANAGER=2, ADMIN=3', () => {
+    expect(AccessLevel.USER).toBe(0);
+    expect(AccessLevel.MOD).toBe(1);
+    expect(AccessLevel.MANAGER).toBe(2);
+    expect(AccessLevel.ADMIN).toBe(3);
+  });
+});

--- a/src/shared/pathUtils.test.ts
+++ b/src/shared/pathUtils.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+import { safeResolve } from './pathUtils';
+
+describe('safeResolve', () => {
+  const base = '/srv/files';
+
+  it('returns the resolved path for a safe single segment', () => {
+    expect(safeResolve(base, 'audio.mp3')).toBe('/srv/files/audio.mp3');
+  });
+
+  it('returns the resolved path for a safe nested path', () => {
+    expect(safeResolve(base, 'sfx', 'effects', 'bang.wav')).toBe('/srv/files/sfx/effects/bang.wav');
+  });
+
+  it('returns null for a path that escapes base via ..', () => {
+    expect(safeResolve(base, '../secret.txt')).toBeNull();
+  });
+
+  it('returns null for a deeply nested traversal', () => {
+    expect(safeResolve(base, 'a', '../../etc/passwd')).toBeNull();
+  });
+
+  it('returns the base path itself when no parts given', () => {
+    expect(safeResolve(base)).toBe(path.resolve(base));
+  });
+
+  it('returns null for an absolute path that is outside base', () => {
+    expect(safeResolve(base, '/etc/passwd')).toBeNull();
+  });
+
+  it('returns the path when it exactly equals the base', () => {
+    // path.relative(base, base) is '' which does not start with '..'
+    const result = safeResolve(base, '.');
+    expect(result).toBe(path.resolve(base));
+  });
+
+  it('handles a base without trailing slash', () => {
+    expect(safeResolve('/srv/files', 'ok.mp3')).toBe('/srv/files/ok.mp3');
+  });
+
+  it('handles a base with a trailing slash', () => {
+    expect(safeResolve('/srv/files/', 'ok.mp3')).toBe('/srv/files/ok.mp3');
+  });
+
+  it('returns the correct path for a file with spaces in name', () => {
+    expect(safeResolve(base, 'my sound.mp3')).toBe('/srv/files/my sound.mp3');
+  });
+
+  it('returns null when joining results in a sibling directory', () => {
+    // /srv/files + ../otherfolder/x would be /srv/otherfolder/x — outside base
+    expect(safeResolve('/srv/files', '../otherfolder/x')).toBeNull();
+  });
+});

--- a/src/twitch/monitor/twitchMonitorMultitwitch.test.ts
+++ b/src/twitch/monitor/twitchMonitorMultitwitch.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../shared/logger', () => ({ createLogger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn() }) }));
+vi.mock('../../discord/discordBot', () => ({ getDiscordClient: vi.fn().mockReturnValue(null) }));
+vi.mock('./twitchMonitorEmbed', () => ({ buildEmbed: vi.fn() }));
+
+import { groupGameKey, buildMultiTwitchContext, getMultitwitchPreview } from './twitchMonitorMultitwitch';
+import type { LiveState } from './twitchMonitorTypes';
+
+function makeState(overrides: Partial<LiveState> = {}): LiveState {
+  return {
+    streamerId: 1,
+    login: 'alice',
+    groupId: 10,
+    currentGame: 'Minecraft',
+    title: 'Playing',
+    currentStream: {} as any,
+    messageId: 'msg1',
+    channelId: 'chan1',
+    offlineTimer: null,
+    group: { id: 10, name: 'G', discord_channel: 'c', live_message: 'l', new_game_message: 'g', multi_twitch: true, delete_old_posts: false },
+    ...overrides,
+  };
+}
+
+// ─── groupGameKey ─────────────────────────────────────────────────────────────
+
+describe('groupGameKey', () => {
+  it('combines groupId and lowercase game with :: separator', () => {
+    expect(groupGameKey(5, 'Minecraft')).toBe('5::minecraft');
+  });
+
+  it('lowercases the game name', () => {
+    expect(groupGameKey(1, 'FORTNITE')).toBe('1::fortnite');
+  });
+
+  it('is deterministic for the same inputs', () => {
+    expect(groupGameKey(3, 'Valorant')).toBe(groupGameKey(3, 'Valorant'));
+  });
+
+  it('produces different keys for different groupIds', () => {
+    expect(groupGameKey(1, 'Minecraft')).not.toBe(groupGameKey(2, 'Minecraft'));
+  });
+
+  it('produces different keys for different games', () => {
+    expect(groupGameKey(1, 'Minecraft')).not.toBe(groupGameKey(1, 'Fortnite'));
+  });
+});
+
+// ─── buildMultiTwitchContext ──────────────────────────────────────────────────
+
+describe('buildMultiTwitchContext', () => {
+  it('returns empty map for no states', () => {
+    const ctx = buildMultiTwitchContext([]);
+    expect(ctx).toBeDefined();
+  });
+
+  it('groups participants by group+game key', () => {
+    const states = [
+      makeState({ login: 'alice', groupId: 1, currentGame: 'Minecraft' }),
+      makeState({ login: 'bob',   groupId: 1, currentGame: 'Minecraft' }),
+    ];
+    const ctx = buildMultiTwitchContext(states);
+    const key = groupGameKey(1, 'Minecraft');
+    expect(ctx).toHaveProperty('participantsByGroupAndGame');
+    // Access via the returned object — use the same key format
+    const participants = (ctx as any).participantsByGroupAndGame.get(key);
+    expect(participants).toContain('alice');
+    expect(participants).toContain('bob');
+  });
+
+  it('sorts participants alphabetically', () => {
+    const states = [
+      makeState({ login: 'zara',  groupId: 1, currentGame: 'Minecraft' }),
+      makeState({ login: 'alice', groupId: 1, currentGame: 'Minecraft' }),
+      makeState({ login: 'bob',   groupId: 1, currentGame: 'Minecraft' }),
+    ];
+    const ctx = buildMultiTwitchContext(states);
+    const key = groupGameKey(1, 'Minecraft');
+    const participants = (ctx as any).participantsByGroupAndGame.get(key);
+    expect(participants).toEqual(['alice', 'bob', 'zara']);
+  });
+
+  it('deduplicates the same login appearing twice', () => {
+    const states = [
+      makeState({ login: 'alice', groupId: 1, currentGame: 'Minecraft' }),
+      makeState({ login: 'alice', groupId: 1, currentGame: 'Minecraft' }),
+    ];
+    const ctx = buildMultiTwitchContext(states);
+    const key = groupGameKey(1, 'Minecraft');
+    const participants = (ctx as any).participantsByGroupAndGame.get(key);
+    expect(participants).toHaveLength(1);
+  });
+
+  it('separates participants by group', () => {
+    const states = [
+      makeState({ login: 'alice', groupId: 1, currentGame: 'Minecraft' }),
+      makeState({ login: 'bob',   groupId: 2, currentGame: 'Minecraft' }),
+    ];
+    const ctx = buildMultiTwitchContext(states);
+    const key1 = groupGameKey(1, 'Minecraft');
+    const key2 = groupGameKey(2, 'Minecraft');
+    expect((ctx as any).participantsByGroupAndGame.get(key1)).not.toContain('bob');
+    expect((ctx as any).participantsByGroupAndGame.get(key2)).not.toContain('alice');
+  });
+
+  it('separates participants by game', () => {
+    const states = [
+      makeState({ login: 'alice', groupId: 1, currentGame: 'Minecraft' }),
+      makeState({ login: 'bob',   groupId: 1, currentGame: 'Fortnite' }),
+    ];
+    const ctx = buildMultiTwitchContext(states);
+    expect((ctx as any).participantsByGroupAndGame.get(groupGameKey(1, 'Minecraft'))).not.toContain('bob');
+    expect((ctx as any).participantsByGroupAndGame.get(groupGameKey(1, 'Fortnite'))).not.toContain('alice');
+  });
+});
+
+// ─── getMultitwitchPreview ────────────────────────────────────────────────────
+
+describe('getMultitwitchPreview', () => {
+  function ctxWith(entries: Array<[string, string[]]>) {
+    const map = new Map<string, string[]>(entries);
+    return { participantsByGroupAndGame: map } as any;
+  }
+
+  it('returns applicable=false and url=null when only one participant', () => {
+    const state = makeState({ login: 'alice', groupId: 1, currentGame: 'Minecraft' });
+    const ctx = ctxWith([[groupGameKey(1, 'Minecraft'), ['alice']]]);
+    const result = getMultitwitchPreview(state, ctx);
+    expect(result.applicable).toBe(false);
+    expect(result.url).toBeNull();
+    expect(result.participants).toEqual(['alice']);
+  });
+
+  it('returns applicable=false and url=null when no entry in context', () => {
+    const state = makeState({ login: 'alice', groupId: 1, currentGame: 'Minecraft' });
+    const result = getMultitwitchPreview(state, ctxWith([]));
+    expect(result.applicable).toBe(false);
+    expect(result.url).toBeNull();
+  });
+
+  it('returns applicable=true and url=null when multi_twitch=false but multiple participants', () => {
+    const state = makeState({ login: 'alice', groupId: 1, currentGame: 'Minecraft', group: { ...makeState().group, multi_twitch: false } });
+    const ctx = ctxWith([[groupGameKey(1, 'Minecraft'), ['alice', 'bob']]]);
+    const result = getMultitwitchPreview(state, ctx);
+    expect(result.applicable).toBe(true);
+    expect(result.enabled).toBe(false);
+    expect(result.url).toBeNull();
+    expect(result.participants).toEqual(['alice', 'bob']);
+  });
+
+  it('returns enabled=true and correct url when multi_twitch=true and 2+ participants', () => {
+    const state = makeState({ login: 'alice', groupId: 1, currentGame: 'Minecraft' });
+    const ctx = ctxWith([[groupGameKey(1, 'Minecraft'), ['alice', 'bob']]]);
+    const result = getMultitwitchPreview(state, ctx);
+    expect(result.enabled).toBe(true);
+    expect(result.applicable).toBe(true);
+    expect(result.url).toBe('https://www.multitwitch.tv/alice/bob');
+    expect(result.participants).toEqual(['alice', 'bob']);
+  });
+
+  it('includes all participants in the url', () => {
+    const state = makeState({ login: 'alice', groupId: 1, currentGame: 'Minecraft' });
+    const ctx = ctxWith([[groupGameKey(1, 'Minecraft'), ['alice', 'bob', 'carol']]]);
+    const result = getMultitwitchPreview(state, ctx);
+    expect(result.url).toBe('https://www.multitwitch.tv/alice/bob/carol');
+  });
+
+  it('reflects the enabled flag from the group when not applicable', () => {
+    const state = makeState({ login: 'alice', groupId: 1, currentGame: 'Minecraft', group: { ...makeState().group, multi_twitch: false } });
+    const result = getMultitwitchPreview(state, ctxWith([]));
+    expect(result.enabled).toBe(false);
+  });
+});

--- a/src/twitch/monitor/twitchMonitorOffline.test.ts
+++ b/src/twitch/monitor/twitchMonitorOffline.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../shared/logger', () => ({ createLogger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn() }) }));
+vi.mock('../twitchApi', () => ({ getStreams: vi.fn() }));
+vi.mock('./twitchMonitorAnnouncements', () => ({ deleteAnnouncement: vi.fn() }));
+vi.mock('../../shared/statusStore', () => ({ setTwitchChannelLive: vi.fn() }));
+
+import { cancelOfflineTimersForLogin, runOfflineCheck } from './twitchMonitorOffline';
+import { getStreams } from '../twitchApi';
+import { deleteAnnouncement } from './twitchMonitorAnnouncements';
+import { setTwitchChannelLive } from '../../shared/statusStore';
+import type { LiveState } from './twitchMonitorTypes';
+
+function makeState(overrides: Partial<LiveState> = {}): LiveState {
+  return {
+    streamerId: 1,
+    login: 'alice',
+    groupId: 10,
+    currentGame: 'Minecraft',
+    title: 'Playing',
+    currentStream: {} as any,
+    messageId: 'msg1',
+    channelId: 'chan1',
+    offlineTimer: null,
+    group: { id: 10, name: 'G', discord_channel: 'c', live_message: 'l', new_game_message: 'g', multi_twitch: true, delete_old_posts: false },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─── cancelOfflineTimersForLogin ─────────────────────────────────────────────
+
+describe('cancelOfflineTimersForLogin', () => {
+  it('clears the offlineTimer for matching login and sets it to null', () => {
+    const timer = setTimeout(() => {}, 99999);
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const state = makeState({ login: 'alice', offlineTimer: timer });
+    const map = new Map([['k1', state]]);
+
+    cancelOfflineTimersForLogin(map, 'alice');
+
+    expect(clearSpy).toHaveBeenCalledWith(timer);
+    expect(state.offlineTimer).toBeNull();
+    clearTimeout(timer);
+  });
+
+  it('does not clear timers for a different login', () => {
+    const timer = setTimeout(() => {}, 99999);
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const state = makeState({ login: 'bob', offlineTimer: timer });
+    const map = new Map([['k1', state]]);
+
+    cancelOfflineTimersForLogin(map, 'alice');
+
+    expect(clearSpy).not.toHaveBeenCalled();
+    expect(state.offlineTimer).not.toBeNull();
+    clearTimeout(timer);
+  });
+
+  it('does nothing when the map is empty', () => {
+    expect(() => cancelOfflineTimersForLogin(new Map(), 'alice')).not.toThrow();
+  });
+
+  it('skips states where offlineTimer is already null', () => {
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const state = makeState({ login: 'alice', offlineTimer: null });
+    const map = new Map([['k1', state]]);
+
+    cancelOfflineTimersForLogin(map, 'alice');
+
+    expect(clearSpy).not.toHaveBeenCalled();
+  });
+
+  it('cancels timers across multiple states for the same login', () => {
+    const t1 = setTimeout(() => {}, 99999);
+    const t2 = setTimeout(() => {}, 99999);
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const s1 = makeState({ login: 'alice', offlineTimer: t1 });
+    const s2 = makeState({ login: 'alice', offlineTimer: t2 });
+    const map = new Map([['k1', s1], ['k2', s2]]);
+
+    cancelOfflineTimersForLogin(map, 'alice');
+
+    expect(clearSpy).toHaveBeenCalledTimes(2);
+    expect(s1.offlineTimer).toBeNull();
+    expect(s2.offlineTimer).toBeNull();
+    clearTimeout(t1);
+    clearTimeout(t2);
+  });
+});
+
+// ─── runOfflineCheck ──────────────────────────────────────────────────────────
+
+describe('runOfflineCheck', () => {
+  it('returns early and does nothing when state is not in liveStates', async () => {
+    const map = new Map<string, LiveState>();
+    await runOfflineCheck(map, new Map(), 'missing', 'alice', 'alice');
+    expect(getStreams).not.toHaveBeenCalled();
+  });
+
+  it('returns early when userId is not found in loginToUserId', async () => {
+    const state = makeState();
+    const map = new Map([['k1', state]]);
+    await runOfflineCheck(map, new Map(), 'k1', 'alice', 'alice');
+    expect(getStreams).not.toHaveBeenCalled();
+    expect(state.offlineTimer).toBeNull();
+  });
+
+  it('deletes the announcement and sets channel offline when stream is no longer live', async () => {
+    vi.mocked(getStreams).mockResolvedValue([]);
+    const state = makeState();
+    const liveStates = new Map([['k1', state]]);
+    const loginToUserId = new Map([['alice', 'uid123']]);
+
+    await runOfflineCheck(liveStates, loginToUserId, 'k1', 'alice', 'alice');
+
+    expect(getStreams).toHaveBeenCalledWith(['uid123']);
+    expect(setTwitchChannelLive).toHaveBeenCalledWith('alice', false);
+    expect(deleteAnnouncement).toHaveBeenCalledWith(liveStates, 'k1');
+    expect(state.offlineTimer).toBeNull();
+  });
+
+  it('does not delete announcement when stream is still live', async () => {
+    vi.mocked(getStreams).mockResolvedValue([{ user_id: 'uid123', type: 'live' } as any]);
+    const state = makeState();
+    const liveStates = new Map([['k1', state]]);
+    const loginToUserId = new Map([['alice', 'uid123']]);
+
+    await runOfflineCheck(liveStates, loginToUserId, 'k1', 'alice', 'alice');
+
+    expect(deleteAnnouncement).not.toHaveBeenCalled();
+    expect(setTwitchChannelLive).not.toHaveBeenCalled();
+    expect(state.offlineTimer).toBeNull();
+  });
+
+  it('nulls offlineTimer in the finally block even when an error is thrown', async () => {
+    vi.mocked(getStreams).mockRejectedValue(new Error('API error'));
+    const state = makeState();
+    const liveStates = new Map([['k1', state]]);
+    const loginToUserId = new Map([['alice', 'uid123']]);
+
+    await expect(runOfflineCheck(liveStates, loginToUserId, 'k1', 'alice', 'alice')).rejects.toThrow('API error');
+    expect(state.offlineTimer).toBeNull();
+  });
+
+  it('treats a non-live stream type as offline', async () => {
+    vi.mocked(getStreams).mockResolvedValue([{ user_id: 'uid123', type: 'vodcast' } as any]);
+    const state = makeState();
+    const liveStates = new Map([['k1', state]]);
+    const loginToUserId = new Map([['alice', 'uid123']]);
+
+    await runOfflineCheck(liveStates, loginToUserId, 'k1', 'alice', 'alice');
+
+    expect(deleteAnnouncement).toHaveBeenCalled();
+  });
+});

--- a/src/web/middleware.test.ts
+++ b/src/web/middleware.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../db', () => ({
+  findApprovedKeyByHash: vi.fn(),
+  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
+}));
+vi.mock('./csrf', () => ({
+  ensureSessionCsrfToken: vi.fn().mockReturnValue('csrf-token'),
+}));
+
+import { requireAuth, requireManager, requireMod, requireAdmin, requireApiKey } from './middleware';
+import { findApprovedKeyByHash } from '../db';
+
+function makeReq(overrides: object = {}): any {
+  return {
+    session: {},
+    headers: {},
+    ...overrides,
+  };
+}
+
+function makeRes(): any {
+  const res: any = {
+    status: vi.fn().mockReturnThis(),
+    redirect: vi.fn(),
+    render: vi.fn(),
+    json: vi.fn(),
+  };
+  return res;
+}
+
+const next = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─── requireAuth ─────────────────────────────────────────────────────────────
+
+describe('requireAuth', () => {
+  it('calls next() when session.user is set', () => {
+    const req = makeReq({ session: { user: { accessLevel: 0 } } });
+    requireAuth(req, makeRes(), next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('redirects to /auth/login when session.user is absent', () => {
+    const req = makeReq({ session: {} });
+    const res = makeRes();
+    requireAuth(req, res, next);
+    expect(res.redirect).toHaveBeenCalledWith('/auth/login');
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+// ─── requireMod ──────────────────────────────────────────────────────────────
+
+describe('requireMod', () => {
+  it('calls next() when access level is MOD (1)', () => {
+    const req = makeReq({ session: { user: { accessLevel: 1 } } });
+    requireMod(req, makeRes(), next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('calls next() when access level is higher than MOD', () => {
+    const req = makeReq({ session: { user: { accessLevel: 3 } } });
+    requireMod(req, makeRes(), next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('returns 403 when access level is USER (0)', () => {
+    const req = makeReq({ session: { user: { accessLevel: 0 } } });
+    const res = makeRes();
+    requireMod(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.render).toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when session.user is absent', () => {
+    const req = makeReq({ session: {} });
+    const res = makeRes();
+    requireMod(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('renders error template with Mod-required message', () => {
+    const req = makeReq({ session: {} });
+    const res = makeRes();
+    requireMod(req, res, next);
+    const [template, data] = res.render.mock.calls[0];
+    expect(template).toBe('error');
+    expect(data.message).toContain('Mod');
+  });
+});
+
+// ─── requireManager ──────────────────────────────────────────────────────────
+
+describe('requireManager', () => {
+  it('calls next() when access level is MANAGER (2)', () => {
+    const req = makeReq({ session: { user: { accessLevel: 2 } } });
+    requireManager(req, makeRes(), next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('calls next() when access level is ADMIN (3)', () => {
+    const req = makeReq({ session: { user: { accessLevel: 3 } } });
+    requireManager(req, makeRes(), next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('returns 403 when access level is MOD (1)', () => {
+    const req = makeReq({ session: { user: { accessLevel: 1 } } });
+    const res = makeRes();
+    requireManager(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when no session user', () => {
+    const req = makeReq({ session: {} });
+    const res = makeRes();
+    requireManager(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('renders error template with Manager-required message', () => {
+    const req = makeReq({ session: { user: { accessLevel: 0 } } });
+    const res = makeRes();
+    requireManager(req, res, next);
+    const [template, data] = res.render.mock.calls[0];
+    expect(template).toBe('error');
+    expect(data.message).toContain('Manager');
+  });
+});
+
+// ─── requireAdmin ─────────────────────────────────────────────────────────────
+
+describe('requireAdmin', () => {
+  it('calls next() when access level is ADMIN (3)', () => {
+    const req = makeReq({ session: { user: { accessLevel: 3 } } });
+    requireAdmin(req, makeRes(), next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('returns 403 when access level is MANAGER (2)', () => {
+    const req = makeReq({ session: { user: { accessLevel: 2 } } });
+    const res = makeRes();
+    requireAdmin(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when no session user', () => {
+    const req = makeReq({ session: {} });
+    const res = makeRes();
+    requireAdmin(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('renders error template with Admin-required message', () => {
+    const req = makeReq({ session: { user: { accessLevel: 0 } } });
+    const res = makeRes();
+    requireAdmin(req, res, next);
+    const [, data] = res.render.mock.calls[0];
+    expect(data.message).toContain('Admin');
+  });
+});
+
+// ─── requireApiKey ────────────────────────────────────────────────────────────
+
+describe('requireApiKey', () => {
+  it('returns 401 when Authorization header is absent', async () => {
+    const req = makeReq({ headers: {} });
+    const res = makeRes();
+    await requireApiKey(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ ok: false, error: 'Unauthorized' });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when Authorization header does not start with Bearer', async () => {
+    const req = makeReq({ headers: { authorization: 'Basic abc' } });
+    const res = makeRes();
+    await requireApiKey(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when findApprovedKeyByHash returns null', async () => {
+    vi.mocked(findApprovedKeyByHash).mockResolvedValue(null);
+    const req = makeReq({ headers: { authorization: 'Bearer mytoken' } });
+    const res = makeRes();
+    await requireApiKey(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('sets req.apiKeyOwner and calls next() when key is valid', async () => {
+    vi.mocked(findApprovedKeyByHash).mockResolvedValue({ discord_id: 'user42' } as any);
+    const req = makeReq({ headers: { authorization: 'Bearer validtoken' } });
+    const res = makeRes();
+    await requireApiKey(req, res, next);
+    expect(req.apiKeyOwner).toBe('user42');
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('hashes the token before looking it up', async () => {
+    vi.mocked(findApprovedKeyByHash).mockResolvedValue({ discord_id: 'u1' } as any);
+    const req = makeReq({ headers: { authorization: 'Bearer mytoken' } });
+    await requireApiKey(req, makeRes(), next);
+    const passedHash: string = vi.mocked(findApprovedKeyByHash).mock.calls[0][0];
+    // SHA256 of 'mytoken' is a 64-char hex string
+    expect(passedHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(passedHash).not.toBe('mytoken');
+  });
+
+  it('returns 500 when findApprovedKeyByHash throws', async () => {
+    vi.mocked(findApprovedKeyByHash).mockRejectedValue(new Error('DB error'));
+    const req = makeReq({ headers: { authorization: 'Bearer tok' } });
+    const res = makeRes();
+    await requireApiKey(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ ok: false, error: 'Internal server error' });
+    expect(next).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Add test files for 4 previously uncovered `src/db` modules: `users`, `commandConflicts`, `sfx`, `streamdeckKeys`
- Extend `commandLocks.test.ts` with `acquireNamedLock` and `isAnyCommandTakenAcrossTables` suites
- ~130 new test cases; all pass with TypeScript clean

## What's covered

| File | New tests |
|---|---|
| `users.test.ts` | `findUser`, `findUserByTwitchName`, `getAllUsers`, `upsertUserRecord`, `updateDiscordName`, `getTwitchEnabledChannels`, `setTwitchBotEnabledRecord`, `updateAccessLevel`, `removeUserRecord` |
| `commandConflicts.test.ts` | `assertDiscordTriggerAvailable`, `assertMultiTwitchTriggerAvailable`, `assertNoSingleTwitchAssignmentOverlap`, `assertNoTwitchChannelTriggerConflict`, `getCommandTriggerStringById`, `getUserTwitchEligibility`, `insertUserCommandAssignment` |
| `sfx.test.ts` | `findTrigger`, `findSoundFiles`, `getPublicSfxTriggers`, `getAllSfxTriggers` (including aggregation and BIT flag mapping) |
| `streamdeckKeys.test.ts` | `findApprovedKeyByHash` (timing-safe comparison), `getApiKeyStatus`, `approveApiKey`, `denyApiKey`, `revokeApiKey`, `getPendingRequests`, `getAllApiKeys`, `requestApiKey` |
| `commandLocks.test.ts` | `acquireNamedLock` (success/timeout/null/unexpected), `isAnyCommandTakenAcrossTables` (short-circuit, per-table filtering, excludes) |

## Test plan

- `npx tsc --noEmit` — no errors
- `npm test` — 659 tests, all pass

https://claude.ai/code/session_01DNLtYg8ZzSNR5fAzw9p85k
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNLtYg8ZzSNR5fAzw9p85k)_