### PR TITLE
Add unit tests for src/db core modules

### DIFF
--- a/src/db/commandConflicts.test.ts
+++ b/src/db/commandConflicts.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../shared/logger', () => ({ createLogger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn() }) }));
+vi.mock('./pool', () => ({ getPool: vi.fn() }));
+vi.mock('mysql2/promise', () => ({ default: {} }));
+vi.mock('../twitch/twitchChannelName', () => ({
+  normalizeTwitchChannelName: vi.fn((s: string) => (s ? s.toLowerCase() : null)),
+}));
+vi.mock('./commandLocks', () => ({
+  acquireNamedLock: vi.fn().mockResolvedValue(undefined),
+  releaseNamedLock: vi.fn().mockResolvedValue(undefined),
+  getCommandWriteLockName: vi.fn((s: string) => `bcuk_cmd_${s}`),
+  isDeadlockError: vi.fn().mockReturnValue(false),
+  MAX_DEADLOCK_RETRIES: 3,
+}));
+vi.mock('./commandStringUtils', () => ({
+  CommandConflictError: class CommandConflictError extends Error {
+    commands: string[];
+    constructor(cmds: string[]) {
+      super(String(cmds));
+      this.commands = cmds;
+    }
+  },
+}));
+
+import {
+  assertDiscordTriggerAvailable,
+  assertMultiTwitchTriggerAvailable,
+  assertNoSingleTwitchAssignmentOverlap,
+  assertNoTwitchChannelTriggerConflict,
+  getCommandTriggerStringById,
+  getUserTwitchEligibility,
+  insertUserCommandAssignment,
+} from './commandConflicts';
+import { CommandConflictError } from './commandStringUtils';
+import { normalizeTwitchChannelName } from '../twitch/twitchChannelName';
+
+// Cast to any to satisfy SqlExecutor (Pool | PoolConnection) without importing full mysql types
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeExecutor(rows: unknown[] = []): any {
+  return { execute: vi.fn().mockResolvedValue([[...rows], []]) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(normalizeTwitchChannelName).mockImplementation((s: string) => s ? s.toLowerCase() : null);
+});
+
+// ─── assertDiscordTriggerAvailable ───────────────────────────────────────────
+
+describe('assertDiscordTriggerAvailable', () => {
+  it('does not throw when no conflict rows returned', async () => {
+    const exec = makeExecutor([]);
+    await expect(assertDiscordTriggerAvailable('!test', exec)).resolves.not.toThrow();
+  });
+
+  it('throws CommandConflictError when a conflict row is found', async () => {
+    const exec = makeExecutor([{ command_id: 1 }]);
+    await expect(assertDiscordTriggerAvailable('!test', exec)).rejects.toBeInstanceOf(CommandConflictError);
+  });
+
+  it('includes the trigger string in the conflict error', async () => {
+    const exec = makeExecutor([{ command_id: 1 }]);
+    const error = await assertDiscordTriggerAvailable('!test', exec).catch((e) => e);
+    expect(error.commands).toContain('!test');
+  });
+
+  it('adds AND command_id <> ? clause when excludeCommandId is provided', async () => {
+    const exec = makeExecutor([]);
+    await assertDiscordTriggerAvailable('!test', exec, 42);
+    const sql: string = exec.execute.mock.calls[0][0];
+    expect(sql).toContain('command_id <> ?');
+    expect(exec.execute.mock.calls[0][1]).toContain(42);
+  });
+
+  it('does not add exclude clause when excludeCommandId is undefined', async () => {
+    const exec = makeExecutor([]);
+    await assertDiscordTriggerAvailable('!test', exec);
+    const sql: string = exec.execute.mock.calls[0][0];
+    expect(sql).not.toContain('command_id <> ?');
+  });
+});
+
+// ─── assertMultiTwitchTriggerAvailable ───────────────────────────────────────
+
+describe('assertMultiTwitchTriggerAvailable', () => {
+  it('does not throw when no multi-twitch conflict', async () => {
+    const exec = makeExecutor([]);
+    await expect(assertMultiTwitchTriggerAvailable(exec, '!test')).resolves.not.toThrow();
+  });
+
+  it('throws CommandConflictError when a multi-twitch conflict exists', async () => {
+    const exec = makeExecutor([{ command_id: 5 }]);
+    await expect(assertMultiTwitchTriggerAvailable(exec, '!test')).rejects.toBeInstanceOf(CommandConflictError);
+  });
+
+  it('uses exclude clause when excludeCommandId is provided', async () => {
+    const exec = makeExecutor([]);
+    await assertMultiTwitchTriggerAvailable(exec, '!test', 7);
+    const sql: string = exec.execute.mock.calls[0][0];
+    expect(sql).toContain('c.command_id <> ?');
+    expect(exec.execute.mock.calls[0][1]).toContain(7);
+  });
+
+  it('does not use exclude clause when no excludeCommandId', async () => {
+    const exec = makeExecutor([]);
+    await assertMultiTwitchTriggerAvailable(exec, '!test');
+    const sql: string = exec.execute.mock.calls[0][0];
+    expect(sql).not.toContain('c.command_id <> ?');
+  });
+});
+
+// ─── assertNoSingleTwitchAssignmentOverlap ────────────────────────────────────
+
+describe('assertNoSingleTwitchAssignmentOverlap', () => {
+  it('does not throw when no overlap rows returned', async () => {
+    const exec = makeExecutor([]);
+    await expect(assertNoSingleTwitchAssignmentOverlap(exec, 1, '!test')).resolves.not.toThrow();
+  });
+
+  it('throws CommandConflictError when overlap exists', async () => {
+    const exec = makeExecutor([{ command_id: 2 }]);
+    await expect(assertNoSingleTwitchAssignmentOverlap(exec, 1, '!test')).rejects.toBeInstanceOf(CommandConflictError);
+  });
+});
+
+// ─── assertNoTwitchChannelTriggerConflict ─────────────────────────────────────
+
+describe('assertNoTwitchChannelTriggerConflict', () => {
+  it('does not throw when no conflict', async () => {
+    const exec = makeExecutor([]);
+    await expect(assertNoTwitchChannelTriggerConflict(exec, 1, '!test', 'alice')).resolves.not.toThrow();
+  });
+
+  it('throws CommandConflictError when conflict found', async () => {
+    const exec = makeExecutor([{ command_id: 3 }]);
+    await expect(assertNoTwitchChannelTriggerConflict(exec, 1, '!test', 'alice')).rejects.toBeInstanceOf(CommandConflictError);
+  });
+
+  it('passes commandId, triggerString, and normalizedTwitchName to the query', async () => {
+    const exec = makeExecutor([]);
+    await assertNoTwitchChannelTriggerConflict(exec, 10, '!clap', 'alice');
+    const params: unknown[] = exec.execute.mock.calls[0][1];
+    expect(params).toContain(10);
+    expect(params).toContain('!clap');
+    expect(params).toContain('alice');
+  });
+});
+
+// ─── getCommandTriggerStringById ─────────────────────────────────────────────
+
+describe('getCommandTriggerStringById', () => {
+  it('throws when no command found', async () => {
+    const exec = makeExecutor([]);
+    await expect(getCommandTriggerStringById(exec, 99)).rejects.toThrow('Custom command not found: 99');
+  });
+
+  it('returns trimmed lowercase trigger string', async () => {
+    const exec = makeExecutor([{ trigger_string: '  !CLAP  ' }]);
+    const result = await getCommandTriggerStringById(exec, 1);
+    expect(result).toBe('!clap');
+  });
+});
+
+// ─── getUserTwitchEligibility ─────────────────────────────────────────────────
+
+describe('getUserTwitchEligibility', () => {
+  it('throws when user not found', async () => {
+    const exec = makeExecutor([]);
+    await expect(getUserTwitchEligibility(exec, '999')).rejects.toThrow('User not found: 999');
+  });
+
+  it('returns null normalizedTwitchName when twitch_name is null', async () => {
+    const exec = makeExecutor([{ twitch_name: null, is_twitch_bot_enabled: 0 }]);
+    const result = await getUserTwitchEligibility(exec, '1');
+    expect(result.normalizedTwitchName).toBeNull();
+    expect(result.isTwitchBotEnabled).toBe(false);
+  });
+
+  it('normalizes twitch_name through normalizeTwitchChannelName', async () => {
+    vi.mocked(normalizeTwitchChannelName).mockReturnValue('alice');
+    const exec = makeExecutor([{ twitch_name: 'Alice', is_twitch_bot_enabled: 1 }]);
+    const result = await getUserTwitchEligibility(exec, '1');
+    expect(result.normalizedTwitchName).toBe('alice');
+    expect(result.isTwitchBotEnabled).toBe(true);
+  });
+
+  it('handles is_twitch_bot_enabled as a Buffer with value 0x01 → true', async () => {
+    const exec = makeExecutor([{ twitch_name: 'alice', is_twitch_bot_enabled: Buffer.from([1]) }]);
+    const result = await getUserTwitchEligibility(exec, '1');
+    expect(result.isTwitchBotEnabled).toBe(true);
+  });
+
+  it('handles is_twitch_bot_enabled as a Buffer with value 0x00 → false', async () => {
+    const exec = makeExecutor([{ twitch_name: 'alice', is_twitch_bot_enabled: Buffer.from([0]) }]);
+    const result = await getUserTwitchEligibility(exec, '1');
+    expect(result.isTwitchBotEnabled).toBe(false);
+  });
+
+  it('handles is_twitch_bot_enabled as numeric 1 → true', async () => {
+    const exec = makeExecutor([{ twitch_name: 'alice', is_twitch_bot_enabled: 1 }]);
+    const result = await getUserTwitchEligibility(exec, '1');
+    expect(result.isTwitchBotEnabled).toBe(true);
+  });
+
+  it('handles is_twitch_bot_enabled as numeric 0 → false', async () => {
+    const exec = makeExecutor([{ twitch_name: 'alice', is_twitch_bot_enabled: 0 }]);
+    const result = await getUserTwitchEligibility(exec, '1');
+    expect(result.isTwitchBotEnabled).toBe(false);
+  });
+});
+
+// ─── insertUserCommandAssignment ──────────────────────────────────────────────
+
+describe('insertUserCommandAssignment', () => {
+  it('executes an INSERT with commandId and discordId', async () => {
+    const exec = makeExecutor();
+    await insertUserCommandAssignment(exec, 5, 'user123');
+    expect(exec.execute).toHaveBeenCalledOnce();
+    const [sql, params] = exec.execute.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('INSERT INTO twitch_user_commands');
+    expect(params).toContain(5);
+    expect(params).toContain('user123');
+  });
+});

