### PR TITLE
refactor: consolidate DB boolean conversion and improve Discord client lifecycle

### DIFF
--- a/src/db/customCommands.test.ts
+++ b/src/db/customCommands.test.ts
@@ -132,7 +132,7 @@ describe('getAllCustomCommandsWithAssignments', () => {
     expect(result[1].is_multi_twitch).toBe(true);
   });
 
-  it('maps BIT(1) Buffer fields for is_discord_enabled and is_multi_twitch', async () => {
+  it('maps BIT(1) Buffer([1]) fields for is_discord_enabled and is_multi_twitch as true', async () => {
     const row = { command_id: 1, trigger_string: '!ok', output: 'ok', is_discord_enabled: Buffer.from([1]), is_multi_twitch: Buffer.from([1]), assigned_discord_id: null, user_discord_id: null, discord_name: null, twitch_name: null, access_level: 0, is_twitch_bot_enabled: 0 };
     const pool = makePool();
     pool.execute.mockResolvedValue([[row], []]);
@@ -140,6 +140,26 @@ describe('getAllCustomCommandsWithAssignments', () => {
     const result = await getAllCustomCommandsWithAssignments();
     expect(result[0].is_discord_enabled).toBe(true);
     expect(result[0].is_multi_twitch).toBe(true);
+  });
+
+  it('maps BIT(1) Buffer([0]) fields for is_discord_enabled and is_multi_twitch as false', async () => {
+    const row = { command_id: 1, trigger_string: '!ok', output: 'ok', is_discord_enabled: Buffer.from([0]), is_multi_twitch: Buffer.from([0]), assigned_discord_id: null, user_discord_id: null, discord_name: null, twitch_name: null, access_level: 0, is_twitch_bot_enabled: 0 };
+    const pool = makePool();
+    pool.execute.mockResolvedValue([[row], []]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await getAllCustomCommandsWithAssignments();
+    expect(result[0].is_discord_enabled).toBe(false);
+    expect(result[0].is_multi_twitch).toBe(false);
+  });
+
+  it('maps null fields for is_discord_enabled and is_multi_twitch as false', async () => {
+    const row = { command_id: 1, trigger_string: '!ok', output: 'ok', is_discord_enabled: null, is_multi_twitch: null, assigned_discord_id: null, user_discord_id: null, discord_name: null, twitch_name: null, access_level: 0, is_twitch_bot_enabled: 0 };
+    const pool = makePool();
+    pool.execute.mockResolvedValue([[row], []]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await getAllCustomCommandsWithAssignments();
+    expect(result[0].is_discord_enabled).toBe(false);
+    expect(result[0].is_multi_twitch).toBe(false);
   });
 
   it('marks user as orphaned when user_discord_id is null', async () => {

--- a/src/db/customCommands.ts
+++ b/src/db/customCommands.ts
@@ -1,5 +1,6 @@
 import mysql from 'mysql2/promise';
 import { getPool } from './pool';
+import { fromBit } from './utils';
 import { AccessLevel } from './users';
 import type { AccessLevelValue } from './users';
 import { assertNotReservedCommand } from './reservedCommands';
@@ -36,17 +37,13 @@ export interface DbCustomCommandWithAssignments extends DbCustomCommand {
 
 // ─── Row mappers ─────────────────────────────────────────────────────────────
 
-function mapBool(value: unknown): boolean {
-  return Buffer.isBuffer(value) ? value[0] === 1 : Number(value) === 1;
-}
-
 function mapCustomCommand(row: mysql.RowDataPacket): DbCustomCommand {
   return {
     command_id: row.command_id,
     trigger_string: row.trigger_string,
     output: row.output,
-    is_discord_enabled: mapBool(row.is_discord_enabled),
-    is_multi_twitch: mapBool(row.is_multi_twitch),
+    is_discord_enabled: fromBit(row.is_discord_enabled),
+    is_multi_twitch: fromBit(row.is_multi_twitch),
   };
 }
 
@@ -80,7 +77,7 @@ export async function getAllCustomCommandsWithAssignments(): Promise<DbCustomCom
         discord_name: row.discord_name ?? null,
         twitch_name: row.twitch_name ?? null,
         access_level: row.access_level ?? AccessLevel.USER,
-        is_twitch_bot_enabled: mapBool(row.is_twitch_bot_enabled),
+        is_twitch_bot_enabled: fromBit(row.is_twitch_bot_enabled),
         is_orphaned_user: row.user_discord_id === null || row.user_discord_id === undefined,
       });
     }

--- a/src/db/customCommands.ts
+++ b/src/db/customCommands.ts
@@ -49,6 +49,7 @@ function mapCustomCommand(row: mysql.RowDataPacket): DbCustomCommand {
 
 // ─── Queries ─────────────────────────────────────────────────────────────────
 
+/** Return all custom commands, each with its full list of assigned users. */
 export async function getAllCustomCommandsWithAssignments(): Promise<DbCustomCommandWithAssignments[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
     `SELECT c.command_id, c.trigger_string, c.output, c.is_discord_enabled, c.is_multi_twitch,
@@ -88,6 +89,16 @@ export async function getAllCustomCommandsWithAssignments(): Promise<DbCustomCom
 
 // ─── CRUD ─────────────────────────────────────────────────────────────────────
 
+/**
+ * Create a new custom command. Validates and normalises the trigger string, checks for
+ * conflicts, and invalidates the lookup cache on success.
+ *
+ * @param triggerString - Full prefixed command string (e.g. `!clap`); lowercased before storing.
+ * @param output - Response text, max 2000 characters.
+ * @param isDiscordEnabled - When true, the command responds in Discord.
+ * @param isMultiTwitch - When true, the command can be assigned to multiple Twitch streamers.
+ * @returns The auto-incremented `command_id` of the newly created row.
+ */
 export async function addCustomCommand(
   triggerString: string,
   output: string,
@@ -127,6 +138,17 @@ export async function addCustomCommand(
   return commandId;
 }
 
+/**
+ * Update an existing custom command's trigger string, output, and flags.
+ * Validates conflicts against other commands, throws {@link CommandNotFoundError}
+ * if the command does not exist, and invalidates the lookup cache on success.
+ *
+ * @param commandId - ID of the command to update.
+ * @param triggerString - New trigger string; lowercased before storing.
+ * @param output - New response text, max 2000 characters.
+ * @param isDiscordEnabled - Whether the command responds in Discord.
+ * @param isMultiTwitch - Whether the command can be assigned to multiple Twitch streamers.
+ */
 export async function updateCustomCommand(
   commandId: number,
   triggerString: string,
@@ -170,6 +192,13 @@ export async function updateCustomCommand(
   invalidateCustomCommandLookupCache();
 }
 
+/**
+ * Delete a custom command and all its user assignments within a transaction.
+ * Throws {@link CommandNotFoundError} if the command does not exist.
+ * Invalidates the lookup cache only after a successful commit.
+ *
+ * @param commandId - ID of the command to delete.
+ */
 export async function removeCustomCommand(commandId: number): Promise<void> {
   const connection = await getPool().getConnection();
   const lockName = `bcuk_cmdid_${commandId}`;
@@ -200,6 +229,15 @@ export async function removeCustomCommand(commandId: number): Promise<void> {
   }
 }
 
+/**
+ * Assign a Discord user to a custom command's Twitch streamer list.
+ * Acquires a named lock for the command ID, then delegates to
+ * {@link assignUserToCommandWithinTransaction} to check cross-command conflicts
+ * before inserting. Invalidates the lookup cache on success.
+ *
+ * @param commandId - ID of the command to assign the user to.
+ * @param discordId - Discord snowflake of the user to assign.
+ */
 export async function assignUserToCommand(commandId: number, discordId: string): Promise<void> {
   const connection = await getPool().getConnection();
 
@@ -223,6 +261,12 @@ export async function assignUserToCommand(commandId: number, discordId: string):
   }
 }
 
+/**
+ * Remove a Discord user's assignment from a custom command and invalidate the lookup cache.
+ *
+ * @param commandId - ID of the command to remove the assignment from.
+ * @param discordId - Discord snowflake of the user to unassign.
+ */
 export async function unassignUserFromCommand(commandId: number, discordId: string): Promise<void> {
   await getPool().execute(
     'DELETE FROM twitch_user_commands WHERE command_id = ? AND discord_id = ?',

--- a/src/db/eventSub.test.ts
+++ b/src/db/eventSub.test.ts
@@ -138,6 +138,14 @@ describe('getAllEventSubStreamers', () => {
     const [s] = await getAllEventSubStreamers();
     expect(s.eventsub_token_expiry).toBeNull();
   });
+
+  it('returns null for token when EVENTSUB_TOKEN_SECRET is absent but token value is present', async () => {
+    mockSecret = undefined;
+    const row = makeRow({ eventsub_access_token: 'some-encrypted-token' });
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const [s] = await getAllEventSubStreamers();
+    expect(s.eventsub_access_token).toBeNull();
+  });
 });
 
 // ─── getStreamerByDiscordId ───────────────────────────────────────────────────
@@ -175,6 +183,14 @@ describe('getStreamerById', () => {
     vi.mocked(getPool).mockReturnValue(pool as any);
     await getStreamerById(42);
     expect(pool.execute.mock.calls[0][1]).toContain(42);
+  });
+
+  it('maps and returns the found row', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([makeRow({ id: 7, twitch_name: 'bob' })]) as any);
+    const result = await getStreamerById(7);
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe(7);
+    expect(result!.twitch_name).toBe('bob');
   });
 });
 

--- a/src/db/eventSub.ts
+++ b/src/db/eventSub.ts
@@ -1,5 +1,6 @@
 import mysql from 'mysql2/promise';
 import { getPool } from './pool';
+import { fromBit } from './utils';
 import { EVENTSUB_TOKEN_SECRET } from '../shared/config';
 import { encryptToken, decryptToken } from '../shared/crypto';
 
@@ -25,19 +26,15 @@ export interface DbStreamerEventSub {
   config: EventSubConfig | null;
 }
 
-function mapBool(value: unknown): boolean {
-  return Buffer.isBuffer(value) ? value[0] === 1 : value == 1;
-}
-
 function mapConfig(r: mysql.RowDataPacket): EventSubConfig {
   return {
-    follow_enabled: mapBool(r.follow_enabled),
+    follow_enabled: fromBit(r.follow_enabled),
     follow_message: r.follow_message,
-    sub_enabled: mapBool(r.sub_enabled),
+    sub_enabled: fromBit(r.sub_enabled),
     sub_message: r.sub_message,
     resub_message: r.resub_message,
     giftsub_message: r.giftsub_message,
-    raid_enabled: mapBool(r.raid_enabled),
+    raid_enabled: fromBit(r.raid_enabled),
     raid_message: r.raid_message,
   };
 }

--- a/src/db/eventSub.ts
+++ b/src/db/eventSub.ts
@@ -70,6 +70,7 @@ const EVENT_SUB_SELECT = `
   c.sub_enabled, c.sub_message, c.resub_message, c.giftsub_message,
   c.raid_enabled, c.raid_message`;
 
+/** Return all Twitch-bot-enabled streamers with their EventSub OAuth tokens and event config. */
 export async function getAllEventSubStreamers(): Promise<DbStreamerEventSub[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
     `SELECT ${EVENT_SUB_SELECT}
@@ -82,6 +83,11 @@ export async function getAllEventSubStreamers(): Promise<DbStreamerEventSub[]> {
   return rows.map(mapStreamerEventSub);
 }
 
+/**
+ * Look up a streamer by their Discord snowflake ID. Returns null if not found.
+ *
+ * @param discordId - Discord user snowflake to search for.
+ */
 export async function getStreamerByDiscordId(discordId: string): Promise<DbStreamerEventSub | null> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
     `SELECT ${EVENT_SUB_SELECT}
@@ -94,6 +100,11 @@ export async function getStreamerByDiscordId(discordId: string): Promise<DbStrea
   return rows.length === 0 ? null : mapStreamerEventSub(rows[0]);
 }
 
+/**
+ * Look up a streamer by their DB row ID. Returns null if not found.
+ *
+ * @param id - Primary key of the `streamer` row.
+ */
 export async function getStreamerById(id: number): Promise<DbStreamerEventSub | null> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
     `SELECT ${EVENT_SUB_SELECT}
@@ -106,6 +117,16 @@ export async function getStreamerById(id: number): Promise<DbStreamerEventSub | 
   return rows.length === 0 ? null : mapStreamerEventSub(rows[0]);
 }
 
+/**
+ * Encrypt and persist a streamer's EventSub OAuth tokens. Throws if
+ * `EVENTSUB_TOKEN_SECRET` is not configured, to prevent storing plaintext credentials.
+ *
+ * @param streamerId - DB row ID of the streamer to update.
+ * @param twitchUserId - Twitch user ID associated with the tokens.
+ * @param accessToken - OAuth access token (encrypted before storage).
+ * @param refreshToken - OAuth refresh token (encrypted before storage).
+ * @param expiryMs - Token expiry as Unix epoch milliseconds, or null if unknown.
+ */
 export async function saveStreamerToken(
   streamerId: number,
   twitchUserId: string,
@@ -124,6 +145,11 @@ export async function saveStreamerToken(
   );
 }
 
+/**
+ * Null out all OAuth token fields for a streamer (used on logout or token revocation).
+ *
+ * @param streamerId - DB row ID of the streamer whose tokens should be cleared.
+ */
 export async function clearStreamerToken(streamerId: number): Promise<void> {
   await getPool().execute(
     `UPDATE streamer
@@ -144,6 +170,12 @@ const DEFAULT_EVENT_CONFIG: EventSubConfig = {
   raid_message: 'Welcome raiders from {from_display}! Thank you for the {viewers} person raid!',
 };
 
+/**
+ * Insert a default event config row for a streamer if one does not already exist.
+ * Uses INSERT IGNORE so it is safe to call multiple times without overwriting existing config.
+ *
+ * @param streamerId - DB row ID of the streamer to initialise config for.
+ */
 export async function initEventConfig(streamerId: number): Promise<void> {
   const c = DEFAULT_EVENT_CONFIG;
   await getPool().execute(
@@ -161,6 +193,13 @@ export async function initEventConfig(streamerId: number): Promise<void> {
   );
 }
 
+/**
+ * Upsert the event config for a streamer. Inserts a new row or updates all fields
+ * if a row for this streamer already exists.
+ *
+ * @param streamerId - DB row ID of the streamer.
+ * @param config - Full event config to persist; boolean flags are stored as BIT(1).
+ */
 export async function saveEventConfig(streamerId: number, config: EventSubConfig): Promise<void> {
   await getPool().execute(
     `INSERT INTO streamer_event_config

--- a/src/db/sfx.ts
+++ b/src/db/sfx.ts
@@ -1,5 +1,6 @@
 import mysql from 'mysql2/promise';
 import { getPool } from './pool';
+import { fromBit } from './utils';
 
 export interface SfxTrigger {
   id: bigint;
@@ -28,10 +29,6 @@ export interface SfxTriggerRow {
   files: Array<{ id: number; file: string; weight: number; hidden: boolean }>;
 }
 
-function mapBool(value: unknown): boolean {
-  return Buffer.isBuffer(value) ? value[0] === 1 : value == 1;
-}
-
 /**
  * Look up a trigger by its command string (case-insensitive).
  * Hidden triggers ARE included — the hidden flag only affects public listing, not playback.
@@ -49,7 +46,7 @@ export async function findTrigger(command: string): Promise<SfxTrigger | null> {
     id: BigInt(row.id),
     trigger_command: row.trigger_command,
     category_id: row.category_id,
-    hidden: mapBool(row.hidden),
+    hidden: fromBit(row.hidden),
     description: row.description,
   };
 }
@@ -71,7 +68,7 @@ export async function findSoundFiles(triggerId: bigint): Promise<SfxFile[]> {
     file: row.file,
     trigger_command: row.trigger_command,
     weight: row.weight,
-    hidden: mapBool(row.hidden),
+    hidden: fromBit(row.hidden),
     category_id: row.category_id,
   }));
 }
@@ -122,7 +119,7 @@ export async function getAllSfxTriggers(): Promise<SfxTriggerRow[]> {
         triggerId: r.triggerId,
         triggerCommand: r.triggerCommand,
         description: r.description ?? null,
-        hidden: mapBool(r.triggerHidden),
+        hidden: fromBit(r.triggerHidden),
         categoryName: r.categoryName ?? null,
         files: [],
       });
@@ -132,7 +129,7 @@ export async function getAllSfxTriggers(): Promise<SfxTriggerRow[]> {
         id: r.sfxId,
         file: r.file,
         weight: r.weight,
-        hidden: mapBool(r.sfxHidden),
+        hidden: fromBit(r.sfxHidden),
       });
     }
   }

--- a/src/db/sfx.ts
+++ b/src/db/sfx.ts
@@ -79,6 +79,7 @@ export interface PublicSfxTrigger {
   description: string | null;
 }
 
+/** Return all non-hidden SFX triggers for public display, ordered by category then command. */
 export async function getPublicSfxTriggers(): Promise<PublicSfxTrigger[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
     `SELECT t.trigger_command AS triggerCommand, c.name AS categoryName, t.description
@@ -94,6 +95,7 @@ export async function getPublicSfxTriggers(): Promise<PublicSfxTrigger[]> {
   }));
 }
 
+/** Return all SFX triggers (including hidden) with their associated sound files, for the admin panel. */
 export async function getAllSfxTriggers(): Promise<SfxTriggerRow[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
     `SELECT

--- a/src/db/streamMonitor.ts
+++ b/src/db/streamMonitor.ts
@@ -1,5 +1,6 @@
 import mysql from 'mysql2/promise';
 import { getPool } from './pool';
+import { fromBit } from './utils';
 
 export interface DbStreamGroup {
   id: number;
@@ -45,9 +46,6 @@ export interface DbStreamerFull {
   group: DbStreamGroup;
 }
 
-function mapBool(value: unknown): boolean {
-  return Buffer.isBuffer(value) ? value[0] === 1 : value == 1;
-}
 
 function mapStreamGroup(r: mysql.RowDataPacket): DbStreamGroup {
   return {
@@ -56,8 +54,8 @@ function mapStreamGroup(r: mysql.RowDataPacket): DbStreamGroup {
     discord_channel: String(r.discord_channel),
     live_message: r.live_message,
     new_game_message: r.new_game_message,
-    multi_twitch: mapBool(r.multi_twitch),
-    delete_old_posts: mapBool(r.delete_old_posts),
+    multi_twitch: fromBit(r.multi_twitch),
+    delete_old_posts: fromBit(r.delete_old_posts),
   };
 }
 
@@ -145,8 +143,8 @@ export async function getAllStreamersWithGroups(): Promise<DbStreamerFull[]> {
       discord_channel: String(r.discord_channel),
       live_message: r.live_message,
       new_game_message: r.new_game_message,
-      multi_twitch: mapBool(r.multi_twitch),
-      delete_old_posts: mapBool(r.delete_old_posts),
+      multi_twitch: fromBit(r.multi_twitch),
+      delete_old_posts: fromBit(r.delete_old_posts),
     },
   }));
 }

--- a/src/db/streamMonitor.ts
+++ b/src/db/streamMonitor.ts
@@ -46,7 +46,6 @@ export interface DbStreamerFull {
   group: DbStreamGroup;
 }
 
-
 function mapStreamGroup(r: mysql.RowDataPacket): DbStreamGroup {
   return {
     id: r.id,

--- a/src/db/streamMonitor.ts
+++ b/src/db/streamMonitor.ts
@@ -69,6 +69,7 @@ function streamGroupParams(input: AddStreamGroupInput): Array<string | number> {
   ];
 }
 
+/** Return all stream groups ordered by name. */
 export async function getAllStreamGroups(): Promise<DbStreamGroup[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
     `SELECT id, name, discord_channel, live_message, new_game_message, multi_twitch, delete_old_posts
@@ -77,6 +78,11 @@ export async function getAllStreamGroups(): Promise<DbStreamGroup[]> {
   return rows.map(mapStreamGroup);
 }
 
+/**
+ * Insert a new stream group.
+ *
+ * @param input - Stream group fields to store.
+ */
 export async function addStreamGroup(input: AddStreamGroupInput): Promise<void> {
   await getPool().execute(
     `INSERT INTO stream_group (name, discord_channel, live_message, new_game_message, multi_twitch, delete_old_posts)
@@ -85,6 +91,11 @@ export async function addStreamGroup(input: AddStreamGroupInput): Promise<void> 
   );
 }
 
+/**
+ * Update all fields of an existing stream group.
+ *
+ * @param input - Updated stream group fields; `id` identifies the row to update.
+ */
 export async function updateStreamGroup(input: UpdateStreamGroupInput): Promise<void> {
   await getPool().execute(
     `UPDATE stream_group SET name=?, discord_channel=?, live_message=?, new_game_message=?, multi_twitch=?, delete_old_posts=?
@@ -93,10 +104,16 @@ export async function updateStreamGroup(input: UpdateStreamGroupInput): Promise<
   );
 }
 
+/**
+ * Delete a stream group by ID.
+ *
+ * @param id - Primary key of the stream group to remove.
+ */
 export async function removeStreamGroup(id: number): Promise<void> {
   await getPool().execute('DELETE FROM stream_group WHERE id = ?', [id]);
 }
 
+/** Return all streamers with their group name, ordered by group then Twitch name (flat view for the admin panel). */
 export async function getAllStreamers(): Promise<DbStreamer[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
     `SELECT s.id, s.discord_id, s.group_id,
@@ -117,6 +134,7 @@ export async function getAllStreamers(): Promise<DbStreamer[]> {
   }));
 }
 
+/** Return all streamers with their full group configuration, ordered by group then Twitch name (used by twitchMonitor). */
 export async function getAllStreamersWithGroups(): Promise<DbStreamerFull[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
     `SELECT s.id, s.discord_id, s.group_id,
@@ -148,6 +166,12 @@ export async function getAllStreamersWithGroups(): Promise<DbStreamerFull[]> {
   }));
 }
 
+/**
+ * Add a streamer to a stream group.
+ *
+ * @param discordId - Discord snowflake of the user to register as a streamer.
+ * @param groupId - ID of the stream group to add the streamer to.
+ */
 export async function addStreamer(discordId: string, groupId: number): Promise<void> {
   await getPool().execute(
     'INSERT INTO streamer (discord_id, group_id) VALUES (?, ?)',
@@ -155,14 +179,32 @@ export async function addStreamer(discordId: string, groupId: number): Promise<v
   );
 }
 
+/**
+ * Remove a streamer row by its DB ID.
+ *
+ * @param id - Primary key of the streamer row to delete.
+ */
 export async function removeStreamer(id: number): Promise<void> {
   await getPool().execute('DELETE FROM streamer WHERE id = ?', [id]);
 }
 
+/**
+ * Remove all streamers belonging to a given stream group.
+ *
+ * @param groupId - ID of the stream group whose streamers should be deleted.
+ */
 export async function removeStreamersByGroup(groupId: number): Promise<void> {
   await getPool().execute('DELETE FROM streamer WHERE group_id = ?', [groupId]);
 }
 
+/**
+ * Persist the Discord message details for a streamer's current live post.
+ *
+ * @param id - DB row ID of the streamer.
+ * @param messageId - Discord message snowflake of the live announcement post.
+ * @param channelId - Discord channel snowflake where the post was sent.
+ * @param game - Game title reported at the time of going live.
+ */
 export async function setStreamerLive(
   id: number,
   messageId: string,
@@ -175,6 +217,11 @@ export async function setStreamerLive(
   );
 }
 
+/**
+ * Clear a streamer's live post state, nulling the stored message, channel, and game.
+ *
+ * @param id - DB row ID of the streamer to mark as offline.
+ */
 export async function clearStreamerLive(id: number): Promise<void> {
   await getPool().execute(
     'UPDATE streamer SET discord_message_id=NULL, discord_channel_id=NULL, live_game=NULL WHERE id=?',

--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../shared/config', () => ({
+  DISCORD_TOKEN: 'mock-token',
+  DISCORD_GUILD_ID: 'guild-id',
+  DISCORD_VOICE_CHANNEL_ID: 'vc-id',
+  SFX_FOLDER: '/tmp/sfx',
+  OVERLAY_FOLDER: '/tmp/overlay',
+  GLOBAL_COOLDOWN_MS: 0,
+  EVENTSUB_TOKEN_SECRET: undefined,
+}));
+vi.mock('../commands/commandRouter', () => ({ handleCommand: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../commands/customCommandHandler', () => ({ executeCustomCommandForDiscord: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../commands/counterHandler', () => ({ executeCounterCommandForDiscord: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../shared/statusStore', () => ({ setDiscordReady: vi.fn() }));
+vi.mock('../shared/logger', () => ({ createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }));
+vi.mock('discord.js', () => ({
+  Client: vi.fn(),
+  GatewayIntentBits: { Guilds: 1, GuildMessages: 2, MessageContent: 4, GuildVoiceStates: 8 },
+}));
+
+type DiscordBotModule = typeof import('./discordBot');
+type CommandRouterModule = typeof import('../commands/commandRouter');
+type CustomCommandModule = typeof import('../commands/customCommandHandler');
+
+let mod: DiscordBotModule;
+let commands: CommandRouterModule;
+let customCmds: CustomCommandModule;
+let mockInstance: ReturnType<typeof makeMockClient>;
+let mockGuild: { name: string; members: { fetch: ReturnType<typeof vi.fn> } };
+
+function makeMockClient() {
+  mockGuild = { name: 'TestGuild', members: { fetch: vi.fn().mockResolvedValue({ displayName: 'Alice' }) } };
+  return {
+    on: vi.fn().mockReturnThis(),
+    once: vi.fn().mockReturnThis(),
+    login: vi.fn().mockResolvedValue(undefined),
+    destroy: vi.fn(),
+    user: { tag: 'Bot#1234' },
+    guilds: {
+      cache: { get: vi.fn().mockReturnValue(null) },
+      fetch: vi.fn().mockResolvedValue(mockGuild),
+    },
+  };
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  mockInstance = makeMockClient();
+  const djs = await import('discord.js');
+  vi.mocked(djs.Client).mockImplementation(function () { return mockInstance; } as any);
+  // Import commandRouter first so discordBot.ts picks up the same cached instance
+  commands = await import('../commands/commandRouter.js') as CommandRouterModule;
+  customCmds = await import('../commands/customCommandHandler.js') as CustomCommandModule;
+  mod = await import('./discordBot.js') as DiscordBotModule;
+});
+
+// ─── getDiscordClient ─────────────────────────────────────────────────────────
+
+describe('getDiscordClient', () => {
+  it('returns null before startDiscordBot is called', () => {
+    expect(mod.getDiscordClient()).toBeNull();
+  });
+
+  it('returns the client instance after clientReady fires', async () => {
+    mod.startDiscordBot();
+    const readyCb = mockInstance.once.mock.calls.find(([event]: string[]) => event === 'clientReady')?.[1];
+    await readyCb(mockInstance);
+    expect(mod.getDiscordClient()).toBe(mockInstance);
+  });
+});
+
+// ─── fetchMemberDisplayName ───────────────────────────────────────────────────
+
+describe('fetchMemberDisplayName', () => {
+  it('returns null when client is not ready', async () => {
+    expect(await mod.fetchMemberDisplayName('123')).toBeNull();
+  });
+
+  it('returns the member displayName when client is ready and fetch succeeds', async () => {
+    mod.startDiscordBot();
+    const readyCb = mockInstance.once.mock.calls.find(([event]: string[]) => event === 'clientReady')?.[1];
+    await readyCb(mockInstance);  // fires clientReady → sets client and cachedGuild
+
+    const result = await mod.fetchMemberDisplayName('user123');
+    expect(result).toBe('Alice');
+  });
+
+  it('returns null when guild member fetch throws', async () => {
+    mockGuild.members.fetch.mockRejectedValueOnce(new Error('not found'));
+    mod.startDiscordBot();
+    const readyCb = mockInstance.once.mock.calls.find(([event]: string[]) => event === 'clientReady')?.[1];
+    await readyCb(mockInstance);
+
+    const result = await mod.fetchMemberDisplayName('missing');
+    expect(result).toBeNull();
+  });
+});
+
+// ─── startDiscordBot — messageCreate handler ──────────────────────────────────
+
+describe('startDiscordBot — messageCreate handler', () => {
+  function getMessageCreateCb() {
+    mod.startDiscordBot();
+    return mockInstance.on.mock.calls.find(([event]: string[]) => event === 'messageCreate')?.[1] as Function;
+  }
+
+  it('skips bot messages without calling command handlers', () => {
+    const cb = getMessageCreateCb();
+    cb({ author: { bot: true }, guildId: 'guild-id', content: '!test', member: null });
+    expect(vi.mocked(commands.handleCommand)).not.toHaveBeenCalled();
+  });
+
+  it('skips messages from the wrong guild', () => {
+    const cb = getMessageCreateCb();
+    cb({ author: { bot: false, username: 'Alice' }, guildId: 'other-guild', content: '!test', member: null });
+    expect(vi.mocked(commands.handleCommand)).not.toHaveBeenCalled();
+  });
+
+  it('dispatches to command handlers for valid guild messages', () => {
+    const cb = getMessageCreateCb();
+    const msg = { author: { bot: false, username: 'Alice' }, guildId: 'guild-id', content: '!test', member: { displayName: 'Alice' } };
+    cb(msg);
+    expect(vi.mocked(commands.handleCommand)).toHaveBeenCalledWith('!test', 'discord');
+    expect(vi.mocked(customCmds.executeCustomCommandForDiscord)).toHaveBeenCalledWith(msg, 'Alice');
+  });
+});
+
+// ─── startDiscordBot — clientReady error path ─────────────────────────────────
+
+describe('startDiscordBot — clientReady error path', () => {
+  it('catches guild fetch errors without crashing', async () => {
+    mockInstance.guilds.fetch.mockRejectedValueOnce(new Error('guild unavailable'));
+    mod.startDiscordBot();
+    const readyCb = mockInstance.once.mock.calls.find(([event]: string[]) => event === 'clientReady')?.[1];
+    await expect(readyCb(mockInstance)).resolves.toBeUndefined();
+  });
+});
+
+// ─── startDiscordBot — error event ───────────────────────────────────────────
+
+describe('startDiscordBot — error event', () => {
+  it('registers an error handler that does not throw', () => {
+    mod.startDiscordBot();
+    const errorCb = mockInstance.on.mock.calls.find(([event]: string[]) => event === 'error')?.[1] as Function;
+    expect(() => errorCb(new Error('ws error'))).not.toThrow();
+  });
+});
+
+// ─── stopDiscordBot ───────────────────────────────────────────────────────────
+
+describe('stopDiscordBot', () => {
+  it('does not throw when called before startDiscordBot (existing?.destroy is safe)', () => {
+    expect(() => mod.stopDiscordBot()).not.toThrow();
+    expect(mod.getDiscordClient()).toBeNull();
+  });
+
+  it('calls destroy on the existing client and nulls the reference', async () => {
+    mod.startDiscordBot();
+    const readyCb = mockInstance.once.mock.calls.find(([event]: string[]) => event === 'clientReady')?.[1];
+    await readyCb(mockInstance);
+    expect(mod.getDiscordClient()).not.toBeNull();
+
+    mod.stopDiscordBot();
+
+    expect(mod.getDiscordClient()).toBeNull();
+    expect(mockInstance.destroy).toHaveBeenCalledOnce();
+  });
+
+  it('swallows errors thrown by destroy', async () => {
+    mod.startDiscordBot();
+    const readyCb = mockInstance.once.mock.calls.find(([event]: string[]) => event === 'clientReady')?.[1];
+    await readyCb(mockInstance);
+    mockInstance.destroy.mockImplementationOnce(() => { throw new Error('destroy failed'); });
+
+    expect(() => mod.stopDiscordBot()).not.toThrow();
+    expect(mod.getDiscordClient()).toBeNull();
+  });
+});

--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -182,4 +182,20 @@ describe('stopDiscordBot', () => {
     expect(() => mod.stopDiscordBot()).not.toThrow();
     expect(mod.getDiscordClient()).toBeNull();
   });
+
+  it('destroys a booting client when stopDiscordBot is called before clientReady fires', () => {
+    mod.startDiscordBot();
+    expect(mod.getDiscordClient()).toBeNull();
+    mod.stopDiscordBot();
+    expect(mockInstance.destroy).toHaveBeenCalledOnce();
+    expect(mod.getDiscordClient()).toBeNull();
+  });
+
+  it('discards a clientReady event that fires after stopDiscordBot', async () => {
+    mod.startDiscordBot();
+    const readyCb = mockInstance.once.mock.calls.find(([event]: string[]) => event === 'clientReady')?.[1];
+    mod.stopDiscordBot();
+    await readyCb(mockInstance); // fires late, after stop
+    expect(mod.getDiscordClient()).toBeNull();
+  });
 });

--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -67,6 +67,12 @@ describe('getDiscordClient', () => {
     expect(mod.getDiscordClient()).toBeNull();
   });
 
+  it('is idempotent — a second call while booting does not create a second Client', () => {
+    mod.startDiscordBot();
+    mod.startDiscordBot(); // should be a no-op
+    expect(mockInstance.login).toHaveBeenCalledOnce();
+  });
+
   it('returns the client instance after clientReady fires', async () => {
     mod.startDiscordBot();
     expect(mod.getDiscordClient()).toBeNull();

--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -62,8 +62,14 @@ describe('getDiscordClient', () => {
     expect(mod.getDiscordClient()).toBeNull();
   });
 
+  it('returns null after startDiscordBot but before clientReady fires', () => {
+    mod.startDiscordBot();
+    expect(mod.getDiscordClient()).toBeNull();
+  });
+
   it('returns the client instance after clientReady fires', async () => {
     mod.startDiscordBot();
+    expect(mod.getDiscordClient()).toBeNull();
     const readyCb = mockInstance.once.mock.calls.find(([event]: string[]) => event === 'clientReady')?.[1];
     await readyCb(mockInstance);
     expect(mod.getDiscordClient()).toBe(mockInstance);

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -55,14 +55,17 @@ export async function fetchMemberDisplayName(discordId: string, force = false): 
 }
 
 /**
- * Create and connect a Discord client. The module-level client (returned by
- * {@link getDiscordClient}) is set only once `clientReady` fires, so callers
- * cannot observe a partially-initialised client.
+ * Create and connect a Discord client. No-op if a client is already running or
+ * booting — call {@link stopDiscordBot} first to replace it.
  *
- * If {@link stopDiscordBot} is called before the connection completes, the
- * in-flight client is destroyed and the `clientReady` handler is discarded.
+ * The module-level client (returned by {@link getDiscordClient}) is set only
+ * once `clientReady` fires, so callers cannot observe a partially-initialised
+ * client. If {@link stopDiscordBot} is called before the connection completes,
+ * the in-flight client is destroyed and the `clientReady` handler is discarded.
+ * If login fails, `bootingClient` is cleared so the next call can retry.
  */
 export function startDiscordBot(): void {
+  if (client || bootingClient) return;
   const localClient = new Client({
     intents: [
       GatewayIntentBits.Guilds,
@@ -113,7 +116,10 @@ export function startDiscordBot(): void {
     log.error('Client error:', err);
   });
 
-  localClient.login(DISCORD_TOKEN).catch((err) => log.error('Login failed:', err));
+  localClient.login(DISCORD_TOKEN).catch((err) => {
+    log.error('Login failed:', err);
+    bootingClient = null; // clear so the next startDiscordBot() call can retry
+  });
 }
 
 /**

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -9,6 +9,7 @@ import { createLogger } from '../shared/logger';
 const log = createLogger('Discord');
 
 let client: Client | null = null;
+let bootingClient: Client | null = null;
 let cachedGuild: Guild | null = null;
 
 /** Returns the Discord.js Client once it has fired `clientReady`, or null before then. */
@@ -33,6 +34,14 @@ async function getConfiguredGuild(): Promise<Guild> {
   return cachedGuild;
 }
 
+/**
+ * Fetch the display name of a Discord guild member.
+ * Returns null if the client is not ready, the guild is unavailable, or the member is not found.
+ *
+ * @param discordId - Discord user snowflake ID to look up.
+ * @param force - When true, bypasses the guild member cache and fetches fresh from the API.
+ * @returns The member's server display name, or null on any failure.
+ */
 export async function fetchMemberDisplayName(discordId: string, force = false): Promise<string | null> {
   if (!client) return null;
   try {
@@ -45,6 +54,14 @@ export async function fetchMemberDisplayName(discordId: string, force = false): 
   }
 }
 
+/**
+ * Create and connect a Discord client. The module-level client (returned by
+ * {@link getDiscordClient}) is set only once `clientReady` fires, so callers
+ * cannot observe a partially-initialised client.
+ *
+ * If {@link stopDiscordBot} is called before the connection completes, the
+ * in-flight client is destroyed and the `clientReady` handler is discarded.
+ */
 export function startDiscordBot(): void {
   const localClient = new Client({
     intents: [
@@ -54,6 +71,7 @@ export function startDiscordBot(): void {
       GatewayIntentBits.GuildVoiceStates,
     ],
   });
+  bootingClient = localClient;
 
   localClient.on('messageCreate', (message) => {
     if (message.author.bot) return;
@@ -75,8 +93,14 @@ export function startDiscordBot(): void {
   });
 
   localClient.once('clientReady', async (c) => {
+    if (bootingClient !== localClient) {
+      // stopDiscordBot() ran during boot — discard this ready client
+      try { c.destroy(); } catch { /* ignore */ }
+      return;
+    }
+    bootingClient = null;
+    client = c;
     log.info(`Logged in as ${c.user.tag}`);
-    client = c; // only set module-level client once the bot is truly ready
     try {
       const guild = await getConfiguredGuild();
       setDiscordReady(c.user.tag, guild.name);
@@ -92,14 +116,26 @@ export function startDiscordBot(): void {
   localClient.login(DISCORD_TOKEN).catch((err) => log.error('Login failed:', err));
 }
 
+/**
+ * Disconnect and destroy the Discord client, including any client that is
+ * still connecting. Idempotent — safe to call before {@link startDiscordBot}.
+ * Errors thrown by `destroy()` are caught and logged rather than propagated.
+ */
 export function stopDiscordBot(): void {
-  const existing = client;
+  const existingReady = client;
+  const existingBooting = bootingClient;
   client = null;
+  bootingClient = null;
   cachedGuild = null;
   try {
-    existing?.destroy();
+    existingReady?.destroy();
   } catch (err) {
     log.error('Error destroying client:', err);
+  }
+  try {
+    existingBooting?.destroy();
+  } catch (err) {
+    log.error('Error destroying booting client:', err);
   }
   log.info('Client destroyed.');
 }

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -8,19 +8,18 @@ import { createLogger } from '../shared/logger';
 
 const log = createLogger('Discord');
 
-let client: Client;
+let client: Client | null = null;
 let cachedGuild: Guild | null = null;
-let _discordClient: Client | null = null;
 
 /** Returns the Discord.js Client once it has fired `clientReady`, or null before then. */
-export function getDiscordClient(): Client | null { return _discordClient; }
+export function getDiscordClient(): Client | null { return client; }
 
 async function getConfiguredGuild(): Promise<Guild> {
-  if (!_discordClient) {
+  if (!client) {
     throw new Error('Discord client is not ready');
   }
 
-  const guildFromCache = _discordClient!.guilds.cache.get(DISCORD_GUILD_ID);
+  const guildFromCache = client.guilds.cache.get(DISCORD_GUILD_ID);
   if (guildFromCache) {
     cachedGuild = guildFromCache;
     return guildFromCache;
@@ -30,12 +29,12 @@ async function getConfiguredGuild(): Promise<Guild> {
     return cachedGuild;
   }
 
-  cachedGuild = await _discordClient!.guilds.fetch(DISCORD_GUILD_ID);
+  cachedGuild = await client.guilds.fetch(DISCORD_GUILD_ID);
   return cachedGuild;
 }
 
 export async function fetchMemberDisplayName(discordId: string, force = false): Promise<string | null> {
-  if (!_discordClient) return null;
+  if (!client) return null;
   try {
     const guild = await getConfiguredGuild();
     const member = await guild.members.fetch({ user: discordId, force });
@@ -77,7 +76,7 @@ export function startDiscordBot(): void {
 
   client.once('clientReady', async (c) => {
     log.info(`Logged in as ${c.user.tag}`);
-    _discordClient = c;
+    client = c;
     try {
       const guild = await getConfiguredGuild();
       setDiscordReady(c.user.tag, guild.name);
@@ -94,10 +93,11 @@ export function startDiscordBot(): void {
 }
 
 export function stopDiscordBot(): void {
-  _discordClient = null;
+  const existing = client;
+  client = null;
   cachedGuild = null;
   try {
-    client?.destroy();
+    existing?.destroy();
   } catch (err) {
     log.error('Error destroying client:', err);
   }

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -46,7 +46,7 @@ export async function fetchMemberDisplayName(discordId: string, force = false): 
 }
 
 export function startDiscordBot(): void {
-  client = new Client({
+  const localClient = new Client({
     intents: [
       GatewayIntentBits.Guilds,
       GatewayIntentBits.GuildMessages,
@@ -55,7 +55,7 @@ export function startDiscordBot(): void {
     ],
   });
 
-  client.on('messageCreate', (message) => {
+  localClient.on('messageCreate', (message) => {
     if (message.author.bot) return;
     if (message.guildId !== DISCORD_GUILD_ID) return;
 
@@ -74,9 +74,9 @@ export function startDiscordBot(): void {
     );
   });
 
-  client.once('clientReady', async (c) => {
+  localClient.once('clientReady', async (c) => {
     log.info(`Logged in as ${c.user.tag}`);
-    client = c;
+    client = c; // only set module-level client once the bot is truly ready
     try {
       const guild = await getConfiguredGuild();
       setDiscordReady(c.user.tag, guild.name);
@@ -85,11 +85,11 @@ export function startDiscordBot(): void {
     }
   });
 
-  client.on('error', (err) => {
+  localClient.on('error', (err) => {
     log.error('Client error:', err);
   });
 
-  client.login(DISCORD_TOKEN).catch((err) => log.error('Login failed:', err));
+  localClient.login(DISCORD_TOKEN).catch((err) => log.error('Login failed:', err));
 }
 
 export function stopDiscordBot(): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import { registerCounterTwitchRuntime } from './commands/counterHandler';
 import { registerMultiTwitchRuntime } from './commands/multiCommandHandler';
 import { registerShoutoutRuntime } from './commands/shoutoutHandler';
 import { registerCountdownTwitchRuntime } from './commands/countdownHandler';
-import { registerEventSubOverlayRuntime } from './twitch/eventsub/twitchEventSubHandler';
+import { registerEventSubOverlayRuntime, registerEventSubTwitchRuntime } from './twitch/eventsub/twitchEventSubHandler';
 import { pushOverlayEvent } from './web/routes/overlaySource';
 import { startCounterScheduler, stopCounterScheduler } from './commands/counterScheduler';
 import { createLogger } from './shared/logger';
@@ -63,6 +63,7 @@ async function main(): Promise<void> {
   registerShoutoutRuntime({ send: sayInChannel });
   registerCountdownTwitchRuntime({ send: sayInChannel });
   registerEventSubOverlayRuntime({ pushOverlayEvent });
+  registerEventSubTwitchRuntime({ send: sayInChannel });
 
   setChannelJoinedHook(() => reloadEventSubSubscriptions());
   startDiscordBot();

--- a/src/twitch/eventsub/twitchEventSubHandler.test.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.test.ts
@@ -1,14 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('../twitchBot', () => ({ sayInChannel: vi.fn() }));
 vi.mock('../../db', () => ({ getVideosForReward: vi.fn() }));
 vi.mock('../../commands/soundSelector', () => ({ pickWeightedRandom: vi.fn() }));
 vi.mock('../../shared/logger', () => ({ createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }));
 
-import { handleFollow, handleSub, handleResub, handleGiftSub, handleRaid, handleRedemption, registerEventSubOverlayRuntime } from './twitchEventSubHandler';
-import { sayInChannel } from '../twitchBot';
+import { handleFollow, handleSub, handleResub, handleGiftSub, handleRaid, handleRedemption, registerEventSubOverlayRuntime, registerEventSubTwitchRuntime } from './twitchEventSubHandler';
 import { getVideosForReward } from '../../db';
 import { pickWeightedRandom } from '../../commands/soundSelector';
+
+const mockSend = vi.fn<(channel: string, message: string) => Promise<void>>();
+registerEventSubTwitchRuntime({ send: mockSend });
 
 const mockPushOverlayEvent = vi.fn();
 registerEventSubOverlayRuntime({ pushOverlayEvent: mockPushOverlayEvent });
@@ -53,7 +54,7 @@ describe('handleFollow', () => {
 
   it('does not call sayInChannel when follow_enabled is false', async () => {
     await handleFollow('streamer', event, makeConfig({ follow_enabled: false }));
-    expect(sayInChannel).not.toHaveBeenCalled();
+    expect(mockSend).not.toHaveBeenCalled();
   });
 
   it('calls sayInChannel with substituted {username} and {display_name} when follow_enabled is true', async () => {
@@ -61,8 +62,8 @@ describe('handleFollow', () => {
       follow_enabled: true,
       follow_message: 'Welcome {username} aka {display_name}!',
     }));
-    expect(sayInChannel).toHaveBeenCalledOnce();
-    expect(sayInChannel).toHaveBeenCalledWith('streamer', 'Welcome testuser aka TestUser!');
+    expect(mockSend).toHaveBeenCalledOnce();
+    expect(mockSend).toHaveBeenCalledWith('streamer', 'Welcome testuser aka TestUser!');
   });
 });
 
@@ -80,12 +81,12 @@ describe('handleSub', () => {
 
   it('does not call sayInChannel when sub_enabled is false', async () => {
     await handleSub('streamer', { ...baseEvent }, makeConfig({ sub_enabled: false }));
-    expect(sayInChannel).not.toHaveBeenCalled();
+    expect(mockSend).not.toHaveBeenCalled();
   });
 
   it('does not call sayInChannel when is_gift is true even if sub_enabled is true', async () => {
     await handleSub('streamer', { ...baseEvent, is_gift: true }, makeConfig({ sub_enabled: true }));
-    expect(sayInChannel).not.toHaveBeenCalled();
+    expect(mockSend).not.toHaveBeenCalled();
   });
 
   it('calls sayInChannel with {tier} and {tier_name} substituted (Tier 1)', async () => {
@@ -93,7 +94,7 @@ describe('handleSub', () => {
       sub_enabled: true,
       sub_message: 'tier={tier} name={tier_name}',
     }));
-    expect(sayInChannel).toHaveBeenCalledWith('streamer', 'tier=1000 name=Tier 1');
+    expect(mockSend).toHaveBeenCalledWith('streamer', 'tier=1000 name=Tier 1');
   });
 
   it('tierName maps 2000 to Tier 2', async () => {
@@ -101,7 +102,7 @@ describe('handleSub', () => {
       sub_enabled: true,
       sub_message: 'name={tier_name}',
     }));
-    expect(sayInChannel).toHaveBeenCalledWith('streamer', 'name=Tier 2');
+    expect(mockSend).toHaveBeenCalledWith('streamer', 'name=Tier 2');
   });
 
   it('tierName maps 3000 to Tier 3', async () => {
@@ -109,7 +110,7 @@ describe('handleSub', () => {
       sub_enabled: true,
       sub_message: 'name={tier_name}',
     }));
-    expect(sayInChannel).toHaveBeenCalledWith('streamer', 'name=Tier 3');
+    expect(mockSend).toHaveBeenCalledWith('streamer', 'name=Tier 3');
   });
 
   it('tierName passes unknown tier through unchanged', async () => {
@@ -117,7 +118,7 @@ describe('handleSub', () => {
       sub_enabled: true,
       sub_message: 'name={tier_name}',
     }));
-    expect(sayInChannel).toHaveBeenCalledWith('streamer', 'name=prime');
+    expect(mockSend).toHaveBeenCalledWith('streamer', 'name=prime');
   });
 });
 
@@ -139,7 +140,7 @@ describe('handleResub', () => {
       sub_enabled: true,
       resub_message: 'months={months} streak={streak}',
     }));
-    expect(sayInChannel).toHaveBeenCalledWith('streamer', 'months=6 streak=3');
+    expect(mockSend).toHaveBeenCalledWith('streamer', 'months=6 streak=3');
   });
 
   it('substitutes {streak} as "0" when streak_months is null', async () => {
@@ -147,7 +148,7 @@ describe('handleResub', () => {
       sub_enabled: true,
       resub_message: 'streak={streak}',
     }));
-    expect(sayInChannel).toHaveBeenCalledWith('streamer', 'streak=0');
+    expect(mockSend).toHaveBeenCalledWith('streamer', 'streak=0');
   });
 
   it('substitutes {streak} as the number string when streak_months is set', async () => {
@@ -155,12 +156,12 @@ describe('handleResub', () => {
       sub_enabled: true,
       resub_message: 'streak={streak}',
     }));
-    expect(sayInChannel).toHaveBeenCalledWith('streamer', 'streak=12');
+    expect(mockSend).toHaveBeenCalledWith('streamer', 'streak=12');
   });
 
   it('does not call sayInChannel when sub_enabled is false', async () => {
     await handleResub('streamer', baseEvent, makeConfig({ sub_enabled: false }));
-    expect(sayInChannel).not.toHaveBeenCalled();
+    expect(mockSend).not.toHaveBeenCalled();
   });
 });
 
@@ -179,7 +180,7 @@ describe('handleGiftSub', () => {
 
   it('does not call sayInChannel when sub_enabled is false', async () => {
     await handleGiftSub('streamer', baseEvent, makeConfig({ sub_enabled: false }));
-    expect(sayInChannel).not.toHaveBeenCalled();
+    expect(mockSend).not.toHaveBeenCalled();
   });
 
   it('uses "anonymous" and "Anonymous" for {gifter} and {gifter_display} when is_anonymous is true', async () => {
@@ -187,7 +188,7 @@ describe('handleGiftSub', () => {
       sub_enabled: true,
       giftsub_message: '{gifter} / {gifter_display}',
     }));
-    expect(sayInChannel).toHaveBeenCalledWith('streamer', 'anonymous / Anonymous');
+    expect(mockSend).toHaveBeenCalledWith('streamer', 'anonymous / Anonymous');
   });
 
   it('uses event.user_login as {gifter} when is_anonymous is false', async () => {
@@ -195,7 +196,7 @@ describe('handleGiftSub', () => {
       sub_enabled: true,
       giftsub_message: '{gifter} / {gifter_display}',
     }));
-    expect(sayInChannel).toHaveBeenCalledWith('streamer', 'gifter / GifterDisplay');
+    expect(mockSend).toHaveBeenCalledWith('streamer', 'gifter / GifterDisplay');
   });
 
   it('substitutes {count} correctly', async () => {
@@ -203,7 +204,7 @@ describe('handleGiftSub', () => {
       sub_enabled: true,
       giftsub_message: 'count={count}',
     }));
-    expect(sayInChannel).toHaveBeenCalledWith('streamer', 'count=3');
+    expect(mockSend).toHaveBeenCalledWith('streamer', 'count=3');
   });
 });
 
@@ -220,7 +221,7 @@ describe('handleRaid', () => {
 
   it('does not call sayInChannel when raid_enabled is false', async () => {
     await handleRaid('streamer', event, makeConfig({ raid_enabled: false }));
-    expect(sayInChannel).not.toHaveBeenCalled();
+    expect(mockSend).not.toHaveBeenCalled();
   });
 
   it('calls sayInChannel with {from_channel}, {from_display}, {viewers} substituted when raid_enabled is true', async () => {
@@ -228,7 +229,7 @@ describe('handleRaid', () => {
       raid_enabled: true,
       raid_message: '{from_channel} ({from_display}) viewers={viewers}',
     }));
-    expect(sayInChannel).toHaveBeenCalledWith('streamer', 'raider (RaiderDisplay) viewers=42');
+    expect(mockSend).toHaveBeenCalledWith('streamer', 'raider (RaiderDisplay) viewers=42');
   });
 });
 

--- a/src/twitch/eventsub/twitchEventSubHandler.test.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.test.ts
@@ -52,12 +52,12 @@ describe('handleFollow', () => {
     broadcaster_user_login: 'streamer',
   };
 
-  it('does not call sayInChannel when follow_enabled is false', async () => {
+  it('does not call injected runtime when follow_enabled is false', async () => {
     await handleFollow('streamer', event, makeConfig({ follow_enabled: false }));
     expect(mockSend).not.toHaveBeenCalled();
   });
 
-  it('calls sayInChannel with substituted {username} and {display_name} when follow_enabled is true', async () => {
+  it('calls injected runtime (mockSend) with substituted {username} and {display_name} when follow_enabled is true', async () => {
     await handleFollow('streamer', event, makeConfig({
       follow_enabled: true,
       follow_message: 'Welcome {username} aka {display_name}!',
@@ -79,17 +79,17 @@ describe('handleSub', () => {
     is_gift: false,
   };
 
-  it('does not call sayInChannel when sub_enabled is false', async () => {
+  it('does not call injected runtime when sub_enabled is false', async () => {
     await handleSub('streamer', { ...baseEvent }, makeConfig({ sub_enabled: false }));
     expect(mockSend).not.toHaveBeenCalled();
   });
 
-  it('does not call sayInChannel when is_gift is true even if sub_enabled is true', async () => {
+  it('does not call injected runtime when is_gift is true even if sub_enabled is true', async () => {
     await handleSub('streamer', { ...baseEvent, is_gift: true }, makeConfig({ sub_enabled: true }));
     expect(mockSend).not.toHaveBeenCalled();
   });
 
-  it('calls sayInChannel with {tier} and {tier_name} substituted (Tier 1)', async () => {
+  it('calls injected runtime (mockSend) with {tier} and {tier_name} substituted (Tier 1)', async () => {
     await handleSub('streamer', { ...baseEvent, tier: '1000' }, makeConfig({
       sub_enabled: true,
       sub_message: 'tier={tier} name={tier_name}',
@@ -135,7 +135,7 @@ describe('handleResub', () => {
     streak_months: 3,
   };
 
-  it('calls sayInChannel with {months} and {streak} substituted when sub_enabled is true', async () => {
+  it('calls injected runtime (mockSend) with {months} and {streak} substituted when sub_enabled is true', async () => {
     await handleResub('streamer', baseEvent, makeConfig({
       sub_enabled: true,
       resub_message: 'months={months} streak={streak}',
@@ -159,7 +159,7 @@ describe('handleResub', () => {
     expect(mockSend).toHaveBeenCalledWith('streamer', 'streak=12');
   });
 
-  it('does not call sayInChannel when sub_enabled is false', async () => {
+  it('does not call injected runtime when sub_enabled is false', async () => {
     await handleResub('streamer', baseEvent, makeConfig({ sub_enabled: false }));
     expect(mockSend).not.toHaveBeenCalled();
   });
@@ -178,7 +178,7 @@ describe('handleGiftSub', () => {
     is_anonymous: false,
   };
 
-  it('does not call sayInChannel when sub_enabled is false', async () => {
+  it('does not call injected runtime when sub_enabled is false', async () => {
     await handleGiftSub('streamer', baseEvent, makeConfig({ sub_enabled: false }));
     expect(mockSend).not.toHaveBeenCalled();
   });
@@ -219,12 +219,12 @@ describe('handleRaid', () => {
     viewers: 42,
   };
 
-  it('does not call sayInChannel when raid_enabled is false', async () => {
+  it('does not call injected runtime when raid_enabled is false', async () => {
     await handleRaid('streamer', event, makeConfig({ raid_enabled: false }));
     expect(mockSend).not.toHaveBeenCalled();
   });
 
-  it('calls sayInChannel with {from_channel}, {from_display}, {viewers} substituted when raid_enabled is true', async () => {
+  it('calls injected runtime (mockSend) with {from_channel}, {from_display}, {viewers} substituted when raid_enabled is true', async () => {
     await handleRaid('streamer', event, makeConfig({
       raid_enabled: true,
       raid_message: '{from_channel} ({from_display}) viewers={viewers}',

--- a/src/twitch/eventsub/twitchEventSubHandler.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.ts
@@ -1,4 +1,3 @@
-import { sayInChannel } from '../twitchBot';
 import type { EventSubConfig } from '../../db';
 import { getVideosForReward } from '../../db';
 import { pickWeightedRandom } from '../../commands/soundSelector';
@@ -28,6 +27,19 @@ let _overlayRuntime: EventSubOverlayRuntime | null = null;
 /** Register the overlay push function. Called from index.ts after startWebPanel(). */
 export function registerEventSubOverlayRuntime(runtime: EventSubOverlayRuntime): void {
   _overlayRuntime = runtime;
+}
+
+// Runtime injection for the Twitch chat send function — avoids a direct import
+// of twitchBot from core EventSub handler code.  Registered from index.ts.
+interface EventSubTwitchRuntime {
+  send: (channel: string, message: string) => Promise<void>;
+}
+
+let _twitchRuntime: EventSubTwitchRuntime | null = null;
+
+/** Register the Twitch chat send function. Called from index.ts after startTwitchBot(). */
+export function registerEventSubTwitchRuntime(runtime: EventSubTwitchRuntime): void {
+  _twitchRuntime = runtime;
 }
 
 export interface FollowEvent {
@@ -92,7 +104,7 @@ export async function handleFollow(login: string, event: FollowEvent, config: Ev
     username: event.user_login,
     display_name: event.user_name,
   });
-  await sayInChannel(login, msg);
+  await _twitchRuntime?.send(login, msg);
 }
 
 export async function handleSub(login: string, event: SubEvent, config: EventSubConfig): Promise<void> {
@@ -103,7 +115,7 @@ export async function handleSub(login: string, event: SubEvent, config: EventSub
     tier: event.tier,
     tier_name: tierName(event.tier),
   });
-  await sayInChannel(login, msg);
+  await _twitchRuntime?.send(login, msg);
 }
 
 export async function handleResub(login: string, event: ResubEvent, config: EventSubConfig): Promise<void> {
@@ -116,7 +128,7 @@ export async function handleResub(login: string, event: ResubEvent, config: Even
     months: String(event.cumulative_months),
     streak: event.streak_months != null ? String(event.streak_months) : '0',
   });
-  await sayInChannel(login, msg);
+  await _twitchRuntime?.send(login, msg);
 }
 
 export async function handleGiftSub(login: string, event: GiftSubEvent, config: EventSubConfig): Promise<void> {
@@ -130,7 +142,7 @@ export async function handleGiftSub(login: string, event: GiftSubEvent, config: 
     tier: event.tier,
     tier_name: tierName(event.tier),
   });
-  await sayInChannel(login, msg);
+  await _twitchRuntime?.send(login, msg);
 }
 
 export async function handleRaid(login: string, event: RaidEvent, config: EventSubConfig): Promise<void> {
@@ -140,7 +152,7 @@ export async function handleRaid(login: string, event: RaidEvent, config: EventS
     from_display: event.from_broadcaster_user_name,
     viewers: String(event.viewers),
   });
-  await sayInChannel(login, msg);
+  await _twitchRuntime?.send(login, msg);
 }
 
 export async function handleRedemption(

--- a/src/twitch/eventsub/twitchEventSubHandler.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.ts
@@ -205,6 +205,16 @@ export async function handleRaid(login: string, event: RaidEvent, config: EventS
   await _twitchRuntime?.send(login, msg);
 }
 
+/**
+ * Handle a channel.channel_points_custom_reward_redemption.add EventSub notification.
+ * Looks up videos configured for the redeemed reward and triggers an overlay event if found.
+ * No-ops when no videos are configured for the reward or `_overlayRuntime` is absent.
+ *
+ * @param login - Broadcaster login name.
+ * @param event - Redemption event payload including reward ID and user details.
+ * @param _config - Streamer event config (unused for redemptions; reserved for future use).
+ * @param streamerId - DB row ID of the streamer, used to scope video lookups.
+ */
 export async function handleRedemption(
   login: string,
   event: RedemptionEvent,

--- a/src/twitch/eventsub/twitchEventSubHandler.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.ts
@@ -37,7 +37,15 @@ interface EventSubTwitchRuntime {
 
 let _twitchRuntime: EventSubTwitchRuntime | null = null;
 
-/** Register the Twitch chat send function. Called from index.ts after startTwitchBot(). */
+/**
+ * Register the Twitch chat send function. Called from index.ts during initialisation,
+ * before startTwitchBot(), so the runtime is in place before the first event arrives.
+ * Stores the provided runtime in the module-level _twitchRuntime variable for later use.
+ *
+ * @param runtime - The {@link EventSubTwitchRuntime} to store; must supply a `send` function
+ *   that delivers a chat message to the given channel.
+ * @returns void
+ */
 export function registerEventSubTwitchRuntime(runtime: EventSubTwitchRuntime): void {
   _twitchRuntime = runtime;
 }

--- a/src/twitch/eventsub/twitchEventSubHandler.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.ts
@@ -106,6 +106,15 @@ function tierName(tier: string): string {
   return ({ '1000': 'Tier 1', '2000': 'Tier 2', '3000': 'Tier 3' } as Record<string, string>)[tier] ?? tier;
 }
 
+/**
+ * Handle a channel.follow EventSub notification.
+ * Sends a chat message to the broadcaster's channel using the injected `_twitchRuntime`.
+ * No-ops when `config.follow_enabled` is false or `_twitchRuntime` has not been registered.
+ *
+ * @param login - Broadcaster login name (chat channel to send to).
+ * @param event - Follow event payload from Twitch EventSub.
+ * @param config - Streamer's event response configuration.
+ */
 export async function handleFollow(login: string, event: FollowEvent, config: EventSubConfig): Promise<void> {
   if (!config.follow_enabled) return;
   const msg = fill(config.follow_message, {
@@ -115,6 +124,14 @@ export async function handleFollow(login: string, event: FollowEvent, config: Ev
   await _twitchRuntime?.send(login, msg);
 }
 
+/**
+ * Handle a channel.subscribe EventSub notification.
+ * No-ops when `config.sub_enabled` is false, the subscription is a gift, or `_twitchRuntime` is absent.
+ *
+ * @param login - Broadcaster login name.
+ * @param event - Subscribe event payload; gift subs are silently skipped (handled by handleGiftSub).
+ * @param config - Streamer's event response configuration.
+ */
 export async function handleSub(login: string, event: SubEvent, config: EventSubConfig): Promise<void> {
   if (!config.sub_enabled || event.is_gift) return;
   const msg = fill(config.sub_message, {
@@ -126,6 +143,14 @@ export async function handleSub(login: string, event: SubEvent, config: EventSub
   await _twitchRuntime?.send(login, msg);
 }
 
+/**
+ * Handle a channel.subscription.message (resub) EventSub notification.
+ * No-ops when `config.sub_enabled` is false or `_twitchRuntime` is absent.
+ *
+ * @param login - Broadcaster login name.
+ * @param event - Resub event payload including cumulative and streak month counts.
+ * @param config - Streamer's event response configuration.
+ */
 export async function handleResub(login: string, event: ResubEvent, config: EventSubConfig): Promise<void> {
   if (!config.sub_enabled) return;
   const msg = fill(config.resub_message, {
@@ -139,6 +164,15 @@ export async function handleResub(login: string, event: ResubEvent, config: Even
   await _twitchRuntime?.send(login, msg);
 }
 
+/**
+ * Handle a channel.subscription.gift EventSub notification.
+ * Anonymous gifters are reported as "anonymous" / "Anonymous".
+ * No-ops when `config.sub_enabled` is false or `_twitchRuntime` is absent.
+ *
+ * @param login - Broadcaster login name.
+ * @param event - Gift-sub event payload; `is_anonymous` controls gifter display name.
+ * @param config - Streamer's event response configuration.
+ */
 export async function handleGiftSub(login: string, event: GiftSubEvent, config: EventSubConfig): Promise<void> {
   if (!config.sub_enabled) return;
   const gifter = event.is_anonymous ? 'anonymous' : event.user_login;
@@ -153,6 +187,14 @@ export async function handleGiftSub(login: string, event: GiftSubEvent, config: 
   await _twitchRuntime?.send(login, msg);
 }
 
+/**
+ * Handle a channel.raid EventSub notification.
+ * No-ops when `config.raid_enabled` is false or `_twitchRuntime` is absent.
+ *
+ * @param login - Broadcaster login name (the raid target's channel).
+ * @param event - Raid event payload including the raiding channel and viewer count.
+ * @param config - Streamer's event response configuration.
+ */
 export async function handleRaid(login: string, event: RaidEvent, config: EventSubConfig): Promise<void> {
   if (!config.raid_enabled) return;
   const msg = fill(config.raid_message, {

--- a/src/web/csrf.test.ts
+++ b/src/web/csrf.test.ts
@@ -96,3 +96,14 @@ describe('csrfProtection — body takes priority over header', () => {
     expect(res.status).toBe(200);
   });
 });
+
+describe('csrfProtection — query takes priority over body and header', () => {
+  it('uses query token when query, body, and header tokens are all present', async () => {
+    const res = await supertest(buildApp())
+      .post(`/test?_csrf=${SESSION_TOKEN}`)
+      .send('_csrf=wrong-body-token')
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .set('X-CSRF-Token', 'wrong-header-token');
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/web/csrf.test.ts
+++ b/src/web/csrf.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import express from 'express';
 import supertest from 'supertest';
 import { csrfProtection } from './csrf';

--- a/src/web/csrf.test.ts
+++ b/src/web/csrf.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest';
+import express from 'express';
+import supertest from 'supertest';
+import { csrfProtection } from './csrf';
+
+const SESSION_TOKEN = 'a'.repeat(64); // 32 hex bytes
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: false }));
+  app.use((req: any, _res: any, next: any) => {
+    req.session = { csrfToken: SESSION_TOKEN };
+    next();
+  });
+  app.use(csrfProtection);
+  app.use((err: any, _req: any, res: any, _next: any) => {
+    res.status(err?.code === 'EBADCSRFTOKEN' ? 403 : 500).json({ code: err?.code });
+  });
+  app.post('/test', (_req, res) => res.json({ ok: true }));
+  app.get('/test', (_req, res) => res.json({ ok: true }));
+  return app;
+}
+
+describe('csrfProtection — safe methods', () => {
+  it('allows GET without a token', async () => {
+    const res = await supertest(buildApp()).get('/test');
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('csrfProtection — body token', () => {
+  it('accepts POST with correct _csrf in body', async () => {
+    const res = await supertest(buildApp())
+      .post('/test')
+      .send(`_csrf=${SESSION_TOKEN}`)
+      .set('Content-Type', 'application/x-www-form-urlencoded');
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects POST with wrong _csrf in body', async () => {
+    const res = await supertest(buildApp())
+      .post('/test')
+      .send('_csrf=wrong-token')
+      .set('Content-Type', 'application/x-www-form-urlencoded');
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('EBADCSRFTOKEN');
+  });
+
+  it('rejects POST with no token', async () => {
+    const res = await supertest(buildApp()).post('/test');
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('csrfProtection — X-CSRF-Token header', () => {
+  it('accepts POST with correct X-CSRF-Token header', async () => {
+    const res = await supertest(buildApp())
+      .post('/test')
+      .set('X-CSRF-Token', SESSION_TOKEN);
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects POST with wrong X-CSRF-Token header', async () => {
+    const res = await supertest(buildApp())
+      .post('/test')
+      .set('X-CSRF-Token', 'bad-token');
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('EBADCSRFTOKEN');
+  });
+});
+
+describe('csrfProtection — X-XSRF-Token header', () => {
+  it('accepts POST with correct X-XSRF-Token header', async () => {
+    const res = await supertest(buildApp())
+      .post('/test')
+      .set('X-XSRF-Token', SESSION_TOKEN);
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects POST with wrong X-XSRF-Token header', async () => {
+    const res = await supertest(buildApp())
+      .post('/test')
+      .set('X-XSRF-Token', 'bad-token');
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('csrfProtection — body takes priority over header', () => {
+  it('uses body token when both are present', async () => {
+    const res = await supertest(buildApp())
+      .post('/test')
+      .send(`_csrf=${SESSION_TOKEN}`)
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .set('X-CSRF-Token', 'wrong-header-token');
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/web/csrf.test.ts
+++ b/src/web/csrf.test.ts
@@ -99,6 +99,16 @@ describe('csrfProtection — body takes priority over header', () => {
   });
 });
 
+describe('csrfProtection — X-CSRF-Token falls back to X-XSRF-Token when empty', () => {
+  it('uses X-XSRF-Token when X-CSRF-Token is an empty string', async () => {
+    const res = await supertest(buildApp())
+      .post('/test')
+      .set('X-CSRF-Token', '')
+      .set('X-XSRF-Token', SESSION_TOKEN);
+    expect(res.status).toBe(200);
+  });
+});
+
 describe('csrfProtection — query takes priority over body and header', () => {
   it('uses query token when query, body, and header tokens are all present', async () => {
     const res = await supertest(buildApp())

--- a/src/web/csrf.test.ts
+++ b/src/web/csrf.test.ts
@@ -50,6 +50,7 @@ describe('csrfProtection — body token', () => {
   it('rejects POST with no token', async () => {
     const res = await supertest(buildApp()).post('/test');
     expect(res.status).toBe(403);
+    expect(res.body.code).toBe('EBADCSRFTOKEN');
   });
 });
 
@@ -83,6 +84,7 @@ describe('csrfProtection — X-XSRF-Token header', () => {
       .post('/test')
       .set('X-XSRF-Token', 'bad-token');
     expect(res.status).toBe(403);
+    expect(res.body.code).toBe('EBADCSRFTOKEN');
   });
 });
 

--- a/src/web/csrf.ts
+++ b/src/web/csrf.ts
@@ -9,6 +9,12 @@ function createCsrfError(): Error & { code: string } {
   return error;
 }
 
+/**
+ * Return the session's CSRF token, generating and storing a new one if absent.
+ *
+ * @param req - Express request with a `session` object attached.
+ * @returns The 64-character hex CSRF token bound to this session.
+ */
 export function ensureSessionCsrfToken(req: Parameters<RequestHandler>[0]): string {
   if (typeof req.session.csrfToken !== 'string' || req.session.csrfToken.length === 0) {
     req.session.csrfToken = crypto.randomBytes(32).toString('hex');
@@ -27,6 +33,13 @@ function getSubmittedCsrfToken(req: Parameters<RequestHandler>[0]): string | nul
   return null;
 }
 
+/**
+ * Express middleware that enforces CSRF protection on all non-safe HTTP methods.
+ * Safe methods (GET, HEAD, OPTIONS) pass through unconditionally.
+ * Unsafe methods must supply a token matching the session's `csrfToken` via query
+ * (`_csrf`), form body (`_csrf`), `X-CSRF-Token`, or `X-XSRF-Token` header.
+ * Mismatches call `next` with an error bearing `code: 'EBADCSRFTOKEN'`.
+ */
 export const csrfProtection: RequestHandler = (req, _res, next) => {
   const sessionToken = ensureSessionCsrfToken(req);
   req.csrfToken = () => sessionToken;

--- a/src/web/csrf.ts
+++ b/src/web/csrf.ts
@@ -18,11 +18,11 @@ export function ensureSessionCsrfToken(req: Parameters<RequestHandler>[0]): stri
 }
 
 function getSubmittedCsrfToken(req: Parameters<RequestHandler>[0]): string | null {
-  // Query param and header checked first — both are available before multipart body parsing.
+  // Query param checked first — available before multipart body parsing (Multer).
   if (typeof req.query?._csrf === 'string') return req.query._csrf;
-  const header = req.headers['x-csrf-token'];
-  if (typeof header === 'string' && header.length > 0) return header;
   if (typeof req.body?._csrf === 'string') return req.body._csrf;
+  const header = req.headers['x-csrf-token'] ?? req.headers['x-xsrf-token'];
+  if (typeof header === 'string') return header;
   return null;
 }
 

--- a/src/web/csrf.ts
+++ b/src/web/csrf.ts
@@ -21,7 +21,8 @@ function getSubmittedCsrfToken(req: Parameters<RequestHandler>[0]): string | nul
   // Query param checked first — available before multipart body parsing (Multer).
   if (typeof req.query?._csrf === 'string') return req.query._csrf;
   if (typeof req.body?._csrf === 'string') return req.body._csrf;
-  const header = req.headers['x-csrf-token'] ?? req.headers['x-xsrf-token'];
+  const xcsrf = req.headers['x-csrf-token'];
+  const header = (typeof xcsrf === 'string' && xcsrf.trim() !== '') ? xcsrf : req.headers['x-xsrf-token'];
   if (typeof header === 'string') return header;
   return null;
 }

--- a/src/web/csrf.ts
+++ b/src/web/csrf.ts
@@ -36,9 +36,15 @@ function getSubmittedCsrfToken(req: Parameters<RequestHandler>[0]): string | nul
 /**
  * Express middleware that enforces CSRF protection on all non-safe HTTP methods.
  * Safe methods (GET, HEAD, OPTIONS) pass through unconditionally.
- * Unsafe methods must supply a token matching the session's `csrfToken` via query
- * (`_csrf`), form body (`_csrf`), `X-CSRF-Token`, or `X-XSRF-Token` header.
- * Mismatches call `next` with an error bearing `code: 'EBADCSRFTOKEN'`.
+ *
+ * For unsafe methods the submitted token is resolved in this priority order:
+ * 1. Query parameter `_csrf`
+ * 2. Form/JSON body field `_csrf`
+ * 3. `X-CSRF-Token` header (ignored when empty)
+ * 4. `X-XSRF-Token` header
+ *
+ * The submitted token must match the session's `csrfToken` via constant-time
+ * comparison. Mismatches call `next` with an error bearing `code: 'EBADCSRFTOKEN'`.
  */
 export const csrfProtection: RequestHandler = (req, _res, next) => {
   const sessionToken = ensureSessionCsrfToken(req);


### PR DESCRIPTION
Combines #235, #250, #234, #247 into a single reviewable unit.

## Changes

- **#235** `discordBot.ts` — consolidate dual `client`/`_discordClient` variables into one nullable; fixes a latent bug where `stopDiscordBot` before `startDiscordBot` would silently fail
- **#250** `twitchEventSubHandler.ts` + `index.ts` — decouple handler from `twitchBot` via `registerEventSubTwitchRuntime`, matching the established pattern; conflict-resolved against the already-merged overlay runtime injection (#249)
- **#234** `db/sfx.ts`, `db/customCommands.ts`, `db/streamMonitor.ts`, `db/eventSub.ts` — replace four private `mapBool` helpers with the canonical `fromBit` from `db/utils.ts`; eliminates a subtle `Number(v)===1` vs `v==1` inconsistency
- **#247** `csrf.ts` — extend `getSubmittedCsrfToken` to accept `X-CSRF-Token` and `X-XSRF-Token` headers; conflict-resolved to preserve query-param support (→ body → headers)

## Test plan

- [ ] `npx tsc --noEmit`
- [ ] `npm test`

Supersedes #235, #250, #234, #247

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjEddaqAJgAUkFsmNvUjTb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Twitch EventSub registers a chat-sending runtime at startup; event handlers send chat via a pluggable runtime when configured.

* **Bug Fixes / Behavior**
  * CSRF token extraction precedence changed to query > body > headers; header handling is more permissive.

* **Tests**
  * Added/expanded tests for CSRF, EventSub chat sending, Discord bot lifecycle, and DB boolean mapping.

* **Chores**
  * Standardized DB bit/boolean conversion across modules and hardened Discord bot startup/shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->