### PR TITLE
fix: truncate Multer originalname when used as video display name

### DIFF
--- a/src/web/routes/overlayAdminMutations.ts
+++ b/src/web/routes/overlayAdminMutations.ts
@@ -53,7 +53,7 @@ router.post('/settings/videos/upload', requireAuth, upload.single('video'), csrf
     const streamer = await requireStreamer(req, res);
     if (!streamer) return;
     if (!req.file) return res.redirect('/overlay/settings?error=invalid_file');
-    const name = (typeof req.body?.name === 'string' ? req.body.name.trim().slice(0, 100) : '') || req.file.originalname;
+    const name = (typeof req.body?.name === 'string' ? req.body.name.trim().slice(0, 100) : '') || req.file.originalname.trim().slice(0, 100);
     await saveVideoFile(streamer, req.file, name);
     res.redirect('/overlay/settings?success=video_uploaded');
   } catch (err: any) {


### PR DESCRIPTION
## Issue

When no `name` field was provided in the upload form, the route fell back to `req.file.originalname` as the display name stored in the database:

```ts
const name = (typeof req.body?.name === 'string' ? req.body.name.trim().slice(0, 100) : '') || req.file.originalname;
```

`originalname` is taken directly from the `filename` parameter of the multipart `Content-Disposition` header and can contain arbitrary characters, null bytes, Unicode control characters, or strings of arbitrary length. There was no length cap or character sanitisation applied before it was inserted into the database. The user-supplied `name` field already had `.trim().slice(0, 100)` applied; the `originalname` fallback was inconsistent.

## Fix

Apply the same `.trim().slice(0, 100)` treatment to `originalname`:

```ts
const name = (…) || req.file.originalname.trim().slice(0, 100);
```

## Severity

**Low** — no XSS risk (EJS escapes with `<%= %>`), but the inconsistency could corrupt stored data or cause issues with downstream processing.

## Label

`security`

https://claude.ai/code/session_01C42xo4Gr7nLy9fe18mg7ep

---
_Generated by [Claude Code](https://claude.ai/code/session_01C42xo4Gr7nLy9fe18mg7ep)_