### PR TITLE
fix: remove direct process.env access from EJS template

### DIFF
--- a/src/web/routes/overlayAdmin.test.ts
+++ b/src/web/routes/overlayAdmin.test.ts
@@ -35,7 +35,7 @@ vi.mock('../../shared/logger', () => ({
 
 vi.mock('./overlayAdminMutations', async () => {
   const { Router } = await import('express');
-  return { router: Router() };
+  return { router: Router(), MAX_UPLOAD_MB: 100 };
 });
 
 import express from 'express';

--- a/src/web/routes/overlayAdmin.ts
+++ b/src/web/routes/overlayAdmin.ts
@@ -9,7 +9,7 @@ import { PUBLIC_URL } from '../../shared/config';
 import { getCustomRewards, TwitchCustomReward } from '../../twitch/twitchApi';
 import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
 import { filterQueryParam } from './shared';
-import { router as mutationsRouter } from './overlayAdminMutations';
+import { router as mutationsRouter, MAX_UPLOAD_MB } from './overlayAdminMutations';
 import { router as rewardMutationsRouter } from './overlayAdminRewardMutations';
 
 const log = createLogger('OverlayAdmin');
@@ -55,6 +55,7 @@ router.get('/settings', requireAuth, csrfProtection, async (req, res) => {
       rewards,
       twitchRewards,
       baseUrl: PUBLIC_URL,
+      maxFileMb: MAX_UPLOAD_MB,
       error:   filterQueryParam(req.query.error,   KNOWN_ERRORS),
       success: filterQueryParam(req.query.success, KNOWN_SUCCESSES),
     });

--- a/src/web/routes/overlayAdminMutations.ts
+++ b/src/web/routes/overlayAdminMutations.ts
@@ -19,7 +19,9 @@ const log = createLogger('OverlayAdmin');
 export const router = Router();
 
 const parsedMaxMb = parseInt(process.env.OVERLAY_MAX_FILE_MB ?? '100', 10);
-const MAX_FILE_BYTES = (Number.isFinite(parsedMaxMb) && parsedMaxMb > 0 ? parsedMaxMb : 100) * 1024 * 1024;
+/** Maximum upload size in megabytes, passed to templates to avoid direct process.env access in EJS. */
+export const MAX_UPLOAD_MB = Number.isFinite(parsedMaxMb) && parsedMaxMb > 0 ? parsedMaxMb : 100;
+const MAX_FILE_BYTES = MAX_UPLOAD_MB * 1024 * 1024;
 
 export const upload = multer({
   storage: multer.memoryStorage(),

--- a/views/overlayAdmin.ejs
+++ b/views/overlayAdmin.ejs
@@ -84,7 +84,7 @@
                 <button type="submit" class="btn">Upload</button>
               </div>
             </div>
-            <p class="hint" style="margin-top:0.4rem;">WebM with alpha channel recommended for transparent overlays. Max <%= process.env.OVERLAY_MAX_FILE_MB || '100' %> MB.</p>
+            <p class="hint" style="margin-top:0.4rem;">WebM with alpha channel recommended for transparent overlays. Max <%= maxFileMb %> MB.</p>
           </form>
         </div>
       </div>


### PR DESCRIPTION
## Issue

`views/overlayAdmin.ejs` read an environment variable directly:

```ejs
Max <%= process.env.OVERLAY_MAX_FILE_MB || '100' %> MB.
```

EJS templates have access to the full Node.js `process` object. While this specific read (`OVERLAY_MAX_FILE_MB`) is benign, it establishes a pattern where the entire `process.env` — including `SESSION_SECRET`, `DISCORD_CLIENT_SECRET`, `TWITCH_OAUTH_TOKEN`, `DB_PASSWORD` — is reachable from any template. A future author using `<%-` (unescaped) or reading a sensitive key by mistake could leak secrets to clients.

## Fix

- Export `MAX_UPLOAD_MB` (the already-parsed and range-validated integer) from `overlayAdminMutations.ts` — it was already computed there for the Multer limit.
- Pass it as `maxFileMb` from the route handler in `overlayAdmin.ts`.
- Replace `<%= process.env.OVERLAY_MAX_FILE_MB || '100' %>` with `<%= maxFileMb %>` in the template.
- Update the test mock to include `MAX_UPLOAD_MB: 100`.

## Severity

**Low** — the specific access is harmless today, but the pattern creates future risk.

## Label

`security`

https://claude.ai/code/session_01C42xo4Gr7nLy9fe18mg7ep

---
_Generated by [Claude Code](https://claude.ai/code/session_01C42xo4Gr7nLy9fe18mg7ep)_