### PR TITLE
Add edge-case tests for confirmed coverage gaps

### DIFF
--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./shared/logger', () => ({ createLogger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn() }) }));
+vi.mock('./db/pool', () => ({ getPool: vi.fn(), closePool: vi.fn() }));
+
+vi.mock('./db/users', () => ({
+  upsertUserRecord: vi.fn(),
+  setTwitchBotEnabledRecord: vi.fn(),
+  removeUserRecord: vi.fn(),
+  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
+  ACCESS_LEVEL_LABELS: {},
+  findUser: vi.fn(),
+  findUserByTwitchName: vi.fn(),
+  getAllUsers: vi.fn(),
+  updateDiscordName: vi.fn(),
+  getTwitchEnabledChannels: vi.fn(),
+  updateAccessLevel: vi.fn(),
+}));
+
+vi.mock('./db/customCommandCache', () => ({
+  invalidateCustomCommandLookupCache: vi.fn(),
+  getCustomCommandForTwitchChannel: vi.fn(),
+  getCustomCommandForDiscord: vi.fn(),
+}));
+
+vi.mock('./db/customCommands', () => ({
+  getAllCustomCommandsWithAssignments: vi.fn(),
+  addCustomCommand: vi.fn(),
+  updateCustomCommand: vi.fn(),
+  removeCustomCommand: vi.fn(),
+  assignUserToCommand: vi.fn(),
+  unassignUserFromCommand: vi.fn(),
+}));
+
+vi.mock('./db/commandLocks', () => ({
+  CommandNotFoundError: class extends Error {},
+  CommandConflictError: class extends Error {},
+  isMysqlDuplicateEntryError: vi.fn(),
+  isCustomCommandTriggerTaken: vi.fn(),
+}));
+
+vi.mock('./db/reservedCommands', () => ({
+  ReservedCommandError: class extends Error {},
+  RESERVED_BUILT_IN_COMMANDS: [],
+}));
+
+vi.mock('./db/counters', () => ({
+  CounterNotFoundError: class extends Error {},
+  getAllCounters: vi.fn(),
+  addCounter: vi.fn(),
+  updateCounter: vi.fn(),
+  removeCounter: vi.fn(),
+  resetCounterCurrentValue: vi.fn(),
+  incrementCounter: vi.fn(),
+  archiveAndResetYearlyCounters: vi.fn(),
+}));
+
+vi.mock('./db/counterCache', () => ({
+  invalidateCounterLookupCache: vi.fn(),
+  findCounterByCommand: vi.fn(),
+  isCounterCommandTaken: vi.fn(),
+}));
+
+vi.mock('./db/streamMonitor', () => ({
+  getAllStreamGroups: vi.fn(),
+  addStreamGroup: vi.fn(),
+  updateStreamGroup: vi.fn(),
+  removeStreamGroup: vi.fn(),
+  getAllStreamers: vi.fn(),
+  getAllStreamersWithGroups: vi.fn(),
+  addStreamer: vi.fn(),
+  removeStreamer: vi.fn(),
+  removeStreamersByGroup: vi.fn(),
+  setStreamerLive: vi.fn(),
+  clearStreamerLive: vi.fn(),
+}));
+
+vi.mock('./db/eventSub', () => ({
+  getAllEventSubStreamers: vi.fn(),
+  getStreamerByDiscordId: vi.fn(),
+  getStreamerById: vi.fn(),
+  saveStreamerToken: vi.fn(),
+  clearStreamerToken: vi.fn(),
+  initEventConfig: vi.fn(),
+  saveEventConfig: vi.fn(),
+}));
+
+vi.mock('./db/sfx', () => ({
+  findTrigger: vi.fn(),
+  findSoundFiles: vi.fn(),
+  getAllSfxTriggers: vi.fn(),
+  getPublicSfxTriggers: vi.fn(),
+}));
+
+vi.mock('./db/overlayVideos', () => ({
+  getVideosForStreamer: vi.fn(),
+  addVideo: vi.fn(),
+  getVideoById: vi.fn(),
+  deleteVideo: vi.fn(),
+  getRewardsForStreamer: vi.fn(),
+  upsertReward: vi.fn(),
+  setRewardVideos: vi.fn(),
+  deleteReward: vi.fn(),
+  getVideosForReward: vi.fn(),
+}));
+
+vi.mock('./db/streamdeckKeys', () => ({
+  requestApiKey: vi.fn(),
+  findApprovedKeyByHash: vi.fn(),
+  getApiKeyStatus: vi.fn(),
+  approveApiKey: vi.fn(),
+  denyApiKey: vi.fn(),
+  revokeApiKey: vi.fn(),
+  getPendingRequests: vi.fn(),
+  getAllApiKeys: vi.fn(),
+}));
+
+vi.mock('./db/lookupCache', () => ({
+  createManagedLookupCache: vi.fn(),
+}));
+
+import { upsertUserRecord, setTwitchBotEnabledRecord, removeUserRecord } from './db/users';
+import { invalidateCustomCommandLookupCache } from './db/customCommandCache';
+import { upsertUser, updateTwitchBotEnabled, removeUser } from './db';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(upsertUserRecord).mockResolvedValue(false);
+  vi.mocked(setTwitchBotEnabledRecord).mockResolvedValue(undefined);
+  vi.mocked(removeUserRecord).mockResolvedValue(undefined);
+});
+
+// ─── upsertUser ───────────────────────────────────────────────────────────────
+
+describe('upsertUser', () => {
+  it('calls invalidateCustomCommandLookupCache when twitchName is a non-null string', async () => {
+    vi.mocked(upsertUserRecord).mockResolvedValue(true);
+    await upsertUser('1', 'Alice', 0, 'alice_chan');
+    expect(invalidateCustomCommandLookupCache).toHaveBeenCalledOnce();
+  });
+
+  it('calls invalidateCustomCommandLookupCache when twitchName is explicitly null', async () => {
+    vi.mocked(upsertUserRecord).mockResolvedValue(true);
+    await upsertUser('1', 'Alice', 0, null);
+    expect(invalidateCustomCommandLookupCache).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT call invalidateCustomCommandLookupCache when twitchName is omitted (undefined)', async () => {
+    vi.mocked(upsertUserRecord).mockResolvedValue(false);
+    await upsertUser('1', 'Alice', 0);
+    expect(invalidateCustomCommandLookupCache).not.toHaveBeenCalled();
+  });
+
+  it('propagates errors from upsertUserRecord without calling invalidate', async () => {
+    vi.mocked(upsertUserRecord).mockRejectedValue(new Error('DB error'));
+    await expect(upsertUser('1', 'Alice', 0, 'alice')).rejects.toThrow('DB error');
+    expect(invalidateCustomCommandLookupCache).not.toHaveBeenCalled();
+  });
+});
+
+// ─── updateTwitchBotEnabled ───────────────────────────────────────────────────
+
+describe('updateTwitchBotEnabled', () => {
+  it('always calls invalidateCustomCommandLookupCache on success', async () => {
+    await updateTwitchBotEnabled('1', true);
+    expect(invalidateCustomCommandLookupCache).toHaveBeenCalledOnce();
+  });
+
+  it('also calls invalidate when disabling', async () => {
+    await updateTwitchBotEnabled('1', false);
+    expect(invalidateCustomCommandLookupCache).toHaveBeenCalledOnce();
+  });
+
+  it('propagates errors from setTwitchBotEnabledRecord', async () => {
+    vi.mocked(setTwitchBotEnabledRecord).mockRejectedValue(new Error('DB error'));
+    await expect(updateTwitchBotEnabled('1', true)).rejects.toThrow('DB error');
+  });
+});
+
+// ─── removeUser ───────────────────────────────────────────────────────────────
+
+describe('removeUser', () => {
+  it('always calls invalidateCustomCommandLookupCache on success', async () => {
+    await removeUser('1');
+    expect(invalidateCustomCommandLookupCache).toHaveBeenCalledOnce();
+  });
+
+  it('propagates errors from removeUserRecord', async () => {
+    vi.mocked(removeUserRecord).mockRejectedValue(new Error('DB error'));
+    await expect(removeUser('1')).rejects.toThrow('DB error');
+  });
+});

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -174,6 +174,7 @@ describe('updateTwitchBotEnabled', () => {
   it('propagates errors from setTwitchBotEnabledRecord', async () => {
     vi.mocked(setTwitchBotEnabledRecord).mockRejectedValue(new Error('DB error'));
     await expect(updateTwitchBotEnabled('1', true)).rejects.toThrow('DB error');
+    expect(invalidateCustomCommandLookupCache).not.toHaveBeenCalled();
   });
 });
 
