### PR TITLE
security(Low): validate discord_id as snowflake in add-streamer route

### DIFF
--- a/src/web/routes/streams.test.ts
+++ b/src/web/routes/streams.test.ts
@@ -127,4 +127,20 @@ describe('POST /streams/streamers/add — array and missing input handling', () 
     expect(res.status).toBe(302);
     expect(res.headers.location).toContain('error=missing_fields');
   });
+
+  it('redirects with missing_fields when discord_id is not a valid snowflake', async () => {
+    const res = await supertest(buildApp())
+      .post('/streams/streamers/add')
+      .send('discord_id=not-a-snowflake&group_id=1');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain('error=missing_fields');
+  });
+
+  it('redirects with missing_fields when discord_id is too short', async () => {
+    const res = await supertest(buildApp())
+      .post('/streams/streamers/add')
+      .send('discord_id=1234&group_id=1');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain('error=missing_fields');
+  });
 });

--- a/src/web/routes/streams.ts
+++ b/src/web/routes/streams.ts
@@ -17,7 +17,7 @@ import { csrfProtection } from '../csrf';
 import { requireManager } from '../middleware';
 import { restartTwitchMonitor, getLiveStates } from '../../twitch/monitor/twitchMonitor';
 import { AccessLevel } from '../../db';
-import { parsePositiveIntId, filterQueryParam } from './shared';
+import { parsePositiveIntId, filterQueryParam, normalizeDiscordId } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
@@ -175,7 +175,7 @@ router.post('/streams/groups/remove', requireManager, csrfProtection, async (req
 
 router.post('/streams/streamers/add', requireManager, csrfProtection, async (req, res) => {
   const { discord_id, group_id } = req.body as { discord_id?: string | string[]; group_id?: string | string[] };
-  const discordId = typeof discord_id === 'string' ? discord_id.trim() : null;
+  const discordId = normalizeDiscordId(typeof discord_id === 'string' ? discord_id : undefined);
   const rawGroupId = Array.isArray(group_id) ? group_id[0] : group_id;
   const groupId = typeof rawGroupId === 'string' ? rawGroupId.trim() : null;
   if (!discordId || !groupId) return res.redirect('/admin/streams?error=missing_fields');


### PR DESCRIPTION
## Issue

**Severity: Low**

`POST /streams/streamers/add` accepted any string as `discord_id` — it only called `.trim()` before passing the value to `findUser` and `addStreamer`. An arbitrary string (e.g. SQL-like input, excessively long value) could be forwarded to the database layer without any structural check.

## Fix

Replace the bare `.trim()` with `normalizeDiscordId` from `./shared`, which enforces the 17–20 digit snowflake pattern:

```ts
// Before
const discordId = typeof discord_id === 'string' ? discord_id.trim() : null;

// After
const discordId = normalizeDiscordId(typeof discord_id === 'string' ? discord_id : undefined);
```

`normalizeDiscordId` returns `null` for anything that doesn't match `/^\d{17,20}$/`, so invalid input is rejected with `error=missing_fields` before touching the DB.

## Tests

Two new test cases added to `streams.test.ts`:
- Non-numeric discord_id (`not-a-snowflake`) → `error=missing_fields`
- Too-short numeric string (`1234`) → `error=missing_fields`

**Label:** `security`  
**Severity:** Low

---
_Generated by [Claude Code](https://claude.ai/code/session_01C42xo4Gr7nLy9fe18mg7ep)_