### PR TITLE
Per-streamer Discord audio routing

### DIFF
--- a/migrations/add_discord_guild_routing.sql
+++ b/migrations/add_discord_guild_routing.sql
@@ -1,0 +1,6 @@
+-- Add per-user Discord guild routing so each streamer's SFX plays in their own server.
+-- discord_guild_id: Discord server (guild) snowflake the user's SFX audio should play in.
+-- NULL means fall back to the bot-wide DISCORD_GUILD_ID env-var default.
+-- The bot resolves which voice channel to use dynamically based on where the user is sitting.
+ALTER TABLE `user`
+  ADD COLUMN `discord_guild_id` VARCHAR(20) NULL DEFAULT NULL;

--- a/src/audio/audioPlayer.ts
+++ b/src/audio/audioPlayer.ts
@@ -13,7 +13,6 @@ import {
   type DiscordGatewayAdapterLibraryMethods,
 } from '@discordjs/voice';
 import { Client, ChannelType, type VoiceBasedChannel } from 'discord.js';
-import { DISCORD_GUILD_ID, DISCORD_VOICE_CHANNEL_ID } from '../shared/config';
 import { setVoiceConnected, setVoiceDisconnected, setVoiceIdle } from '../shared/statusStore';
 
 const log = createLogger('AudioPlayer');
@@ -24,25 +23,65 @@ import {
   releasePreviousConnection,
   cleanupFailedConnect,
 } from './audioConnectionHandlers';
+import type { GuildAudioContext } from './audioTypes';
 
-let connection: VoiceConnection | null = null;
-let player: DjsAudioPlayer;
-let playing = false;
+// ─── Per-guild session state ──────────────────────────────────────────────────
+
+interface AudioSession {
+  connection: VoiceConnection | null;
+  player: DjsAudioPlayer;
+  playing: boolean;
+  adapterCleanup: (() => void) | null;
+  reconnectTimer: NodeJS.Timeout | null;
+  reconnectAttempts: number;
+  shouldAutoReconnect: boolean;
+  currentAttemptId: number;
+  currentChannelId: string | null;
+  targetChannelId: string | undefined;
+}
+
+const sessions = new Map<string, AudioSession>();
 let activeClient: Client | null = null;
-let reconnectTimer: NodeJS.Timeout | null = null;
-let reconnectAttempts = 0;
-let shouldAutoReconnect = false;
-let currentAttemptId = 0;
-let currentChannelId: string | null = null;
-let targetChannelId: string | undefined = undefined;
+
+function getOrCreateSession(guildId: string): AudioSession {
+  const existing = sessions.get(guildId);
+  if (existing) return existing;
+
+  const player = createAudioPlayer({
+    behaviors: { noSubscriber: NoSubscriberBehavior.Pause },
+  });
+  player.on(AudioPlayerStatus.Idle, () => {
+    const s = sessions.get(guildId);
+    if (s) {
+      s.playing = false;
+      setVoiceIdle();
+    }
+  });
+  player.on('error', (err) => {
+    log.error(`[${guildId}] Error: ${err.message}`, err);
+    const s = sessions.get(guildId);
+    if (s) s.playing = false;
+  });
+
+  const session: AudioSession = {
+    connection: null,
+    player,
+    playing: false,
+    adapterCleanup: null,
+    reconnectTimer: null,
+    reconnectAttempts: 0,
+    shouldAutoReconnect: false,
+    currentAttemptId: 0,
+    currentChannelId: null,
+    targetChannelId: undefined,
+  };
+  sessions.set(guildId, session);
+  return session;
+}
 
 // ─── Voice adapter ────────────────────────────────────────────────────────────
 // Bypasses discord.js's built-in voiceAdapterCreator to avoid type/version
 // incompatibilities with discord.js v14. Listens to raw gateway events instead.
-
-// Tracks the cleanup function for the currently active adapter so it can be
-// removed before a new one is registered, preventing listener accumulation.
-let activeAdapterCleanup: (() => void) | null = null;
 
 type RawPacket = { t: string; d: Record<string, unknown> };
 
