### PR TITLE
Add unit tests for counters, streamMonitor, overlayVideos, pathUtils

### DIFF
--- a/src/db/counters.test.ts
+++ b/src/db/counters.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./pool', () => ({ getPool: vi.fn() }));
+vi.mock('mysql2/promise', () => ({ default: {} }));
+vi.mock('./commandLocks', () => ({
+  runSerializedCommandWrite: vi.fn(async (_cmds: unknown, _opts: unknown, fn: (conn: unknown) => Promise<unknown>) => fn(mockConnection)),
+}));
+vi.mock('./commandStringUtils', () => ({
+  requireTrimmedString: vi.fn((v: string, _name: string, _max?: number) => {
+    const t = v.trim();
+    if (!t) throw new Error(`${_name} is required`);
+    return t;
+  }),
+  CommandConflictError: class CommandConflictError extends Error {
+    constructor(cmds: string[]) { super(String(cmds)); }
+  },
+}));
+vi.mock('./reservedCommands', () => ({
+  assertNotReservedCommand: vi.fn(),
+}));
+vi.mock('./utils', () => ({
+  fromBit: vi.fn((v: unknown) => (Buffer.isBuffer(v) ? v[0] === 1 : v == 1)),
+}));
+vi.mock('./counterCache', () => ({
+  invalidateCounterLookupCache: vi.fn(),
+}));
+
+// Shared mock connection used by runSerializedCommandWrite
+const mockConnection = {
+  execute: vi.fn(),
+  beginTransaction: vi.fn().mockResolvedValue(undefined),
+  commit: vi.fn().mockResolvedValue(undefined),
+  rollback: vi.fn().mockResolvedValue(undefined),
+  release: vi.fn(),
+};
+
+import { getPool } from './pool';
+import {
+  getAllCounters,
+  addCounter,
+  updateCounter,
+  removeCounter,
+  resetCounterCurrentValue,
+  incrementCounter,
+  archiveAndResetYearlyCounters,
+  CounterNotFoundError,
+} from './counters';
+import { runSerializedCommandWrite } from './commandLocks';
+import { assertNotReservedCommand } from './reservedCommands';
+import { invalidateCounterLookupCache } from './counterCache';
+
+function makePool(rows: unknown[] = [], meta: unknown = {}) {
+  const conn = {
+    execute: vi.fn(),
+    beginTransaction: vi.fn().mockResolvedValue(undefined),
+    commit: vi.fn().mockResolvedValue(undefined),
+    rollback: vi.fn().mockResolvedValue(undefined),
+    release: vi.fn(),
+  };
+  return {
+    execute: vi.fn().mockResolvedValue([[...rows], meta]),
+    getConnection: vi.fn().mockResolvedValue(conn),
+    _conn: conn,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─── CounterNotFoundError ────────────────────────────────────────────────────
+
+describe('CounterNotFoundError', () => {
+  it('has name CounterNotFoundError', () => {
+    const err = new CounterNotFoundError(42);
+    expect(err.name).toBe('CounterNotFoundError');
+  });
+
+  it('includes the id in the message', () => {
+    expect(new CounterNotFoundError(7).message).toContain('7');
+  });
+
+  it('is an instance of Error', () => {
+    expect(new CounterNotFoundError(1)).toBeInstanceOf(Error);
+  });
+});
+
+// ─── getAllCounters ───────────────────────────────────────────────────────────
+
+describe('getAllCounters', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    expect(await getAllCounters()).toEqual([]);
+  });
+
+  it('maps rows via fromBit for reset_yearly', async () => {
+    const rows = [
+      { id: 1, trigger_command: '!hits', check_command: '!checkhits', message: 'msg', increment_message: 'inc', reset_yearly: 1, current_value: 5 },
+      { id: 2, trigger_command: '!deaths', check_command: '!checkdeaths', message: 'm2', increment_message: 'i2', reset_yearly: 0, current_value: 0 },
+    ];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await getAllCounters();
+    expect(result).toHaveLength(2);
+    expect(result[0].reset_yearly).toBe(true);
+    expect(result[1].reset_yearly).toBe(false);
+    expect(result[0].current_value).toBe(5);
+  });
+});
+
+// ─── addCounter ──────────────────────────────────────────────────────────────
+
+describe('addCounter', () => {
+  it('throws when trigger and check command are the same', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    await expect(addCounter('!hits', '!hits', 'msg', 'inc', false)).rejects.toThrow('must be different');
+  });
+
+  it('calls assertNotReservedCommand for both commands', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    mockConnection.execute.mockResolvedValue([{}, []]);
+    await addCounter('!hits', '!checkhits', 'msg', 'inc', false);
+    expect(assertNotReservedCommand).toHaveBeenCalledWith('!hits');
+    expect(assertNotReservedCommand).toHaveBeenCalledWith('!checkhits');
+  });
+
+  it('calls runSerializedCommandWrite with both commands', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    mockConnection.execute.mockResolvedValue([{}, []]);
+    await addCounter('!hits', '!checkhits', 'msg', 'inc', true);
+    expect(runSerializedCommandWrite).toHaveBeenCalledWith(
+      ['!hits', '!checkhits'],
+      undefined,
+      expect.any(Function),
+    );
+  });
+
+  it('invalidates the counter cache after success', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    mockConnection.execute.mockResolvedValue([{}, []]);
+    await addCounter('!hits', '!checkhits', 'msg', 'inc', false);
+    expect(invalidateCounterLookupCache).toHaveBeenCalled();
+  });
+
+  it('throws when trigger and check differ only by case (normalized to same value)', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    await expect(addCounter('!HITS', '!hits', 'msg', 'inc', false)).rejects.toThrow('must be different');
+  });
+});
+
+// ─── updateCounter ────────────────────────────────────────────────────────────
+
+describe('updateCounter', () => {
+  it('throws when trigger and check are the same', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([{ trigger_command: '!old', check_command: '!oldcheck' }]) as any);
+    await expect(updateCounter({ id: 1, triggerCommand: '!hits', checkCommand: '!hits', message: 'm', incrementMessage: 'i', resetYearly: false }))
+      .rejects.toThrow('must be different');
+  });
+
+  it('throws CounterNotFoundError when getCounterCommandsById returns null', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    await expect(updateCounter({ id: 99, triggerCommand: '!hits', checkCommand: '!check', message: 'm', incrementMessage: 'i', resetYearly: false }))
+      .rejects.toBeInstanceOf(CounterNotFoundError);
+  });
+
+  it('calls assertNotReservedCommand for both commands', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([{ trigger_command: '!old', check_command: '!oldcheck' }]) as any);
+    mockConnection.execute.mockResolvedValue([{ affectedRows: 1 }, []]);
+    await updateCounter({ id: 1, triggerCommand: '!new', checkCommand: '!newcheck', message: 'm', incrementMessage: 'i', resetYearly: false });
+    expect(assertNotReservedCommand).toHaveBeenCalledWith('!new');
+    expect(assertNotReservedCommand).toHaveBeenCalledWith('!newcheck');
+  });
+
+  it('invalidates the counter cache after success', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([{ trigger_command: '!old', check_command: '!oldcheck' }]) as any);
+    mockConnection.execute.mockResolvedValue([{ affectedRows: 1 }, []]);
+    await updateCounter({ id: 1, triggerCommand: '!new', checkCommand: '!check', message: 'm', incrementMessage: 'i', resetYearly: false });
+    expect(invalidateCounterLookupCache).toHaveBeenCalled();
+  });
+});
+
+// ─── removeCounter ────────────────────────────────────────────────────────────
+
+describe('removeCounter', () => {
+  it('throws CounterNotFoundError when counter does not exist', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    await expect(removeCounter(99)).rejects.toBeInstanceOf(CounterNotFoundError);
+  });
+
+  it('calls runSerializedCommandWrite with existing commands', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([{ trigger_command: '!hits', check_command: '!checkhits' }]) as any);
+    mockConnection.execute.mockResolvedValue([{ affectedRows: 1 }, []]);
+    await removeCounter(1);
+    expect(runSerializedCommandWrite).toHaveBeenCalledWith(
+      ['!hits', '!checkhits'],
+      { excludeCounterId: 1 },
+      expect.any(Function),
+    );
+  });
+
+  it('invalidates cache after removal', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([{ trigger_command: '!hits', check_command: '!checkhits' }]) as any);
+    mockConnection.execute.mockResolvedValue([{ affectedRows: 1 }, []]);
+    await removeCounter(1);
+    expect(invalidateCounterLookupCache).toHaveBeenCalled();
+  });
+});
+
+// ─── resetCounterCurrentValue ─────────────────────────────────────────────────
+
+describe('resetCounterCurrentValue', () => {
+  it('throws CounterNotFoundError when no rows affected and counter not found', async () => {
+    const pool = makePool();
+    pool.execute
+      .mockResolvedValueOnce([{ affectedRows: 0 }, []])  // UPDATE: ResultSetHeader (affectedRows=0)
+      .mockResolvedValueOnce([[], []]);                    // EXISTS check: no rows
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(resetCounterCurrentValue(99)).rejects.toBeInstanceOf(CounterNotFoundError);
+  });
+
+  it('does not throw when affectedRows > 0', async () => {
+    const pool = makePool();
+    pool.execute.mockResolvedValue([{ affectedRows: 1 }, []]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(resetCounterCurrentValue(1)).resolves.not.toThrow();
+  });
+
+  it('invalidates cache on success', async () => {
+    const pool = makePool();
+    pool.execute.mockResolvedValue([[{ affectedRows: 1 }], []]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await resetCounterCurrentValue(1);
+    expect(invalidateCounterLookupCache).toHaveBeenCalled();
+  });
+});
+
+// ─── incrementCounter ─────────────────────────────────────────────────────────
+
+describe('incrementCounter', () => {
+  it('throws CounterNotFoundError when UPDATE affects 0 rows', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute
+      .mockResolvedValueOnce([{ affectedRows: 0 }, []]);  // UPDATE: ResultSetHeader
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(incrementCounter(99)).rejects.toBeInstanceOf(CounterNotFoundError);
+    expect(conn.rollback).toHaveBeenCalled();
+  });
+
+  it('returns the new current_value on success', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute
+      .mockResolvedValueOnce([{ affectedRows: 1 }, []])       // UPDATE: ResultSetHeader
+      .mockResolvedValueOnce([[{ current_value: 7 }], []]);    // SELECT: rows
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await incrementCounter(1);
+    expect(result).toBe(7);
+    expect(conn.commit).toHaveBeenCalled();
+  });
+
+  it('releases the connection even when it throws', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute.mockRejectedValue(new Error('DB error'));
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(incrementCounter(1)).rejects.toThrow('DB error');
+    expect(conn.release).toHaveBeenCalled();
+  });
+
+  it('invalidates cache on success', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute
+      .mockResolvedValueOnce([[{ affectedRows: 1 }], []])
+      .mockResolvedValueOnce([[{ current_value: 3 }], []]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await incrementCounter(1);
+    expect(invalidateCounterLookupCache).toHaveBeenCalled();
+  });
+});
+
+// ─── archiveAndResetYearlyCounters ────────────────────────────────────────────
+
+describe('archiveAndResetYearlyCounters', () => {
+  it('throws for a year before 2020', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    await expect(archiveAndResetYearlyCounters(2019)).rejects.toThrow('Invalid archive year: 2019');
+  });
+
+  it('throws for a year after 2100', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    await expect(archiveAndResetYearlyCounters(2101)).rejects.toThrow('Invalid archive year: 2101');
+  });
+
+  it('accepts year 2020 (lower boundary)', async () => {
+    const pool = makePool();
+    pool.execute.mockResolvedValue([{ affectedRows: 3 }, []]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(archiveAndResetYearlyCounters(2020)).resolves.toBe(3);
+  });
+
+  it('accepts year 2100 (upper boundary)', async () => {
+    const pool = makePool();
+    pool.execute.mockResolvedValue([{ affectedRows: 0 }, []]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(archiveAndResetYearlyCounters(2100)).resolves.toBe(0);
+  });
+
+  it('returns the number of affected rows', async () => {
+    const pool = makePool();
+    pool.execute.mockResolvedValue([{ affectedRows: 5 }, []]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    expect(await archiveAndResetYearlyCounters(2024)).toBe(5);
+  });
+
+  it('includes the column name for the given year in the SQL', async () => {
+    const pool = makePool();
+    pool.execute.mockResolvedValue([{ affectedRows: 1 }, []]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await archiveAndResetYearlyCounters(2024);
+    const [sql] = pool.execute.mock.calls[0] as [string];
+    expect(sql).toContain('value2024');
+  });
+
+  it('invalidates cache after archiving', async () => {
+    const pool = makePool();
+    pool.execute.mockResolvedValue([{ affectedRows: 2 }, []]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await archiveAndResetYearlyCounters(2025);
+    expect(invalidateCounterLookupCache).toHaveBeenCalled();
+  });
+});

--- a/src/db/counters.test.ts
+++ b/src/db/counters.test.ts
@@ -226,7 +226,7 @@ describe('resetCounterCurrentValue', () => {
 
   it('invalidates cache on success', async () => {
     const pool = makePool();
-    pool.execute.mockResolvedValue([[{ affectedRows: 1 }], []]);
+    pool.execute.mockResolvedValue([{ affectedRows: 1 }, []]);
     vi.mocked(getPool).mockReturnValue(pool as any);
     await resetCounterCurrentValue(1);
     expect(invalidateCounterLookupCache).toHaveBeenCalled();
@@ -271,7 +271,7 @@ describe('incrementCounter', () => {
     const pool = makePool();
     const conn = pool._conn;
     conn.execute
-      .mockResolvedValueOnce([[{ affectedRows: 1 }], []])
+      .mockResolvedValueOnce([{ affectedRows: 1 }, []])
       .mockResolvedValueOnce([[{ current_value: 3 }], []]);
     vi.mocked(getPool).mockReturnValue(pool as any);
     await incrementCounter(1);

--- a/src/db/overlayVideos.test.ts
+++ b/src/db/overlayVideos.test.ts
@@ -75,7 +75,7 @@ describe('addVideo', () => {
 
   it('passes streamerId, name, filename to execute', async () => {
     const pool = makePool();
-    pool.execute.mockResolvedValue([[{ insertId: 1 }], []]);
+    pool.execute.mockResolvedValue([{ insertId: 1 }, []]);
     vi.mocked(getPool).mockReturnValue(pool as any);
     await addVideo(5, 'MyVid', 'vid.mp4');
     expect(pool.execute.mock.calls[0][1]).toEqual([5, 'MyVid', 'vid.mp4']);
@@ -206,7 +206,7 @@ describe('upsertReward', () => {
 
   it('passes streamerId and twitchRewardId to execute', async () => {
     const pool = makePool();
-    pool.execute.mockResolvedValue([[{ insertId: 1 }], []]);
+    pool.execute.mockResolvedValue([{ insertId: 1 }, []]);
     vi.mocked(getPool).mockReturnValue(pool as any);
     await upsertReward(7, 'rewardXYZ');
     expect(pool.execute.mock.calls[0][1]).toEqual([7, 'rewardXYZ']);

--- a/src/db/overlayVideos.test.ts
+++ b/src/db/overlayVideos.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./pool', () => ({ getPool: vi.fn() }));
+vi.mock('mysql2/promise', () => ({ default: {} }));
+
+import { getPool } from './pool';
+import {
+  getVideosForStreamer,
+  addVideo,
+  getVideoById,
+  deleteVideo,
+  getRewardsForStreamer,
+  upsertReward,
+  setRewardVideos,
+  deleteReward,
+  getVideosForReward,
+} from './overlayVideos';
+
+function makePool(rows: unknown[] = [], meta: unknown = {}) {
+  const conn = {
+    execute: vi.fn(),
+    beginTransaction: vi.fn().mockResolvedValue(undefined),
+    commit: vi.fn().mockResolvedValue(undefined),
+    rollback: vi.fn().mockResolvedValue(undefined),
+    release: vi.fn(),
+  };
+  return {
+    execute: vi.fn().mockResolvedValue([[...rows], meta]),
+    getConnection: vi.fn().mockResolvedValue(conn),
+    _conn: conn,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─── getVideosForStreamer ─────────────────────────────────────────────────────
+
+describe('getVideosForStreamer', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    expect(await getVideosForStreamer(1)).toEqual([]);
+  });
+
+  it('maps rows correctly', async () => {
+    const now = new Date();
+    const rows = [{ id: 10, streamer_id: 1, name: 'Intro', filename: 'intro.mp4', created_at: now }];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const [v] = await getVideosForStreamer(1);
+    expect(v.id).toBe(10);
+    expect(v.name).toBe('Intro');
+    expect(v.filename).toBe('intro.mp4');
+    expect(v.created_at).toBe(now);
+  });
+
+  it('queries with the given streamerId', async () => {
+    const pool = makePool([]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await getVideosForStreamer(42);
+    expect(pool.execute.mock.calls[0][1]).toContain(42);
+  });
+});
+
+// ─── addVideo ────────────────────────────────────────────────────────────────
+
+describe('addVideo', () => {
+  it('returns the insertId from the result', async () => {
+    const pool = makePool();
+    pool.execute.mockResolvedValue([{ insertId: 99 }, []]);  // ResultSetHeader format
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const id = await addVideo(1, 'Clip', 'clip.mp4');
+    expect(id).toBe(99);
+  });
+
+  it('passes streamerId, name, filename to execute', async () => {
+    const pool = makePool();
+    pool.execute.mockResolvedValue([[{ insertId: 1 }], []]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await addVideo(5, 'MyVid', 'vid.mp4');
+    expect(pool.execute.mock.calls[0][1]).toEqual([5, 'MyVid', 'vid.mp4']);
+  });
+});
+
+// ─── getVideoById ─────────────────────────────────────────────────────────────
+
+describe('getVideoById', () => {
+  it('returns null when no rows found', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    expect(await getVideoById(1, 1)).toBeNull();
+  });
+
+  it('maps the found row', async () => {
+    const now = new Date();
+    const row = { id: 5, streamer_id: 2, name: 'Clip', filename: 'clip.mp4', created_at: now };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const v = await getVideoById(5, 2);
+    expect(v!.id).toBe(5);
+    expect(v!.name).toBe('Clip');
+  });
+
+  it('queries with videoId and streamerId', async () => {
+    const pool = makePool([]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await getVideoById(7, 3);
+    expect(pool.execute.mock.calls[0][1]).toEqual([7, 3]);
+  });
+});
+
+// ─── deleteVideo ──────────────────────────────────────────────────────────────
+
+describe('deleteVideo', () => {
+  it('returns null when video not found', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute.mockResolvedValueOnce([[], []]);  // SELECT returns no rows
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await deleteVideo(99, 1);
+    expect(result).toBeNull();
+    expect(conn.rollback).toHaveBeenCalled();
+  });
+
+  it('returns null when DELETE affects 0 rows', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute
+      .mockResolvedValueOnce([[{ filename: 'old.mp4' }], []])  // SELECT: rows
+      .mockResolvedValueOnce([{ affectedRows: 0 }, []]);         // DELETE: ResultSetHeader
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await deleteVideo(1, 1);
+    expect(result).toBeNull();
+    expect(conn.rollback).toHaveBeenCalled();
+  });
+
+  it('returns filename on success', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute
+      .mockResolvedValueOnce([[{ filename: 'clip.mp4' }], []])  // SELECT: rows
+      .mockResolvedValueOnce([{ affectedRows: 1 }, []]);          // DELETE: ResultSetHeader
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await deleteVideo(1, 1);
+    expect(result).toBe('clip.mp4');
+    expect(conn.commit).toHaveBeenCalled();
+  });
+
+  it('releases connection even when an error is thrown', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute.mockRejectedValue(new Error('DB error'));
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(deleteVideo(1, 1)).rejects.toThrow('DB error');
+    expect(conn.release).toHaveBeenCalled();
+  });
+});
+
+// ─── getRewardsForStreamer ─────────────────────────────────────────────────────
+
+describe('getRewardsForStreamer', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    expect(await getRewardsForStreamer(1)).toEqual([]);
+  });
+
+  it('groups videos under their reward', async () => {
+    const rows = [
+      { id: 1, streamer_id: 1, twitch_reward_id: 'rwdA', video_id: 10, weight: 2, name: 'Intro', filename: 'intro.mp4' },
+      { id: 1, streamer_id: 1, twitch_reward_id: 'rwdA', video_id: 11, weight: 1, name: 'Outro', filename: 'outro.mp4' },
+    ];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await getRewardsForStreamer(1);
+    expect(result).toHaveLength(1);
+    expect(result[0].twitch_reward_id).toBe('rwdA');
+    expect(result[0].videos).toHaveLength(2);
+    expect(result[0].videos[0].weight).toBe(2);
+  });
+
+  it('handles multiple rewards', async () => {
+    const rows = [
+      { id: 1, streamer_id: 1, twitch_reward_id: 'rwdA', video_id: 10, weight: 1, name: 'A', filename: 'a.mp4' },
+      { id: 2, streamer_id: 1, twitch_reward_id: 'rwdB', video_id: 20, weight: 3, name: 'B', filename: 'b.mp4' },
+    ];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await getRewardsForStreamer(1);
+    expect(result).toHaveLength(2);
+  });
+
+  it('skips null video_id rows (reward with no videos)', async () => {
+    const rows = [{ id: 1, streamer_id: 1, twitch_reward_id: 'rwdA', video_id: null, weight: null, name: null, filename: null }];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await getRewardsForStreamer(1);
+    expect(result).toHaveLength(1);
+    expect(result[0].videos).toHaveLength(0);
+  });
+});
+
+// ─── upsertReward ─────────────────────────────────────────────────────────────
+
+describe('upsertReward', () => {
+  it('returns the insertId', async () => {
+    const pool = makePool();
+    pool.execute.mockResolvedValue([{ insertId: 5 }, []]);  // ResultSetHeader format
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    expect(await upsertReward(1, 'reward123')).toBe(5);
+  });
+
+  it('passes streamerId and twitchRewardId to execute', async () => {
+    const pool = makePool();
+    pool.execute.mockResolvedValue([[{ insertId: 1 }], []]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await upsertReward(7, 'rewardXYZ');
+    expect(pool.execute.mock.calls[0][1]).toEqual([7, 'rewardXYZ']);
+  });
+});
+
+// ─── setRewardVideos ──────────────────────────────────────────────────────────
+
+describe('setRewardVideos', () => {
+  it('rolls back and returns when reward does not belong to streamer', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute.mockResolvedValueOnce([[], []]);  // ownership check: no rows
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await setRewardVideos(1, 99, [{ videoId: 5, weight: 2 }]);
+    expect(conn.rollback).toHaveBeenCalled();
+    expect(conn.commit).not.toHaveBeenCalled();
+  });
+
+  it('commits when all videos belong to streamer', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute
+      .mockResolvedValueOnce([[{ id: 1 }], []])         // ownership check: rows
+      .mockResolvedValueOnce([{ affectedRows: 1 }, []])  // DELETE: ResultSetHeader
+      .mockResolvedValueOnce([{ affectedRows: 1 }, []]);  // INSERT: ResultSetHeader
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await setRewardVideos(1, 1, [{ videoId: 5, weight: 2 }]);
+    expect(conn.commit).toHaveBeenCalled();
+  });
+
+  it('throws when a video does not belong to the streamer', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute
+      .mockResolvedValueOnce([[{ id: 1 }], []])         // ownership check: rows
+      .mockResolvedValueOnce([{ affectedRows: 1 }, []])  // DELETE: ResultSetHeader
+      .mockResolvedValueOnce([{ affectedRows: 0 }, []]);  // INSERT: affectedRows=0 → wrong streamer
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(setRewardVideos(1, 1, [{ videoId: 999, weight: 1 }])).rejects.toThrow('does not belong to streamer');
+    expect(conn.rollback).toHaveBeenCalled();
+  });
+
+  it('releases connection on error', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute
+      .mockResolvedValueOnce([[{ id: 1 }], []])
+      .mockRejectedValueOnce(new Error('DB crash'));
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(setRewardVideos(1, 1, [])).rejects.toThrow('DB crash');
+    expect(conn.release).toHaveBeenCalled();
+  });
+
+  it('clamps weight to minimum of 1 via Math.max', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute
+      .mockResolvedValueOnce([[{ id: 1 }], []])         // ownership check
+      .mockResolvedValueOnce([{ affectedRows: 1 }, []])  // DELETE
+      .mockResolvedValueOnce([{ affectedRows: 1 }, []]); // INSERT
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await setRewardVideos(1, 1, [{ videoId: 5, weight: 0 }]);
+    const insertParams: unknown[] = conn.execute.mock.calls[2][1];
+    expect(insertParams[1]).toBe(1);  // Math.max(1, 0) = 1
+  });
+});
+
+// ─── deleteReward ─────────────────────────────────────────────────────────────
+
+describe('deleteReward', () => {
+  it('executes DELETE with rewardId and streamerId', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await deleteReward(3, 7);
+    expect(pool.execute.mock.calls[0][1]).toEqual([3, 7]);
+  });
+});
+
+// ─── getVideosForReward ───────────────────────────────────────────────────────
+
+describe('getVideosForReward', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    expect(await getVideosForReward('rwd1', 1)).toEqual([]);
+  });
+
+  it('maps filename and weight', async () => {
+    const rows = [{ filename: 'clip.mp4', weight: 3 }, { filename: 'outro.mp4', weight: 1 }];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await getVideosForReward('rwd1', 1);
+    expect(result[0]).toEqual({ file: 'clip.mp4', weight: 3 });
+    expect(result[1]).toEqual({ file: 'outro.mp4', weight: 1 });
+  });
+
+  it('queries with twitchRewardId and streamerId', async () => {
+    const pool = makePool([]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await getVideosForReward('rwdABC', 5);
+    expect(pool.execute.mock.calls[0][1]).toEqual(['rwdABC', 5]);
+  });
+});

--- a/src/db/streamMonitor.test.ts
+++ b/src/db/streamMonitor.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./pool', () => ({ getPool: vi.fn() }));
+vi.mock('mysql2/promise', () => ({ default: {} }));
+
+import { getPool } from './pool';
+import {
+  getAllStreamGroups,
+  addStreamGroup,
+  updateStreamGroup,
+  removeStreamGroup,
+  getAllStreamers,
+  getAllStreamersWithGroups,
+  addStreamer,
+  removeStreamer,
+  removeStreamersByGroup,
+  setStreamerLive,
+  clearStreamerLive,
+} from './streamMonitor';
+
+function makePool(rows: unknown[] = []) {
+  return { execute: vi.fn().mockResolvedValue([[...rows], []]) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─── getAllStreamGroups ────────────────────────────────────────────────────────
+
+describe('getAllStreamGroups', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    expect(await getAllStreamGroups()).toEqual([]);
+  });
+
+  it('maps multi_twitch as numeric 1 → true', async () => {
+    const row = { id: 1, name: 'G', discord_channel: '123', live_message: 'live', new_game_message: 'game', multi_twitch: 1, delete_old_posts: 0 };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const [group] = await getAllStreamGroups();
+    expect(group.multi_twitch).toBe(true);
+    expect(group.delete_old_posts).toBe(false);
+  });
+
+  it('maps multi_twitch as Buffer 0x01 → true', async () => {
+    const row = { id: 1, name: 'G', discord_channel: '123', live_message: 'l', new_game_message: 'g', multi_twitch: Buffer.from([1]), delete_old_posts: Buffer.from([0]) };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const [group] = await getAllStreamGroups();
+    expect(group.multi_twitch).toBe(true);
+    expect(group.delete_old_posts).toBe(false);
+  });
+
+  it('coerces discord_channel to string', async () => {
+    const row = { id: 1, name: 'G', discord_channel: 99999n, live_message: 'l', new_game_message: 'g', multi_twitch: 0, delete_old_posts: 0 };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const [group] = await getAllStreamGroups();
+    expect(group.discord_channel).toBe('99999');
+  });
+
+  it('maps multiple rows', async () => {
+    const rows = [
+      { id: 1, name: 'A', discord_channel: '1', live_message: '', new_game_message: '', multi_twitch: 0, delete_old_posts: 0 },
+      { id: 2, name: 'B', discord_channel: '2', live_message: '', new_game_message: '', multi_twitch: 1, delete_old_posts: 1 },
+    ];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await getAllStreamGroups();
+    expect(result).toHaveLength(2);
+    expect(result[1].id).toBe(2);
+    expect(result[1].multi_twitch).toBe(true);
+  });
+});
+
+// ─── addStreamGroup ───────────────────────────────────────────────────────────
+
+describe('addStreamGroup', () => {
+  it('passes multiTwitch=true as 1 and deleteOldPosts=false as 0', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await addStreamGroup({ name: 'G', discordChannel: '123', liveMessage: 'l', newGameMessage: 'g', multiTwitch: true, deleteOldPosts: false });
+    const params: unknown[] = pool.execute.mock.calls[0][1];
+    expect(params).toContain(1);  // multiTwitch
+    expect(params).toContain(0);  // deleteOldPosts
+  });
+
+  it('includes all fields in the INSERT params', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await addStreamGroup({ name: 'MyGroup', discordChannel: 'chan1', liveMessage: 'is live', newGameMessage: 'new game', multiTwitch: false, deleteOldPosts: true });
+    const params: unknown[] = pool.execute.mock.calls[0][1];
+    expect(params).toContain('MyGroup');
+    expect(params).toContain('chan1');
+    expect(params).toContain('is live');
+    expect(params).toContain('new game');
+  });
+});
+
+// ─── updateStreamGroup ────────────────────────────────────────────────────────
+
+describe('updateStreamGroup', () => {
+  it('includes the id as the last WHERE param', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await updateStreamGroup({ id: 42, name: 'G', discordChannel: 'c', liveMessage: 'l', newGameMessage: 'g', multiTwitch: false, deleteOldPosts: false });
+    const params: unknown[] = pool.execute.mock.calls[0][1];
+    expect(params[params.length - 1]).toBe(42);
+  });
+
+  it('uses UPDATE in the SQL', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await updateStreamGroup({ id: 1, name: 'G', discordChannel: 'c', liveMessage: 'l', newGameMessage: 'g', multiTwitch: false, deleteOldPosts: false });
+    expect((pool.execute.mock.calls[0][0] as string).toLowerCase()).toContain('update');
+  });
+});
+
+// ─── removeStreamGroup ────────────────────────────────────────────────────────
+
+describe('removeStreamGroup', () => {
+  it('executes DELETE with the group id', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await removeStreamGroup(7);
+    const params: unknown[] = pool.execute.mock.calls[0][1];
+    expect(params).toContain(7);
+    expect((pool.execute.mock.calls[0][0] as string).toLowerCase()).toContain('delete');
+  });
+});
+
+// ─── getAllStreamers ──────────────────────────────────────────────────────────
+
+describe('getAllStreamers', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    expect(await getAllStreamers()).toEqual([]);
+  });
+
+  it('maps rows and coerces discord_id to string', async () => {
+    const row = { id: 1, discord_id: 123n, group_id: 5, twitch_name: 'alice', discord_name: 'Alice', group_name: 'Group A' };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const [s] = await getAllStreamers();
+    expect(s.discord_id).toBe('123');
+    expect(s.twitch_name).toBe('alice');
+    expect(s.group_name).toBe('Group A');
+  });
+
+  it('maps null twitch_name and discord_name to null', async () => {
+    const row = { id: 2, discord_id: '456', group_id: 1, twitch_name: null, discord_name: null, group_name: 'G' };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const [s] = await getAllStreamers();
+    expect(s.twitch_name).toBeNull();
+    expect(s.discord_name).toBeNull();
+  });
+});
+
+// ─── getAllStreamersWithGroups ─────────────────────────────────────────────────
+
+describe('getAllStreamersWithGroups', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    expect(await getAllStreamersWithGroups()).toEqual([]);
+  });
+
+  it('builds nested group object from flat row', async () => {
+    const row = {
+      id: 1, discord_id: '111', group_id: 2, twitch_name: 'alice',
+      discord_message_id: 'msg1', discord_channel_id: 'chan1', live_game: 'Minecraft',
+      group_name: 'Streamers', discord_channel: 'ch', live_message: 'live', new_game_message: 'newgame',
+      multi_twitch: 1, delete_old_posts: 0,
+    };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const [s] = await getAllStreamersWithGroups();
+    expect(s.live_game).toBe('Minecraft');
+    expect(s.discord_message_id).toBe('msg1');
+    expect(s.group.id).toBe(2);
+    expect(s.group.multi_twitch).toBe(true);
+    expect(s.group.delete_old_posts).toBe(false);
+  });
+
+  it('coerces discord_channel_id to string when set', async () => {
+    const row = {
+      id: 1, discord_id: '1', group_id: 1, twitch_name: 'bob',
+      discord_message_id: null, discord_channel_id: 99999n, live_game: null,
+      group_name: 'G', discord_channel: 'c', live_message: 'l', new_game_message: 'g',
+      multi_twitch: 0, delete_old_posts: 0,
+    };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const [s] = await getAllStreamersWithGroups();
+    expect(s.discord_channel_id).toBe('99999');
+  });
+
+  it('maps null discord_channel_id to null', async () => {
+    const row = {
+      id: 1, discord_id: '1', group_id: 1, twitch_name: 'bob',
+      discord_message_id: null, discord_channel_id: null, live_game: null,
+      group_name: 'G', discord_channel: 'c', live_message: 'l', new_game_message: 'g',
+      multi_twitch: 0, delete_old_posts: 0,
+    };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const [s] = await getAllStreamersWithGroups();
+    expect(s.discord_channel_id).toBeNull();
+  });
+});
+
+// ─── addStreamer / removeStreamer / removeStreamersByGroup ────────────────────
+
+describe('addStreamer', () => {
+  it('inserts with discordId and groupId', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await addStreamer('user1', 3);
+    expect(pool.execute.mock.calls[0][1]).toEqual(['user1', 3]);
+  });
+});
+
+describe('removeStreamer', () => {
+  it('deletes by id', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await removeStreamer(5);
+    expect(pool.execute.mock.calls[0][1]).toContain(5);
+  });
+});
+
+describe('removeStreamersByGroup', () => {
+  it('deletes by group_id', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await removeStreamersByGroup(10);
+    expect(pool.execute.mock.calls[0][1]).toContain(10);
+  });
+});
+
+// ─── setStreamerLive / clearStreamerLive ──────────────────────────────────────
+
+describe('setStreamerLive', () => {
+  it('updates with messageId, channelId, game, and id', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await setStreamerLive(1, 'msg42', 'chan99', 'Fortnite');
+    const params: unknown[] = pool.execute.mock.calls[0][1];
+    expect(params).toContain('msg42');
+    expect(params).toContain('chan99');
+    expect(params).toContain('Fortnite');
+    expect(params).toContain(1);
+  });
+});
+
+describe('clearStreamerLive', () => {
+  it('executes UPDATE with id', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await clearStreamerLive(7);
+    const [sql, params] = pool.execute.mock.calls[0] as [string, unknown[]];
+    expect(sql.toLowerCase()).toContain('update');
+    expect(params).toContain(7);
+  });
+});

