### PR TITLE
security: input validation for stream and streamer routes

### DIFF
--- a/src/web/routes/streams.test.ts
+++ b/src/web/routes/streams.test.ts
@@ -129,6 +129,22 @@ describe('POST /streams/streamers/add — array and missing input handling', () 
     expect(res.status).toBe(302);
     expect(res.headers.location).toContain('error=missing_fields');
   });
+
+  it('redirects with missing_fields when discord_id is not a valid snowflake', async () => {
+    const res = await supertest(buildApp())
+      .post('/streams/streamers/add')
+      .send('discord_id=not-a-snowflake&group_id=1');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain('error=missing_fields');
+  });
+
+  it('redirects with missing_fields when discord_id is too short', async () => {
+    const res = await supertest(buildApp())
+      .post('/streams/streamers/add')
+      .send('discord_id=1234&group_id=1');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain('error=missing_fields');
+  });
 });
 
 describe('POST /streams/groups/add — field length capping', () => {

--- a/src/web/routes/streams.test.ts
+++ b/src/web/routes/streams.test.ts
@@ -40,7 +40,7 @@ vi.mock('../../db/users', () => ({ AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, A
 import express from 'express';
 import supertest from 'supertest';
 import router from './streams';
-import { getAllStreamGroups, getAllStreamers, getAllUsers, findUser, addStreamer } from '../../db';
+import { getAllStreamGroups, getAllStreamers, getAllUsers, findUser, addStreamer, addStreamGroup, updateStreamGroup } from '../../db';
 import { AccessLevel } from '../../db/users';
 
 type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3 };
@@ -65,6 +65,8 @@ beforeEach(() => {
   vi.mocked(getAllUsers).mockResolvedValue([]);
   vi.mocked(findUser).mockResolvedValue(null);
   vi.mocked(addStreamer).mockResolvedValue(undefined);
+  vi.mocked(addStreamGroup).mockResolvedValue(undefined);
+  vi.mocked(updateStreamGroup).mockResolvedValue(undefined);
 });
 
 describe('GET /streams — query param filtering', () => {
@@ -126,5 +128,47 @@ describe('POST /streams/streamers/add — array and missing input handling', () 
       .send('discord_id=100000000000000001');
     expect(res.status).toBe(302);
     expect(res.headers.location).toContain('error=missing_fields');
+  });
+});
+
+describe('POST /streams/groups/add — field length capping', () => {
+  const longStr = (n: number) => 'x'.repeat(n);
+
+  it('truncates name to 100 chars, discordChannel to 20, messages to 2000', async () => {
+    const res = await supertest(buildApp())
+      .post('/streams/groups/add')
+      .send(
+        `name=${longStr(200)}&discord_channel=${longStr(30)}&live_message=${longStr(3000)}&new_game_message=${longStr(3000)}`,
+      );
+    expect(res.status).toBe(302);
+    expect(vi.mocked(addStreamGroup)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: longStr(100),
+        discordChannel: longStr(20),
+        liveMessage: longStr(2000),
+        newGameMessage: longStr(2000),
+      }),
+    );
+  });
+});
+
+describe('POST /streams/groups/update — field length capping', () => {
+  const longStr = (n: number) => 'x'.repeat(n);
+
+  it('truncates name to 100 chars, discordChannel to 20, messages to 2000', async () => {
+    const res = await supertest(buildApp())
+      .post('/streams/groups/update')
+      .send(
+        `group_id=1&name=${longStr(200)}&discord_channel=${longStr(30)}&live_message=${longStr(3000)}&new_game_message=${longStr(3000)}`,
+      );
+    expect(res.status).toBe(302);
+    expect(vi.mocked(updateStreamGroup)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: longStr(100),
+        discordChannel: longStr(20),
+        liveMessage: longStr(2000),
+        newGameMessage: longStr(2000),
+      }),
+    );
   });
 });

--- a/src/web/routes/streams.test.ts
+++ b/src/web/routes/streams.test.ts
@@ -166,6 +166,59 @@ describe('POST /streams/groups/add — field length capping', () => {
       }),
     );
   });