--- a/src/db/commandLocks.test.ts
+++ b/src/db/commandLocks.test.ts
@@ -1,19 +1,24 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../logger', () => ({ createLogger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn() }) }));
+vi.mock('../shared/logger', () => ({ createLogger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn() }) }));
 vi.mock('./pool', () => ({ getPool: vi.fn() }));
 vi.mock('mysql2/promise', () => ({ default: {} }));
 vi.mock('./commandStringUtils', () => ({
   CommandConflictError: class CommandConflictError extends Error {
+    commands: string[];
     constructor(cmds: string[]) {
       super(String(cmds));
+      this.commands = cmds;
     }
   },
-  normalizeCommandInputs: vi.fn(),
-  buildInClausePlaceholders: vi.fn(),
+  normalizeCommandInputs: vi.fn((x: string | string[]) => (Array.isArray(x) ? x : [x]).map((s: string) => s.trim().toLowerCase()).filter(Boolean)),
+  buildInClausePlaceholders: vi.fn((n: number) => Array(n).fill('?').join(',')),
 }));
 
-import { isDeadlockError, getCommandWriteLockName } from './commandLocks';
+import { getPool } from './pool';
+import { isDeadlockError, getCommandWriteLockName, acquireNamedLock, isAnyCommandTakenAcrossTables } from './commandLocks';
+import { CommandConflictError } from './commandStringUtils';
 
 describe('isDeadlockError', () => {
   it('returns true when code is ER_LOCK_DEADLOCK', () => {
@@ -78,5 +83,122 @@ describe('getCommandWriteLockName', () => {
     const hashPart = lockName.slice(prefix.length);
     expect(hashPart).toHaveLength(48);
     expect(hashPart).toMatch(/^[0-9a-f]{48}$/);
+  });
+});
+
+// ─── acquireNamedLock ─────────────────────────────────────────────────────────
+
+describe('acquireNamedLock', () => {
+  function makeConn(lockStatus: unknown) {
+    return { execute: vi.fn().mockResolvedValue([[{ lock_status: lockStatus }], []]) };
+  }
+
+  it('resolves without error when lock_status is the string "1"', async () => {
+    await expect(acquireNamedLock(makeConn('1') as any, 'test_lock')).resolves.not.toThrow();
+  });
+
+  it('resolves without error when lock_status is the number 1', async () => {
+    await expect(acquireNamedLock(makeConn(1) as any, 'test_lock')).resolves.not.toThrow();
+  });
+
+  it('throws a timeout error when lock_status is the string "0"', async () => {
+    await expect(acquireNamedLock(makeConn('0') as any, 'test_lock')).rejects.toThrow('Timed out acquiring command write lock');
+  });
+
+  it('throws a timeout error when lock_status is the number 0', async () => {
+    await expect(acquireNamedLock(makeConn(0) as any, 'test_lock')).rejects.toThrow('Timed out acquiring command write lock');
+  });
+
+  it('throws an internal error when lock_status is null', async () => {
+    await expect(acquireNamedLock(makeConn(null) as any, 'test_lock')).rejects.toThrow('Internal error acquiring command write lock');
+  });
+
+  it('throws an unexpected-result error for an unrecognized lock_status value', async () => {
+    await expect(acquireNamedLock(makeConn('unexpected') as any, 'test_lock')).rejects.toThrow('Unexpected result acquiring command write lock');
+  });
+
+  it('includes the lock name in the error message', async () => {
+    const error = await acquireNamedLock(makeConn('0') as any, 'bcuk_cmd_abc123').catch((e) => e);
+    expect(error.message).toContain('bcuk_cmd_abc123');
+  });
+
+  it('calls GET_LOCK with the lock name and timeout', async () => {
+    const conn = makeConn('1');
+    await acquireNamedLock(conn as any, 'my_lock');
+    const [sql, params] = conn.execute.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('GET_LOCK');
+    expect(params[0]).toBe('my_lock');
+  });
+});
+
+// ─── isAnyCommandTakenAcrossTables ────────────────────────────────────────────
+
+describe('isAnyCommandTakenAcrossTables', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns false immediately for an empty array without querying', async () => {
+    const pool = { execute: vi.fn() };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await isAnyCommandTakenAcrossTables([]);
+    expect(result).toBe(false);
+    expect(pool.execute).not.toHaveBeenCalled();
+  });
+
+  it('returns false when both tables return no rows', async () => {
+    const pool = { execute: vi.fn().mockResolvedValue([[]]  ) };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await isAnyCommandTakenAcrossTables('!test');
+    expect(result).toBe(false);
+  });
+
+  it('returns true when custom_command table returns a row', async () => {
+    const pool = {
+      execute: vi.fn()
+        .mockResolvedValueOnce([[{ '1': 1 }]])  // custom_command hit
+        .mockResolvedValueOnce([[]]),             // counter miss
+    };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await isAnyCommandTakenAcrossTables('!test');
+    expect(result).toBe(true);
+  });
+
+  it('returns true when only counter table returns a row', async () => {
+    const pool = {
+      execute: vi.fn()
+        .mockResolvedValueOnce([[]])               // custom_command miss
+        .mockResolvedValueOnce([[{ '1': 1 }]]),   // counter hit
+    };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await isAnyCommandTakenAcrossTables('!test');
+    expect(result).toBe(true);
+  });
+
+  it('skips custom_command table when includeCustomCommandTable is false', async () => {
+    const pool = { execute: vi.fn().mockResolvedValue([[]]  ) };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await isAnyCommandTakenAcrossTables('!test', undefined, pool as any, { includeCustomCommandTable: false, includeCounterTable: true });
+    const sql: string = pool.execute.mock.calls[0][0];
+    expect(sql).toContain('counter');
+    expect(sql).not.toContain('custom_command');
+  });
+
+  it('skips counter table when includeCounterTable is false', async () => {
+    const pool = { execute: vi.fn().mockResolvedValue([[]]  ) };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await isAnyCommandTakenAcrossTables('!test', undefined, pool as any, { includeCustomCommandTable: true, includeCounterTable: false });
+    expect(pool.execute).toHaveBeenCalledOnce();
+    const sql: string = pool.execute.mock.calls[0][0];
+    expect(sql).toContain('custom_command');
+  });
+
+  it('passes excludeCustomCommandId to custom_command query', async () => {
+    const pool = { execute: vi.fn().mockResolvedValue([[]]  ) };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await isAnyCommandTakenAcrossTables('!test', { excludeCustomCommandId: 7 }, pool as any);
+    const customCmdCall = pool.execute.mock.calls.find((args) => (args[0] as string).includes('custom_command'));
+    expect(customCmdCall).toBeDefined();
+    expect(customCmdCall![1]).toContain(7);
   });
 });

