### PR TITLE
fix(Medium): add cleanup interval to prevent sessionCache unbounded growth

### DIFF
--- a/src/commands/customCommandHandler.test.ts
+++ b/src/commands/customCommandHandler.test.ts
@@ -27,6 +27,8 @@ import {
   executeCustomCommandForDiscord,
   executeCustomCommandForTwitch,
   registerTwitchChatRuntime,
+  purgeExpiredSessionCache,
+  sessionCache,
 } from './customCommandHandler';
 import { getCustomCommandForDiscord, getCustomCommandForTwitchChannel } from '../db';
 import { recordCommandTestEntry } from './commandMonitorStore';
@@ -158,5 +160,44 @@ describe('executeCustomCommandForTwitch', () => {
     // Falls back to source channel only
     expect(mockRuntime.send).toHaveBeenCalledTimes(1);
     expect(mockRuntime.send).toHaveBeenCalledWith('#a', 'Hi!');
+  });
+});
+
+// ─── Session cache cleanup ────────────────────────────────────────────────────
+
+describe('purgeExpiredSessionCache', () => {
+  beforeEach(() => {
+    sessionCache.clear();
+  });
+
+  it('removes entries whose expiry has passed', () => {
+    const now = Date.now();
+    sessionCache.set('user-expired', { sessionId: 'abc', expiry: now - 1 });
+    sessionCache.set('user-fresh',   { sessionId: 'xyz', expiry: now + 60_000 });
+
+    purgeExpiredSessionCache();
+
+    expect(sessionCache.has('user-expired')).toBe(false);
+    expect(sessionCache.has('user-fresh')).toBe(true);
+  });
+
+  it('leaves all entries intact when none have expired', () => {
+    const now = Date.now();
+    sessionCache.set('user-a', { sessionId: '1', expiry: now + 10_000 });
+    sessionCache.set('user-b', { sessionId: '2', expiry: now + 20_000 });
+
+    purgeExpiredSessionCache();
+
+    expect(sessionCache.size).toBe(2);
+  });
+
+  it('empties the map when all entries have expired', () => {
+    const past = Date.now() - 1000;
+    sessionCache.set('user-a', { sessionId: '1', expiry: past });
+    sessionCache.set('user-b', { sessionId: '2', expiry: past });
+
+    purgeExpiredSessionCache();
+
+    expect(sessionCache.size).toBe(0);
   });
 });

--- a/src/commands/customCommandHandler.ts
+++ b/src/commands/customCommandHandler.ts
@@ -55,8 +55,19 @@ interface SessionCacheEntry {
 }
 const SESSION_CACHE_TTL_MS = 30_000;
 const SHORT_RETRY_TTL_MS = 5_000;
-const sessionCache = new Map<string, SessionCacheEntry>();
+export const sessionCache = new Map<string, SessionCacheEntry>();
 const inFlightRefreshes = new Map<string, Promise<void>>();
+
+/** Remove all entries whose TTL has elapsed. Called by the cleanup interval and exported for tests. */
+export function purgeExpiredSessionCache(): void {
+  const now = Date.now();
+  for (const [userId, entry] of sessionCache) {
+    if (now > entry.expiry) sessionCache.delete(userId);
+  }
+}
+
+// Purge expired entries so the cache does not grow without bound over long uptimes.
+setInterval(purgeExpiredSessionCache, SESSION_CACHE_TTL_MS).unref();
 
 export async function resolveSharedChatSessionId(userId: string): Promise<string | null> {
   const now = Date.now();


### PR DESCRIPTION
## Issue

**Severity: Medium**

`sessionCache` in `customCommandHandler.ts` stored per-user Twitch shared-chat session IDs with an `expiry` timestamp, but nothing ever removed entries from the `Map` once they expired. On long-running instances with many unique callers (multiple channel deployments, large numbers of chatters), the Map grows without bound, leaking memory proportional to the number of distinct user IDs ever seen.

## Fix

Extract a `purgeExpiredSessionCache()` function that iterates the Map and deletes entries whose `expiry` has elapsed, then schedule it on `setInterval(…, SESSION_CACHE_TTL_MS).unref()` so it runs every 30 s and doesn't prevent process exit.

The function is exported (as is `sessionCache`) so tests can assert directly without fighting fake-timer module-import ordering.

## Tests

Three new cases in `purgeExpiredSessionCache` describe block:
- Removes only the expired entry, leaving fresh entries intact
- No-ops when all entries are still fresh
- Empties the map when all entries have expired

**Label:** `code-review`  
**Severity:** Medium

---
_Generated by [Claude Code](https://claude.ai/code/session_01C42xo4Gr7nLy9fe18mg7ep)_