### PR TITLE
fix: route eventsub db imports through the db.ts facade

### DIFF
--- a/src/twitch/eventsub/twitchApiEventSub.ts
+++ b/src/twitch/eventsub/twitchApiEventSub.ts
@@ -1,7 +1,8 @@
 import { createLogger } from '../../shared/logger';
 import { TWITCH_CLIENT_ID, TWITCH_CLIENT_SECRET } from '../../shared/config';
 import { twitchFetch, authHeaders } from '../twitchApi';
-import { DbStreamerEventSub, saveStreamerToken, clearStreamerToken } from '../../db/eventSub';
+import type { DbStreamerEventSub } from '../../db';
+import { saveStreamerToken, clearStreamerToken } from '../../db';
 
 const log = createLogger('TwitchToken');
 const TOKEN_BUFFER_MS = 5 * 60 * 1000;

--- a/src/twitch/eventsub/twitchEventSubHandler.test.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../twitchBot', () => ({ sayInChannel: vi.fn() }));
-vi.mock('../../db/overlayVideos', () => ({ getVideosForReward: vi.fn() }));
+vi.mock('../../db', () => ({ getVideosForReward: vi.fn() }));
 vi.mock('../../web/routes/overlaySource', () => ({ pushOverlayEvent: vi.fn() }));
 vi.mock('../../commands/soundSelector', () => ({ pickWeightedRandom: vi.fn() }));
 vi.mock('../../shared/logger', () => ({ createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }));
 
 import { handleFollow, handleSub, handleResub, handleGiftSub, handleRaid, handleRedemption } from './twitchEventSubHandler';
 import { sayInChannel } from '../twitchBot';
-import { getVideosForReward } from '../../db/overlayVideos';
+import { getVideosForReward } from '../../db';
 import { pushOverlayEvent } from '../../web/routes/overlaySource';
 import { pickWeightedRandom } from '../../commands/soundSelector';
 

--- a/src/twitch/eventsub/twitchEventSubHandler.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.ts
@@ -1,6 +1,6 @@
 import { sayInChannel } from '../twitchBot';
-import { EventSubConfig } from '../../db/eventSub';
-import { getVideosForReward } from '../../db/overlayVideos';
+import type { EventSubConfig } from '../../db';
+import { getVideosForReward } from '../../db';
 import { pushOverlayEvent } from '../../web/routes/overlaySource';
 import { pickWeightedRandom } from '../../commands/soundSelector';
 import { createLogger } from '../../shared/logger';

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '../../shared/logger';
 import { getAllEventSubStreamers, clearStreamerToken } from '../../db';
-import type { DbStreamerEventSub, EventSubConfig } from '../../db/eventSub';
+import type { DbStreamerEventSub, EventSubConfig } from '../../db';
 import { getUsers } from '../twitchApi';
 import { getActiveChannels } from '../twitchBot';
 import { normalizeTwitchChannelName } from '../twitchChannelName';


### PR DESCRIPTION
## Issue

Three files under `src/twitch/eventsub/` were importing database symbols directly from `src/db/eventSub` and `src/db/overlayVideos`, bypassing the `src/db.ts` facade:

| File | Direct import |
|------|--------------|
| `twitchEventSubHandler.ts` | `EventSubConfig` from `../../db/eventSub`; `getVideosForReward` from `../../db/overlayVideos` |
| `twitchApiEventSub.ts` | `DbStreamerEventSub`, `saveStreamerToken`, `clearStreamerToken` from `../../db/eventSub` |
| `twitchEventSubSubscriptions.ts` | `DbStreamerEventSub`, `EventSubConfig` (type) from `../../db/eventSub` |

`CLAUDE.md` explicitly requires: *"Import DB functions from `src/db.ts` only, never `src/db/*` directly. The facade wraps some functions with cache-invalidation side effects."*

## Fix

All five symbols were already re-exported from `src/db.ts`, so the fix is a pure import-path change to `../../db` in all three files. The `twitchEventSubHandler.test.ts` `vi.mock` path is updated to match the new import source.

## Severity

**High** — architectural invariant violation. Any cache-invalidation or logging wrappers added to the facade in the future would be silently bypassed by these direct imports.

## Label

`code-review`

https://claude.ai/code/session_01C42xo4Gr7nLy9fe18mg7ep

---
_Generated by [Claude Code](https://claude.ai/code/session_01C42xo4Gr7nLy9fe18mg7ep)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code reorganization across the Twitch EventSub module for improved maintainability and structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->