### PR TITLE
refactor(db): use fromBit utility in mapUser instead of duplicating bit conversion

### DIFF
--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -2,6 +2,7 @@ import mysql from 'mysql2/promise';
 import { normalizeTwitchChannelName } from '../twitch/twitchChannelName';
 import { getPool } from './pool';
 import { createLogger } from '../shared/logger';
+import { fromBit } from './utils';
 
 const log = createLogger('DB');
 
@@ -33,7 +34,7 @@ function mapUser(r: mysql.RowDataPacket): DbUser {
   return {
     discord_id: String(r.discord_id),
     discord_name: r.discord_name,
-    is_twitch_bot_enabled: Buffer.isBuffer(r.is_twitch_bot_enabled) ? r.is_twitch_bot_enabled[0] === 1 : r.is_twitch_bot_enabled == 1,
+    is_twitch_bot_enabled: fromBit(r.is_twitch_bot_enabled),
     twitch_name: r.twitch_name,
     access_level: r.access_level,
   };


### PR DESCRIPTION
## Issue

**Severity: Medium** | **Label: code-review**

`mapUser` in `src/db/users.ts` manually inlined the MySQL `BIT(1)` → `boolean` conversion:

```ts
Buffer.isBuffer(r.is_twitch_bot_enabled) ? r.is_twitch_bot_enabled[0] === 1 : r.is_twitch_bot_enabled == 1
```

The identical logic already exists as `fromBit()` in `src/db/utils.ts`. This is a DRY violation — if the conversion logic ever needs to change (e.g. to handle a new driver return type), it would need to be updated in two places.

## Fix

Import and use `fromBit` in `mapUser`, removing the inline duplication.

```ts
// Before
is_twitch_bot_enabled: Buffer.isBuffer(r.is_twitch_bot_enabled) ? r.is_twitch_bot_enabled[0] === 1 : r.is_twitch_bot_enabled == 1,

// After
is_twitch_bot_enabled: fromBit(r.is_twitch_bot_enabled),
```

## Files Changed

- `src/db/users.ts` — import `fromBit`, replace inline expression

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMZ18pP4usL8jZuBZGxABV)_