### PR TITLE
security(Medium): cap SSE connections per channel to prevent resource exhaustion

### DIFF
--- a/src/web/routes/overlaySource.test.ts
+++ b/src/web/routes/overlaySource.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../shared/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+}));
+
+vi.mock('../../shared/config', () => ({
+  OVERLAY_FOLDER: '/app/overlay-videos',
+}));
+
+vi.mock('fs', () => ({
+  default: { promises: { access: vi.fn() } },
+}));
+
+import express from 'express';
+import supertest from 'supertest';
+import router, { MAX_SSE_CONNECTIONS_PER_CHANNEL, connections } from './overlaySource';
+
+function buildApp() {
+  const app = express();
+  app.use(router);
+  return app;
+}
+
+beforeEach(() => {
+  connections.clear();
+  vi.clearAllMocks();
+});
+
+describe('MAX_SSE_CONNECTIONS_PER_CHANNEL', () => {
+  it('defaults to 10', () => {
+    expect(MAX_SSE_CONNECTIONS_PER_CHANNEL).toBe(10);
+  });
+});
+
+describe('GET /:login/events — SSE connection limit', () => {
+  it('returns 429 when the per-channel slot is full', async () => {
+    // Pre-fill the channel with dummy response objects to simulate MAX connections
+    const dummies = new Set(
+      Array.from({ length: MAX_SSE_CONNECTIONS_PER_CHANNEL }, () => ({}) as any),
+    );
+    connections.set('testchannel', dummies);
+
+    const res = await supertest(buildApp()).get('/testchannel/events');
+    expect(res.status).toBe(429);
+  });
+
+  it('accepts a connection when the channel is below the limit', async () => {
+    // One fewer than the limit — should not be rejected
+    const dummies = new Set(
+      Array.from({ length: MAX_SSE_CONNECTIONS_PER_CHANNEL - 1 }, () => ({}) as any),
+    );
+    connections.set('testchannel', dummies);
+
+    // SSE responses never complete; timeout at transport level means we just
+    // verify status is not 429 (headers arrive before the body stalls).
+    const req = supertest(buildApp()).get('/testchannel/events');
+    const p = new Promise<number>((resolve) => {
+      req
+        .buffer(false)
+        .parse((_res, _cb) => {
+          resolve(_res.statusCode ?? 0);
+          (_res as any).resume();
+        })
+        .end();
+    });
+    const status = await p;
+    expect(status).not.toBe(429);
+    expect(status).toBe(200);
+  });
+});

