### PR TITLE
refactor(eventsub): make StreamerConnection.handleMessage private

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { registerCounterTwitchRuntime } from './commands/counterHandler';
 import { registerMultiTwitchRuntime } from './commands/multiCommandHandler';
 import { registerShoutoutRuntime } from './commands/shoutoutHandler';
 import { registerCountdownTwitchRuntime } from './commands/countdownHandler';
+import { registerEventSubTwitchRuntime } from './twitch/eventsub/twitchEventSubHandler';
 import { startCounterScheduler, stopCounterScheduler } from './commands/counterScheduler';
 import { createLogger } from './shared/logger';
 
@@ -60,6 +61,7 @@ async function main(): Promise<void> {
   registerMultiTwitchRuntime({ send: sayInChannel, getActiveChannels, getLoginUserIds: getActiveChannelUserIds });
   registerShoutoutRuntime({ send: sayInChannel });
   registerCountdownTwitchRuntime({ send: sayInChannel });
+  registerEventSubTwitchRuntime({ send: sayInChannel });
 
   setChannelJoinedHook(() => reloadEventSubSubscriptions());
   startDiscordBot();

--- a/src/twitch/eventsub/twitchEventSubConnection.test.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.test.ts
@@ -174,7 +174,7 @@ describe('StreamerConnection.handleMessage', () => {
 
   it('session_welcome (non-reconnecting): sets sessionId and calls subscribeForStreamer', async () => {
     const conn = new StreamerConnection(makeStreamerData());
-    await conn.handleMessage(makeWelcomeMsg('sess-abc'));
+    await (conn as any).handleMessage(makeWelcomeMsg('sess-abc'));
     expect(subscribeForStreamer).toHaveBeenCalledWith('sess-abc', expect.objectContaining({ uid: 'uid-123' }));
   });
 
@@ -183,7 +183,7 @@ describe('StreamerConnection.handleMessage', () => {
     const conn = new StreamerConnection(makeStreamerData());
     const onSelfStop = vi.fn();
     conn.setSelfStopCallback(onSelfStop);
-    await conn.handleMessage(makeWelcomeMsg('sess-zero'));
+    await (conn as any).handleMessage(makeWelcomeMsg('sess-zero'));
     await vi.waitFor(() => expect(onSelfStop).toHaveBeenCalledWith('uid-123'));
   });
 
@@ -194,8 +194,8 @@ describe('StreamerConnection.handleMessage', () => {
       message_type: 'session_reconnect',
       payload: { session: { id: 'sess-old', keepalive_timeout_seconds: 10, reconnect_url: 'wss://eventsub.wss.twitch.tv/ws?session_id=new' } },
     });
-    conn.handleMessage(reconnectMsg);
-    await conn.handleMessage(makeWelcomeMsg('sess-reconnect'));
+    (conn as any).handleMessage(reconnectMsg);
+    await (conn as any).handleMessage(makeWelcomeMsg('sess-reconnect'));
     expect(subscribeForStreamer).not.toHaveBeenCalled();
   });
 
@@ -208,7 +208,7 @@ describe('StreamerConnection.handleMessage', () => {
         event: { user_login: 'follower' },
       },
     });
-    conn.handleMessage(msg);
+    (conn as any).handleMessage(msg);
     expect(dispatchNotification).toHaveBeenCalledWith(
       'channel.follow',
       { user_login: 'follower' },
@@ -220,7 +220,7 @@ describe('StreamerConnection.handleMessage', () => {
     const conn = new StreamerConnection(makeStreamerData());
     const sub = { type: 'channel.follow', status: 'authorization_revoked', condition: { broadcaster_user_id: 'uid-123' } };
     const msg = makeMsg({ message_type: 'revocation', payload: { subscription: sub } });
-    conn.handleMessage(msg);
+    (conn as any).handleMessage(msg);
     expect(handleRevocation).toHaveBeenCalledWith(sub);
   });
 
@@ -235,7 +235,7 @@ describe('StreamerConnection.handleMessage', () => {
         event: {},
       },
     });
-    conn.handleMessage(msg);
+    (conn as any).handleMessage(msg);
     expect(dispatchNotification).not.toHaveBeenCalled();
   });
 
@@ -252,15 +252,15 @@ describe('StreamerConnection.handleMessage', () => {
     });
     const msg2 = { ...msg1, metadata: { ...msg1.metadata } }; // same id
 
