### PR TITLE
Multi-server (multi-guild) support

### DIFF
--- a/DATABASE-SCHEMA.md
+++ b/DATABASE-SCHEMA.md
@@ -247,7 +247,7 @@ Expected constraints:
 
 ## `streamdeck_api_keys`
 
-Per-user Streamdeck API keys. Created outside this repository; `migrations/multi_guild.sql` adds the `guild_id` column.
+Per-user Streamdeck API keys. Defined in `schema.sql`. For existing deployments where this table was created externally (before the multi-guild migration), `migrations/multi_guild.sql` conditionally adds the `guild_id` column.
 
 | Column | Type | Notes |
 | --- | --- | --- |

--- a/DATABASE-SCHEMA.md
+++ b/DATABASE-SCHEMA.md
@@ -86,6 +86,32 @@ Stores SFX categories.
 | `id` | `INT` PK | Category identifier |
 | `name` | `VARCHAR(...)` | Display name |
 
+## `guild`
+
+Registry of every Discord server the bot serves, plus per-guild configuration. Created by `migrations/multi_guild.sql`. Populated automatically by the `guildCreate` handler when the bot is added to a server.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `guild_id` | `BIGINT` PK | Discord guild (server) ID |
+| `name` | `VARCHAR(255)` | Display name, synced from Discord |
+| `voice_channel_id` | `BIGINT` nullable | Default voice channel for this guild (replaces the `DISCORD_VOICE_CHANNEL_ID` env var) |
+| `created_at` | `TIMESTAMP` | When the guild was registered |
+
+## `guild_member`
+
+Per-guild access levels. Replaces the single global `user.access_level`. A user with no row in a given guild is treated as access level `0` (User). Created by `migrations/multi_guild.sql`.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `guild_id` | `BIGINT` | FK to `guild.guild_id` `ON DELETE CASCADE` |
+| `discord_id` | `BIGINT` | FK to `user.discord_id` `ON DELETE CASCADE` |
+| `access_level` | `INT` | `0=USER`, `1=MOD`, `2=MANAGER`, `3=ADMIN` — scoped to this guild |
+
+Expected constraints:
+
+- Composite primary key `(guild_id, discord_id)`.
+- Cross-guild super-admin is expressed by `user.is_owner`, not by a `guild_member` row.
+
 ## `user`
 
 Stores web/admin users plus Twitch bot participation state.
@@ -97,7 +123,8 @@ Stores web/admin users plus Twitch bot participation state.
 | `is_twitch_bot_enabled` | `BIT(1)` or `TINYINT(1)` | Whether the Twitch bot should join this user's Twitch channel |
 | `twitch_name` | `VARCHAR(...)` nullable | Twitch channel name; should be unique when non-null |
 | `twitchoauth` | `VARCHAR(...)` nullable | Legacy/optional Twitch auth storage |
-| `access_level` | `INT` | `0=USER`, `1=MOD`, `2=MANAGER`, `3=ADMIN` |
+| `access_level` | `INT` | `0=USER`, `1=MOD`, `2=MANAGER`, `3=ADMIN`. **Deprecated** — per-guild access lives in `guild_member`; this column is migrated into `guild_member` and dropped in a later migration |
+| `is_owner` | `TINYINT(1)` | Global super-admin flag. Set manually in the DB only; never settable through the web panel |
 
 Expected constraints and behavior:
 
@@ -111,8 +138,9 @@ Stores configuration for Twitch announcement groups.
 | Column | Type | Notes |
 | --- | --- | --- |
 | `id` | `INT` PK | Group identifier |
+| `guild_id` | `BIGINT` | FK to `guild.guild_id`; the server this group belongs to |
 | `name` | `VARCHAR(...)` | Display name |
-| `discord_channel` | `BIGINT` | Channel ID for announcements |
+| `discord_channel` | `BIGINT` | Channel ID for announcements (must belong to `guild_id`) |
 | `live_message` | `TEXT` | Go-live message template |
 | `new_game_message` | `TEXT` | Game-change message template |
 | `multi_twitch` | `BIT(1)` or `TINYINT(1)` | Enables multitwitch URL field in embeds |
@@ -163,7 +191,7 @@ Created by `migrations/twitch_eventsub.sql`.
 
 ## `custom_command`
 
-Stores custom text commands managed through the admin panel.
+Stores custom text commands managed through the admin panel. This is a **global catalog** shared across all guilds (no `guild_id`); per-guild deviations (disable / output override) live in `guild_command_override`. On Discord, every catalog command is enabled by default in every guild.
 
 | Column | Type | Notes |
 | --- | --- | --- |
