### PR TITLE
Add tests for sfxPublic, commandAssignments, and auth web routes

### DIFF
--- a/src/web/routes/auth.test.ts
+++ b/src/web/routes/auth.test.ts
@@ -8,7 +8,6 @@ vi.mock('../../shared/config', () => ({
 vi.mock('../../db', () => ({
   findUser: vi.fn().mockResolvedValue(null),
   updateDiscordName: vi.fn().mockResolvedValue(undefined),
-  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
 }));
 vi.mock('../../discord/discordBot', () => ({
   fetchMemberDisplayName: vi.fn().mockResolvedValue(null),
@@ -26,7 +25,8 @@ vi.mock('../../shared/logger', () => ({
 import express from 'express';
 import supertest from 'supertest';
 import router from './auth';
-import { findUser, updateDiscordName, AccessLevel } from '../../db';
+import { findUser, updateDiscordName } from '../../db';
+import { AccessLevel } from '../../db/users';
 import { fetchMemberDisplayName } from '../../discord/discordBot';
 
 function buildApp(sessionOverrides: Record<string, unknown> = {}) {

--- a/src/web/routes/auth.test.ts
+++ b/src/web/routes/auth.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../shared/config', () => ({
+  DISCORD_CLIENT_ID: 'client_id',
+  DISCORD_CLIENT_SECRET: 'client_secret',
+  DISCORD_CALLBACK_URL: 'http://localhost/auth/discord/callback',
+}));
+vi.mock('../../db', () => ({
+  findUser: vi.fn().mockResolvedValue(null),
+  updateDiscordName: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../discord/discordBot', () => ({
+  fetchMemberDisplayName: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('../csrf', () => ({
+  csrfProtection: (_req: any, _res: any, next: any) => next(),
+}));
+vi.mock('../middleware', () => ({
+  requireAuth: (_req: any, _res: any, next: any) => next(),
+}));
+vi.mock('../../shared/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+}));
+
+import express from 'express';
+import supertest from 'supertest';
+import router from './auth';
+import { findUser, updateDiscordName } from '../../db';
+import { fetchMemberDisplayName } from '../../discord/discordBot';
+
+function buildApp(sessionOverrides: Record<string, unknown> = {}) {
+  const app = express();
+  app.use(express.urlencoded({ extended: false }));
+  app.use((req: any, _res: any, next: any) => {
+    req.session = {
+      oauthState: undefined,
+      user: undefined,
+      destroy: vi.fn((cb: () => void) => cb()),
+      regenerate: vi.fn((cb: (err: null) => void) => cb(null)),
+      save: vi.fn((cb: (err: null) => void) => cb(null)),
+      ...sessionOverrides,
+    };
+    next();
+  });
+  app.use((req: any, res: any, next: any) => {
+    res.render = (view: string, locals: unknown) =>
+      res.status((res as any).statusCode || 200).json({ view, locals });
+    next();
+  });
+  app.use(router);
+  return app;
+}
+
+function mockFetch(responses: { ok: boolean; json?: () => Promise<unknown>; status?: number }[]) {
+  let callIndex = 0;
+  return vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+    const r = responses[callIndex++];
+    return Promise.resolve({ ok: r.ok, status: r.status ?? 200, json: r.json ?? (() => Promise.resolve({})) } as Response);
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(findUser).mockResolvedValue(null);
+  vi.mocked(fetchMemberDisplayName).mockResolvedValue(null);
+});
+
+// ─── GET /discord ─────────────────────────────────────────────────────────────
+
+describe('GET /discord', () => {
+  it('redirects to Discord OAuth URL', async () => {
+    const res = await supertest(buildApp()).get('/discord');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain('discord.com/oauth2/authorize');
+  });
+
+  it('includes client_id and state in the redirect URL', async () => {
+    const res = await supertest(buildApp()).get('/discord');
+    expect(res.headers.location).toContain('client_id=client_id');
+    expect(res.headers.location).toContain('state=');
+  });
+});
+
+// ─── GET /discord/callback ────────────────────────────────────────────────────
+
+describe('GET /discord/callback', () => {
+  it('renders error 400 when state does not match session', async () => {
+    const res = await supertest(buildApp({ oauthState: 'expected' }))
+      .get('/discord/callback?code=abc&state=wrong');
+    expect(res.status).toBe(400);
+    expect((res.body as any).view).toBe('error');
+  });
+
+  it('renders error 400 when code is missing', async () => {
+    const res = await supertest(buildApp({ oauthState: 'abc' }))
+      .get('/discord/callback?state=abc');
+    expect(res.status).toBe(400);
+  });
+
+  it('renders error 500 when token exchange fails', async () => {
+    mockFetch([{ ok: false, status: 400 }]);
+    const res = await supertest(buildApp({ oauthState: 'state123' }))
+      .get('/discord/callback?code=code&state=state123');
+    expect(res.status).toBe(500);
+    expect((res.body as any).view).toBe('error');
+  });
+
+  it('renders error 500 when profile fetch fails', async () => {
+    mockFetch([
+      { ok: true, json: () => Promise.resolve({ access_token: 'tok' }) },
+      { ok: false, status: 401 },
+    ]);
+    const res = await supertest(buildApp({ oauthState: 'state123' }))
+      .get('/discord/callback?code=code&state=state123');
+    expect(res.status).toBe(500);
+  });
+
+  it('renders error 403 when user is not in the whitelist', async () => {
+    mockFetch([
+      { ok: true, json: () => Promise.resolve({ access_token: 'tok' }) },
+      { ok: true, json: () => Promise.resolve({ id: '999', username: 'stranger', avatar: null }) },
+    ]);
+    vi.mocked(findUser).mockResolvedValue(null);
+    const res = await supertest(buildApp({ oauthState: 'state123' }))
+      .get('/discord/callback?code=code&state=state123');
+    expect(res.status).toBe(403);
+  });
+
+  it('redirects to / on successful authentication', async () => {
+    mockFetch([
+      { ok: true, json: () => Promise.resolve({ access_token: 'tok' }) },
+      { ok: true, json: () => Promise.resolve({ id: '111', username: 'alice', avatar: null }) },
+    ]);
+    vi.mocked(findUser).mockResolvedValue({ discord_id: '111', discord_name: 'alice', is_twitch_bot_enabled: false, twitch_name: null, access_level: 0 } as any);
+    const res = await supertest(buildApp({ oauthState: 'state123' }))
+      .get('/discord/callback?code=code&state=state123');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/');
+  });
+
+  it('updates discord name when fetchMemberDisplayName returns a value', async () => {
+    mockFetch([
+      { ok: true, json: () => Promise.resolve({ access_token: 'tok' }) },
+      { ok: true, json: () => Promise.resolve({ id: '111', username: 'alice', avatar: null }) },
+    ]);
+    vi.mocked(findUser).mockResolvedValue({ discord_id: '111', discord_name: 'OldName', is_twitch_bot_enabled: false, twitch_name: null, access_level: 0 } as any);
+    vi.mocked(fetchMemberDisplayName).mockResolvedValue('NewDisplayName');
+    const res = await supertest(buildApp({ oauthState: 'state123' }))
+      .get('/discord/callback?code=code&state=state123');
+    expect(res.status).toBe(302);
+    expect(updateDiscordName).toHaveBeenCalledWith('111', 'NewDisplayName');
+  });
+});
+
+// ─── GET /login ───────────────────────────────────────────────────────────────
+
+describe('GET /login', () => {
+  it('renders login page when not authenticated', async () => {
+    const res = await supertest(buildApp()).get('/login');
+    expect(res.status).toBe(200);
+    expect((res.body as any).view).toBe('login');
+  });
+
+  it('redirects to / when already authenticated', async () => {
+    const res = await supertest(buildApp({ user: { discordId: '1', discordName: 'Alice', accessLevel: 0 } })).get('/login');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/');
+  });
+});
+
+// ─── POST /logout ─────────────────────────────────────────────────────────────
+
+describe('POST /logout', () => {
+  it('destroys session and redirects to /auth/login', async () => {
+    const res = await supertest(buildApp({ user: { discordId: '1' } })).post('/logout');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/auth/login');
+  });
+});

--- a/src/web/routes/auth.test.ts
+++ b/src/web/routes/auth.test.ts
@@ -172,8 +172,10 @@ describe('GET /login', () => {
 
 describe('POST /logout', () => {
   it('destroys session and redirects to /auth/login', async () => {
-    const res = await supertest(buildApp({ user: { discordId: '1' } })).post('/logout');
+    const destroy = vi.fn((cb: () => void) => cb());
+    const res = await supertest(buildApp({ user: { discordId: '1' }, destroy })).post('/logout');
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/auth/login');
+    expect(destroy).toHaveBeenCalled();
   });
 });

--- a/src/web/routes/auth.test.ts
+++ b/src/web/routes/auth.test.ts
@@ -8,6 +8,7 @@ vi.mock('../../shared/config', () => ({
 vi.mock('../../db', () => ({
   findUser: vi.fn().mockResolvedValue(null),
   updateDiscordName: vi.fn().mockResolvedValue(undefined),
+  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
 }));
 vi.mock('../../discord/discordBot', () => ({
   fetchMemberDisplayName: vi.fn().mockResolvedValue(null),
@@ -25,7 +26,7 @@ vi.mock('../../shared/logger', () => ({
 import express from 'express';
 import supertest from 'supertest';
 import router from './auth';
-import { findUser, updateDiscordName } from '../../db';
+import { findUser, updateDiscordName, AccessLevel } from '../../db';
 import { fetchMemberDisplayName } from '../../discord/discordBot';
 
 function buildApp(sessionOverrides: Record<string, unknown> = {}) {
@@ -120,7 +121,6 @@ describe('GET /discord/callback', () => {
       { ok: true, json: () => Promise.resolve({ access_token: 'tok' }) },
       { ok: true, json: () => Promise.resolve({ id: '999', username: 'stranger', avatar: null }) },
     ]);
-    vi.mocked(findUser).mockResolvedValue(null);
     const res = await supertest(buildApp({ oauthState: 'state123' }))
       .get('/discord/callback?code=code&state=state123');
     expect(res.status).toBe(403);
@@ -131,7 +131,7 @@ describe('GET /discord/callback', () => {
       { ok: true, json: () => Promise.resolve({ access_token: 'tok' }) },
       { ok: true, json: () => Promise.resolve({ id: '111', username: 'alice', avatar: null }) },
     ]);
-    vi.mocked(findUser).mockResolvedValue({ discord_id: '111', discord_name: 'alice', is_twitch_bot_enabled: false, twitch_name: null, access_level: 0 } as any);
+    vi.mocked(findUser).mockResolvedValue({ discord_id: '111', discord_name: 'alice', is_twitch_bot_enabled: false, twitch_name: null, access_level: AccessLevel.USER } as any);
     const res = await supertest(buildApp({ oauthState: 'state123' }))
       .get('/discord/callback?code=code&state=state123');
     expect(res.status).toBe(302);
@@ -143,7 +143,7 @@ describe('GET /discord/callback', () => {
       { ok: true, json: () => Promise.resolve({ access_token: 'tok' }) },
       { ok: true, json: () => Promise.resolve({ id: '111', username: 'alice', avatar: null }) },
     ]);
-    vi.mocked(findUser).mockResolvedValue({ discord_id: '111', discord_name: 'OldName', is_twitch_bot_enabled: false, twitch_name: null, access_level: 0 } as any);
+    vi.mocked(findUser).mockResolvedValue({ discord_id: '111', discord_name: 'OldName', is_twitch_bot_enabled: false, twitch_name: null, access_level: AccessLevel.USER } as any);
     vi.mocked(fetchMemberDisplayName).mockResolvedValue('NewDisplayName');
     const res = await supertest(buildApp({ oauthState: 'state123' }))
       .get('/discord/callback?code=code&state=state123');
@@ -162,7 +162,7 @@ describe('GET /login', () => {
   });
 
   it('redirects to / when already authenticated', async () => {
-    const res = await supertest(buildApp({ user: { discordId: '1', discordName: 'Alice', accessLevel: 0 } })).get('/login');
+    const res = await supertest(buildApp({ user: { discordId: '1', discordName: 'Alice', accessLevel: AccessLevel.USER } })).get('/login');
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/');
   });

--- a/src/web/routes/commandAssignments.test.ts
+++ b/src/web/routes/commandAssignments.test.ts
@@ -8,7 +8,6 @@ vi.mock('../../db', () => {
     findUser: vi.fn().mockResolvedValue(null),
     CommandConflictError,
     isMysqlDuplicateEntryError: vi.fn().mockReturnValue(false),
-    AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
   };
 });
 vi.mock('../csrf', () => ({
@@ -20,11 +19,15 @@ vi.mock('../middleware', () => ({
 vi.mock('../../shared/logger', () => ({
   createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
 }));
+vi.mock('../../db/users', () => ({
+  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
+}));
 
 import express from 'express';
 import supertest from 'supertest';
 import router from './commandAssignments';
-import { assignUserToCommand, unassignUserFromCommand, findUser, CommandConflictError, isMysqlDuplicateEntryError, AccessLevel } from '../../db';
+import { assignUserToCommand, unassignUserFromCommand, findUser, CommandConflictError, isMysqlDuplicateEntryError } from '../../db';
+import { AccessLevel } from '../../db/users';
 
 function buildApp() {
   const app = express();

--- a/src/web/routes/commandAssignments.test.ts
+++ b/src/web/routes/commandAssignments.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../db', () => {
+  class CommandConflictError extends Error {}
+  return {
+    assignUserToCommand: vi.fn().mockResolvedValue(undefined),
+    unassignUserFromCommand: vi.fn().mockResolvedValue(undefined),
+    findUser: vi.fn().mockResolvedValue(null),
+    CommandConflictError,
+    isMysqlDuplicateEntryError: vi.fn().mockReturnValue(false),
+  };
+});
+vi.mock('../csrf', () => ({
+  csrfProtection: (_req: any, _res: any, next: any) => next(),
+}));
+vi.mock('../middleware', () => ({
+  requireMod: (_req: any, _res: any, next: any) => next(),
+}));
+vi.mock('../../shared/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+}));
+
+import express from 'express';
+import supertest from 'supertest';
+import router from './commandAssignments';
+import { assignUserToCommand, unassignUserFromCommand, findUser, CommandConflictError, isMysqlDuplicateEntryError } from '../../db';
+
+function buildApp() {
+  const app = express();
+  app.use(express.urlencoded({ extended: false }));
+  app.use(router);
+  return app;
+}
+
+const VALID_COMMAND_ID = '5';
+const VALID_DISCORD_ID = '123456789012345678'; // 18 digits
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(findUser).mockResolvedValue({ discord_id: VALID_DISCORD_ID, discord_name: 'Alice', is_twitch_bot_enabled: true, twitch_name: 'alice', access_level: 0 } as any);
+  vi.mocked(assignUserToCommand).mockResolvedValue(undefined);
+  vi.mocked(unassignUserFromCommand).mockResolvedValue(undefined);
+  vi.mocked(isMysqlDuplicateEntryError).mockReturnValue(false);
+});
+
+// ─── POST /commands/assign ────────────────────────────────────────────────────
+
+describe('POST /commands/assign', () => {
+  it('redirects to /commands on success', async () => {
+    const res = await supertest(buildApp())
+      .post('/commands/assign')
+      .send(`command_id=${VALID_COMMAND_ID}&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/commands');
+  });
+
+  it('redirects to ?error=missing_fields when fields are absent', async () => {
+    const res = await supertest(buildApp()).post('/commands/assign').send('');
+    expect(res.headers.location).toBe('/commands?error=missing_fields');
+  });
+
+  it('redirects to ?error=invalid_id for non-numeric command_id', async () => {
+    const res = await supertest(buildApp())
+      .post('/commands/assign')
+      .send(`command_id=abc&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/commands?error=invalid_id');
+  });
+
+  it('redirects to ?error=invalid_id for invalid discord_id', async () => {
+    const res = await supertest(buildApp())
+      .post('/commands/assign')
+      .send(`command_id=${VALID_COMMAND_ID}&discord_id=bad`);
+    expect(res.headers.location).toBe('/commands?error=invalid_id');
+  });
+
+  it('redirects to ?error=invalid_assignment_user when user not found', async () => {
+    vi.mocked(findUser).mockResolvedValue(null);
+    const res = await supertest(buildApp())
+      .post('/commands/assign')
+      .send(`command_id=${VALID_COMMAND_ID}&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/commands?error=invalid_assignment_user');
+  });
+
+  it('redirects to ?error=invalid_assignment_user when user has no twitch_name', async () => {
+    vi.mocked(findUser).mockResolvedValue({ discord_id: VALID_DISCORD_ID, discord_name: 'Alice', is_twitch_bot_enabled: false, twitch_name: null, access_level: 0 } as any);
+    const res = await supertest(buildApp())
+      .post('/commands/assign')
+      .send(`command_id=${VALID_COMMAND_ID}&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/commands?error=invalid_assignment_user');
+  });
+
+  it('redirects to ?error=command_taken when CommandConflictError is thrown', async () => {
+    vi.mocked(assignUserToCommand).mockRejectedValueOnce(new (CommandConflictError as any)('conflict'));
+    const res = await supertest(buildApp())
+      .post('/commands/assign')
+      .send(`command_id=${VALID_COMMAND_ID}&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/commands?error=command_taken');
+  });
+
+  it('redirects to ?error=command_taken when isMysqlDuplicateEntryError returns true', async () => {
+    vi.mocked(isMysqlDuplicateEntryError).mockReturnValue(true);
+    vi.mocked(assignUserToCommand).mockRejectedValueOnce(new Error('ER_DUP_ENTRY'));
+    const res = await supertest(buildApp())
+      .post('/commands/assign')
+      .send(`command_id=${VALID_COMMAND_ID}&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/commands?error=command_taken');
+  });
+
+  it('redirects to ?error=assign_failed on unexpected error', async () => {
+    vi.mocked(assignUserToCommand).mockRejectedValueOnce(new Error('unexpected'));
+    const res = await supertest(buildApp())
+      .post('/commands/assign')
+      .send(`command_id=${VALID_COMMAND_ID}&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/commands?error=assign_failed');
+  });
+});
+
+// ─── POST /commands/unassign ──────────────────────────────────────────────────
+
+describe('POST /commands/unassign', () => {
+  it('redirects to /commands on success', async () => {
+    const res = await supertest(buildApp())
+      .post('/commands/unassign')
+      .send(`command_id=${VALID_COMMAND_ID}&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/commands');
+  });
+
+  it('redirects to ?error=missing_fields when fields are absent', async () => {
+    const res = await supertest(buildApp()).post('/commands/unassign').send('');
+    expect(res.headers.location).toBe('/commands?error=missing_fields');
+  });
+
+  it('redirects to ?error=invalid_id for non-numeric command_id', async () => {
+    const res = await supertest(buildApp())
+      .post('/commands/unassign')
+      .send(`command_id=abc&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/commands?error=invalid_id');
+  });
+
+  it('redirects to ?error=unassign_failed on unexpected error', async () => {
+    vi.mocked(unassignUserFromCommand).mockRejectedValueOnce(new Error('db error'));
+    const res = await supertest(buildApp())
+      .post('/commands/unassign')
+      .send(`command_id=${VALID_COMMAND_ID}&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/commands?error=unassign_failed');
+  });
+});

--- a/src/web/routes/commandAssignments.test.ts
+++ b/src/web/routes/commandAssignments.test.ts
@@ -8,6 +8,7 @@ vi.mock('../../db', () => {
     findUser: vi.fn().mockResolvedValue(null),
     CommandConflictError,
     isMysqlDuplicateEntryError: vi.fn().mockReturnValue(false),
+    AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
   };
 });
 vi.mock('../csrf', () => ({
@@ -23,7 +24,7 @@ vi.mock('../../shared/logger', () => ({
 import express from 'express';
 import supertest from 'supertest';
 import router from './commandAssignments';
-import { assignUserToCommand, unassignUserFromCommand, findUser, CommandConflictError, isMysqlDuplicateEntryError } from '../../db';
+import { assignUserToCommand, unassignUserFromCommand, findUser, CommandConflictError, isMysqlDuplicateEntryError, AccessLevel } from '../../db';
 
 function buildApp() {
   const app = express();
@@ -37,7 +38,7 @@ const VALID_DISCORD_ID = '123456789012345678'; // 18 digits
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(findUser).mockResolvedValue({ discord_id: VALID_DISCORD_ID, discord_name: 'Alice', is_twitch_bot_enabled: true, twitch_name: 'alice', access_level: 0 } as any);
+  vi.mocked(findUser).mockResolvedValue({ discord_id: VALID_DISCORD_ID, discord_name: 'Alice', is_twitch_bot_enabled: true, twitch_name: 'alice', access_level: AccessLevel.USER } as any);
   vi.mocked(assignUserToCommand).mockResolvedValue(undefined);
   vi.mocked(unassignUserFromCommand).mockResolvedValue(undefined);
   vi.mocked(isMysqlDuplicateEntryError).mockReturnValue(false);
@@ -82,7 +83,7 @@ describe('POST /commands/assign', () => {
   });
 
   it('redirects to ?error=invalid_assignment_user when user has no twitch_name', async () => {
-    vi.mocked(findUser).mockResolvedValue({ discord_id: VALID_DISCORD_ID, discord_name: 'Alice', is_twitch_bot_enabled: false, twitch_name: null, access_level: 0 } as any);
+    vi.mocked(findUser).mockResolvedValue({ discord_id: VALID_DISCORD_ID, discord_name: 'Alice', is_twitch_bot_enabled: false, twitch_name: null, access_level: AccessLevel.USER } as any);
     const res = await supertest(buildApp())
       .post('/commands/assign')
       .send(`command_id=${VALID_COMMAND_ID}&discord_id=${VALID_DISCORD_ID}`);
@@ -135,6 +136,13 @@ describe('POST /commands/unassign', () => {
     const res = await supertest(buildApp())
       .post('/commands/unassign')
       .send(`command_id=abc&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/commands?error=invalid_id');
+  });
+
+  it('redirects to ?error=invalid_id for malformed discord_id', async () => {
+    const res = await supertest(buildApp())
+      .post('/commands/unassign')
+      .send(`command_id=${VALID_COMMAND_ID}&discord_id=bad`);
     expect(res.headers.location).toBe('/commands?error=invalid_id');
   });
 

--- a/src/web/routes/sfxPublic.test.ts
+++ b/src/web/routes/sfxPublic.test.ts
@@ -9,14 +9,18 @@ vi.mock('../../shared/logger', () => ({
 vi.mock('../middleware', () => ({
   requireAuth: (_req: any, _res: any, next: any) => next(),
 }));
+vi.mock('../../db/users', () => ({
+  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
+}));
 
 import express from 'express';
 import supertest from 'supertest';
 import { getPublicSfxTriggers } from '../../db';
+import { AccessLevel } from '../../db/users';
 
 let router: any;
 
-function buildApp(sessionUser: unknown = { discordId: '1', discordName: 'Test', accessLevel: 0 }) {
+function buildApp(sessionUser: unknown = { discordId: '1', discordName: 'Test', accessLevel: AccessLevel.USER }) {
   const app = express();
   app.use((req: any, _res: any, next: any) => {
     req.session = { user: sessionUser };
@@ -56,7 +60,7 @@ describe('GET /sfx-list', () => {
   });
 
   it('passes session user to the template', async () => {
-    const user = { discordId: '42', discordName: 'Alice', accessLevel: 1 };
+    const user = { discordId: '42', discordName: 'Alice', accessLevel: AccessLevel.MOD };
     vi.mocked(getPublicSfxTriggers).mockResolvedValue([]);
     const res = await supertest(buildApp(user)).get('/sfx-list');
     expect(res.status).toBe(200);

--- a/src/web/routes/sfxPublic.test.ts
+++ b/src/web/routes/sfxPublic.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../db', () => ({
+  getPublicSfxTriggers: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('../../shared/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+}));
+vi.mock('../middleware', () => ({
+  requireAuth: (_req: any, _res: any, next: any) => next(),
+}));
+
+import express from 'express';
+import supertest from 'supertest';
+import router from './sfxPublic';
+import { getPublicSfxTriggers } from '../../db';
+
+function buildApp(sessionUser: unknown = { discordId: '1', discordName: 'Test', accessLevel: 0 }) {
+  const app = express();
+  app.use((req: any, _res: any, next: any) => {
+    req.session = { user: sessionUser };
+    next();
+  });
+  app.use((req: any, res: any, next: any) => {
+    res.render = (view: string, locals: unknown) => res.json({ view, locals });
+    next();
+  });
+  app.use(router);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getPublicSfxTriggers).mockResolvedValue([]);
+});
+
+describe('GET /sfx-list', () => {
+  // Error test runs first so the module-level cache is cold
+  it('returns 500 and renders error page when getPublicSfxTriggers throws', async () => {
+    vi.mocked(getPublicSfxTriggers).mockRejectedValueOnce(new Error('DB down'));
+    const res = await supertest(buildApp()).get('/sfx-list');
+    expect(res.status).toBe(500);
+    expect((res.body as any).view).toBe('error');
+  });
+
+  it('renders sfx-public with triggers', async () => {
+    const triggers = [{ triggerCommand: '!bang', categoryName: null, description: null }];
+    vi.mocked(getPublicSfxTriggers).mockResolvedValue(triggers);
+    const res = await supertest(buildApp()).get('/sfx-list');
+    expect(res.status).toBe(200);
+    const body = res.body as { view: string; locals: { triggers: unknown } };
+    expect(body.view).toBe('sfx-public');
+    expect(body.locals.triggers).toEqual(triggers);
+  });
+
+  it('passes session user to the template', async () => {
+    const user = { discordId: '42', discordName: 'Alice', accessLevel: 1 };
+    vi.mocked(getPublicSfxTriggers).mockResolvedValue([]);
+    const res = await supertest(buildApp(user)).get('/sfx-list');
+    expect(res.status).toBe(200);
+    expect((res.body as any).locals.user).toEqual(user);
+  });
+
+  it('passes null user when session has no user', async () => {
+    vi.mocked(getPublicSfxTriggers).mockResolvedValue([]);
+    const res = await supertest(buildApp(null)).get('/sfx-list');
+    expect((res.body as any).locals.user).toBeNull();
+  });
+});

--- a/src/web/routes/sfxPublic.test.ts
+++ b/src/web/routes/sfxPublic.test.ts
@@ -12,8 +12,9 @@ vi.mock('../middleware', () => ({
 
 import express from 'express';
 import supertest from 'supertest';
-import router from './sfxPublic';
 import { getPublicSfxTriggers } from '../../db';
+
+let router: any;
 
 function buildApp(sessionUser: unknown = { discordId: '1', discordName: 'Test', accessLevel: 0 }) {
   const app = express();
@@ -29,13 +30,14 @@ function buildApp(sessionUser: unknown = { discordId: '1', discordName: 'Test', 
   return app;
 }
 
-beforeEach(() => {
+beforeEach(async () => {
+  vi.resetModules();
   vi.clearAllMocks();
   vi.mocked(getPublicSfxTriggers).mockResolvedValue([]);
+  router = (await import('./sfxPublic.js')).default;
 });
 
 describe('GET /sfx-list', () => {
-  // Error test runs first so the module-level cache is cold
   it('returns 500 and renders error page when getPublicSfxTriggers throws', async () => {
     vi.mocked(getPublicSfxTriggers).mockRejectedValueOnce(new Error('DB down'));
     const res = await supertest(buildApp()).get('/sfx-list');
@@ -64,6 +66,8 @@ describe('GET /sfx-list', () => {
   it('passes null user when session has no user', async () => {
     vi.mocked(getPublicSfxTriggers).mockResolvedValue([]);
     const res = await supertest(buildApp(null)).get('/sfx-list');
+    expect(res.status).toBe(200);
+    expect((res.body as any).view).toBe('sfx-public');
     expect((res.body as any).locals.user).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- 29 tests across 3 previously-untested route files
- **`sfxPublic`**: GET /sfx-list renders correct view with triggers, error path (500), session user forwarded, null user when unauthenticated
- **`commandAssignments`**: POST /commands/assign — missing fields, invalid IDs, user not found, no twitch_name, CommandConflictError, duplicate-entry, unexpected error; POST /commands/unassign — same structural coverage
- **`auth`**: GET /discord OAuth redirect contains client_id and state; GET /discord/callback — state mismatch (400), missing code (400), token exchange failure (500), profile fetch failure (500), user not in whitelist (403), successful login redirect, discord_name sync via fetchMemberDisplayName; GET /login renders or redirects based on session; POST /logout destroys session

## Test plan

- [x] All 29 tests pass locally
- [x] TypeScript compiles without errors

https://claude.ai/code/session_01DNLtYg8ZzSNR5fAzw9p85k

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNLtYg8ZzSNR5fAzw9p85k)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests for authentication flows (Discord OAuth, callback error paths, login, logout, and display-name update) to verify redirects, error responses, and name-sync behavior.
  * Added tests for command assignment/unassignment covering success, input validation errors, conflict and duplicate-entry conditions, and failure paths.
  * Added tests for the public SFX list route covering successful render, error handling, and user presence in template locals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->