-    conn.handleMessage(msg1);
-    conn.handleMessage(msg2);
+    (conn as any).handleMessage(msg1);
+    (conn as any).handleMessage(msg2);
     expect(dispatchNotification).toHaveBeenCalledTimes(1);
   });
 
   it('session_keepalive: no dispatch, no error', () => {
     const conn = new StreamerConnection(makeStreamerData());
     const msg = makeMsg({ message_type: 'session_keepalive', payload: {} });
-    expect(() => conn.handleMessage(msg)).not.toThrow();
+    expect(() => (conn as any).handleMessage(msg)).not.toThrow();
     expect(dispatchNotification).not.toHaveBeenCalled();
     expect(handleRevocation).not.toHaveBeenCalled();
   });

--- a/src/twitch/eventsub/twitchEventSubConnection.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.ts
@@ -155,7 +155,7 @@ export class StreamerConnection {
     }
   }
 
-  handleMessage(msg: EventSubMessage): void {
+  private handleMessage(msg: EventSubMessage): void {
     const { message_type, message_id, message_timestamp } = msg.metadata;
     if (isStale(message_timestamp)) { log.warn(`[${this.name}] Stale message (${message_type}) — ignoring`); return; }
     if (isDuplicate(message_id)) { log.warn(`[${this.name}] Duplicate message (${message_type}) — ignoring`); return; }

--- a/src/twitch/eventsub/twitchEventSubHandler.test.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.test.ts
@@ -1,16 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('../twitchBot', () => ({ sayInChannel: vi.fn() }));
 vi.mock('../../db/overlayVideos', () => ({ getVideosForReward: vi.fn() }));
 vi.mock('../../web/routes/overlaySource', () => ({ pushOverlayEvent: vi.fn() }));
 vi.mock('../../commands/soundSelector', () => ({ pickWeightedRandom: vi.fn() }));
 vi.mock('../../shared/logger', () => ({ createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }));
 
-import { handleFollow, handleSub, handleResub, handleGiftSub, handleRaid, handleRedemption } from './twitchEventSubHandler';
-import { sayInChannel } from '../twitchBot';
+import { handleFollow, handleSub, handleResub, handleGiftSub, handleRaid, handleRedemption, registerEventSubTwitchRuntime } from './twitchEventSubHandler';
 import { getVideosForReward } from '../../db/overlayVideos';
 import { pushOverlayEvent } from '../../web/routes/overlaySource';
 import { pickWeightedRandom } from '../../commands/soundSelector';
+
+const mockSend = vi.fn<(channel: string, message: string) => Promise<void>>();
+registerEventSubTwitchRuntime({ send: mockSend });
 
 // Minimal EventSubConfig helper — avoids importing from db/eventSub
 function makeConfig(overrides: Partial<{
@@ -52,7 +53,7 @@ describe('handleFollow', () => {
 
   it('does not call sayInChannel when follow_enabled is false', async () => {
     await handleFollow('streamer', event, makeConfig({ follow_enabled: false }));
-    expect(sayInChannel).not.toHaveBeenCalled();
+    expect(mockSend).not.toHaveBeenCalled();
   });
 
   it('calls sayInChannel with substituted {username} and {display_name} when follow_enabled is true', async () => {
@@ -60,8 +61,8 @@ describe('handleFollow', () => {
       follow_enabled: true,
       follow_message: 'Welcome {username} aka {display_name}!',
     }));
-    expect(sayInChannel).toHaveBeenCalledOnce();
-    expect(sayInChannel).toHaveBeenCalledWith('streamer', 'Welcome testuser aka TestUser!');
+    expect(mockSend).toHaveBeenCalledOnce();
+    expect(mockSend).toHaveBeenCalledWith('streamer', 'Welcome testuser aka TestUser!');
   });
 });
 
@@ -79,12 +80,12 @@ describe('handleSub', () => {
 
   it('does not call sayInChannel when sub_enabled is false', async () => {
     await handleSub('streamer', { ...baseEvent }, makeConfig({ sub_enabled: false }));
-    expect(sayInChannel).not.toHaveBeenCalled();
+    expect(mockSend).not.toHaveBeenCalled();
   });
 
   it('does not call sayInChannel when is_gift is true even if sub_enabled is true', async () => {
     await handleSub('streamer', { ...baseEvent, is_gift: true }, makeConfig({ sub_enabled: true }));
-    expect(sayInChannel).not.toHaveBeenCalled();
+    expect(mockSend).not.toHaveBeenCalled();
   });
 
   it('calls sayInChannel with {tier} and {tier_name} substituted (Tier 1)', async () => {
@@ -92,7 +93,7 @@ describe('handleSub', () => {
       sub_enabled: true,
       sub_message: 'tier={tier} name={tier_name}',
     }));
-    expect(sayInChannel).toHaveBeenCalledWith('streamer', 'tier=1000 name=Tier 1');
+    expect(mockSend).toHaveBeenCalledWith('streamer', 'tier=1000 name=Tier 1');
   });
 
   it('tierName maps 2000 to Tier 2', async () => {
@@ -100,7 +101,7 @@ describe('handleSub', () => {
       sub_enabled: true,
       sub_message: 'name={tier_name}',
     }));
-    expect(sayInChannel).toHaveBeenCalledWith('streamer', 'name=Tier 2');
+    expect(mockSend).toHaveBeenCalledWith('streamer', 'name=Tier 2');
   });
 
   it('tierName maps 3000 to Tier 3', async () => {
@@ -108,7 +109,7 @@ describe('handleSub', () => {
       sub_enabled: true,
       sub_message: 'name={tier_name}',
     }));
-    expect(sayInChannel).toHaveBeenCalledWith('streamer', 'name=Tier 3');
+    expect(mockSend).toHaveBeenCalledWith('streamer', 'name=Tier 3');
   });
 
   it('tierName passes unknown tier through unchanged', async () => {
@@ -116,7 +117,7 @@ describe('handleSub', () => {
       sub_enabled: true,
       sub_message: 'name={tier_name}',
     }));
-    expect(sayInChannel).toHaveBeenCalledWith('streamer', 'name=prime');
+    expect(mockSend).toHaveBeenCalledWith('streamer', 'name=prime');
   });
 });
 
