### PR TITLE
security(Low): cap stream group field lengths before DB write

### DIFF
--- a/src/web/routes/streams.test.ts
+++ b/src/web/routes/streams.test.ts
@@ -40,7 +40,7 @@ vi.mock('../../db/users', () => ({ AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, A
 import express from 'express';
 import supertest from 'supertest';
 import router from './streams';
-import { getAllStreamGroups, getAllStreamers, getAllUsers, findUser, addStreamer } from '../../db';
+import { getAllStreamGroups, getAllStreamers, getAllUsers, findUser, addStreamer, addStreamGroup, updateStreamGroup } from '../../db';
 import { AccessLevel } from '../../db/users';
 
 type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3 };
@@ -65,6 +65,8 @@ beforeEach(() => {
   vi.mocked(getAllUsers).mockResolvedValue([]);
   vi.mocked(findUser).mockResolvedValue(null);
   vi.mocked(addStreamer).mockResolvedValue(undefined);
+  vi.mocked(addStreamGroup).mockResolvedValue(undefined);
+  vi.mocked(updateStreamGroup).mockResolvedValue(undefined);
 });
 
 describe('GET /streams — query param filtering', () => {
@@ -126,5 +128,47 @@ describe('POST /streams/streamers/add — array and missing input handling', () 
       .send('discord_id=100000000000000001');
     expect(res.status).toBe(302);
     expect(res.headers.location).toContain('error=missing_fields');
+  });
+});
+
+describe('POST /streams/groups/add — field length capping', () => {
+  const longStr = (n: number) => 'x'.repeat(n);
+
+  it('truncates name to 100 chars, discordChannel to 20, messages to 2000', async () => {
+    const res = await supertest(buildApp())
+      .post('/streams/groups/add')
+      .send(
+        `name=${longStr(200)}&discord_channel=${longStr(30)}&live_message=${longStr(3000)}&new_game_message=${longStr(3000)}`,
+      );
+    expect(res.status).toBe(302);
+    expect(vi.mocked(addStreamGroup)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: longStr(100),
+        discordChannel: longStr(20),
+        liveMessage: longStr(2000),
+        newGameMessage: longStr(2000),
+      }),
+    );
+  });
+});
+
+describe('POST /streams/groups/update — field length capping', () => {
+  const longStr = (n: number) => 'x'.repeat(n);
+
+  it('truncates name to 100 chars, discordChannel to 20, messages to 2000', async () => {
+    const res = await supertest(buildApp())
+      .post('/streams/groups/update')
+      .send(
+        `group_id=1&name=${longStr(200)}&discord_channel=${longStr(30)}&live_message=${longStr(3000)}&new_game_message=${longStr(3000)}`,
+      );
+    expect(res.status).toBe(302);
+    expect(vi.mocked(updateStreamGroup)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: longStr(100),
+        discordChannel: longStr(20),
+        liveMessage: longStr(2000),
+        newGameMessage: longStr(2000),
+      }),
+    );
   });
 });

--- a/src/web/routes/streams.ts
+++ b/src/web/routes/streams.ts
@@ -108,10 +108,10 @@ router.post('/streams/groups/add', requireManager, csrfProtection, async (req, r
 
   try {
     await addStreamGroup({
-      name: name!.trim(),
-      discordChannel: discord_channel!.trim(),
-      liveMessage: live_message!.trim(),
-      newGameMessage: new_game_message!.trim(),
+      name: name!.trim().slice(0, 100),
+      discordChannel: discord_channel!.trim().slice(0, 20),
+      liveMessage: live_message!.trim().slice(0, 2000),
+      newGameMessage: new_game_message!.trim().slice(0, 2000),
       multiTwitch: multi_twitch,
       deleteOldPosts: delete_old_posts,
     });
@@ -138,10 +138,10 @@ router.post('/streams/groups/update', requireManager, csrfProtection, async (req
   try {
     await updateStreamGroup({
       id: parsedGroupId,
-      name: name!.trim(),
-      discordChannel: discord_channel!.trim(),
-      liveMessage: live_message!.trim(),
-      newGameMessage: new_game_message!.trim(),
+      name: name!.trim().slice(0, 100),
+      discordChannel: discord_channel!.trim().slice(0, 20),
+      liveMessage: live_message!.trim().slice(0, 2000),
+      newGameMessage: new_game_message!.trim().slice(0, 2000),
       multiTwitch: multi_twitch,
       deleteOldPosts: delete_old_posts,
     });


### PR DESCRIPTION
## Issue

**Severity: Low**

The `POST /streams/groups/add` and `POST /streams/groups/update` routes passed `name`, `discord_channel`, `live_message`, and `new_game_message` directly to the DB after only trimming whitespace. There were no length limits, so arbitrarily long strings could be forwarded to MySQL, risking data truncation errors or oversized payloads.

## Fix

Apply `trim().slice(0, N)` to each field before the DB call, matching the existing pattern used elsewhere in the codebase (e.g. overlay video names):

| Field | Limit | Rationale |
|---|---|---|
| `name` | 100 | Reasonable group name length |
| `discord_channel` | 20 | Discord snowflake IDs are max 20 digits |
| `live_message` | 2000 | Discord message character limit |
| `new_game_message` | 2000 | Discord message character limit |

Both the add and update routes are fixed.

## Tests

Two new test suites added to `streams.test.ts` verifying that oversized inputs are silently capped before `addStreamGroup`/`updateStreamGroup` are called.

**Label:** `security`  
**Severity:** Low

---
_Generated by [Claude Code](https://claude.ai/code/session_01C42xo4Gr7nLy9fe18mg7ep)_