### PR TITLE
security(csrf): eliminate token-length timing side-channel in CSRF comparison

### DIFF
--- a/src/web/csrf.ts
+++ b/src/web/csrf.ts
@@ -40,16 +40,11 @@ export const csrfProtection: RequestHandler = (req, _res, next) => {
     return;
   }
 
-  const submittedBuffer = Buffer.from(submittedToken);
-  const sessionBuffer = Buffer.from(sessionToken);
-  const sameLength = submittedBuffer.length === sessionBuffer.length;
-  const len = Math.max(submittedBuffer.length, sessionBuffer.length);
-  const a = Buffer.alloc(len);
-  const b = Buffer.alloc(len);
-  submittedBuffer.copy(a);
-  sessionBuffer.copy(b);
-  const sameValue = crypto.timingSafeEqual(a, b);
-  if (!sameLength || !sameValue) {
+  // Compare hex digests so both buffers are always the same byte length,
+  // eliminating any timing side-channel from a length mismatch check.
+  const a = Buffer.from(crypto.createHash('sha256').update(submittedToken).digest('hex'));
+  const b = Buffer.from(crypto.createHash('sha256').update(sessionToken).digest('hex'));
+  if (!crypto.timingSafeEqual(a, b)) {
     next(createCsrfError());
     return;
   }


### PR DESCRIPTION
## Issue

**Severity: Low** | **Label: security**

`src/web/csrf.ts` performed a plain JavaScript length comparison (`sameLength = submittedBuffer.length === sessionBuffer.length`) before calling `crypto.timingSafeEqual`. This early branch leaks whether the attacker's submitted token has the same byte length as the session token via timing, bypassing the purpose of a constant-time comparison.

### Attack Scenario

An attacker with many requests could measure response latency to determine the expected CSRF token length. In practice the session token is always 64 hex characters (fixed), so the leak is low-value — but the pattern is incorrect and should be fixed regardless.

## Fix

Hash both the submitted token and the session token with SHA-256 before comparing. SHA-256 digests are always 64 hex characters regardless of input length, so `timingSafeEqual` always sees equal-length buffers and no length side-channel exists.

```ts
// Before
const sameLength = submittedBuffer.length === sessionBuffer.length;
// ... pad buffers to same length ...
const sameValue = crypto.timingSafeEqual(a, b);
if (!sameLength || !sameValue) { ... }

// After
const a = Buffer.from(crypto.createHash('sha256').update(submittedToken).digest('hex'));
const b = Buffer.from(crypto.createHash('sha256').update(sessionToken).digest('hex'));
if (!crypto.timingSafeEqual(a, b)) { ... }
```

## Files Changed

- `src/web/csrf.ts` — replaced length-check + padded comparison with hash-then-compare

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMZ18pP4usL8jZuBZGxABV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSRF token validation to enhance security by preventing timing-based attacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->