### PR TITLE
security(Medium): bind EventSub OAuth callback to authenticated session user

### DIFF
--- a/src/web/routes/eventsubCallback.test.ts
+++ b/src/web/routes/eventsubCallback.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../shared/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+}));
+
+vi.mock('../../db', () => ({
+  getStreamerById: vi.fn(),
+  saveStreamerToken: vi.fn(),
+  initEventConfig: vi.fn(),
+}));
+
+vi.mock('../../twitch/eventsub/twitchApiEventSub', () => ({
+  exchangeCode: vi.fn(),
+  getUserFromToken: vi.fn(),
+}));
+
+vi.mock('../../shared/config', () => ({
+  TWITCH_EVENTSUB_REDIRECT_URI: 'https://example.com/auth/twitch/eventsub/callback',
+}));
+
+vi.mock('../../twitch/eventsub/twitchEventSub', () => ({
+  reloadEventSubSubscriptions: vi.fn(),
+}));
+
+vi.mock('../../twitch/eventsub/twitchEventSubSubscriptions', () => ({
+  clearAuthFailedSubs: vi.fn(),
+}));
+
+import express from 'express';
+import supertest from 'supertest';
+import router from './eventsubCallback';
+import { getStreamerById, saveStreamerToken, initEventConfig } from '../../db';
+import { exchangeCode, getUserFromToken } from '../../twitch/eventsub/twitchApiEventSub';
+
+type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3 };
+
+const MOCK_STREAMER = {
+  id: 1,
+  discord_id: '100000000000000001',
+  twitch_name: 'teststreamer',
+  twitch_user_id: 'twitch123',
+};
+
+const SESSION_USER: SessionUser = {
+  discordId: MOCK_STREAMER.discord_id,
+  discordName: 'TestUser',
+  discordAvatar: null,
+  accessLevel: 1,
+};
+
+function buildApp(sessionOverrides: Record<string, any> = {}) {
+  const app = express();
+  app.use((req: any, _res: any, next: any) => {
+    req.session = {
+      eventsubOAuthState: 'valid-state-abc',
+      eventsubStreamerId: MOCK_STREAMER.id,
+      user: SESSION_USER,
+      ...sessionOverrides,
+    };
+    next();
+  });
+  app.use(router);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getStreamerById).mockResolvedValue(MOCK_STREAMER as any);
+  vi.mocked(exchangeCode).mockResolvedValue({
+    access_token: 'access',
+    refresh_token: 'refresh',
+    expires_in: 3600,
+  } as any);
+  vi.mocked(getUserFromToken).mockResolvedValue({ login: 'teststreamer', id: 'twitch123' } as any);
+  vi.mocked(saveStreamerToken).mockResolvedValue(undefined);
+  vi.mocked(initEventConfig).mockResolvedValue(undefined);
+});
+
+describe('GET /twitch/eventsub/callback — state validation', () => {
+  it('rejects with state_mismatch when state param does not match session', async () => {
+    const res = await supertest(buildApp())
+      .get('/twitch/eventsub/callback?code=abc&state=wrong-state');
+    expect(res.headers.location).toContain('error=eventsub_oauth_state_mismatch');
+  });
+
+  it('rejects with state_mismatch when session has no state', async () => {
+    const res = await supertest(buildApp({ eventsubOAuthState: undefined }))
+      .get('/twitch/eventsub/callback?code=abc&state=valid-state-abc');
+    expect(res.headers.location).toContain('error=eventsub_oauth_state_mismatch');
+  });
+
+  it('redirects with denied error when OAuth returns error param', async () => {
+    const res = await supertest(buildApp())
+      .get('/twitch/eventsub/callback?error=access_denied');
+    expect(res.headers.location).toContain('error=eventsub_oauth_denied');
+  });
+});
+
+describe('GET /twitch/eventsub/callback — user binding', () => {
+  it('rejects when authenticated user does not own the streamer record', async () => {
+    const differentUser: SessionUser = { ...SESSION_USER, discordId: '999999999999999999' };
+    const res = await supertest(buildApp({ user: differentUser }))
+      .get('/twitch/eventsub/callback?code=abc&state=valid-state-abc');
+    expect(res.headers.location).toContain('error=eventsub_oauth_state_mismatch');
+    expect(vi.mocked(saveStreamerToken)).not.toHaveBeenCalled();
+  });
+
+  it('succeeds when authenticated user owns the streamer record', async () => {
+    const res = await supertest(buildApp())
+      .get('/twitch/eventsub/callback?code=abc&state=valid-state-abc');
+    expect(res.headers.location).toContain('success=twitch_connected');
+    expect(vi.mocked(saveStreamerToken)).toHaveBeenCalled();
+  });
+
+  it('succeeds when there is no authenticated user in session (unauthenticated callback)', async () => {
+    const res = await supertest(buildApp({ user: undefined }))
+      .get('/twitch/eventsub/callback?code=abc&state=valid-state-abc');
+    expect(res.headers.location).toContain('success=twitch_connected');
+    expect(vi.mocked(saveStreamerToken)).toHaveBeenCalled();
+  });
+});

