### PR TITLE
refactor: replace duplicate mapBool helpers with shared fromBit utility

### DIFF
--- a/src/db/customCommands.ts
+++ b/src/db/customCommands.ts
@@ -1,5 +1,6 @@
 import mysql from 'mysql2/promise';
 import { getPool } from './pool';
+import { fromBit } from './utils';
 import { AccessLevel } from './users';
 import type { AccessLevelValue } from './users';
 import { assertNotReservedCommand } from './reservedCommands';
@@ -36,17 +37,13 @@ export interface DbCustomCommandWithAssignments extends DbCustomCommand {
 
 // ─── Row mappers ─────────────────────────────────────────────────────────────
 
-function mapBool(value: unknown): boolean {
-  return Buffer.isBuffer(value) ? value[0] === 1 : Number(value) === 1;
-}
-
 function mapCustomCommand(row: mysql.RowDataPacket): DbCustomCommand {
   return {
     command_id: row.command_id,
     trigger_string: row.trigger_string,
     output: row.output,
-    is_discord_enabled: mapBool(row.is_discord_enabled),
-    is_multi_twitch: mapBool(row.is_multi_twitch),
+    is_discord_enabled: fromBit(row.is_discord_enabled),
+    is_multi_twitch: fromBit(row.is_multi_twitch),
   };
 }
 
@@ -80,7 +77,7 @@ export async function getAllCustomCommandsWithAssignments(): Promise<DbCustomCom
         discord_name: row.discord_name ?? null,
         twitch_name: row.twitch_name ?? null,
         access_level: row.access_level ?? AccessLevel.USER,
-        is_twitch_bot_enabled: mapBool(row.is_twitch_bot_enabled),
+        is_twitch_bot_enabled: fromBit(row.is_twitch_bot_enabled),
         is_orphaned_user: row.user_discord_id === null || row.user_discord_id === undefined,
       });
     }

--- a/src/db/eventSub.ts
+++ b/src/db/eventSub.ts
@@ -1,5 +1,6 @@
 import mysql from 'mysql2/promise';
 import { getPool } from './pool';
+import { fromBit } from './utils';
 import { EVENTSUB_TOKEN_SECRET } from '../shared/config';
 import { encryptToken, decryptToken } from '../shared/crypto';
 
@@ -25,19 +26,15 @@ export interface DbStreamerEventSub {
   config: EventSubConfig | null;
 }
 
-function mapBool(value: unknown): boolean {
-  return Buffer.isBuffer(value) ? value[0] === 1 : value == 1;
-}
-
 function mapConfig(r: mysql.RowDataPacket): EventSubConfig {
   return {
-    follow_enabled: mapBool(r.follow_enabled),
+    follow_enabled: fromBit(r.follow_enabled),
     follow_message: r.follow_message,
-    sub_enabled: mapBool(r.sub_enabled),
+    sub_enabled: fromBit(r.sub_enabled),
     sub_message: r.sub_message,
     resub_message: r.resub_message,
     giftsub_message: r.giftsub_message,
-    raid_enabled: mapBool(r.raid_enabled),
+    raid_enabled: fromBit(r.raid_enabled),
     raid_message: r.raid_message,
   };
 }

--- a/src/db/sfx.ts
+++ b/src/db/sfx.ts
@@ -1,5 +1,6 @@
 import mysql from 'mysql2/promise';
 import { getPool } from './pool';
