### PR TITLE
Replace raw access level numbers with AccessLevel constants in existing tests

### DIFF
--- a/src/web/routes/admin.test.ts
+++ b/src/web/routes/admin.test.ts
@@ -54,10 +54,13 @@ vi.mock('../../shared/logger', () => ({
   createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
 }));
 
+vi.mock('../../db/users', () => ({ AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 } }));
+
 import express from 'express';
 import supertest from 'supertest';
 import router from './admin';
 import { findUser, getAllUsers, updateAccessLevel } from '../../db';
+import { AccessLevel } from '../../db/users';
 import { normalizeTwitchChannelName } from '../../twitch/twitchChannelName';
 import {
   DuplicateTwitchNameError,
@@ -70,8 +73,8 @@ import {
 
 type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3 };
 
-const ADMIN: SessionUser = { discordId: '100000000000000001', discordName: 'AdminUser', discordAvatar: null, accessLevel: 3 };
-const MANAGER: SessionUser = { discordId: '200000000000000001', discordName: 'ManagerUser', discordAvatar: null, accessLevel: 2 };
+const ADMIN: SessionUser = { discordId: '100000000000000001', discordName: 'AdminUser', discordAvatar: null, accessLevel: AccessLevel.ADMIN };
+const MANAGER: SessionUser = { discordId: '200000000000000001', discordName: 'ManagerUser', discordAvatar: null, accessLevel: AccessLevel.MANAGER };
 const VALID_ID = '300000000000000001';
 
 function buildApp(sessionUser: SessionUser = ADMIN) {
@@ -189,14 +192,14 @@ describe('POST /users/add', () => {
   });
 
   it('redirects ?error=target_above_level when manager edits a user at their own level', async () => {
-    vi.mocked(findUser).mockResolvedValue({ access_level: 2 } as any); // target at manager's level
+    vi.mocked(findUser).mockResolvedValue({ access_level: AccessLevel.MANAGER } as any); // target at manager's level
     const res = await supertest(buildApp(MANAGER)).post('/users/add').type('form')
       .send({ discord_id: VALID_ID, access_level: '1' }); // granting level 1 (below manager) is otherwise valid
     expect(res.headers.location).toBe('/admin/users?error=target_above_level');
   });
 
   it('admin bypasses the manager permission checks', async () => {
-    vi.mocked(findUser).mockResolvedValue({ access_level: 3 } as any);
+    vi.mocked(findUser).mockResolvedValue({ access_level: AccessLevel.ADMIN } as any);
     const res = await supertest(buildApp(ADMIN)).post('/users/add').type('form')
       .send({ discord_id: VALID_ID, access_level: '3' });
     expect(res.headers.location).toBe('/admin/users');
@@ -274,7 +277,7 @@ describe('POST /users/update', () => {
   });
 
   it('redirects ?error=target_above_level when manager edits user at their level', async () => {
-    vi.mocked(findUser).mockResolvedValue({ access_level: 2 } as any);
+    vi.mocked(findUser).mockResolvedValue({ access_level: AccessLevel.MANAGER } as any);
     const res = await supertest(buildApp(MANAGER)).post('/users/update').type('form')
       .send({ discord_id: VALID_ID, access_level: '1' });
     expect(res.headers.location).toBe('/admin/users?error=target_above_level');

--- a/src/web/routes/adminUserMutations.test.ts
+++ b/src/web/routes/adminUserMutations.test.ts
@@ -18,6 +18,8 @@ vi.mock('../../twitch/twitchChannelName', () => ({
   normalizeTwitchChannelName: vi.fn((name: string | null) => name?.toLowerCase() ?? null),
 }));
 
+vi.mock('../../db/users', () => ({ AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 } }));
+
 import {
   addOrUpdateUserMutation,
   removeUserMutation,
@@ -31,6 +33,7 @@ import {
   getTwitchEnabledChannels,
 } from '../../db';
 import { joinTwitchChannel, partTwitchChannel } from '../../twitch/twitchBot';
+import { AccessLevel } from '../../db/users';
 
 type MockDbUser = {
   discord_id: string;
@@ -43,7 +46,7 @@ type MockDbUser = {
 const BASE_USER: MockDbUser = {
   discord_id: '111',
   discord_name: 'TestUser',
-  access_level: 0,
+  access_level: AccessLevel.USER,
   twitch_name: null,
   is_twitch_bot_enabled: false,
 };

--- a/src/web/routes/commands.test.ts
+++ b/src/web/routes/commands.test.ts
@@ -37,6 +37,8 @@ vi.mock('../../logger', () => ({
   createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
 }));
 
+vi.mock('../../db/users', () => ({ AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 } }));
+
 import express from 'express';
 import supertest from 'supertest';
 import router from './commands';
@@ -54,6 +56,7 @@ import {
   CommandNotFoundError,
   ReservedCommandError,
 } from '../../db';
+import { AccessLevel } from '../../db/users';
 
 function buildApp() {
   const app = express();
@@ -63,7 +66,7 @@ function buildApp() {
     next();
   });
   app.use((req: any, _res: any, next: any) => {
-    req.session = { user: { discord_id: '1', discord_name: 'TestUser', access_level: 2 } };
+    req.session = { user: { discord_id: '1', discord_name: 'TestUser', access_level: AccessLevel.MANAGER } };
     next();
   });
   app.use(router);
@@ -466,7 +469,7 @@ describe('GET /commands', () => {
       next();
     });
     app.use((req: any, _res: any, next: any) => {
-      req.session = { user: { discord_id: '1', discord_name: 'TestUser', access_level: 2 } };
+      req.session = { user: { discord_id: '1', discord_name: 'TestUser', access_level: AccessLevel.MANAGER } };
       next();
     });
     app.use(router);
@@ -486,7 +489,7 @@ describe('GET /commands', () => {
       next();
     });
     app.use((req: any, _res: any, next: any) => {
-      req.session = { user: { discord_id: '1', discord_name: 'TestUser', access_level: 2 } };
+      req.session = { user: { discord_id: '1', discord_name: 'TestUser', access_level: AccessLevel.MANAGER } };
       next();
     });
     app.use(router);
@@ -503,7 +506,7 @@ describe('GET /commands', () => {
       next();
     });
     app.use((req: any, _res: any, next: any) => {
-      req.session = { user: { discord_id: '1', discord_name: 'TestUser', access_level: 2 } };
+      req.session = { user: { discord_id: '1', discord_name: 'TestUser', access_level: AccessLevel.MANAGER } };
       next();
     });
     app.use(router);
@@ -539,7 +542,7 @@ describe('GET /commands', () => {
       next();
     });
     app.use((req: any, _res: any, next: any) => {
-      req.session = { user: { discord_id: '1', discord_name: 'TestUser', access_level: 2 } };
+      req.session = { user: { discord_id: '1', discord_name: 'TestUser', access_level: AccessLevel.MANAGER } };
       next();
     });
     app.use(router);

--- a/src/web/routes/counters.test.ts
+++ b/src/web/routes/counters.test.ts
@@ -35,6 +35,8 @@ vi.mock('../../logger', () => ({
   createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
 }));
 
+vi.mock('../../db/users', () => ({ AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 } }));
+
 import express from 'express';
 import supertest from 'supertest';
 import router from './counters';
@@ -49,6 +51,7 @@ import {
   CounterNotFoundError,
   ReservedCommandError,
 } from '../../db';
+import { AccessLevel } from '../../db/users';
 
 function buildApp() {
   const app = express();
@@ -58,7 +61,7 @@ function buildApp() {
     next();
   });
   app.use((req: any, _res: any, next: any) => {
-    req.session = { user: { discord_id: '1', discord_name: 'TestUser', access_level: 2 } };
+    req.session = { user: { discord_id: '1', discord_name: 'TestUser', access_level: AccessLevel.MANAGER } };
     next();
   });
   app.use(router);

--- a/src/web/routes/overlayAdmin.test.ts
+++ b/src/web/routes/overlayAdmin.test.ts
@@ -42,9 +42,10 @@ import express from 'express';
 import supertest from 'supertest';
 import router from './overlayAdmin';
 import { getStreamerByDiscordId } from '../../db';
+import { AccessLevel } from '../../db/users';
 
 type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3 };
-const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: 1 };
+const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: AccessLevel.MOD };
 
 function buildApp(sessionUser: SessionUser = USER) {
   const app = express();

--- a/src/web/routes/overlayAdminMutations.test.ts
+++ b/src/web/routes/overlayAdminMutations.test.ts
@@ -42,10 +42,11 @@ import express from 'express';
 import supertest from 'supertest';
 import { router } from './overlayAdminMutations';
 import { getStreamerByDiscordId, addVideo, deleteVideo } from '../../db';
+import { AccessLevel } from '../../db/users';
 import fs from 'fs';
 
 type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3 };
-const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: 0 };
+const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: AccessLevel.USER };
 
 const MOCK_STREAMER = {
   id: 123,

--- a/src/web/routes/overlayAdminRewardMutations.test.ts
+++ b/src/web/routes/overlayAdminRewardMutations.test.ts
@@ -27,13 +27,16 @@ vi.mock('../../config', () => ({
   PUBLIC_URL: 'https://example.com',
 }));
 
+vi.mock('../../db/users', () => ({ AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 } }));
+
 import express from 'express';
 import supertest from 'supertest';
 import { router } from './overlayAdminRewardMutations';
 import { getStreamerByDiscordId, upsertReward, setRewardVideos, deleteReward } from '../../db';
+import { AccessLevel } from '../../db/users';
 
 type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3 };
