### PR TITLE
Add unit tests for twitchMonitorMultitwitch and twitchMonitorOffline

### DIFF
--- a/src/twitch/monitor/twitchMonitorMultitwitch.test.ts
+++ b/src/twitch/monitor/twitchMonitorMultitwitch.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../shared/logger', () => ({ createLogger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn() }) }));
+vi.mock('../../discord/discordBot', () => ({ getDiscordClient: vi.fn().mockReturnValue(null) }));
+vi.mock('./twitchMonitorEmbed', () => ({ buildEmbed: vi.fn() }));
+
+import { groupGameKey, buildMultiTwitchContext, getMultitwitchPreview } from './twitchMonitorMultitwitch';
+import type { LiveState } from './twitchMonitorTypes';
+
+function makeState(overrides: Partial<LiveState> = {}): LiveState {
+  return {
+    streamerId: 1,
+    login: 'alice',
+    groupId: 10,
+    currentGame: 'Minecraft',
+    title: 'Playing',
+    currentStream: {} as any,
+    messageId: 'msg1',
+    channelId: 'chan1',
+    offlineTimer: null,
+    group: { id: 10, name: 'G', discord_channel: 'c', live_message: 'l', new_game_message: 'g', multi_twitch: true, delete_old_posts: false },
+    ...overrides,
+  };
+}
+
+// ─── groupGameKey ─────────────────────────────────────────────────────────────
+
+describe('groupGameKey', () => {
+  it('combines groupId and lowercase game with :: separator', () => {
+    expect(groupGameKey(5, 'Minecraft')).toBe('5::minecraft');
+  });
+
+  it('lowercases the game name', () => {
+    expect(groupGameKey(1, 'FORTNITE')).toBe('1::fortnite');
+  });
+
+  it('is deterministic for the same inputs', () => {
+    expect(groupGameKey(3, 'Valorant')).toBe(groupGameKey(3, 'Valorant'));
+  });
+
+  it('produces different keys for different groupIds', () => {
+    expect(groupGameKey(1, 'Minecraft')).not.toBe(groupGameKey(2, 'Minecraft'));
+  });
+
+  it('produces different keys for different games', () => {
+    expect(groupGameKey(1, 'Minecraft')).not.toBe(groupGameKey(1, 'Fortnite'));
+  });
+});
+
+// ─── buildMultiTwitchContext ──────────────────────────────────────────────────
+
+describe('buildMultiTwitchContext', () => {
+  it('returns empty map for no states', () => {
+    const ctx = buildMultiTwitchContext([]);
+    expect(ctx).toBeDefined();
+  });
+
+  it('groups participants by group+game key', () => {
+    const states = [
+      makeState({ login: 'alice', groupId: 1, currentGame: 'Minecraft' }),
+      makeState({ login: 'bob',   groupId: 1, currentGame: 'Minecraft' }),
+    ];
+    const ctx = buildMultiTwitchContext(states);
+    const key = groupGameKey(1, 'Minecraft');
+    expect(ctx).toHaveProperty('participantsByGroupAndGame');
+    // Access via the returned object — use the same key format
+    const participants = (ctx as any).participantsByGroupAndGame.get(key);
+    expect(participants).toContain('alice');
+    expect(participants).toContain('bob');
+  });
+
+  it('sorts participants alphabetically', () => {
+    const states = [
+      makeState({ login: 'zara',  groupId: 1, currentGame: 'Minecraft' }),
+      makeState({ login: 'alice', groupId: 1, currentGame: 'Minecraft' }),
+      makeState({ login: 'bob',   groupId: 1, currentGame: 'Minecraft' }),
+    ];
+    const ctx = buildMultiTwitchContext(states);
+    const key = groupGameKey(1, 'Minecraft');
+    const participants = (ctx as any).participantsByGroupAndGame.get(key);
+    expect(participants).toEqual(['alice', 'bob', 'zara']);
+  });
+
+  it('deduplicates the same login appearing twice', () => {
+    const states = [
+      makeState({ login: 'alice', groupId: 1, currentGame: 'Minecraft' }),
+      makeState({ login: 'alice', groupId: 1, currentGame: 'Minecraft' }),
+    ];
+    const ctx = buildMultiTwitchContext(states);
+    const key = groupGameKey(1, 'Minecraft');
+    const participants = (ctx as any).participantsByGroupAndGame.get(key);
+    expect(participants).toHaveLength(1);
+  });
+
+  it('separates participants by group', () => {
+    const states = [
+      makeState({ login: 'alice', groupId: 1, currentGame: 'Minecraft' }),
+      makeState({ login: 'bob',   groupId: 2, currentGame: 'Minecraft' }),
+    ];
+    const ctx = buildMultiTwitchContext(states);
+    const key1 = groupGameKey(1, 'Minecraft');
+    const key2 = groupGameKey(2, 'Minecraft');
+    expect((ctx as any).participantsByGroupAndGame.get(key1)).not.toContain('bob');
+    expect((ctx as any).participantsByGroupAndGame.get(key2)).not.toContain('alice');
+  });
+
+  it('separates participants by game', () => {
+    const states = [
+      makeState({ login: 'alice', groupId: 1, currentGame: 'Minecraft' }),
+      makeState({ login: 'bob',   groupId: 1, currentGame: 'Fortnite' }),
+    ];
+    const ctx = buildMultiTwitchContext(states);
+    expect((ctx as any).participantsByGroupAndGame.get(groupGameKey(1, 'Minecraft'))).not.toContain('bob');
+    expect((ctx as any).participantsByGroupAndGame.get(groupGameKey(1, 'Fortnite'))).not.toContain('alice');
+  });
+});
+
+// ─── getMultitwitchPreview ────────────────────────────────────────────────────
+
+describe('getMultitwitchPreview', () => {
+  function ctxWith(entries: Array<[string, string[]]>) {
+    const map = new Map<string, string[]>(entries);
+    return { participantsByGroupAndGame: map } as any;
+  }
+
+  it('returns applicable=false and url=null when only one participant', () => {
+    const state = makeState({ login: 'alice', groupId: 1, currentGame: 'Minecraft' });
+    const ctx = ctxWith([[groupGameKey(1, 'Minecraft'), ['alice']]]);
+    const result = getMultitwitchPreview(state, ctx);
+    expect(result.applicable).toBe(false);
+    expect(result.url).toBeNull();
+    expect(result.participants).toEqual(['alice']);
+  });
+
+  it('returns applicable=false and url=null when no entry in context', () => {
+    const state = makeState({ login: 'alice', groupId: 1, currentGame: 'Minecraft' });
+    const result = getMultitwitchPreview(state, ctxWith([]));
+    expect(result.applicable).toBe(false);
+    expect(result.url).toBeNull();
+  });
+
+  it('returns applicable=true and url=null when multi_twitch=false but multiple participants', () => {
+    const state = makeState({ login: 'alice', groupId: 1, currentGame: 'Minecraft', group: { ...makeState().group, multi_twitch: false } });
+    const ctx = ctxWith([[groupGameKey(1, 'Minecraft'), ['alice', 'bob']]]);
+    const result = getMultitwitchPreview(state, ctx);
+    expect(result.applicable).toBe(true);
+    expect(result.enabled).toBe(false);
+    expect(result.url).toBeNull();
+    expect(result.participants).toEqual(['alice', 'bob']);
+  });
+
+  it('returns enabled=true and correct url when multi_twitch=true and 2+ participants', () => {
+    const state = makeState({ login: 'alice', groupId: 1, currentGame: 'Minecraft' });
+    const ctx = ctxWith([[groupGameKey(1, 'Minecraft'), ['alice', 'bob']]]);
+    const result = getMultitwitchPreview(state, ctx);
+    expect(result.enabled).toBe(true);
+    expect(result.applicable).toBe(true);
+    expect(result.url).toBe('https://www.multitwitch.tv/alice/bob');
+    expect(result.participants).toEqual(['alice', 'bob']);
+  });
+
+  it('includes all participants in the url', () => {
+    const state = makeState({ login: 'alice', groupId: 1, currentGame: 'Minecraft' });
+    const ctx = ctxWith([[groupGameKey(1, 'Minecraft'), ['alice', 'bob', 'carol']]]);
+    const result = getMultitwitchPreview(state, ctx);
+    expect(result.url).toBe('https://www.multitwitch.tv/alice/bob/carol');
+  });
+
+  it('reflects the enabled flag from the group when not applicable', () => {
+    const state = makeState({ login: 'alice', groupId: 1, currentGame: 'Minecraft', group: { ...makeState().group, multi_twitch: false } });
+    const result = getMultitwitchPreview(state, ctxWith([]));
+    expect(result.enabled).toBe(false);
+  });
+});

