### PR TITLE
fix: apply rate limiting to authenticated users

### DIFF
--- a/src/web/rateLimits.test.ts
+++ b/src/web/rateLimits.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import type { Request } from 'express';
+import type { SessionUser } from '../types/express';
+import {
+  ipKey,
+  generalLimiterSkip,
+  sessionLimiterKey,
+  sessionLimiterSkip,
+  streamdeckLimiterKey,
+} from './rateLimits';
+
+const authedUser: SessionUser = {
+  discordId: '123456789',
+  discordName: 'TestUser',
+  discordAvatar: null,
+  accessLevel: 0,
+};
+
+function makeReq(overrides: Partial<{
+  path: string;
+  ip: string;
+  sessionUser: SessionUser | undefined;
+  authHeader: string | undefined;
+  socketRemoteAddress: string | undefined;
+}>): Request {
+  const { path = '/dashboard', ip = '1.2.3.4', sessionUser, authHeader, socketRemoteAddress } = overrides;
+  return {
+    path,
+    ip,
+    socket: { remoteAddress: socketRemoteAddress },
+    session: { user: sessionUser } as Request['session'],
+    headers: authHeader !== undefined ? { authorization: authHeader } : {},
+  } as unknown as Request;
+}
+
+// ---------------------------------------------------------------------------
+// ipKey
+// ---------------------------------------------------------------------------
+describe('ipKey', () => {
+  it('returns req.ip when present', () => {
+    expect(ipKey(makeReq({ ip: '10.0.0.1' }))).toBe('10.0.0.1');
+  });
+
+  it('falls back to socket.remoteAddress when req.ip is undefined', () => {
+    const req = { ip: undefined, socket: { remoteAddress: '192.168.1.1' } } as unknown as Request;
+    expect(ipKey(req)).toBe('192.168.1.1');
+  });
+
+  it('returns "unknown" when both ip and socket.remoteAddress are absent', () => {
+    const req = { ip: undefined, socket: { remoteAddress: undefined } } as unknown as Request;
+    expect(ipKey(req)).toBe('unknown');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generalLimiterSkip
+// ---------------------------------------------------------------------------
+describe('generalLimiterSkip', () => {
+  it('skips (true) for unauthenticated request to /api/streamdeck path', () => {
+    expect(generalLimiterSkip(makeReq({ path: '/api/streamdeck/sfx', sessionUser: undefined }))).toBe(true);
+  });
+
+  it('skips (true) for authenticated request to /api/streamdeck path', () => {
+    expect(generalLimiterSkip(makeReq({ path: '/api/streamdeck/voice/join', sessionUser: authedUser }))).toBe(true);
+  });
+
+  it('skips (true) for an authenticated request to a non-streamdeck path', () => {
+    expect(generalLimiterSkip(makeReq({ path: '/dashboard', sessionUser: authedUser }))).toBe(true);
+  });
+
+  it('does NOT skip (false) for an unauthenticated request to a non-streamdeck path', () => {
+    expect(generalLimiterSkip(makeReq({ path: '/dashboard', sessionUser: undefined }))).toBe(false);
+  });
+
+  it('does NOT skip (false) for an unauthenticated request to /api (non-streamdeck)', () => {
+    expect(generalLimiterSkip(makeReq({ path: '/api/status', sessionUser: undefined }))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sessionLimiterSkip
+// ---------------------------------------------------------------------------
+describe('sessionLimiterSkip', () => {
+  it('skips (true) for /api/streamdeck path even when authenticated', () => {
+    expect(sessionLimiterSkip(makeReq({ path: '/api/streamdeck/sfx', sessionUser: authedUser }))).toBe(true);
+  });
+
+  it('skips (true) for unauthenticated request to non-streamdeck path', () => {
+    expect(sessionLimiterSkip(makeReq({ path: '/dashboard', sessionUser: undefined }))).toBe(true);
+  });
+
+  it('skips (true) for unauthenticated request to /api/streamdeck path', () => {
+    expect(sessionLimiterSkip(makeReq({ path: '/api/streamdeck/sfx', sessionUser: undefined }))).toBe(true);
+  });
+
+  it('does NOT skip (false) for authenticated request to non-streamdeck path', () => {
+    expect(sessionLimiterSkip(makeReq({ path: '/dashboard', sessionUser: authedUser }))).toBe(false);
+  });
+
+  it('does NOT skip (false) for authenticated request to /api/status', () => {
+    expect(sessionLimiterSkip(makeReq({ path: '/api/status', sessionUser: authedUser }))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sessionLimiterKey
+// ---------------------------------------------------------------------------
+describe('sessionLimiterKey', () => {
+  it('returns the Discord ID for authenticated requests', () => {
+    expect(sessionLimiterKey(makeReq({ sessionUser: authedUser }))).toBe('123456789');
+  });
+
+  it('returns "__unauthenticated__" when there is no session user', () => {
+    expect(sessionLimiterKey(makeReq({ sessionUser: undefined }))).toBe('__unauthenticated__');
+  });
+
+  it('keys different users to different buckets', () => {
+    const userA = { ...authedUser, discordId: 'aaa' };
+    const userB = { ...authedUser, discordId: 'bbb' };
+    expect(sessionLimiterKey(makeReq({ sessionUser: userA }))).not.toBe(
+      sessionLimiterKey(makeReq({ sessionUser: userB })),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// streamdeckLimiterKey
+// ---------------------------------------------------------------------------
+describe('streamdeckLimiterKey', () => {
+  it('returns the Bearer token when a valid Authorization header is present', () => {
+    expect(streamdeckLimiterKey(makeReq({ authHeader: 'Bearer my-secret-token' }))).toBe('my-secret-token');
+  });
+
+  it('falls back to req.ip when no Authorization header is present', () => {
+    expect(streamdeckLimiterKey(makeReq({ ip: '5.6.7.8', authHeader: undefined }))).toBe('5.6.7.8');
+  });
+
+  it('falls back to req.ip when Authorization header is not a Bearer token', () => {
+    expect(streamdeckLimiterKey(makeReq({ ip: '5.6.7.8', authHeader: 'Basic dXNlcjpwYXNz' }))).toBe('5.6.7.8');
+  });
+
+  it('falls back to socket.remoteAddress when req.ip is absent', () => {
+    const req = {
+      ip: undefined,
+      socket: { remoteAddress: '9.10.11.12' },
+      headers: {},
+    } as unknown as Request;
+    expect(streamdeckLimiterKey(req)).toBe('9.10.11.12');
+  });
+
+  it('returns "unknown" when no IP source and no Bearer token are available', () => {
+    const req = {
+      ip: undefined,
+      socket: { remoteAddress: undefined },
+      headers: {},
+    } as unknown as Request;
+    expect(streamdeckLimiterKey(req)).toBe('unknown');
+  });
+});

--- a/src/web/rateLimits.ts
+++ b/src/web/rateLimits.ts
@@ -1,0 +1,32 @@
+import { ipKeyGenerator } from 'express-rate-limit';
+import type { Request } from 'express';
+
+export function ipKey(req: Request): string {
+  return ipKeyGenerator(req.ip ?? req.socket?.remoteAddress ?? 'unknown');
+}
+
+/** generalLimiter skip — bypasses the IP bucket for session users (covered by
+ *  sessionLimiter) and for the Streamdeck API (its own token-keyed limiter). */
+export function generalLimiterSkip(req: Request): boolean {
+  return req.path.startsWith('/api/streamdeck') || !!req.session?.user;
+}
+
+/** sessionLimiter keyGenerator — keys by Discord ID so each account gets its
+ *  own bucket regardless of IP sharing. The fallback is never reached in
+ *  practice because sessionLimiter.skip returns true for unauthenticated reqs. */
+export function sessionLimiterKey(req: Request): string {
+  return req.session?.user?.discordId ?? '__unauthenticated__';
+}
+
+/** sessionLimiter skip — only applies to authenticated, non-Streamdeck requests. */
+export function sessionLimiterSkip(req: Request): boolean {
+  return req.path.startsWith('/api/streamdeck') || !req.session?.user;
+}
+
+/** streamdeckLimiter keyGenerator — keys by Bearer token so each API key gets
+ *  its own bucket regardless of which IP the request originates from. */
+export function streamdeckLimiterKey(req: Request): string {
+  const auth = req.headers['authorization'];
+  const token = auth?.startsWith('Bearer ') ? auth.slice(7) : null;
+  return token ?? ipKeyGenerator(req.ip ?? req.socket?.remoteAddress ?? 'unknown');
+}

--- a/src/web/rateLimits.ts
+++ b/src/web/rateLimits.ts
@@ -1,30 +1,56 @@
 import { ipKeyGenerator } from 'express-rate-limit';
 import type { Request } from 'express';
 
+/**
+ * Derives a rate-limit key from the request's IP address.
+ * Falls back to socket.remoteAddress, then "unknown" if neither is available.
+ * @param req - Express request object
+ * @returns IP-based rate-limit key
+ */
 export function ipKey(req: Request): string {
   return ipKeyGenerator(req.ip ?? req.socket?.remoteAddress ?? 'unknown');
 }
 
-/** generalLimiter skip — bypasses the IP bucket for session users (covered by
- *  sessionLimiter) and for the Streamdeck API (its own token-keyed limiter). */
+/**
+ * Determines whether to skip the general IP-based rate limiter.
+ * Skips for authenticated session users (covered by sessionLimiter) and
+ * for the Streamdeck API (its own token-keyed limiter).
+ * @param req - Express request object
+ * @returns true if the general limiter should be skipped
+ */
 export function generalLimiterSkip(req: Request): boolean {
   return req.path.startsWith('/api/streamdeck') || !!req.session?.user;
 }
 
-/** sessionLimiter keyGenerator — keys by Discord ID so each account gets its
- *  own bucket regardless of IP sharing. The fallback is never reached in
- *  practice because sessionLimiter.skip returns true for unauthenticated reqs. */
+/**
+ * Generates a per-account rate-limit key using the Discord ID.
+ * Each authenticated account gets its own bucket regardless of IP sharing.
+ * The fallback is never reached in practice because sessionLimiterSkip
+ * returns true for unauthenticated requests.
+ * @param req - Express request object
+ * @returns Discord ID for authenticated users, or "__unauthenticated__" fallback
+ */
 export function sessionLimiterKey(req: Request): string {
   return req.session?.user?.discordId ?? '__unauthenticated__';
 }
 
-/** sessionLimiter skip — only applies to authenticated, non-Streamdeck requests. */
+/**
+ * Determines whether to skip the per-session rate limiter.
+ * Only applies to authenticated, non-Streamdeck requests.
+ * @param req - Express request object
+ * @returns true if the session limiter should be skipped
+ */
 export function sessionLimiterSkip(req: Request): boolean {
   return req.path.startsWith('/api/streamdeck') || !req.session?.user;
 }
 
-/** streamdeckLimiter keyGenerator — keys by Bearer token so each API key gets
- *  its own bucket regardless of which IP the request originates from. */
+/**
+ * Generates a rate-limit key for the Streamdeck API.
+ * Keys by Bearer token so each API key gets its own bucket regardless of IP.
+ * Falls back to IP-based keying when no Bearer token is present.
+ * @param req - Express request object
+ * @returns Bearer token value, or IP-based fallback key
+ */
 export function streamdeckLimiterKey(req: Request): string {
   const auth = req.headers['authorization'];
   const token = auth?.startsWith('Bearer ') ? auth.slice(7) : null;

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -73,14 +73,10 @@ const generalLimiter = rateLimit({
   limit: 100,
   standardHeaders: 'draft-8',
   legacyHeaders: false,
-  // Authenticated users are keyed by Discord ID so each account gets its own
-  // bucket regardless of IP sharing (proxies, NAT). Unauthenticated requests
-  // fall back to IP. Streamdeck API has its own limiter and is excluded here.
-  keyGenerator: (req) => {
-    if (req.path.startsWith('/api/streamdeck')) return '__streamdeck__';
-    return req.session?.user?.discordId ?? (req.ip ?? req.socket?.remoteAddress ?? 'unknown');
-  },
-  skip: (req) => req.path.startsWith('/api/streamdeck'),
+  keyGenerator: ipKey,
+  // Skip authenticated users (covered by sessionLimiter) and the Streamdeck API
+  // (its own limiter). This prevents panel pollers from exhausting the shared IP bucket.
+  skip: (req) => req.path.startsWith('/api/streamdeck') || !!req.session?.user,
 });
 // Tighter limit for auth endpoints to protect against OAuth quota exhaustion
 const authLimiter = rateLimit({
@@ -104,6 +100,18 @@ const streamdeckLimiter = rateLimit({
     return token ?? ipKeyGenerator(req.ip ?? req.socket?.remoteAddress ?? 'unknown');
   },
   message: 'Too many requests, please try again shortly.',
+});
+// Per-account limit for session-authenticated panel users. Dashboard polling alone
+// can reach ~420 req/15 min (status + command-monitor + streams-live), so 600 gives
+// headroom while still capping a compromised or runaway session. Skips unauthenticated
+// requests (covered by generalLimiter) and the Streamdeck API (its own limiter).
+const sessionLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 600,
+  standardHeaders: 'draft-8',
+  legacyHeaders: false,
+  keyGenerator: (req) => req.session?.user?.discordId ?? '__unauthenticated__',
+  skip: (req) => req.path.startsWith('/api/streamdeck') || !req.session?.user,
 });
 // Body parsers
 app.use(express.urlencoded({ extended: false }));
@@ -133,8 +141,9 @@ app.use(
   }),
 );
 
-// General rate limiter — placed after session so authenticated users can be skipped
+// Rate limiters — placed after session middleware so req.session is populated
 app.use(generalLimiter);
+app.use(sessionLimiter);
 
 app.use((req, res, next) => {
   res.locals.user = req.session.user ?? null;

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -73,10 +73,14 @@ const generalLimiter = rateLimit({
   limit: 100,
   standardHeaders: 'draft-8',
   legacyHeaders: false,
-  keyGenerator: ipKey,
-  // Skip authenticated users (session already proves identity) and the Streamdeck API
-  // which has its own limiter. This prevents panel pollers from exhausting the budget.
-  skip: (req) => req.path.startsWith('/api/streamdeck') || !!req.session?.user,
+  // Authenticated users are keyed by Discord ID so each account gets its own
+  // bucket regardless of IP sharing (proxies, NAT). Unauthenticated requests
+  // fall back to IP. Streamdeck API has its own limiter and is excluded here.
+  keyGenerator: (req) => {
+    if (req.path.startsWith('/api/streamdeck')) return '__streamdeck__';
+    return req.session?.user?.discordId ?? (req.ip ?? req.socket?.remoteAddress ?? 'unknown');
+  },
+  skip: (req) => req.path.startsWith('/api/streamdeck'),
 });
 // Tighter limit for auth endpoints to protect against OAuth quota exhaustion
 const authLimiter = rateLimit({

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -4,7 +4,7 @@ import type { ErrorRequestHandler } from 'express';
 import session from 'express-session';
 import MySQLStore from 'express-mysql-session';
 import helmet from 'helmet';
-import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
+import rateLimit from 'express-rate-limit';
 import path from 'path';
 import { WEB_PORT, SESSION_SECRET, DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME } from '../shared/config';
 
@@ -30,6 +30,13 @@ import overlaySourceRouter from './routes/overlaySource';
 import overlayAdminRouter from './routes/overlayAdmin';
 import { requireAuth } from './middleware';
 import { ensureSessionCsrfToken } from './csrf';
+import {
+  ipKey,
+  generalLimiterSkip,
+  sessionLimiterKey,
+  sessionLimiterSkip,
+  streamdeckLimiterKey,
+} from './rateLimits';
 
 const app = express();
 
@@ -66,17 +73,13 @@ app.set('views', path.join(__dirname, '../../views'));
 app.use(express.static(path.join(__dirname, '../../public')));
 
 // Rate limiting — applied after static assets so file downloads aren't counted
-const ipKey = (req: express.Request) => ipKeyGenerator(req.ip ?? req.socket?.remoteAddress ?? 'unknown');
-
 const generalLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   limit: 100,
   standardHeaders: 'draft-8',
   legacyHeaders: false,
   keyGenerator: ipKey,
-  // Skip authenticated users (covered by sessionLimiter) and the Streamdeck API
-  // (its own limiter). This prevents panel pollers from exhausting the shared IP bucket.
-  skip: (req) => req.path.startsWith('/api/streamdeck') || !!req.session?.user,
+  skip: generalLimiterSkip,
 });
 // Tighter limit for auth endpoints to protect against OAuth quota exhaustion
 const authLimiter = rateLimit({
@@ -94,11 +97,7 @@ const streamdeckLimiter = rateLimit({
   limit: 120,
   standardHeaders: 'draft-8',
   legacyHeaders: false,
-  keyGenerator: (req) => {
-    const auth = req.headers['authorization'];
-    const token = auth?.startsWith('Bearer ') ? auth.slice(7) : null;
-    return token ?? ipKeyGenerator(req.ip ?? req.socket?.remoteAddress ?? 'unknown');
-  },
+  keyGenerator: streamdeckLimiterKey,
   message: 'Too many requests, please try again shortly.',
 });
 // Per-account limit for session-authenticated panel users. Dashboard polling alone
@@ -110,8 +109,8 @@ const sessionLimiter = rateLimit({
   limit: 600,
   standardHeaders: 'draft-8',
   legacyHeaders: false,
-  keyGenerator: (req) => req.session?.user?.discordId ?? '__unauthenticated__',
-  skip: (req) => req.path.startsWith('/api/streamdeck') || !req.session?.user,
+  keyGenerator: sessionLimiterKey,
+  skip: sessionLimiterSkip,
 });
 // Body parsers
 app.use(express.urlencoded({ extended: false }));


### PR DESCRIPTION
## Issue

`generalLimiter` unconditionally skipped every request where `req.session?.user` was truthy:

```ts
skip: (req) => req.path.startsWith('/api/streamdeck') || !!req.session?.user,
```

Any authenticated account — including the lowest-privilege User level — could make unlimited requests to every route. This left the video upload endpoint (Multer buffers up to 100 MB in RAM per request), voice-control API, and admin mutation endpoints completely unthrottled for any logged-in user. A compromised or malicious account could exhaust database connections or allocate large amounts of heap by hammering these endpoints.

The comment explains the original intent: prevent panel pollers from exhausting the shared IP bucket when multiple users share a NAT/proxy IP. That's a valid concern but a blanket skip is the wrong solution.

## Fix

Changed the `keyGenerator` to use the authenticated user's Discord ID when present, so each account gets its own 100-requests-per-15-minutes bucket regardless of IP sharing. Unauthenticated requests still key by IP. The Streamdeck API retains its dedicated limiter and is excluded via `skip`.

```ts
keyGenerator: (req) => {
  if (req.path.startsWith('/api/streamdeck')) return '__streamdeck__';
  return req.session?.user?.discordId ?? (req.ip ?? req.socket?.remoteAddress ?? 'unknown');
},
skip: (req) => req.path.startsWith('/api/streamdeck'),
```

## Severity

**High** — any authenticated user bypassed all general rate limiting, leaving resource-intensive endpoints unprotected.

## Label

`security`

https://claude.ai/code/session_01C42xo4Gr7nLy9fe18mg7ep

---
_Generated by [Claude Code](https://claude.ai/code/session_01C42xo4Gr7nLy9fe18mg7ep)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved rate limiting for authenticated panel users: 15-minute window with a higher capacity.

* **Refactor**
  * Centralized rate-limit logic with clearer token-vs-IP keying, special-case handling for the streamdeck endpoint, and middleware ordering to ensure session-aware limits.

* **Tests**
  * Added unit tests covering keying and skip/allow behavior for rate limiting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->