--- a/src/db/commandLocks.test.ts
+++ b/src/db/commandLocks.test.ts
@@ -18,7 +18,6 @@ vi.mock('./commandStringUtils', () => ({
 
 import { getPool } from './pool';
 import { isDeadlockError, getCommandWriteLockName, acquireNamedLock, isAnyCommandTakenAcrossTables } from './commandLocks';
-import { CommandConflictError } from './commandStringUtils';
 
 describe('isDeadlockError', () => {
   it('returns true when code is ER_LOCK_DEADLOCK', () => {

--- a/src/db/sfx.test.ts
+++ b/src/db/sfx.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./pool', () => ({ getPool: vi.fn() }));
+vi.mock('mysql2/promise', () => ({ default: {} }));
+
+import { getPool } from './pool';
+import { findTrigger, findSoundFiles, getPublicSfxTriggers, getAllSfxTriggers } from './sfx';
+
+function makePool(rows: unknown[] = []) {
+  return { execute: vi.fn().mockResolvedValue([[...rows], []]) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─── findTrigger ─────────────────────────────────────────────────────────────
+
+describe('findTrigger', () => {
+  it('returns null when no rows found', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    const result = await findTrigger('!bang');
+    expect(result).toBeNull();
+  });
+
+  it('maps a row with numeric hidden=1 to true', async () => {
+    const row = { id: '1', trigger_command: '!bang', category_id: null, hidden: 1, description: null };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const result = await findTrigger('!bang');
+    expect(result).not.toBeNull();
+    expect(result!.hidden).toBe(true);
+  });
+
+  it('maps a row with numeric hidden=0 to false', async () => {
+    const row = { id: '2', trigger_command: '!clap', category_id: 3, hidden: 0, description: 'Clap sound' };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const result = await findTrigger('!clap');
+    expect(result!.hidden).toBe(false);
+    expect(result!.description).toBe('Clap sound');
+    expect(result!.category_id).toBe(3);
+  });
+
+  it('maps a row with Buffer hidden=0x01 to true', async () => {
+    const row = { id: '3', trigger_command: '!wow', category_id: null, hidden: Buffer.from([1]), description: null };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const result = await findTrigger('!wow');
+    expect(result!.hidden).toBe(true);
+  });
+
+  it('maps a row with Buffer hidden=0x00 to false', async () => {
+    const row = { id: '4', trigger_command: '!ok', category_id: null, hidden: Buffer.from([0]), description: null };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const result = await findTrigger('!ok');
+    expect(result!.hidden).toBe(false);
+  });
+
+  it('converts id to BigInt', async () => {
+    const row = { id: '9007199254740993', trigger_command: '!big', category_id: null, hidden: 0, description: null };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const result = await findTrigger('!big');
+    expect(result!.id).toBe(9007199254740993n);
+  });
+
+  it('lowercases the command string before querying', async () => {
+    const pool = makePool([]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await findTrigger('!BANG');
+    const params: unknown[] = pool.execute.mock.calls[0][1];
+    expect(params[0]).toBe('!bang');
+  });
+});
+
+// ─── findSoundFiles ───────────────────────────────────────────────────────────
+
+describe('findSoundFiles', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    const result = await findSoundFiles(1n);
+    expect(result).toEqual([]);
+  });
+
+  it('maps rows correctly including Buffer hidden flag', async () => {
+    const rows = [
+      { id: 10, trigger_id: '1', file: 'bang.mp3', trigger_command: '!bang', weight: 2, hidden: Buffer.from([0]), category_id: null },
+      { id: 11, trigger_id: '1', file: 'bang2.mp3', trigger_command: '!bang', weight: 1, hidden: 1, category_id: 3 },
+    ];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await findSoundFiles(1n);
+    expect(result).toHaveLength(2);
+    expect(result[0].file).toBe('bang.mp3');
+    expect(result[0].hidden).toBe(false);
+    expect(result[0].trigger_id).toBe(1n);
+    expect(result[1].hidden).toBe(true);
+    expect(result[1].category_id).toBe(3);
+  });
+
+  it('passes triggerId as string to the query', async () => {
+    const pool = makePool([]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await findSoundFiles(42n);
+    const params: unknown[] = pool.execute.mock.calls[0][1];
+    expect(params[0]).toBe('42');
+  });
+});
+
+// ─── getPublicSfxTriggers ─────────────────────────────────────────────────────
+
+describe('getPublicSfxTriggers', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    const result = await getPublicSfxTriggers();
+    expect(result).toEqual([]);
+  });
+
+  it('maps rows with null categoryName and description', async () => {
+    const rows = [{ triggerCommand: '!test', categoryName: null, description: null }];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await getPublicSfxTriggers();
+    expect(result[0]).toEqual({ triggerCommand: '!test', categoryName: null, description: null });
+  });
+
+  it('maps rows with categoryName and description', async () => {
+    const rows = [{ triggerCommand: '!clap', categoryName: 'Reactions', description: 'Clap sound' }];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await getPublicSfxTriggers();
+    expect(result[0]).toEqual({ triggerCommand: '!clap', categoryName: 'Reactions', description: 'Clap sound' });
+  });
+});
+
+// ─── getAllSfxTriggers ────────────────────────────────────────────────────────
+
+describe('getAllSfxTriggers', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    const result = await getAllSfxTriggers();
+    expect(result).toEqual([]);
+  });
+
+  it('groups multiple sound files under the same trigger', async () => {
+    const rows = [
+      { triggerId: '1', triggerCommand: '!bang', description: null, triggerHidden: 0, categoryName: null, sfxId: 10, file: 'a.mp3', weight: 1, sfxHidden: 0 },
+      { triggerId: '1', triggerCommand: '!bang', description: null, triggerHidden: 0, categoryName: null, sfxId: 11, file: 'b.mp3', weight: 2, sfxHidden: 1 },
+    ];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await getAllSfxTriggers();
+    expect(result).toHaveLength(1);
+    expect(result[0].files).toHaveLength(2);
+    expect(result[0].files[0].file).toBe('a.mp3');
+    expect(result[0].files[1].hidden).toBe(true);
+  });
+
+  it('handles multiple distinct triggers', async () => {
+    const rows = [
+      { triggerId: '1', triggerCommand: '!bang', description: null, triggerHidden: 0, categoryName: null, sfxId: 10, file: 'a.mp3', weight: 1, sfxHidden: 0 },
+      { triggerId: '2', triggerCommand: '!clap', description: 'Clap', triggerHidden: 1, categoryName: 'Reactions', sfxId: 20, file: 'c.mp3', weight: 3, sfxHidden: 0 },
+    ];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await getAllSfxTriggers();
+    expect(result).toHaveLength(2);
+    expect(result[1].triggerCommand).toBe('!clap');
+    expect(result[1].hidden).toBe(true);
+    expect(result[1].categoryName).toBe('Reactions');
+  });
+
+  it('skips adding to files array when sfxId is null (trigger with no files)', async () => {
+    const rows = [
+      { triggerId: '1', triggerCommand: '!silent', description: null, triggerHidden: 0, categoryName: null, sfxId: null, file: null, weight: null, sfxHidden: null },
+    ];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await getAllSfxTriggers();
+    expect(result).toHaveLength(1);
+    expect(result[0].files).toHaveLength(0);
+  });
+
+  it('maps triggerHidden as Buffer correctly', async () => {
+    const rows = [
+      { triggerId: '1', triggerCommand: '!test', description: null, triggerHidden: Buffer.from([1]), categoryName: null, sfxId: null, file: null, weight: null, sfxHidden: null },
+    ];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await getAllSfxTriggers();
+    expect(result[0].hidden).toBe(true);
+  });
+});

--- a/src/db/streamdeckKeys.test.ts
+++ b/src/db/streamdeckKeys.test.ts
@@ -7,6 +7,7 @@ vi.mock('./users', () => ({
 }));
 
 import { getPool } from './pool';
+import { AccessLevel } from './users';
 import {
   findApprovedKeyByHash,
   getApiKeyStatus,
@@ -204,7 +205,7 @@ describe('requestApiKey', () => {
     const row = { discord_id: '1', status: 'denied', requested_at: new Date(), approved_at: null, approved_by: null, user_name: null, approver_name: null };
     const pool = makePool([row]);
     vi.mocked(getPool).mockReturnValue(pool as any);
-    await expect(requestApiKey('1', 0)).rejects.toThrow('denied');
+    await expect(requestApiKey('1', AccessLevel.USER)).rejects.toThrow('denied');
   });
 
   it('returns status=approved for MANAGER access level (2)', async () => {
@@ -218,7 +219,7 @@ describe('requestApiKey', () => {
         }]]),
     };
     vi.mocked(getPool).mockReturnValue(pool as any);
-    const result = await requestApiKey('1', 2);
+    const result = await requestApiKey('1', AccessLevel.MANAGER);
     expect(result.status).toBe('approved');
     expect(result.plain).toHaveLength(64); // 32 bytes as hex
   });
