### PR TITLE
security(crypto): throw on plaintext EventSub tokens instead of silently using them

### DIFF
--- a/src/shared/crypto.test.ts
+++ b/src/shared/crypto.test.ts
@@ -44,8 +44,10 @@ describe('decryptToken', () => {
     expect(decryptToken(token, VALID_SECRET)).toBe(plaintext);
   });
 
-  it('returns unencrypted strings unchanged (migration path)', () => {
-    expect(decryptToken('plaintext-token', VALID_SECRET)).toBe('plaintext-token');
+  it('throws on plaintext tokens (migration path removed — re-auth required)', () => {
+    expect(() => decryptToken('plaintext-token', VALID_SECRET)).toThrow(
+      'Stored token is not encrypted',
+    );
   });
 
   it('throws on malformed encrypted token (missing parts)', () => {

--- a/src/shared/crypto.ts
+++ b/src/shared/crypto.ts
@@ -23,11 +23,16 @@ export function encryptToken(plaintext: string, secret: string): string {
   return `${ENC_PREFIX}${iv.toString('base64')}.${tag.toString('base64')}.${data.toString('base64')}`;
 }
 
-/** Decrypts a token produced by encryptToken. Returns plaintext values unchanged (migration path). */
+/**
+ * Decrypts a token produced by encryptToken.
+ * Throws if a plaintext token is encountered when a secret is available — the EventSub
+ * OAuth flow must be re-run to produce an encrypted token.
+ */
 export function decryptToken(stored: string, secret: string): string {
   if (!stored.startsWith(ENC_PREFIX)) {
-    log.warn('Decrypting a plaintext (unencrypted) token — re-run the EventSub OAuth flow to re-encrypt it');
-    return stored;
+    throw new Error(
+      'Stored token is not encrypted. Re-run the EventSub OAuth flow to re-encrypt it.',
+    );
   }
   const key = parseKey(secret);
   const [ivB64, tagB64, dataB64] = stored.slice(ENC_PREFIX.length).split('.');


### PR DESCRIPTION
## Issue

**Severity: High** | **Label: security**

`decryptToken` in `src/shared/crypto.ts` contained a migration path that silently returned plaintext (unencrypted) tokens unchanged when they did not carry the `enc:` prefix. The code only logged a warning.

### Attack Scenario

If the database is ever compromised, any legacy plaintext Twitch OAuth tokens stored before the encryption feature was enabled are immediately readable and usable by an attacker — no additional effort required. The silent pass-through also masked operator errors where `EVENTSUB_TOKEN_SECRET` is configured but old tokens were never re-encrypted.

## Fix

Remove the silent pass-through. `decryptToken` now throws an explicit error:

```
Stored token is not encrypted. Re-run the EventSub OAuth flow to re-encrypt it.
```

Operators must complete the Twitch OAuth connect flow for any streamer whose token predates encryption. This converts a silent data-exposure risk into an explicit, operator-visible failure.

The migration test case is updated to assert the new `throw` behaviour.

## Files Changed

- `src/shared/crypto.ts` — removed silent plaintext return, replaced with throw
- `src/shared/crypto.test.ts` — updated test expectation to match new behaviour

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMZ18pP4usL8jZuBZGxABV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Token decryption now strictly enforces encryption requirements and raises an error when plaintext tokens are encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->