### PR TITLE
security(Medium): validate video uploads via magic bytes, not client MIME type

### DIFF
--- a/src/web/routes/overlayAdminMutations.test.ts
+++ b/src/web/routes/overlayAdminMutations.test.ts
@@ -40,10 +40,14 @@ vi.mock('fs', () => ({
 
 import express from 'express';
 import supertest from 'supertest';
-import { router } from './overlayAdminMutations';
+import { router, detectVideoType } from './overlayAdminMutations';
 import { getStreamerByDiscordId, addVideo, deleteVideo } from '../../db';
 import { AccessLevel } from '../../db/users';
 import fs from 'fs';
+
+// Minimal buffers with correct magic bytes for each format
+const WEBM_BUF = Buffer.from([0x1a, 0x45, 0xdf, 0xa3, 0x00, 0x00, 0x00, 0x00]);
+const MP4_BUF  = Buffer.from([0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70]);
 
 type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3 };
 const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: AccessLevel.USER };
@@ -98,23 +102,43 @@ describe('POST /settings/videos/upload', () => {
     const res = await supertest(buildApp())
       .post('/settings/videos/upload')
       .field('name', 'Test Video')
-      .attach('video', Buffer.from('fake video'), { filename: 'test.mp4', contentType: 'video/mp4' });
+      .attach('video', MP4_BUF, { filename: 'test.mp4', contentType: 'video/mp4' });
     expect(res.headers.location).toBe('/overlay/settings?error=upload_failed');
     expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalled();
     const writtenPath = vi.mocked(fs.promises.writeFile).mock.calls[0][0] as string;
     expect(vi.mocked(fs.promises.rm)).toHaveBeenCalledWith(writtenPath, { force: true });
   });
 
-  it('successfully uploads a valid video file', async () => {
+  it('successfully uploads a valid mp4 file', async () => {
     vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
     const res = await supertest(buildApp())
       .post('/settings/videos/upload')
       .field('name', 'Test Video')
-      .attach('video', Buffer.from('fake video'), { filename: 'test.mp4', contentType: 'video/mp4' });
+      .attach('video', MP4_BUF, { filename: 'test.mp4', contentType: 'video/mp4' });
     expect(res.headers.location).toBe('/overlay/settings?success=video_uploaded');
     expect(vi.mocked(fs.promises.mkdir)).toHaveBeenCalled();
     expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalled();
     expect(vi.mocked(addVideo)).toHaveBeenCalled();
+  });
+
+  it('successfully uploads a valid webm file', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp())
+      .post('/settings/videos/upload')
+      .field('name', 'Test WebM')
+      .attach('video', WEBM_BUF, { filename: 'test.webm', contentType: 'video/webm' });
+    expect(res.headers.location).toBe('/overlay/settings?success=video_uploaded');
+    expect(vi.mocked(addVideo)).toHaveBeenCalled();
+  });
+
+  it('rejects a file with no recognised magic bytes even if MIME type is correct', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp())
+      .post('/settings/videos/upload')
+      .field('name', 'Bad File')
+      .attach('video', Buffer.from('not a real video'), { filename: 'evil.mp4', contentType: 'video/mp4' });
+    expect(res.headers.location).toBe('/overlay/settings?error=invalid_file');
+    expect(vi.mocked(fs.promises.writeFile)).not.toHaveBeenCalled();
   });
 });
 