@@ -233,7 +234,7 @@ describe('requestApiKey', () => {
         }]]),
     };
     vi.mocked(getPool).mockReturnValue(pool as any);
-    const result = await requestApiKey('1', 0);
+    const result = await requestApiKey('1', AccessLevel.USER);
     expect(result.status).toBe('pending');
   });
 
@@ -247,7 +248,7 @@ describe('requestApiKey', () => {
         }]]),
     };
     vi.mocked(getPool).mockReturnValue(pool as any);
-    const result = await requestApiKey('1', 1);
+    const result = await requestApiKey('1', AccessLevel.MOD);
     expect(result.plain).toMatch(/^[0-9a-f]{64}$/);
   });
 });

--- a/src/db/streamdeckKeys.test.ts
+++ b/src/db/streamdeckKeys.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./pool', () => ({ getPool: vi.fn() }));
+vi.mock('mysql2/promise', () => ({ default: {} }));
+vi.mock('./users', () => ({
+  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
+}));
+
+import { getPool } from './pool';
+import {
+  findApprovedKeyByHash,
+  getApiKeyStatus,
+  approveApiKey,
+  denyApiKey,
+  revokeApiKey,
+  getPendingRequests,
+  getAllApiKeys,
+  requestApiKey,
+} from './streamdeckKeys';
+import { createHash } from 'crypto';
+
+function makePool(rows: unknown[] = []) {
+  return { execute: vi.fn().mockResolvedValue([[...rows], []]) };
+}
+
+function sha256hex(s: string) {
+  return createHash('sha256').update(s).digest('hex');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─── findApprovedKeyByHash ────────────────────────────────────────────────────
+
+describe('findApprovedKeyByHash', () => {
+  it('returns null when no rows found', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    const result = await findApprovedKeyByHash('a'.repeat(64));
+    expect(result).toBeNull();
+  });
+
+  it('returns null when stored hash does not match incoming hash', async () => {
+    const incoming = 'aa'.repeat(32); // 64 hex chars
+    const stored = 'bb'.repeat(32);   // different 64 hex chars
+    const row = { discord_id: '1', key_hash: stored, status: 'approved', requested_at: new Date(), approved_at: null, approved_by: null };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const result = await findApprovedKeyByHash(incoming);
+    expect(result).toBeNull();
+  });
+
+  it('returns the mapped row when hash matches', async () => {
+    const hash = sha256hex('mysecretkey');
+    const row = { discord_id: '42', key_hash: hash, status: 'approved', requested_at: new Date(), approved_at: new Date(), approved_by: '1' };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const result = await findApprovedKeyByHash(hash);
+    expect(result).not.toBeNull();
+    expect(result!.discord_id).toBe('42');
+    expect(result!.status).toBe('approved');
+  });
+
+  it('returns null when stored and incoming hash have different lengths', async () => {
+    const incoming = 'ab'.repeat(32); // 64 chars
+    const stored = 'ab'.repeat(16);   // 32 chars — different length
+    const row = { discord_id: '1', key_hash: stored, status: 'approved', requested_at: new Date(), approved_at: null, approved_by: null };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const result = await findApprovedKeyByHash(incoming);
+    expect(result).toBeNull();
+  });
+});
+
+// ─── getApiKeyStatus ──────────────────────────────────────────────────────────
+
+describe('getApiKeyStatus', () => {
+  it('returns null when no rows found', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    const result = await getApiKeyStatus('999');
+    expect(result).toBeNull();
+  });
+
+  it('maps a row with all fields', async () => {
+    const now = new Date();
+    const row = {
+      discord_id: '123',
+      status: 'pending',
+      requested_at: now,
+      approved_at: null,
+      approved_by: null,
+      user_name: null,
+      approver_name: null,
+    };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const result = await getApiKeyStatus('123');
+    expect(result!.discord_id).toBe('123');
+    expect(result!.status).toBe('pending');
+    expect(result!.requested_at).toBe(now);
+    expect(result!.approved_at).toBeNull();
+    expect(result!.approved_by).toBeNull();
+  });
+
+  it('maps a row with approver info', async () => {
+    const row = {
+      discord_id: '1',
+      status: 'approved',
+      requested_at: new Date(),
+      approved_at: new Date(),
+      approved_by: '99',
+      user_name: 'Alice',
+      approver_name: 'Admin',
+    };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const result = await getApiKeyStatus('1');
+    expect(result!.approved_by).toBe('99');
+    expect(result!.user_name).toBe('Alice');
+    expect(result!.approver_name).toBe('Admin');
+  });
+});
+
+// ─── approveApiKey ────────────────────────────────────────────────────────────
+
+describe('approveApiKey', () => {
+  it('executes UPDATE with approvedBy and discordId', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await approveApiKey('user1', 'admin1');
+    const [sql, params] = pool.execute.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("status = 'approved'");
+    expect(params).toContain('admin1');
+    expect(params).toContain('user1');
+  });
+});
+
+// ─── denyApiKey ───────────────────────────────────────────────────────────────
+
+describe('denyApiKey', () => {
+  it('executes UPDATE setting status to denied', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await denyApiKey('user1');
+    const [sql, params] = pool.execute.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("status = 'denied'");
+    expect(params).toContain('user1');
+  });
+});
+
+// ─── revokeApiKey ─────────────────────────────────────────────────────────────
+
+describe('revokeApiKey', () => {
+  it('executes UPDATE setting status to revoked', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await revokeApiKey('user1');
+    const [sql, params] = pool.execute.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("status = 'revoked'");
+    expect(params).toContain('user1');
+  });
+});
+
+// ─── getPendingRequests ───────────────────────────────────────────────────────
+
+describe('getPendingRequests', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    const result = await getPendingRequests();
+    expect(result).toEqual([]);
+  });
+
+  it('maps pending rows', async () => {
+    const row = { discord_id: '1', status: 'pending', requested_at: new Date(), approved_at: null, approved_by: null, user_name: 'Alice', approver_name: null };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const result = await getPendingRequests();
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe('pending');
+    expect(result[0].user_name).toBe('Alice');
+  });
+});
+
+// ─── getAllApiKeys ────────────────────────────────────────────────────────────
+
+describe('getAllApiKeys', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    const result = await getAllApiKeys();
+    expect(result).toEqual([]);
+  });
+
+  it('maps multiple rows with different statuses', async () => {
+    const rows = [
+      { discord_id: '1', status: 'approved', requested_at: new Date(), approved_at: new Date(), approved_by: '2', user_name: 'Alice', approver_name: 'Admin' },
+      { discord_id: '3', status: 'revoked', requested_at: new Date(), approved_at: null, approved_by: null, user_name: 'Bob', approver_name: null },
+    ];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await getAllApiKeys();
+    expect(result).toHaveLength(2);
+    expect(result[0].status).toBe('approved');
+    expect(result[1].status).toBe('revoked');
+  });
+});
+
+// ─── requestApiKey ────────────────────────────────────────────────────────────
+
+describe('requestApiKey', () => {
+  it('throws when existing status is denied', async () => {
+    const row = { discord_id: '1', status: 'denied', requested_at: new Date(), approved_at: null, approved_by: null, user_name: null, approver_name: null };
+    const pool = makePool([row]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(requestApiKey('1', 0)).rejects.toThrow('denied');
+  });
+
+  it('returns status=approved for MANAGER access level (2)', async () => {
+    // First call returns null (no existing row), second returns approved row
+    const pool = {
+      execute: vi.fn()
+        .mockResolvedValueOnce([[]])    // getApiKeyStatus initial
+        .mockResolvedValueOnce([[]])    // INSERT
+        .mockResolvedValueOnce([[{     // getApiKeyStatus after insert
+          discord_id: '1', status: 'approved', requested_at: new Date(), approved_at: new Date(), approved_by: '1', user_name: null, approver_name: null,
+        }]]),
+    };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await requestApiKey('1', 2);
+    expect(result.status).toBe('approved');
+    expect(result.plain).toHaveLength(64); // 32 bytes as hex
+  });
+
+  it('returns status=pending for USER access level (0)', async () => {
+    const pool = {
+      execute: vi.fn()
+        .mockResolvedValueOnce([[]])   // getApiKeyStatus initial
+        .mockResolvedValueOnce([[]])   // INSERT
+        .mockResolvedValueOnce([[{    // getApiKeyStatus after insert
+          discord_id: '1', status: 'pending', requested_at: new Date(), approved_at: null, approved_by: null, user_name: null, approver_name: null,
+        }]]),
+    };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await requestApiKey('1', 0);
+    expect(result.status).toBe('pending');
+  });
+
+  it('generates a 64-character hex plain key', async () => {
+    const pool = {
+      execute: vi.fn()
+        .mockResolvedValueOnce([[]])
+        .mockResolvedValueOnce([[]])
+        .mockResolvedValueOnce([[{
+          discord_id: '1', status: 'pending', requested_at: new Date(), approved_at: null, approved_by: null, user_name: null, approver_name: null,
+        }]]),
+    };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await requestApiKey('1', 1);
+    expect(result.plain).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/src/db/users.test.ts
+++ b/src/db/users.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../shared/logger', () => ({ createLogger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn() }) }));
+vi.mock('./pool', () => ({ getPool: vi.fn() }));
+vi.mock('mysql2/promise', () => ({ default: {} }));
+vi.mock('../twitch/twitchChannelName', () => ({
+  normalizeTwitchChannelName: vi.fn((s: string) => (s ? s.toLowerCase() : null)),
+}));
+
+import { getPool } from './pool';
+import {
+  findUser,
+  findUserByTwitchName,
+  getAllUsers,
+  upsertUserRecord,
+  updateDiscordName,
+  getTwitchEnabledChannels,
+  setTwitchBotEnabledRecord,
+  updateAccessLevel,
+  removeUserRecord,
+  AccessLevel,
+} from './users';
+import { normalizeTwitchChannelName } from '../twitch/twitchChannelName';
+
+function makeConnection(executeResult: unknown = [[], []]) {
+  return {
+    execute: vi.fn().mockResolvedValue(executeResult),
+    release: vi.fn(),
+  };
+}
+
+function makePool(executeResult: unknown = [[], []], connectionExecuteResult?: unknown) {
+  const conn = makeConnection(connectionExecuteResult ?? [[], []]);
+  return {
+    execute: vi.fn().mockResolvedValue(executeResult),
+    getConnection: vi.fn().mockResolvedValue(conn),
+    _conn: conn,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(normalizeTwitchChannelName).mockImplementation((s: string) => (s ? s.toLowerCase() : null));
+});
+
+// ─── findUser ────────────────────────────────────────────────────────────────
+
+describe('findUser', () => {
+  it('returns null when no rows found', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([[]]  ) as any);
+    const result = await findUser('123');
+    expect(result).toBeNull();
+  });
+
+  it('maps a row with numeric is_twitch_bot_enabled = 1 to true', async () => {
+    const row = { discord_id: '123', discord_name: 'Alice', is_twitch_bot_enabled: 1, twitch_name: 'alice', access_level: 0 };
+    vi.mocked(getPool).mockReturnValue(makePool([[row]]) as any);
+    const user = await findUser('123');
+    expect(user).not.toBeNull();
+    expect(user!.is_twitch_bot_enabled).toBe(true);
+    expect(user!.discord_id).toBe('123');
+  });
+
+  it('maps a row with numeric is_twitch_bot_enabled = 0 to false', async () => {
+    const row = { discord_id: '456', discord_name: 'Bob', is_twitch_bot_enabled: 0, twitch_name: null, access_level: 1 };
+    vi.mocked(getPool).mockReturnValue(makePool([[row]]) as any);
+    const user = await findUser('456');
+    expect(user!.is_twitch_bot_enabled).toBe(false);
+  });
+
+  it('maps a row with Buffer is_twitch_bot_enabled 0x01 to true', async () => {
+    const row = { discord_id: '789', discord_name: 'Carol', is_twitch_bot_enabled: Buffer.from([1]), twitch_name: 'carol', access_level: 2 };
+    vi.mocked(getPool).mockReturnValue(makePool([[row]]) as any);
+    const user = await findUser('789');
+    expect(user!.is_twitch_bot_enabled).toBe(true);
+  });
+
+  it('maps a row with Buffer is_twitch_bot_enabled 0x00 to false', async () => {
+    const row = { discord_id: '789', discord_name: 'Carol', is_twitch_bot_enabled: Buffer.from([0]), twitch_name: 'carol', access_level: 2 };
+    vi.mocked(getPool).mockReturnValue(makePool([[row]]) as any);
+    const user = await findUser('789');
+    expect(user!.is_twitch_bot_enabled).toBe(false);
+  });
+
+  it('coerces discord_id to string', async () => {
+    const row = { discord_id: 999n, discord_name: 'Bigint', is_twitch_bot_enabled: 0, twitch_name: null, access_level: 0 };
+    vi.mocked(getPool).mockReturnValue(makePool([[row]]) as any);
+    const user = await findUser('999');
+    expect(user!.discord_id).toBe('999');
+  });
+});
+
+// ─── findUserByTwitchName ─────────────────────────────────────────────────────
+
+describe('findUserByTwitchName', () => {
+  it('returns null when normalizeTwitchChannelName returns null (blank/invalid name)', async () => {
+    vi.mocked(normalizeTwitchChannelName).mockReturnValue(null);
+    const pool = makePool([[]]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await findUserByTwitchName('');
+    expect(result).toBeNull();
+    expect(pool.execute).not.toHaveBeenCalled();
+  });
+
+  it('returns null when query returns no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([[]]) as any);
+    const result = await findUserByTwitchName('alice');
+    expect(result).toBeNull();
+  });
+
+  it('maps a found row correctly', async () => {
+    const row = { discord_id: '111', discord_name: 'Alice', is_twitch_bot_enabled: 1, twitch_name: 'alice', access_level: 0 };
+    vi.mocked(getPool).mockReturnValue(makePool([[row]]) as any);
+    const result = await findUserByTwitchName('alice');
+    expect(result!.discord_id).toBe('111');
+  });
+
+  it('uses an exclude query when excludeDiscordId is provided', async () => {
+    const pool = makePool([[]]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await findUserByTwitchName('alice', '999');
+    const sql: string = vi.mocked(pool.execute).mock.calls[0][0] as string;
+    expect(sql).toContain('discord_id <> ?');
+  });
+
+  it('does not use an exclude clause when no excludeDiscordId provided', async () => {
+    const pool = makePool([[]]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await findUserByTwitchName('alice');
+    const sql: string = vi.mocked(pool.execute).mock.calls[0][0] as string;
+    expect(sql).not.toContain('discord_id <> ?');
+  });
+});
+
+// ─── getAllUsers ──────────────────────────────────────────────────────────────
+
+describe('getAllUsers', () => {
+  it('returns an empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([[]]) as any);
+    const result = await getAllUsers();
+    expect(result).toEqual([]);
+  });
+
+  it('maps multiple rows', async () => {
+    const rows = [
+      { discord_id: '1', discord_name: 'A', is_twitch_bot_enabled: 0, twitch_name: null, access_level: 3 },
+      { discord_id: '2', discord_name: 'B', is_twitch_bot_enabled: 1, twitch_name: 'b', access_level: 0 },
+    ];
+    vi.mocked(getPool).mockReturnValue(makePool([rows]) as any);
+    const result = await getAllUsers();
+    expect(result).toHaveLength(2);
+    expect(result[0].discord_id).toBe('1');
+    expect(result[1].is_twitch_bot_enabled).toBe(true);
+  });
+});
+
+// ─── upsertUserRecord ─────────────────────────────────────────────────────────
+
+describe('upsertUserRecord', () => {
+  it('throws for an invalid access level', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    await expect(upsertUserRecord('1', 'Alice', 99)).rejects.toThrow('Invalid accessLevel: 99');
+  });
+
+  it('accepts all valid access levels', async () => {
+    for (const level of Object.values(AccessLevel)) {
+      const pool = makePool();
+      vi.mocked(getPool).mockReturnValue(pool as any);
+      await expect(upsertUserRecord('1', 'Alice', level)).resolves.not.toThrow();
+    }
+  });
+
+  it('returns true when twitchName is provided (even if null)', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    const result = await upsertUserRecord('1', 'Alice', 0, null);
+    expect(result).toBe(true);
+  });
+
+  it('returns false when twitchName is not provided (undefined)', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    const result = await upsertUserRecord('1', 'Alice', 0);
+    expect(result).toBe(false);
+  });
+
+  it('throws when twitchName is an empty string', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    await expect(upsertUserRecord('1', 'Alice', 0, '')).rejects.toThrow('Invalid twitchName');
+  });
+
+  it('throws when twitchName is whitespace-only', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    await expect(upsertUserRecord('1', 'Alice', 0, '   ')).rejects.toThrow('Invalid twitchName');
+  });
+
+  it('throws when normalizeTwitchChannelName returns null for twitchName', async () => {
+    vi.mocked(normalizeTwitchChannelName).mockReturnValue(null);
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    await expect(upsertUserRecord('1', 'Alice', 0, 'invalid!')).rejects.toThrow('Invalid twitchName');
+  });
+
+  it('trims discordName and passes null when blank', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await upsertUserRecord('1', '   ', 0);
+    const params = pool._conn.execute.mock.calls[1][1] as unknown[];
+    expect(params[1]).toBeNull();
+  });
+});
+
+// ─── updateDiscordName ────────────────────────────────────────────────────────
+
+describe('updateDiscordName', () => {
+  it('passes trimmed name to the query', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await updateDiscordName('1', '  Alice  ');
+    expect(pool.execute).toHaveBeenCalledWith(expect.any(String), ['Alice', '1']);
+  });
+
+  it('passes null when name is blank after trimming', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await updateDiscordName('1', '   ');
+    expect(pool.execute).toHaveBeenCalledWith(expect.any(String), [null, '1']);
+  });
+});
+
+// ─── getTwitchEnabledChannels ─────────────────────────────────────────────────
+
+describe('getTwitchEnabledChannels', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([[]]) as any);
+    const result = await getTwitchEnabledChannels();
+    expect(result).toEqual([]);
+  });
+
+  it('maps twitch_name through normalizeTwitchChannelName', async () => {
+    vi.mocked(normalizeTwitchChannelName).mockImplementation((s) => `normalized_${s}`);
+    const rows = [{ twitch_name: 'Alice' }, { twitch_name: 'Bob' }];
+    vi.mocked(getPool).mockReturnValue(makePool([rows]) as any);
+    const result = await getTwitchEnabledChannels();
+    expect(result).toEqual(['normalized_Alice', 'normalized_Bob']);
+  });
+
+  it('filters out entries where normalizeTwitchChannelName returns null', async () => {
+    vi.mocked(normalizeTwitchChannelName).mockReturnValueOnce('alice').mockReturnValueOnce(null);
+    const rows = [{ twitch_name: 'alice' }, { twitch_name: 'bad!' }];
+    vi.mocked(getPool).mockReturnValue(makePool([rows]) as any);
+    const result = await getTwitchEnabledChannels();
+    expect(result).toEqual(['alice']);
+  });
+});
+
+// ─── updateAccessLevel ────────────────────────────────────────────────────────
+
+describe('updateAccessLevel', () => {
+  it('throws for an invalid access level', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    await expect(updateAccessLevel('1', 5)).rejects.toThrow('Invalid accessLevel: 5');
+  });
+
+  it('accepts all valid access levels', async () => {
+    for (const level of Object.values(AccessLevel)) {
+      vi.mocked(getPool).mockReturnValue(makePool() as any);
+      await expect(updateAccessLevel('1', level)).resolves.not.toThrow();
+    }
+  });
+});
+
+// ─── setTwitchBotEnabledRecord ────────────────────────────────────────────────
+
+describe('setTwitchBotEnabledRecord', () => {
+  it('passes 1 when enabled=true', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await setTwitchBotEnabledRecord('1', true);
+    const params = pool._conn.execute.mock.calls[1][1] as unknown[];
+    expect(params[0]).toBe(1);
+  });
+
+  it('passes 0 when enabled=false', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await setTwitchBotEnabledRecord('1', false);
+    const params = pool._conn.execute.mock.calls[1][1] as unknown[];
+    expect(params[0]).toBe(0);
+  });
+});
+
+// ─── removeUserRecord ─────────────────────────────────────────────────────────
+
+describe('removeUserRecord', () => {
+  it('executes a DELETE with the discord_id', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await removeUserRecord('42');
+    const sql: string = pool._conn.execute.mock.calls[1][0] as string;
+    expect(sql).toContain('DELETE FROM');
+    const params = pool._conn.execute.mock.calls[1][1] as unknown[];
+    expect(params).toContain('42');
+  });
+});
+
+// ─── AccessLevel constant ─────────────────────────────────────────────────────
+
+describe('AccessLevel', () => {
+  it('has USER=0, MOD=1, MANAGER=2, ADMIN=3', () => {
+    expect(AccessLevel.USER).toBe(0);
+    expect(AccessLevel.MOD).toBe(1);
+    expect(AccessLevel.MANAGER).toBe(2);
+    expect(AccessLevel.ADMIN).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

- `users.test.ts` — `findUser`, `findUserByTwitchName`, `getAllUsers`, `upsertUserRecord` (invalid access level, blank twitch name), `updateDiscordName`, `getTwitchEnabledChannels`, `setTwitchBotEnabledRecord`, `updateAccessLevel`, `removeUserRecord`
- `commandConflicts.test.ts` — all conflict assertion functions, `getCommandTriggerStringById`, `getUserTwitchEligibility` (BIT(1) as Buffer and numeric), `insertUserCommandAssignment`
- `sfx.test.ts` — `findTrigger`, `findSoundFiles`, `getPublicSfxTriggers`, `getAllSfxTriggers` (row aggregation, null sfxId, Buffer hidden flags)
- `streamdeckKeys.test.ts` — `findApprovedKeyByHash` (timing-safe comparison, length mismatch), `getApiKeyStatus`, `approveApiKey`, `denyApiKey`, `revokeApiKey`, `getPendingRequests`, `getAllApiKeys`, `requestApiKey` (denied/pending/approved paths)
- `commandLocks.test.ts` extended — `acquireNamedLock` (all lock_status variants: `"1"`, `1`, `"0"`, `0`, `null`, unexpected), `isAnyCommandTakenAcrossTables` (empty input, per-table filtering, excludeId passthrough)

## Test plan

- `npx tsc --noEmit` — clean
- `npm test` — all tests pass

https://claude.ai/code/session_01DNLtYg8ZzSNR5fAzw9p85k

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNLtYg8ZzSNR5fAzw9p85k)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test coverage for database operations and API features. New test suites now provide coverage for command conflict detection, lock management, sound effect operations, API key authentication and approval workflows, and user record management, ensuring improved system reliability and overall code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->