### PR TITLE
perf: decouple seenMessageIds cleanup from isDuplicate hot path

### DIFF
--- a/src/twitch/eventsub/twitchEventSubConnection.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.ts
@@ -227,13 +227,19 @@ export class StreamerConnection {
 // TTL-based dedup: messageId → expiry timestamp (shared across all per-streamer connections)
 const seenMessageIds = new Map<string, number>();
 
-/** Returns true if messageId has been seen within MESSAGE_TTL_MS; records it otherwise. */
-export function isDuplicate(messageId: string): boolean {
+// Purge expired entries on a fixed interval so isDuplicate stays O(1).
+setInterval(() => {
   const now = Date.now();
   for (const [id, expiry] of seenMessageIds) {
     if (now > expiry) seenMessageIds.delete(id);
   }
-  if (seenMessageIds.has(messageId)) return true;
+}, MESSAGE_TTL_MS).unref();
+
+/** Returns true if messageId has been seen within MESSAGE_TTL_MS; records it otherwise. */
+export function isDuplicate(messageId: string): boolean {
+  const now = Date.now();
+  const expiry = seenMessageIds.get(messageId);
+  if (expiry !== undefined && now <= expiry) return true;
   seenMessageIds.set(messageId, now + MESSAGE_TTL_MS);
   return false;
 }


### PR DESCRIPTION
## Issue

`isDuplicate` iterated over the entire `seenMessageIds` map on every call to purge stale entries:

```ts
export function isDuplicate(messageId: string): boolean {
  const now = Date.now();
  for (const [id, expiry] of seenMessageIds) {   // O(n) on every message
    if (now > expiry) seenMessageIds.delete(id);
  }
  …
}
```

With `MESSAGE_TTL_MS = 10 minutes` and many active streamers, the map accumulates entries at one per notification. Under high event volume this becomes a measurable O(n) scan on every incoming EventSub message.

## Fix

- Extracted the purge loop to a `setInterval` that fires once per `MESSAGE_TTL_MS` period. The timer is `.unref()`'d so it does not prevent Node.js from exiting.
- `isDuplicate` itself is now O(1): it calls `Map.get(messageId)` and checks the stored expiry against `Date.now()`. Expired entries are skipped at read-time even before the interval fires, preserving correct TTL behaviour (verified by existing test using `vi.advanceTimersByTime`).

## Severity

**Medium** — performance: O(n) cleanup on every message; becomes noticeable with many simultaneous streamer connections under high event volume.

## Label

`code-review`

https://claude.ai/code/session_01C42xo4Gr7nLy9fe18mg7ep

---
_Generated by [Claude Code](https://claude.ai/code/session_01C42xo4Gr7nLy9fe18mg7ep)_