+
+  it('preserves fields exactly at the limits without over-truncation', async () => {
+    const res = await supertest(buildApp())
+      .post('/streams/groups/add')
+      .send(
+        `name=${longStr(100)}&discord_channel=${longStr(20)}&live_message=${longStr(2000)}&new_game_message=${longStr(2000)}`,
+      );
+    expect(res.status).toBe(302);
+    expect(vi.mocked(addStreamGroup)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: longStr(100),
+        discordChannel: longStr(20),
+        liveMessage: longStr(2000),
+        newGameMessage: longStr(2000),
+      }),
+    );
+  });
+
+  it('preserves fields under the limits unchanged', async () => {
+    const res = await supertest(buildApp())
+      .post('/streams/groups/add')
+      .send(
+        `name=${longStr(50)}&discord_channel=${longStr(10)}&live_message=${longStr(1000)}&new_game_message=${longStr(1000)}`,
+      );
+    expect(res.status).toBe(302);
+    expect(vi.mocked(addStreamGroup)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: longStr(50),
+        discordChannel: longStr(10),
+        liveMessage: longStr(1000),
+        newGameMessage: longStr(1000),
+      }),
+    );
+  });
+
+  it('trims leading/trailing whitespace before applying the length cap', async () => {
+    // Wrap each value in two spaces (%20 encoding); values are over-limit after trimming
+    const padded = (n: number) => `%20%20${longStr(n)}%20%20`;
+    const res = await supertest(buildApp())
+      .post('/streams/groups/add')
+      .send(
+        `name=${padded(105)}&discord_channel=${padded(25)}&live_message=${padded(2005)}&new_game_message=${padded(2005)}`,
+      );
+    expect(res.status).toBe(302);
+    expect(vi.mocked(addStreamGroup)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: longStr(100),
+        discordChannel: longStr(20),
+        liveMessage: longStr(2000),
+        newGameMessage: longStr(2000),
+      }),
+    );
+  });
 });
 
 describe('POST /streams/groups/update — field length capping', () => {
@@ -176,6 +229,58 @@ describe('POST /streams/groups/update — field length capping', () => {
       .post('/streams/groups/update')
       .send(
         `group_id=1&name=${longStr(200)}&discord_channel=${longStr(30)}&live_message=${longStr(3000)}&new_game_message=${longStr(3000)}`,
+      );
+    expect(res.status).toBe(302);
+    expect(vi.mocked(updateStreamGroup)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: longStr(100),
+        discordChannel: longStr(20),
+        liveMessage: longStr(2000),
+        newGameMessage: longStr(2000),
+      }),
+    );
+  });
+
+  it('preserves fields exactly at the limits without over-truncation', async () => {
+    const res = await supertest(buildApp())
+      .post('/streams/groups/update')
+      .send(
+        `group_id=1&name=${longStr(100)}&discord_channel=${longStr(20)}&live_message=${longStr(2000)}&new_game_message=${longStr(2000)}`,
+      );
+    expect(res.status).toBe(302);
+    expect(vi.mocked(updateStreamGroup)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: longStr(100),
+        discordChannel: longStr(20),
+        liveMessage: longStr(2000),
+        newGameMessage: longStr(2000),
+      }),
+    );
+  });
+
+  it('preserves fields under the limits unchanged', async () => {
+    const res = await supertest(buildApp())
+      .post('/streams/groups/update')
+      .send(
+        `group_id=1&name=${longStr(50)}&discord_channel=${longStr(10)}&live_message=${longStr(1000)}&new_game_message=${longStr(1000)}`,
+      );
+    expect(res.status).toBe(302);
+    expect(vi.mocked(updateStreamGroup)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: longStr(50),
+        discordChannel: longStr(10),
+        liveMessage: longStr(1000),
+        newGameMessage: longStr(1000),
+      }),
+    );
+  });
+
+  it('trims leading/trailing whitespace before applying the length cap', async () => {
+    const padded = (n: number) => `%20%20${longStr(n)}%20%20`;
+    const res = await supertest(buildApp())
+      .post('/streams/groups/update')
+      .send(
+        `group_id=1&name=${padded(105)}&discord_channel=${padded(25)}&live_message=${padded(2005)}&new_game_message=${padded(2005)}`,
       );
     expect(res.status).toBe(302);
     expect(vi.mocked(updateStreamGroup)).toHaveBeenCalledWith(

--- a/src/web/routes/streams.ts
+++ b/src/web/routes/streams.ts
@@ -108,10 +108,10 @@ router.post('/streams/groups/add', requireManager, csrfProtection, async (req, r
 
   try {
     await addStreamGroup({
-      name: name!.trim(),
-      discordChannel: discord_channel!.trim(),
-      liveMessage: live_message!.trim(),
-      newGameMessage: new_game_message!.trim(),
+      name: name!.trim().slice(0, 100),
+      discordChannel: discord_channel!.trim().slice(0, 20),
+      liveMessage: live_message!.trim().slice(0, 2000),
+      newGameMessage: new_game_message!.trim().slice(0, 2000),
       multiTwitch: multi_twitch,
       deleteOldPosts: delete_old_posts,
     });
@@ -138,10 +138,10 @@ router.post('/streams/groups/update', requireManager, csrfProtection, async (req
   try {
     await updateStreamGroup({
       id: parsedGroupId,
-      name: name!.trim(),
-      discordChannel: discord_channel!.trim(),
-      liveMessage: live_message!.trim(),
-      newGameMessage: new_game_message!.trim(),
+      name: name!.trim().slice(0, 100),
+      discordChannel: discord_channel!.trim().slice(0, 20),
+      liveMessage: live_message!.trim().slice(0, 2000),
+      newGameMessage: new_game_message!.trim().slice(0, 2000),
       multiTwitch: multi_twitch,
       deleteOldPosts: delete_old_posts,
     });

--- a/src/web/routes/streams.ts
+++ b/src/web/routes/streams.ts
@@ -17,7 +17,7 @@ import { csrfProtection } from '../csrf';
 import { requireManager } from '../middleware';
 import { restartTwitchMonitor, getLiveStates } from '../../twitch/monitor/twitchMonitor';
 import { AccessLevel } from '../../db';
-import { parsePositiveIntId, filterQueryParam } from './shared';
+import { parsePositiveIntId, filterQueryParam, normalizeDiscordId } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
@@ -175,7 +175,7 @@ router.post('/streams/groups/remove', requireManager, csrfProtection, async (req
 
 router.post('/streams/streamers/add', requireManager, csrfProtection, async (req, res) => {
   const { discord_id, group_id } = req.body as { discord_id?: string | string[]; group_id?: string | string[] };
-  const discordId = typeof discord_id === 'string' ? discord_id.trim() : null;
+  const discordId = normalizeDiscordId(typeof discord_id === 'string' ? discord_id : undefined);
   const rawGroupId = Array.isArray(group_id) ? group_id[0] : group_id;
   const groupId = typeof rawGroupId === 'string' ? rawGroupId.trim() : null;
   if (!discordId || !groupId) return res.redirect('/admin/streams?error=missing_fields');


### PR DESCRIPTION
Combines #243, #242 into a single reviewable unit.

## Changes

- **#243** `streams.ts` — cap `name` (100), `discord_channel` (20), `live_message` (2000), and `new_game_message` (2000) before the DB write on both add and update group routes
- **#242** `streams.ts` — replace bare `.trim()` on `discord_id` with `normalizeDiscordId`, enforcing the 17–20 digit snowflake pattern before touching the DB

## Test plan

- [ ] `npx tsc --noEmit`
- [ ] `npm test`

Supersedes #243, #242

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjEddaqAJgAUkFsmNvUjTb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for Discord ID inputs to ensure proper format and length requirements.
  * Added automatic truncation of stream group configuration fields (names, channels, and messages) to prevent data overflow and ensure consistency.
  * Enhanced error handling for missing or invalid field values in stream configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->