### PR TITLE
security(Low): accept CSRF token via X-CSRF-Token and X-XSRF-Token headers

### DIFF
--- a/src/web/csrf.test.ts
+++ b/src/web/csrf.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest';
+import express from 'express';
+import supertest from 'supertest';
+import { csrfProtection } from './csrf';
+
+const SESSION_TOKEN = 'a'.repeat(64); // 32 hex bytes
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: false }));
+  app.use((req: any, _res: any, next: any) => {
+    req.session = { csrfToken: SESSION_TOKEN };
+    next();
+  });
+  app.use(csrfProtection);
+  app.use((err: any, _req: any, res: any, _next: any) => {
+    res.status(err?.code === 'EBADCSRFTOKEN' ? 403 : 500).json({ code: err?.code });
+  });
+  app.post('/test', (_req, res) => res.json({ ok: true }));
+  app.get('/test', (_req, res) => res.json({ ok: true }));
+  return app;
+}
+
+describe('csrfProtection — safe methods', () => {
+  it('allows GET without a token', async () => {
+    const res = await supertest(buildApp()).get('/test');
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('csrfProtection — body token', () => {
+  it('accepts POST with correct _csrf in body', async () => {
+    const res = await supertest(buildApp())
+      .post('/test')
+      .send(`_csrf=${SESSION_TOKEN}`)
+      .set('Content-Type', 'application/x-www-form-urlencoded');
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects POST with wrong _csrf in body', async () => {
+    const res = await supertest(buildApp())
+      .post('/test')
+      .send('_csrf=wrong-token')
+      .set('Content-Type', 'application/x-www-form-urlencoded');
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('EBADCSRFTOKEN');
+  });
+
+  it('rejects POST with no token', async () => {
+    const res = await supertest(buildApp()).post('/test');
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('csrfProtection — X-CSRF-Token header', () => {
+  it('accepts POST with correct X-CSRF-Token header', async () => {
+    const res = await supertest(buildApp())
+      .post('/test')
+      .set('X-CSRF-Token', SESSION_TOKEN);
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects POST with wrong X-CSRF-Token header', async () => {
+    const res = await supertest(buildApp())
+      .post('/test')
+      .set('X-CSRF-Token', 'bad-token');
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('EBADCSRFTOKEN');
+  });
+});
+
+describe('csrfProtection — X-XSRF-Token header', () => {
+  it('accepts POST with correct X-XSRF-Token header', async () => {
+    const res = await supertest(buildApp())
+      .post('/test')
+      .set('X-XSRF-Token', SESSION_TOKEN);
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects POST with wrong X-XSRF-Token header', async () => {
+    const res = await supertest(buildApp())
+      .post('/test')
+      .set('X-XSRF-Token', 'bad-token');
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('csrfProtection — body takes priority over header', () => {
+  it('uses body token when both are present', async () => {
+    const res = await supertest(buildApp())
+      .post('/test')
+      .send(`_csrf=${SESSION_TOKEN}`)
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .set('X-CSRF-Token', 'wrong-header-token');
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/web/csrf.ts
+++ b/src/web/csrf.ts
@@ -18,9 +18,10 @@ export function ensureSessionCsrfToken(req: Parameters<RequestHandler>[0]): stri
 }
 
 function getSubmittedCsrfToken(req: Parameters<RequestHandler>[0]): string | null {
-  if (typeof req.body?._csrf === 'string') {
-    return req.body._csrf;
-  }
+  if (typeof req.body?._csrf === 'string') return req.body._csrf;
+
+  const header = req.headers['x-csrf-token'] ?? req.headers['x-xsrf-token'];
+  if (typeof header === 'string') return header;
 
   return null;
 }


### PR DESCRIPTION
## Issue

**Severity: Low**

The CSRF middleware only read the submitted token from `req.body._csrf`. This made it impossible to protect fetch/XHR-based mutations without encoding the token in the request body — the standard approach for programmatic clients is to set a request header instead.

## Fix

Extend `getSubmittedCsrfToken` to also check:
1. `X-CSRF-Token` (widely used standard header)
2. `X-XSRF-Token` (Angular / axios cookie-based convention)

Body field retains priority when both are present, preserving existing form behaviour:

```ts
function getSubmittedCsrfToken(req): string | null {
  if (typeof req.body?._csrf === 'string') return req.body._csrf;
  const header = req.headers['x-csrf-token'] ?? req.headers['x-xsrf-token'];
  if (typeof header === 'string') return header;
  return null;
}
```

No change to session token generation or the timing-safe comparison.

## Tests

New `csrf.test.ts` covering:
- Safe methods (GET) pass through without a token
- Correct/incorrect body `_csrf` field
- Correct/incorrect `X-CSRF-Token` header
- Correct/incorrect `X-XSRF-Token` header
- Body takes priority over header when both are present

**Label:** `security`  
**Severity:** Low

---
_Generated by [Claude Code](https://claude.ai/code/session_01C42xo4Gr7nLy9fe18mg7ep)_