### PR TITLE
fix: coalesce concurrent sfxPublic cache-miss requests into one DB query

### DIFF
--- a/src/web/routes/sfxPublic.ts
+++ b/src/web/routes/sfxPublic.ts
@@ -9,12 +9,18 @@ const router = Router();
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
 let cache: { data: PublicSfxTrigger[]; expiresAt: number } | null = null;
+let inFlight: Promise<PublicSfxTrigger[]> | null = null;
 
 async function getCachedData(): Promise<PublicSfxTrigger[]> {
   if (cache && Date.now() < cache.expiresAt) return cache.data;
-  const data = await getPublicSfxTriggers();
-  cache = { data, expiresAt: Date.now() + CACHE_TTL_MS };
-  return data;
+  if (inFlight) return inFlight;
+  inFlight = getPublicSfxTriggers()
+    .then((data) => {
+      cache = { data, expiresAt: Date.now() + CACHE_TTL_MS };
+      return data;
+    })
+    .finally(() => { inFlight = null; });
+  return inFlight;
 }
 
 router.get('/sfx-list', async (req, res) => {


### PR DESCRIPTION
## Issue

`sfxPublic.ts`'s `getCachedData` had no in-flight request deduplication:

```ts
async function getCachedData(): Promise<PublicSfxTrigger[]> {
  if (cache && Date.now() < cache.expiresAt) return cache.data;
  const data = await getPublicSfxTriggers();  // ← no guard
  cache = { data, expiresAt: Date.now() + CACHE_TTL_MS };
  return data;
}
```

When the TTL expires and multiple concurrent requests arrive simultaneously, all pass the `cache.expiresAt` check before any fetch completes. Each fires a separate `getPublicSfxTriggers()` DB query — a thundering-herd problem on every cache expiry. This is in contrast to the sophisticated `ManagedLookupCache` used elsewhere in the codebase that handles this correctly.

## Fix

Added an `inFlight` promise that is set when a fetch begins and cleared in `.finally()`. Concurrent callers during an in-flight fetch return the same promise, so only one DB query runs per cache-miss window.

## Severity

**Medium** — correctness/performance: redundant DB queries on every cache expiry under concurrent load.

## Label

`code-review`

https://claude.ai/code/session_01C42xo4Gr7nLy9fe18mg7ep

---
_Generated by [Claude Code](https://claude.ai/code/session_01C42xo4Gr7nLy9fe18mg7ep)_