+import { fromBit } from './utils';
 
 export interface SfxTrigger {
   id: bigint;
@@ -28,10 +29,6 @@ export interface SfxTriggerRow {
   files: Array<{ id: number; file: string; weight: number; hidden: boolean }>;
 }
 
-function mapBool(value: unknown): boolean {
-  return Buffer.isBuffer(value) ? value[0] === 1 : value == 1;
-}
-
 /**
  * Look up a trigger by its command string (case-insensitive).
  * Hidden triggers ARE included — the hidden flag only affects public listing, not playback.
@@ -49,7 +46,7 @@ export async function findTrigger(command: string): Promise<SfxTrigger | null> {
     id: BigInt(row.id),
     trigger_command: row.trigger_command,
     category_id: row.category_id,
-    hidden: mapBool(row.hidden),
+    hidden: fromBit(row.hidden),
     description: row.description,
   };
 }
@@ -71,7 +68,7 @@ export async function findSoundFiles(triggerId: bigint): Promise<SfxFile[]> {
     file: row.file,
     trigger_command: row.trigger_command,
     weight: row.weight,
-    hidden: mapBool(row.hidden),
+    hidden: fromBit(row.hidden),
     category_id: row.category_id,
   }));
 }
@@ -122,7 +119,7 @@ export async function getAllSfxTriggers(): Promise<SfxTriggerRow[]> {
         triggerId: r.triggerId,
         triggerCommand: r.triggerCommand,
         description: r.description ?? null,
-        hidden: mapBool(r.triggerHidden),
+        hidden: fromBit(r.triggerHidden),
         categoryName: r.categoryName ?? null,
         files: [],
       });
@@ -132,7 +129,7 @@ export async function getAllSfxTriggers(): Promise<SfxTriggerRow[]> {
         id: r.sfxId,
         file: r.file,
         weight: r.weight,
-        hidden: mapBool(r.sfxHidden),
+        hidden: fromBit(r.sfxHidden),
       });
     }
   }

--- a/src/db/streamMonitor.ts
+++ b/src/db/streamMonitor.ts
@@ -1,5 +1,6 @@
 import mysql from 'mysql2/promise';
 import { getPool } from './pool';
+import { fromBit } from './utils';
 
 export interface DbStreamGroup {
   id: number;
@@ -45,9 +46,6 @@ export interface DbStreamerFull {
   group: DbStreamGroup;
 }
 
-function mapBool(value: unknown): boolean {
-  return Buffer.isBuffer(value) ? value[0] === 1 : value == 1;
-}
 
 function mapStreamGroup(r: mysql.RowDataPacket): DbStreamGroup {
   return {
@@ -56,8 +54,8 @@ function mapStreamGroup(r: mysql.RowDataPacket): DbStreamGroup {
     discord_channel: String(r.discord_channel),
     live_message: r.live_message,
     new_game_message: r.new_game_message,
-    multi_twitch: mapBool(r.multi_twitch),
-    delete_old_posts: mapBool(r.delete_old_posts),
+    multi_twitch: fromBit(r.multi_twitch),
+    delete_old_posts: fromBit(r.delete_old_posts),
   };
 }
 
@@ -145,8 +143,8 @@ export async function getAllStreamersWithGroups(): Promise<DbStreamerFull[]> {
       discord_channel: String(r.discord_channel),
       live_message: r.live_message,
       new_game_message: r.new_game_message,
-      multi_twitch: mapBool(r.multi_twitch),
-      delete_old_posts: mapBool(r.delete_old_posts),
+      multi_twitch: fromBit(r.multi_twitch),
+      delete_old_posts: fromBit(r.delete_old_posts),
     },
   }));
 }

--- a/src/db/streamMonitor.ts
+++ b/src/db/streamMonitor.ts
@@ -46,7 +46,6 @@ export interface DbStreamerFull {
   group: DbStreamGroup;
 }
 
-
 function mapStreamGroup(r: mysql.RowDataPacket): DbStreamGroup {
   return {
     id: r.id,


### PR DESCRIPTION
## Issue

Four `db/` files each defined an identical private `mapBool` function for decoding MySQL `BIT(1)` columns:

- `src/db/sfx.ts`
- `src/db/customCommands.ts`
- `src/db/streamMonitor.ts`
- `src/db/eventSub.ts`

`src/db/utils.ts` already exports `fromBit`, which is the canonical implementation used by `users.ts` and `counters.ts`. The four duplicates were inconsistent: `customCommands.ts` used `Number(value) === 1` while the others used `value == 1`, creating a subtle divergence for the same underlying column type.

## Fix

Removed all four private `mapBool` functions and replaced every call site with an imported `fromBit` from `./utils`, matching the pattern already established in `users.ts` and `counters.ts`.

## Severity

**Medium** — DRY violation with subtle inconsistency (`Number(value) === 1` vs `value == 1`) across the same column-decoding logic.

## Label

`code-review`

https://claude.ai/code/session_01C42xo4Gr7nLy9fe18mg7ep

---
_Generated by [Claude Code](https://claude.ai/code/session_01C42xo4Gr7nLy9fe18mg7ep)_