--- a/src/web/routes/eventsubCallback.test.ts
+++ b/src/web/routes/eventsubCallback.test.ts
@@ -32,8 +32,9 @@ import supertest from 'supertest';
 import router from './eventsubCallback';
 import { getStreamerById, saveStreamerToken, initEventConfig } from '../../db';
 import { exchangeCode, getUserFromToken } from '../../twitch/eventsub/twitchApiEventSub';
+import { AccessLevel, AccessLevelValue } from '../../db/users';
 
-type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3 };
+type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: AccessLevelValue };
 
 const MOCK_STREAMER = {
   id: 1,
@@ -46,7 +47,7 @@ const SESSION_USER: SessionUser = {
   discordId: MOCK_STREAMER.discord_id,
   discordName: 'TestUser',
   discordAvatar: null,
-  accessLevel: 1,
+  accessLevel: AccessLevel.MOD,
 };
 
 function buildApp(sessionOverrides: Record<string, any> = {}) {
@@ -104,6 +105,8 @@ describe('GET /twitch/eventsub/callback — user binding', () => {
       .get('/twitch/eventsub/callback?code=abc&state=valid-state-abc');
     expect(res.headers.location).toContain('error=eventsub_oauth_state_mismatch');
     expect(vi.mocked(saveStreamerToken)).not.toHaveBeenCalled();
+    expect(vi.mocked(exchangeCode)).not.toHaveBeenCalled();
+    expect(vi.mocked(getUserFromToken)).not.toHaveBeenCalled();
   });
 
   it('succeeds when authenticated user owns the streamer record', async () => {

--- a/src/web/routes/eventsubCallback.ts
+++ b/src/web/routes/eventsubCallback.ts
@@ -40,20 +40,21 @@ router.get('/twitch/eventsub/callback', async (req, res) => {
   }
 
   try {
-    const tokens = await exchangeCode(code, TWITCH_EVENTSUB_REDIRECT_URI);
-    const twitchUser = await getUserFromToken(tokens.access_token);
-    if (!twitchUser) return res.redirect('/user/settings?error=eventsub_token_invalid');
-
     const streamer = await getStreamerById(streamerId);
     if (!streamer) return res.redirect('/user/settings?error=invalid_id');
 
-    // If there is an authenticated session user, verify they own this streamer record.
-    // Prevents a shared-browser scenario where a different user completes another's OAuth flow.
+    // If there is an authenticated session user, verify they own this streamer record before
+    // consuming the one-time OAuth code. Prevents a shared-browser scenario where a different
+    // user completes another's OAuth flow.
     const sessionUser = req.session.user;
     if (sessionUser && streamer.discord_id !== sessionUser.discordId) {
       log.warn(`EventSub OAuth user mismatch: session user ${sessionUser.discordId} does not own streamer ${streamerId}`);
       return res.redirect('/user/settings?error=eventsub_oauth_state_mismatch');
     }
+
+    const tokens = await exchangeCode(code, TWITCH_EVENTSUB_REDIRECT_URI);
+    const twitchUser = await getUserFromToken(tokens.access_token);
+    if (!twitchUser) return res.redirect('/user/settings?error=eventsub_token_invalid');
 
     const expectedLogin = streamer.twitch_name?.toLowerCase();
     if (!expectedLogin || twitchUser.login.toLowerCase() !== expectedLogin) {

--- a/src/web/routes/eventsubCallback.ts
+++ b/src/web/routes/eventsubCallback.ts
@@ -47,6 +47,14 @@ router.get('/twitch/eventsub/callback', async (req, res) => {
     const streamer = await getStreamerById(streamerId);
     if (!streamer) return res.redirect('/user/settings?error=invalid_id');
 
+    // If there is an authenticated session user, verify they own this streamer record.
+    // Prevents a shared-browser scenario where a different user completes another's OAuth flow.
+    const sessionUser = req.session.user;
+    if (sessionUser && streamer.discord_id !== sessionUser.discordId) {
+      log.warn(`EventSub OAuth user mismatch: session user ${sessionUser.discordId} does not own streamer ${streamerId}`);
+      return res.redirect('/user/settings?error=eventsub_oauth_state_mismatch');
+    }
+
     const expectedLogin = streamer.twitch_name?.toLowerCase();
     if (!expectedLogin || twitchUser.login.toLowerCase() !== expectedLogin) {
       log.warn(`EventSub OAuth mismatch: expected ${streamer.twitch_name ?? 'unknown'}, got ${twitchUser.login}`);


### PR DESCRIPTION
## Issue

**Severity: Medium**

The `GET /auth/twitch/eventsub/callback` route verified the OAuth `state` parameter (preventing CSRF) and the returned Twitch login (preventing wrong-account swaps), but it did not cross-check the currently authenticated Discord user against the streamer record being authorised. In a shared-browser or session-theft scenario, a different Discord user with access to the same browser session could complete an OAuth flow initiated by the original user, attaching their Twitch credentials to the wrong Discord account.

## Fix

After loading the streamer by `eventsubStreamerId`, if `req.session.user` is present (the user is still authenticated), verify that `streamer.discord_id === sessionUser.discordId` before proceeding. Mismatches redirect to `?error=eventsub_oauth_state_mismatch` and the token is never saved.

Unauthenticated callbacks (Twitch has redirected back and the session may not have a `user` object) are unaffected — the existing state nonce + Twitch login checks cover that path.

```ts
const sessionUser = req.session.user;
if (sessionUser && streamer.discord_id !== sessionUser.discordId) {
  log.warn(`EventSub OAuth user mismatch: session user ${sessionUser.discordId} does not own streamer ${streamerId}`);
  return res.redirect('/user/settings?error=eventsub_oauth_state_mismatch');
}
```

## Tests

New `eventsubCallback.test.ts`:
- State mismatch cases (wrong state, missing session state, OAuth error param)
- Rejects when authenticated user's `discordId` doesn't match `streamer.discord_id`
- Succeeds when authenticated user owns the streamer record
- Succeeds when there is no authenticated user (normal redirect-back path)

**Label:** `security`  
**Severity:** Medium

---
_Generated by [Claude Code](https://claude.ai/code/session_01C42xo4Gr7nLy9fe18mg7ep)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added ownership verification to the Twitch EventSub OAuth callback so only streamer owners can connect Twitch; callback now halts and redirects on ownership or state mismatches.

* **Tests**
  * Added end-to-end tests covering OAuth state validation, denial handling, ownership checks, and successful connect flows with token save verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->