@@ -126,7 +150,7 @@ describe('POST /settings/videos/upload — path traversal protection', () => {
     const res = await supertest(buildApp())
       .post('/settings/videos/upload')
       .field('name', 'Test Video')
-      .attach('video', Buffer.from('fake video'), { filename: 'test.mp4', contentType: 'video/mp4' });
+      .attach('video', MP4_BUF, { filename: 'test.mp4', contentType: 'video/mp4' });
     expect(res.headers.location).toBe('/overlay/settings?error=invalid_path');
     expect(vi.mocked(fs.promises.writeFile)).not.toHaveBeenCalled();
     expect(vi.mocked(addVideo)).not.toHaveBeenCalled();
@@ -137,7 +161,7 @@ describe('POST /settings/videos/upload — path traversal protection', () => {
     const res = await supertest(buildApp())
       .post('/settings/videos/upload')
       .field('name', 'Test Video')
-      .attach('video', Buffer.from('fake video'), { filename: 'test.mp4', contentType: 'video/mp4' });
+      .attach('video', MP4_BUF, { filename: 'test.mp4', contentType: 'video/mp4' });
     expect(res.headers.location).toBe('/overlay/settings?error=invalid_path');
     expect(vi.mocked(fs.promises.writeFile)).not.toHaveBeenCalled();
     expect(vi.mocked(addVideo)).not.toHaveBeenCalled();
@@ -148,7 +172,7 @@ describe('POST /settings/videos/upload — path traversal protection', () => {
     const res = await supertest(buildApp())
       .post('/settings/videos/upload')
       .field('name', 'Test Video')
-      .attach('video', Buffer.from('fake video'), { filename: 'test.mp4', contentType: 'video/mp4' });
+      .attach('video', MP4_BUF, { filename: 'test.mp4', contentType: 'video/mp4' });
     expect(res.headers.location).toBe('/overlay/settings?success=video_uploaded');
     expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalled();
     expect(vi.mocked(addVideo)).toHaveBeenCalled();
@@ -184,5 +208,25 @@ describe('POST /settings/videos/:id/delete', () => {
     const res = await supertest(buildApp()).post('/settings/videos/1/delete');
     expect(res.headers.location).toBe('/overlay/settings?success=video_deleted');
     expect(vi.mocked(fs.promises.rm)).not.toHaveBeenCalled();
+  });
+});
+
+// --- detectVideoType unit tests ---
+
+describe('detectVideoType', () => {
+  it('detects WebM by EBML magic bytes', () => {
+    expect(detectVideoType(Buffer.from([0x1a, 0x45, 0xdf, 0xa3, 0x00, 0x00]))).toBe('webm');
+  });
+
+  it('detects MP4 by ftyp box at bytes 4–7', () => {
+    expect(detectVideoType(Buffer.from([0x00, 0x00, 0x00, 0x1c, 0x66, 0x74, 0x79, 0x70]))).toBe('mp4');
+  });
+
+  it('returns null for unrecognised bytes', () => {
+    expect(detectVideoType(Buffer.from('not a video'))).toBeNull();
+  });
+
+  it('returns null for a buffer that is too short', () => {
+    expect(detectVideoType(Buffer.from([0x1a, 0x45]))).toBeNull();
   });
 });

--- a/src/web/routes/overlayAdminMutations.ts
+++ b/src/web/routes/overlayAdminMutations.ts
@@ -36,10 +36,10 @@ export const upload = multer({
  * MP4: ftyp box signature at bytes 4–7: 0x66 0x74 0x79 0x70
  */
 export function detectVideoType(buf: Buffer): 'webm' | 'mp4' | null {
-  if (buf.length >= 4 && buf[0] === 0x1a && buf[1] === 0x45 && buf[2] === 0xdf && buf[3] === 0xa3) {
+  if (buf.subarray(0, 4).equals(Buffer.from([0x1a, 0x45, 0xdf, 0xa3]))) {
     return 'webm';
   }
-  if (buf.length >= 8 && buf[4] === 0x66 && buf[5] === 0x74 && buf[6] === 0x79 && buf[7] === 0x70) {
+  if (buf.subarray(4, 8).equals(Buffer.from([0x66, 0x74, 0x79, 0x70]))) {
     return 'mp4';
   }
   return null;

--- a/src/web/routes/overlayAdminMutations.ts
+++ b/src/web/routes/overlayAdminMutations.ts
@@ -30,10 +30,26 @@ export const upload = multer({
   },
 });
 
+/**
+ * Detect video type from buffer magic bytes, independent of the client-supplied MIME type.
+ * WebM: EBML header 0x1A 0x45 0xDF 0xA3
+ * MP4: ftyp box signature at bytes 4–7: 0x66 0x74 0x79 0x70
+ */
+export function detectVideoType(buf: Buffer): 'webm' | 'mp4' | null {
+  if (buf.length >= 4 && buf[0] === 0x1a && buf[1] === 0x45 && buf[2] === 0xdf && buf[3] === 0xa3) {
+    return 'webm';
+  }
+  if (buf.length >= 8 && buf[4] === 0x66 && buf[5] === 0x74 && buf[6] === 0x79 && buf[7] === 0x70) {
+    return 'mp4';
+  }
+  return null;
+}
+
 async function saveVideoFile(streamer: DbStreamerEventSub, file: Express.Multer.File, name: string): Promise<void> {
   const dir = safeResolve(OVERLAY_FOLDER, String(streamer.id));
   if (!dir) throw Object.assign(new Error('Path traversal blocked'), { code: 'invalid_path' });
-  const ext = file.mimetype === 'video/webm' ? 'webm' : 'mp4';
+  const ext = detectVideoType(file.buffer);
+  if (!ext) throw Object.assign(new Error('Invalid file type'), { code: 'invalid_file' });
   const filename = `${randomUUID()}.${ext}`;
   await fs.promises.mkdir(dir, { recursive: true });
   const fullPath = path.join(dir, filename);
@@ -56,8 +72,10 @@ router.post('/settings/videos/upload', requireAuth, upload.single('video'), csrf
     const name = (typeof req.body?.name === 'string' ? req.body.name.trim().slice(0, 100) : '') || req.file.originalname;
     await saveVideoFile(streamer, req.file, name);
     res.redirect('/overlay/settings?success=video_uploaded');
-  } catch (err: any) {
-    if (err?.code === 'invalid_path') return res.redirect('/overlay/settings?error=invalid_path');
+  } catch (err: unknown) {
+    const code = (err as any)?.code;
+    if (code === 'invalid_path') return res.redirect('/overlay/settings?error=invalid_path');
+    if (code === 'invalid_file') return res.redirect('/overlay/settings?error=invalid_file');
     log.error('Overlay video upload error:', err);
     res.redirect('/overlay/settings?error=upload_failed');
   }

--- a/src/web/routes/overlayAdminMutations.ts
+++ b/src/web/routes/overlayAdminMutations.ts
@@ -73,7 +73,7 @@ router.post('/settings/videos/upload', requireAuth, upload.single('video'), csrf
     await saveVideoFile(streamer, req.file, name);
     res.redirect('/overlay/settings?success=video_uploaded');
   } catch (err: unknown) {
-    const code = (err as any)?.code;
+    const code = err instanceof Error ? (err as NodeJS.ErrnoException).code : undefined;
     if (code === 'invalid_path') return res.redirect('/overlay/settings?error=invalid_path');
     if (code === 'invalid_file') return res.redirect('/overlay/settings?error=invalid_file');
     log.error('Overlay video upload error:', err);


### PR DESCRIPTION
## Issue

**Severity: Medium**

The overlay video upload route used `file.mimetype` — which comes from the `Content-Type` header sent by the browser — to determine the file extension and validate format. A client can trivially spoof this by sending any file with `Content-Type: video/mp4`, bypassing the format check entirely.

## Fix

Add a `detectVideoType(buf: Buffer)` helper that inspects the file's actual magic bytes:

| Format | Magic bytes |
|---|---|
| WebM | `0x1A 0x45 0xDF 0xA3` (EBML header, bytes 0–3) |
| MP4 | `0x66 0x74 0x79 0x70` (`ftyp` box, bytes 4–7) |

`saveVideoFile` now calls `detectVideoType` on the buffer and:
- Uses the magic-bytes result as the file extension (not `file.mimetype`)
- Throws `{ code: 'invalid_file' }` if the magic bytes don't match either format
- The route's `catch` block redirects to `?error=invalid_file` before any disk write occurs

The multer `fileFilter` is kept as a first-pass check on the declared Content-Type so obvious non-video uploads are rejected before buffering.

## Tests

- Existing tests updated to use minimal valid-magic-byte buffers (`WEBM_BUF`, `MP4_BUF`)
- New: rejects file with no recognised magic bytes even if MIME type is `video/mp4`
- New: `detectVideoType` unit tests for both formats, unknown bytes, and too-short buffer

**Label:** `security`  
**Severity:** Medium

---
_Generated by [Claude Code](https://claude.ai/code/session_01C42xo4Gr7nLy9fe18mg7ep)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Video file uploads are now validated based on actual file content, enhancing upload security and reliability.
  * Invalid video files are properly rejected during the upload process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->