@@ -188,5 +189,6 @@ describe('removeUser', () => {
   it('propagates errors from removeUserRecord', async () => {
     vi.mocked(removeUserRecord).mockRejectedValue(new Error('DB error'));
     await expect(removeUser('1')).rejects.toThrow('DB error');
+    expect(invalidateCustomCommandLookupCache).not.toHaveBeenCalled();
   });
 });

--- a/src/db/commandLocks.test.ts
+++ b/src/db/commandLocks.test.ts
@@ -17,7 +17,8 @@ vi.mock('./commandStringUtils', () => ({
 }));
 
 import { getPool } from './pool';
-import { isDeadlockError, getCommandWriteLockName, acquireNamedLock, isAnyCommandTakenAcrossTables } from './commandLocks';
+import { isDeadlockError, getCommandWriteLockName, acquireNamedLock, isAnyCommandTakenAcrossTables, runSerializedCommandWrite, MAX_DEADLOCK_RETRIES } from './commandLocks';
+import { CommandConflictError } from './commandStringUtils';
 
 describe('isDeadlockError', () => {
   it('returns true when code is ER_LOCK_DEADLOCK', () => {
@@ -199,5 +200,111 @@ describe('isAnyCommandTakenAcrossTables', () => {
     const customCmdCall = pool.execute.mock.calls.find((args) => (args[0] as string).includes('custom_command'));
     expect(customCmdCall).toBeDefined();
     expect(customCmdCall![1]).toContain(7);
+  });
+});
+
+// ─── runSerializedCommandWrite ────────────────────────────────────────────────
+
+// existsResults: array of row arrays returned for each SELECT 1 FROM check.
+// Pass [[]] for "no conflict" (empty rows), [[{ '1': 1 }]] for "conflict".
+function makeSerializedWriteConnection(existsResults: Array<unknown[]> = [[], []]) {
+  let existsCallIndex = 0;
+  const conn = {
+    execute: vi.fn(async (sql: string) => {
+      if (sql.startsWith('SELECT GET_LOCK')) return [[{ lock_status: '1' }], []];
+      if (sql.startsWith('SELECT RELEASE_LOCK')) return [[], []];
+      if (sql.startsWith('SELECT 1 FROM')) return [existsResults[existsCallIndex++] ?? [], []];
+      return [[], []];
+    }),
+    beginTransaction: vi.fn().mockResolvedValue(undefined),
+    commit: vi.fn().mockResolvedValue(undefined),
+    rollback: vi.fn().mockResolvedValue(undefined),
+    release: vi.fn(),
+  };
+  return conn;
+}
+
+describe('runSerializedCommandWrite', () => {
+  it('calls writeOperation once and commits when no conflict and no deadlock', async () => {
+    const conn = makeSerializedWriteConnection();
+    vi.mocked(getPool).mockReturnValue({ getConnection: vi.fn().mockResolvedValue(conn) } as any);
+
+    const writeOp = vi.fn().mockResolvedValue('result');
+    const result = await runSerializedCommandWrite('!test', undefined, writeOp);
+
+    expect(writeOp).toHaveBeenCalledOnce();
+    expect(conn.commit).toHaveBeenCalledOnce();
+    expect(conn.rollback).not.toHaveBeenCalled();
+    expect(conn.release).toHaveBeenCalled();
+    expect(result).toBe('result');
+  });
+
+  it('throws CommandConflictError immediately (no retry) when command is taken', async () => {
+    // First exists check returns a row (trigger taken); second check not reached
+    const conn = makeSerializedWriteConnection([[{ '1': 1 }], []]);
+    vi.mocked(getPool).mockReturnValue({ getConnection: vi.fn().mockResolvedValue(conn) } as any);
+
+    const writeOp = vi.fn();
+    await expect(runSerializedCommandWrite('!test', undefined, writeOp)).rejects.toBeInstanceOf(CommandConflictError);
+    expect(writeOp).not.toHaveBeenCalled();
+    expect(conn.rollback).toHaveBeenCalledOnce();
+    expect(conn.release).toHaveBeenCalled();
+  });
+
+  it('retries on deadlock and succeeds on second attempt', async () => {
+    const conn = makeSerializedWriteConnection();
+    vi.mocked(getPool).mockReturnValue({ getConnection: vi.fn().mockResolvedValue(conn) } as any);
+
+    const deadlockError = Object.assign(new Error('Deadlock'), { code: 'ER_LOCK_DEADLOCK' });
+    const writeOp = vi.fn()
+      .mockRejectedValueOnce(deadlockError)
+      .mockResolvedValueOnce('ok');
+
+    const result = await runSerializedCommandWrite('!test', undefined, writeOp);
+
+    expect(writeOp).toHaveBeenCalledTimes(2);
+    expect(conn.rollback).toHaveBeenCalledOnce();
+    expect(conn.commit).toHaveBeenCalledOnce();
+    expect(result).toBe('ok');
+    expect(conn.release).toHaveBeenCalled();
+  });
+
+  it(`throws after ${MAX_DEADLOCK_RETRIES} consecutive deadlocks`, async () => {
+    const conn = makeSerializedWriteConnection();
+    vi.mocked(getPool).mockReturnValue({ getConnection: vi.fn().mockResolvedValue(conn) } as any);
+
+    const deadlockError = Object.assign(new Error('Deadlock'), { code: 'ER_LOCK_DEADLOCK' });
+    const writeOp = vi.fn().mockRejectedValue(deadlockError);
+
+    await expect(runSerializedCommandWrite('!test', undefined, writeOp)).rejects.toThrow('Deadlock');
+    expect(writeOp).toHaveBeenCalledTimes(MAX_DEADLOCK_RETRIES);
+    expect(conn.rollback).toHaveBeenCalledTimes(MAX_DEADLOCK_RETRIES);
+    expect(conn.release).toHaveBeenCalled();
+  });
+
+  it('re-throws non-deadlock errors immediately without retry', async () => {
+    const conn = makeSerializedWriteConnection();
+    vi.mocked(getPool).mockReturnValue({ getConnection: vi.fn().mockResolvedValue(conn) } as any);
+
+    const dupError = Object.assign(new Error('Duplicate entry'), { code: 'ER_DUP_ENTRY' });
+    const writeOp = vi.fn().mockRejectedValue(dupError);
+
+    await expect(runSerializedCommandWrite('!test', undefined, writeOp)).rejects.toThrow('Duplicate entry');
+    expect(writeOp).toHaveBeenCalledOnce();
+    expect(conn.release).toHaveBeenCalled();
+  });
+
+  it('releases connection even when acquireNamedLock throws', async () => {
+    const conn = {
+      execute: vi.fn().mockResolvedValue([[{ lock_status: '0' }]]),
+      beginTransaction: vi.fn(),
+      commit: vi.fn(),
+      rollback: vi.fn(),
+      release: vi.fn(),
+    };
+    vi.mocked(getPool).mockReturnValue({ getConnection: vi.fn().mockResolvedValue(conn) } as any);
+
+    await expect(runSerializedCommandWrite('!test', undefined, vi.fn())).rejects.toThrow();
+    expect(conn.release).toHaveBeenCalled();
   });
 });

--- a/src/db/lookupCache.test.ts
+++ b/src/db/lookupCache.test.ts
@@ -135,7 +135,36 @@ describe('createManagedLookupCache', () => {
     });
   });
 