-const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: 0 };
+const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: AccessLevel.USER };
 
 const MOCK_STREAMER = {
   id: 123,

--- a/src/web/routes/shared.test.ts
+++ b/src/web/routes/shared.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { Response } from 'express';
 import type { SessionUser } from '../../types/express';
+
+vi.mock('../../db/users', () => ({ AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 } }));
+
+import { AccessLevel } from '../../db/users';
 import {
   parsePositiveIntId,
   trimField,
@@ -194,7 +198,7 @@ describe('renderError', () => {
       discordId: '123456789012345678',
       discordName: 'TestUser',
       discordAvatar: null,
-      accessLevel: 1,
+      accessLevel: AccessLevel.MOD,
     };
     renderError(res, 500, 'Server error', user);
     expect(render).toHaveBeenCalledWith('error', {

--- a/src/web/routes/streams.test.ts
+++ b/src/web/routes/streams.test.ts
@@ -35,13 +35,16 @@ vi.mock('../../shared/logger', () => ({
   createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
 }));
 
+vi.mock('../../db/users', () => ({ AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 } }));
+
 import express from 'express';
 import supertest from 'supertest';
 import router from './streams';
 import { getAllStreamGroups, getAllStreamers, getAllUsers, findUser, addStreamer } from '../../db';
+import { AccessLevel } from '../../db/users';
 
 type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3 };
-const MANAGER: SessionUser = { discordId: '200000000000000001', discordName: 'ManagerUser', discordAvatar: null, accessLevel: 2 };
+const MANAGER: SessionUser = { discordId: '200000000000000001', discordName: 'ManagerUser', discordAvatar: null, accessLevel: AccessLevel.MANAGER };
 
 function buildApp(sessionUser: SessionUser = MANAGER) {
   const app = express();

--- a/src/web/routes/userSettings.test.ts
+++ b/src/web/routes/userSettings.test.ts
@@ -40,9 +40,10 @@ import express from 'express';
 import supertest from 'supertest';
 import router from './userSettings';
 import { findUser, getStreamerByDiscordId } from '../../db';
+import { AccessLevel } from '../../db/users';
 
 type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3 };
-const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: 1 };
+const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: AccessLevel.MOD };
 
 function buildApp(sessionUser: SessionUser = USER) {
   const app = express();


### PR DESCRIPTION
## Summary

- Applies the same `AccessLevel` constant pattern to 10 pre-existing test files that were using raw `0/1/2/3` literals for access levels
- Imports `AccessLevel` from `../../db/users` (canonical source) rather than `../../db`
- Files that don't already mock `../../shared/config` get `vi.mock('../../db/users', ...)` to prevent the `db/pool → shared/config` load chain from throwing on missing env vars
- Files where production code (`adminUserValidation.ts`) also imports `AccessLevel` from `../../db` retain it in the db mock factory too — removing it would break the route under test

## Files changed

| File | Change |
|---|---|
| `overlayAdminMutations.test.ts` | `accessLevel: 0` → `AccessLevel.USER` |
| `userSettings.test.ts` | `accessLevel: 1` → `AccessLevel.MOD` |
| `overlayAdmin.test.ts` | `accessLevel: 1` → `AccessLevel.MOD` |
| `overlayAdminRewardMutations.test.ts` | `accessLevel: 0` → `AccessLevel.USER`, add `vi.mock('../../db/users')` |
| `admin.test.ts` | `accessLevel: 2/3` → `MANAGER/ADMIN`, `access_level: 2/3` → `AccessLevel.MANAGER/ADMIN` |
| `streams.test.ts` | `accessLevel: 2` → `AccessLevel.MANAGER`, add `vi.mock('../../db/users')` |
| `shared.test.ts` | `accessLevel: 1` → `AccessLevel.MOD`, add `vi.mock('../../db/users')` |
| `adminUserMutations.test.ts` | `access_level: 0` → `AccessLevel.USER`, add `vi.mock('../../db/users')` |
| `counters.test.ts` | `access_level: 2` → `AccessLevel.MANAGER`, add `vi.mock('../../db/users')` |
| `commands.test.ts` | `access_level: 2` × 5 → `AccessLevel.MANAGER`, add `vi.mock('../../db/users')` |

## Test plan

- [x] All 196 tests across the 10 modified files pass
- [x] TypeScript compiles without errors

https://claude.ai/code/session_01DNLtYg8ZzSNR5fAzw9p85k

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNLtYg8ZzSNR5fAzw9p85k)_