### PR TITLE
fix(twitchApi): guard against infinite loop in chunks() when size <= 0

### DIFF
--- a/src/twitch/twitchApi.ts
+++ b/src/twitch/twitchApi.ts
@@ -51,6 +51,7 @@ export function authHeaders(token: string): Record<string, string> {
 }
 
 function chunks<T>(arr: T[], size: number): T[][] {
+  if (size <= 0) throw new Error(`chunks: size must be > 0, got ${size}`);
   const result: T[][] = [];
   for (let i = 0; i < arr.length; i += size) result.push(arr.slice(i, i + size));
   return result;


### PR DESCRIPTION
## Issue

**Severity: Low** | **Label: code-review**

`chunks<T>(arr, size)` in `src/twitch/twitchApi.ts` had no guard against a zero or negative `size` argument. When `size <= 0`, the loop `for (let i = 0; i < arr.length; i += size)` never advances `i` — it hangs the process indefinitely on any non-empty array.

All three callers (`getUsers`, `getStreams`, `getChannelInfo`) pass the compile-time constant `100`, so this cannot be triggered today, but it is a latent defect that would be hard to diagnose if the constant were ever changed.

## Fix

Add an upfront guard that throws a descriptive error:

```ts
function chunks<T>(arr: T[], size: number): T[][] {
  if (size <= 0) throw new Error(`chunks: size must be > 0, got ${size}`);
  ...
}
```

## Files Changed

- `src/twitch/twitchApi.ts` — added size guard to `chunks()`

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMZ18pP4usL8jZuBZGxABV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for chunking operations to handle invalid inputs with improved error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->