### PR TITLE
Multi-server (multi-guild) support — PR 2: runtime guild-awareness + access shim

### DIFF
--- a/src/commands/customCommandHandler.test.ts
+++ b/src/commands/customCommandHandler.test.ts
@@ -39,6 +39,7 @@ function mockMsg(content: string) {
   return {
     id: 'msg-1',
     content,
+    guildId: 'guild-1',
     reply: vi.fn().mockResolvedValue(undefined),
   };
 }
@@ -98,6 +99,33 @@ describe('executeCustomCommandForDiscord', () => {
     msg.reply.mockRejectedValue(new Error('Unknown message'));
 
     await expect(executeCustomCommandForDiscord(msg as any)).resolves.toBeUndefined();
+  });
+
+  it('threads an explicit guildId into the override-aware lookup', async () => {
+    vi.mocked(getCustomCommandForDiscord).mockResolvedValue({ output: 'Hi!', is_multi_twitch: false } as any);
+    const msg = mockMsg('!hello');
+
+    await executeCustomCommandForDiscord(msg as any, 'viewer1', 'explicit-guild');
+
+    expect(vi.mocked(getCustomCommandForDiscord)).toHaveBeenCalledWith('!hello', 'explicit-guild');
+  });
+
+  it('falls back to the message guild when no guildId is passed', async () => {
+    vi.mocked(getCustomCommandForDiscord).mockResolvedValue({ output: 'Hi!', is_multi_twitch: false } as any);
+    const msg = mockMsg('!hello');
+
+    await executeCustomCommandForDiscord(msg as any, 'viewer1');
+
+    expect(vi.mocked(getCustomCommandForDiscord)).toHaveBeenCalledWith('!hello', 'guild-1');
+  });
+
+  it('does nothing when no guild context is available', async () => {
+    const msg = { id: 'm', content: '!hello', guildId: null, reply: vi.fn() };
+
+    await executeCustomCommandForDiscord(msg as any, 'viewer1');
+
+    expect(vi.mocked(getCustomCommandForDiscord)).not.toHaveBeenCalled();
+    expect(msg.reply).not.toHaveBeenCalled();
   });
 });
 

