### PR TITLE
fix: use catch (err: unknown) in overlay upload route

### DIFF
--- a/src/web/routes/overlayAdminMutations.ts
+++ b/src/web/routes/overlayAdminMutations.ts
@@ -56,8 +56,10 @@ router.post('/settings/videos/upload', requireAuth, upload.single('video'), csrf
     const name = (typeof req.body?.name === 'string' ? req.body.name.trim().slice(0, 100) : '') || req.file.originalname;
     await saveVideoFile(streamer, req.file, name);
     res.redirect('/overlay/settings?success=video_uploaded');
-  } catch (err: any) {
-    if (err?.code === 'invalid_path') return res.redirect('/overlay/settings?error=invalid_path');
+  } catch (err: unknown) {
+    if (err instanceof Error && (err as NodeJS.ErrnoException).code === 'invalid_path') {
+      return res.redirect('/overlay/settings?error=invalid_path');
+    }
     log.error('Overlay video upload error:', err);
     res.redirect('/overlay/settings?error=upload_failed');
   }


### PR DESCRIPTION
## Issue

`overlayAdminMutations.ts` had the only `catch (err: any)` clause in the entire codebase:

```ts
} catch (err: any) {
  if (err?.code === 'invalid_path') return res.redirect(…);
```

Using `: any` suppresses TypeScript's `useUnknownInCatchVariables` strict-mode protection (enabled by default in TypeScript 4.4+) and the `no-explicit-any` lint rule. Every other catch clause in the codebase uses `unknown` with proper type narrowing.

## Fix

Changed to `catch (err: unknown)` with `instanceof Error` + `NodeJS.ErrnoException` narrowing:

```ts
} catch (err: unknown) {
  if (err instanceof Error && (err as NodeJS.ErrnoException).code === 'invalid_path') {
    return res.redirect('/overlay/settings?error=invalid_path');
  }
```

## Severity

**Low** — no runtime behaviour change; type-safety and consistency improvement.

## Label

`code-review`

https://claude.ai/code/session_01C42xo4Gr7nLy9fe18mg7ep

---
_Generated by [Claude Code](https://claude.ai/code/session_01C42xo4Gr7nLy9fe18mg7ep)_