-  // ─── Scenario 3: backoff reset after success ────────────────────────────────
+  // ─── Scenario 3: concurrent getCache() calls coalesce ─────────────────────
+  // When multiple callers call getCache() simultaneously while no cache is
+  // loaded, they should all share the same in-flight loadCache() promise rather
+  // than spawning separate refreshes.
+
+  describe('concurrent getCache() calls coalesce to a single loadCache() invocation', () => {
+    it('calls loadCache exactly once for two simultaneous calls', async () => {
+      let resolve!: (v: TC) => void;
+      const freshResult: TC = { loadedAt: Date.now(), data: 'loaded' };
+
+      const createEmptyCache = vi.fn(() => ({ loadedAt: 0, data: 'empty' } as TC));
+      const loadCache = vi.fn<() => Promise<TC>>(() => new Promise<TC>(r => { resolve = r; }));
+
+      const { getCache } = createManagedLookupCache({ ...BASE_OPTS, createEmptyCache, loadCache });
+
+      // Both calls issued before the first refresh resolves.
+      const p1 = getCache();
+      const p2 = getCache();
+
+      resolve(freshResult);
+
+      const [r1, r2] = await Promise.all([p1, p2]);
+
+      expect(loadCache).toHaveBeenCalledOnce();
+      expect(r1).toMatchObject({ data: 'loaded' });
+      expect(r2).toMatchObject({ data: 'loaded' });
+    });
+  });
+
+  // ─── Scenario 5: backoff reset after success ────────────────────────────────
   // After a successful refresh resetRefreshFailureState() sets refreshAllowedAt=0
   // and refreshFailureCount=0. The next getCache() call after TTL should
   // immediately start a background refresh with no extra delay, even if earlier