--- a/src/shared/pathUtils.test.ts
+++ b/src/shared/pathUtils.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+import { safeResolve } from './pathUtils';
+
+describe('safeResolve', () => {
+  const base = '/srv/files';
+
+  it('returns the resolved path for a safe single segment', () => {
+    expect(safeResolve(base, 'audio.mp3')).toBe('/srv/files/audio.mp3');
+  });
+
+  it('returns the resolved path for a safe nested path', () => {
+    expect(safeResolve(base, 'sfx', 'effects', 'bang.wav')).toBe('/srv/files/sfx/effects/bang.wav');
+  });
+
+  it('returns null for a path that escapes base via ..', () => {
+    expect(safeResolve(base, '../secret.txt')).toBeNull();
+  });
+
+  it('returns null for a deeply nested traversal', () => {
+    expect(safeResolve(base, 'a', '../../etc/passwd')).toBeNull();
+  });
+
+  it('returns the base path itself when no parts given', () => {
+    expect(safeResolve(base)).toBe(path.resolve(base));
+  });
+
+  it('returns null for an absolute path that is outside base', () => {
+    expect(safeResolve(base, '/etc/passwd')).toBeNull();
+  });
+
+  it('returns the path when it exactly equals the base', () => {
+    // path.relative(base, base) is '' which does not start with '..'
+    const result = safeResolve(base, '.');
+    expect(result).toBe(path.resolve(base));
+  });
+
+  it('handles a base without trailing slash', () => {
+    expect(safeResolve('/srv/files', 'ok.mp3')).toBe('/srv/files/ok.mp3');
+  });
+
+  it('handles a base with a trailing slash', () => {
+    expect(safeResolve('/srv/files/', 'ok.mp3')).toBe('/srv/files/ok.mp3');
+  });
+
+  it('returns the correct path for a file with spaces in name', () => {
+    expect(safeResolve(base, 'my sound.mp3')).toBe('/srv/files/my sound.mp3');
+  });
+
+  it('returns null when joining results in a sibling directory', () => {
+    // /srv/files + ../otherfolder/x would be /srv/otherfolder/x — outside base
+    expect(safeResolve('/srv/files', '../otherfolder/x')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- `counters.test.ts` — `CounterNotFoundError`, `getAllCounters` (BIT mapping), `addCounter`/`updateCounter` (trigger≠check validation, reserved command checks, cache invalidation), `removeCounter` (CounterNotFoundError when missing), `resetCounterCurrentValue` (existence check), `incrementCounter` (transaction, rollback on error, returns new value), `archiveAndResetYearlyCounters` (year boundary 2020–2100, correct column name in SQL, affectedRows return)
- `streamMonitor.test.ts` — all stream group CRUD, `getAllStreamers`/`getAllStreamersWithGroups` (nested group object, BIT(1) Buffer and numeric, discord_channel_id coercion), streamer CRUD, `setStreamerLive`, `clearStreamerLive`
- `overlayVideos.test.ts` — `getRewardsForStreamer` (aggregation, null video_id), `deleteVideo` (null when not found, null when DELETE affects 0, returns filename on success, releases connection on error), `setRewardVideos` (ownership check rollback, video ownership error, weight clamped to min 1), `addVideo`/`upsertReward` (insertId), `getVideosForReward` (file/weight mapping)
- `pathUtils.test.ts` — `safeResolve` path traversal guard (pure function, no mocks): safe paths, `..` escape, absolute escape, sibling directory

## Test plan

- `npx tsc --noEmit` — clean
- `npm test` — all tests pass

https://claude.ai/code/session_01DNLtYg8ZzSNR5fAzw9p85k

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNLtYg8ZzSNR5fAzw9p85k)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for database operations and utility functions to improve code quality and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->