### PR TITLE
refactor: consolidate Discord client into a single nullable variable

### DIFF
--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -8,19 +8,18 @@ import { createLogger } from '../shared/logger';
 
 const log = createLogger('Discord');
 
-let client: Client;
+let client: Client | null = null;
 let cachedGuild: Guild | null = null;
-let _discordClient: Client | null = null;
 
 /** Returns the Discord.js Client once it has fired `clientReady`, or null before then. */
-export function getDiscordClient(): Client | null { return _discordClient; }
+export function getDiscordClient(): Client | null { return client; }
 
 async function getConfiguredGuild(): Promise<Guild> {
-  if (!_discordClient) {
+  if (!client) {
     throw new Error('Discord client is not ready');
   }
 
-  const guildFromCache = _discordClient!.guilds.cache.get(DISCORD_GUILD_ID);
+  const guildFromCache = client.guilds.cache.get(DISCORD_GUILD_ID);
   if (guildFromCache) {
     cachedGuild = guildFromCache;
     return guildFromCache;
@@ -30,12 +29,12 @@ async function getConfiguredGuild(): Promise<Guild> {
     return cachedGuild;
   }
 
-  cachedGuild = await _discordClient!.guilds.fetch(DISCORD_GUILD_ID);
+  cachedGuild = await client.guilds.fetch(DISCORD_GUILD_ID);
   return cachedGuild;
 }
 
 export async function fetchMemberDisplayName(discordId: string, force = false): Promise<string | null> {
-  if (!_discordClient) return null;
+  if (!client) return null;
   try {
     const guild = await getConfiguredGuild();
     const member = await guild.members.fetch({ user: discordId, force });
@@ -77,7 +76,7 @@ export function startDiscordBot(): void {
 
   client.once('clientReady', async (c) => {
     log.info(`Logged in as ${c.user.tag}`);
-    _discordClient = c;
+    client = c;
     try {
       const guild = await getConfiguredGuild();
       setDiscordReady(c.user.tag, guild.name);
@@ -94,10 +93,11 @@ export function startDiscordBot(): void {
 }
 
 export function stopDiscordBot(): void {
-  _discordClient = null;
+  const existing = client;
+  client = null;
   cachedGuild = null;
   try {
-    client?.destroy();
+    existing?.destroy();
   } catch (err) {
     log.error('Error destroying client:', err);
   }


### PR DESCRIPTION
## Issue

`discordBot.ts` had two separate variables for the same underlying object:

```ts
let client: Client;           // unguarded — used for listeners, login
let _discordClient: Client | null = null;  // null-safe — exposed via getDiscordClient()
```

This had a latent bug: `stopDiscordBot()` set `_discordClient = null` then called `client?.destroy()`. Because `client` was not typed as nullable, the `?.` never fired its guard — but if `stopDiscordBot` was called before `startDiscordBot` (e.g. in tests or on fast shutdown), `client` was an uninitialized `let` binding and the optional chain would silently fail.

## Fix

Consolidated into a single `let client: Client | null = null`. In `stopDiscordBot`, the reference is captured in `existing` before `client` is nulled, so `destroy()` still fires correctly. Redundant non-null assertions (`client!.guilds.cache.get(...)`) removed from `getConfiguredGuild` since TypeScript now tracks the nullability correctly through the `if (!client)` guard.

## Severity

**Medium** — architectural clarity; the latent bug is low-impact in practice but the dual-variable pattern creates confusion for future readers.

## Label

`code-review`

https://claude.ai/code/session_01C42xo4Gr7nLy9fe18mg7ep

---
_Generated by [Claude Code](https://claude.ai/code/session_01C42xo4Gr7nLy9fe18mg7ep)_