@@ -61,6 +100,7 @@ function makeAdapterCleanup(
   channel: VoiceBasedChannel,
   onRaw: (packet: RawPacket) => void,
   originalMax: number,
+  session: AudioSession,
 ): () => void {
   let cleanedUp = false;
   return function cleanup(): void {
@@ -68,13 +108,13 @@ function makeAdapterCleanup(
     cleanedUp = true;
     channel.client.off('raw', onRaw);
     if (originalMax !== 0) channel.client.setMaxListeners(originalMax);
-    activeAdapterCleanup = null;
+    session.adapterCleanup = null;
   };
 }
 
-function buildAdapter(channel: VoiceBasedChannel): DiscordGatewayAdapterCreator {
+function buildAdapter(channel: VoiceBasedChannel, session: AudioSession): DiscordGatewayAdapterCreator {
   return (methods: DiscordGatewayAdapterLibraryMethods) => {
-    if (activeAdapterCleanup) activeAdapterCleanup();
+    if (session.adapterCleanup) session.adapterCleanup();
 
     const onRaw = makeOnRaw(methods);
     const originalMax = channel.client.getMaxListeners();
@@ -82,8 +122,8 @@ function buildAdapter(channel: VoiceBasedChannel): DiscordGatewayAdapterCreator 
     if (originalMax !== 0) channel.client.setMaxListeners(originalMax + 1);
     channel.client.on('raw', onRaw);
 
-    const cleanup = makeAdapterCleanup(channel, onRaw, originalMax);
-    activeAdapterCleanup = cleanup;
+    const cleanup = makeAdapterCleanup(channel, onRaw, originalMax, session);
+    session.adapterCleanup = cleanup;
 
     return {
       sendPayload: (payload: unknown) => {
@@ -106,111 +146,101 @@ const RECONNECT_BASE_DELAY_MS = 5_000;
 const RECONNECT_MAX_DELAY_MS = 60_000;
 const VOICE_CONNECT_TIMEOUT_MS = 30_000;
 
-function clearReconnectTimer(): void {
-  if (reconnectTimer) {
-    clearTimeout(reconnectTimer);
-    reconnectTimer = null;
+function clearReconnectTimer(session: AudioSession): void {
+  if (session.reconnectTimer) {
+    clearTimeout(session.reconnectTimer);
+    session.reconnectTimer = null;
   }
 }
 
-function scheduleReconnect(reason: string): void {
-  if (!shouldAutoReconnect || !activeClient || reconnectTimer || connection) return;
+function scheduleReconnect(guildId: string, reason: string): void {
+  const session = sessions.get(guildId);
+  if (!session) return;
+  if (!session.shouldAutoReconnect || !activeClient || session.reconnectTimer || session.connection) return;
 
-  const scheduledAttemptId = currentAttemptId;
-  const delay = Math.min(RECONNECT_BASE_DELAY_MS * 2 ** reconnectAttempts, RECONNECT_MAX_DELAY_MS);
-  reconnectAttempts += 1;
+  const scheduledAttemptId = session.currentAttemptId;
+  const delay = Math.min(RECONNECT_BASE_DELAY_MS * 2 ** session.reconnectAttempts, RECONNECT_MAX_DELAY_MS);
+  session.reconnectAttempts += 1;
 
-  log.warn(`Scheduling voice rejoin in ${delay}ms (${reason}).`);
-  reconnectTimer = setTimeout(() => {
-    reconnectTimer = null;
-    if (scheduledAttemptId !== currentAttemptId) return;
-    if (!shouldAutoReconnect || !activeClient || connection) return;
-    connect(activeClient, targetChannelId).catch((err) => {
-      log.error('Voice rejoin failed:', err);
+  log.warn(`[${guildId}] Scheduling voice rejoin in ${delay}ms (${reason}).`);
+  session.reconnectTimer = setTimeout(() => {
+    session.reconnectTimer = null;
+    if (scheduledAttemptId !== session.currentAttemptId) return;
+    if (!session.shouldAutoReconnect || !activeClient || session.connection) return;
+    if (!session.targetChannelId) return;
+    connect(activeClient, { guildId, voiceChannelId: session.targetChannelId }).catch((err) => {
+      log.error(`[${guildId}] Voice rejoin failed:`, err);
     });
   }, delay);
 }
 
-function getPlayer(): DjsAudioPlayer {
-  if (!player) {
-    player = createAudioPlayer({
-      behaviors: { noSubscriber: NoSubscriberBehavior.Pause },
-    });
-    player.on(AudioPlayerStatus.Idle, () => {
-      playing = false;
-      setVoiceIdle();
-    });
-    player.on('error', (err) => {
-      log.error(`Error: ${err.message}`, err);
-      playing = false;
-    });
-  }
-  return player;
-}
-
-function tearDownPlayer(): void {
+function tearDownSession(guildId: string): void {
+  const session = sessions.get(guildId);
+  if (!session) return;
   try {
-    getPlayer().stop(true);
+    session.player.stop(true);
   } catch {
     // Ignore audio stop errors during disconnect cleanup.
   }
-  playing = false;
-  currentChannelId = null;
+  session.playing = false;
+  session.currentChannelId = null;
   setVoiceDisconnected();
 }
 
-function makeDeps(): ConnectionHandlerDeps {
+function makeDeps(guildId: string): ConnectionHandlerDeps {
+  const session = getOrCreateSession(guildId);
   return {
-    getAttemptId: () => currentAttemptId,
-    getConnection: () => connection,
-    setConnection: (c) => { connection = c; },
-    tearDown: tearDownPlayer,
-    scheduleReconnect,
+    getAttemptId: () => session.currentAttemptId,
+    getConnection: () => session.connection,
+    setConnection: (c) => { session.connection = c; },
+    tearDown: () => tearDownSession(guildId),
+    scheduleReconnect: (reason) => scheduleReconnect(guildId, reason),
   };
 }
 
 /**
- * Join the specified voice channel or the configured one and subscribe the audio player.
- * Should be called once the Discord client is ready.
+ * Join the specified voice channel in the given guild and subscribe the audio player.
+ * Creates a new per-guild session if one does not already exist.
  */
-export async function connect(client: Client, channelId?: string): Promise<void> {
-  clearReconnectTimer();
-  const attemptId = ++currentAttemptId;
+export async function connect(client: Client, ctx: GuildAudioContext): Promise<void> {
+  const { guildId, voiceChannelId } = ctx;
+  const session = getOrCreateSession(guildId);
+
+  clearReconnectTimer(session);
+  const attemptId = ++session.currentAttemptId;
   let nextConnection: VoiceConnection | null = null;
 
   activeClient = client;
-  targetChannelId = channelId;
-  shouldAutoReconnect = true;
+  session.targetChannelId = voiceChannelId;
+  session.shouldAutoReconnect = true;
 
-  const previousConnection = connection;
-  const deps = makeDeps();
+  const previousConnection = session.connection;
+  const deps = makeDeps(guildId);
 
   try {
-    const resolvedChannelId = channelId || DISCORD_VOICE_CHANNEL_ID;
-
-    if (!DISCORD_GUILD_ID || !resolvedChannelId) {
-      throw new Error('Missing DISCORD_GUILD_ID or voice channel ID');
+    if (!guildId || !voiceChannelId) {
+      throw new Error('Missing guildId or voiceChannelId');
     }
 
-    const guild = await client.guilds.fetch(DISCORD_GUILD_ID);
-    if (attemptId !== currentAttemptId) return;
+    const guild = await client.guilds.fetch(guildId);
+    if (attemptId !== session.currentAttemptId) return;
 
-    const channel = await guild.channels.fetch(resolvedChannelId);
-    if (attemptId !== currentAttemptId) return;
+    const channel = await guild.channels.fetch(voiceChannelId);
+    if (attemptId !== session.currentAttemptId) return;
 
     if (!channel || channel.type !== ChannelType.GuildVoice) {
-      throw new Error(`Channel ${resolvedChannelId} is not a voice channel`);
+      throw new Error(`Channel ${voiceChannelId} is not a voice channel`);
     }
 
     nextConnection = joinVoiceChannel({
       channelId: channel.id,
       guildId: guild.id,
-      adapterCreator: buildAdapter(channel),
+      adapterCreator: buildAdapter(channel, session),
       selfDeaf: false,
       selfMute: false,
     });
 
-    if (attemptId !== currentAttemptId) {
+    if (attemptId !== session.currentAttemptId) {
       nextConnection.destroy();
       return;
     }
@@ -220,31 +250,31 @@ export async function connect(client: Client, channelId?: string): Promise<void>
 
     await entersState(joinedConnection, VoiceConnectionStatus.Ready, VOICE_CONNECT_TIMEOUT_MS);
 
-    if (attemptId !== currentAttemptId) {
+    if (attemptId !== session.currentAttemptId) {
       joinedConnection.destroy();
       return;
     }
 
     releasePreviousConnection(previousConnection, joinedConnection, deps);
-    connection = joinedConnection;
-    currentChannelId = channel.id;
+    session.connection = joinedConnection;
+    session.currentChannelId = channel.id;
 
-    clearReconnectTimer();
-    log.info('Voice connection ready.');
-    reconnectAttempts = 0;
+    clearReconnectTimer(session);
+    log.info(`[${guildId}] Voice connection ready.`);
+    session.reconnectAttempts = 0;
 
-    joinedConnection.subscribe(getPlayer());
+    joinedConnection.subscribe(session.player);
     setVoiceConnected(channel.name);
-    log.info(`Joined voice channel: ${channel.name}`);
+    log.info(`[${guildId}] Joined voice channel: ${channel.name}`);
   } catch (err) {
-    if (attemptId === currentAttemptId) {
+    if (attemptId === session.currentAttemptId) {
       cleanupFailedConnect(previousConnection, nextConnection, deps);
     } else {
       nextConnection?.destroy();
     }
 
-    if (attemptId === currentAttemptId && shouldAutoReconnect && !isPermanentVoiceMisconfigurationError(err)) {
-      scheduleReconnect('connect failed');
+    if (attemptId === session.currentAttemptId && session.shouldAutoReconnect && !isPermanentVoiceMisconfigurationError(err)) {
+      scheduleReconnect(guildId, 'connect failed');
     }
 
     throw err;
@@ -252,50 +282,80 @@ export async function connect(client: Client, channelId?: string): Promise<void>
 }
 
 /**
- * Disconnect from the current voice channel, if connected.
+ * Disconnect from the voice channel for a specific guild.
  * Safe to call when already disconnected.
  */
-export function disconnect(): void {
-  currentAttemptId += 1;
-  shouldAutoReconnect = false;
-  activeClient = null;
-  targetChannelId = undefined;
-  clearReconnectTimer();
-  reconnectAttempts = 0;
-  currentChannelId = null;
+export function disconnect(guildId: string): void {
+  const session = sessions.get(guildId);
+  if (!session) return;
 
-  const existingConnection = connection;
+  session.currentAttemptId += 1;
+  session.shouldAutoReconnect = false;
+  session.targetChannelId = undefined;
+  clearReconnectTimer(session);
+  session.reconnectAttempts = 0;
+  session.currentChannelId = null;
+
+  const existingConnection = session.connection;
   if (existingConnection) {
     existingConnection.destroy();
-    connection = null;
+    session.connection = null;
     try {
-      getPlayer().stop(true);
+      session.player.stop(true);
     } catch {
       // Ignore audio stop errors during disconnect cleanup.
     }
-    playing = false;
+    session.playing = false;
     setVoiceDisconnected();
-    log.info('Disconnected from voice channel.');
+    log.info(`[${guildId}] Disconnected from voice channel.`);
   }
 }
 
-/** Returns true if a sound is currently being played. */
-export function isPlaying(): boolean {
-  return playing;
+/**
+ * Disconnect all active guild voice sessions. Called during process shutdown.
+ */
+export function disconnectAll(): void {
+  for (const guildId of sessions.keys()) {
+    disconnect(guildId);
+  }
+  sessions.clear();
+  activeClient = null;
 }
 
-/** Returns true if the bot is currently joined to a voice channel. */
-export function isConnected(): boolean {
-  return connection !== null;
+/**
+ * Returns true if a sound is currently being played in the given guild.
+ * If guildId is omitted, returns true if any guild is playing.
+ */
+export function isPlaying(guildId?: string): boolean {
+  if (guildId !== undefined) {
+    return sessions.get(guildId)?.playing ?? false;
+  }
+  for (const s of sessions.values()) {
+    if (s.playing) return true;
+  }
+  return false;
 }
 
-/** Returns the current voice channel ID if connected, null otherwise. */
-export function getCurrentChannelId(): string | null {
-  return currentChannelId;
+/**
+ * Returns true if the bot is currently joined to a voice channel in the given guild.
+ */
+export function isConnected(guildId: string): boolean {
+  return (sessions.get(guildId)?.connection ?? null) !== null;
 }
 
-/** Marks playback as active and sends the resource to the audio player. */
-export function startPlayback(resource: AudioResource): void {
-  playing = true;
-  getPlayer().play(resource);
+/**
+ * Returns the current voice channel ID for the given guild if connected, null otherwise.
+ */
+export function getCurrentChannelId(guildId: string): string | null {
+  return sessions.get(guildId)?.currentChannelId ?? null;
+}
+
+/**
+ * Marks playback as active and sends the resource to the audio player for the given guild.
+ */
+export function startPlayback(resource: AudioResource, guildId: string): void {
+  const session = sessions.get(guildId);
+  if (!session) throw new Error(`No audio session for guild ${guildId}`);
+  session.playing = true;
+  session.player.play(resource);
 }

--- a/src/audio/audioTypes.ts
+++ b/src/audio/audioTypes.ts
@@ -1,0 +1,8 @@
+/**
+ * Identifies the Discord guild and voice channel where an SFX should play.
+ * voiceChannelId is resolved dynamically at playback time (where the streamer is sitting).
+ */
+export interface GuildAudioContext {
+  guildId: string;
+  voiceChannelId: string;
+}

--- a/src/audio/sfxPlayer.test.ts
+++ b/src/audio/sfxPlayer.test.ts
@@ -10,6 +10,8 @@ vi.mock('./audioPlayer', () => ({
   startPlayback: vi.fn(),
 }));
 
+const TEST_GUILD = 'guild123';
+
 vi.mock('@discordjs/voice', () => ({
   createAudioResource: vi.fn((p: string) => ({ resourcePath: p })),
 }));
@@ -38,12 +40,12 @@ beforeEach(() => {
 describe('playFile', () => {
   it('throws VoiceNotConnectedError when not connected to a voice channel', () => {
     vi.mocked(isConnected).mockReturnValue(false);
-    expect(() => playFile(path.posix.join(SFX_ROOT, 'ding.mp3'))).toThrow(VoiceNotConnectedError);
+    expect(() => playFile(path.posix.join(SFX_ROOT, 'ding.mp3'), TEST_GUILD)).toThrow(VoiceNotConnectedError);
   });
 
   it('blocks a path that resolves outside the SFX folder', () => {
     vi.mocked(isConnected).mockReturnValue(true);
-    expect(() => playFile('/etc/passwd')).toThrow('Path traversal blocked');
+    expect(() => playFile('/etc/passwd', TEST_GUILD)).toThrow('Path traversal blocked');
   });
 
   it('blocks a symlink whose real path resolves outside the SFX folder', () => {
@@ -54,7 +56,7 @@ describe('playFile', () => {
     vi.mocked(fs.realpathSync).mockImplementation((p) =>
       String(p) === SFX_ROOT ? SFX_ROOT : outsidePath,
     );
-    expect(() => playFile(path.posix.join(SFX_ROOT, 'evil.mp3'))).toThrow('Path traversal blocked');
+    expect(() => playFile(path.posix.join(SFX_ROOT, 'evil.mp3'), TEST_GUILD)).toThrow('Path traversal blocked');
   });
 
   it('starts playback for a valid file inside the SFX folder', () => {
@@ -63,7 +65,7 @@ describe('playFile', () => {
     vi.mocked(fs.statSync).mockReturnValue({ isFile: () => true } as ReturnType<typeof fs.statSync>);
 
     const filePath = path.posix.join(SFX_ROOT, 'ding.mp3');
-    playFile(filePath);
+    playFile(filePath, TEST_GUILD);
 
     expect(vi.mocked(createAudioResource)).toHaveBeenCalledWith(filePath);
     expect(vi.mocked(startPlayback)).toHaveBeenCalledOnce();
@@ -73,7 +75,7 @@ describe('playFile', () => {
     vi.mocked(isConnected).mockReturnValue(true);
     vi.mocked(fs.existsSync).mockReturnValue(false);
 
-    expect(() => playFile(path.posix.join(SFX_ROOT, 'missing.mp3'))).toThrow('Sound file not found');
+    expect(() => playFile(path.posix.join(SFX_ROOT, 'missing.mp3'), TEST_GUILD)).toThrow('Sound file not found');
   });
 
   it('throws when the resolved path is a directory, not a file', () => {
@@ -81,6 +83,6 @@ describe('playFile', () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.statSync).mockReturnValue({ isFile: () => false } as ReturnType<typeof fs.statSync>);
 
-    expect(() => playFile(path.posix.join(SFX_ROOT, 'notafile'))).toThrow('Sound path is not a file');
+    expect(() => playFile(path.posix.join(SFX_ROOT, 'notafile'), TEST_GUILD)).toThrow('Sound path is not a file');
   });
 });

--- a/src/audio/sfxPlayer.ts
+++ b/src/audio/sfxPlayer.ts
@@ -34,11 +34,14 @@ function getRealSfxRoot(): string {
 }
 
 /**
- * Play a local sound file into the connected voice channel.
- * Throws if not connected or the file does not exist.
+ * Play a local sound file into the connected voice channel for the given guild.
+ * Throws VoiceNotConnectedError if not connected, or if the file is invalid.
+ *
+ * @param filePath Filename relative to SFX_FOLDER or absolute path within it.
+ * @param guildId  Discord guild ID of the audio session to use.
  */
-export function playFile(filePath: string): void {
-  if (!isConnected()) {
+export function playFile(filePath: string, guildId: string): void {
+  if (!isConnected(guildId)) {
     throw new VoiceNotConnectedError();
   }
 
@@ -63,5 +66,5 @@ export function playFile(filePath: string): void {
     throw new Error(`Sound path is not a file: ${resolved}`);
   }
 
-  startPlayback(createAudioResource(resolved));
+  startPlayback(createAudioResource(resolved), guildId);
 }

--- a/src/audio/voiceResolver.test.ts
+++ b/src/audio/voiceResolver.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../shared/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock('../shared/config', () => ({
+  DISCORD_GUILD_ID: 'defaultGuild',
+  DISCORD_VOICE_CHANNEL_ID: 'defaultChannel',
+}));
+
+vi.mock('../db', () => ({
+  findUserByTwitchName: vi.fn(),
+  findUserByDiscordGuildId: vi.fn(),
+}));
+
+import { findUserByTwitchName, findUserByDiscordGuildId } from '../db';
+import type { DbUser } from '../db';
+import {
+  resolveCurrentVoiceChannel,
+  resolveContextForTwitchChannel,
+  resolveContextForDiscordGuild,
+} from './voiceResolver';
+
+function makeClient(voiceChannelId: string | null = 'vc1', shouldThrow = false): any {
+  return {
+    guilds: {
+      fetch: vi.fn().mockResolvedValue({
+        members: {
+          fetch: shouldThrow
+            ? vi.fn().mockRejectedValue(new Error('Not found'))
+            : vi.fn().mockResolvedValue({ voice: { channelId: voiceChannelId } }),
+        },
+      }),
+    },
+  };
+}
+
+function makeUser(overrides: Partial<DbUser> = {}): DbUser {
+  return {
+    discord_id: 'user1',
+    discord_name: 'Alice',
+    is_twitch_bot_enabled: true,
+    twitch_name: 'alice',
+    access_level: 2,
+    discord_guild_id: 'guild1',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('resolveCurrentVoiceChannel', () => {
+  it('returns the voice channel ID when user is in voice', async () => {
+    const client = makeClient('vc1');
+    const result = await resolveCurrentVoiceChannel(client, 'guild1', 'user1');
+    expect(result).toBe('vc1');
+  });
+
+  it('returns null when user is not in a voice channel', async () => {
+    const client = makeClient(null);
+    const result = await resolveCurrentVoiceChannel(client, 'guild1', 'user1');
+    expect(result).toBeNull();
+  });
+
+  it('returns null and logs a warning when member fetch throws', async () => {
+    const client = makeClient(null, true);
+    const result = await resolveCurrentVoiceChannel(client, 'guild1', 'user1');
+    expect(result).toBeNull();
+  });
+});
+
+describe('resolveContextForTwitchChannel', () => {
+  it('returns ctx with user guild and current voice channel', async () => {
+    vi.mocked(findUserByTwitchName).mockResolvedValue(makeUser());
+    const client = makeClient('vc42');
+    const ctx = await resolveContextForTwitchChannel(client, 'alice');
+    expect(ctx).toEqual({ guildId: 'guild1', voiceChannelId: 'vc42' });
+  });
+
+  it('returns null when user not in voice', async () => {
+    vi.mocked(findUserByTwitchName).mockResolvedValue(makeUser());
+    const client = makeClient(null);
+    const ctx = await resolveContextForTwitchChannel(client, 'alice');
+    expect(ctx).toBeNull();
+  });
+
+  it('returns fallback context when no user found', async () => {
+    vi.mocked(findUserByTwitchName).mockResolvedValue(null);
+    const client = makeClient('vc1');
+    const ctx = await resolveContextForTwitchChannel(client, 'unknown');
+    expect(ctx).toEqual({ guildId: 'defaultGuild', voiceChannelId: 'defaultChannel' });
+  });
+
+  it('returns fallback context when user has no guild configured', async () => {
+    vi.mocked(findUserByTwitchName).mockResolvedValue(makeUser({ discord_guild_id: null }));
+    const client = makeClient('vc1');
+    const ctx = await resolveContextForTwitchChannel(client, 'alice');
+    expect(ctx).toEqual({ guildId: 'defaultGuild', voiceChannelId: 'defaultChannel' });
+  });
+});
+
+describe('resolveContextForDiscordGuild', () => {
+  it('returns ctx with configured user guild and current voice channel', async () => {
+    vi.mocked(findUserByDiscordGuildId).mockResolvedValue(makeUser());
+    const client = makeClient('vc7');
+    const ctx = await resolveContextForDiscordGuild(client, 'guild1');
+    expect(ctx).toEqual({ guildId: 'guild1', voiceChannelId: 'vc7' });
+  });
+
+  it('returns null when user not in voice', async () => {
+    vi.mocked(findUserByDiscordGuildId).mockResolvedValue(makeUser());
+    const client = makeClient(null);
+    const ctx = await resolveContextForDiscordGuild(client, 'guild1');
+    expect(ctx).toBeNull();
+  });
+
+  it('returns null when guild is unknown and not the default guild', async () => {
+    vi.mocked(findUserByDiscordGuildId).mockResolvedValue(null);
+    const client = makeClient('vc1');
+    const ctx = await resolveContextForDiscordGuild(client, 'unknownGuild');
+    expect(ctx).toBeNull();
+  });
+
+  it('returns fallback context when guild matches default and no user configured', async () => {
+    vi.mocked(findUserByDiscordGuildId).mockResolvedValue(null);
+    const client = makeClient('vc1');
+    const ctx = await resolveContextForDiscordGuild(client, 'defaultGuild');
+    expect(ctx).toEqual({ guildId: 'defaultGuild', voiceChannelId: 'defaultChannel' });
+  });
+});

--- a/src/audio/voiceResolver.ts
+++ b/src/audio/voiceResolver.ts
@@ -1,0 +1,86 @@
+import { createLogger } from '../shared/logger';
+import { Client } from 'discord.js';
+import { DISCORD_GUILD_ID, DISCORD_VOICE_CHANNEL_ID } from '../shared/config';
+import { findUserByTwitchName, findUserByDiscordGuildId } from '../db';
+import type { GuildAudioContext } from './audioTypes';
+
+const log = createLogger('VoiceResolver');
+
+/**
+ * Find the voice channel the given Discord user is currently sitting in within the guild.
+ * Returns null if the user is not in a voice channel or cannot be fetched.
+ */
+export async function resolveCurrentVoiceChannel(
+  client: Client,
+  guildId: string,
+  discordUserId: string,
+): Promise<string | null> {
+  try {
+    const guild = await client.guilds.fetch(guildId);
+    const member = await guild.members.fetch({ user: discordUserId, force: true });
+    return member.voice.channelId ?? null;
+  } catch (err) {
+    log.warn(`[${guildId}] Could not resolve voice channel for user ${discordUserId}:`, err);
+    return null;
+  }
+}
+
+/**
+ * Build a GuildAudioContext for the owner of the given Twitch channel.
+ * Looks up the user by twitch_name, then finds which voice channel they are currently in.
+ * Returns null if no user is found, no guild is configured, or the user is not in voice.
+ */
+export async function resolveContextForTwitchChannel(
+  client: Client,
+  twitchChannel: string,
+): Promise<GuildAudioContext | null> {
+  const user = await findUserByTwitchName(twitchChannel);
+  if (!user?.discord_guild_id) {
+    return getFallbackContext(client);
+  }
+
+  const voiceChannelId = await resolveCurrentVoiceChannel(client, user.discord_guild_id, user.discord_id);
+  if (!voiceChannelId) {
+    log.info(`[twitch:${twitchChannel}] Streamer not in a voice channel in guild ${user.discord_guild_id} — skipping SFX`);
+    return null;
+  }
+
+  return { guildId: user.discord_guild_id, voiceChannelId };
+}
+
+/**
+ * Build a GuildAudioContext for the given Discord guild.
+ * Finds the user configured for that guild, then resolves which voice channel they are in.
+ * Returns null if no user is found or the user is not in a voice channel.
+ */
+export async function resolveContextForDiscordGuild(
+  client: Client,
+  guildId: string,
+): Promise<GuildAudioContext | null> {
+  const user = await findUserByDiscordGuildId(guildId);
+  if (!user) {
+    // Unknown guild — check if it's the default guild, fall back if so
+    if (guildId === DISCORD_GUILD_ID) {
+      return getFallbackContext(client);
+    }
+    log.info(`[discord:${guildId}] No user configured for this guild — skipping SFX`);
+    return null;
+  }
+
+  const voiceChannelId = await resolveCurrentVoiceChannel(client, guildId, user.discord_id);
+  if (!voiceChannelId) {
+    log.info(`[discord:${guildId}] Streamer not in a voice channel — skipping SFX`);
+    return null;
+  }
+
+  return { guildId, voiceChannelId };
+}
+
+/**
+ * Fall back to the env-var default guild, using DISCORD_VOICE_CHANNEL_ID as a static channel.
+ * Used when no per-user routing is configured.
+ */
+async function getFallbackContext(_client: Client): Promise<GuildAudioContext | null> {
+  if (!DISCORD_GUILD_ID || !DISCORD_VOICE_CHANNEL_ID) return null;
+  return { guildId: DISCORD_GUILD_ID, voiceChannelId: DISCORD_VOICE_CHANNEL_ID };
+}

--- a/src/commands/commandRouter.test.ts
+++ b/src/commands/commandRouter.test.ts
@@ -7,7 +7,11 @@ const SFX_ROOT = '/sfx';
 vi.mock('../shared/config', () => ({
   SFX_FOLDER: '/sfx',
   GLOBAL_COOLDOWN_MS: 3_000,
+  DISCORD_GUILD_ID: 'defaultGuild',
+  DISCORD_VOICE_CHANNEL_ID: 'defaultChannel',
 }));
+
+const TEST_CTX = { guildId: 'guild1', voiceChannelId: 'chan1' };
 
 vi.mock('../db', () => ({
   findTrigger: vi.fn(),
@@ -59,15 +63,24 @@ describe('handleCommand', () => {
     vi.mocked(isPlaying).mockReturnValue(false);
     vi.mocked(findTrigger).mockResolvedValue(null);
 
-    await handleCommand('!unknown', 'twitch');
+    await handleCommand('!unknown', 'twitch', TEST_CTX);
 
+    expect(vi.mocked(playFile)).not.toHaveBeenCalled();
+  });
+
+  it('skips SFX silently when no ctx is provided (streamer not in voice)', async () => {
+    vi.mocked(isPlaying).mockReturnValue(false);
+
+    await handleCommand('!ding', 'twitch');
+
+    expect(vi.mocked(findTrigger)).not.toHaveBeenCalled();
     expect(vi.mocked(playFile)).not.toHaveBeenCalled();
   });
 
   it('ignores the command while audio is already playing', async () => {
     vi.mocked(isPlaying).mockReturnValue(true);
 
-    await handleCommand('!ding', 'twitch');
+    await handleCommand('!ding', 'twitch', TEST_CTX);
 
     expect(vi.mocked(findTrigger)).not.toHaveBeenCalled();
     expect(vi.mocked(playFile)).not.toHaveBeenCalled();
@@ -80,14 +93,14 @@ describe('handleCommand', () => {
     vi.mocked(findSoundFiles).mockResolvedValue(FILES);
     vi.mocked(pickWeightedRandom).mockReturnValue('ding.mp3');
 
-    await handleCommand('!ding', 'twitch');
+    await handleCommand('!ding', 'twitch', TEST_CTX);
     expect(vi.mocked(playFile)).toHaveBeenCalledTimes(1);
 
     // Second call at the same timestamp — cooldown has not elapsed
     vi.clearAllMocks();
     vi.spyOn(Date, 'now').mockReturnValue(mockNow);
 
-    await handleCommand('!ding', 'twitch');
+    await handleCommand('!ding', 'twitch', TEST_CTX);
 
     expect(vi.mocked(findTrigger)).not.toHaveBeenCalled();
     expect(vi.mocked(playFile)).not.toHaveBeenCalled();
@@ -99,10 +112,10 @@ describe('handleCommand', () => {
     vi.mocked(findSoundFiles).mockResolvedValue(FILES);
     vi.mocked(pickWeightedRandom).mockReturnValue('ding.mp3');
 
-    await handleCommand('!ding discord', 'discord');
+    await handleCommand('!ding discord', 'discord', TEST_CTX);
 
     expect(vi.mocked(findTrigger)).toHaveBeenCalledWith('!ding');
-    expect(vi.mocked(playFile)).toHaveBeenCalledWith(path.posix.join(SFX_ROOT, 'ding.mp3'));
+    expect(vi.mocked(playFile)).toHaveBeenCalledWith(path.posix.join(SFX_ROOT, 'ding.mp3'), TEST_CTX.guildId);
     expect(vi.mocked(setVoicePlaying)).toHaveBeenCalledWith('ding.mp3', '!ding', 'discord');
   });
 
@@ -116,10 +129,10 @@ describe('handleCommand', () => {
     const firstTriggerPromise = new Promise<typeof TRIGGER>((resolve) => { resolveFirst = resolve; });
     vi.mocked(findTrigger).mockReturnValueOnce(firstTriggerPromise as ReturnType<typeof findTrigger>);
 
-    const first = handleCommand('!ding', 'twitch');
+    const first = handleCommand('!ding', 'twitch', TEST_CTX);
 
     // Second call arrives while first is suspended inside findTrigger
-    await handleCommand('!ding', 'twitch');
+    await handleCommand('!ding', 'twitch', TEST_CTX);
     expect(vi.mocked(findTrigger)).toHaveBeenCalledTimes(1); // second was blocked
 
     // Let the first call complete
@@ -136,7 +149,7 @@ describe('handleCommand', () => {
     vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
     vi.mocked(findSoundFiles).mockResolvedValue([]);
 
-    await handleCommand('!ding', 'twitch');
+    await handleCommand('!ding', 'twitch', TEST_CTX);
 
     expect(vi.mocked(playFile)).not.toHaveBeenCalled();
   });
@@ -150,7 +163,7 @@ describe('handleCommand', () => {
 
     const errorSpy = vi.spyOn(console, 'error');
 
-    await handleCommand('!ding', 'twitch');
+    await handleCommand('!ding', 'twitch', TEST_CTX);
 
     // setVoicePlaying must NOT be called when playback fails
     expect(vi.mocked(setVoicePlaying)).not.toHaveBeenCalled();
@@ -167,7 +180,7 @@ describe('handleCommand', () => {
 
     const errorSpy = vi.spyOn(console, 'error');
 
-    await handleCommand('!ding', 'twitch');
+    await handleCommand('!ding', 'twitch', TEST_CTX);
 
     expect(errorSpy).not.toHaveBeenCalled();
     expect(vi.mocked(setVoicePlaying)).not.toHaveBeenCalled();
@@ -180,7 +193,7 @@ describe('handleCommand', () => {
       vi.mocked(findSoundFiles).mockResolvedValue(FILES);
       vi.mocked(pickWeightedRandom).mockReturnValue('../../../etc/passwd');
 
-      await handleCommand('!exploit', 'twitch');
+      await handleCommand('!exploit', 'twitch', TEST_CTX);
 
       expect(vi.mocked(playFile)).not.toHaveBeenCalled();
       expect(vi.mocked(setVoicePlaying)).not.toHaveBeenCalled();
@@ -192,7 +205,7 @@ describe('handleCommand', () => {
       vi.mocked(findSoundFiles).mockResolvedValue(FILES);
       vi.mocked(pickWeightedRandom).mockReturnValue('..%2F..%2Fetc%2Fpasswd');
 
-      await handleCommand('!exploit', 'twitch');
+      await handleCommand('!exploit', 'twitch', TEST_CTX);
 
       expect(vi.mocked(playFile)).not.toHaveBeenCalled();
       expect(vi.mocked(setVoicePlaying)).not.toHaveBeenCalled();
@@ -204,7 +217,7 @@ describe('handleCommand', () => {
       vi.mocked(findSoundFiles).mockResolvedValue(FILES);
       vi.mocked(pickWeightedRandom).mockReturnValue('/etc/passwd');
 
-      await handleCommand('!exploit', 'twitch');
+      await handleCommand('!exploit', 'twitch', TEST_CTX);
 
       expect(vi.mocked(playFile)).not.toHaveBeenCalled();
       expect(vi.mocked(setVoicePlaying)).not.toHaveBeenCalled();
@@ -217,9 +230,9 @@ describe('handleCommand', () => {
       vi.mocked(pickWeightedRandom).mockReturnValue('valid-sound.mp3');
       vi.mocked(playFile).mockImplementation(() => {}); // Reset to no-op
 
-      await handleCommand('!safe', 'twitch');
+      await handleCommand('!safe', 'twitch', TEST_CTX);
 
-      expect(vi.mocked(playFile)).toHaveBeenCalledWith(path.posix.join(SFX_ROOT, 'valid-sound.mp3'));
+      expect(vi.mocked(playFile)).toHaveBeenCalledWith(path.posix.join(SFX_ROOT, 'valid-sound.mp3'), TEST_CTX.guildId);
       expect(vi.mocked(setVoicePlaying)).toHaveBeenCalledWith('valid-sound.mp3', '!safe', 'twitch');
     });
 
@@ -230,9 +243,9 @@ describe('handleCommand', () => {
       vi.mocked(pickWeightedRandom).mockReturnValue('category/sound.mp3');
       vi.mocked(playFile).mockImplementation(() => {}); // Reset to no-op
 
-      await handleCommand('!safe', 'twitch');
+      await handleCommand('!safe', 'twitch', TEST_CTX);
 
-      expect(vi.mocked(playFile)).toHaveBeenCalledWith(path.posix.join(SFX_ROOT, 'category', 'sound.mp3'));
+      expect(vi.mocked(playFile)).toHaveBeenCalledWith(path.posix.join(SFX_ROOT, 'category', 'sound.mp3'), TEST_CTX.guildId);
       expect(vi.mocked(setVoicePlaying)).toHaveBeenCalledWith('category/sound.mp3', '!safe', 'twitch');
     });
   });

--- a/src/commands/commandRouter.ts
+++ b/src/commands/commandRouter.ts
@@ -8,13 +8,18 @@ import { SFX_FOLDER, GLOBAL_COOLDOWN_MS } from '../shared/config';
 import { setVoicePlaying } from '../shared/statusStore';
 import { safeResolve } from '../shared/pathUtils';
 import { recordCommandTestEntry } from './commandMonitorStore';
+import type { GuildAudioContext } from '../audio/audioTypes';
 
 const log = createLogger('CommandRouter');
 
 let lastPlayedAt = 0;
 let inFlight = false;
 
-async function lookupAndPlay(command: string, source: 'twitch' | 'discord' | 'tiktok'): Promise<void> {
+async function lookupAndPlay(
+  command: string,
+  source: 'twitch' | 'discord' | 'tiktok',
+  ctx: GuildAudioContext,
+): Promise<void> {
   const trigger = await findTrigger(command);
   if (!trigger) return;
 
@@ -31,16 +36,16 @@ async function lookupAndPlay(command: string, source: 'twitch' | 'discord' | 'ti
     return;
   }
 
-  log.info(`[${source}] Playing '${filename}' for trigger '${command}'`);
+  log.info(`[${source}] Playing '${filename}' for trigger '${command}' in guild ${ctx.guildId}`);
 
   try {
-    playFile(fullPath);
+    playFile(fullPath, ctx.guildId);
     lastPlayedAt = Date.now();
     setVoicePlaying(filename, command, source);
     recordCommandTestEntry({ source, command, response: filename, channel: null, user: null });
   } catch (err) {
     if (err instanceof VoiceNotConnectedError) {
-      log.info(`[${source}] Skipping '${command}' — not connected to voice channel`);
+      log.info(`[${source}] Skipping '${command}' — not connected to voice channel in guild ${ctx.guildId}`);
     } else {
       log.error(`[${source}] Failed to play ${fullPath}:`, err);
     }
@@ -52,9 +57,14 @@ async function lookupAndPlay(command: string, source: 'twitch' | 'discord' | 'ti
  * Performs all checks (prefix, cooldown, playing state, DB lookup) before playing.
  *
  * @param rawMessage The full message string as received from chat.
- * @param source     Label used for console logging ('twitch' | 'discord').
+ * @param source     Label used for console logging ('twitch' | 'discord' | 'tiktok').
+ * @param ctx        Guild and voice channel to play audio in. If omitted, SFX is skipped silently.
  */
-export async function handleCommand(rawMessage: string, source: 'twitch' | 'discord' | 'tiktok'): Promise<void> {
+export async function handleCommand(
+  rawMessage: string,
+  source: 'twitch' | 'discord' | 'tiktok',
+  ctx?: GuildAudioContext,
+): Promise<void> {
   const trimmed = rawMessage.trim();
 
   // Extract the first word of the message — this is matched directly against
@@ -75,10 +85,13 @@ export async function handleCommand(rawMessage: string, source: 'twitch' | 'disc
     return;
   }
 
+  // No audio context means the streamer is not in a voice channel — skip SFX silently.
+  if (!ctx) return;
+
   // Claim the slot before any await so concurrent message handlers see the flag.
   inFlight = true;
   try {
-    await lookupAndPlay(command, source);
+    await lookupAndPlay(command, source, ctx);
   } finally {
     inFlight = false;
   }

--- a/src/db.ts
+++ b/src/db.ts
@@ -5,8 +5,9 @@ export { getPool, closePool } from './db/pool';
 
 export {
   AccessLevel, ACCESS_LEVEL_LABELS,
-  findUser, findUserByTwitchName, getAllUsers,
+  findUser, findUserByTwitchName, findUserByDiscordGuildId, getAllUsers,
   updateDiscordName, getTwitchEnabledChannels, updateAccessLevel,
+  updateGuildRoutingRecord,
 } from './db/users';
 export type { AccessLevelValue, DbUser } from './db/users';
 

--- a/src/db/users.test.ts
+++ b/src/db/users.test.ts
@@ -11,12 +11,14 @@ import { getPool } from './pool';
 import {
   findUser,
   findUserByTwitchName,
+  findUserByDiscordGuildId,
   getAllUsers,
   upsertUserRecord,
   updateDiscordName,
   getTwitchEnabledChannels,
   setTwitchBotEnabledRecord,
   updateAccessLevel,
+  updateGuildRoutingRecord,
   removeUserRecord,
   AccessLevel,
 } from './users';
@@ -298,6 +300,57 @@ describe('removeUserRecord', () => {
     expect(sql).toContain('DELETE FROM');
     const params = pool._conn.execute.mock.calls[1][1] as unknown[];
     expect(params).toContain('42');
+  });
+});
+
+// ─── findUserByDiscordGuildId ─────────────────────────────────────────────────
+
+describe('findUserByDiscordGuildId', () => {
+  it('returns null when no rows found', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([[]]) as any);
+    const result = await findUserByDiscordGuildId('999');
+    expect(result).toBeNull();
+  });
+
+  it('maps a found row correctly', async () => {
+    const row = { discord_id: '123', discord_name: 'Alice', is_twitch_bot_enabled: 1, twitch_name: 'alice', access_level: 2, discord_guild_id: '999' };
+    vi.mocked(getPool).mockReturnValue(makePool([[row]]) as any);
+    const result = await findUserByDiscordGuildId('999');
+    expect(result?.discord_id).toBe('123');
+    expect(result?.discord_guild_id).toBe('999');
+  });
+
+  it('passes guildId as query param', async () => {
+    const pool = makePool([[]]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await findUserByDiscordGuildId('12345');
+    const params = vi.mocked(pool.execute).mock.calls[0][1] as unknown[];
+    expect(params).toContain('12345');
+  });
+});
+
+// ─── updateGuildRoutingRecord ─────────────────────────────────────────────────
+
+describe('updateGuildRoutingRecord', () => {
+  it('executes an UPDATE with guildId and discordId', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await updateGuildRoutingRecord('42', '999');
+    const sql: string = pool._conn.execute.mock.calls[1][0] as string;
+    expect(sql).toContain('UPDATE');
+    expect(sql).toContain('discord_guild_id');
+    const params = pool._conn.execute.mock.calls[1][1] as unknown[];
+    expect(params).toContain('999');
+    expect(params).toContain('42');
+  });
+
+  it('passes null to clear routing', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await updateGuildRoutingRecord('42', null);
+    const params = pool._conn.execute.mock.calls[1][1] as unknown[];
+    expect(params[0]).toBeNull();
+    expect(params[1]).toBe('42');
   });
 });
 

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -28,6 +28,7 @@ export interface DbUser {
   is_twitch_bot_enabled: boolean;
   twitch_name: string | null;
   access_level: number;
+  discord_guild_id: string | null;
 }
 
 function mapUser(r: mysql.RowDataPacket): DbUser {
@@ -37,12 +38,13 @@ function mapUser(r: mysql.RowDataPacket): DbUser {
     is_twitch_bot_enabled: fromBit(r.is_twitch_bot_enabled),
     twitch_name: r.twitch_name,
     access_level: r.access_level,
+    discord_guild_id: r.discord_guild_id ?? null,
   };
 }
 
 export async function findUser(discordId: string): Promise<DbUser | null> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    'SELECT discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level FROM `user` WHERE discord_id = ?',
+    'SELECT discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level, discord_guild_id FROM `user` WHERE discord_id = ?',
     [discordId],
   );
   return rows.length === 0 ? null : mapUser(rows[0]);
@@ -55,12 +57,12 @@ export async function findUserByTwitchName(twitchName: string, excludeDiscordId?
   }
 
   const sql = excludeDiscordId
-    ? `SELECT discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level
+    ? `SELECT discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level, discord_guild_id
        FROM \`user\`
        WHERE twitch_name = ?
          AND discord_id <> ?
        LIMIT 1`
-    : `SELECT discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level
+    : `SELECT discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level, discord_guild_id
        FROM \`user\`
        WHERE twitch_name = ?
        LIMIT 1`;
@@ -73,9 +75,32 @@ export async function findUserByTwitchName(twitchName: string, excludeDiscordId?
 
 export async function getAllUsers(): Promise<DbUser[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    'SELECT discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level FROM `user` ORDER BY access_level DESC, discord_name ASC',
+    'SELECT discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level, discord_guild_id FROM `user` ORDER BY access_level DESC, discord_name ASC',
   );
   return rows.map(mapUser);
+}
+
+/**
+ * Find the user configured to route audio to the given Discord guild.
+ * Returns null if no user has that guild ID configured.
+ */
+export async function findUserByDiscordGuildId(guildId: string): Promise<DbUser | null> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    'SELECT discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level, discord_guild_id FROM `user` WHERE discord_guild_id = ? LIMIT 1',
+    [guildId],
+  );
+  return rows.length === 0 ? null : mapUser(rows[0]);
+}
+
+/**
+ * Set or clear the Discord guild used for audio routing for a user.
+ * Pass null to clear the routing and revert to the env-var default.
+ */
+export async function updateGuildRoutingRecord(discordId: string, guildId: string | null): Promise<void> {
+  await withShortLockTimeout((conn) => conn.execute(
+    'UPDATE `user` SET discord_guild_id = ? WHERE discord_id = ?',
+    [guildId, discordId],
+  ));
 }
 
 // Short timeout so callers fail fast instead of hanging 50s under lock contention.

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -1,6 +1,7 @@
 import { Client, GatewayIntentBits, Guild } from 'discord.js';
 import { DISCORD_TOKEN, DISCORD_GUILD_ID } from '../shared/config';
 import { handleCommand } from '../commands/commandRouter';
+import { resolveContextForDiscordGuild } from '../audio/voiceResolver';
 import { executeCustomCommandForDiscord } from '../commands/customCommandHandler';
 import { executeCounterCommandForDiscord } from '../commands/counterHandler';
 import { setDiscordReady } from '../shared/statusStore';
@@ -58,21 +59,26 @@ export function startDiscordBot(): void {
 
   client.on('messageCreate', (message) => {
     if (message.author.bot) return;
-    if (message.guildId !== DISCORD_GUILD_ID) return;
+    if (!message.guildId) return; // ignore DMs
 
     const displayName = message.member?.displayName ?? message.author.username;
 
-    executeCustomCommandForDiscord(message, displayName).catch((err) =>
-      log.error('Custom command error:', err),
-    );
+    // Custom commands and counters only run in the primary configured guild.
+    if (message.guildId === DISCORD_GUILD_ID) {
+      executeCustomCommandForDiscord(message, displayName).catch((err) =>
+        log.error('Custom command error:', err),
+      );
 
-    executeCounterCommandForDiscord(message, displayName).catch((err) =>
-      log.error('Counter command error:', err),
-    );
+      executeCounterCommandForDiscord(message, displayName).catch((err) =>
+        log.error('Counter command error:', err),
+      );
+    }
 
-    handleCommand(message.content, 'discord').catch((err) =>
-      log.error('Command handler error:', err),
-    );
+    // SFX commands run in any guild the bot is in, routing audio to that guild's voice channel.
+    const guildId = message.guildId;
+    resolveContextForDiscordGuild(client, guildId)
+      .then((ctx) => handleCommand(message.content, 'discord', ctx ?? undefined))
+      .catch((err) => log.error('Command handler error:', err));
   });
 
   client.once('clientReady', async (c) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { startTikTokBot, stopTikTokBot } from './tiktok/tiktokBot';
 import { startTwitchMonitor, stopTwitchMonitor } from './twitch/monitor/twitchMonitor';
 import { startEventSub, stopEventSub, reloadEventSubSubscriptions } from './twitch/eventsub/twitchEventSub';
 import { startWebPanel } from './web/server';
-import { disconnect } from './audio/audioPlayer';
+import { disconnectAll } from './audio/audioPlayer';
 import { registerTwitchChatRuntime } from './commands/customCommandHandler';
 import { registerCounterTwitchRuntime } from './commands/counterHandler';
 import { registerMultiTwitchRuntime } from './commands/multiCommandHandler';
@@ -28,7 +28,7 @@ async function shutdown(signal: string): Promise<void> {
   stopTikTokBot();
   await stopTwitchBot();
   stopDiscordBot();
-  disconnect();
+  disconnectAll();
   await closePool();
   process.exit(0);
 }

--- a/src/twitch/twitchBot.test.ts
+++ b/src/twitch/twitchBot.test.ts
@@ -71,6 +71,14 @@ vi.mock('../commands/countdownHandler', () => ({
   executeCountdownForTwitch: vi.fn(),
 }));
 
+vi.mock('../audio/voiceResolver', () => ({
+  resolveContextForTwitchChannel: vi.fn().mockResolvedValue({ guildId: 'g1', voiceChannelId: 'vc1' }),
+}));
+
+vi.mock('../discord/discordBot', () => ({
+  getDiscordClient: vi.fn().mockReturnValue({}),
+}));
+
 // ─── Imports (after mocks) ────────────────────────────────────────────────────
 
 import {
@@ -188,7 +196,7 @@ describe('handleTwitchMessage', () => {
     expect(executeCustomCommandForTwitch).toHaveBeenCalledWith('streamer', 'hello', null);
   });
 
-  it('dispatches all six executors for a normal message', () => {
+  it('dispatches all six executors for a normal message', async () => {
     vi.mocked(executeCustomCommandForTwitch).mockResolvedValue(undefined);
     vi.mocked(executeCounterCommandForTwitch).mockResolvedValue(undefined);
     vi.mocked(executeMultiCommandForTwitch).mockResolvedValue(undefined);
@@ -197,6 +205,8 @@ describe('handleTwitchMessage', () => {
     vi.mocked(executeCountdownForTwitch).mockResolvedValue(undefined);
 
     sendMessage('#streamer', makeTags({ 'display-name': 'Alice' }), '!cmd');
+    // handleCommand is called after resolveContextForTwitchChannel resolves
+    await Promise.resolve();
 
     expect(executeCustomCommandForTwitch).toHaveBeenCalledOnce();
     expect(executeCounterCommandForTwitch).toHaveBeenCalledOnce();

--- a/src/twitch/twitchBot.ts
+++ b/src/twitch/twitchBot.ts
@@ -1,6 +1,7 @@
 import tmi from 'tmi.js';
 import { TWITCH_USERNAME, TWITCH_OAUTH_TOKEN } from '../shared/config';
 import { handleCommand } from '../commands/commandRouter';
+import { resolveContextForTwitchChannel } from '../audio/voiceResolver';
 import { executeCustomCommandForTwitch } from '../commands/customCommandHandler';
 import { executeCounterCommandForTwitch } from '../commands/counterHandler';
 import { executeMultiCommandForTwitch } from '../commands/multiCommandHandler';
@@ -8,6 +9,7 @@ import { executeShoutoutForTwitch } from '../commands/shoutoutHandler';
 import { executeCountdownForTwitch } from '../commands/countdownHandler';
 import { setTwitchChannel } from '../shared/statusStore';
 import { normalizeTwitchChannelName } from './twitchChannelName';
+import { getDiscordClient } from '../discord/discordBot';
 import { createLogger } from '../shared/logger';
 import {
   setTmiClient,
@@ -53,7 +55,13 @@ function handleTwitchMessage(
     fireAndForget(executeCounterCommandForTwitch(normalizedChannel, message, displayName), 'Counter command error');
     fireAndForget(executeMultiCommandForTwitch(normalizedChannel, message, displayName), 'Multi command error');
     fireAndForget(executeShoutoutForTwitch(normalizedChannel, message, displayName, isMod), 'Shoutout error');
-    fireAndForget(handleCommand(message, 'twitch'), 'Command handler error');
+    const discordClient = getDiscordClient();
+    const sfxPromise = discordClient
+      ? resolveContextForTwitchChannel(discordClient, normalizedChannel).then((ctx) =>
+          handleCommand(message, 'twitch', ctx ?? undefined),
+        )
+      : Promise.resolve();
+    fireAndForget(sfxPromise, 'Command handler error');
     fireAndForget(executeCountdownForTwitch(normalizedChannel, message), 'Countdown error');
   } catch (err) {
     log.error('Unexpected error in message handler:', err);

--- a/src/web/routes/api.ts
+++ b/src/web/routes/api.ts
@@ -3,6 +3,7 @@ import { Router } from 'express';
 import { getStatus } from '../../shared/statusStore';
 import { requireAuth, requireMod } from '../middleware';
 import { connect, disconnect, getCurrentChannelId } from '../../audio/audioPlayer';
+import type { GuildAudioContext } from '../../audio/audioTypes';
 import { getDiscordClient } from '../../discord/discordBot';
 import { csrfProtection } from '../csrf';
 import { getAvailableVoiceChannels } from '../../discord/discordUtils';
@@ -25,7 +26,7 @@ router.get('/voice/channels', requireMod, async (_req, res) => {
       ok: true,
       channels,
       defaultChannelId: DISCORD_VOICE_CHANNEL_ID,
-      currentChannelId: getCurrentChannelId(),
+      currentChannelId: getCurrentChannelId(DISCORD_GUILD_ID),
     });
   } catch (err) {
     log.error('Failed to list voice channels:', err);
@@ -51,10 +52,11 @@ router.post('/voice/join', requireMod, csrfProtection, async (req, res) => {
       res.status(400).json({ ok: false, error: 'Invalid channel ID' });
       return;
     }
-    const resolvedChannelId = trimmedChannelId || undefined;
+    const resolvedChannelId = trimmedChannelId || DISCORD_VOICE_CHANNEL_ID;
+    const ctx: GuildAudioContext = { guildId: DISCORD_GUILD_ID, voiceChannelId: resolvedChannelId };
 
-    disconnect();
-    await connect(discordClient, resolvedChannelId);
+    disconnect(DISCORD_GUILD_ID);
+    await connect(discordClient, ctx);
     res.json({ ok: true });
   } catch (err) {
     log.error('Voice rejoin failed:', err);
@@ -64,7 +66,7 @@ router.post('/voice/join', requireMod, csrfProtection, async (req, res) => {
 
 // Leave the voice channel — Mod and above
 router.post('/voice/leave', requireMod, csrfProtection, (_req, res) => {
-  disconnect();
+  disconnect(DISCORD_GUILD_ID);
   res.json({ ok: true });
 });
 

--- a/src/web/routes/streamdeck.test.ts
+++ b/src/web/routes/streamdeck.test.ts
@@ -45,6 +45,7 @@ vi.mock('../../shared/logger', () => ({
 
 vi.mock('../../shared/config', () => ({
   DISCORD_GUILD_ID: 'guild-123',
+  DISCORD_VOICE_CHANNEL_ID: 'default-chan',
 }));
 
 import express from 'express';
@@ -99,8 +100,8 @@ describe('POST /sfx', () => {
       .send({ command: '!ding' })
       .expect(200);
 
-    expect(vi.mocked(playFile)).toHaveBeenCalledWith('only1_v2.mp3');
-    expect(vi.mocked(playFile)).not.toHaveBeenCalledWith(expect.stringContaining('/'));
+    expect(vi.mocked(playFile)).toHaveBeenCalledWith('only1_v2.mp3', 'guild-123');
+    expect(vi.mocked(playFile)).not.toHaveBeenCalledWith(expect.stringContaining('/'), expect.anything());
   });
 
   it('returns 200 and the filename on success', async () => {
@@ -282,8 +283,8 @@ describe('POST /voice/join', () => {
       .expect(200);
 
     expect(res.body).toEqual({ ok: true });
-    expect(vi.mocked(disconnect)).toHaveBeenCalled();
-    expect(vi.mocked(connect)).toHaveBeenCalledWith({}, '123456789012345678');
+    expect(vi.mocked(disconnect)).toHaveBeenCalledWith('guild-123');
+    expect(vi.mocked(connect)).toHaveBeenCalledWith({}, { guildId: 'guild-123', voiceChannelId: '123456789012345678' });
   });
 
   it('returns 500 when connect throws', async () => {
@@ -303,6 +304,6 @@ describe('POST /voice/leave', () => {
     const res = await supertest(buildApp()).post('/voice/leave').expect(200);
 
     expect(res.body).toEqual({ ok: true });
-    expect(vi.mocked(disconnect)).toHaveBeenCalled();
+    expect(vi.mocked(disconnect)).toHaveBeenCalledWith('guild-123');
   });
 });

--- a/src/web/routes/streamdeck.ts
+++ b/src/web/routes/streamdeck.ts
@@ -8,6 +8,7 @@ import { DISCORD_GUILD_ID } from '../../shared/config';
 import { requireApiKey } from '../middleware';
 import { getAvailableVoiceChannels } from '../../discord/discordUtils';
 import { connect, disconnect } from '../../audio/audioPlayer';
+import type { GuildAudioContext } from '../../audio/audioTypes';
 import { getDiscordClient } from '../../discord/discordBot';
 import { normalizeDiscordId } from './shared';
 
@@ -62,7 +63,7 @@ router.post('/sfx', requireApiKey, async (req, res) => {
   const filename = pickWeightedRandom(files);
 
   try {
-    playFile(filename);
+    playFile(filename, DISCORD_GUILD_ID);
     setVoicePlaying(filename, normalizedCommand, 'streamdeck');
     log.info(`Playing '${filename.replace(/[\r\n]/g, '')}' for trigger '${normalizedCommand.replace(/[\r\n]/g, '')}'`);
     res.json({ ok: true, file: filename });
@@ -104,9 +105,10 @@ router.post('/voice/join', requireApiKey, async (req, res) => {
     return;
   }
 
+  const ctx: GuildAudioContext = { guildId: DISCORD_GUILD_ID, voiceChannelId: normalizedChannelId };
   try {
-    disconnect();
-    await connect(discordClient, normalizedChannelId);
+    disconnect(DISCORD_GUILD_ID);
+    await connect(discordClient, ctx);
     res.json({ ok: true });
   } catch (err) {
     log.error('Voice join failed:', err);
@@ -115,7 +117,7 @@ router.post('/voice/join', requireApiKey, async (req, res) => {
 });
 
 router.post('/voice/leave', requireApiKey, (_req, res) => {
-  disconnect();
+  disconnect(DISCORD_GUILD_ID);
   res.json({ ok: true });
 });
 

--- a/src/web/routes/userSettings.test.ts
+++ b/src/web/routes/userSettings.test.ts
@@ -5,6 +5,8 @@ vi.mock('../../db', () => ({
   getStreamerByDiscordId: vi.fn(),
   saveEventConfig: vi.fn(),
   clearStreamerToken: vi.fn(),
+  updateGuildRoutingRecord: vi.fn(),
+  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
 }));
 
 vi.mock('../csrf', () => ({
@@ -39,7 +41,7 @@ vi.mock('../../shared/logger', () => ({
 import express from 'express';
 import supertest from 'supertest';
 import router from './userSettings';
-import { findUser, getStreamerByDiscordId } from '../../db';
+import { findUser, getStreamerByDiscordId, updateGuildRoutingRecord } from '../../db';
 import { AccessLevel } from '../../db/users';
 
 type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3 };
@@ -139,5 +141,86 @@ describe('GET / — successExpectedAccount', () => {
     const res = await supertest(buildApp()).get('/?error=eventsub_wrong_account&expected=mychannel&expected=other');
     expect(res.status).toBe(200);
     expect(res.body.successExpectedAccount).toBeUndefined();
+  });
+});
+
+describe('POST /guild-routing', () => {
+  const MANAGER_USER: SessionUser = { ...USER, accessLevel: AccessLevel.MANAGER };
+
+  function buildDbUser(overrides: Record<string, unknown> = {}) {
+    return {
+      discord_id: MANAGER_USER.discordId,
+      discord_name: 'TestUser',
+      is_twitch_bot_enabled: false,
+      twitch_name: null,
+      access_level: AccessLevel.MANAGER,
+      discord_guild_id: null,
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    vi.mocked(updateGuildRoutingRecord).mockResolvedValue(undefined);
+  });
+
+  it('saves a valid guild ID and redirects to success', async () => {
+    vi.mocked(findUser).mockResolvedValue(buildDbUser() as any);
+
+    const res = await supertest(buildApp(MANAGER_USER))
+      .post('/guild-routing')
+      .send('discord_guild_id=123456789012345678');
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/user/settings?success=guild_routing_saved');
+    expect(vi.mocked(updateGuildRoutingRecord)).toHaveBeenCalledWith(MANAGER_USER.discordId, '123456789012345678');
+  });
+
+  it('clears routing when guild ID is empty and redirects to success', async () => {
+    vi.mocked(findUser).mockResolvedValue(buildDbUser({ discord_guild_id: '999' }) as any);
+
+    const res = await supertest(buildApp(MANAGER_USER))
+      .post('/guild-routing')
+      .send('discord_guild_id=');
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/user/settings?success=guild_routing_saved');
+    expect(vi.mocked(updateGuildRoutingRecord)).toHaveBeenCalledWith(MANAGER_USER.discordId, null);
+  });
+
+  it('redirects to invalid error for a non-numeric guild ID', async () => {
+    vi.mocked(findUser).mockResolvedValue(buildDbUser() as any);
+
+    const res = await supertest(buildApp(MANAGER_USER))
+      .post('/guild-routing')
+      .send('discord_guild_id=not-a-snowflake');
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/user/settings?error=guild_routing_invalid');
+    expect(vi.mocked(updateGuildRoutingRecord)).not.toHaveBeenCalled();
+  });
+
+  it('redirects to forbidden error when user is below Manager level', async () => {
+    const modUser: SessionUser = { ...USER, accessLevel: AccessLevel.MOD };
+    vi.mocked(findUser).mockResolvedValue(buildDbUser({ access_level: AccessLevel.MOD }) as any);
+
+    const res = await supertest(buildApp(modUser))
+      .post('/guild-routing')
+      .send('discord_guild_id=123456789012345678');
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/user/settings?error=guild_routing_forbidden');
+    expect(vi.mocked(updateGuildRoutingRecord)).not.toHaveBeenCalled();
+  });
+
+  it('redirects to failed error when DB throws', async () => {
+    vi.mocked(findUser).mockResolvedValue(buildDbUser() as any);
+    vi.mocked(updateGuildRoutingRecord).mockRejectedValue(new Error('DB down'));
+
+    const res = await supertest(buildApp(MANAGER_USER))
+      .post('/guild-routing')
+      .send('discord_guild_id=123456789012345678');
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/user/settings?error=guild_routing_failed');
   });
 });

--- a/src/web/routes/userSettings.ts
+++ b/src/web/routes/userSettings.ts
@@ -1,7 +1,7 @@
 import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import { randomBytes } from 'crypto';
-import { findUser, getStreamerByDiscordId, saveEventConfig, clearStreamerToken, EventSubConfig } from '../../db';
+import { findUser, getStreamerByDiscordId, saveEventConfig, clearStreamerToken, updateGuildRoutingRecord, AccessLevel, EventSubConfig } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
 import { trimField, renderError, filterQueryParam } from './shared';
@@ -24,8 +24,11 @@ const KNOWN_ERRORS = new Set([
   'eventsub_token_invalid',
   'eventsub_wrong_account',
   'invalid_id',
+  'guild_routing_failed',
+  'guild_routing_invalid',
+  'guild_routing_forbidden',
 ]);
-const KNOWN_SUCCESSES = new Set(['twitch_connected']);
+const KNOWN_SUCCESSES = new Set(['twitch_connected', 'guild_routing_saved']);
 
 const ERROR_MESSAGES: Record<string, string> = {
   no_streamer_record:            'You are not configured as a monitored streamer.',
@@ -37,6 +40,9 @@ const ERROR_MESSAGES: Record<string, string> = {
   eventsub_token_invalid:        'Could not verify the Twitch account. Please try again.',
   eventsub_wrong_account:        'Wrong Twitch account — please authorize with your own broadcaster account.',
   invalid_id:                    'Invalid request — please try again.',
+  guild_routing_failed:          'Failed to save audio routing. Please try again.',
+  guild_routing_invalid:         'Invalid Discord server ID — must be a numeric snowflake.',
+  guild_routing_forbidden:       'You do not have permission to change audio routing.',
 };
 
 function getFriendlyError(key: string): string {
@@ -185,6 +191,36 @@ router.post('/eventsub-config', requireAuth, csrfProtection, async (req, res) =>
   } catch (err) {
     log.error('EventSub config save error:', err);
     res.redirect('/user/settings?error=eventsub_config_failed');
+  }
+});
+
+// POST /user/guild-routing — set or clear per-user Discord guild for audio routing (Manager+)
+router.post('/guild-routing', requireAuth, csrfProtection, async (req, res) => {
+  try {
+    const discordId = req.session.user!.discordId;
+    const dbUser = await findUser(discordId);
+
+    if (!dbUser || dbUser.access_level < AccessLevel.MANAGER) {
+      return res.redirect('/user/settings?error=guild_routing_forbidden');
+    }
+
+    const body = req.body as Record<string, string | undefined>;
+    const rawGuildId = trimField(body.discord_guild_id);
+
+    let guildId: string | null = null;
+    if (rawGuildId) {
+      // Snowflake IDs are 17-20 digit numbers
+      if (!/^\d{17,20}$/.test(rawGuildId)) {
+        return res.redirect('/user/settings?error=guild_routing_invalid');
+      }
+      guildId = rawGuildId;
+    }
+
+    await updateGuildRoutingRecord(discordId, guildId);
+    return res.redirect('/user/settings?success=guild_routing_saved');
+  } catch (err) {
+    log.error('Guild routing save error:', err);
+    return res.redirect('/user/settings?error=guild_routing_failed');
   }
 });
 

--- a/views/userSettings.ejs
+++ b/views/userSettings.ejs
@@ -143,6 +143,46 @@
     </section>
     <% } %>
 
+  <!-- ── Discord Audio Routing (Manager+) ─────────────────────────────── -->
+  <% if (user && user.accessLevel >= 2) { %>
+  <main class="main-content">
+    <section class="section">
+      <h2 class="section-title">Discord Audio Routing</h2>
+      <div class="card">
+        <div class="card-body">
+          <p class="hint">
+            Set the Discord server where SFX commands from your Twitch chat will play.
+            The bot will join whichever voice channel you are currently in within that server.
+            Leave blank to use the bot-wide default server.
+          </p>
+          <% if (error === 'guild_routing_failed') { %><p class="error-text"><%= getFriendlyError('guild_routing_failed') %></p><% } %>
+          <% if (error === 'guild_routing_invalid') { %><p class="error-text"><%= getFriendlyError('guild_routing_invalid') %></p><% } %>
+          <% if (error === 'guild_routing_forbidden') { %><p class="error-text"><%= getFriendlyError('guild_routing_forbidden') %></p><% } %>
+          <% if (success === 'guild_routing_saved') { %><p class="success-text">Audio routing saved.</p><% } %>
+          <form method="POST" action="/user/settings/guild-routing">
+            <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+            <div class="form-row-wrap">
+              <label>
+                <span class="hint hint-compact">Discord Server (Guild) ID</span>
+                <input class="input" type="text" name="discord_guild_id"
+                       value="<%= dbUser && dbUser.discord_guild_id ? dbUser.discord_guild_id : '' %>"
+                       placeholder="e.g. 123456789012345678"
+                       maxlength="20" pattern="\d{17,20}">
+              </label>
+            </div>
+            <div class="button-row-wrap">
+              <button type="submit" class="btn">Save Routing</button>
+              <% if (dbUser && dbUser.discord_guild_id) { %>
+              <button type="submit" name="discord_guild_id" value="" class="btn btn-ghost">Clear Routing</button>
+              <% } %>
+            </div>
+          </form>
+        </div>
+      </div>
+    </section>
+  </main>
+  <% } %>
+
   </main>
 
   <%- include('partials/pwa-register') %>


### PR DESCRIPTION
## Summary

- Each streamer can configure their own Discord server (guild ID) in the user settings panel (Manager+ only). The bot dynamically finds which voice channel the streamer is currently sitting in and plays SFX there — no fixed channel needed.
- `audioPlayer.ts` refactored from a singleton to a `Map<guildId, AudioSession>`, enabling fully independent concurrent voice connections per streamer.
- New `voiceResolver.ts` resolves the audio target at command time via `guild.members.fetch().voice.channelId`.
- `GuildAudioContext` threaded from Twitch/Discord message receipt through `commandRouter` down to `sfxPlayer.playFile`.
- Discord SFX now works in any guild the bot is in; custom commands and counters remain restricted to the primary `DISCORD_GUILD_ID`.
- New `discord_guild_id` column on the `user` table (migration in `migrations/add_discord_guild_routing.sql`).
- `disconnectAll()` replaces `disconnect()` in shutdown to clean up all guild sessions.

## Test plan

- [ ] Run DB migration: `ALTER TABLE user ADD COLUMN discord_guild_id VARCHAR(20) NULL DEFAULT NULL`
- [ ] Log in as Manager+, go to User Settings — verify the Discord Audio Routing section appears
- [ ] Enter your Discord server's guild ID, click Save — confirm DB row updated
- [ ] Join a voice channel in that server, fire an SFX from Twitch chat — confirm audio plays in your current voice channel
- [ ] Move to a different voice channel, fire SFX again — confirm bot follows you
- [ ] Leave voice entirely, fire SFX — confirm nothing plays (no crash)
- [ ] Configure two streamers with different guild IDs, trigger SFX from each Twitch channel — confirm independent audio in each guild
- [ ] Clear routing for a user — confirm SFX falls back to the bot-wide env-var default
- [ ] Send the bot a DM — confirm no crash

https://claude.ai/code/session_017NHtK1LqqUi8GY6kFbg6UV

---
_Generated by [Claude Code](https://claude.ai/code/session_017NHtK1LqqUi8GY6kFbg6UV)_