--- a/src/commands/customCommandHandler.ts
+++ b/src/commands/customCommandHandler.ts
@@ -147,6 +147,19 @@ async function broadcastToActiveChannels(sourceChannel: string, command: string,
 
 // ─── Execute functions ────────────────────────────────────────────────────────
 
+/**
+ * Checks a Discord message against the custom command catalog and replies if a match is found.
+ *
+ * Guild context is resolved in priority order: the explicit `guildId` argument, then
+ * `message.guildId`. Returns without action when no guild context is available.
+ * The guild's per-guild override overlay is applied before the reply (disabled commands
+ * are skipped; output overrides replace the catalog text). Discord not-found errors
+ * (e.g. message deleted before the reply lands) are silently swallowed.
+ *
+ * @param message - The Discord message to inspect and, if matched, reply to.
+ * @param username - Display name for the monitoring entry; null or omitted if unknown.
+ * @param guildId - Explicit guild ID for override-aware lookup; falls back to message.guildId.
+ */
 export async function executeCustomCommandForDiscord(
   message: Message,
   username?: string | null,

--- a/src/commands/customCommandHandler.ts
+++ b/src/commands/customCommandHandler.ts
@@ -150,11 +150,17 @@ async function broadcastToActiveChannels(sourceChannel: string, command: string,
 export async function executeCustomCommandForDiscord(
   message: Message,
   username?: string | null,
+  guildId?: string,
 ): Promise<void> {
   const command = extractCommand(message.content);
   if (!command) return;
 
-  const result = await lookupCommand(command, getCustomCommandForDiscord);
+  // Prefer the explicitly threaded guildId; fall back to the message's own guild.
+  // The Discord lookup applies that guild's per-guild override overlay.
+  const resolvedGuildId = guildId ?? message.guildId;
+  if (!resolvedGuildId) return;
+
+  const result = await lookupCommand(command, (cmd) => getCustomCommandForDiscord(cmd, resolvedGuildId));
   if (!result) return;
 
   recordCommandTestEntry({

--- a/src/commands/customCommandHandler.ts
+++ b/src/commands/customCommandHandler.ts
@@ -159,6 +159,7 @@ async function broadcastToActiveChannels(sourceChannel: string, command: string,
  * @param message - The Discord message to inspect and, if matched, reply to.
  * @param username - Display name for the monitoring entry; null or omitted if unknown.
  * @param guildId - Explicit guild ID for override-aware lookup; falls back to message.guildId.
+ * @returns Resolves when the command is handled (or skipped).
  */
 export async function executeCustomCommandForDiscord(
   message: Message,

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,6 +1,13 @@
 export type { RefreshingLookupCache, ManagedLookupCacheOptions, ManagedLookupCache } from './db/lookupCache';
 export { getPool, closePool } from './db/pool';
 
+// ─── Guilds ──────────────────────────────────────────────────────────────────
+
+export {
+  getAllGuilds, getGuildById, upsertGuild, setGuildVoiceChannel,
+} from './db/guilds';
+export type { DbGuild } from './db/guilds';
+
 // ─── User / access-level ────────────────────────────────────────────────────
 
 export {

--- a/src/db.ts
+++ b/src/db.ts
@@ -4,7 +4,7 @@ export { getPool, closePool } from './db/pool';
 // ─── Guilds ──────────────────────────────────────────────────────────────────
 
 export {
-  getAllGuilds, getGuildById, upsertGuild, setGuildVoiceChannel,
+  getAllGuilds, getProvisionedGuilds, getGuildById, upsertGuild, setGuildVoiceChannel,
 } from './db/guilds';
 export type { DbGuild } from './db/guilds';
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -14,6 +14,11 @@ export {
 } from './db/guildMembers';
 export type { DbGuildMember } from './db/guildMembers';
 
+export {
+  getOverridesForGuild, getAllOverrides, upsertOverride, removeOverride,
+} from './db/guildCommandOverrides';
+export type { DbGuildCommandOverride } from './db/guildCommandOverrides';
+
 // ─── User / access-level ────────────────────────────────────────────────────
 
 export {

--- a/src/db.ts
+++ b/src/db.ts
@@ -8,6 +8,12 @@ export {
 } from './db/guilds';
 export type { DbGuild } from './db/guilds';
 
+export {
+  getGuildMembers, getMemberAccessLevel, setMemberAccessLevel,
+  removeGuildMember, getEffectiveAccessLevel,
+} from './db/guildMembers';
+export type { DbGuildMember } from './db/guildMembers';
+
 // ─── User / access-level ────────────────────────────────────────────────────
 
 export {

--- a/src/db/customCommandCache.test.ts
+++ b/src/db/customCommandCache.test.ts
@@ -19,6 +19,10 @@ vi.mock('./users', () => ({
   getTwitchEnabledChannels: vi.fn(),
 }));
 
+vi.mock('./guildCommandOverrides', () => ({
+  getAllOverrides: vi.fn(),
+}));
+
 vi.mock('../twitchChannelName', () => ({
   normalizeTwitchChannelName: vi.fn((name: string | null) => {
     if (!name) return null;
@@ -30,6 +34,9 @@ vi.mock('../twitchChannelName', () => ({
 import { getCustomCommandForDiscord, getCustomCommandForTwitchChannel } from './customCommandCache';
 import { getAllCustomCommandsWithAssignments } from './customCommands';
 import { getTwitchEnabledChannels } from './users';
+import { getAllOverrides } from './guildCommandOverrides';
+
+const GUILD = 'guild-1';
 
 type MockCommand = {
   command_id: number;
@@ -60,41 +67,42 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(getAllCustomCommandsWithAssignments).mockResolvedValue([]);
   vi.mocked(getTwitchEnabledChannels).mockResolvedValue([]);
+  vi.mocked(getAllOverrides).mockResolvedValue([]);
 });
 
 // ─── getCustomCommandForDiscord ───────────────────────────────────────────────
 
 describe('getCustomCommandForDiscord', () => {
   it('returns null for empty string', async () => {
-    expect(await getCustomCommandForDiscord('')).toBeNull();
+    expect(await getCustomCommandForDiscord('', GUILD)).toBeNull();
   });
 
   it('returns null for whitespace-only string', async () => {
-    expect(await getCustomCommandForDiscord('   ')).toBeNull();
+    expect(await getCustomCommandForDiscord('   ', GUILD)).toBeNull();
   });
 
   it('returns the command when trigger matches (case-insensitive)', async () => {
     vi.mocked(getAllCustomCommandsWithAssignments).mockResolvedValue([makeCommand()] as any);
-    const result = await getCustomCommandForDiscord('!CLAP');
+    const result = await getCustomCommandForDiscord('!CLAP', GUILD);
     expect(result).not.toBeNull();
     expect(result?.trigger_string).toBe('!clap');
   });
 
   it('trims whitespace from the query before lookup', async () => {
     vi.mocked(getAllCustomCommandsWithAssignments).mockResolvedValue([makeCommand()] as any);
-    expect(await getCustomCommandForDiscord('  !clap  ')).not.toBeNull();
+    expect(await getCustomCommandForDiscord('  !clap  ', GUILD)).not.toBeNull();
   });
 
   it('returns null when the command is not discord-enabled', async () => {
     vi.mocked(getAllCustomCommandsWithAssignments).mockResolvedValue([
       makeCommand({ is_discord_enabled: false }),
     ] as any);
-    expect(await getCustomCommandForDiscord('!clap')).toBeNull();
+    expect(await getCustomCommandForDiscord('!clap', GUILD)).toBeNull();
   });
 
   it('returns null when trigger does not match', async () => {
     vi.mocked(getAllCustomCommandsWithAssignments).mockResolvedValue([makeCommand()] as any);
-    expect(await getCustomCommandForDiscord('!other')).toBeNull();
+    expect(await getCustomCommandForDiscord('!other', GUILD)).toBeNull();
   });
 
   it('collision: lower command_id wins', async () => {
@@ -102,16 +110,64 @@ describe('getCustomCommandForDiscord', () => {
       makeCommand({ command_id: 2, output: 'second' }),
       makeCommand({ command_id: 1, output: 'first' }),
     ] as any);
-    const result = await getCustomCommandForDiscord('!clap');
+    const result = await getCustomCommandForDiscord('!clap', GUILD);
     expect(result?.output).toBe('first');
   });
 
   it('returns a copy — mutating result does not affect subsequent lookups', async () => {
     vi.mocked(getAllCustomCommandsWithAssignments).mockResolvedValue([makeCommand()] as any);
-    const first = await getCustomCommandForDiscord('!clap');
+    const first = await getCustomCommandForDiscord('!clap', GUILD);
     (first as any).output = 'mutated';
-    const second = await getCustomCommandForDiscord('!clap');
+    const second = await getCustomCommandForDiscord('!clap', GUILD);
     expect(second?.output).toBe('*claps*');
+  });
+});
+
+// ─── getCustomCommandForDiscord — per-guild overrides ─────────────────────────
+
+describe('getCustomCommandForDiscord — per-guild overrides', () => {
+  it('returns the catalog command when the guild has no override', async () => {
+    vi.mocked(getAllCustomCommandsWithAssignments).mockResolvedValue([makeCommand()] as any);
+    vi.mocked(getAllOverrides).mockResolvedValue([
+      { guild_id: 'other-guild', command_id: 1, is_disabled: true, output: null },
+    ] as any);
+    const result = await getCustomCommandForDiscord('!clap', GUILD);
+    expect(result?.output).toBe('*claps*');
+  });
+
+  it('returns null when the guild has disabled the command', async () => {
+    vi.mocked(getAllCustomCommandsWithAssignments).mockResolvedValue([makeCommand()] as any);
+    vi.mocked(getAllOverrides).mockResolvedValue([
+      { guild_id: GUILD, command_id: 1, is_disabled: true, output: null },
+    ] as any);
+    expect(await getCustomCommandForDiscord('!clap', GUILD)).toBeNull();
+  });
+
+  it('substitutes the guild output when the override sets one', async () => {
+    vi.mocked(getAllCustomCommandsWithAssignments).mockResolvedValue([makeCommand()] as any);
+    vi.mocked(getAllOverrides).mockResolvedValue([
+      { guild_id: GUILD, command_id: 1, is_disabled: false, output: 'guild text' },
+    ] as any);
+    const result = await getCustomCommandForDiscord('!clap', GUILD);
+    expect(result?.output).toBe('guild text');
+  });
+
+  it('uses the catalog output when the override output is null', async () => {
+    vi.mocked(getAllCustomCommandsWithAssignments).mockResolvedValue([makeCommand()] as any);
+    vi.mocked(getAllOverrides).mockResolvedValue([
+      { guild_id: GUILD, command_id: 1, is_disabled: false, output: null },
+    ] as any);
+    const result = await getCustomCommandForDiscord('!clap', GUILD);
+    expect(result?.output).toBe('*claps*');
+  });
+
+  it('isolates overrides between guilds', async () => {
+    vi.mocked(getAllCustomCommandsWithAssignments).mockResolvedValue([makeCommand()] as any);
+    vi.mocked(getAllOverrides).mockResolvedValue([
+      { guild_id: GUILD, command_id: 1, is_disabled: false, output: 'only here' },
+    ] as any);
+    expect((await getCustomCommandForDiscord('!clap', GUILD))?.output).toBe('only here');
+    expect((await getCustomCommandForDiscord('!clap', 'other-guild'))?.output).toBe('*claps*');
   });
 });
 

--- a/src/db/customCommandCache.ts
+++ b/src/db/customCommandCache.ts
@@ -11,6 +11,7 @@ import {
   type DbCustomCommandWithAssignments,
   type DbCustomCommandAssignedUser,
 } from './customCommands';
+import { getAllOverrides, type DbGuildCommandOverride } from './guildCommandOverrides';
 
 const log = createLogger('DB');
 
@@ -19,6 +20,9 @@ const log = createLogger('DB');
 interface CustomCommandLookupCache extends RefreshingLookupCache {
   discordByTrigger: Map<string, DbCustomCommand>;
   twitchByChannelAndTrigger: Map<string, DbCustomCommand>;
+  // Per-guild Discord overlay on the global catalog: guild_id → (command_id → override).
+  // Sparse — only guilds/commands with a deviation appear. Twitch lookups ignore this.
+  overridesByGuild: Map<string, Map<number, DbGuildCommandOverride>>;
 }
 
 interface TwitchCommandCandidate {
@@ -41,7 +45,24 @@ function createEmptyCustomCommandLookupCache(): CustomCommandLookupCache {
     loadedAt: 0,
     discordByTrigger: new Map<string, DbCustomCommand>(),
     twitchByChannelAndTrigger: new Map<string, DbCustomCommand>(),
+    overridesByGuild: new Map<string, Map<number, DbGuildCommandOverride>>(),
   };
+}
+
+/** Index a flat list of override rows by guild_id → command_id for O(1) overlay lookups. */
+function buildOverridesByGuild(
+  overrides: DbGuildCommandOverride[],
+): Map<string, Map<number, DbGuildCommandOverride>> {
+  const byGuild = new Map<string, Map<number, DbGuildCommandOverride>>();
+  for (const override of overrides) {
+    let guildMap = byGuild.get(override.guild_id);
+    if (!guildMap) {
+      guildMap = new Map<number, DbGuildCommandOverride>();
+      byGuild.set(override.guild_id, guildMap);
+    }
+    guildMap.set(override.command_id, override);
+  }
+  return byGuild;
 }
 
 function getTwitchCommandCacheKey(channelName: string, triggerString: string): string | null {
@@ -189,6 +210,7 @@ function registerAssignedTwitchCandidates(
 function buildCustomCommandLookupCache(
   commands: DbCustomCommandWithAssignments[],
   activeTwitchChannels: string[],
+  overrides: DbGuildCommandOverride[],
 ): CustomCommandLookupCache {
   const discordByTrigger = new Map<string, DbCustomCommand>();
   const twitchCandidateByChannelAndTrigger = new Map<string, TwitchCommandCandidate>();
@@ -237,6 +259,7 @@ function buildCustomCommandLookupCache(
     loadedAt: Date.now(),
     discordByTrigger,
     twitchByChannelAndTrigger,
+    overridesByGuild: buildOverridesByGuild(overrides),
   };
 }
 
@@ -253,11 +276,12 @@ const customCommandLookupCacheState = createManagedLookupCache<CustomCommandLook
   refreshFailureMaxBackoffMs: CACHE_REFRESH_FAILURE_MAX_BACKOFF_MS,
   createEmptyCache: createEmptyCustomCommandLookupCache,
   loadCache: async () => {
-    const [commands, activeTwitchChannels] = await Promise.all([
+    const [commands, activeTwitchChannels, overrides] = await Promise.all([
       getAllCustomCommandsWithAssignments(),
       getTwitchEnabledChannels(),
+      getAllOverrides(),
     ]);
-    return buildCustomCommandLookupCache(commands, activeTwitchChannels);
+    return buildCustomCommandLookupCache(commands, activeTwitchChannels, overrides);
   },
 });
 
@@ -278,7 +302,22 @@ export async function getCustomCommandForTwitchChannel(channelName: string, trig
   return cachedCommand ? { ...cachedCommand } : null;
 }
 
-export async function getCustomCommandForDiscord(triggerString: string): Promise<DbCustomCommand | null> {
+/**
+ * Resolve a Discord custom command for a guild, applying that guild's override.
+ *
+ * Resolution: start from the global catalog command; if the guild has an override
+ * row for it, `is_disabled` ⇒ the command does not fire (null), and a non-null
+ * `output` ⇒ that text replaces the catalog output. No override row ⇒ catalog
+ * default. Guilds without any overrides resolve to the plain catalog command.
+ *
+ * @param triggerString The full prefixed trigger (e.g. `!clap`); matched case-insensitively.
+ * @param guildId The guild the message came from (BIGINT snowflake as a string).
+ * @returns The (possibly output-substituted) command, or null if absent or disabled.
+ */
+export async function getCustomCommandForDiscord(
+  triggerString: string,
+  guildId: string,
+): Promise<DbCustomCommand | null> {
   const normalizedTriggerString = triggerString.trim().toLowerCase();
   if (!normalizedTriggerString) {
     return null;
@@ -286,5 +325,19 @@ export async function getCustomCommandForDiscord(triggerString: string): Promise
 
   const cache = await customCommandLookupCacheState.getCache();
   const cachedCommand = cache.discordByTrigger.get(normalizedTriggerString);
-  return cachedCommand ? { ...cachedCommand } : null;
+  if (!cachedCommand) {
+    return null;
+  }
+
+  const override = cache.overridesByGuild.get(guildId)?.get(cachedCommand.command_id);
+  if (override) {
+    if (override.is_disabled) {
+      return null;
+    }
+    if (override.output !== null) {
+      return { ...cachedCommand, output: override.output };
+    }
+  }
+
+  return { ...cachedCommand };
 }

--- a/src/db/guildCommandOverrides.test.ts
+++ b/src/db/guildCommandOverrides.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./pool', () => ({ getPool: vi.fn() }));
+vi.mock('mysql2/promise', () => ({ default: {} }));
+vi.mock('./utils', () => ({ fromBit: (v: unknown) => v === 1 || v === true }));
+
+import { getPool } from './pool';
+import {
+  getOverridesForGuild,
+  getAllOverrides,
+  upsertOverride,
+  removeOverride,
+} from './guildCommandOverrides';
+
+function makePool() {
+  return { execute: vi.fn().mockResolvedValue([[], []]) };
+}
+
+let pool: ReturnType<typeof makePool>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  pool = makePool();
+  vi.mocked(getPool).mockReturnValue(pool as never);
+});
+
+describe('getOverridesForGuild', () => {
+  it('maps rows, stringifies guild_id, and decodes is_disabled', async () => {
+    pool.execute.mockResolvedValueOnce([
+      [
+        { guild_id: 111, command_id: 5, is_disabled: 1, output: null },
+        { guild_id: 111, command_id: 6, is_disabled: 0, output: 'custom text' },
+      ],
+      [],
+    ]);
+
+    const result = await getOverridesForGuild('111');
+
+    expect(result).toEqual([
+      { guild_id: '111', command_id: 5, is_disabled: true, output: null },
+      { guild_id: '111', command_id: 6, is_disabled: false, output: 'custom text' },
+    ]);
+    expect(pool.execute).toHaveBeenCalledWith(expect.stringContaining('WHERE guild_id = ?'), ['111']);
+  });
+});
+
+describe('getAllOverrides', () => {
+  it('reads every override row with no guild filter', async () => {
+    pool.execute.mockResolvedValueOnce([[], []]);
+    await getAllOverrides();
+    const [sql, params] = pool.execute.mock.calls[0];
+    expect(sql).not.toContain('WHERE');
+    expect(params).toBeUndefined();
+  });
+});
+
+describe('upsertOverride', () => {
+  it('upserts disable + output, coercing the boolean to TINYINT', async () => {
+    await upsertOverride('111', 5, { isDisabled: true, output: 'hi' });
+    const [sql, params] = pool.execute.mock.calls[0];
+    expect(sql).toContain('INSERT INTO guild_command_override');
+    expect(sql).toContain('ON DUPLICATE KEY UPDATE is_disabled = new_override.is_disabled, output = new_override.output');
+    expect(params).toEqual(['111', 5, 1, 'hi']);
+  });
+
+  it('passes null output through unchanged', async () => {
+    await upsertOverride('111', 5, { isDisabled: false, output: null });
+    expect(pool.execute.mock.calls[0][1]).toEqual(['111', 5, 0, null]);
+  });
+});
+
+describe('removeOverride', () => {
+  it('deletes the override row', async () => {
+    await removeOverride('111', 5);
+    expect(pool.execute).toHaveBeenCalledWith(
+      expect.stringContaining('DELETE FROM guild_command_override'),
+      ['111', 5],
+    );
+  });
+});

--- a/src/db/guildCommandOverrides.test.ts
+++ b/src/db/guildCommandOverrides.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('./pool', () => ({ getPool: vi.fn() }));
 vi.mock('mysql2/promise', () => ({ default: {} }));
-vi.mock('./utils', () => ({ fromBit: (v: unknown) => v === 1 || v === true }));
 
 import { getPool } from './pool';
 import {
@@ -25,11 +24,13 @@ beforeEach(() => {
 });
 
 describe('getOverridesForGuild', () => {
-  it('maps rows, stringifies guild_id, and decodes is_disabled', async () => {
+  it('maps rows, stringifies guild_id, and decodes BIT is_disabled via real fromBit', async () => {
+    // MySQL BIT(1) columns arrive as single-byte Buffers, not plain integers.
+    // Using real Buffer fixtures here validates the actual fromBit decoding path.
     pool.execute.mockResolvedValueOnce([
       [
-        { guild_id: 111, command_id: 5, is_disabled: 1, output: null },
-        { guild_id: 111, command_id: 6, is_disabled: 0, output: 'custom text' },
+        { guild_id: 111, command_id: 5, is_disabled: Buffer.from([1]), output: null },
+        { guild_id: 111, command_id: 6, is_disabled: Buffer.from([0]), output: 'custom text' },
       ],
       [],
     ]);

--- a/src/db/guildCommandOverrides.ts
+++ b/src/db/guildCommandOverrides.ts
@@ -1,0 +1,80 @@
+import mysql from 'mysql2/promise';
+import { getPool } from './pool';
+import { fromBit } from './utils';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/**
+ * A per-guild deviation from the global custom_command catalog.
+ *
+ * Sparse by design: a row exists only where a guild has changed something —
+ * disabled the command for itself, or replaced its Discord output text. No row
+ * means the guild uses the catalog default (enabled, catalog output). The Twitch
+ * path never consults overrides.
+ */
+export interface DbGuildCommandOverride {
+  guild_id: string;
+  command_id: number;
+  is_disabled: boolean;
+  /** Per-guild replacement output; null means "use the catalog output". */
+  output: string | null;
+}
+
+function mapOverride(row: mysql.RowDataPacket): DbGuildCommandOverride {
+  return {
+    guild_id: String(row.guild_id),
+    command_id: row.command_id,
+    is_disabled: fromBit(row.is_disabled),
+    output: row.output,
+  };
+}
+
+// ─── Queries ─────────────────────────────────────────────────────────────────
+
+/** Returns every override row for a guild. */
+export async function getOverridesForGuild(guildId: string): Promise<DbGuildCommandOverride[]> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    'SELECT guild_id, command_id, is_disabled, output FROM guild_command_override WHERE guild_id = ?',
+    [guildId],
+  );
+  return rows.map(mapOverride);
+}
+
+/** Returns every override row across all guilds (used to build the per-guild overlay cache). */
+export async function getAllOverrides(): Promise<DbGuildCommandOverride[]> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    'SELECT guild_id, command_id, is_disabled, output FROM guild_command_override',
+  );
+  return rows.map(mapOverride);
+}
+
+// ─── Mutations ─────────────────────────────────────────────────────────────────
+
+/**
+ * Inserts or updates a guild's override for a catalog command.
+ *
+ * @param guildId BIGINT snowflake as a string.
+ * @param commandId The catalog command's command_id.
+ * @param override.isDisabled When true, the command does not fire in this guild.
+ * @param override.output Replacement Discord output, or null to use the catalog output.
+ */
+export async function upsertOverride(
+  guildId: string,
+  commandId: number,
+  override: { isDisabled: boolean; output: string | null },
+): Promise<void> {
+  await getPool().execute(
+    `INSERT INTO guild_command_override (guild_id, command_id, is_disabled, output)
+     VALUES (?, ?, ?, ?) AS new_override
+     ON DUPLICATE KEY UPDATE is_disabled = new_override.is_disabled, output = new_override.output`,
+    [guildId, commandId, override.isDisabled ? 1 : 0, override.output],
+  );
+}
+
+/** Removes a guild's override for a command, reverting it to the catalog default. No-op if absent. */
+export async function removeOverride(guildId: string, commandId: number): Promise<void> {
+  await getPool().execute(
+    'DELETE FROM guild_command_override WHERE guild_id = ? AND command_id = ?',
+    [guildId, commandId],
+  );
+}

--- a/src/db/guildCommandOverrides.ts
+++ b/src/db/guildCommandOverrides.ts
@@ -31,7 +31,12 @@ function mapOverride(row: mysql.RowDataPacket): DbGuildCommandOverride {
 
 // ─── Queries ─────────────────────────────────────────────────────────────────
 
-/** Returns every override row for a guild. */
+/**
+ * Returns every override row for a guild.
+ *
+ * @param guildId BIGINT snowflake as a string.
+ * @returns All override rows for that guild; empty array if none exist.
+ */
 export async function getOverridesForGuild(guildId: string): Promise<DbGuildCommandOverride[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
     'SELECT guild_id, command_id, is_disabled, output FROM guild_command_override WHERE guild_id = ?',
@@ -40,7 +45,11 @@ export async function getOverridesForGuild(guildId: string): Promise<DbGuildComm
   return rows.map(mapOverride);
 }
 
-/** Returns every override row across all guilds (used to build the per-guild overlay cache). */
+/**
+ * Returns every override row across all guilds (used to build the per-guild overlay cache).
+ *
+ * @returns All override rows for all guilds; empty array if none exist.
+ */
 export async function getAllOverrides(): Promise<DbGuildCommandOverride[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
     'SELECT guild_id, command_id, is_disabled, output FROM guild_command_override',
@@ -57,6 +66,7 @@ export async function getAllOverrides(): Promise<DbGuildCommandOverride[]> {
  * @param commandId The catalog command's command_id.
  * @param override.isDisabled When true, the command does not fire in this guild.
  * @param override.output Replacement Discord output, or null to use the catalog output.
+ * @returns Resolves when the upsert is complete.
  */
 export async function upsertOverride(
   guildId: string,
@@ -71,7 +81,13 @@ export async function upsertOverride(
   );
 }
 
-/** Removes a guild's override for a command, reverting it to the catalog default. No-op if absent. */
+/**
+ * Removes a guild's override for a command, reverting it to the catalog default. No-op if absent.
+ *
+ * @param guildId BIGINT snowflake as a string.
+ * @param commandId The catalog command's command_id.
+ * @returns Resolves when the delete is complete.
+ */
 export async function removeOverride(guildId: string, commandId: number): Promise<void> {
   await getPool().execute(
     'DELETE FROM guild_command_override WHERE guild_id = ? AND command_id = ?',

--- a/src/db/guildMembers.test.ts
+++ b/src/db/guildMembers.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./pool', () => ({ getPool: vi.fn() }));
+vi.mock('mysql2/promise', () => ({ default: {} }));
+vi.mock('./users', () => ({
+  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
+  findUser: vi.fn(),
+}));
+
+import { getPool } from './pool';
+import { findUser } from './users';
+import {
+  getGuildMembers,
+  getMemberAccessLevel,
+  setMemberAccessLevel,
+  removeGuildMember,
+  getEffectiveAccessLevel,
+} from './guildMembers';
+
+function makePool() {
+  return { execute: vi.fn().mockResolvedValue([[], []]) };
+}
+
+let pool: ReturnType<typeof makePool>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  pool = makePool();
+  vi.mocked(getPool).mockReturnValue(pool as never);
+});
+
+describe('getGuildMembers', () => {
+  it('maps rows and stringifies BIGINTs', async () => {
+    pool.execute.mockResolvedValueOnce([
+      [
+        { guild_id: 111, discord_id: 222, access_level: 3 },
+        { guild_id: 111, discord_id: 333, access_level: 1 },
+      ],
+      [],
+    ]);
+
+    const result = await getGuildMembers('111');
+
+    expect(result).toEqual([
+      { guild_id: '111', discord_id: '222', access_level: 3 },
+      { guild_id: '111', discord_id: '333', access_level: 1 },
+    ]);
+  });
+});
+
+describe('getMemberAccessLevel', () => {
+  it('returns the access level when a row exists', async () => {
+    pool.execute.mockResolvedValueOnce([[{ access_level: 2 }], []]);
+    expect(await getMemberAccessLevel('111', '222')).toBe(2);
+  });
+
+  it('returns null when no membership row exists', async () => {
+    pool.execute.mockResolvedValueOnce([[], []]);
+    expect(await getMemberAccessLevel('111', '999')).toBeNull();
+  });
+});
+
+describe('setMemberAccessLevel', () => {
+  it('upserts the membership row', async () => {
+    await setMemberAccessLevel('111', '222', 2);
+    const [sql, params] = pool.execute.mock.calls[0];
+    expect(sql).toContain('INSERT INTO guild_member');
+    expect(sql).toContain('ON DUPLICATE KEY UPDATE access_level = new_member.access_level');
+    expect(params).toEqual(['111', '222', 2]);
+  });
+
+  it('rejects an invalid access level', async () => {
+    await expect(setMemberAccessLevel('111', '222', 7)).rejects.toThrow('Invalid accessLevel');
+    expect(pool.execute).not.toHaveBeenCalled();
+  });
+});
+
+describe('removeGuildMember', () => {
+  it('deletes the membership row', async () => {
+    await removeGuildMember('111', '222');
+    expect(pool.execute).toHaveBeenCalledWith(
+      expect.stringContaining('DELETE FROM guild_member'),
+      ['111', '222'],
+    );
+  });
+});
+
+describe('getEffectiveAccessLevel (PR 2 shim)', () => {
+  it('returns the legacy user.access_level regardless of guild', async () => {
+    vi.mocked(findUser).mockResolvedValueOnce({
+      discord_id: '222',
+      discord_name: 'Alice',
+      is_twitch_bot_enabled: false,
+      twitch_name: null,
+      access_level: 2,
+    });
+
+    expect(await getEffectiveAccessLevel('any-guild', '222')).toBe(2);
+    // Shim must not touch guild_member yet.
+    expect(pool.execute).not.toHaveBeenCalled();
+  });
+
+  it('defaults to USER (0) when the user has no row', async () => {
+    vi.mocked(findUser).mockResolvedValueOnce(null);
+    expect(await getEffectiveAccessLevel('any-guild', '999')).toBe(0);
+  });
+});

--- a/src/db/guildMembers.test.ts
+++ b/src/db/guildMembers.test.ts
@@ -30,20 +30,25 @@ beforeEach(() => {
 });
 
 describe('getGuildMembers', () => {
-  it('maps rows and stringifies BIGINTs', async () => {
+  it('maps rows and preserves BIGINT snowflakes as strings without precision loss', async () => {
+    // These values exceed Number.MAX_SAFE_INTEGER; coercing to Number would corrupt them.
+    const GUILD  = 915557543463727107n;
+    const ALICE  = 799843684990877696n;
+    const BOB    = 799843684990877697n;
+
     pool.execute.mockResolvedValueOnce([
       [
-        { guild_id: 111, discord_id: 222, access_level: 3 },
-        { guild_id: 111, discord_id: 333, access_level: 1 },
+        { guild_id: GUILD, discord_id: ALICE, access_level: 3 },
+        { guild_id: GUILD, discord_id: BOB,   access_level: 1 },
       ],
       [],
     ]);
 
-    const result = await getGuildMembers('111');
+    const result = await getGuildMembers(String(GUILD));
 
     expect(result).toEqual([
-      { guild_id: '111', discord_id: '222', access_level: 3 },
-      { guild_id: '111', discord_id: '333', access_level: 1 },
+      { guild_id: '915557543463727107', discord_id: '799843684990877696', access_level: 3 },
+      { guild_id: '915557543463727107', discord_id: '799843684990877697', access_level: 1 },
     ]);
   });
 });

--- a/src/db/guildMembers.ts
+++ b/src/db/guildMembers.ts
@@ -21,7 +21,12 @@ function mapGuildMember(row: mysql.RowDataPacket): DbGuildMember {
 
 // ─── Queries ─────────────────────────────────────────────────────────────────
 
-/** Returns every membership row for a guild, highest access level first. */
+/**
+ * Returns every membership row for a guild, ordered by access level descending.
+ *
+ * @param guildId - Guild snowflake ID.
+ * @returns Array of guild member rows, highest access level first.
+ */
 export async function getGuildMembers(guildId: string): Promise<DbGuildMember[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
     `SELECT guild_id, discord_id, access_level
@@ -36,6 +41,10 @@ export async function getGuildMembers(guildId: string): Promise<DbGuildMember[]>
 /**
  * Returns a user's access level within a specific guild, or null if they have no
  * membership row there. Reads the guild_member table directly.
+ *
+ * @param guildId - Guild snowflake ID.
+ * @param discordId - User snowflake ID.
+ * @returns The access level (0–3), or null if no membership row exists.
  */
 export async function getMemberAccessLevel(guildId: string, discordId: string): Promise<number | null> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
@@ -50,9 +59,9 @@ export async function getMemberAccessLevel(guildId: string, discordId: string): 
 /**
  * Sets (inserting or updating) a user's access level within a guild.
  *
- * @param guildId BIGINT snowflake as a string.
- * @param discordId BIGINT snowflake as a string.
- * @param accessLevel One of the AccessLevel values (0–3).
+ * @param guildId - Guild snowflake ID.
+ * @param discordId - User snowflake ID.
+ * @param accessLevel - One of the AccessLevel values (0–3); rejects invalid values.
  */
 export async function setMemberAccessLevel(guildId: string, discordId: string, accessLevel: number): Promise<void> {
   if (!(Object.values(AccessLevel) as number[]).includes(accessLevel)) {
@@ -66,7 +75,12 @@ export async function setMemberAccessLevel(guildId: string, discordId: string, a
   );
 }
 
-/** Removes a user's membership row from a guild. No-op if no row exists. */
+/**
+ * Removes a user's membership row from a guild. No-op if no row exists.
+ *
+ * @param guildId - Guild snowflake ID.
+ * @param discordId - User snowflake ID.
+ */
 export async function removeGuildMember(guildId: string, discordId: string): Promise<void> {
   await getPool().execute(
     'DELETE FROM guild_member WHERE guild_id = ? AND discord_id = ?',

--- a/src/db/guildMembers.ts
+++ b/src/db/guildMembers.ts
@@ -1,0 +1,98 @@
+import mysql from 'mysql2/promise';
+import { getPool } from './pool';
+import { AccessLevel, findUser } from './users';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/** A per-guild membership row: a user's access level within one specific guild. */
+export interface DbGuildMember {
+  guild_id: string;
+  discord_id: string;
+  access_level: number;
+}
+
+function mapGuildMember(row: mysql.RowDataPacket): DbGuildMember {
+  return {
+    guild_id: String(row.guild_id),
+    discord_id: String(row.discord_id),
+    access_level: row.access_level,
+  };
+}
+
+// ─── Queries ─────────────────────────────────────────────────────────────────
+
+/** Returns every membership row for a guild, highest access level first. */
+export async function getGuildMembers(guildId: string): Promise<DbGuildMember[]> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT guild_id, discord_id, access_level
+     FROM guild_member
+     WHERE guild_id = ?
+     ORDER BY access_level DESC`,
+    [guildId],
+  );
+  return rows.map(mapGuildMember);
+}
+
+/**
+ * Returns a user's access level within a specific guild, or null if they have no
+ * membership row there. Reads the guild_member table directly.
+ */
+export async function getMemberAccessLevel(guildId: string, discordId: string): Promise<number | null> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    'SELECT access_level FROM guild_member WHERE guild_id = ? AND discord_id = ? LIMIT 1',
+    [guildId, discordId],
+  );
+  return rows.length === 0 ? null : (rows[0].access_level as number);
+}
+
+// ─── Mutations ─────────────────────────────────────────────────────────────────
+
+/**
+ * Sets (inserting or updating) a user's access level within a guild.
+ *
+ * @param guildId BIGINT snowflake as a string.
+ * @param discordId BIGINT snowflake as a string.
+ * @param accessLevel One of the AccessLevel values (0–3).
+ */
+export async function setMemberAccessLevel(guildId: string, discordId: string, accessLevel: number): Promise<void> {
+  if (!(Object.values(AccessLevel) as number[]).includes(accessLevel)) {
+    throw new Error(`Invalid accessLevel: ${accessLevel}`);
+  }
+  await getPool().execute(
+    `INSERT INTO guild_member (guild_id, discord_id, access_level)
+     VALUES (?, ?, ?) AS new_member
+     ON DUPLICATE KEY UPDATE access_level = new_member.access_level`,
+    [guildId, discordId, accessLevel],
+  );
+}
+
+/** Removes a user's membership row from a guild. No-op if no row exists. */
+export async function removeGuildMember(guildId: string, discordId: string): Promise<void> {
+  await getPool().execute(
+    'DELETE FROM guild_member WHERE guild_id = ? AND discord_id = ?',
+    [guildId, discordId],
+  );
+}
+
+// ─── Effective access-level shim ───────────────────────────────────────────────
+
+/**
+ * Resolves a user's effective access level for a guild.
+ *
+ * COMPATIBILITY SHIM (PR 2): while only one guild exists and the web panel still
+ * writes the legacy `user.access_level` column, this returns that legacy value so
+ * every existing reader keeps behaving identically. It deliberately does NOT read
+ * `guild_member` yet — that table is seeded from `access_level` at migration time
+ * but would drift the moment an admin changes a level through the current UI.
+ *
+ * PR 3 flips the source to `guild_member` (per-guild) and adds the `is_owner`
+ * short-circuit once the readers and the admin UI are migrated together.
+ *
+ * @param _guildId Accepted now so callers can thread guildId through; unused until PR 3.
+ * @param discordId BIGINT snowflake as a string.
+ * @returns The user's access level, or AccessLevel.USER (0) if they have no user row.
+ */
+export async function getEffectiveAccessLevel(_guildId: string, discordId: string): Promise<number> {
+  const user = await findUser(discordId);
+  return user ? user.access_level : AccessLevel.USER;
+}

--- a/src/db/guildMembers.ts
+++ b/src/db/guildMembers.ts
@@ -62,6 +62,7 @@ export async function getMemberAccessLevel(guildId: string, discordId: string): 
  * @param guildId - Guild snowflake ID.
  * @param discordId - User snowflake ID.
  * @param accessLevel - One of the AccessLevel values (0–3); rejects invalid values.
+ * @returns Resolves when the upsert is complete.
  */
 export async function setMemberAccessLevel(guildId: string, discordId: string, accessLevel: number): Promise<void> {
   if (!(Object.values(AccessLevel) as number[]).includes(accessLevel)) {
@@ -80,6 +81,7 @@ export async function setMemberAccessLevel(guildId: string, discordId: string, a
  *
  * @param guildId - Guild snowflake ID.
  * @param discordId - User snowflake ID.
+ * @returns Resolves when the delete is complete.
  */
 export async function removeGuildMember(guildId: string, discordId: string): Promise<void> {
   await getPool().execute(

--- a/src/db/guilds.test.ts
+++ b/src/db/guilds.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./pool', () => ({ getPool: vi.fn() }));
+vi.mock('mysql2/promise', () => ({ default: {} }));
+
+import { getPool } from './pool';
+import { getAllGuilds, getGuildById, upsertGuild, setGuildVoiceChannel } from './guilds';
+
+function makePool() {
+  return { execute: vi.fn().mockResolvedValue([[], []]) };
+}
+
+let pool: ReturnType<typeof makePool>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  pool = makePool();
+  vi.mocked(getPool).mockReturnValue(pool as never);
+});
+
+describe('getAllGuilds', () => {
+  it('maps rows and stringifies BIGINT columns', async () => {
+    pool.execute.mockResolvedValueOnce([
+      [
+        { guild_id: 111n, name: 'Alpha', voice_channel_id: 222n },
+        { guild_id: 333n, name: 'Beta', voice_channel_id: null },
+      ],
+      [],
+    ]);
+
+    const result = await getAllGuilds();
+
+    expect(result).toEqual([
+      { guild_id: '111', name: 'Alpha', voice_channel_id: '222' },
+      { guild_id: '333', name: 'Beta', voice_channel_id: null },
+    ]);
+  });
+
+  it('returns an empty array when no guilds exist', async () => {
+    pool.execute.mockResolvedValueOnce([[], []]);
+    expect(await getAllGuilds()).toEqual([]);
+  });
+});
+
+describe('getGuildById', () => {
+  it('returns the mapped guild when found', async () => {
+    pool.execute.mockResolvedValueOnce([
+      [{ guild_id: 111, name: 'Alpha', voice_channel_id: 222 }],
+      [],
+    ]);
+
+    const result = await getGuildById('111');
+
+    expect(result).toEqual({ guild_id: '111', name: 'Alpha', voice_channel_id: '222' });
+    expect(pool.execute).toHaveBeenCalledWith(expect.stringContaining('WHERE guild_id = ?'), ['111']);
+  });
+
+  it('returns null when the guild is not registered', async () => {
+    pool.execute.mockResolvedValueOnce([[], []]);
+    expect(await getGuildById('999')).toBeNull();
+  });
+});
+
+describe('upsertGuild', () => {
+  it('inserts with a name-only conflict update so existing config is preserved', async () => {
+    await upsertGuild('111', 'Alpha');
+
+    const [sql, params] = pool.execute.mock.calls[0];
+    expect(sql).toContain('INSERT INTO guild');
+    expect(sql).toContain('ON DUPLICATE KEY UPDATE name = new_guild.name');
+    expect(sql).not.toContain('voice_channel_id =');
+    expect(params).toEqual(['111', 'Alpha']);
+  });
+});
+
+describe('setGuildVoiceChannel', () => {
+  it('updates the voice channel for a guild', async () => {
+    await setGuildVoiceChannel('111', '222');
+    expect(pool.execute).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE guild SET voice_channel_id = ?'),
+      ['222', '111'],
+    );
+  });
+
+  it('clears the voice channel when passed null', async () => {
+    await setGuildVoiceChannel('111', null);
+    expect(pool.execute).toHaveBeenCalledWith(expect.any(String), [null, '111']);
+  });
+});

--- a/src/db/guilds.test.ts
+++ b/src/db/guilds.test.ts
@@ -4,7 +4,7 @@ vi.mock('./pool', () => ({ getPool: vi.fn() }));
 vi.mock('mysql2/promise', () => ({ default: {} }));
 
 import { getPool } from './pool';
-import { getAllGuilds, getGuildById, upsertGuild, setGuildVoiceChannel } from './guilds';
+import { getAllGuilds, getProvisionedGuilds, getGuildById, upsertGuild, setGuildVoiceChannel } from './guilds';
 
 function makePool() {
   return { execute: vi.fn().mockResolvedValue([[], []]) };
@@ -39,6 +39,27 @@ describe('getAllGuilds', () => {
   it('returns an empty array when no guilds exist', async () => {
     pool.execute.mockResolvedValueOnce([[], []]);
     expect(await getAllGuilds()).toEqual([]);
+  });
+});
+
+describe('getProvisionedGuilds', () => {
+  it('filters to guilds with at least one member and maps BIGINT columns', async () => {
+    pool.execute.mockResolvedValueOnce([
+      [{ guild_id: 111n, name: 'Alpha', voice_channel_id: 222n }],
+      [],
+    ]);
+
+    const result = await getProvisionedGuilds();
+
+    expect(result).toEqual([{ guild_id: '111', name: 'Alpha', voice_channel_id: '222' }]);
+    const [sql] = pool.execute.mock.calls[0];
+    expect(sql).toContain('EXISTS');
+    expect(sql).toContain('guild_member');
+  });
+
+  it('returns an empty array when no guild has members', async () => {
+    pool.execute.mockResolvedValueOnce([[], []]);
+    expect(await getProvisionedGuilds()).toEqual([]);
   });
 });
 

--- a/src/db/guilds.ts
+++ b/src/db/guilds.ts
@@ -33,6 +33,28 @@ export async function getAllGuilds(): Promise<DbGuild[]> {
   return rows.map(mapGuild);
 }
 
+/**
+ * Returns the guilds the bot should actively serve: those with at least one
+ * guild_member row. A bare `guild` row alone does not qualify.
+ *
+ * This is the "registered guild" set the in-memory registry loads. The
+ * member-presence gate is what makes (un)registration durable: a guild
+ * discovered via `guildCreate` (or re-inserted on reconnect) is inert until the
+ * Owner provisions its first member, and removing every member durably stops the
+ * bot serving it even though reconnects keep re-inserting the bare guild row.
+ *
+ * @returns Servable guilds ordered by name.
+ */
+export async function getProvisionedGuilds(): Promise<DbGuild[]> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT g.guild_id, g.name, g.voice_channel_id
+     FROM guild g
+     WHERE EXISTS (SELECT 1 FROM guild_member gm WHERE gm.guild_id = g.guild_id)
+     ORDER BY g.name`,
+  );
+  return rows.map(mapGuild);
+}
+
 /** Returns a single guild by its ID, or null if it is not registered. */
 export async function getGuildById(guildId: string): Promise<DbGuild | null> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(

--- a/src/db/guilds.ts
+++ b/src/db/guilds.ts
@@ -1,0 +1,76 @@
+import mysql from 'mysql2/promise';
+import { getPool } from './pool';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/** A registered Discord guild (server) the bot serves, plus its per-guild config. */
+export interface DbGuild {
+  guild_id: string;
+  name: string;
+  /** Default voice channel for this guild; replaces the legacy DISCORD_VOICE_CHANNEL_ID env var. */
+  voice_channel_id: string | null;
+}
+
+// ─── Row mapper ───────────────────────────────────────────────────────────────
+
+// guild_id and voice_channel_id are BIGINT → strings (bigNumberStrings: true).
+// Never coerce to Number — snowflakes lose precision.
+function mapGuild(row: mysql.RowDataPacket): DbGuild {
+  return {
+    guild_id: String(row.guild_id),
+    name: row.name,
+    voice_channel_id: row.voice_channel_id === null ? null : String(row.voice_channel_id),
+  };
+}
+
+// ─── Queries ─────────────────────────────────────────────────────────────────
+
+/** Returns every registered guild, ordered by name. */
+export async function getAllGuilds(): Promise<DbGuild[]> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    'SELECT guild_id, name, voice_channel_id FROM guild ORDER BY name',
+  );
+  return rows.map(mapGuild);
+}
+
+/** Returns a single guild by its ID, or null if it is not registered. */
+export async function getGuildById(guildId: string): Promise<DbGuild | null> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    'SELECT guild_id, name, voice_channel_id FROM guild WHERE guild_id = ? LIMIT 1',
+    [guildId],
+  );
+  return rows.length === 0 ? null : mapGuild(rows[0]);
+}
+
+// ─── Mutations ─────────────────────────────────────────────────────────────────
+
+/**
+ * Inserts a guild row if it does not exist, otherwise refreshes its name.
+ *
+ * Insert-if-not-exists by design: `guildCreate` fires on every reconnect, not
+ * just the first join, so this must never wipe existing per-guild config
+ * (e.g. voice_channel_id). Only the display name is refreshed on conflict.
+ *
+ * @param guildId BIGINT snowflake as a string.
+ * @param name Human-friendly server name.
+ */
+export async function upsertGuild(guildId: string, name: string): Promise<void> {
+  await getPool().execute(
+    `INSERT INTO guild (guild_id, name) VALUES (?, ?) AS new_guild
+     ON DUPLICATE KEY UPDATE name = new_guild.name`,
+    [guildId, name],
+  );
+}
+
+/**
+ * Sets (or clears) the default voice channel for a guild.
+ *
+ * @param guildId BIGINT snowflake as a string.
+ * @param voiceChannelId BIGINT snowflake as a string, or null to clear.
+ */
+export async function setGuildVoiceChannel(guildId: string, voiceChannelId: string | null): Promise<void> {
+  await getPool().execute(
+    'UPDATE guild SET voice_channel_id = ? WHERE guild_id = ?',
+    [voiceChannelId, guildId],
+  );
+}

--- a/src/db/guilds.ts
+++ b/src/db/guilds.ts
@@ -55,7 +55,7 @@ export async function getProvisionedGuilds(): Promise<DbGuild[]> {
   return rows.map(mapGuild);
 }
 
-/** Returns a single guild by its ID, or null if it is not registered. */
+/** Returns a single guild by its ID, or null if it is not found in the guild table. */
 export async function getGuildById(guildId: string): Promise<DbGuild | null> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
     'SELECT guild_id, name, voice_channel_id FROM guild WHERE guild_id = ? LIMIT 1',

--- a/src/db/guilds.ts
+++ b/src/db/guilds.ts
@@ -55,7 +55,12 @@ export async function getProvisionedGuilds(): Promise<DbGuild[]> {
   return rows.map(mapGuild);
 }
 
-/** Returns a single guild by its ID, or null if it is not found in the guild table. */
+/**
+ * Returns a single guild by its ID, or null if it is not found in the guild table.
+ *
+ * @param guildId BIGINT snowflake as a string.
+ * @returns The guild row, or null if absent (including unprovisioned discovered guilds).
+ */
 export async function getGuildById(guildId: string): Promise<DbGuild | null> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
     'SELECT guild_id, name, voice_channel_id FROM guild WHERE guild_id = ? LIMIT 1',
@@ -75,6 +80,7 @@ export async function getGuildById(guildId: string): Promise<DbGuild | null> {
  *
  * @param guildId BIGINT snowflake as a string.
  * @param name Human-friendly server name.
+ * @returns Resolves when the upsert is complete.
  */
 export async function upsertGuild(guildId: string, name: string): Promise<void> {
   await getPool().execute(
@@ -89,6 +95,7 @@ export async function upsertGuild(guildId: string, name: string): Promise<void> 
  *
  * @param guildId BIGINT snowflake as a string.
  * @param voiceChannelId BIGINT snowflake as a string, or null to clear.
+ * @returns Resolves when the update is complete.
  */
 export async function setGuildVoiceChannel(guildId: string, voiceChannelId: string | null): Promise<void> {
   await getPool().execute(

--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -146,7 +146,7 @@ describe('startDiscordBot — messageCreate handler', () => {
     const msg = { author: { bot: false, username: 'Alice' }, guildId: 'guild-id', content: '!test', member: { displayName: 'Alice' } };
     cb(msg);
     expect(vi.mocked(commands.handleCommand)).toHaveBeenCalledWith('!test', 'discord');
-    expect(vi.mocked(customCmds.executeCustomCommandForDiscord)).toHaveBeenCalledWith(msg, 'Alice');
+    expect(vi.mocked(customCmds.executeCustomCommandForDiscord)).toHaveBeenCalledWith(msg, 'Alice', 'guild-id');
   });
 });
 

--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -13,6 +13,12 @@ vi.mock('../commands/commandRouter', () => ({ handleCommand: vi.fn().mockResolve
 vi.mock('../commands/customCommandHandler', () => ({ executeCustomCommandForDiscord: vi.fn().mockResolvedValue(undefined) }));
 vi.mock('../commands/counterHandler', () => ({ executeCounterCommandForDiscord: vi.fn().mockResolvedValue(undefined) }));
 vi.mock('../shared/statusStore', () => ({ setDiscordReady: vi.fn() }));
+vi.mock('./guildRegistry', () => ({
+  // Only the legacy configured guild is registered in these tests.
+  isRegisteredGuild: vi.fn((id: string) => id === 'guild-id'),
+  reloadGuildRegistry: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../db/guilds', () => ({ upsertGuild: vi.fn().mockResolvedValue(undefined) }));
 vi.mock('../shared/logger', () => ({ createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }));
 vi.mock('discord.js', () => ({
   Client: vi.fn(),
@@ -123,18 +129,46 @@ describe('startDiscordBot — messageCreate handler', () => {
     expect(vi.mocked(commands.handleCommand)).not.toHaveBeenCalled();
   });
 
-  it('skips messages from the wrong guild', () => {
+  it('skips messages from an unregistered guild', () => {
     const cb = getMessageCreateCb();
     cb({ author: { bot: false, username: 'Alice' }, guildId: 'other-guild', content: '!test', member: null });
     expect(vi.mocked(commands.handleCommand)).not.toHaveBeenCalled();
   });
 
-  it('dispatches to command handlers for valid guild messages', () => {
+  it('skips DMs (no guildId)', () => {
+    const cb = getMessageCreateCb();
+    cb({ author: { bot: false, username: 'Alice' }, guildId: null, content: '!test', member: null });
+    expect(vi.mocked(commands.handleCommand)).not.toHaveBeenCalled();
+  });
+
+  it('dispatches to command handlers for registered guild messages', () => {
     const cb = getMessageCreateCb();
     const msg = { author: { bot: false, username: 'Alice' }, guildId: 'guild-id', content: '!test', member: { displayName: 'Alice' } };
     cb(msg);
     expect(vi.mocked(commands.handleCommand)).toHaveBeenCalledWith('!test', 'discord');
     expect(vi.mocked(customCmds.executeCustomCommandForDiscord)).toHaveBeenCalledWith(msg, 'Alice');
+  });
+});
+
+// ─── startDiscordBot — guildCreate handler ────────────────────────────────────
+
+describe('startDiscordBot — guildCreate handler', () => {
+  function getGuildCreateCb() {
+    mod.startDiscordBot();
+    return mockInstance.on.mock.calls.find(([event]: string[]) => event === 'guildCreate')?.[1] as Function;
+  }
+
+  it('registers the guild row and reloads the registry (no auto-whitelist)', async () => {
+    const guilds = await import('../db/guilds.js');
+    const registry = await import('./guildRegistry.js');
+    const cb = getGuildCreateCb();
+
+    await cb({ id: 'new-guild', name: 'New Server' });
+    // Let the upsert → reload promise chain settle.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(vi.mocked(guilds.upsertGuild)).toHaveBeenCalledWith('new-guild', 'New Server');
+    expect(vi.mocked(registry.reloadGuildRegistry)).toHaveBeenCalled();
   });
 });
 

--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -52,6 +52,9 @@ function makeMockClient() {
 
 beforeEach(async () => {
   vi.resetModules();
+  // vi.mock() creates one shared mock instance per factory; resetModules clears the
+  // module cache but not call counts, so clearAllMocks() is needed before each test.
+  vi.clearAllMocks();
   mockInstance = makeMockClient();
   const djs = await import('discord.js');
   vi.mocked(djs.Client).mockImplementation(function () { return mockInstance; } as any);
@@ -175,15 +178,17 @@ describe('startDiscordBot — guildCreate handler', () => {
     expect(upsertOrder).toBeLessThan(reloadOrder);
   });
 
-  it('swallows upsertGuild errors without throwing', async () => {
+  it('swallows upsertGuild errors and does not call reloadGuildRegistry', async () => {
     const guilds = await import('../db.js');
+    const registry = await import('./guildRegistry.js');
     vi.mocked(guilds.upsertGuild).mockRejectedValueOnce(new Error('db error'));
     const cb = getGuildCreateCb();
 
     cb({ id: 'new-guild', name: 'New Server' });
     // Let the promise chain's .catch branch execute.
     await new Promise((resolve) => setImmediate(resolve));
-    // No assertion needed beyond reaching here without an unhandled rejection.
+
+    expect(vi.mocked(registry.reloadGuildRegistry)).not.toHaveBeenCalled();
   });
 });
 

--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -18,7 +18,7 @@ vi.mock('./guildRegistry', () => ({
   isRegisteredGuild: vi.fn((id: string) => id === 'guild-id'),
   reloadGuildRegistry: vi.fn().mockResolvedValue(undefined),
 }));
-vi.mock('../db/guilds', () => ({ upsertGuild: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../db', () => ({ upsertGuild: vi.fn().mockResolvedValue(undefined) }));
 vi.mock('../shared/logger', () => ({ createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }));
 vi.mock('discord.js', () => ({
   Client: vi.fn(),
@@ -159,7 +159,7 @@ describe('startDiscordBot — guildCreate handler', () => {
   }
 
   it('registers the guild row and reloads the registry (no auto-whitelist)', async () => {
-    const guilds = await import('../db/guilds.js');
+    const guilds = await import('../db.js');
     const registry = await import('./guildRegistry.js');
     const cb = getGuildCreateCb();
 

--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -169,6 +169,10 @@ describe('startDiscordBot — guildCreate handler', () => {
 
     expect(vi.mocked(guilds.upsertGuild)).toHaveBeenCalledWith('new-guild', 'New Server');
     expect(vi.mocked(registry.reloadGuildRegistry)).toHaveBeenCalled();
+
+    const [upsertOrder] = vi.mocked(guilds.upsertGuild).mock.invocationCallOrder;
+    const [reloadOrder] = vi.mocked(registry.reloadGuildRegistry).mock.invocationCallOrder;
+    expect(upsertOrder).toBeLessThan(reloadOrder);
   });
 
   it('swallows upsertGuild errors without throwing', async () => {

--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -170,6 +170,17 @@ describe('startDiscordBot — guildCreate handler', () => {
     expect(vi.mocked(guilds.upsertGuild)).toHaveBeenCalledWith('new-guild', 'New Server');
     expect(vi.mocked(registry.reloadGuildRegistry)).toHaveBeenCalled();
   });
+
+  it('swallows upsertGuild errors without throwing', async () => {
+    const guilds = await import('../db.js');
+    vi.mocked(guilds.upsertGuild).mockRejectedValueOnce(new Error('db error'));
+    const cb = getGuildCreateCb();
+
+    cb({ id: 'new-guild', name: 'New Server' });
+    // Let the promise chain's .catch branch execute.
+    await new Promise((resolve) => setImmediate(resolve));
+    // No assertion needed beyond reaching here without an unhandled rejection.
+  });
 });
 
 // ─── startDiscordBot — clientReady error path ─────────────────────────────────

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -4,34 +4,29 @@ import { handleCommand } from '../commands/commandRouter';
 import { executeCustomCommandForDiscord } from '../commands/customCommandHandler';
 import { executeCounterCommandForDiscord } from '../commands/counterHandler';
 import { setDiscordReady } from '../shared/statusStore';
+import { isRegisteredGuild, reloadGuildRegistry } from './guildRegistry';
+import { upsertGuild } from '../db/guilds';
 import { createLogger } from '../shared/logger';
 
 const log = createLogger('Discord');
 
 let client: Client | null = null;
 let bootingClient: Client | null = null;
-let cachedGuild: Guild | null = null;
 
 /** Returns the Discord.js Client once it has fired `clientReady`, or null before then. */
 export function getDiscordClient(): Client | null { return client; }
 
-async function getConfiguredGuild(): Promise<Guild> {
+/**
+ * Resolve a guild by ID from the discord.js cache, falling back to a fetch.
+ * @throws if the client is not ready.
+ */
+async function getGuild(guildId: string): Promise<Guild> {
   if (!client) {
     throw new Error('Discord client is not ready');
   }
-
-  const guildFromCache = client.guilds.cache.get(DISCORD_GUILD_ID);
-  if (guildFromCache) {
-    cachedGuild = guildFromCache;
-    return guildFromCache;
-  }
-
-  if (cachedGuild) {
-    return cachedGuild;
-  }
-
-  cachedGuild = await client.guilds.fetch(DISCORD_GUILD_ID);
-  return cachedGuild;
+  const cached = client.guilds.cache.get(guildId);
+  if (cached) return cached;
+  return client.guilds.fetch(guildId);
 }
 
 /**
@@ -40,12 +35,19 @@ async function getConfiguredGuild(): Promise<Guild> {
  *
  * @param discordId - Discord user snowflake ID to look up.
  * @param force - When true, bypasses the guild member cache and fetches fresh from the API.
+ * @param guildId - Guild to look the member up in. Defaults to the legacy configured guild
+ *   so existing single-guild callers (e.g. web login) keep working until the web panel
+ *   threads its own guild context through in a later phase.
  * @returns The member's server display name, or null on any failure.
  */
-export async function fetchMemberDisplayName(discordId: string, force = false): Promise<string | null> {
+export async function fetchMemberDisplayName(
+  discordId: string,
+  force = false,
+  guildId: string = DISCORD_GUILD_ID,
+): Promise<string | null> {
   if (!client) return null;
   try {
-    const guild = await getConfiguredGuild();
+    const guild = await getGuild(guildId);
     const member = await guild.members.fetch({ user: discordId, force });
     return member.displayName;
   } catch (err) {
@@ -63,6 +65,9 @@ export async function fetchMemberDisplayName(discordId: string, force = false): 
  * client. If {@link stopDiscordBot} is called before the connection completes,
  * the in-flight client is destroyed and the `clientReady` handler is discarded.
  * If login fails, `bootingClient` is cleared so the next call can retry.
+ *
+ * The guild registry must be loaded (see {@link reloadGuildRegistry}) before the
+ * client connects, so the `messageCreate` gate can recognise registered guilds.
  */
 export function startDiscordBot(): void {
   if (client || bootingClient) return;
@@ -78,7 +83,7 @@ export function startDiscordBot(): void {
 
   localClient.on('messageCreate', (message) => {
     if (message.author.bot) return;
-    if (message.guildId !== DISCORD_GUILD_ID) return;
+    if (!message.guildId || !isRegisteredGuild(message.guildId)) return;
 
     const displayName = message.member?.displayName ?? message.author.username;
 
@@ -95,6 +100,17 @@ export function startDiscordBot(): void {
     );
   });
 
+  // Bootstrap Option B: when the bot is added to a server, register the guild row
+  // only — no auto-whitelisting. The bot Owner provisions the first guild_member
+  // through the panel. guildCreate also fires on reconnect, so upsertGuild is
+  // insert-if-not-exists and never wipes existing per-guild config.
+  localClient.on('guildCreate', (guild) => {
+    upsertGuild(guild.id, guild.name)
+      .then(() => reloadGuildRegistry())
+      .then(() => log.info(`Registered guild '${guild.name}' (${guild.id}).`))
+      .catch((err) => log.error(`Failed to register guild ${guild.id}:`, err));
+  });
+
   localClient.once('clientReady', async (c) => {
     if (bootingClient !== localClient) {
       // stopDiscordBot() ran during boot — discard this ready client
@@ -105,7 +121,7 @@ export function startDiscordBot(): void {
     client = c;
     log.info(`Logged in as ${c.user.tag}`);
     try {
-      const guild = await getConfiguredGuild();
+      const guild = await getGuild(DISCORD_GUILD_ID);
       setDiscordReady(c.user.tag, guild.name);
     } catch (err) {
       log.error('Failed to initialise:', err);
@@ -132,7 +148,6 @@ export function stopDiscordBot(): void {
   const existingBooting = bootingClient;
   client = null;
   bootingClient = null;
-  cachedGuild = null;
   try {
     existingReady?.destroy();
   } catch (err) {

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -5,7 +5,7 @@ import { executeCustomCommandForDiscord } from '../commands/customCommandHandler
 import { executeCounterCommandForDiscord } from '../commands/counterHandler';
 import { setDiscordReady } from '../shared/statusStore';
 import { isRegisteredGuild, reloadGuildRegistry } from './guildRegistry';
-import { upsertGuild } from '../db/guilds';
+import { upsertGuild } from '../db';
 import { createLogger } from '../shared/logger';
 
 const log = createLogger('Discord');

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -86,8 +86,9 @@ export function startDiscordBot(): void {
     if (!message.guildId || !isRegisteredGuild(message.guildId)) return;
 
     const displayName = message.member?.displayName ?? message.author.username;
+    const guildId = message.guildId;
 
-    executeCustomCommandForDiscord(message, displayName).catch((err) =>
+    executeCustomCommandForDiscord(message, displayName, guildId).catch((err) =>
       log.error('Custom command error:', err),
     );
 

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -101,10 +101,13 @@ export function startDiscordBot(): void {
     );
   });
 
-  // Bootstrap Option B: when the bot is added to a server, register the guild row
-  // only — no auto-whitelisting. The bot Owner provisions the first guild_member
-  // through the panel. guildCreate also fires on reconnect, so upsertGuild is
-  // insert-if-not-exists and never wipes existing per-guild config.
+  // Bootstrap Option B: when the bot is added to a server, record the guild row
+  // only — no auto-whitelisting. The guild is NOT served until the Owner
+  // provisions its first guild_member through the panel (the registry gates on
+  // member presence, see guildRegistry / getProvisionedGuilds). guildCreate also
+  // fires on reconnect, so upsertGuild is insert-if-not-exists and never wipes
+  // existing per-guild config; and because a bare guild row isn't served, a
+  // reconnect cannot silently re-enable a guild whose members were removed.
   localClient.on('guildCreate', (guild) => {
     upsertGuild(guild.id, guild.name)
       .then(() => reloadGuildRegistry())

--- a/src/discord/guildRegistry.test.ts
+++ b/src/discord/guildRegistry.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../shared/logger', () => ({ createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }));
-vi.mock('../db', () => ({ getAllGuilds: vi.fn() }));
+vi.mock('../db', () => ({ getProvisionedGuilds: vi.fn() }));
 
-import { getAllGuilds } from '../db';
+import { getProvisionedGuilds } from '../db';
 import {
   reloadGuildRegistry,
   isRegisteredGuild,
@@ -20,7 +20,7 @@ beforeEach(() => {
 
 describe('reloadGuildRegistry', () => {
   it('loads guilds from the DB into the registry', async () => {
-    vi.mocked(getAllGuilds).mockResolvedValueOnce([
+    vi.mocked(getProvisionedGuilds).mockResolvedValueOnce([
       { guild_id: '111', name: 'Alpha', voice_channel_id: '222' },
       { guild_id: '333', name: 'Beta', voice_channel_id: null },
     ]);
@@ -33,13 +33,13 @@ describe('reloadGuildRegistry', () => {
   });
 
   it('replaces the previous registry contents on reload', async () => {
-    vi.mocked(getAllGuilds).mockResolvedValueOnce([
+    vi.mocked(getProvisionedGuilds).mockResolvedValueOnce([
       { guild_id: '111', name: 'Alpha', voice_channel_id: null },
     ]);
     await reloadGuildRegistry();
     expect(isRegisteredGuild('111')).toBe(true);
 
-    vi.mocked(getAllGuilds).mockResolvedValueOnce([
+    vi.mocked(getProvisionedGuilds).mockResolvedValueOnce([
       { guild_id: '999', name: 'Gamma', voice_channel_id: null },
     ]);
     await reloadGuildRegistry();
@@ -49,12 +49,12 @@ describe('reloadGuildRegistry', () => {
   });
 
   it('leaves the previous registry intact when the DB read fails', async () => {
-    vi.mocked(getAllGuilds).mockResolvedValueOnce([
+    vi.mocked(getProvisionedGuilds).mockResolvedValueOnce([
       { guild_id: '111', name: 'Alpha', voice_channel_id: null },
     ]);
     await reloadGuildRegistry();
 
-    vi.mocked(getAllGuilds).mockRejectedValueOnce(new Error('db down'));
+    vi.mocked(getProvisionedGuilds).mockRejectedValueOnce(new Error('db down'));
     await expect(reloadGuildRegistry()).rejects.toThrow('db down');
 
     expect(isRegisteredGuild('111')).toBe(true);
@@ -69,7 +69,7 @@ describe('isRegisteredGuild', () => {
 
 describe('getRegisteredGuild', () => {
   it('returns the cached config for a known guild', async () => {
-    vi.mocked(getAllGuilds).mockResolvedValueOnce([
+    vi.mocked(getProvisionedGuilds).mockResolvedValueOnce([
       { guild_id: '111', name: 'Alpha', voice_channel_id: '222' },
     ]);
     await reloadGuildRegistry();
@@ -81,7 +81,7 @@ describe('getRegisteredGuild', () => {
 
 describe('getRegisteredGuilds', () => {
   it('returns every cached guild config', async () => {
-    vi.mocked(getAllGuilds).mockResolvedValueOnce([
+    vi.mocked(getProvisionedGuilds).mockResolvedValueOnce([
       { guild_id: '111', name: 'Alpha', voice_channel_id: null },
       { guild_id: '333', name: 'Beta', voice_channel_id: null },
     ]);

--- a/src/discord/guildRegistry.test.ts
+++ b/src/discord/guildRegistry.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../shared/logger', () => ({ createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }));
-vi.mock('../db/guilds', () => ({ getAllGuilds: vi.fn() }));
+vi.mock('../db', () => ({ getAllGuilds: vi.fn() }));
 
-import { getAllGuilds } from '../db/guilds';
+import { getAllGuilds } from '../db';
 import {
   reloadGuildRegistry,
   isRegisteredGuild,

--- a/src/discord/guildRegistry.test.ts
+++ b/src/discord/guildRegistry.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../shared/logger', () => ({ createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }));
+vi.mock('../db/guilds', () => ({ getAllGuilds: vi.fn() }));
+
+import { getAllGuilds } from '../db/guilds';
+import {
+  reloadGuildRegistry,
+  isRegisteredGuild,
+  getRegisteredGuild,
+  getRegisteredGuildIds,
+  getRegisteredGuilds,
+  __resetGuildRegistryForTests,
+} from './guildRegistry';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetGuildRegistryForTests();
+});
+
+describe('reloadGuildRegistry', () => {
+  it('loads guilds from the DB into the registry', async () => {
+    vi.mocked(getAllGuilds).mockResolvedValueOnce([
+      { guild_id: '111', name: 'Alpha', voice_channel_id: '222' },
+      { guild_id: '333', name: 'Beta', voice_channel_id: null },
+    ]);
+
+    await reloadGuildRegistry();
+
+    expect(isRegisteredGuild('111')).toBe(true);
+    expect(isRegisteredGuild('333')).toBe(true);
+    expect(getRegisteredGuildIds()).toEqual(['111', '333']);
+  });
+
+  it('replaces the previous registry contents on reload', async () => {
+    vi.mocked(getAllGuilds).mockResolvedValueOnce([
+      { guild_id: '111', name: 'Alpha', voice_channel_id: null },
+    ]);
+    await reloadGuildRegistry();
+    expect(isRegisteredGuild('111')).toBe(true);
+
+    vi.mocked(getAllGuilds).mockResolvedValueOnce([
+      { guild_id: '999', name: 'Gamma', voice_channel_id: null },
+    ]);
+    await reloadGuildRegistry();
+
+    expect(isRegisteredGuild('111')).toBe(false);
+    expect(isRegisteredGuild('999')).toBe(true);
+  });
+
+  it('leaves the previous registry intact when the DB read fails', async () => {
+    vi.mocked(getAllGuilds).mockResolvedValueOnce([
+      { guild_id: '111', name: 'Alpha', voice_channel_id: null },
+    ]);
+    await reloadGuildRegistry();
+
+    vi.mocked(getAllGuilds).mockRejectedValueOnce(new Error('db down'));
+    await expect(reloadGuildRegistry()).rejects.toThrow('db down');
+
+    expect(isRegisteredGuild('111')).toBe(true);
+  });
+});
+
+describe('isRegisteredGuild', () => {
+  it('returns false for unknown guilds', () => {
+    expect(isRegisteredGuild('nope')).toBe(false);
+  });
+});
+
+describe('getRegisteredGuild', () => {
+  it('returns the cached config for a known guild', async () => {
+    vi.mocked(getAllGuilds).mockResolvedValueOnce([
+      { guild_id: '111', name: 'Alpha', voice_channel_id: '222' },
+    ]);
+    await reloadGuildRegistry();
+
+    expect(getRegisteredGuild('111')).toEqual({ guild_id: '111', name: 'Alpha', voice_channel_id: '222' });
+    expect(getRegisteredGuild('nope')).toBeUndefined();
+  });
+});
+
+describe('getRegisteredGuilds', () => {
+  it('returns every cached guild config', async () => {
+    vi.mocked(getAllGuilds).mockResolvedValueOnce([
+      { guild_id: '111', name: 'Alpha', voice_channel_id: null },
+      { guild_id: '333', name: 'Beta', voice_channel_id: null },
+    ]);
+    await reloadGuildRegistry();
+
+    expect(getRegisteredGuilds()).toHaveLength(2);
+    expect(getRegisteredGuilds().map((g) => g.guild_id)).toEqual(['111', '333']);
+  });
+});

--- a/src/discord/guildRegistry.ts
+++ b/src/discord/guildRegistry.ts
@@ -1,26 +1,35 @@
 import { createLogger } from '../shared/logger';
-import { getAllGuilds, type DbGuild } from '../db';
+import { getProvisionedGuilds, type DbGuild } from '../db';
 
 const log = createLogger('GuildRegistry');
 
 // ─── In-memory registry ─────────────────────────────────────────────────────
 //
 // The bot decides whether to process a guild's messages by consulting this
-// in-memory map rather than hitting the DB on every message. It is loaded once
-// at startup via reloadGuildRegistry() and refreshed whenever the set of guilds
-// changes — both from the discord.js `guildCreate` handler and when the Owner
-// adds/removes a guild through the web panel. Without a refresh, new-guild
-// messages would be dropped until a restart (see the multi-guild plan, Pitfall #9).
+// in-memory map rather than hitting the DB on every message. It holds only the
+// guilds the bot should serve — those with at least one guild_member row (see
+// getProvisionedGuilds). A bare `guild` row is not enough.
+//
+// The member-presence gate is what makes registration durable against reconnects:
+// `guildCreate` fires on every reconnect, not just first join, and re-inserts the
+// guild row — but an un-provisioned guild never enters the registry, so a guild
+// whose members were removed cannot be silently re-enabled.
+//
+// It is loaded once at startup via reloadGuildRegistry() and must be refreshed
+// whenever the served set changes: the `guildCreate` handler, and (in PR3) when
+// the Owner provisions/removes a guild's members through the web panel. Without a
+// refresh, newly-provisioned guilds are dropped until a restart (Pitfall #9).
 
 let registry = new Map<string, DbGuild>();
 
 /**
  * Reloads the in-memory guild registry from the database. Call once at startup
- * and after any change to the set of registered guilds. On failure the previous
- * registry is left intact so a transient DB error cannot blank the whitelist.
+ * and after any change to the served set (members provisioned/removed). Loads
+ * only provisioned guilds (≥1 member). On failure the previous registry is left
+ * intact so a transient DB error cannot blank the whitelist.
  */
 export async function reloadGuildRegistry(): Promise<void> {
-  const guilds = await getAllGuilds();
+  const guilds = await getProvisionedGuilds();
   const next = new Map<string, DbGuild>();
   for (const guild of guilds) {
     next.set(guild.guild_id, guild);

--- a/src/discord/guildRegistry.ts
+++ b/src/discord/guildRegistry.ts
@@ -1,0 +1,55 @@
+import { createLogger } from '../shared/logger';
+import { getAllGuilds, type DbGuild } from '../db/guilds';
+
+const log = createLogger('GuildRegistry');
+
+// ─── In-memory registry ─────────────────────────────────────────────────────
+//
+// The bot decides whether to process a guild's messages by consulting this
+// in-memory map rather than hitting the DB on every message. It is loaded once
+// at startup via reloadGuildRegistry() and refreshed whenever the set of guilds
+// changes — both from the discord.js `guildCreate` handler and when the Owner
+// adds/removes a guild through the web panel. Without a refresh, new-guild
+// messages would be dropped until a restart (see the multi-guild plan, Pitfall #9).
+
+let registry = new Map<string, DbGuild>();
+
+/**
+ * Reloads the in-memory guild registry from the database. Call once at startup
+ * and after any change to the set of registered guilds. On failure the previous
+ * registry is left intact so a transient DB error cannot blank the whitelist.
+ */
+export async function reloadGuildRegistry(): Promise<void> {
+  const guilds = await getAllGuilds();
+  const next = new Map<string, DbGuild>();
+  for (const guild of guilds) {
+    next.set(guild.guild_id, guild);
+  }
+  registry = next;
+  log.info(`Loaded ${registry.size} guild(s) into the registry.`);
+}
+
+/** Returns true if the given guild ID is registered and the bot should serve it. */
+export function isRegisteredGuild(guildId: string): boolean {
+  return registry.has(guildId);
+}
+
+/** Returns the cached guild config for an ID, or undefined if it is not registered. */
+export function getRegisteredGuild(guildId: string): DbGuild | undefined {
+  return registry.get(guildId);
+}
+
+/** Returns the IDs of every registered guild. */
+export function getRegisteredGuildIds(): string[] {
+  return [...registry.keys()];
+}
+
+/** Returns every registered guild's config. */
+export function getRegisteredGuilds(): DbGuild[] {
+  return [...registry.values()];
+}
+
+/** Test-only: clears the in-memory registry so each test starts from a clean slate. */
+export function __resetGuildRegistryForTests(): void {
+  registry = new Map<string, DbGuild>();
+}

--- a/src/discord/guildRegistry.ts
+++ b/src/discord/guildRegistry.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '../shared/logger';
-import { getAllGuilds, type DbGuild } from '../db/guilds';
+import { getAllGuilds, type DbGuild } from '../db';
 
 const log = createLogger('GuildRegistry');
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -67,7 +67,18 @@ let exitSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
   vi.resetModules();
-  exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never);
+  // vi.mock() creates one shared mock instance per factory; resetModules clears the
+  // module cache but does not reset call counts. clearAllMocks() resets counts to 0
+  // so failure-path assertions on mocks like startDiscordBot start from a clean slate.
+  vi.clearAllMocks();
+  // Throw on the first call so main() stops executing after a catch block calls
+  // process.exit(1). Revert to a no-op on subsequent calls so the outer
+  // main().catch() path — which also calls process.exit(1) after the inner throw
+  // propagates out — doesn't produce an unhandled rejection.
+  exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {
+    exitSpy.mockImplementation((() => {}) as never);
+    throw new Error('process.exit');
+  }) as never);
 });
 
 afterEach(() => {
@@ -97,17 +108,20 @@ describe('startup — guild registry preload', () => {
     expect(registryCallOrder).toBeLessThan(botCallOrder);
   });
 
-  it('calls process.exit(1) when reloadGuildRegistry rejects', async () => {
+  it('calls process.exit(1) and does not start the bot when reloadGuildRegistry rejects', async () => {
     const { reloadGuildRegistry } = await import('./discord/guildRegistry.js');
+    const { startDiscordBot } = await import('./discord/discordBot.js');
     vi.mocked(reloadGuildRegistry).mockRejectedValueOnce(new Error('DB unavailable'));
 
     await runMain();
 
     expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(vi.mocked(startDiscordBot)).not.toHaveBeenCalled();
   });
 
-  it('calls process.exit(1) when the DB connection ping fails', async () => {
+  it('calls process.exit(1) and does not start the bot when the DB connection ping fails', async () => {
     const db = await import('./db.js');
+    const { startDiscordBot } = await import('./discord/discordBot.js');
     vi.mocked(db.getPool).mockReturnValueOnce({
       getConnection: vi.fn().mockRejectedValue(new Error('connect ECONNREFUSED')),
     } as any);
@@ -115,5 +129,6 @@ describe('startup — guild registry preload', () => {
     await runMain();
 
     expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(vi.mocked(startDiscordBot)).not.toHaveBeenCalled();
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// All vi.mock calls are hoisted before imports. After vi.resetModules() in beforeEach,
+// re-importing any of these modules will re-run the factory and give fresh vi.fn() instances.
+
+vi.mock('mediaplex', () => ({}));
+vi.mock('./db', () => ({
+  getPool: vi.fn(() => ({
+    getConnection: vi.fn().mockResolvedValue({
+      ping: vi.fn().mockResolvedValue(undefined),
+      release: vi.fn(),
+    }),
+  })),
+  closePool: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('./discord/discordBot', () => ({
+  startDiscordBot: vi.fn(),
+  stopDiscordBot: vi.fn(),
+}));
+vi.mock('./discord/guildRegistry', () => ({
+  reloadGuildRegistry: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('./twitch/twitchBot', () => ({
+  startTwitchBot: vi.fn().mockResolvedValue(undefined),
+  stopTwitchBot: vi.fn().mockResolvedValue(undefined),
+  sayInChannel: vi.fn(),
+}));
+vi.mock('./twitch/twitchChannelMembership', () => ({
+  getActiveChannels: vi.fn(),
+  getActiveChannelUserIds: vi.fn(),
+  setChannelJoinedHook: vi.fn(),
+}));
+vi.mock('./tiktok/tiktokBot', () => ({
+  startTikTokBot: vi.fn().mockResolvedValue(undefined),
+  stopTikTokBot: vi.fn(),
+}));
+vi.mock('./twitch/monitor/twitchMonitor', () => ({
+  startTwitchMonitor: vi.fn().mockResolvedValue(undefined),
+  stopTwitchMonitor: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('./twitch/eventsub/twitchEventSub', () => ({
+  startEventSub: vi.fn(),
+  stopEventSub: vi.fn(),
+  reloadEventSubSubscriptions: vi.fn(),
+}));
+vi.mock('./web/server', () => ({ startWebPanel: vi.fn() }));
+vi.mock('./audio/audioPlayer', () => ({ disconnect: vi.fn() }));
+vi.mock('./commands/customCommandHandler', () => ({ registerTwitchChatRuntime: vi.fn() }));
+vi.mock('./commands/counterHandler', () => ({ registerCounterTwitchRuntime: vi.fn() }));
+vi.mock('./commands/multiCommandHandler', () => ({ registerMultiTwitchRuntime: vi.fn() }));
+vi.mock('./commands/shoutoutHandler', () => ({ registerShoutoutRuntime: vi.fn() }));
+vi.mock('./commands/countdownHandler', () => ({ registerCountdownTwitchRuntime: vi.fn() }));
+vi.mock('./twitch/eventsub/twitchEventSubHandler', () => ({
+  registerEventSubOverlayRuntime: vi.fn(),
+  registerEventSubTwitchRuntime: vi.fn(),
+}));
+vi.mock('./web/routes/overlaySource', () => ({ pushOverlayEvent: vi.fn() }));
+vi.mock('./commands/counterScheduler', () => ({
+  startCounterScheduler: vi.fn(),
+  stopCounterScheduler: vi.fn(),
+}));
+vi.mock('./shared/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+let exitSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  vi.resetModules();
+  exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as never);
+});
+
+afterEach(() => {
+  exitSpy.mockRestore();
+});
+
+/** Imports index.ts (which fires main() immediately) and waits for it to settle. */
+async function runMain(): Promise<void> {
+  await import('./index.js');
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+// ─── Startup preload contract ─────────────────────────────────────────────────
+
+describe('startup — guild registry preload', () => {
+  it('calls reloadGuildRegistry before startDiscordBot on a clean startup', async () => {
+    const { reloadGuildRegistry } = await import('./discord/guildRegistry.js');
+    const { startDiscordBot } = await import('./discord/discordBot.js');
+
+    await runMain();
+
+    expect(vi.mocked(reloadGuildRegistry)).toHaveBeenCalledOnce();
+    expect(vi.mocked(startDiscordBot)).toHaveBeenCalledOnce();
+
+    const [registryCallOrder] = vi.mocked(reloadGuildRegistry).mock.invocationCallOrder;
+    const [botCallOrder] = vi.mocked(startDiscordBot).mock.invocationCallOrder;
+    expect(registryCallOrder).toBeLessThan(botCallOrder);
+  });
+
+  it('calls process.exit(1) when reloadGuildRegistry rejects', async () => {
+    const { reloadGuildRegistry } = await import('./discord/guildRegistry.js');
+    vi.mocked(reloadGuildRegistry).mockRejectedValueOnce(new Error('DB unavailable'));
+
+    await runMain();
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('calls process.exit(1) when the DB connection ping fails', async () => {
+    const db = await import('./db.js');
+    vi.mocked(db.getPool).mockReturnValueOnce({
+      getConnection: vi.fn().mockRejectedValue(new Error('connect ECONNREFUSED')),
+    } as any);
+
+    await runMain();
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { getPool, closePool } from './db';
 import { startTwitchBot, stopTwitchBot, sayInChannel } from './twitch/twitchBot';
 import { getActiveChannels, getActiveChannelUserIds, setChannelJoinedHook } from './twitch/twitchChannelMembership';
 import { startDiscordBot, stopDiscordBot } from './discord/discordBot';
+import { reloadGuildRegistry } from './discord/guildRegistry';
 import { startTikTokBot, stopTikTokBot } from './tiktok/tiktokBot';
 import { startTwitchMonitor, stopTwitchMonitor } from './twitch/monitor/twitchMonitor';
 import { startEventSub, stopEventSub, reloadEventSubSubscriptions } from './twitch/eventsub/twitchEventSub';
@@ -64,6 +65,15 @@ async function main(): Promise<void> {
   registerCountdownTwitchRuntime({ send: sayInChannel });
   registerEventSubOverlayRuntime({ pushOverlayEvent });
   registerEventSubTwitchRuntime({ send: sayInChannel });
+
+  // Load the guild registry before the Discord client connects so the
+  // messageCreate gate recognises registered guilds from the first message.
+  try {
+    await reloadGuildRegistry();
+  } catch (err) {
+    log.error('Cannot load guild registry:', err);
+    process.exit(1);
+  }
 
   setChannelJoinedHook(() => reloadEventSubSubscriptions());
   startDiscordBot();


### PR DESCRIPTION
## Phase 2 of 3 — Runtime guild-awareness + access shim

Builds on the schema migration merged in #272. This PR makes the runtime *guild-aware* without changing any observable behaviour on the single-guild bot: `guildId` resolves to the one registered legacy guild everywhere, and the web UI is untouched.

### Design note — counters are global
A deviation from the original plan: **counters are global** (one shared set across all guilds), not per-guild. They keep their current behaviour and need no `guildId` threading. The `counter.guild_id` column added by #272's migration is left unused by code (it harmlessly defaults to the legacy guild on insert). Per-guild deviation remains a **custom-command-only** concept (global catalog + per-guild Discord override overlay).

### Included in this slice (runtime plumbing) — complete

**Guild registry foundation** (`src/db/guilds.ts`, `src/discord/guildRegistry.ts`)
- `DbGuild` + `getAllGuilds`/`getGuildById`/`upsertGuild`/`setGuildVoiceChannel`.
- `upsertGuild` is insert-if-not-exists (name-only conflict update) so the `guildCreate` reconnect path never wipes per-guild config.
- In-memory registry `Map` loaded at startup via `reloadGuildRegistry()`; `isRegisteredGuild`/`getRegisteredGuild` back the message gate. A failed reload leaves the previous registry intact.

**Access shim** (`src/db/guildMembers.ts`)
- Per-guild access-level CRUD (`getGuildMembers`, `getMemberAccessLevel`, `setMemberAccessLevel`, `removeGuildMember`).
- `getEffectiveAccessLevel(guildId, discordId)` returns the **legacy `user.access_level`** for now so every existing reader keeps behaving identically. It deliberately does *not* read `guild_member` yet (that table would drift while the current web panel still writes `user.access_level`). PR 3 flips the source and adds the `is_owner` short-circuit once readers + admin UI migrate together.

**Discord message gate + bootstrap** (`src/discord/discordBot.ts`, `src/index.ts`)
- Hard `!== DISCORD_GUILD_ID` filter replaced with the registry check.
- `guildCreate` handler implements **Bootstrap Option B**: register the guild row only, no auto-whitelist.
- `getConfiguredGuild()` → guild-id-parameterised `getGuild()`; `fetchMemberDisplayName` gains an optional `guildId` (defaults to the legacy guild).
- Registry loaded at startup before the client connects.

**Per-guild Discord command override overlay** (`src/db/guildCommandOverrides.ts`, `src/db/customCommandCache.ts`)
- CRUD for the sparse `guild_command_override` overlay.
- `getCustomCommandForDiscord(trigger, guildId)` resolves catalog → override: `is_disabled` ⇒ null, non-null `output` ⇒ substitute, no row ⇒ catalog default. Twitch lookup unchanged.
- `customCommandHandler` + `discordBot` thread `message.guildId` through.

### Remaining — separate slice (voice/statusStore)
Per the plan's splitting valve, the voice refactor is a focused follow-up:
- Per-guild voice connection `Map` in `audioPlayer.ts` (the reconnect state machine is the riskiest file in the codebase — worth isolating).
- Per-guild `statusStore` voice/ready state + `/status` scoping.
- `connect()` gains an explicit `guildId`; `api.ts`/`streamdeck.ts` pass it.

### Invariant
Every commit passes `npx tsc --noEmit && npm test` (1236 tests) and has **no observable effect** on the running single-guild bot — the registry holds exactly one guild until go-live.

https://claude.ai/code/session_01QfGqskn817m3wmrwDjEqh3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a cached guild registry loaded during startup and refreshed on guild creation.
  * Implemented per-guild Discord custom command overrides (disable/enable and output substitution).
  * Added DB support for guilds, guild members/access levels, and per-guild command overrides.

* **Bug Fixes**
  * Custom commands now resolve using the correct guild context; messages without a guild (or missing/invalid guild) are ignored safely.

* **Tests**
  * Expanded coverage for guild registry, per-guild overrides, guild-aware command resolution, and new guild/member/override DB helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->