### PR TITLE
Add 10-minute expiry to Discord and Twitch OAuth states

### DIFF
--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -11,9 +11,9 @@ export interface SessionUser {
 declare module 'express-session' {
   interface SessionData {
     user?: SessionUser;
-    oauthState?: string;
+    oauthState?: { value: string; expiresAt: number };
     csrfToken?: string;
-    eventsubOAuthState?: string;
+    eventsubOAuthState?: { value: string; expiresAt: number };
     eventsubStreamerId?: number;
   }
 }

--- a/src/web/routes/auth.test.ts
+++ b/src/web/routes/auth.test.ts
@@ -86,21 +86,28 @@ describe('GET /discord', () => {
 
 describe('GET /discord/callback', () => {
   it('renders error 400 when state does not match session', async () => {
-    const res = await supertest(buildApp({ oauthState: 'expected' }))
+    const res = await supertest(buildApp({ oauthState: { value: 'expected', expiresAt: Date.now() + 60_000 } }))
       .get('/discord/callback?code=abc&state=wrong');
     expect(res.status).toBe(400);
     expect((res.body as any).view).toBe('error');
   });
 
   it('renders error 400 when code is missing', async () => {
-    const res = await supertest(buildApp({ oauthState: 'abc' }))
+    const res = await supertest(buildApp({ oauthState: { value: 'abc', expiresAt: Date.now() + 60_000 } }))
       .get('/discord/callback?state=abc');
     expect(res.status).toBe(400);
   });
 
+  it('renders error 400 when OAuth state has expired', async () => {
+    const res = await supertest(buildApp({ oauthState: { value: 'state123', expiresAt: Date.now() - 1 } }))
+      .get('/discord/callback?code=code&state=state123');
+    expect(res.status).toBe(400);
+    expect((res.body as any).view).toBe('error');
+  });
+
   it('renders error 500 when token exchange fails', async () => {
     mockFetch([{ ok: false, status: 400 }]);
-    const res = await supertest(buildApp({ oauthState: 'state123' }))
+    const res = await supertest(buildApp({ oauthState: { value: 'state123', expiresAt: Date.now() + 60_000 } }))
       .get('/discord/callback?code=code&state=state123');
     expect(res.status).toBe(500);
     expect((res.body as any).view).toBe('error');
@@ -111,7 +118,7 @@ describe('GET /discord/callback', () => {
       { ok: true, json: () => Promise.resolve({ access_token: 'tok' }) },
       { ok: false, status: 401 },
     ]);
-    const res = await supertest(buildApp({ oauthState: 'state123' }))
+    const res = await supertest(buildApp({ oauthState: { value: 'state123', expiresAt: Date.now() + 60_000 } }))
       .get('/discord/callback?code=code&state=state123');
     expect(res.status).toBe(500);
   });
@@ -121,7 +128,7 @@ describe('GET /discord/callback', () => {
       { ok: true, json: () => Promise.resolve({ access_token: 'tok' }) },
       { ok: true, json: () => Promise.resolve({ id: '999', username: 'stranger', avatar: null }) },
     ]);
-    const res = await supertest(buildApp({ oauthState: 'state123' }))
+    const res = await supertest(buildApp({ oauthState: { value: 'state123', expiresAt: Date.now() + 60_000 } }))
       .get('/discord/callback?code=code&state=state123');
     expect(res.status).toBe(403);
   });
@@ -132,7 +139,7 @@ describe('GET /discord/callback', () => {
       { ok: true, json: () => Promise.resolve({ id: '111', username: 'alice', avatar: null }) },
     ]);
     vi.mocked(findUser).mockResolvedValue({ discord_id: '111', discord_name: 'alice', is_twitch_bot_enabled: false, twitch_name: null, access_level: AccessLevel.USER } as any);
-    const res = await supertest(buildApp({ oauthState: 'state123' }))
+    const res = await supertest(buildApp({ oauthState: { value: 'state123', expiresAt: Date.now() + 60_000 } }))
       .get('/discord/callback?code=code&state=state123');
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/');
@@ -145,7 +152,7 @@ describe('GET /discord/callback', () => {
     ]);
     vi.mocked(findUser).mockResolvedValue({ discord_id: '111', discord_name: 'OldName', is_twitch_bot_enabled: false, twitch_name: null, access_level: AccessLevel.USER } as any);
     vi.mocked(fetchMemberDisplayName).mockResolvedValue('NewDisplayName');
-    const res = await supertest(buildApp({ oauthState: 'state123' }))
+    const res = await supertest(buildApp({ oauthState: { value: 'state123', expiresAt: Date.now() + 60_000 } }))
       .get('/discord/callback?code=code&state=state123');
     expect(res.status).toBe(302);
     expect(updateDiscordName).toHaveBeenCalledWith('111', 'NewDisplayName');

--- a/src/web/routes/auth.ts
+++ b/src/web/routes/auth.ts
@@ -14,7 +14,7 @@ const router = Router();
 // ─── Redirect to Discord OAuth2 ─────────────────────────────────────────────
 router.get('/discord', (req, res) => {
   const state = crypto.randomBytes(16).toString('hex');
-  req.session.oauthState = state;
+  req.session.oauthState = { value: state, expiresAt: Date.now() + 10 * 60 * 1000 };
 
   const params = new URLSearchParams({
     client_id: DISCORD_CLIENT_ID,
@@ -31,10 +31,11 @@ router.get('/discord', (req, res) => {
 router.get('/discord/callback', async (req, res) => {
   const { code, state } = req.query as { code?: string; state?: string };
 
-  if (!code || !state || state !== req.session.oauthState) {
+  const storedOAuth = req.session.oauthState;
+  delete req.session.oauthState;
+  if (!code || !state || !storedOAuth || state !== storedOAuth.value || Date.now() > storedOAuth.expiresAt) {
     return renderError(res, 400, 'Invalid OAuth2 state — please try logging in again.', undefined);
   }
-  delete req.session.oauthState;
 
   try {
     // 1. Exchange code for access token

--- a/src/web/routes/auth.ts
+++ b/src/web/routes/auth.ts
@@ -33,7 +33,8 @@ router.get('/discord/callback', async (req, res) => {
 
   const storedOAuth = req.session.oauthState;
   delete req.session.oauthState;
-  if (!code || !state || !storedOAuth || state !== storedOAuth.value || Date.now() > storedOAuth.expiresAt) {
+  const stateValid = !!storedOAuth && state === storedOAuth.value && Date.now() <= storedOAuth.expiresAt;
+  if (!code || !state || !stateValid) {
     return renderError(res, 400, 'Invalid OAuth2 state — please try logging in again.', undefined);
   }
 

--- a/src/web/routes/eventsubCallback.test.ts
+++ b/src/web/routes/eventsubCallback.test.ts
@@ -91,10 +91,23 @@ describe('GET /twitch/eventsub/callback — state validation', () => {
     expect(res.headers.location).toContain('error=eventsub_oauth_state_mismatch');
   });
 
-  it('redirects with denied error when OAuth returns error param', async () => {
-    const res = await supertest(buildApp())
-      .get('/twitch/eventsub/callback?error=access_denied');
+  it('redirects with denied error when OAuth returns error param and clears session state', async () => {
+    let capturedSession: any;
+    const app = express();
+    app.use((req: any, _res: any, next: any) => {
+      req.session = {
+        eventsubOAuthState: { value: 'valid-state-abc', expiresAt: Date.now() + 60_000 },
+        eventsubStreamerId: MOCK_STREAMER.id,
+        user: SESSION_USER,
+      };
+      capturedSession = req.session;
+      next();
+    });
+    app.use(router);
+    const res = await supertest(app).get('/twitch/eventsub/callback?error=access_denied');
     expect(res.headers.location).toContain('error=eventsub_oauth_denied');
+    expect(capturedSession.eventsubOAuthState).toBeUndefined();
+    expect(capturedSession.eventsubStreamerId).toBeUndefined();
   });
 
   it('rejects with state_mismatch when OAuth state has expired', async () => {

--- a/src/web/routes/eventsubCallback.test.ts
+++ b/src/web/routes/eventsubCallback.test.ts
@@ -54,7 +54,7 @@ function buildApp(sessionOverrides: Record<string, any> = {}) {
   const app = express();
   app.use((req: any, _res: any, next: any) => {
     req.session = {
-      eventsubOAuthState: 'valid-state-abc',
+      eventsubOAuthState: { value: 'valid-state-abc', expiresAt: Date.now() + 60_000 },
       eventsubStreamerId: MOCK_STREAMER.id,
       user: SESSION_USER,
       ...sessionOverrides,
@@ -95,6 +95,12 @@ describe('GET /twitch/eventsub/callback — state validation', () => {
     const res = await supertest(buildApp())
       .get('/twitch/eventsub/callback?error=access_denied');
     expect(res.headers.location).toContain('error=eventsub_oauth_denied');
+  });
+
+  it('rejects with state_mismatch when OAuth state has expired', async () => {
+    const res = await supertest(buildApp({ eventsubOAuthState: { value: 'valid-state-abc', expiresAt: Date.now() - 1 } }))
+      .get('/twitch/eventsub/callback?code=abc&state=valid-state-abc');
+    expect(res.headers.location).toContain('error=eventsub_oauth_state_mismatch');
   });
 });
 

--- a/src/web/routes/eventsubCallback.ts
+++ b/src/web/routes/eventsubCallback.ts
@@ -15,17 +15,17 @@ const router = Router();
 router.get('/twitch/eventsub/callback', async (req, res) => {
   const { code, state, error } = req.query as Record<string, string | undefined>;
 
+  const storedOAuth = req.session.eventsubOAuthState;
+  const streamerId = req.session.eventsubStreamerId;
+
+  // Clear state from session immediately to prevent replay — even on OAuth errors.
+  delete req.session.eventsubOAuthState;
+  delete req.session.eventsubStreamerId;
+
   if (error) {
     log.warn(`EventSub OAuth denied: ${error}`);
     return res.redirect('/user/settings?error=eventsub_oauth_denied');
   }
-
-  const storedOAuth = req.session.eventsubOAuthState;
-  const streamerId = req.session.eventsubStreamerId;
-
-  // Clear state from session immediately to prevent replay
-  delete req.session.eventsubOAuthState;
-  delete req.session.eventsubStreamerId;
 
   if (!code || !state || !storedOAuth || !streamerId) {
     return res.redirect('/user/settings?error=eventsub_oauth_state_mismatch');

--- a/src/web/routes/eventsubCallback.ts
+++ b/src/web/routes/eventsubCallback.ts
@@ -20,17 +20,17 @@ router.get('/twitch/eventsub/callback', async (req, res) => {
     return res.redirect('/user/settings?error=eventsub_oauth_denied');
   }
 
-  const expectedState = req.session.eventsubOAuthState;
+  const storedOAuth = req.session.eventsubOAuthState;
   const streamerId = req.session.eventsubStreamerId;
 
   // Clear state from session immediately to prevent replay
   delete req.session.eventsubOAuthState;
   delete req.session.eventsubStreamerId;
 
-  if (!code || !state || !expectedState || !streamerId) {
+  if (!code || !state || !storedOAuth || !streamerId) {
     return res.redirect('/user/settings?error=eventsub_oauth_state_mismatch');
   }
-  if (state !== expectedState) {
+  if (state !== storedOAuth.value || Date.now() > storedOAuth.expiresAt) {
     return res.redirect('/user/settings?error=eventsub_oauth_state_mismatch');
   }
 

--- a/src/web/routes/userSettings.test.ts
+++ b/src/web/routes/userSettings.test.ts
@@ -141,3 +141,31 @@ describe('GET / — successExpectedAccount', () => {
     expect(res.body.successExpectedAccount).toBeUndefined();
   });
 });
+
+describe('GET /twitch-connect — session state shape', () => {
+  it('writes eventsubOAuthState as { value, expiresAt } with a 10-minute expiry window', async () => {
+    vi.mocked(findUser).mockResolvedValue({ is_twitch_bot_enabled: true } as any);
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue({ id: 42, twitch_name: 'streamer' } as any);
+
+    let capturedSession: any;
+    const app = express();
+    app.use((req: any, res: any, next: any) => {
+      req.session = { user: USER };
+      capturedSession = req.session;
+      res.render = (view: string, locals?: any) => res.json({ view, ...locals });
+      next();
+    });
+    app.use(router);
+
+    const now = Date.now();
+    const res = await supertest(app).get('/twitch-connect');
+
+    expect(res.status).toBe(302);
+    expect(capturedSession.eventsubOAuthState).toBeDefined();
+    expect(typeof capturedSession.eventsubOAuthState.value).toBe('string');
+    expect(capturedSession.eventsubOAuthState.value.length).toBeGreaterThan(0);
+    expect(capturedSession.eventsubOAuthState.expiresAt).toBeGreaterThan(now + 9 * 60 * 1000);
+    expect(capturedSession.eventsubOAuthState.expiresAt).toBeLessThan(now + 11 * 60 * 1000);
+    expect(capturedSession.eventsubStreamerId).toBe(42);
+  });
+});

--- a/src/web/routes/userSettings.ts
+++ b/src/web/routes/userSettings.ts
@@ -104,7 +104,7 @@ router.get('/twitch-connect', requireAuth, async (req, res) => {
     }
 
     const state = randomBytes(16).toString('hex');
-    req.session.eventsubOAuthState = state;
+    req.session.eventsubOAuthState = { value: state, expiresAt: Date.now() + 10 * 60 * 1000 };
     req.session.eventsubStreamerId = streamer.id;
 
     const params = new URLSearchParams({


### PR DESCRIPTION
## Summary

- OAuth state values for both the Discord login flow (`/auth/discord`) and Twitch EventSub flow (`/user/twitch-connect`) were stored in the session as plain strings with no expiry, leaving them valid for the full 24-hour session lifetime
- Each state is now stored as `{ value: string; expiresAt: number }` and rejected on callback if more than 10 minutes have elapsed, following standard OAuth/OIDC best practice
- The state is still deleted from the session immediately on callback (before any validation) to prevent replay — the expiry check is an additional layer on top of that

## Files changed

- `src/types/express.d.ts` — updated session type for `oauthState` and `eventsubOAuthState`
- `src/web/routes/auth.ts` — store state with expiry; validate on callback
- `src/web/routes/userSettings.ts` — store EventSub state with expiry
- `src/web/routes/eventsubCallback.ts` — validate EventSub state value and expiry
- `src/web/routes/auth.test.ts` — updated tests + new expired-state test case
- `src/web/routes/eventsubCallback.test.ts` — updated tests + new expired-state test case

## Test plan

- [ ] `npx tsc --noEmit` — no type errors
- [ ] `npm test` — all 1199 tests pass (verified locally)
- [ ] Log in via Discord, verify normal login still works
- [ ] Connect Twitch EventSub, verify normal OAuth flow still works
- [ ] (Optional) Manually set `expiresAt` to a past timestamp in a debug session and verify the callback rejects with the appropriate error

https://claude.ai/code/session_01VFE2NiJWGi6NbxytQe5Rf1

---
_Generated by [Claude Code](https://claude.ai/code/session_01VFE2NiJWGi6NbxytQe5Rf1)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened Discord and Twitch OAuth flows: OAuth state now includes an expiry and is validated/cleared on callback to prevent expired or replayed authentication attempts.

* **Tests**
  * Updated authentication tests to cover expired-state scenarios and verify proper clearing and validation of OAuth state during callbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->