--- a/src/twitch/monitor/twitchMonitorOffline.test.ts
+++ b/src/twitch/monitor/twitchMonitorOffline.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../shared/logger', () => ({ createLogger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn() }) }));
+vi.mock('../twitchApi', () => ({ getStreams: vi.fn() }));
+vi.mock('./twitchMonitorAnnouncements', () => ({ deleteAnnouncement: vi.fn() }));
+vi.mock('../../shared/statusStore', () => ({ setTwitchChannelLive: vi.fn() }));
+
+import { cancelOfflineTimersForLogin, runOfflineCheck } from './twitchMonitorOffline';
+import { getStreams } from '../twitchApi';
+import { deleteAnnouncement } from './twitchMonitorAnnouncements';
+import { setTwitchChannelLive } from '../../shared/statusStore';
+import type { LiveState } from './twitchMonitorTypes';
+
+function makeState(overrides: Partial<LiveState> = {}): LiveState {
+  return {
+    streamerId: 1,
+    login: 'alice',
+    groupId: 10,
+    currentGame: 'Minecraft',
+    title: 'Playing',
+    currentStream: {} as any,
+    messageId: 'msg1',
+    channelId: 'chan1',
+    offlineTimer: null,
+    group: { id: 10, name: 'G', discord_channel: 'c', live_message: 'l', new_game_message: 'g', multi_twitch: true, delete_old_posts: false },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─── cancelOfflineTimersForLogin ─────────────────────────────────────────────
+
+describe('cancelOfflineTimersForLogin', () => {
+  it('clears the offlineTimer for matching login and sets it to null', () => {
+    const timer = setTimeout(() => {}, 99999);
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const state = makeState({ login: 'alice', offlineTimer: timer });
+    const map = new Map([['k1', state]]);
+
+    cancelOfflineTimersForLogin(map, 'alice');
+
+    expect(clearSpy).toHaveBeenCalledWith(timer);
+    expect(state.offlineTimer).toBeNull();
+    clearTimeout(timer);
+  });
+
+  it('does not clear timers for a different login', () => {
+    const timer = setTimeout(() => {}, 99999);
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const state = makeState({ login: 'bob', offlineTimer: timer });
+    const map = new Map([['k1', state]]);
+
+    cancelOfflineTimersForLogin(map, 'alice');
+
+    expect(clearSpy).not.toHaveBeenCalled();
+    expect(state.offlineTimer).not.toBeNull();
+    clearTimeout(timer);
+  });
+
+  it('does nothing when the map is empty', () => {
+    expect(() => cancelOfflineTimersForLogin(new Map(), 'alice')).not.toThrow();
+  });
+
+  it('skips states where offlineTimer is already null', () => {
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const state = makeState({ login: 'alice', offlineTimer: null });
+    const map = new Map([['k1', state]]);
+
+    cancelOfflineTimersForLogin(map, 'alice');
+
+    expect(clearSpy).not.toHaveBeenCalled();
+  });
+
+  it('cancels timers across multiple states for the same login', () => {
+    const t1 = setTimeout(() => {}, 99999);
+    const t2 = setTimeout(() => {}, 99999);
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+    const s1 = makeState({ login: 'alice', offlineTimer: t1 });
+    const s2 = makeState({ login: 'alice', offlineTimer: t2 });
+    const map = new Map([['k1', s1], ['k2', s2]]);
+
+    cancelOfflineTimersForLogin(map, 'alice');
+
+    expect(clearSpy).toHaveBeenCalledTimes(2);
+    expect(s1.offlineTimer).toBeNull();
+    expect(s2.offlineTimer).toBeNull();
+    clearTimeout(t1);
+    clearTimeout(t2);
+  });
+});
+
+// ─── runOfflineCheck ──────────────────────────────────────────────────────────
+
+describe('runOfflineCheck', () => {
+  it('returns early and does nothing when state is not in liveStates', async () => {
+    const map = new Map<string, LiveState>();
+    await runOfflineCheck(map, new Map(), 'missing', 'alice', 'alice');
+    expect(getStreams).not.toHaveBeenCalled();
+  });
+
+  it('returns early when userId is not found in loginToUserId', async () => {
+    const state = makeState();
+    const map = new Map([['k1', state]]);
+    await runOfflineCheck(map, new Map(), 'k1', 'alice', 'alice');
+    expect(getStreams).not.toHaveBeenCalled();
+    expect(state.offlineTimer).toBeNull();
+  });
+
+  it('deletes the announcement and sets channel offline when stream is no longer live', async () => {
+    vi.mocked(getStreams).mockResolvedValue([]);
+    const state = makeState();
+    const liveStates = new Map([['k1', state]]);
+    const loginToUserId = new Map([['alice', 'uid123']]);
+
+    await runOfflineCheck(liveStates, loginToUserId, 'k1', 'alice', 'alice');
+
+    expect(getStreams).toHaveBeenCalledWith(['uid123']);
+    expect(setTwitchChannelLive).toHaveBeenCalledWith('alice', false);
+    expect(deleteAnnouncement).toHaveBeenCalledWith(liveStates, 'k1');
+    expect(state.offlineTimer).toBeNull();
+  });
+
+  it('does not delete announcement when stream is still live', async () => {
+    vi.mocked(getStreams).mockResolvedValue([{ user_id: 'uid123', type: 'live' } as any]);
+    const state = makeState();
+    const liveStates = new Map([['k1', state]]);
+    const loginToUserId = new Map([['alice', 'uid123']]);
+
+    await runOfflineCheck(liveStates, loginToUserId, 'k1', 'alice', 'alice');
+
+    expect(deleteAnnouncement).not.toHaveBeenCalled();
+    expect(setTwitchChannelLive).not.toHaveBeenCalled();
+    expect(state.offlineTimer).toBeNull();
+  });
+
+  it('nulls offlineTimer in the finally block even when an error is thrown', async () => {
+    vi.mocked(getStreams).mockRejectedValue(new Error('API error'));
+    const state = makeState();
+    const liveStates = new Map([['k1', state]]);
+    const loginToUserId = new Map([['alice', 'uid123']]);
+
+    await expect(runOfflineCheck(liveStates, loginToUserId, 'k1', 'alice', 'alice')).rejects.toThrow('API error');
+    expect(state.offlineTimer).toBeNull();
+  });
+
+  it('treats a non-live stream type as offline', async () => {
+    vi.mocked(getStreams).mockResolvedValue([{ user_id: 'uid123', type: 'vodcast' } as any]);
+    const state = makeState();
+    const liveStates = new Map([['k1', state]]);
+    const loginToUserId = new Map([['alice', 'uid123']]);
+
+    await runOfflineCheck(liveStates, loginToUserId, 'k1', 'alice', 'alice');
+
+    expect(deleteAnnouncement).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- `twitchMonitorMultitwitch.test.ts` — pure helper functions with no mocking needed beyond Discord client:
  - `groupGameKey`: format, lowercasing, uniqueness by group/game
  - `buildMultiTwitchContext`: participant grouping, alphabetical sort, deduplication, separation by group and by game
  - `getMultitwitchPreview`: all four branches (not applicable, applicable but disabled, enabled with 2+ participants, 3-participant URL)
- `twitchMonitorOffline.test.ts`:
  - `cancelOfflineTimersForLogin`: clears timer and nulls it for matching login, skips other logins, handles already-null timers, cancels across multiple states for same login
  - `runOfflineCheck`: early returns (missing state, missing userId), deletes announcement and sets channel offline when stream ends, skips deletion when still live, nulls `offlineTimer` in `finally` even on error, treats non-`live` stream type as offline

## Test plan

- `npx tsc --noEmit` — clean
- `npm test` — all tests pass

https://claude.ai/code/session_01DNLtYg8ZzSNR5fAzw9p85k

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNLtYg8ZzSNR5fAzw9p85k)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for multitwitch helper functions, including game grouping and participant context generation.
  * Added test suite for offline monitoring to validate timer management and stream status verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->