### PR TITLE
fix: cache memory leaks and O(n) hot-path cleanup

### DIFF
--- a/src/commands/customCommandHandler.test.ts
+++ b/src/commands/customCommandHandler.test.ts
@@ -27,6 +27,8 @@ import {
   executeCustomCommandForDiscord,
   executeCustomCommandForTwitch,
   registerTwitchChatRuntime,
+  purgeExpiredSessionCache,
+  sessionCache,
 } from './customCommandHandler';
 import { getCustomCommandForDiscord, getCustomCommandForTwitchChannel } from '../db';
 import { recordCommandTestEntry } from './commandMonitorStore';
@@ -158,5 +160,44 @@ describe('executeCustomCommandForTwitch', () => {
     // Falls back to source channel only
     expect(mockRuntime.send).toHaveBeenCalledTimes(1);
     expect(mockRuntime.send).toHaveBeenCalledWith('#a', 'Hi!');
+  });
+});
+
+// ─── Session cache cleanup ────────────────────────────────────────────────────
+
+describe('purgeExpiredSessionCache', () => {
+  beforeEach(() => {
+    sessionCache.clear();
+  });
+
+  it('removes entries whose expiry has passed', () => {
+    const now = Date.now();
+    sessionCache.set('user-expired', { sessionId: 'abc', expiry: now - 1 });
+    sessionCache.set('user-fresh',   { sessionId: 'xyz', expiry: now + 60_000 });
+
+    purgeExpiredSessionCache();
+
+    expect(sessionCache.has('user-expired')).toBe(false);
+    expect(sessionCache.has('user-fresh')).toBe(true);
+  });
+
+  it('leaves all entries intact when none have expired', () => {
+    const now = Date.now();
+    sessionCache.set('user-a', { sessionId: '1', expiry: now + 10_000 });
+    sessionCache.set('user-b', { sessionId: '2', expiry: now + 20_000 });
+
+    purgeExpiredSessionCache();
+
+    expect(sessionCache.size).toBe(2);
+  });
+
+  it('empties the map when all entries have expired', () => {
+    const past = Date.now() - 1000;
+    sessionCache.set('user-a', { sessionId: '1', expiry: past });
+    sessionCache.set('user-b', { sessionId: '2', expiry: past });
+
+    purgeExpiredSessionCache();
+
+    expect(sessionCache.size).toBe(0);
   });
 });

--- a/src/commands/customCommandHandler.ts
+++ b/src/commands/customCommandHandler.ts
@@ -55,8 +55,19 @@ interface SessionCacheEntry {
 }
 const SESSION_CACHE_TTL_MS = 30_000;
 const SHORT_RETRY_TTL_MS = 5_000;
-const sessionCache = new Map<string, SessionCacheEntry>();
+export const sessionCache = new Map<string, SessionCacheEntry>();
 const inFlightRefreshes = new Map<string, Promise<void>>();
