### PR TITLE
fix: use path.posix in safeResolve for cross-platform test compatibility

### DIFF
--- a/src/shared/pathUtils.test.ts
+++ b/src/shared/pathUtils.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import path from 'path';
 import { safeResolve } from './pathUtils';
 
+const posix = path.posix;
+
 describe('safeResolve', () => {
   const base = '/srv/files';
 
@@ -22,7 +24,7 @@ describe('safeResolve', () => {
   });
 
   it('returns the base path itself when no parts given', () => {
-    expect(safeResolve(base)).toBe(path.resolve(base));
+    expect(safeResolve(base)).toBe(posix.resolve(base));
   });
 
   it('returns null for an absolute path that is outside base', () => {
@@ -32,7 +34,7 @@ describe('safeResolve', () => {
   it('returns the path when it exactly equals the base', () => {
     // path.relative(base, base) is '' which does not start with '..'
     const result = safeResolve(base, '.');
-    expect(result).toBe(path.resolve(base));
+    expect(result).toBe(posix.resolve(base));
   });
 
   it('handles a base without trailing slash', () => {

--- a/src/shared/pathUtils.ts
+++ b/src/shared/pathUtils.ts
@@ -3,11 +3,14 @@ import path from 'path';
 /**
  * Resolves `parts` relative to `base` and returns the absolute path, or null
  * if the result would escape `base` (path traversal guard).
+ *
+ * Uses path.posix so behaviour is consistent across platforms (base paths are
+ * always POSIX-style since the bot targets Linux).
  */
 export function safeResolve(base: string, ...parts: string[]): string | null {
-  const resolvedBase = path.resolve(base);
-  const target = path.resolve(resolvedBase, ...parts);
-  const rel = path.relative(resolvedBase, target);
-  if (rel.startsWith('..') || path.isAbsolute(rel)) return null;
+  const resolvedBase = path.posix.resolve(base);
+  const target = path.posix.resolve(resolvedBase, ...parts);
+  const rel = path.posix.relative(resolvedBase, target);
+  if (rel.startsWith('..') || path.posix.isAbsolute(rel)) return null;
   return target;
 }


### PR DESCRIPTION
## Summary

- `safeResolve` in `src/shared/pathUtils.ts` used `path.resolve` which on Windows produces drive-letter paths (`F:\srv\files\...`), causing tests with hardcoded POSIX paths to fail.
- Switched to `path.posix` throughout `safeResolve` — the bot targets Linux and all base paths are POSIX-style, so this is the correct semantic.
- Updated the test's two `path.resolve(base)` references to `path.posix.resolve(base)` for consistency.

## Test plan

- [ ] `npm test src/shared/pathUtils.test.ts` — all 11 tests pass on both Linux and Windows

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7rvEtYJRqAEmoAQyWpKTN)_