### PR TITLE
fix(db): skip cache invalidation in resetCounterCurrentValue when value unchanged

### DIFF
--- a/src/db/counters.ts
+++ b/src/db/counters.ts
@@ -221,8 +221,10 @@ export async function resetCounterCurrentValue(id: number): Promise<void> {
     [id],
   );
 
-  if (result.affectedRows === 0 && !(await counterExists(id))) {
-    throw new CounterNotFoundError(id);
+  if (result.affectedRows === 0) {
+    if (!(await counterExists(id))) throw new CounterNotFoundError(id);
+    // Counter exists but value was already 0 — nothing changed, skip invalidation.
+    return;
   }
 
   invalidateCounterLookupCache();


### PR DESCRIPTION
## Issue

**Severity: Medium** | **Label: code-review**

`resetCounterCurrentValue` in `src/db/counters.ts` called `invalidateCounterLookupCache()` unconditionally — even when `affectedRows === 0`, meaning the counter's `current_value` was already `0` and no write occurred. Unnecessary cache invalidations force all subsequent lookups to re-query the database, adding latency with no benefit.

```ts
// Before: invalidation happens even when nothing changed
if (result.affectedRows === 0 && !(await counterExists(id))) {
  throw new CounterNotFoundError(id);
}
invalidateCounterLookupCache(); // always called
```

## Fix

Return early when `affectedRows === 0` and the counter exists (no-op case), so `invalidateCounterLookupCache()` is only reached when the value was actually changed.

```ts
if (result.affectedRows === 0) {
  if (!(await counterExists(id))) throw new CounterNotFoundError(id);
  return; // value already 0, nothing changed
}
invalidateCounterLookupCache();
```

## Files Changed

- `src/db/counters.ts` — guard `invalidateCounterLookupCache()` behind `affectedRows > 0`

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMZ18pP4usL8jZuBZGxABV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved counter reset operation with enhanced edge case handling and optimized cache invalidation for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->