### PR TITLE
Allow cell-specific Twitch EventSub reconnect hostnames

### DIFF
--- a/src/twitch/eventsub/twitchEventSubConnection.test.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.test.ts
@@ -49,6 +49,15 @@ describe('buildReconnectUrl', () => {
     expect(buildReconnectUrl('wss://evil.example.com/ws')).toBeNull();
   });
 
+  it('accepts cell-specific subdomains (e.g. cell-a.eventsub.wss.twitch.tv)', () => {
+    const result = buildReconnectUrl('wss://cell-a.eventsub.wss.twitch.tv/ws?challenge=abc&id=123');
+    expect(result).toBe('wss://cell-a.eventsub.wss.twitch.tv/ws?challenge=abc&id=123');
+  });
+
+  it('returns null for a subdomain that only ends with twitch.tv but not the expected suffix', () => {
+    expect(buildReconnectUrl('wss://evil.eventsub.wss.twitch.tv.attacker.com/ws')).toBeNull();
+  });
+
   it('returns null when credentials are present (username)', () => {
     expect(buildReconnectUrl('wss://user@eventsub.wss.twitch.tv/ws')).toBeNull();
   });

--- a/src/twitch/eventsub/twitchEventSubConnection.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.ts
@@ -33,7 +33,7 @@ export function buildReconnectUrl(reconnectUrl: string): string | null {
   const validPorts = new Set(['', '443']);
   const checkResults = {
     protocol: parsed.protocol === 'wss:',
-    hostname: parsed.hostname === 'eventsub.wss.twitch.tv',
+    hostname: parsed.hostname === 'eventsub.wss.twitch.tv' || parsed.hostname.endsWith('.eventsub.wss.twitch.tv'),
     username: !parsed.username,
     password: !parsed.password,
     port: validPorts.has(parsed.port),
@@ -45,7 +45,7 @@ export function buildReconnectUrl(reconnectUrl: string): string | null {
     return null;
   }
   // Reconstruct from validated components so taint analysis sees a clean value
-  const safe = new URL('wss://eventsub.wss.twitch.tv/ws');
+  const safe = new URL(`wss://${parsed.hostname}/ws`);
   safe.search = parsed.search;
   return safe.href;
 }


### PR DESCRIPTION
## Summary

- Twitch's EventSub WebSocket can send reconnect URLs with cell-specific hostnames like `cell-a.eventsub.wss.twitch.tv` for cell-based routing
- The `buildReconnectUrl` validator was rejecting these with `failed checks: hostname`, causing reconnects to fall back to a fresh connection instead of using the Twitch-supplied URL
- Now accepts any `*.eventsub.wss.twitch.tv` subdomain and correctly forwards the validated hostname into the reconstructed safe URL

## Test plan

- [ ] Existing tests still pass (554/554)
- [ ] New test: cell subdomain URL is accepted and round-trips correctly
- [ ] New test: attacker domain ending in `.twitch.tv` but not the expected suffix is still rejected

---
_Generated by [Claude Code](https://claude.ai/code/session_01MfirHbTgx72FBBAvjLXMCW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved EventSub reconnect URL validation to accept alternative endpoint addresses from Twitch while maintaining existing security checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->