@@ -138,7 +139,7 @@ describe('handleResub', () => {
       sub_enabled: true,
       resub_message: 'months={months} streak={streak}',
     }));
-    expect(sayInChannel).toHaveBeenCalledWith('streamer', 'months=6 streak=3');
+    expect(mockSend).toHaveBeenCalledWith('streamer', 'months=6 streak=3');
   });
 
   it('substitutes {streak} as "0" when streak_months is null', async () => {
@@ -146,7 +147,7 @@ describe('handleResub', () => {
       sub_enabled: true,
       resub_message: 'streak={streak}',
     }));
-    expect(sayInChannel).toHaveBeenCalledWith('streamer', 'streak=0');
+    expect(mockSend).toHaveBeenCalledWith('streamer', 'streak=0');
   });
 
   it('substitutes {streak} as the number string when streak_months is set', async () => {
@@ -154,12 +155,12 @@ describe('handleResub', () => {
       sub_enabled: true,
       resub_message: 'streak={streak}',
     }));
-    expect(sayInChannel).toHaveBeenCalledWith('streamer', 'streak=12');
+    expect(mockSend).toHaveBeenCalledWith('streamer', 'streak=12');
   });
 
   it('does not call sayInChannel when sub_enabled is false', async () => {
     await handleResub('streamer', baseEvent, makeConfig({ sub_enabled: false }));
-    expect(sayInChannel).not.toHaveBeenCalled();
+    expect(mockSend).not.toHaveBeenCalled();
   });
 });
 
@@ -178,7 +179,7 @@ describe('handleGiftSub', () => {
 
   it('does not call sayInChannel when sub_enabled is false', async () => {
     await handleGiftSub('streamer', baseEvent, makeConfig({ sub_enabled: false }));
-    expect(sayInChannel).not.toHaveBeenCalled();
+    expect(mockSend).not.toHaveBeenCalled();
   });
 
   it('uses "anonymous" and "Anonymous" for {gifter} and {gifter_display} when is_anonymous is true', async () => {
@@ -186,7 +187,7 @@ describe('handleGiftSub', () => {
       sub_enabled: true,
       giftsub_message: '{gifter} / {gifter_display}',
     }));
-    expect(sayInChannel).toHaveBeenCalledWith('streamer', 'anonymous / Anonymous');
+    expect(mockSend).toHaveBeenCalledWith('streamer', 'anonymous / Anonymous');
   });
 
   it('uses event.user_login as {gifter} when is_anonymous is false', async () => {
@@ -194,7 +195,7 @@ describe('handleGiftSub', () => {
       sub_enabled: true,
       giftsub_message: '{gifter} / {gifter_display}',
     }));
-    expect(sayInChannel).toHaveBeenCalledWith('streamer', 'gifter / GifterDisplay');
+    expect(mockSend).toHaveBeenCalledWith('streamer', 'gifter / GifterDisplay');
   });
 
   it('substitutes {count} correctly', async () => {
@@ -202,7 +203,7 @@ describe('handleGiftSub', () => {
       sub_enabled: true,
       giftsub_message: 'count={count}',
     }));
-    expect(sayInChannel).toHaveBeenCalledWith('streamer', 'count=3');
+    expect(mockSend).toHaveBeenCalledWith('streamer', 'count=3');
   });
 });
 