@@ -199,6 +227,38 @@ ALTER TABLE custom_command
     DROP INDEX uq_custom_command_trigger_string;
 ```
 
+## `guild_command_override`
+
+Sparse per-guild overlay on the **global** `custom_command` catalog. Every catalog command is enabled on Discord by default; a row here exists only where a guild has deviated. Created by `migrations/multi_guild.sql`.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `guild_id` | `BIGINT` | FK to `guild.guild_id` `ON DELETE CASCADE` |
+| `command_id` | `INT UNSIGNED` | FK to `custom_command.command_id` `ON DELETE CASCADE` |
+| `is_disabled` | `TINYINT(1)` | When `1`, the command does not fire on Discord in this guild |
+| `output` | `TEXT` nullable | Per-guild replacement output; `NULL` means use the catalog `output` |
+
+Resolution for a Discord message in a guild: load the global catalog command, then apply the `(guild_id, command_id)` override if present (`is_disabled = 1` ⇒ no fire; non-null `output` ⇒ replace text). **Twitch routing ignores this table** — Twitch chat has no Discord-guild context.
+
+Expected constraints:
+
+- Composite primary key `(guild_id, command_id)`.
+- Both foreign keys use `ON DELETE CASCADE`, so deleting a catalog command or a guild removes its override rows.
+
+## `streamdeck_api_keys`
+
+Per-user Streamdeck API keys. Created outside this repository; `migrations/multi_guild.sql` adds the `guild_id` column.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `discord_id` | `BIGINT` PK | Key owner (one key per user) |
+| `key_hash` | `VARCHAR(...)` | SHA-256 hash of the plaintext key |
+| `guild_id` | `BIGINT` | FK to `guild.guild_id`; the guild this key acts on |
+| `status` | `ENUM`/`VARCHAR` | `pending`, `approved`, `revoked`, or `denied` |
+| `requested_at` | `DATETIME` | When the key was requested |
+| `approved_at` | `DATETIME` nullable | When approved |
+| `approved_by` | `BIGINT` nullable | Approver's `discord_id` |
+
 ## `twitch_user_commands`
 
 Join table mapping users to custom commands.
@@ -222,6 +282,7 @@ Stores counter command definitions and values managed through the admin panel.
 | Column | Type | Notes |
 | --- | --- | --- |
 | `id` | `INT` PK | Counter row identifier |
+| `guild_id` | `BIGINT` | FK to `guild.guild_id`; counters are per-guild |
 | `trigger_command` | `VARCHAR(...)` | Full command token used for increment actions (including prefix) |
 | `check_command` | `VARCHAR(...)` | Full command token used for read/check actions |
 | `message` | `TEXT` | Read/check reply template; `%d` placeholder is used for current value |
@@ -232,16 +293,16 @@ Stores counter command definitions and values managed through the admin panel.
 
 Expected constraints and behavior:
 
-- `trigger_command` and `check_command` should be unique.
+- `trigger_command` and `check_command` should be unique **per guild** (the same counter command may exist in different guilds).
 - Both command columns should store single-token commands including any prefix.
 - Current panel support includes CRUD and manual reset of `current_value`; runtime command handling/scheduler wiring can be implemented independently.
 
-Recommended migrations (run once) for DB-level protection:
+Per-guild uniqueness (applied by `migrations/multi_guild.sql`, which also drops any earlier global `uq_counter_*` constraints):
 
 ```sql
 ALTER TABLE counter
-    ADD CONSTRAINT uq_counter_trigger_command UNIQUE (trigger_command),
-    ADD CONSTRAINT uq_counter_check_command UNIQUE (check_command);
+    ADD CONSTRAINT uq_counter_guild_trigger UNIQUE (guild_id, trigger_command),
+    ADD CONSTRAINT uq_counter_guild_check   UNIQUE (guild_id, check_command);
 
 CREATE INDEX idx_counter_trigger ON counter(trigger_command);
 CREATE INDEX idx_counter_check   ON counter(check_command);

--- a/migrations/multi_guild.sql
+++ b/migrations/multi_guild.sql
@@ -60,8 +60,10 @@ SELECT @legacy_guild_id, discord_id, access_level FROM `user`;
 -- INT. Normalize to UNSIGNED before creating guild_command_override whose FK
 -- requires an exact type match. Auto-increment PKs are always positive so the
 -- signed→unsigned conversion is lossless.