+
+/** Remove all entries whose TTL has elapsed. Called by the cleanup interval and exported for tests. */
+export function purgeExpiredSessionCache(): void {
+  const now = Date.now();
+  for (const [userId, entry] of sessionCache) {
+    if (now > entry.expiry) sessionCache.delete(userId);
+  }
+}
+
+// Purge expired entries so the cache does not grow without bound over long uptimes.
+setInterval(purgeExpiredSessionCache, SESSION_CACHE_TTL_MS).unref();
 
 export async function resolveSharedChatSessionId(userId: string): Promise<string | null> {
   const now = Date.now();

--- a/src/twitch/eventsub/twitchEventSubConnection.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.ts
@@ -225,15 +225,18 @@ export class StreamerConnection {
 }
 
 // TTL-based dedup: messageId → expiry timestamp (shared across all per-streamer connections)
-const seenMessageIds = new Map<string, number>();
+export const seenMessageIds = new Map<string, number>();
 
-// Purge expired entries on a fixed interval so isDuplicate stays O(1).
-setInterval(() => {
+/** Removes all expired entries from the deduplication map. */
+export function purgeExpiredMessageIds(): void {
   const now = Date.now();
   for (const [id, expiry] of seenMessageIds) {
-    if (now > expiry) seenMessageIds.delete(id);
+    if (expiry < now) seenMessageIds.delete(id);
   }
-}, MESSAGE_TTL_MS).unref();
+}
+
+// Purge expired entries on a fixed interval so isDuplicate stays O(1).
+setInterval(purgeExpiredMessageIds, MESSAGE_TTL_MS).unref();
 
 /** Returns true if messageId has been seen within MESSAGE_TTL_MS; records it otherwise. */
 export function isDuplicate(messageId: string): boolean {

--- a/src/twitch/eventsub/twitchEventSubConnection.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.ts
@@ -227,13 +227,19 @@ export class StreamerConnection {
 // TTL-based dedup: messageId → expiry timestamp (shared across all per-streamer connections)
 const seenMessageIds = new Map<string, number>();
 
-/** Returns true if messageId has been seen within MESSAGE_TTL_MS; records it otherwise. */
-export function isDuplicate(messageId: string): boolean {
+// Purge expired entries on a fixed interval so isDuplicate stays O(1).
+setInterval(() => {
   const now = Date.now();
   for (const [id, expiry] of seenMessageIds) {
     if (now > expiry) seenMessageIds.delete(id);
   }
-  if (seenMessageIds.has(messageId)) return true;
+}, MESSAGE_TTL_MS).unref();
+
+/** Returns true if messageId has been seen within MESSAGE_TTL_MS; records it otherwise. */
+export function isDuplicate(messageId: string): boolean {
+  const now = Date.now();
+  const expiry = seenMessageIds.get(messageId);
+  if (expiry !== undefined && now <= expiry) return true;
   seenMessageIds.set(messageId, now + MESSAGE_TTL_MS);
   return false;
 }

--- a/src/web/routes/sfxPublic.test.ts
+++ b/src/web/routes/sfxPublic.test.ts
@@ -74,4 +74,24 @@ describe('GET /sfx-list', () => {
     expect((res.body as any).view).toBe('sfx-public');
     expect((res.body as any).locals.user).toBeNull();
   });
+
+  it('coalesces concurrent cache-miss requests into a single DB query', async () => {
+    let resolveData!: (data: any[]) => void;
+    const pending = new Promise<any[]>((r) => { resolveData = r; });
+    vi.mocked(getPublicSfxTriggers).mockReturnValueOnce(pending as any);
+
+    const app = buildApp();
+    const p1 = supertest(app).get('/sfx-list');
+    const p2 = supertest(app).get('/sfx-list');
+
+    // Yield so both requests reach the await inside getCachedData before the deferred resolves
+    await new Promise<void>((r) => setImmediate(r));
+    resolveData([]);
+
+    const [res1, res2] = await Promise.all([p1, p2]);
+
+    expect(getPublicSfxTriggers).toHaveBeenCalledOnce();
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+  });
 });

--- a/src/web/routes/sfxPublic.ts
+++ b/src/web/routes/sfxPublic.ts
@@ -9,12 +9,18 @@ const router = Router();
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
 let cache: { data: PublicSfxTrigger[]; expiresAt: number } | null = null;
+let inFlight: Promise<PublicSfxTrigger[]> | null = null;
 
 async function getCachedData(): Promise<PublicSfxTrigger[]> {
   if (cache && Date.now() < cache.expiresAt) return cache.data;
-  const data = await getPublicSfxTriggers();
-  cache = { data, expiresAt: Date.now() + CACHE_TTL_MS };
-  return data;
+  if (inFlight) return inFlight;
+  inFlight = getPublicSfxTriggers()
+    .then((data) => {
+      cache = { data, expiresAt: Date.now() + CACHE_TTL_MS };
+      return data;
+    })
+    .finally(() => { inFlight = null; });
+  return inFlight;
 }
 
 router.get('/sfx-list', async (req, res) => {


### PR DESCRIPTION
Combines #248, #236, #237 into a single reviewable unit.

## Changes

- **#248** `customCommandHandler.ts` — add `purgeExpiredSessionCache()` on a `setInterval` so the per-user session Map doesn't grow without bound on long-running instances
- **#236** `sfxPublic.ts` — coalesce concurrent cache-miss fetches into one DB query via an `inFlight` promise (thundering-herd fix)
- **#237** `twitchEventSubConnection.ts` — move `seenMessageIds` cleanup off the `isDuplicate` hot path into a periodic `setInterval`; `isDuplicate` is now O(1)

## Test plan

- [ ] `npx tsc --noEmit`
- [ ] `npm test`

Supersedes #248, #236, #237

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjEddaqAJgAUkFsmNvUjTb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for session cache cleanup behavior

* **Performance**
  * Implemented automatic TTL-based cleanup for session caches to improve memory efficiency
  * Optimized message deduplication to use background purging instead of per-request cleanup
  * Added request deduplication for concurrent cache-miss scenarios to reduce redundant database queries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->