--- a/src/web/routes/overlaySource.test.ts
+++ b/src/web/routes/overlaySource.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('../../shared/logger', () => ({
   createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
@@ -28,8 +28,16 @@ beforeEach(() => {
 });
 
 describe('MAX_SSE_CONNECTIONS_PER_CHANNEL', () => {
-  it('defaults to 10', () => {
-    expect(MAX_SSE_CONNECTIONS_PER_CHANNEL).toBe(10);
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('defaults to 10', async () => {
+    vi.stubEnv('OVERLAY_MAX_SSE_PER_CHANNEL', '10');
+    vi.resetModules();
+    const { MAX_SSE_CONNECTIONS_PER_CHANNEL: limit } = await import('./overlaySource.js');
+    expect(limit).toBe(10);
   });
 });
 

--- a/src/web/routes/overlaySource.test.ts
+++ b/src/web/routes/overlaySource.test.ts
@@ -34,7 +34,7 @@ describe('MAX_SSE_CONNECTIONS_PER_CHANNEL', () => {
   });
 
   it('defaults to 10', async () => {
-    vi.stubEnv('OVERLAY_MAX_SSE_PER_CHANNEL', '10');
+    vi.stubEnv('OVERLAY_MAX_SSE_PER_CHANNEL', '');
     vi.resetModules();
     const { MAX_SSE_CONNECTIONS_PER_CHANNEL: limit } = await import('./overlaySource.js');
     expect(limit).toBe(10);

--- a/src/web/routes/overlaySource.ts
+++ b/src/web/routes/overlaySource.ts
@@ -51,8 +51,11 @@ router.get('/:login/events', (req, res, next) => {
   if (!LOGIN_RE.test(login) || RESERVED_LOGINS.has(login.toLowerCase())) { next(); return; }
   const key = login.toLowerCase();
 
-  const existing = connections.get(key);
-  if (existing && existing.size >= MAX_SSE_CONNECTIONS_PER_CHANNEL) {
+  if (!connections.has(key)) connections.set(key, new Set());
+  const clients = connections.get(key)!;
+  clients.add(res);
+  if (clients.size > MAX_SSE_CONNECTIONS_PER_CHANNEL) {
+    clients.delete(res);
     res.status(429).end();
     return;
   }
@@ -64,9 +67,6 @@ router.get('/:login/events', (req, res, next) => {
   res.flushHeaders();
 
   res.write(': connected\n\n');
-
-  if (!connections.has(key)) connections.set(key, new Set());
-  connections.get(key)!.add(res);
 
   const keepalive = setInterval(() => {
     try {

--- a/src/web/routes/overlaySource.ts
+++ b/src/web/routes/overlaySource.ts
@@ -13,7 +13,11 @@ const FILENAME_RE = /^[\w-]+\.(webm|mp4)$/i;
 const RESERVED_LOGINS = new Set(['settings', 'videos']);
 
 // In-memory map of active SSE connections keyed by Twitch channel login (lowercase).
-const connections = new Map<string, Set<import('express').Response>>();
+export const connections = new Map<string, Set<import('express').Response>>();
+
+const parsedMaxSse = parseInt(process.env.OVERLAY_MAX_SSE_PER_CHANNEL ?? '10', 10);
+export const MAX_SSE_CONNECTIONS_PER_CHANNEL =
+  Number.isFinite(parsedMaxSse) && parsedMaxSse > 0 ? parsedMaxSse : 10;
 
 /** Push a video URL to all browser sources connected for this channel. */
 export function pushOverlayEvent(login: string, videoPath: string): void {
@@ -46,6 +50,12 @@ router.get('/:login/events', (req, res, next) => {
   const { login } = req.params;
   if (!LOGIN_RE.test(login) || RESERVED_LOGINS.has(login.toLowerCase())) { next(); return; }
   const key = login.toLowerCase();
+
+  const existing = connections.get(key);
+  if (existing && existing.size >= MAX_SSE_CONNECTIONS_PER_CHANNEL) {
+    res.status(429).end();
+    return;
+  }
 
   res.setHeader('Content-Type', 'text/event-stream');
   res.setHeader('Cache-Control', 'no-cache');


### PR DESCRIPTION
## Issue

**Severity: Medium**

`GET /overlay/:login/events` (the SSE endpoint) had no per-channel connection limit. An attacker could open an unbounded number of persistent SSE connections for any channel login, exhausting server file descriptors and memory without authentication.

## Fix

Add `MAX_SSE_CONNECTIONS_PER_CHANNEL` (default `10`, configurable via `OVERLAY_MAX_SSE_PER_CHANNEL` env var). When a channel's slot count is already at the limit, the incoming connection is immediately rejected with `429 Too Many Requests` before any headers are flushed.

10 connections covers all realistic OBS browser source setups (typically 1–2 per streamer) with headroom for testing.

The `connections` map is exported (`export const`) so tests can pre-fill it without spawning real SSE connections.

## Tests

New `overlaySource.test.ts`:
- `MAX_SSE_CONNECTIONS_PER_CHANNEL` defaults to 10
- Returns 429 when the channel slot is full (pre-filled via `connections` map)
- Accepts a connection when one slot remains

**Label:** `security`  
**Severity:** Medium

---
_Generated by [Claude Code](https://claude.ai/code/session_01C42xo4Gr7nLy9fe18mg7ep)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-channel connection limiting for overlay streaming: new connections are rejected with HTTP 429 when a channel reaches its concurrent connection cap (defaults to 10; adjustable via environment variable).

* **Tests**
  * Added test coverage for the SSE connection limiting behavior, including boundary and rejection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->