+-- COLUMN_TYPE is 'int' on MySQL 8.0.19+ but 'int(11)' on older builds;
+-- use NOT LIKE '%unsigned%' to reliably detect signed INT regardless of version.
 SET @need_cmd_normalize = (
-  SELECT IF(COLUMN_TYPE = 'int', 1, 0)
+  SELECT IF(COLUMN_TYPE NOT LIKE '%unsigned%', 1, 0)
   FROM information_schema.COLUMNS
   WHERE TABLE_SCHEMA = DATABASE()
     AND TABLE_NAME   = 'custom_command'
@@ -97,7 +99,7 @@ SET @tuc_cmd_type = (
     AND TABLE_NAME   = 'twitch_user_commands'
     AND COLUMN_NAME  = 'command_id'
 );
-SET @sql = IF(@tuc_cmd_type = 'int',
+SET @sql = IF(@tuc_cmd_type NOT LIKE '%unsigned%',
   'ALTER TABLE twitch_user_commands MODIFY COLUMN command_id INT UNSIGNED NOT NULL',
   'SELECT 1');
 PREPARE _s FROM @sql; EXECUTE _s; DEALLOCATE PREPARE _s;

--- a/migrations/multi_guild.sql
+++ b/migrations/multi_guild.sql
@@ -1,0 +1,116 @@
+-- Multi-server (multi-guild) support — Phase 1 schema migration (PR 1).
+--
+-- Adds the guild registry, per-guild access levels, the per-guild command
+-- override overlay, and guild_id scoping on the per-guild data tables. No
+-- application code reads these columns yet, so this migration is safe to apply
+-- to a running single-guild deployment ahead of the code changes.
+--
+-- The legacy guild's existing rows are seeded with the current DISCORD_GUILD_ID.
+-- `user.access_level` is COPIED into `guild_member` but is NOT dropped here —
+-- it is dropped in PR 3 once every reader has migrated to the per-guild level.
+--
+-- BEFORE RUNNING: set @legacy_guild_id to the value of your DISCORD_GUILD_ID env
+-- var, and optionally set @legacy_guild_name to a human-friendly server name.
+SET @legacy_guild_id   = 0;            -- <<< REPLACE with your DISCORD_GUILD_ID
+SET @legacy_guild_name = 'Legacy Guild';
+
+-- ─── guild ──────────────────────────────────────────────────────────────────
+-- Registry of every Discord server the bot serves, plus per-guild config.
+-- Must exist (and be seeded) before any FK references it.
+CREATE TABLE guild (
+    guild_id         BIGINT       NOT NULL,
+    name             VARCHAR(255) NOT NULL DEFAULT '',
+    voice_channel_id BIGINT       NULL,          -- replaces the DISCORD_VOICE_CHANNEL_ID env var
+    created_at       TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (guild_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+INSERT INTO guild (guild_id, name) VALUES (@legacy_guild_id, @legacy_guild_name);
+
+-- ─── guild_member ───────────────────────────────────────────────────────────
+-- Per-guild access levels (0=User, 1=Mod, 2=Manager, 3=Admin). Replaces the
+-- single global user.access_level. is_owner (below) is the only cross-guild role.
+CREATE TABLE guild_member (
+    guild_id     BIGINT NOT NULL,
+    discord_id   BIGINT NOT NULL,
+    access_level INT    NOT NULL DEFAULT 0,
+    PRIMARY KEY (guild_id, discord_id),
+    FOREIGN KEY (guild_id)   REFERENCES guild(guild_id)    ON DELETE CASCADE,
+    FOREIGN KEY (discord_id) REFERENCES `user`(discord_id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Seed the legacy guild's memberships from the current global access levels.
+INSERT INTO guild_member (guild_id, discord_id, access_level)
+SELECT @legacy_guild_id, discord_id, access_level FROM `user`;
+
+-- ─── guild_command_override ───────────────────────────────────────────────────
+-- Sparse overlay on the GLOBAL custom_command catalog. A row exists only where a
+-- guild has deviated: disabled the command, or replaced its Discord output text.
+-- No row → catalog default (enabled, catalog output). Twitch is unaffected.
+CREATE TABLE guild_command_override (
+    guild_id    BIGINT       NOT NULL,
+    command_id  INT UNSIGNED NOT NULL,
+    is_disabled TINYINT(1)   NOT NULL DEFAULT 0,
+    output      TEXT         NULL,
+    PRIMARY KEY (guild_id, command_id),
+    FOREIGN KEY (guild_id)   REFERENCES guild(guild_id)            ON DELETE CASCADE,
+    FOREIGN KEY (command_id) REFERENCES custom_command(command_id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ─── user.is_owner ────────────────────────────────────────────────────────────
+-- Global super-admin flag. Set manually in the DB (never via the web panel).
+-- access_level is intentionally kept here; it is dropped in PR 3.
+ALTER TABLE `user` ADD COLUMN is_owner TINYINT(1) NOT NULL DEFAULT 0;
+
+-- Remember to flag the bot owner(s) afterwards, e.g.:
+--   UPDATE `user` SET is_owner = 1 WHERE discord_id = '<OWNER_DISCORD_ID>';
+
+-- ─── counter.guild_id (per-guild) ─────────────────────────────────────────────
+-- nullable → backfill → NOT NULL + FK, so existing rows survive the add.
+ALTER TABLE counter ADD COLUMN guild_id BIGINT NULL AFTER id;
+UPDATE counter SET guild_id = @legacy_guild_id;
+ALTER TABLE counter
+    MODIFY COLUMN guild_id BIGINT NOT NULL,
+    ADD CONSTRAINT fk_counter_guild FOREIGN KEY (guild_id) REFERENCES guild(guild_id);
+
+-- Global uniqueness on counter command columns is wrong once two guilds exist.
+-- Drop the optional global constraints if present, then add per-guild uniqueness.
+SET @exists = (
+  SELECT COUNT(*) FROM information_schema.statistics
+  WHERE table_schema = DATABASE() AND table_name = 'counter'
+    AND index_name = 'uq_counter_trigger_command'
+);
+SET @sql = IF(@exists > 0,
+  'ALTER TABLE counter DROP INDEX uq_counter_trigger_command',
+  'SELECT ''uq_counter_trigger_command absent''');
+PREPARE _s FROM @sql; EXECUTE _s; DEALLOCATE PREPARE _s;
+
+SET @exists = (
+  SELECT COUNT(*) FROM information_schema.statistics
+  WHERE table_schema = DATABASE() AND table_name = 'counter'
+    AND index_name = 'uq_counter_check_command'
+);
+SET @sql = IF(@exists > 0,
+  'ALTER TABLE counter DROP INDEX uq_counter_check_command',
+  'SELECT ''uq_counter_check_command absent''');
+PREPARE _s FROM @sql; EXECUTE _s; DEALLOCATE PREPARE _s;
+
+ALTER TABLE counter
+    ADD CONSTRAINT uq_counter_guild_trigger UNIQUE (guild_id, trigger_command),
+    ADD CONSTRAINT uq_counter_guild_check   UNIQUE (guild_id, check_command);
+
+-- ─── stream_group.guild_id (per-guild) ────────────────────────────────────────
+ALTER TABLE stream_group ADD COLUMN guild_id BIGINT NULL AFTER id;
+UPDATE stream_group SET guild_id = @legacy_guild_id;
+ALTER TABLE stream_group
+    MODIFY COLUMN guild_id BIGINT NOT NULL,
+    ADD INDEX idx_stream_group_guild (guild_id),
+    ADD CONSTRAINT fk_stream_group_guild FOREIGN KEY (guild_id) REFERENCES guild(guild_id);
+
+-- ─── streamdeck_api_keys.guild_id ─────────────────────────────────────────────
+-- A key grants access to one specific guild. PK stays discord_id (one key/user).
+ALTER TABLE streamdeck_api_keys ADD COLUMN guild_id BIGINT NULL;
+UPDATE streamdeck_api_keys SET guild_id = @legacy_guild_id;
+ALTER TABLE streamdeck_api_keys
+    MODIFY COLUMN guild_id BIGINT NOT NULL,
+    ADD CONSTRAINT fk_streamdeck_guild FOREIGN KEY (guild_id) REFERENCES guild(guild_id);

--- a/migrations/multi_guild.sql
+++ b/migrations/multi_guild.sql
@@ -54,6 +54,60 @@ CREATE TABLE guild_member (
 INSERT INTO guild_member (guild_id, discord_id, access_level)
 SELECT @legacy_guild_id, discord_id, access_level FROM `user`;
 
+-- ─── Normalize command_id to INT UNSIGNED (for FK compatibility) ──────────────
+-- On deployments created before schema.sql standardised INT UNSIGNED, the
+-- custom_command and twitch_user_commands tables may have command_id as signed
+-- INT. Normalize to UNSIGNED before creating guild_command_override whose FK
+-- requires an exact type match. Auto-increment PKs are always positive so the
+-- signed→unsigned conversion is lossless.
+SET @need_cmd_normalize = (
+  SELECT IF(COLUMN_TYPE = 'int', 1, 0)
+  FROM information_schema.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME   = 'custom_command'
+    AND COLUMN_NAME  = 'command_id'
+);
+
+-- Drop the FK from twitch_user_commands → custom_command before modifying the
+-- referenced column (MySQL requires this).
+SET @tuc_fk_name = (
+  SELECT CONSTRAINT_NAME FROM information_schema.KEY_COLUMN_USAGE
+  WHERE TABLE_SCHEMA          = DATABASE()
+    AND TABLE_NAME            = 'twitch_user_commands'
+    AND COLUMN_NAME           = 'command_id'
+    AND REFERENCED_TABLE_NAME = 'custom_command'
+  LIMIT 1
+);
+SET @sql = IF(@need_cmd_normalize = 1 AND @tuc_fk_name IS NOT NULL,
+  CONCAT('ALTER TABLE twitch_user_commands DROP FOREIGN KEY `', @tuc_fk_name, '`'),
+  'SELECT 1');
+PREPARE _s FROM @sql; EXECUTE _s; DEALLOCATE PREPARE _s;
+
+-- Normalize custom_command.command_id.
+SET @sql = IF(@need_cmd_normalize = 1,
+  'ALTER TABLE custom_command MODIFY COLUMN command_id INT UNSIGNED NOT NULL AUTO_INCREMENT',
+  'SELECT 1');
+PREPARE _s FROM @sql; EXECUTE _s; DEALLOCATE PREPARE _s;
+
+-- Normalize twitch_user_commands.command_id (may also be signed INT on the same
+-- deployment; check independently in case its FK was already absent).
+SET @tuc_cmd_type = (
+  SELECT COLUMN_TYPE FROM information_schema.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME   = 'twitch_user_commands'
+    AND COLUMN_NAME  = 'command_id'
+);
+SET @sql = IF(@tuc_cmd_type = 'int',
+  'ALTER TABLE twitch_user_commands MODIFY COLUMN command_id INT UNSIGNED NOT NULL',
+  'SELECT 1');
+PREPARE _s FROM @sql; EXECUTE _s; DEALLOCATE PREPARE _s;
+
+-- Restore the FK if it was dropped.
+SET @sql = IF(@need_cmd_normalize = 1 AND @tuc_fk_name IS NOT NULL,
+  'ALTER TABLE twitch_user_commands ADD FOREIGN KEY (command_id) REFERENCES custom_command(command_id) ON DELETE CASCADE',
+  'SELECT 1');
+PREPARE _s FROM @sql; EXECUTE _s; DEALLOCATE PREPARE _s;
+
 -- ─── guild_command_override ───────────────────────────────────────────────────
 -- Sparse overlay on the GLOBAL custom_command catalog. A row exists only where a
 -- guild has deviated: disabled the command, or replaced its Discord output text.

--- a/migrations/multi_guild.sql
+++ b/migrations/multi_guild.sql
@@ -1,9 +1,12 @@
 -- Multi-server (multi-guild) support — Phase 1 schema migration (PR 1).
 --
 -- Adds the guild registry, per-guild access levels, the per-guild command
--- override overlay, and guild_id scoping on the per-guild data tables. No
--- application code reads these columns yet, so this migration is safe to apply
--- to a running single-guild deployment ahead of the code changes.
+-- override overlay, and guild_id scoping on the per-guild data tables.
+--
+-- Safe to apply to a running single-guild deployment ahead of the code changes:
+-- no application code reads these columns yet, and the new guild_id columns
+-- default to the legacy guild, so current INSERTs (which omit guild_id) keep
+-- working and land in the legacy guild until the runtime is updated.
 --
 -- The legacy guild's existing rows are seeded with the current DISCORD_GUILD_ID.
 -- `user.access_level` is COPIED into `guild_member` but is NOT dropped here —
@@ -13,6 +16,14 @@
 -- var, and optionally set @legacy_guild_name to a human-friendly server name.
 SET @legacy_guild_id   = 0;            -- <<< REPLACE with your DISCORD_GUILD_ID
 SET @legacy_guild_name = 'Legacy Guild';
+
+-- Fail fast if @legacy_guild_id was left at the placeholder. Without this the
+-- migration would backfill every guild-scoped row to an invalid guild id (0),
+-- requiring manual repair. The unknown-column error surfaces the message text.
+SET @sql = IF(@legacy_guild_id IS NULL OR @legacy_guild_id = 0,
+  'SELECT `ABORT: set @legacy_guild_id to your DISCORD_GUILD_ID before running this migration` FROM DUAL',
+  'SELECT 1');
+PREPARE _s FROM @sql; EXECUTE _s; DEALLOCATE PREPARE _s;
 
 -- ─── guild ──────────────────────────────────────────────────────────────────
 -- Registry of every Discord server the bot serves, plus per-guild config.
@@ -66,12 +77,15 @@ ALTER TABLE `user` ADD COLUMN is_owner TINYINT(1) NOT NULL DEFAULT 0;
 --   UPDATE `user` SET is_owner = 1 WHERE discord_id = '<OWNER_DISCORD_ID>';
 
 -- ─── counter.guild_id (per-guild) ─────────────────────────────────────────────
--- nullable → backfill → NOT NULL + FK, so existing rows survive the add.
-ALTER TABLE counter ADD COLUMN guild_id BIGINT NULL AFTER id;
-UPDATE counter SET guild_id = @legacy_guild_id;
-ALTER TABLE counter
-    MODIFY COLUMN guild_id BIGINT NOT NULL,
-    ADD CONSTRAINT fk_counter_guild FOREIGN KEY (guild_id) REFERENCES guild(guild_id);
+-- NOT NULL DEFAULT <legacy guild>: existing rows are backfilled by the default,
+-- and current writes (which omit guild_id) keep working and land in the legacy
+-- guild until the runtime starts supplying guild_id. Dynamic SQL bakes the
+-- operator's guild id in as the literal column default.
+SET @sql = CONCAT(
+  'ALTER TABLE counter ',
+  'ADD COLUMN guild_id BIGINT NOT NULL DEFAULT ', @legacy_guild_id, ' AFTER id, ',
+  'ADD CONSTRAINT fk_counter_guild FOREIGN KEY (guild_id) REFERENCES guild(guild_id)');
+PREPARE _s FROM @sql; EXECUTE _s; DEALLOCATE PREPARE _s;
 
 -- Global uniqueness on counter command columns is wrong once two guilds exist.
 -- Drop the optional global constraints if present, then add per-guild uniqueness.
@@ -100,17 +114,26 @@ ALTER TABLE counter
     ADD CONSTRAINT uq_counter_guild_check   UNIQUE (guild_id, check_command);
 
 -- ─── stream_group.guild_id (per-guild) ────────────────────────────────────────
-ALTER TABLE stream_group ADD COLUMN guild_id BIGINT NULL AFTER id;
-UPDATE stream_group SET guild_id = @legacy_guild_id;
-ALTER TABLE stream_group
-    MODIFY COLUMN guild_id BIGINT NOT NULL,
-    ADD INDEX idx_stream_group_guild (guild_id),
-    ADD CONSTRAINT fk_stream_group_guild FOREIGN KEY (guild_id) REFERENCES guild(guild_id);
+-- NOT NULL DEFAULT <legacy guild> for the same write-compatibility reason as counter.
+SET @sql = CONCAT(
+  'ALTER TABLE stream_group ',
+  'ADD COLUMN guild_id BIGINT NOT NULL DEFAULT ', @legacy_guild_id, ' AFTER id, ',
+  'ADD INDEX idx_stream_group_guild (guild_id), ',
+  'ADD CONSTRAINT fk_stream_group_guild FOREIGN KEY (guild_id) REFERENCES guild(guild_id)');
+PREPARE _s FROM @sql; EXECUTE _s; DEALLOCATE PREPARE _s;
 
 -- ─── streamdeck_api_keys.guild_id ─────────────────────────────────────────────
 -- A key grants access to one specific guild. PK stays discord_id (one key/user).
-ALTER TABLE streamdeck_api_keys ADD COLUMN guild_id BIGINT NULL;
-UPDATE streamdeck_api_keys SET guild_id = @legacy_guild_id;
-ALTER TABLE streamdeck_api_keys
-    MODIFY COLUMN guild_id BIGINT NOT NULL,
-    ADD CONSTRAINT fk_streamdeck_guild FOREIGN KEY (guild_id) REFERENCES guild(guild_id);
+-- This table is created outside this repo, so guard the ALTER behind an existence
+-- check to avoid a partial migration on environments where it is absent.
+SET @sd_exists = (
+  SELECT COUNT(*) FROM information_schema.tables
+  WHERE table_schema = DATABASE() AND table_name = 'streamdeck_api_keys'
+);
+SET @sql = IF(@sd_exists = 0,
+  'SELECT ''streamdeck_api_keys absent — skipping guild_id add''',
+  CONCAT(
+    'ALTER TABLE streamdeck_api_keys ',
+    'ADD COLUMN guild_id BIGINT NOT NULL DEFAULT ', @legacy_guild_id, ', ',
+    'ADD CONSTRAINT fk_streamdeck_guild FOREIGN KEY (guild_id) REFERENCES guild(guild_id)'));
+PREPARE _s FROM @sql; EXECUTE _s; DEALLOCATE PREPARE _s;

--- a/migrations/multi_guild.sql
+++ b/migrations/multi_guild.sql
@@ -54,75 +54,34 @@ CREATE TABLE guild_member (
 INSERT INTO guild_member (guild_id, discord_id, access_level)
 SELECT @legacy_guild_id, discord_id, access_level FROM `user`;
 
--- ─── Normalize command_id to INT UNSIGNED (for FK compatibility) ──────────────
--- On deployments created before schema.sql standardised INT UNSIGNED, the
--- custom_command and twitch_user_commands tables may have command_id as signed
--- INT. Normalize to UNSIGNED before creating guild_command_override whose FK
--- requires an exact type match. Auto-increment PKs are always positive so the
--- signed→unsigned conversion is lossless.
--- COLUMN_TYPE is 'int' on MySQL 8.0.19+ but 'int(11)' on older builds;
--- use NOT LIKE '%unsigned%' to reliably detect signed INT regardless of version.
-SET @need_cmd_normalize = (
-  SELECT IF(COLUMN_TYPE NOT LIKE '%unsigned%', 1, 0)
-  FROM information_schema.COLUMNS
-  WHERE TABLE_SCHEMA = DATABASE()
-    AND TABLE_NAME   = 'custom_command'
-    AND COLUMN_NAME  = 'command_id'
-);
-
--- Drop the FK from twitch_user_commands → custom_command before modifying the
--- referenced column (MySQL requires this).
-SET @tuc_fk_name = (
-  SELECT CONSTRAINT_NAME FROM information_schema.KEY_COLUMN_USAGE
-  WHERE TABLE_SCHEMA          = DATABASE()
-    AND TABLE_NAME            = 'twitch_user_commands'
-    AND COLUMN_NAME           = 'command_id'
-    AND REFERENCED_TABLE_NAME = 'custom_command'
-  LIMIT 1
-);
-SET @sql = IF(@need_cmd_normalize = 1 AND @tuc_fk_name IS NOT NULL,
-  CONCAT('ALTER TABLE twitch_user_commands DROP FOREIGN KEY `', @tuc_fk_name, '`'),
-  'SELECT 1');
-PREPARE _s FROM @sql; EXECUTE _s; DEALLOCATE PREPARE _s;
-
--- Normalize custom_command.command_id.
-SET @sql = IF(@need_cmd_normalize = 1,
-  'ALTER TABLE custom_command MODIFY COLUMN command_id INT UNSIGNED NOT NULL AUTO_INCREMENT',
-  'SELECT 1');
-PREPARE _s FROM @sql; EXECUTE _s; DEALLOCATE PREPARE _s;
-
--- Normalize twitch_user_commands.command_id (may also be signed INT on the same
--- deployment; check independently in case its FK was already absent).
-SET @tuc_cmd_type = (
-  SELECT COLUMN_TYPE FROM information_schema.COLUMNS
-  WHERE TABLE_SCHEMA = DATABASE()
-    AND TABLE_NAME   = 'twitch_user_commands'
-    AND COLUMN_NAME  = 'command_id'
-);
-SET @sql = IF(@tuc_cmd_type NOT LIKE '%unsigned%',
-  'ALTER TABLE twitch_user_commands MODIFY COLUMN command_id INT UNSIGNED NOT NULL',
-  'SELECT 1');
-PREPARE _s FROM @sql; EXECUTE _s; DEALLOCATE PREPARE _s;
-
--- Restore the FK if it was dropped.
-SET @sql = IF(@need_cmd_normalize = 1 AND @tuc_fk_name IS NOT NULL,
-  'ALTER TABLE twitch_user_commands ADD FOREIGN KEY (command_id) REFERENCES custom_command(command_id) ON DELETE CASCADE',
-  'SELECT 1');
-PREPARE _s FROM @sql; EXECUTE _s; DEALLOCATE PREPARE _s;
-
 -- ─── guild_command_override ───────────────────────────────────────────────────
 -- Sparse overlay on the GLOBAL custom_command catalog. A row exists only where a
 -- guild has deviated: disabled the command, or replaced its Discord output text.
 -- No row → catalog default (enabled, catalog output). Twitch is unaffected.
-CREATE TABLE guild_command_override (
-    guild_id    BIGINT       NOT NULL,
-    command_id  INT UNSIGNED NOT NULL,
-    is_disabled TINYINT(1)   NOT NULL DEFAULT 0,
-    output      TEXT         NULL,
-    PRIMARY KEY (guild_id, command_id),
-    FOREIGN KEY (guild_id)   REFERENCES guild(guild_id)            ON DELETE CASCADE,
-    FOREIGN KEY (command_id) REFERENCES custom_command(command_id) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+--
+-- Use dynamic SQL so that guild_command_override.command_id inherits the exact
+-- COLUMN_TYPE of custom_command.command_id. On deployments created before
+-- schema.sql standardised INT UNSIGNED, command_id may be signed int or
+-- int(11); hardcoding INT UNSIGNED triggers MySQL error 3780 (FK type mismatch).
+SET @_cmd_id_type = IFNULL(
+  (SELECT COLUMN_TYPE FROM information_schema.COLUMNS
+   WHERE TABLE_SCHEMA = DATABASE()
+     AND TABLE_NAME   = 'custom_command'
+     AND COLUMN_NAME  = 'command_id'),
+  'int unsigned'
+);
+SET @sql = CONCAT(
+  'CREATE TABLE guild_command_override (',
+  '    guild_id    BIGINT              NOT NULL,',
+  '    command_id  ', @_cmd_id_type, ' NOT NULL,',
+  '    is_disabled TINYINT(1)          NOT NULL DEFAULT 0,',
+  '    output      TEXT                NULL,',
+  '    PRIMARY KEY (guild_id, command_id),',
+  '    FOREIGN KEY (guild_id)   REFERENCES guild(guild_id)            ON DELETE CASCADE,',
+  '    FOREIGN KEY (command_id) REFERENCES custom_command(command_id) ON DELETE CASCADE',
+  ') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci'
+);
+PREPARE _s FROM @sql; EXECUTE _s; DEALLOCATE PREPARE _s;
 
 -- ─── user.is_owner ────────────────────────────────────────────────────────────
 -- Global super-admin flag. Set manually in the DB (never via the web panel).

--- a/schema.sql
+++ b/schema.sql
@@ -97,7 +97,7 @@ CREATE TABLE IF NOT EXISTS guild_member (
 -- ---------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS stream_group (
   id               INT          NOT NULL AUTO_INCREMENT,
-  guild_id         BIGINT       NOT NULL,
+  guild_id         BIGINT       NULL,
   name             VARCHAR(255) NOT NULL,
   discord_channel  BIGINT       NOT NULL,
   live_message     TEXT         NOT NULL,
@@ -199,7 +199,7 @@ CREATE TABLE IF NOT EXISTS guild_command_override (
 -- ---------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS counter (
   id                INT          NOT NULL AUTO_INCREMENT,
-  guild_id          BIGINT       NOT NULL,
+  guild_id          BIGINT       NULL,
   trigger_command   VARCHAR(255) NOT NULL,
   check_command     VARCHAR(255) NOT NULL,
   message           TEXT         NOT NULL,
@@ -266,7 +266,7 @@ CREATE TABLE IF NOT EXISTS overlay_reward_video (
 CREATE TABLE IF NOT EXISTS streamdeck_api_keys (
   discord_id   BIGINT                                       NOT NULL,
   key_hash     VARCHAR(64)                                  NOT NULL,
-  guild_id     BIGINT                                       NOT NULL,
+  guild_id     BIGINT                                       NULL,
   status       ENUM('pending','approved','revoked','denied') NOT NULL DEFAULT 'pending',
   requested_at DATETIME                                     NOT NULL,
   approved_at  DATETIME                                     NULL,

--- a/schema.sql
+++ b/schema.sql
@@ -59,9 +59,37 @@ CREATE TABLE IF NOT EXISTS `user` (
   is_twitch_bot_enabled TINYINT(1)   NOT NULL DEFAULT 0,
   twitch_name           VARCHAR(255) NULL,
   twitchoauth           VARCHAR(512) NULL,
-  access_level          INT          NOT NULL DEFAULT 0,
+  access_level          INT          NOT NULL DEFAULT 0,  -- deprecated: per-guild level lives in guild_member; dropped in a later migration
+  is_owner              TINYINT(1)   NOT NULL DEFAULT 0,  -- global super-admin; set manually in the DB only
   PRIMARY KEY (discord_id),
   UNIQUE KEY uq_user_twitch_name (twitch_name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ---------------------------------------------------------------------------
+-- guild
+-- Registry of every Discord server the bot serves, plus per-guild config.
+-- Populated automatically by the guildCreate handler.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS guild (
+  guild_id         BIGINT       NOT NULL,
+  name             VARCHAR(255) NOT NULL DEFAULT '',
+  voice_channel_id BIGINT       NULL,
+  created_at       TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (guild_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ---------------------------------------------------------------------------
+-- guild_member
+-- Per-guild access levels (0=User, 1=Mod, 2=Manager, 3=Admin). Replaces the
+-- single global user.access_level. No row → access level 0 in that guild.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS guild_member (
+  guild_id     BIGINT NOT NULL,
+  discord_id   BIGINT NOT NULL,
+  access_level INT    NOT NULL DEFAULT 0,
+  PRIMARY KEY (guild_id, discord_id),
+  FOREIGN KEY (guild_id)   REFERENCES guild(guild_id)    ON DELETE CASCADE,
+  FOREIGN KEY (discord_id) REFERENCES `user`(discord_id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ---------------------------------------------------------------------------
@@ -69,13 +97,16 @@ CREATE TABLE IF NOT EXISTS `user` (
 -- ---------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS stream_group (
   id               INT          NOT NULL AUTO_INCREMENT,
+  guild_id         BIGINT       NOT NULL,
   name             VARCHAR(255) NOT NULL,
   discord_channel  BIGINT       NOT NULL,
   live_message     TEXT         NOT NULL,
   new_game_message TEXT         NOT NULL,
   multi_twitch     TINYINT(1)   NOT NULL DEFAULT 0,
   delete_old_posts TINYINT(1)   NOT NULL DEFAULT 0,
-  PRIMARY KEY (id)
+  PRIMARY KEY (id),
+  INDEX idx_stream_group_guild (guild_id),
+  CONSTRAINT fk_stream_group_guild FOREIGN KEY (guild_id) REFERENCES guild(guild_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ---------------------------------------------------------------------------
@@ -145,13 +176,30 @@ CREATE TABLE IF NOT EXISTS twitch_user_commands (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ---------------------------------------------------------------------------
+-- guild_command_override
+-- Sparse per-guild overlay on the global custom_command catalog. A row exists
+-- only where a guild has disabled a command or replaced its Discord output.
+-- No row → catalog default (enabled, catalog output). Twitch ignores this table.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS guild_command_override (
+  guild_id    BIGINT       NOT NULL,
+  command_id  INT UNSIGNED NOT NULL,
+  is_disabled TINYINT(1)   NOT NULL DEFAULT 0,
+  output      TEXT         NULL,
+  PRIMARY KEY (guild_id, command_id),
+  FOREIGN KEY (guild_id)   REFERENCES guild(guild_id)            ON DELETE CASCADE,
+  FOREIGN KEY (command_id) REFERENCES custom_command(command_id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ---------------------------------------------------------------------------
 -- counter
--- Column-level UNIQUEs prevent duplicate trigger/check commands per column.
--- Cross-column uniqueness is enforced at the application layer via advisory
--- locks and isAnyCommandTakenAcrossTables(). See DATABASE-SCHEMA.md.
+-- Per-guild. UNIQUEs are scoped to (guild_id, command) so two guilds may share
+-- a command string. Cross-column uniqueness is enforced at the application
+-- layer via advisory locks and isAnyCommandTakenAcrossTables(). See DATABASE-SCHEMA.md.
 -- ---------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS counter (
   id                INT          NOT NULL AUTO_INCREMENT,
+  guild_id          BIGINT       NOT NULL,
   trigger_command   VARCHAR(255) NOT NULL,
   check_command     VARCHAR(255) NOT NULL,
   message           TEXT         NOT NULL,
@@ -165,8 +213,9 @@ CREATE TABLE IF NOT EXISTS counter (
   value2024         INT          NULL,
   value2025         INT          NULL,
   PRIMARY KEY (id),
-  CONSTRAINT uq_counter_trigger_command UNIQUE (trigger_command),
-  CONSTRAINT uq_counter_check_command   UNIQUE (check_command),
+  CONSTRAINT uq_counter_guild_trigger UNIQUE (guild_id, trigger_command),
+  CONSTRAINT uq_counter_guild_check   UNIQUE (guild_id, check_command),
+  CONSTRAINT fk_counter_guild FOREIGN KEY (guild_id) REFERENCES guild(guild_id),
   INDEX idx_counter_trigger (trigger_command),
   INDEX idx_counter_check   (check_command)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -217,11 +266,13 @@ CREATE TABLE IF NOT EXISTS overlay_reward_video (
 CREATE TABLE IF NOT EXISTS streamdeck_api_keys (
   discord_id   BIGINT                                       NOT NULL,
   key_hash     VARCHAR(64)                                  NOT NULL,
+  guild_id     BIGINT                                       NOT NULL,
   status       ENUM('pending','approved','revoked','denied') NOT NULL DEFAULT 'pending',
   requested_at DATETIME                                     NOT NULL,
   approved_at  DATETIME                                     NULL,
   approved_by  BIGINT                                       NULL,
   PRIMARY KEY (discord_id),
+  CONSTRAINT fk_streamdeck_guild FOREIGN KEY (guild_id) REFERENCES guild(guild_id),
   FOREIGN KEY (approved_by) REFERENCES `user`(discord_id) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 

--- a/schema.sql
+++ b/schema.sql
@@ -94,6 +94,11 @@ CREATE TABLE IF NOT EXISTS guild_member (
 
 -- ---------------------------------------------------------------------------
 -- stream_group
+-- guild_id is NULL here for the PR-1→PR-2 transition: current runtime code
+-- does not yet supply guild_id on INSERT.  PR 2 (runtime guild-awareness) will
+-- update these INSERTs and tighten all three guild_id columns back to NOT NULL.
+-- Existing deployments use migrations/multi_guild.sql which already enforces
+-- NOT NULL DEFAULT <legacy_guild_id> so the two paths converge after PR 2.
 -- ---------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS stream_group (
   id               INT          NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
## Goal

Let a single bot instance serve multiple Discord servers, instead of the current single `DISCORD_GUILD_ID` design.

This is delivered as a sequence of self-contained steps on this branch. Every step keeps the bot **100% functional on the existing single server** — `guildId` is always the legacy `DISCORD_GUILD_ID` and the guild registry holds one guild until a second `guild` row is inserted at go-live.

### Architecture decisions (locked)
- **Single process, single bot identity** across all guilds.
- **Shared SFX library**; **stream groups are per-guild**.
- **Custom commands are a global catalog** (enabled by default on Discord); each server can disable or override a command's output via `guild_command_override`. Any server admin can edit the catalog.
- **Counters are per-guild.**
- **Twitch path is unchanged** — the catalog is global (one `!hello`), so there's no cross-guild collision and no guild scoping needed on the Twitch side.
- Per-guild access lives in `guild_member`; `user.is_owner` is the only cross-guild role.

## Rollout (commits on this branch)

- [x] **Step 1 — Schema & migration (DB only).** `guild`, `guild_member`, `guild_command_override` tables; `guild_id` on `counter`/`stream_group`/`streamdeck_api_keys`; `user.is_owner`; per-guild counter uniqueness; `DATABASE-SCHEMA.md` updated.
- [ ] **Step 2 — Runtime guild-awareness + access shim** (server-side, no UI).
- [ ] **Step 3 — Web panel guild context + config cleanup.**
- [ ] **Go-live** — ops step: insert a second `guild` row + provision its first admin.

## Notes
- The migration (`migrations/multi_guild.sql`) requires the operator to set `@legacy_guild_id` to the current `DISCORD_GUILD_ID` before running, and to flag the bot owner with `is_owner = 1`.
- `user.access_level` is copied into `guild_member` and **kept** for now; it's dropped in Step 3 once all readers use the per-guild level.

https://claude.ai/code/session_01QfGqskn817m3wmrwDjEqh3

---
_Generated by [Claude Code](https://claude.ai/code/session_01QfGqskn817m3wmrwDjEqh3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-guild support across the platform
  * Per-guild access levels and membership-based permissions; global owner flag retained
  * Guild-specific command customization with per-guild enable/disable and output overrides
  * Guild-scoped stream groups, counters, and API key associations

* **Documentation**
  * Database schema docs updated to describe the multi-guild model, deprecation of global access level, and per-guild behaviors

* **Chores**
  * Migration added to convert existing data to the multi-guild schema
<!-- end of auto-generated comment: release notes by coderabbit.ai -->