### PR TITLE
CLOSED: superseded by #239

### DIFF
--- a/src/web/csrf.ts
+++ b/src/web/csrf.ts
@@ -18,6 +18,12 @@ export function ensureSessionCsrfToken(req: Parameters<RequestHandler>[0]): stri
 }
 
 function getSubmittedCsrfToken(req: Parameters<RequestHandler>[0]): string | null {
+  // Check header first so CSRF can be validated before multipart body parsing (e.g. file uploads).
+  const header = req.headers['x-csrf-token'];
+  if (typeof header === 'string' && header.length > 0) {
+    return header;
+  }
+
   if (typeof req.body?._csrf === 'string') {
     return req.body._csrf;
   }

--- a/src/web/routes/overlayAdminMutations.test.ts
+++ b/src/web/routes/overlayAdminMutations.test.ts
@@ -14,10 +14,10 @@ vi.mock('../../db', () => ({
 }));
 
 vi.mock('../csrf', () => ({
-  csrfProtection: (req: any, _res: any, next: any) => {
+  csrfProtection: vi.fn((req: any, _res: any, next: any) => {
     req.csrfToken = () => 'test-csrf-token';
     next();
-  },
+  }),
 }));
 
 vi.mock('../middleware', () => ({
@@ -44,6 +44,7 @@ import { router } from './overlayAdminMutations';
 import { getStreamerByDiscordId, addVideo, deleteVideo } from '../../db';
 import { AccessLevel } from '../../db/users';
 import fs from 'fs';
+import { csrfProtection } from '../csrf';
 
 type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3 };
 const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: AccessLevel.USER };
@@ -115,6 +116,26 @@ describe('POST /settings/videos/upload', () => {
     expect(vi.mocked(fs.promises.mkdir)).toHaveBeenCalled();
     expect(vi.mocked(fs.promises.writeFile)).toHaveBeenCalled();
     expect(vi.mocked(addVideo)).toHaveBeenCalled();
+  });
+});
+
+// --- POST /settings/videos/upload - CSRF Protection ---
+
+describe('POST /settings/videos/upload — CSRF protection', () => {
+  it('rejects with 403 and does not invoke Multer when CSRF token is invalid', async () => {
+    vi.mocked(csrfProtection).mockImplementationOnce((_req, res, _next) => {
+      res.status(403).send('invalid csrf token');
+    });
+
+    const res = await supertest(buildApp())
+      .post('/settings/videos/upload')
+      .field('name', 'Test Video')
+      .attach('video', Buffer.from('fake video'), { filename: 'test.mp4', contentType: 'video/mp4' });
+
+    expect(res.status).toBe(403);
+    // Multer file processing must not have proceeded: no file written, no DB call
+    expect(vi.mocked(fs.promises.writeFile)).not.toHaveBeenCalled();
+    expect(vi.mocked(addVideo)).not.toHaveBeenCalled();
   });
 });
 

--- a/src/web/routes/overlayAdminMutations.ts
+++ b/src/web/routes/overlayAdminMutations.ts
@@ -48,7 +48,7 @@ async function saveVideoFile(streamer: DbStreamerEventSub, file: Express.Multer.
 }
 
 // POST /overlay/settings/videos/upload
-router.post('/settings/videos/upload', requireAuth, upload.single('video'), csrfProtection, async (req, res) => {
+router.post('/settings/videos/upload', requireAuth, csrfProtection, upload.single('video'), async (req, res) => {
   try {
     const streamer = await requireStreamer(req, res);
     if (!streamer) return;


### PR DESCRIPTION
## Summary

- Move `csrfProtection` before `upload.single('video')` in the video upload route so CSRF is validated before multipart file data is processed by Multer
- Add `x-csrf-token` header support to `getSubmittedCsrfToken` so the token can be sent via header (necessary since Multer hasn't parsed the body yet when CSRF runs now)
- Add a CSRF rejection test: mocks `csrfProtection` to return 403, sends a multipart POST, and asserts `fs.promises.writeFile` and `addVideo` are never called — confirming Multer file handling does not proceed on CSRF failure

## Test plan

- [ ] All 1045 existing tests pass (`npm test`)
- [ ] New test `POST /settings/videos/upload — CSRF protection` passes and verifies 403 response + no file I/O or DB calls when CSRF is invalid

https://claude.ai/code/session_01GNNmdBumo96xWXDQ1PYRdQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GNNmdBumo96xWXDQ1PYRdQ)_