### PR TITLE
Fix startup log name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ process.on('SIGINT',  () => { shutdown('SIGINT').catch((err)  => { log.error('Sh
 process.on('SIGTERM', () => { shutdown('SIGTERM').catch((err) => { log.error('Shutdown error:', err); process.exit(1); }); });
 
 async function main(): Promise<void> {
-  log.info('Starting BCUK SFX Bot...');
+  log.info('Starting BCUK Bot 4...');
 
   // Verify DB connection early
   try {


### PR DESCRIPTION
Changes `Starting BCUK SFX Bot...` to `Starting BCUK Bot 4...` in the startup log.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CDJTMi4w59aGrb44LU18Gc)_