### PR TITLE
Add tests for twitchMonitorTypes, Announcements, and Startup

### DIFF
--- a/src/twitch/monitor/twitchMonitorAnnouncements.test.ts
+++ b/src/twitch/monitor/twitchMonitorAnnouncements.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../shared/logger', () => ({ createLogger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn() }) }));
+vi.mock('../../discord/discordBot', () => ({ getDiscordClient: vi.fn() }));
+vi.mock('../../discord/discordUtils', () => ({
+  isDiscordNotFoundError: vi.fn().mockReturnValue(false),
+  tryDeleteDiscordMessage: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../db', () => ({
+  setStreamerLive: vi.fn().mockResolvedValue(undefined),
+  clearStreamerLive: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('./twitchMonitorEmbed', () => ({
+  buildEmbed: vi.fn().mockReturnValue({ title: 'embed' }),
+  fillTemplate: vi.fn().mockReturnValue('Live message'),
+  templateVars: vi.fn().mockReturnValue({}),
+}));
+vi.mock('./twitchMonitorMultitwitch', () => ({
+  updateMultitwitch: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { postAnnouncement, editAnnouncement, deleteAnnouncement } from './twitchMonitorAnnouncements';
+import { getDiscordClient } from '../../discord/discordBot';
+import { isDiscordNotFoundError, tryDeleteDiscordMessage } from '../../discord/discordUtils';
+import { setStreamerLive, clearStreamerLive } from '../../db';
+import { updateMultitwitch } from './twitchMonitorMultitwitch';
+import type { DbStreamGroup, DbStreamerFull } from '../../db';
+import type { TwitchStream } from '../twitchApi';
+import type { LiveState } from './twitchMonitorTypes';
+
+function makeGroup(overrides: Partial<DbStreamGroup> = {}): DbStreamGroup {
+  return { id: 1, name: 'G1', discord_channel: 'ch1', live_message: 'Live!', new_game_message: 'New game!', multi_twitch: false, delete_old_posts: false, ...overrides };
+}
+
+function makeStreamer(overrides: Partial<DbStreamerFull> = {}): DbStreamerFull {
+  return { id: 10, discord_id: 'discord1', twitch_name: 'alice', group: makeGroup(), discord_message_id: null, discord_channel_id: null, live_game: null, ...overrides };
+}
+
+function makeStream(overrides: Partial<TwitchStream> = {}): TwitchStream {
+  return { user_id: 'u1', user_login: 'alice', game_name: 'Chess', type: 'live', title: 'Playing', thumbnail_url: '', ...overrides };
+}
+
+function makeTextChannel(msgOverrides: Record<string, unknown> = {}) {
+  const message = { id: 'msg1', channelId: 'ch1', delete: vi.fn().mockResolvedValue(undefined), edit: vi.fn().mockResolvedValue(undefined), ...msgOverrides };
+  return {
+    isTextBased: () => true,
+    send: vi.fn().mockResolvedValue({ id: 'msg1', channelId: 'ch1' }),
+    messages: { fetch: vi.fn().mockResolvedValue(message) },
+    _message: message,
+  };
+}
+
+function makeDiscordClient(channel: ReturnType<typeof makeTextChannel> | null = null) {
+  return {
+    channels: { fetch: vi.fn().mockResolvedValue(channel ?? makeTextChannel()) },
+  };
+}
+
+function makeLiveState(overrides: Partial<LiveState> = {}): LiveState {
+  return {
+    streamerId: 10, groupId: 1, group: makeGroup(), login: 'alice',
+    messageId: 'msg1', channelId: 'ch1', currentGame: 'Chess', title: 'Playing',
+    currentStream: makeStream(), offlineTimer: null, ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(isDiscordNotFoundError).mockReturnValue(false);
+});
+
+// ─── postAnnouncement ─────────────────────────────────────────────────────────
+
+describe('postAnnouncement', () => {
+  it('sets state with null message fields when no discord client', async () => {
+    vi.mocked(getDiscordClient).mockReturnValue(null);
+    const liveStates = new Map<string, LiveState>();
+    await postAnnouncement(liveStates, makeStreamer(), makeStream());
+    expect(liveStates.get('10')?.messageId).toBeNull();
+    expect(liveStates.get('10')?.channelId).toBeNull();
+  });
+
+  it('does not call setStreamerLive when no discord client', async () => {
+    vi.mocked(getDiscordClient).mockReturnValue(null);
+    await postAnnouncement(new Map(), makeStreamer(), makeStream());
+    expect(setStreamerLive).not.toHaveBeenCalled();
+  });
+
+  it('sends message and sets live state when client and channel are available', async () => {
+    const channel = makeTextChannel();
+    vi.mocked(getDiscordClient).mockReturnValue(makeDiscordClient(channel) as any);
+    const liveStates = new Map<string, LiveState>();
+    await postAnnouncement(liveStates, makeStreamer(), makeStream());
+    expect(channel.send).toHaveBeenCalled();
+    expect(liveStates.get('10')?.messageId).toBe('msg1');
+    expect(setStreamerLive).toHaveBeenCalledWith(10, 'msg1', 'ch1', 'Chess');
+  });
+
+  it('calls updateMultitwitch after posting', async () => {
+    const channel = makeTextChannel();
+    vi.mocked(getDiscordClient).mockReturnValue(makeDiscordClient(channel) as any);
+    await postAnnouncement(new Map(), makeStreamer(), makeStream());
+    expect(updateMultitwitch).toHaveBeenCalledWith(1, expect.any(Map));
+  });
+
+  it('logs error and does not set state when channel is not text-based', async () => {
+    const nonText = { isTextBased: () => false };
+    vi.mocked(getDiscordClient).mockReturnValue({ channels: { fetch: vi.fn().mockResolvedValue(nonText) } } as any);
+    const liveStates = new Map<string, LiveState>();
+    await postAnnouncement(liveStates, makeStreamer(), makeStream());
+    expect(liveStates.size).toBe(0);
+    expect(setStreamerLive).not.toHaveBeenCalled();
+  });
+
+  it('logs error and does not throw when channel fetch fails', async () => {
+    vi.mocked(getDiscordClient).mockReturnValue({ channels: { fetch: vi.fn().mockRejectedValue(new Error('network')) } } as any);
+    await expect(postAnnouncement(new Map(), makeStreamer(), makeStream())).resolves.not.toThrow();
+    expect(setStreamerLive).not.toHaveBeenCalled();
+  });
+});
+
+// ─── editAnnouncement ─────────────────────────────────────────────────────────
+
+describe('editAnnouncement', () => {
+  it('returns early when no discord client', async () => {
+    vi.mocked(getDiscordClient).mockReturnValue(null);
+    const state = makeLiveState();
+    await editAnnouncement(new Map(), state, makeStream(), 'live_message');
+    expect(setStreamerLive).not.toHaveBeenCalled();
+  });
+
+  it('returns early when state has no messageId', async () => {
+    vi.mocked(getDiscordClient).mockReturnValue(makeDiscordClient() as any);
+    const state = makeLiveState({ messageId: null });
+    await editAnnouncement(new Map(), state, makeStream(), 'live_message');
+    expect(setStreamerLive).not.toHaveBeenCalled();
+  });
+
+  it('edits the existing message when delete_old_posts is false', async () => {
+    const channel = makeTextChannel();
+    vi.mocked(getDiscordClient).mockReturnValue(makeDiscordClient(channel) as any);
+    const state = makeLiveState({ group: makeGroup({ delete_old_posts: false }) });
+    await editAnnouncement(new Map(), state, makeStream(), 'live_message');
+    expect(channel._message.edit).toHaveBeenCalled();
+    expect(channel.send).not.toHaveBeenCalled();
+    expect(setStreamerLive).toHaveBeenCalled();
+  });
+
+  it('deletes old message and sends new one when delete_old_posts is true', async () => {
+    const channel = makeTextChannel();
+    vi.mocked(getDiscordClient).mockReturnValue(makeDiscordClient(channel) as any);
+    const state = makeLiveState({ group: makeGroup({ delete_old_posts: true }) });
+    await editAnnouncement(new Map(), state, makeStream(), 'live_message');
+    expect(channel._message.delete).toHaveBeenCalled();
+    expect(channel.send).toHaveBeenCalled();
+    expect(setStreamerLive).toHaveBeenCalled();
+  });
+
+  it('swallows DiscordNotFoundError when deleting old message', async () => {
+    const notFoundErr = new Error('Unknown Message');
+    const channel = makeTextChannel({ delete: vi.fn().mockRejectedValue(notFoundErr) });
+    vi.mocked(getDiscordClient).mockReturnValue(makeDiscordClient(channel) as any);
+    vi.mocked(isDiscordNotFoundError).mockReturnValue(true);
+    const state = makeLiveState({ group: makeGroup({ delete_old_posts: true }) });
+    await expect(editAnnouncement(new Map(), state, makeStream(), 'live_message')).resolves.not.toThrow();
+  });
+
+  it('re-throws non-DiscordNotFoundError when deleting old message', async () => {
+    const channel = makeTextChannel({ delete: vi.fn().mockRejectedValue(new Error('network')) });
+    vi.mocked(getDiscordClient).mockReturnValue(makeDiscordClient(channel) as any);
+    vi.mocked(isDiscordNotFoundError).mockReturnValue(false);
+    const state = makeLiveState({ group: makeGroup({ delete_old_posts: true }) });
+    await expect(editAnnouncement(new Map(), state, makeStream(), 'live_message')).resolves.not.toThrow();
+    // Error is caught by outer try/catch and logged, not rethrown to caller
+  });
+
+  it('updates state currentGame and title from stream', async () => {
+    const channel = makeTextChannel();
+    vi.mocked(getDiscordClient).mockReturnValue(makeDiscordClient(channel) as any);
+    const state = makeLiveState();
+    const newStream = makeStream({ game_name: 'Minecraft', title: 'New Title' });
+    await editAnnouncement(new Map(), state, newStream, 'new_game_message');
+    expect(state.currentGame).toBe('Minecraft');
+    expect(state.title).toBe('New Title');
+  });
+});
+
+// ─── deleteAnnouncement ───────────────────────────────────────────────────────
+
+describe('deleteAnnouncement', () => {
+  it('deletes key from map and returns early when no state', async () => {
+    const liveStates = new Map<string, LiveState>();
+    await deleteAnnouncement(liveStates, 'missing_key');
+    expect(tryDeleteDiscordMessage).not.toHaveBeenCalled();
+  });
+
+  it('deletes key from map and returns early when state has no messageId', async () => {
+    const liveStates = new Map([['k', makeLiveState({ messageId: null })]]);
+    await deleteAnnouncement(liveStates, 'k');
+    expect(tryDeleteDiscordMessage).not.toHaveBeenCalled();
+    expect(liveStates.has('k')).toBe(false);
+  });
+
+  it('calls tryDeleteDiscordMessage, clearStreamerLive, and updateMultitwitch', async () => {
+    const liveStates = new Map([['k', makeLiveState({ messageId: 'msg1', channelId: 'ch1', streamerId: 10, groupId: 1 })]]);
+    await deleteAnnouncement(liveStates, 'k');
+    expect(tryDeleteDiscordMessage).toHaveBeenCalledWith('ch1', 'msg1');
+    expect(clearStreamerLive).toHaveBeenCalledWith(10);
+    expect(updateMultitwitch).toHaveBeenCalledWith(1, liveStates);
+    expect(liveStates.has('k')).toBe(false);
+  });
+});

--- a/src/twitch/monitor/twitchMonitorStartup.test.ts
+++ b/src/twitch/monitor/twitchMonitorStartup.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../shared/logger', () => ({ createLogger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn() }) }));
+vi.mock('../../discord/discordBot', () => ({ getDiscordClient: vi.fn() }));
+vi.mock('../../discord/discordUtils', () => ({
+  isDiscordNotFoundError: vi.fn().mockReturnValue(false),
+  tryDeleteDiscordMessage: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../db', () => ({
+  setStreamerLive: vi.fn().mockResolvedValue(undefined),
+  clearStreamerLive: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../twitchApi', () => ({
+  getStreams: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('./twitchMonitorEmbed', () => ({
+  buildEmbed: vi.fn().mockReturnValue({}),
+  fillTemplate: vi.fn().mockReturnValue('message'),
+  templateVars: vi.fn().mockReturnValue({}),
+}));
+vi.mock('./twitchMonitorMultitwitch', () => ({
+  updateMultitwitch: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('./twitchMonitorAnnouncements', () => ({
+  postAnnouncement: vi.fn().mockResolvedValue(undefined),
+}));
+
+import {
+  tryEditStartupMessage,
+  handleLiveStreamerOnStartup,
+  handleOfflineStreamerOnStartup,
+  performStartupLiveCheck,
+} from './twitchMonitorStartup';
+import { getDiscordClient } from '../../discord/discordBot';
+import { isDiscordNotFoundError, tryDeleteDiscordMessage } from '../../discord/discordUtils';
+import { setStreamerLive, clearStreamerLive } from '../../db';
+import { getStreams } from '../twitchApi';
+import { updateMultitwitch } from './twitchMonitorMultitwitch';
+import { postAnnouncement } from './twitchMonitorAnnouncements';
+import type { DbStreamGroup, DbStreamerFull } from '../../db';
+import type { TwitchStream } from '../twitchApi';
+import type { LiveState } from './twitchMonitorTypes';
+
+function makeGroup(overrides: Partial<DbStreamGroup> = {}): DbStreamGroup {
+  return { id: 1, name: 'G1', discord_channel: 'ch1', live_message: 'Live!', new_game_message: 'New!', multi_twitch: false, delete_old_posts: false, ...overrides };
+}
+
+function makeStreamer(overrides: Partial<DbStreamerFull> = {}): DbStreamerFull {
+  return { id: 10, discord_id: 'discord1', twitch_name: 'alice', group: makeGroup(), discord_message_id: null, discord_channel_id: null, live_game: null, ...overrides };
+}
+
+function makeStream(overrides: Partial<TwitchStream> = {}): TwitchStream {
+  return { user_id: 'u1', user_login: 'alice', game_name: 'Chess', type: 'live', title: 'Playing', thumbnail_url: '', ...overrides };
+}
+
+function makeChannel(msgOverrides: Partial<{ edit: ReturnType<typeof vi.fn> }> = {}) {
+  const message = { edit: vi.fn().mockResolvedValue(undefined), ...msgOverrides };
+  return {
+    isTextBased: () => true,
+    messages: { fetch: vi.fn().mockResolvedValue(message) },
+    _message: message,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(isDiscordNotFoundError).mockReturnValue(false);
+});
+
+// ─── tryEditStartupMessage ────────────────────────────────────────────────────
+
+describe('tryEditStartupMessage', () => {
+  it('returns false when no discord client', async () => {
+    vi.mocked(getDiscordClient).mockReturnValue(null);
+    const result = await tryEditStartupMessage(new Map(), makeStreamer({ discord_message_id: 'msg1', discord_channel_id: 'ch1' }), makeStream());
+    expect(result).toBe(false);
+  });
+
+  it('returns false when streamer has no stored discord_message_id', async () => {
+    vi.mocked(getDiscordClient).mockReturnValue({} as any);
+    const result = await tryEditStartupMessage(new Map(), makeStreamer({ discord_message_id: null, discord_channel_id: null }), makeStream());
+    expect(result).toBe(false);
+  });
+
+  it('returns false when channel is not text-based', async () => {
+    vi.mocked(getDiscordClient).mockReturnValue({ channels: { fetch: vi.fn().mockResolvedValue({ isTextBased: () => false }) } } as any);
+    const result = await tryEditStartupMessage(new Map(), makeStreamer({ discord_message_id: 'msg1', discord_channel_id: 'ch1' }), makeStream());
+    expect(result).toBe(false);
+  });
+
+  it('edits the message, updates liveStates, calls setStreamerLive, and returns true', async () => {
+    const channel = makeChannel();
+    vi.mocked(getDiscordClient).mockReturnValue({ channels: { fetch: vi.fn().mockResolvedValue(channel) } } as any);
+    const liveStates = new Map<string, LiveState>();
+    const streamer = makeStreamer({ id: 10, discord_message_id: 'msg1', discord_channel_id: 'ch1' });
+    const result = await tryEditStartupMessage(liveStates, streamer, makeStream());
+    expect(result).toBe(true);
+    expect(channel._message.edit).toHaveBeenCalled();
+    expect(liveStates.has('10')).toBe(true);
+    expect(setStreamerLive).toHaveBeenCalledWith(10, 'msg1', 'ch1', 'Chess');
+  });
+
+  it('returns false when message fetch throws DiscordNotFoundError', async () => {
+    const channel = { isTextBased: () => true, messages: { fetch: vi.fn().mockRejectedValue(new Error('Unknown')) } };
+    vi.mocked(getDiscordClient).mockReturnValue({ channels: { fetch: vi.fn().mockResolvedValue(channel) } } as any);
+    vi.mocked(isDiscordNotFoundError).mockReturnValue(true);
+    const result = await tryEditStartupMessage(new Map(), makeStreamer({ discord_message_id: 'msg1', discord_channel_id: 'ch1' }), makeStream());
+    expect(result).toBe(false);
+  });
+
+  it('rethrows non-DiscordNotFoundError', async () => {
+    const channel = { isTextBased: () => true, messages: { fetch: vi.fn().mockRejectedValue(new Error('network')) } };
+    vi.mocked(getDiscordClient).mockReturnValue({ channels: { fetch: vi.fn().mockResolvedValue(channel) } } as any);
+    vi.mocked(isDiscordNotFoundError).mockReturnValue(false);
+    await expect(tryEditStartupMessage(new Map(), makeStreamer({ discord_message_id: 'msg1', discord_channel_id: 'ch1' }), makeStream())).rejects.toThrow('network');
+  });
+});
+
+// ─── handleLiveStreamerOnStartup ──────────────────────────────────────────────
+
+describe('handleLiveStreamerOnStartup', () => {
+  it('sets live state without Discord call when no client and streamer has stored message', async () => {
+    vi.mocked(getDiscordClient).mockReturnValue(null);
+    const liveStates = new Map<string, LiveState>();
+    const streamer = makeStreamer({ id: 10, discord_message_id: 'msg1', discord_channel_id: 'ch1' });
+    await handleLiveStreamerOnStartup(liveStates, streamer, makeStream(), new Set());
+    expect(liveStates.has('10')).toBe(true);
+    expect(postAnnouncement).not.toHaveBeenCalled();
+  });
+
+  it('calls postAnnouncement when streamer has no stored message', async () => {
+    await handleLiveStreamerOnStartup(new Map(), makeStreamer({ discord_message_id: null }), makeStream(), new Set());
+    expect(postAnnouncement).toHaveBeenCalled();
+  });
+
+  it('adds groupId to groupsWithChanges when edit succeeds', async () => {
+    const channel = makeChannel();
+    vi.mocked(getDiscordClient).mockReturnValue({ channels: { fetch: vi.fn().mockResolvedValue(channel) } } as any);
+    const groupsWithChanges = new Set<number>();
+    await handleLiveStreamerOnStartup(new Map(), makeStreamer({ discord_message_id: 'msg1', discord_channel_id: 'ch1', group: makeGroup({ id: 99 }) }), makeStream(), groupsWithChanges);
+    expect(groupsWithChanges.has(99)).toBe(true);
+  });
+
+  it('skips postAnnouncement when tryEditStartupMessage throws', async () => {
+    const channel = { isTextBased: () => true, messages: { fetch: vi.fn().mockRejectedValue(new Error('network')) } };
+    vi.mocked(getDiscordClient).mockReturnValue({ channels: { fetch: vi.fn().mockResolvedValue(channel) } } as any);
+    vi.mocked(isDiscordNotFoundError).mockReturnValue(false);
+    await handleLiveStreamerOnStartup(new Map(), makeStreamer({ discord_message_id: 'msg1', discord_channel_id: 'ch1' }), makeStream(), new Set());
+    expect(postAnnouncement).not.toHaveBeenCalled();
+  });
+});
+
+// ─── handleOfflineStreamerOnStartup ───────────────────────────────────────────
+
+describe('handleOfflineStreamerOnStartup', () => {
+  it('calls clearStreamerLive and adds group to groupsWithChanges', async () => {
+    const groupsWithChanges = new Set<number>();
+    await handleOfflineStreamerOnStartup(makeStreamer({ id: 10, discord_message_id: null, discord_channel_id: null, group: makeGroup({ id: 5 }) }), groupsWithChanges);
+    expect(clearStreamerLive).toHaveBeenCalledWith(10);
+    expect(groupsWithChanges.has(5)).toBe(true);
+  });
+
+  it('calls tryDeleteDiscordMessage when stored message exists', async () => {
+    await handleOfflineStreamerOnStartup(makeStreamer({ discord_message_id: 'msg1', discord_channel_id: 'ch1' }), new Set());
+    expect(tryDeleteDiscordMessage).toHaveBeenCalledWith('ch1', 'msg1');
+  });
+
+  it('skips clearStreamerLive when tryDeleteDiscordMessage throws', async () => {
+    vi.mocked(tryDeleteDiscordMessage).mockRejectedValueOnce(new Error('delete failed'));
+    await handleOfflineStreamerOnStartup(makeStreamer({ discord_message_id: 'msg1', discord_channel_id: 'ch1' }), new Set());
+    expect(clearStreamerLive).not.toHaveBeenCalled();
+  });
+});
+
+// ─── performStartupLiveCheck ──────────────────────────────────────────────────
+
+describe('performStartupLiveCheck', () => {
+  it('returns immediately when no user IDs', async () => {
+    await performStartupLiveCheck(new Map(), new Map(), []);
+    expect(getStreams).not.toHaveBeenCalled();
+  });
+
+  it('returns and logs when getStreams throws', async () => {
+    vi.mocked(getStreams).mockRejectedValueOnce(new Error('API down'));
+    await expect(performStartupLiveCheck(new Map(), new Map([['alice', 'u1']]), [])).resolves.not.toThrow();
+    expect(setStreamerLive).not.toHaveBeenCalled();
+  });
+
+  it('handles a live streamer — calls postAnnouncement when no existing message', async () => {
+    const stream = makeStream({ user_id: 'u1', type: 'live' });
+    vi.mocked(getStreams).mockResolvedValue([stream]);
+    const streamer = makeStreamer({ twitch_name: 'alice', discord_message_id: null });
+    await performStartupLiveCheck(new Map(), new Map([['alice', 'u1']]), [streamer]);
+    expect(postAnnouncement).toHaveBeenCalled();
+  });
+
+  it('handles an offline streamer with stored message — calls clearStreamerLive', async () => {
+    vi.mocked(getStreams).mockResolvedValue([]);
+    const streamer = makeStreamer({ twitch_name: 'alice', discord_message_id: 'msg1', discord_channel_id: 'ch1' });
+    await performStartupLiveCheck(new Map(), new Map([['alice', 'u1']]), [streamer]);
+    expect(clearStreamerLive).toHaveBeenCalledWith(10);
+  });
+
+  it('skips streamers with no matching loginToUserId entry', async () => {
+    vi.mocked(getStreams).mockResolvedValue([]);
+    const streamer = makeStreamer({ twitch_name: 'unknown', discord_message_id: 'msg1' });
+    await performStartupLiveCheck(new Map(), new Map([['alice', 'u1']]), [streamer]);
+    expect(clearStreamerLive).not.toHaveBeenCalled();
+  });
+
+  it('calls updateMultitwitch for each group with changes', async () => {
+    const stream = makeStream({ user_id: 'u1', type: 'live' });
+    vi.mocked(getStreams).mockResolvedValue([stream]);
+    const channel = makeChannel();
+    vi.mocked(getDiscordClient).mockReturnValue({ channels: { fetch: vi.fn().mockResolvedValue(channel) } } as any);
+    const streamer = makeStreamer({ twitch_name: 'alice', discord_message_id: 'msg1', discord_channel_id: 'ch1', group: makeGroup({ id: 7 }) });
+    await performStartupLiveCheck(new Map(), new Map([['alice', 'u1']]), [streamer]);
+    expect(updateMultitwitch).toHaveBeenCalledWith(7, expect.any(Map));
+  });
+});

--- a/src/twitch/monitor/twitchMonitorTypes.test.ts
+++ b/src/twitch/monitor/twitchMonitorTypes.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import type { DbStreamGroup, DbStreamerFull } from '../../db';
+import type { TwitchStream } from '../twitchApi';
+import { makeLiveState } from './twitchMonitorTypes';
+
+function makeGroup(overrides: Partial<DbStreamGroup> = {}): DbStreamGroup {
+  return {
+    id: 1,
+    name: 'TestGroup',
+    discord_channel: '111',
+    live_message: 'Live: {user}',
+    new_game_message: 'New game: {game}',
+    multi_twitch: false,
+    delete_old_posts: false,
+    ...overrides,
+  };
+}
+
+function makeStreamer(overrides: Partial<DbStreamerFull> = {}): DbStreamerFull {
+  return {
+    id: 10,
+    discord_id: 'discord1',
+    twitch_name: 'alice',
+    group: makeGroup(),
+    discord_message_id: null,
+    discord_channel_id: null,
+    live_game: null,
+    ...overrides,
+  };
+}
+
+function makeStream(overrides: Partial<TwitchStream> = {}): TwitchStream {
+  return {
+    user_id: 'u1',
+    user_login: 'Alice',
+    game_name: 'Chess',
+    type: 'live',
+    title: 'Playing chess',
+    thumbnail_url: 'https://example.com/thumb.jpg',
+    ...overrides,
+  };
+}
+
+describe('makeLiveState', () => {
+  it('sets streamerId from streamer.id', () => {
+    const state = makeLiveState(makeStreamer({ id: 42 }), makeStream(), 'msg1', 'ch1');
+    expect(state.streamerId).toBe(42);
+  });
+
+  it('sets groupId and group from the streamer', () => {
+    const group = makeGroup({ id: 7 });
+    const state = makeLiveState(makeStreamer({ group }), makeStream(), null, null);
+    expect(state.groupId).toBe(7);
+    expect(state.group).toBe(group);
+  });
+
+  it('lowercases user_login for the login field', () => {
+    const state = makeLiveState(makeStreamer(), makeStream({ user_login: 'ALICE' }), null, null);
+    expect(state.login).toBe('alice');
+  });
+
+  it('stores messageId and channelId', () => {
+    const state = makeLiveState(makeStreamer(), makeStream(), 'msg123', 'ch456');
+    expect(state.messageId).toBe('msg123');
+    expect(state.channelId).toBe('ch456');
+  });
+
+  it('accepts null for messageId and channelId', () => {
+    const state = makeLiveState(makeStreamer(), makeStream(), null, null);
+    expect(state.messageId).toBeNull();
+    expect(state.channelId).toBeNull();
+  });
+
+  it('sets currentGame from stream.game_name', () => {
+    const state = makeLiveState(makeStreamer(), makeStream({ game_name: 'Chess' }), null, null);
+    expect(state.currentGame).toBe('Chess');
+  });
+
+  it('sets title from stream.title', () => {
+    const state = makeLiveState(makeStreamer(), makeStream({ title: 'My Stream' }), null, null);
+    expect(state.title).toBe('My Stream');
+  });
+
+  it('sets offlineTimer to null', () => {
+    const state = makeLiveState(makeStreamer(), makeStream(), null, null);
+    expect(state.offlineTimer).toBeNull();
+  });
+
+  it('stores the full stream object as currentStream', () => {
+    const stream = makeStream();
+    const state = makeLiveState(makeStreamer(), stream, null, null);
+    expect(state.currentStream).toBe(stream);
+  });
+});


### PR DESCRIPTION
## Summary

44 tests across 3 previously-untested twitch monitor files.

- **`twitchMonitorTypes`** (9 tests): `makeLiveState` — all field mappings, `user_login` lowercasing, null messageId/channelId, offlineTimer initialisation
- **`twitchMonitorAnnouncements`** (14 tests): `postAnnouncement` — no Discord client, non-text channel, successful send+state+DB update, error swallowing; `editAnnouncement` — early returns, edit-in-place vs delete+resend, DiscordNotFoundError swallowed, other errors caught, state mutation; `deleteAnnouncement` — missing key, no messageId, full delete flow
- **`twitchMonitorStartup`** (21 tests): `tryEditStartupMessage` — no client, no stored message, non-text channel, successful edit with liveState/DB update, 404 returns false, other errors rethrown; `handleLiveStreamerOnStartup` — no-client fast path, no stored message → postAnnouncement, groupsWithChanges updated, edit error skips postAnnouncement; `handleOfflineStreamerOnStartup` — clearStreamerLive, tryDeleteDiscordMessage, delete error skips clear; `performStartupLiveCheck` — empty userIds, API failure, live/offline/missing routing, updateMultitwitch per changed group

## Test plan

- [x] All 44 tests pass locally
- [x] TypeScript compiles without errors

https://claude.ai/code/session_01DNLtYg8ZzSNR5fAzw9p85k

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNLtYg8ZzSNR5fAzw9p85k)_