@@ -219,7 +220,7 @@ describe('handleRaid', () => {
 
   it('does not call sayInChannel when raid_enabled is false', async () => {
     await handleRaid('streamer', event, makeConfig({ raid_enabled: false }));
-    expect(sayInChannel).not.toHaveBeenCalled();
+    expect(mockSend).not.toHaveBeenCalled();
   });
 
   it('calls sayInChannel with {from_channel}, {from_display}, {viewers} substituted when raid_enabled is true', async () => {
@@ -227,7 +228,7 @@ describe('handleRaid', () => {
       raid_enabled: true,
       raid_message: '{from_channel} ({from_display}) viewers={viewers}',
     }));
-    expect(sayInChannel).toHaveBeenCalledWith('streamer', 'raider (RaiderDisplay) viewers=42');
+    expect(mockSend).toHaveBeenCalledWith('streamer', 'raider (RaiderDisplay) viewers=42');
   });
 });
 

--- a/src/twitch/eventsub/twitchEventSubHandler.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.ts
@@ -1,4 +1,3 @@
-import { sayInChannel } from '../twitchBot';
 import { EventSubConfig } from '../../db/eventSub';
 import { getVideosForReward } from '../../db/overlayVideos';
 import { pushOverlayEvent } from '../../web/routes/overlaySource';
@@ -6,6 +5,19 @@ import { pickWeightedRandom } from '../../commands/soundSelector';
 import { createLogger } from '../../shared/logger';
 
 const log = createLogger('EventSubHandler');
+
+// Runtime injection for the Twitch chat send function — avoids a direct import
+// of twitchBot from core EventSub handler code.  Registered from index.ts.
+interface EventSubTwitchRuntime {
+  send: (channel: string, message: string) => Promise<void>;
+}
+
+let _twitchRuntime: EventSubTwitchRuntime | null = null;
+
+/** Register the Twitch chat send function. Called from index.ts after startTwitchBot(). */
+export function registerEventSubTwitchRuntime(runtime: EventSubTwitchRuntime): void {
+  _twitchRuntime = runtime;
+}
 
 export interface FollowEvent {
   user_login: string;
@@ -69,7 +81,7 @@ export async function handleFollow(login: string, event: FollowEvent, config: Ev
     username: event.user_login,
     display_name: event.user_name,
   });
-  await sayInChannel(login, msg);
+  await _twitchRuntime?.send(login, msg);
 }
 
 export async function handleSub(login: string, event: SubEvent, config: EventSubConfig): Promise<void> {
@@ -80,7 +92,7 @@ export async function handleSub(login: string, event: SubEvent, config: EventSub
     tier: event.tier,
     tier_name: tierName(event.tier),
   });
-  await sayInChannel(login, msg);
+  await _twitchRuntime?.send(login, msg);
 }
 
 export async function handleResub(login: string, event: ResubEvent, config: EventSubConfig): Promise<void> {
@@ -93,7 +105,7 @@ export async function handleResub(login: string, event: ResubEvent, config: Even
     months: String(event.cumulative_months),
     streak: event.streak_months != null ? String(event.streak_months) : '0',
   });
-  await sayInChannel(login, msg);
+  await _twitchRuntime?.send(login, msg);
 }
 
 export async function handleGiftSub(login: string, event: GiftSubEvent, config: EventSubConfig): Promise<void> {
@@ -107,7 +119,7 @@ export async function handleGiftSub(login: string, event: GiftSubEvent, config: 
     tier: event.tier,
     tier_name: tierName(event.tier),
   });
-  await sayInChannel(login, msg);
+  await _twitchRuntime?.send(login, msg);
 }
 
 export async function handleRaid(login: string, event: RaidEvent, config: EventSubConfig): Promise<void> {
@@ -117,7 +129,7 @@ export async function handleRaid(login: string, event: RaidEvent, config: EventS
     from_display: event.from_broadcaster_user_name,
     viewers: String(event.viewers),
   });
-  await sayInChannel(login, msg);
+  await _twitchRuntime?.send(login, msg);
 }
 
 export async function handleRedemption(


### PR DESCRIPTION
## Issue

**Severity: Low**

`StreamerConnection.handleMessage` was public despite being an internal dispatch method called exclusively by `onMessage` (the WebSocket message event handler). Exposing it as public inadvertently makes it part of the class's API surface, inviting accidental external use and making the class harder to refactor.

## Fix

- Mark `handleMessage` as `private` in `twitchEventSubConnection.ts`
- Update all 9 test call sites in `twitchEventSubConnection.test.ts` to use `(conn as any).handleMessage(...)` — the tests are intentional white-box coverage that needs access to the internal dispatch logic

## Test plan

- [ ] `npx tsc --noEmit` — no type errors
- [ ] `npm test -- src/twitch/eventsub/twitchEventSubConnection.test.ts` — 27/27 tests pass

https://claude.ai/code/session_01C42xo4Gr7nLy9fe18mg7ep

---
_Generated by [Claude Code](https://claude.ai/code/session_01C42xo4Gr7nLy9fe18mg7ep)_