### PR TITLE
fix: overlay upload hardening and type safety

### DIFF
--- a/src/web/routes/overlayAdmin.test.ts
+++ b/src/web/routes/overlayAdmin.test.ts
@@ -94,4 +94,10 @@ describe('GET /settings — query param filtering', () => {
     const res = await supertest(buildApp()).get('/settings');
     expect(res.status).toBe(500);
   });
+
+  it('passes MAX_UPLOAD_MB to the template as maxFileMb', async () => {
+    const res = await supertest(buildApp()).get('/settings');
+    expect(res.status).toBe(200);
+    expect(res.body.maxFileMb).toBe(100);
+  });
 });

--- a/src/web/routes/overlayAdmin.test.ts
+++ b/src/web/routes/overlayAdmin.test.ts
@@ -35,7 +35,7 @@ vi.mock('../../shared/logger', () => ({
 
 vi.mock('./overlayAdminMutations', async () => {
   const { Router } = await import('express');
-  return { router: Router() };
+  return { router: Router(), MAX_UPLOAD_MB: 100 };
 });
 
 import express from 'express';

--- a/src/web/routes/overlayAdmin.ts
+++ b/src/web/routes/overlayAdmin.ts
@@ -9,7 +9,7 @@ import { PUBLIC_URL } from '../../shared/config';
 import { getCustomRewards, TwitchCustomReward } from '../../twitch/twitchApi';
 import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
 import { filterQueryParam } from './shared';
-import { router as mutationsRouter } from './overlayAdminMutations';
+import { router as mutationsRouter, MAX_UPLOAD_MB } from './overlayAdminMutations';
 import { router as rewardMutationsRouter } from './overlayAdminRewardMutations';
 
 const log = createLogger('OverlayAdmin');
@@ -55,6 +55,7 @@ router.get('/settings', requireAuth, csrfProtection, async (req, res) => {
       rewards,
       twitchRewards,
       baseUrl: PUBLIC_URL,
+      maxFileMb: MAX_UPLOAD_MB,
       error:   filterQueryParam(req.query.error,   KNOWN_ERRORS),
       success: filterQueryParam(req.query.success, KNOWN_SUCCESSES),
     });

--- a/src/web/routes/overlayAdminMutations.ts
+++ b/src/web/routes/overlayAdminMutations.ts
@@ -19,7 +19,9 @@ const log = createLogger('OverlayAdmin');
 export const router = Router();
 
 const parsedMaxMb = parseInt(process.env.OVERLAY_MAX_FILE_MB ?? '100', 10);
-const MAX_FILE_BYTES = (Number.isFinite(parsedMaxMb) && parsedMaxMb > 0 ? parsedMaxMb : 100) * 1024 * 1024;
+/** Maximum upload size in megabytes, passed to templates to avoid direct process.env access in EJS. */
+export const MAX_UPLOAD_MB = Number.isFinite(parsedMaxMb) && parsedMaxMb > 0 ? parsedMaxMb : 100;
+const MAX_FILE_BYTES = MAX_UPLOAD_MB * 1024 * 1024;
 
 export const upload = multer({
   storage: multer.memoryStorage(),

--- a/src/web/routes/overlayAdminMutations.ts
+++ b/src/web/routes/overlayAdminMutations.ts
@@ -73,7 +73,7 @@ router.post('/settings/videos/upload', requireAuth, csrfProtection, upload.singl
     const streamer = await requireStreamer(req, res);
     if (!streamer) return;
     if (!req.file) return res.redirect('/overlay/settings?error=invalid_file');
-    const name = (typeof req.body?.name === 'string' ? req.body.name.trim().slice(0, 100) : '') || req.file.originalname;
+    const name = (typeof req.body?.name === 'string' ? req.body.name.trim().slice(0, 100) : '') || req.file.originalname.trim().slice(0, 100);
     await saveVideoFile(streamer, req.file, name);
     res.redirect('/overlay/settings?success=video_uploaded');
   } catch (err: unknown) {

--- a/views/overlayAdmin.ejs
+++ b/views/overlayAdmin.ejs
@@ -83,7 +83,7 @@
                 <button type="submit" class="btn">Upload</button>
               </div>
             </div>
-            <p class="hint" style="margin-top:0.4rem;">WebM with alpha channel recommended for transparent overlays. Max <%= process.env.OVERLAY_MAX_FILE_MB || '100' %> MB.</p>
+            <p class="hint" style="margin-top:0.4rem;">WebM with alpha channel recommended for transparent overlays. Max <%= maxFileMb %> MB.</p>
           </form>
         </div>
       </div>


### PR DESCRIPTION
Combines #240, #241 into a single reviewable unit. (#232 was already effectively applied when #244 was merged.)

## Changes

- **#240** `overlayAdminMutations.ts`, `overlayAdmin.ts`, `views/overlayAdmin.ejs` — pass `MAX_UPLOAD_MB` through the route rather than reading `process.env` directly in the EJS template
- **#241** `overlayAdminMutations.ts` — apply `.trim().slice(0, 100)` to `req.file.originalname` fallback, consistent with the explicit `name` field

## Test plan

- [ ] `npx tsc --noEmit`
- [ ] `npm test`

Supersedes #240, #241, #232

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjEddaqAJgAUkFsmNvUjTb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Overlay video file names are now automatically sanitized and limited to 100 characters, preventing potential naming issues.
  * Maximum file size upload limits are now consistently enforced and clearly displayed in the upload interface to guide users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->