### PR TITLE
chore: code style, visibility, and documentation

### DIFF
--- a/src/commands/commandMonitorStore.ts
+++ b/src/commands/commandMonitorStore.ts
@@ -1,5 +1,7 @@
+/** Platform a command was triggered from. */
 export type CommandTestSource = 'twitch' | 'discord' | 'tiktok';
 
+/** A single recorded command execution for the monitor panel. */
 export interface CommandTestEntry {
   id: number;
   source: CommandTestSource;
@@ -14,6 +16,7 @@ const MAX_COMMAND_TEST_ENTRIES = 30;
 const entries: CommandTestEntry[] = [];
 let nextEntryId = 1;
 
+/** Prepends an entry to the in-memory monitor ring buffer (capped at 30). */
 export function recordCommandTestEntry(entry: Omit<CommandTestEntry, 'id' | 'createdAt'>): void {
   entries.unshift({
     id: nextEntryId++,
@@ -26,6 +29,7 @@ export function recordCommandTestEntry(entry: Omit<CommandTestEntry, 'id' | 'cre
   }
 }
 
+/** Returns a snapshot of the recent command monitor entries (newest first). */
 export function getRecentCommandTestEntries(): CommandTestEntry[] {
   return entries.map((entry) => ({
     ...entry,

--- a/src/db/counterCache.ts
+++ b/src/db/counterCache.ts
@@ -68,10 +68,12 @@ const counterLookupCacheState = createManagedLookupCache<CounterLookupCache>({
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 
+/** Marks the counter lookup cache as stale so the next read triggers a refresh. */
 export function invalidateCounterLookupCache(): void {
   counterLookupCacheState.invalidate();
 }
 
+/** Looks up a counter by its trigger or check command string; returns null if not found. */
 export async function findCounterByCommand(command: string): Promise<DbMatchedCounter | null> {
   const normalizedCommand = command.trim().toLowerCase();
   if (!normalizedCommand) return null;
@@ -81,6 +83,7 @@ export async function findCounterByCommand(command: string): Promise<DbMatchedCo
   return counter ? { ...counter } : null;
 }
 
+/** Returns true if any of the given commands conflict with an existing counter (optionally excluding one by ID). */
 export async function isCounterCommandTaken(commandOrCommands: string | string[], excludeCounterId?: number): Promise<boolean> {
   if (Array.isArray(commandOrCommands)) {
     const normalizedCommands = normalizeCommandList(commandOrCommands);

--- a/src/db/customCommands.ts
+++ b/src/db/customCommands.ts
@@ -13,6 +13,7 @@ import { invalidateCustomCommandLookupCache } from './customCommandCache';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
+/** A custom command row from the database. */
 export interface DbCustomCommand {
   command_id: number;
   trigger_string: string;
@@ -21,6 +22,7 @@ export interface DbCustomCommand {
   is_multi_twitch: boolean;
 }
 
+/** A user assigned to a custom command (may be orphaned if their account no longer exists). */
 export interface DbCustomCommandAssignedUser {
   discord_id: string;
   discord_name: string | null;
@@ -30,6 +32,7 @@ export interface DbCustomCommandAssignedUser {
   is_orphaned_user: boolean;
 }
 
+/** A custom command with its full list of assigned users. */
 export interface DbCustomCommandWithAssignments extends DbCustomCommand {
   assigned_users: DbCustomCommandAssignedUser[];
 }
@@ -52,6 +55,7 @@ function mapCustomCommand(row: mysql.RowDataPacket): DbCustomCommand {
 
 // ─── Queries ─────────────────────────────────────────────────────────────────
 
+/** Returns all custom commands with their assigned user lists. */
 export async function getAllCustomCommandsWithAssignments(): Promise<DbCustomCommandWithAssignments[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
     `SELECT c.command_id, c.trigger_string, c.output, c.is_discord_enabled, c.is_multi_twitch,
@@ -91,6 +95,7 @@ export async function getAllCustomCommandsWithAssignments(): Promise<DbCustomCom
 
 // ─── CRUD ─────────────────────────────────────────────────────────────────────
 
+/** Creates a new custom command, validates uniqueness, and returns the new command ID. */
 export async function addCustomCommand(
   triggerString: string,
   output: string,
@@ -130,6 +135,7 @@ export async function addCustomCommand(
   return commandId;
 }
 
+/** Updates an existing custom command's trigger, output, and flags. Throws CommandNotFoundError if not found. */
 export async function updateCustomCommand(
   commandId: number,
   triggerString: string,
@@ -173,6 +179,7 @@ export async function updateCustomCommand(
   invalidateCustomCommandLookupCache();
 }
 
+/** Deletes a custom command and all its user assignments. Throws CommandNotFoundError if not found. */
 export async function removeCustomCommand(commandId: number): Promise<void> {
   const connection = await getPool().getConnection();
   const lockName = `bcuk_cmdid_${commandId}`;
@@ -203,6 +210,7 @@ export async function removeCustomCommand(commandId: number): Promise<void> {
   }
 }
 
+/** Assigns a user (by Discord ID) to a custom command, checking for cross-command conflicts. */
 export async function assignUserToCommand(commandId: number, discordId: string): Promise<void> {
   const connection = await getPool().getConnection();
 
@@ -226,6 +234,7 @@ export async function assignUserToCommand(commandId: number, discordId: string):
   }
 }
 
+/** Removes a user assignment from a custom command; no-ops if the assignment doesn't exist. */
 export async function unassignUserFromCommand(commandId: number, discordId: string): Promise<void> {
   await getPool().execute(
     'DELETE FROM twitch_user_commands WHERE command_id = ? AND discord_id = ?',

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -51,6 +51,7 @@ const rootLogger = winstonCreateLogger({
   ],
 });
 
+/** Returns a child logger tagged with the given module label. */
 export function createLogger(module: string) {
   return rootLogger.child({ label: module });
 }

--- a/src/shared/statusStore.ts
+++ b/src/shared/statusStore.ts
@@ -1,3 +1,4 @@
+/** Live connection and stream status for a single Twitch or TikTok channel. */
 export interface ChannelStatus {
   connected: boolean;
   lastConnectedAt: Date | null;
@@ -24,17 +25,20 @@ const state = {
   tiktok: new Map<string, ChannelStatus>(),
 };
 
+/** Marks the Discord bot as ready with its tag and guild name. */
 export function setDiscordReady(tag: string, guildName: string): void {
   state.discord.ready = true;
   state.discord.tag = tag;
   state.discord.guildName = guildName;
 }
 
+/** Records that the bot has joined a voice channel. */
 export function setVoiceConnected(channelName: string): void {
   state.voice.connected = true;
   state.voice.channelName = channelName;
 }
 
+/** Records that the bot has left the voice channel and clears playback state. */
 export function setVoiceDisconnected(): void {
   state.voice.connected = false;
   state.voice.channelName = null;
@@ -42,6 +46,7 @@ export function setVoiceDisconnected(): void {
   state.voice.currentFile = null;
 }
 
+/** Updates voice state to reflect that a file is now playing. */
 export function setVoicePlaying(file: string, command: string, source: string): void {
   state.voice.playing = true;
   state.voice.currentFile = file;
@@ -50,6 +55,7 @@ export function setVoicePlaying(file: string, command: string, source: string): 
   state.voice.lastPlayedAt = new Date();
 }
 
+/** Clears the playing flag and current file when playback finishes. */
 export function setVoiceIdle(): void {
   state.voice.playing = false;
   state.voice.currentFile = null;
@@ -68,20 +74,24 @@ function updateChannel(map: Map<string, ChannelStatus>, key: string, connected: 
   map.set(key, existing);
 }
 
+/** Updates the connected state for a Twitch channel. */
 export function setTwitchChannel(channel: string, connected: boolean): void {
   updateChannel(state.twitch, channel.toLowerCase().replace(/^#/, ''), connected);
 }
 
+/** Updates the connected state for a TikTok channel. */
 export function setTikTokChannel(username: string, connected: boolean): void {
   updateChannel(state.tiktok, username, connected);
 }
 
+/** Updates the isLive flag for a Twitch channel. No-ops if the channel isn't tracked yet. */
 export function setTwitchChannelLive(login: string, isLive: boolean): void {
   const key = login.toLowerCase().replace(/^#/, '');
   const existing = state.twitch.get(key);
   if (existing) existing.isLive = isLive;
 }
 
+/** Returns a snapshot of the current bot status (Discord, voice, Twitch channels, TikTok channels). */
 export function getStatus() {
   return {
     discord: { ...state.discord },

--- a/src/twitch/eventsub/twitchEventSubConnection.test.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.test.ts
@@ -174,7 +174,7 @@ describe('StreamerConnection.handleMessage', () => {
 
   it('session_welcome (non-reconnecting): sets sessionId and calls subscribeForStreamer', async () => {
     const conn = new StreamerConnection(makeStreamerData());
-    await conn.handleMessage(makeWelcomeMsg('sess-abc'));
+    await (conn as any).handleMessage(makeWelcomeMsg('sess-abc'));
     expect(subscribeForStreamer).toHaveBeenCalledWith('sess-abc', expect.objectContaining({ uid: 'uid-123' }));
   });
 
@@ -183,7 +183,7 @@ describe('StreamerConnection.handleMessage', () => {
     const conn = new StreamerConnection(makeStreamerData());
     const onSelfStop = vi.fn();
     conn.setSelfStopCallback(onSelfStop);
-    await conn.handleMessage(makeWelcomeMsg('sess-zero'));
+    await (conn as any).handleMessage(makeWelcomeMsg('sess-zero'));
     await vi.waitFor(() => expect(onSelfStop).toHaveBeenCalledWith('uid-123'));
   });
 
@@ -194,8 +194,8 @@ describe('StreamerConnection.handleMessage', () => {
       message_type: 'session_reconnect',
       payload: { session: { id: 'sess-old', keepalive_timeout_seconds: 10, reconnect_url: 'wss://eventsub.wss.twitch.tv/ws?session_id=new' } },
     });
-    conn.handleMessage(reconnectMsg);
-    await conn.handleMessage(makeWelcomeMsg('sess-reconnect'));
+    (conn as any).handleMessage(reconnectMsg);
+    await (conn as any).handleMessage(makeWelcomeMsg('sess-reconnect'));
     expect(subscribeForStreamer).not.toHaveBeenCalled();
   });
 
@@ -208,7 +208,7 @@ describe('StreamerConnection.handleMessage', () => {
         event: { user_login: 'follower' },
       },
     });
-    conn.handleMessage(msg);
+    (conn as any).handleMessage(msg);
     expect(dispatchNotification).toHaveBeenCalledWith(
       'channel.follow',
       { user_login: 'follower' },
@@ -220,7 +220,7 @@ describe('StreamerConnection.handleMessage', () => {
     const conn = new StreamerConnection(makeStreamerData());
     const sub = { type: 'channel.follow', status: 'authorization_revoked', condition: { broadcaster_user_id: 'uid-123' } };
     const msg = makeMsg({ message_type: 'revocation', payload: { subscription: sub } });
-    conn.handleMessage(msg);
+    (conn as any).handleMessage(msg);
     expect(handleRevocation).toHaveBeenCalledWith(sub);
   });
 
@@ -235,7 +235,7 @@ describe('StreamerConnection.handleMessage', () => {
         event: {},
       },
     });
-    conn.handleMessage(msg);
+    (conn as any).handleMessage(msg);
     expect(dispatchNotification).not.toHaveBeenCalled();
   });
 
@@ -252,15 +252,15 @@ describe('StreamerConnection.handleMessage', () => {
     });
     const msg2 = { ...msg1, metadata: { ...msg1.metadata } }; // same id
 
-    conn.handleMessage(msg1);
-    conn.handleMessage(msg2);
+    (conn as any).handleMessage(msg1);
+    (conn as any).handleMessage(msg2);
     expect(dispatchNotification).toHaveBeenCalledTimes(1);
   });
 
   it('session_keepalive: no dispatch, no error', () => {
     const conn = new StreamerConnection(makeStreamerData());
     const msg = makeMsg({ message_type: 'session_keepalive', payload: {} });
-    expect(() => conn.handleMessage(msg)).not.toThrow();
+    expect(() => (conn as any).handleMessage(msg)).not.toThrow();
     expect(dispatchNotification).not.toHaveBeenCalled();
     expect(handleRevocation).not.toHaveBeenCalled();
   });

--- a/src/twitch/eventsub/twitchEventSubConnection.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.ts
@@ -8,6 +8,8 @@ export const EVENTSUB_WS_URL = 'wss://eventsub.wss.twitch.tv/ws';
 const RECONNECT_BACKOFF_MAX_MS = 30_000;
 /** How long a message ID is remembered for deduplication (ms). */
 export const MESSAGE_TTL_MS = 10 * 60 * 1000;
+/** Grace period before closing the old WebSocket during a session migration (Twitch-specified window). */
+const SESSION_MIGRATION_CLOSE_DELAY_MS = 5_000;
 
 /** Metadata fields present on every EventSub WebSocket message. */
 export interface EventSubMetadata {
@@ -200,7 +202,7 @@ export class StreamerConnection {
     this.isReconnecting = true;
     log.info(`[${this.name}] Session reconnect — connecting to new session`);
     this.connect(safeUrl);
-    setTimeout(() => { oldSocket?.close(1000, 'reconnect'); }, 5_000);
+    setTimeout(() => { oldSocket?.close(1000, 'reconnect'); }, SESSION_MIGRATION_CLOSE_DELAY_MS);
   }
 
   private scheduleReconnect(): void {

--- a/src/twitch/eventsub/twitchEventSubConnection.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.ts
@@ -155,7 +155,7 @@ export class StreamerConnection {
     }
   }
 
-  handleMessage(msg: EventSubMessage): void {
+  private handleMessage(msg: EventSubMessage): void {
     const { message_type, message_id, message_timestamp } = msg.metadata;
     if (isStale(message_timestamp)) { log.warn(`[${this.name}] Stale message (${message_type}) — ignoring`); return; }
     if (isDuplicate(message_id)) { log.warn(`[${this.name}] Duplicate message (${message_type}) — ignoring`); return; }

--- a/src/twitch/twitchChannelMembership.ts
+++ b/src/twitch/twitchChannelMembership.ts
@@ -18,14 +18,17 @@ const membershipMutationQueue = createMutationQueue();
 const JOIN_THROTTLE_MS = 600;
 let _onChannelJoined: ((channel: string) => void) | null = null;
 
+/** Sets the active tmi.js client instance (called from twitchBot after connect). */
 export function setTmiClient(c: tmi.Client | null): void {
   _client = c;
 }
 
+/** Updates the connected flag (called from twitchBot on connect/disconnect events). */
 export function setConnected(v: boolean): void {
   _connected = v;
 }
 
+/** Registers a callback fired each time the bot successfully joins a channel. */
 export function setChannelJoinedHook(fn: (channel: string) => void): void {
   _onChannelJoined = fn;
 }
@@ -79,6 +82,7 @@ async function joinMissingChannel(channel: string): Promise<void> {
   log.info(`Joined queued channel after reconnect: ${channel}`);
 }
 
+/** Parts channels no longer in activeChannels and joins any queued but unjoined channels. */
 export async function reconcileJoinedChannels(): Promise<void> {
   if (!_client || !_connected) return;
 
@@ -106,6 +110,7 @@ export async function reconcileJoinedChannels(): Promise<void> {
   }
 }
 
+/** Loads enabled channels from the DB, populates activeChannels, and pre-resolves user IDs. */
 export async function initializeActiveChannels(): Promise<void> {
   const configuredChannels = await getTwitchEnabledChannels();
   for (const ch of configuredChannels) {
@@ -131,6 +136,7 @@ export async function initializeActiveChannels(): Promise<void> {
   }
 }
 
+/** Joins a Twitch channel, throttled to respect Twitch rate limits. Serialised via mutationQueue. */
 export async function joinTwitchChannel(channel: string): Promise<void> {
   const normalized = normalizeTwitchChannelName(channel);
   if (!normalized) {
@@ -176,6 +182,7 @@ export async function joinTwitchChannel(channel: string): Promise<void> {
   });
 }
 
+/** Parts a Twitch channel and removes it from active tracking. Serialised via mutationQueue. */
 export async function partTwitchChannel(channel: string): Promise<void> {
   const normalized = normalizeTwitchChannelName(channel);
   if (!normalized) return;
@@ -208,14 +215,17 @@ export async function partTwitchChannel(channel: string): Promise<void> {
   });
 }
 
+/** Returns the set of channels the bot is currently tracking as active. */
 export function getActiveChannels(): ReadonlySet<string> {
   return activeChannels;
 }
 
+/** Returns a map of channel login → Twitch user ID for all active channels. */
 export function getActiveChannelUserIds(): ReadonlyMap<string, string> {
   return activeChannelUserIds;
 }
 
+/** Clears all active channel and user ID state (used in tests). */
 export function clearMembershipState(): void {
   activeChannels.clear();
   activeChannelUserIds.clear();


### PR DESCRIPTION
Combines #251, #231, #252 into a single reviewable unit.

## Changes

- **#251** `twitchEventSubConnection.ts` — mark `handleMessage` as `private`; update 9 test call sites to `(conn as any).handleMessage(...)`
- **#231** `twitchEventSubConnection.ts` — extract the bare `5_000` ms reconnect delay into `SESSION_MIGRATION_CLOSE_DELAY_MS`
- **#252** Multiple files — add missing JSDoc to all exported functions/types in `commandMonitorStore.ts`, `logger.ts`, `twitchChannelMembership.ts`, `counterCache.ts`, `customCommands.ts`, and `statusStore.ts`

## Test plan

- [ ] `npx tsc --noEmit`
- [ ] `npm test`

Supersedes #251, #231, #252

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjEddaqAJgAUkFsmNvUjTb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced API documentation with comprehensive JSDoc comments for core functions and data structures across command monitoring, database operations, logging, and status management.

* **Tests**
  * Updated test suite to maintain consistency with internal refactoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->