--- a/src/web/routes/adminUserMutations.test.ts
+++ b/src/web/routes/adminUserMutations.test.ts
@@ -208,7 +208,7 @@ describe('addOrUpdateUserMutation — DuplicateTwitchNameError', () => {
       addOrUpdateUserMutation({
         discordId: '111',
         discordName: 'TestUser',
-        level: 0,
+        level: AccessLevel.USER,
         normalizedTwitchName: 'taken_chan',
         shouldClearTwitchName: false,
       }),
@@ -236,7 +236,7 @@ describe('addOrUpdateUserMutation — upsertUser throws', () => {
       addOrUpdateUserMutation({
         discordId: '111',
         discordName: 'TestUser',
-        level: 0,
+        level: AccessLevel.USER,
         normalizedTwitchName: 'new_chan',
         shouldClearTwitchName: false,
       }),
@@ -270,7 +270,7 @@ describe('addOrUpdateUserMutation — rollback failure does not mask original er
       addOrUpdateUserMutation({
         discordId: '111',
         discordName: 'TestUser',
-        level: 0,
+        level: AccessLevel.USER,
         normalizedTwitchName: null,
         shouldClearTwitchName: true,
       }),

--- a/src/web/routes/adminUserMutations.test.ts
+++ b/src/web/routes/adminUserMutations.test.ts
@@ -24,9 +24,11 @@ import {
   addOrUpdateUserMutation,
   removeUserMutation,
   toggleTwitchMutation,
+  DuplicateTwitchNameError,
 } from './adminUserMutations';
 import {
   findUser,
+  findUserByTwitchName,
   upsertUser,
   removeUser,
   updateTwitchBotEnabled,
@@ -191,5 +193,87 @@ describe('toggleTwitchMutation — rollback on join/part failure', () => {
 
     expect(vi.mocked(updateTwitchBotEnabled)).toHaveBeenNthCalledWith(1, '111', true);
     expect(vi.mocked(updateTwitchBotEnabled)).toHaveBeenNthCalledWith(2, '111', false);
+  });
+});
+
+describe('addOrUpdateUserMutation — DuplicateTwitchNameError', () => {
+  it('throws DuplicateTwitchNameError when another user already has the given Twitch name', async () => {
+    vi.mocked(findUser)
+      .mockResolvedValueOnce(null); // no pre-existing user for this discordId
+
+    // findUserByTwitchName returns a conflicting user
+    vi.mocked(findUserByTwitchName).mockResolvedValue({ discord_id: '999' } as any);
+
+    await expect(
+      addOrUpdateUserMutation({
+        discordId: '111',
+        discordName: 'TestUser',
+        level: 0,
+        normalizedTwitchName: 'taken_chan',
+        shouldClearTwitchName: false,
+      }),
+    ).rejects.toBeInstanceOf(DuplicateTwitchNameError);
+
+    expect(vi.mocked(upsertUser)).not.toHaveBeenCalled();
+  });
+});
+
+describe('addOrUpdateUserMutation — upsertUser throws', () => {
+  it('does not attempt Twitch channel changes when upsertUser throws', async () => {
+    vi.mocked(findUser)
+      .mockResolvedValueOnce({
+        ...BASE_USER,
+        twitch_name: 'existing_chan',
+        is_twitch_bot_enabled: true,
+      } as any);
+
+    // No conflict on the Twitch name check
+    vi.mocked(findUserByTwitchName).mockResolvedValue(null);
+
+    vi.mocked(upsertUser).mockRejectedValue(new Error('DB write failed'));
+
+    await expect(
+      addOrUpdateUserMutation({
+        discordId: '111',
+        discordName: 'TestUser',
+        level: 0,
+        normalizedTwitchName: 'new_chan',
+        shouldClearTwitchName: false,
+      }),
+    ).rejects.toThrow('DB write failed');
+
+    expect(vi.mocked(joinTwitchChannel)).not.toHaveBeenCalled();
+    expect(vi.mocked(partTwitchChannel)).not.toHaveBeenCalled();
+  });
+});
+
+describe('addOrUpdateUserMutation — rollback failure does not mask original error', () => {
+  it('propagates the original partTwitchChannel error even when the rollback upsertUser also throws', async () => {
+    const existingUser: MockDbUser = {
+      ...BASE_USER,
+      twitch_name: 'streamerchan',
+      is_twitch_bot_enabled: true,
+    };
+
+    vi.mocked(findUser)
+      .mockResolvedValueOnce(existingUser as any)
+      .mockResolvedValueOnce({ ...existingUser, twitch_name: null } as any);
+
+    vi.mocked(partTwitchChannel).mockRejectedValue(new Error('Part failed'));
+    // The rollback upsertUser also fails
+    vi.mocked(upsertUser)
+      .mockResolvedValueOnce(undefined) // first call (main upsert) succeeds
+      .mockRejectedValueOnce(new Error('Rollback DB error')); // second call (rollback) fails
+
+    // The original "Part failed" error must be thrown, not the rollback error
+    await expect(
+      addOrUpdateUserMutation({
+        discordId: '111',
+        discordName: 'TestUser',
+        level: 0,
+        normalizedTwitchName: null,
+        shouldClearTwitchName: true,
+      }),
+    ).rejects.toThrow('Part failed');
   });
 });


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **`src/db.test.ts` (new):** Tests the `db.ts` facade's cache-invalidation gate — verifies `invalidateCustomCommandLookupCache` is called when `twitchName` is provided to `upsertUser` (including explicit `null`), and is _not_ called when `twitchName` is `undefined`. Also covers `updateTwitchBotEnabled` and `removeUser` always invalidating.

- **`commandLocks.test.ts`:** Adds a `runSerializedCommandWrite` describe block. Previously this function was mocked out everywhere so its deadlock-retry loop was never exercised. New tests cover: first-attempt success, conflict error (no retry), deadlock retry succeeds on second attempt, all 3 retries exhausted, non-deadlock error re-thrown immediately, and connection release when lock acquisition fails.

- **`lookupCache.test.ts`:** Adds a concurrent coalescing test — two simultaneous `getCache()` calls while the cache is empty must share a single in-flight `loadCache()` call, not start two separate refreshes.

- **`adminUserMutations.test.ts`:** Adds three missing paths: `DuplicateTwitchNameError` thrown when `findUserByTwitchName` returns a conflict; Twitch channel join/part not attempted when `upsertUser` itself throws; and original error propagation when the rollback `upsertUser` call also throws.

## Test plan

- All 1008 tests pass (`npm test`)
- `npx tsc --noEmit` clean

https://claude.ai/code/session_01BDWmqTSGFKghwba5xkzqhK
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDWmqTSGFKghwba5xkzqhK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for database operations, user management, and command handling.
  * Added validation tests for concurrent operations and error handling to improve system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->