### PR TITLE
Multi-server (multi-guild) support — voice: per-guild connection map

### DIFF
--- a/src/audio/audioConnectionHandlers.ts
+++ b/src/audio/audioConnectionHandlers.ts
@@ -7,6 +7,10 @@ import {
 
 const log = createLogger('AudioConn');
 
+/**
+ * Callbacks injected into the connection handler functions so they can read
+ * and mutate per-guild voice state without a direct import cycle.
+ */
 export interface ConnectionHandlerDeps {
   getAttemptId: () => number;
   getConnection: () => VoiceConnection | null;
@@ -59,6 +63,14 @@ async function handleDisconnected(
   }
 }
 
+/**
+ * Destroys the previous connection if it differs from the newly joined one,
+ * cleaning up state so only the active connection is tracked.
+ *
+ * @param previousConnection - The connection held before this connect attempt, or null.
+ * @param joinedConnection - The connection that just became ready.
+ * @param deps - Per-guild state accessors.
+ */
 export function releasePreviousConnection(
   previousConnection: VoiceConnection | null,
   joinedConnection: VoiceConnection,
@@ -69,6 +81,14 @@ export function releasePreviousConnection(
   if (deps.getConnection() === previousConnection) deps.setConnection(null);
 }
 
+/**
+ * Tears down connections after a failed connect attempt, restoring the state
+ * machine so a reconnect can be scheduled.
+ *
+ * @param previousConnection - The connection held before the failed attempt, or null.
+ * @param nextConnection - The partially-created connection that failed, or null.
+ * @param deps - Per-guild state accessors.
+ */
 export function cleanupFailedConnect(
   previousConnection: VoiceConnection | null,
   nextConnection: VoiceConnection | null,
@@ -89,6 +109,13 @@ export function cleanupFailedConnect(
   }
 }
 
+/**
+ * Attaches error and disconnect event handlers to a newly joined connection.
+ *
+ * @param joinedConnection - The voice connection to attach handlers to.
+ * @param attemptId - The attempt ID at the time of joining; stale callbacks check against this.
+ * @param deps - Per-guild state accessors used within the handlers.
+ */
 export function setupConnectionHandlers(
   joinedConnection: VoiceConnection,
   attemptId: number,

--- a/src/audio/audioConnectionHandlers.ts
+++ b/src/audio/audioConnectionHandlers.ts
@@ -12,10 +12,15 @@ const log = createLogger('AudioConn');
  * and mutate per-guild voice state without a direct import cycle.
  */
 export interface ConnectionHandlerDeps {
+  /** Returns the current attempt ID for the guild, used to detect stale callbacks. */
   getAttemptId: () => number;
+  /** Returns the guild's current active voice connection, or null if none. */
   getConnection: () => VoiceConnection | null;
+  /** Replaces the guild's active connection reference. */
   setConnection: (c: VoiceConnection | null) => void;
+  /** Tears down guild playback state after the voice connection is lost. */
   tearDown: () => void;
+  /** Schedules an exponential-backoff reconnect attempt for the guild. */
   scheduleReconnect: (reason: string) => void;
 }
 

--- a/src/audio/audioConnectionHandlers.ts
+++ b/src/audio/audioConnectionHandlers.ts
@@ -19,6 +19,7 @@ export interface ConnectionHandlerDeps {
   scheduleReconnect: (reason: string) => void;
 }
 
+/** Logs the connection error, suppressing transient DNS failures that self-resolve via the state handler. */
 function handleConnectionError(err: Error, attemptId: number, deps: ConnectionHandlerDeps): void {
   if (attemptId !== deps.getAttemptId()) return;
 
@@ -31,6 +32,7 @@ function handleConnectionError(err: Error, attemptId: number, deps: ConnectionHa
   log.error('Voice connection error:', err);
 }
 
+/** Handles a voice connection drop, allowing a brief reconnect window before tearing down and scheduling a retry. */
 async function handleDisconnected(
   joinedConnection: VoiceConnection,
   attemptId: number,

--- a/src/audio/audioPlayer.test.ts
+++ b/src/audio/audioPlayer.test.ts
@@ -81,6 +81,8 @@ beforeEach(async () => {
     createdConnections.push(conn);
     return conn as never;
   });
+  const utils = await import('../discord/discordUtils.js');
+  vi.mocked(utils.isPermanentVoiceMisconfigurationError).mockReset().mockReturnValue(false);
   mod = await import('./audioPlayer.js') as AudioPlayerModule;
 });
 
@@ -116,6 +118,16 @@ describe('connect', () => {
 
     await expect(mod.connect(client as never, 'guild-A', 'text-chan')).rejects.toThrow('not a voice channel');
     expect(mod.isConnected('guild-A')).toBe(false);
+  });
+
+  it('rejects when the guild ID is missing', async () => {
+    const { client } = makeClient();
+    const utils = await import('../discord/discordUtils.js');
+    // Treat the misconfiguration as permanent so no reconnect timer is scheduled.
+    vi.mocked(utils.isPermanentVoiceMisconfigurationError).mockReturnValue(true);
+
+    await expect(mod.connect(client as never, '', 'chan-1')).rejects.toThrow('Missing guild ID or voice channel ID');
+    expect(client.guilds.fetch).not.toHaveBeenCalled();
   });
 });
 
@@ -192,6 +204,27 @@ describe('reconnect', () => {
 
       expect(vi.mocked(voice.joinVoiceChannel).mock.calls.length).toBeGreaterThan(joinsAfterFirst);
       expect(mod.isConnected('guild-A')).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('logs and keeps retrying when a scheduled reconnect also fails', async () => {
+    vi.useFakeTimers();
+    try {
+      const { client } = makeClient();
+      const voice = await import('@discordjs/voice');
+      // Every Ready wait times out → the initial connect and its retry both fail.
+      vi.mocked(voice.entersState).mockRejectedValue(new Error('still timing out'));
+
+      await expect(mod.connect(client as never, 'guild-A', 'chan-1')).rejects.toThrow('still timing out');
+      const joinsAfterFirst = vi.mocked(voice.joinVoiceChannel).mock.calls.length;
+
+      // Firing the retry exercises the timer callback's connect().catch path.
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(vi.mocked(voice.joinVoiceChannel).mock.calls.length).toBeGreaterThan(joinsAfterFirst);
+      expect(mod.isConnected('guild-A')).toBe(false);
     } finally {
       vi.useRealTimers();
     }

--- a/src/audio/audioPlayer.test.ts
+++ b/src/audio/audioPlayer.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock('../shared/config', () => ({ DISCORD_VOICE_CHANNEL_ID: 'default-vc' }));
+vi.mock('../shared/statusStore', () => ({
+  setVoiceConnected: vi.fn(),
+  setVoiceDisconnected: vi.fn(),
+  setVoiceIdle: vi.fn(),
+}));
+vi.mock('../discord/discordUtils', () => ({
+  isPermanentVoiceMisconfigurationError: vi.fn(() => false),
+}));
+vi.mock('../shared/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+vi.mock('discord.js', () => ({
+  Client: vi.fn(),
+  ChannelType: { GuildVoice: 2 },
+}));
+
+// Each joinVoiceChannel call returns a fresh fake connection so per-guild
+// state can be asserted independently.
+function makeConnection() {
+  return {
+    on: vi.fn().mockReturnThis(),
+    subscribe: vi.fn(),
+    destroy: vi.fn(),
+    state: { status: 'ready' },
+  };
+}
+const createdConnections: ReturnType<typeof makeConnection>[] = [];
+
+vi.mock('@discordjs/voice', () => ({
+  createAudioPlayer: vi.fn(() => ({ on: vi.fn(), stop: vi.fn(), play: vi.fn() })),
+  joinVoiceChannel: vi.fn(() => {
+    const conn = makeConnection();
+    createdConnections.push(conn);
+    return conn;
+  }),
+  entersState: vi.fn().mockResolvedValue(undefined),
+  AudioPlayerStatus: { Idle: 'idle' },
+  VoiceConnectionStatus: { Ready: 'ready', Signalling: 'signalling', Connecting: 'connecting', Disconnected: 'disconnected', Destroyed: 'destroyed' },
+  NoSubscriberBehavior: { Pause: 'pause' },
+}));
+
+type AudioPlayerModule = typeof import('./audioPlayer');
+
+let mod: AudioPlayerModule;
+
+// A fake Discord client whose channel lookups succeed for any guild/channel by
+// default; individual tests override channels.fetch to exercise failure paths.
+function makeClient(channelType: number = 2) {
+  const channelsFetch = vi.fn(async (channelId: string) => ({
+    id: channelId,
+    type: channelType,
+    name: `vc-${channelId}`,
+    client: { on: vi.fn(), off: vi.fn(), getMaxListeners: () => 10, setMaxListeners: vi.fn() },
+    guild: { shard: { send: vi.fn() } },
+  }));
+  const client = {
+    guilds: {
+      fetch: vi.fn(async (guildId: string) => ({ id: guildId, channels: { fetch: channelsFetch } })),
+    },
+  };
+  return { client, channelsFetch };
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  createdConnections.length = 0;
+  mod = await import('./audioPlayer.js') as AudioPlayerModule;
+});
+
+describe('connect', () => {
+  it('joins the requested channel in the requested guild', async () => {
+    const { client } = makeClient();
+    const voice = await import('@discordjs/voice');
+    const status = await import('../shared/statusStore.js');
+
+    await mod.connect(client as never, 'guild-A', 'chan-1');
+
+    expect(vi.mocked(voice.joinVoiceChannel)).toHaveBeenCalledWith(
+      expect.objectContaining({ guildId: 'guild-A', channelId: 'chan-1' }),
+    );
+    expect(mod.isConnected('guild-A')).toBe(true);
+    expect(mod.getCurrentChannelId('guild-A')).toBe('chan-1');
+    expect(vi.mocked(status.setVoiceConnected)).toHaveBeenCalledWith('vc-chan-1');
+  });
+
+  it('falls back to the default channel when none is given', async () => {
+    const { client } = makeClient();
+    const voice = await import('@discordjs/voice');
+
+    await mod.connect(client as never, 'guild-A');
+
+    expect(vi.mocked(voice.joinVoiceChannel)).toHaveBeenCalledWith(
+      expect.objectContaining({ channelId: 'default-vc' }),
+    );
+  });
+
+  it('rejects and stays disconnected when the channel is not a voice channel', async () => {
+    const { client } = makeClient(0 /* not GuildVoice */);
+
+    await expect(mod.connect(client as never, 'guild-A', 'text-chan')).rejects.toThrow('not a voice channel');
+    expect(mod.isConnected('guild-A')).toBe(false);
+  });
+});
+
+describe('per-guild isolation', () => {
+  it('tracks connections for two guilds independently', async () => {
+    const a = makeClient();
+    const b = makeClient();
+
+    await mod.connect(a.client as never, 'guild-A', 'chan-A');
+    await mod.connect(b.client as never, 'guild-B', 'chan-B');
+
+    expect(mod.isConnected('guild-A')).toBe(true);
+    expect(mod.isConnected('guild-B')).toBe(true);
+    expect(mod.isConnected()).toBe(true);
+    expect(mod.getCurrentChannelId('guild-A')).toBe('chan-A');
+    expect(mod.getCurrentChannelId('guild-B')).toBe('chan-B');
+  });
+
+  it('disconnecting one guild leaves the other connected and does not clear global voice status', async () => {
+    const a = makeClient();
+    const b = makeClient();
+    const status = await import('../shared/statusStore.js');
+    await mod.connect(a.client as never, 'guild-A', 'chan-A');
+    await mod.connect(b.client as never, 'guild-B', 'chan-B');
+    vi.mocked(status.setVoiceDisconnected).mockClear();
+
+    mod.disconnect('guild-A');
+
+    expect(mod.isConnected('guild-A')).toBe(false);
+    expect(mod.isConnected('guild-B')).toBe(true);
+    // Another guild is still connected, so the shared/global voice status must not be cleared.
+    expect(vi.mocked(status.setVoiceDisconnected)).not.toHaveBeenCalled();
+  });
+
+  it('disconnect() with no guild tears down every guild and clears voice status', async () => {
+    const a = makeClient();
+    const b = makeClient();
+    const status = await import('../shared/statusStore.js');
+    await mod.connect(a.client as never, 'guild-A', 'chan-A');
+    await mod.connect(b.client as never, 'guild-B', 'chan-B');
+    vi.mocked(status.setVoiceDisconnected).mockClear();
+
+    mod.disconnect();
+
+    expect(mod.isConnected('guild-A')).toBe(false);
+    expect(mod.isConnected('guild-B')).toBe(false);
+    expect(mod.isConnected()).toBe(false);
+    expect(vi.mocked(status.setVoiceDisconnected)).toHaveBeenCalled();
+  });
+});
+
+describe('isConnected / getCurrentChannelId for unknown guilds', () => {
+  it('reports not connected and null channel without throwing', () => {
+    expect(mod.isConnected('never-seen')).toBe(false);
+    expect(mod.getCurrentChannelId('never-seen')).toBeNull();
+  });
+});

--- a/src/audio/audioPlayer.test.ts
+++ b/src/audio/audioPlayer.test.ts
@@ -120,6 +120,16 @@ describe('connect', () => {
     expect(mod.isConnected('guild-A')).toBe(false);
   });
 
+  it('rejects and stays disconnected when the channel does not exist in the guild (cross-guild channel ID)', async () => {
+    const { client, channelsFetch } = makeClient();
+    // guild.channels.fetch returns null for a channel that belongs to a different guild.
+    channelsFetch.mockResolvedValueOnce(null as never);
+
+    await expect(mod.connect(client as never, 'guild-A', 'chan-from-other-guild'))
+      .rejects.toThrow('not a voice channel');
+    expect(mod.isConnected('guild-A')).toBe(false);
+  });
+
   it('rejects when the guild ID is missing', async () => {
     const { client } = makeClient();
     const utils = await import('../discord/discordUtils.js');

--- a/src/audio/audioPlayer.test.ts
+++ b/src/audio/audioPlayer.test.ts
@@ -162,6 +162,38 @@ describe('per-guild isolation', () => {
     expect(vi.mocked(status.setVoiceDisconnected)).not.toHaveBeenCalled();
   });
 
+  it('a scheduled reconnect in one guild does not affect the other guild', async () => {
+    vi.useFakeTimers();
+    try {
+      const a = makeClient();
+      const b = makeClient();
+      const voice = await import('@discordjs/voice');
+
+      // Guild-A fails to connect → reconnect timer scheduled.
+      vi.mocked(voice.entersState).mockRejectedValueOnce(new Error('guild-A timeout'));
+      await expect(mod.connect(a.client as never, 'guild-A', 'chan-A')).rejects.toThrow('guild-A timeout');
+      expect(mod.isConnected('guild-A')).toBe(false);
+
+      // Guild-B connects successfully.
+      await mod.connect(b.client as never, 'guild-B', 'chan-B');
+      expect(mod.isConnected('guild-B')).toBe(true);
+
+      const joinCountBeforeTimer = vi.mocked(voice.joinVoiceChannel).mock.calls.length;
+
+      // Guild-A's reconnect timer fires and also fails; guild-B must be unaffected.
+      vi.mocked(voice.entersState).mockRejectedValue(new Error('still failing'));
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(mod.isConnected('guild-B')).toBe(true);
+      expect(mod.getCurrentChannelId('guild-B')).toBe('chan-B');
+      // Guild-A retried (one extra join), guild-B did not.
+      expect(vi.mocked(voice.joinVoiceChannel).mock.calls.length).toBeGreaterThan(joinCountBeforeTimer);
+      expect(mod.isConnected('guild-A')).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('disconnect() with no guild tears down every guild and clears voice status', async () => {
     const a = makeClient();
     const b = makeClient();
@@ -183,6 +215,13 @@ describe('isConnected / getCurrentChannelId for unknown guilds', () => {
   it('reports not connected and null channel without throwing', () => {
     expect(mod.isConnected('never-seen')).toBe(false);
     expect(mod.getCurrentChannelId('never-seen')).toBeNull();
+  });
+
+  it('disconnect() on a never-connected guild is a no-op and does not allocate state', async () => {
+    const status = await import('../shared/statusStore.js');
+    mod.disconnect('never-connected');
+    expect(mod.isConnected('never-connected')).toBe(false);
+    expect(vi.mocked(status.setVoiceDisconnected)).not.toHaveBeenCalled();
   });
 });
 
@@ -228,6 +267,23 @@ describe('reconnect', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('a second connect() to the same guild supersedes an in-flight one at the next await point', async () => {
+    const { client } = makeClient();
+    const voice = await import('@discordjs/voice');
+
+    // Start two connects without awaiting the first. The second call increments
+    // currentAttemptId before the first connect reaches its next checkpoint
+    // (guilds.fetch resolves as a microtask), so the first connect exits silently.
+    const firstConnect = mod.connect(client as never, 'guild-A', 'chan-1');
+    await mod.connect(client as never, 'guild-A', 'chan-2');
+    await firstConnect; // already resolved early — must not throw
+
+    expect(mod.isConnected('guild-A')).toBe(true);
+    expect(mod.getCurrentChannelId('guild-A')).toBe('chan-2');
+    // First connect exits before joinVoiceChannel; only one join total.
+    expect(vi.mocked(voice.joinVoiceChannel).mock.calls.length).toBe(1);
   });
 
   it('clears a pending reconnect timer when connect is called again', async () => {

--- a/src/audio/audioPlayer.test.ts
+++ b/src/audio/audioPlayer.test.ts
@@ -70,6 +70,17 @@ beforeEach(async () => {
   vi.resetModules();
   vi.clearAllMocks();
   createdConnections.length = 0;
+  // clearAllMocks resets call history but not implementations, so restore the
+  // default happy-path behaviour explicitly (tests below override per-case).
+  const voice = await import('@discordjs/voice');
+  vi.mocked(voice.entersState).mockReset().mockResolvedValue(undefined as never);
+  vi.mocked(voice.createAudioPlayer).mockReset()
+    .mockImplementation(() => ({ on: vi.fn(), stop: vi.fn(), play: vi.fn() }) as never);
+  vi.mocked(voice.joinVoiceChannel).mockReset().mockImplementation(() => {
+    const conn = makeConnection();
+    createdConnections.push(conn);
+    return conn as never;
+  });
   mod = await import('./audioPlayer.js') as AudioPlayerModule;
 });
 
@@ -160,5 +171,111 @@ describe('isConnected / getCurrentChannelId for unknown guilds', () => {
   it('reports not connected and null channel without throwing', () => {
     expect(mod.isConnected('never-seen')).toBe(false);
     expect(mod.getCurrentChannelId('never-seen')).toBeNull();
+  });
+});
+
+describe('reconnect', () => {
+  it('schedules a reconnect after a failed connect and retries when the timer fires', async () => {
+    vi.useFakeTimers();
+    try {
+      const { client } = makeClient();
+      const voice = await import('@discordjs/voice');
+      // First join attempt times out waiting for Ready → connect rejects.
+      vi.mocked(voice.entersState).mockRejectedValueOnce(new Error('ready timeout'));
+
+      await expect(mod.connect(client as never, 'guild-A', 'chan-1')).rejects.toThrow('ready timeout');
+      expect(mod.isConnected('guild-A')).toBe(false);
+      const joinsAfterFirst = vi.mocked(voice.joinVoiceChannel).mock.calls.length;
+
+      // The scheduled retry (entersState now resolves) should connect successfully.
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(vi.mocked(voice.joinVoiceChannel).mock.calls.length).toBeGreaterThan(joinsAfterFirst);
+      expect(mod.isConnected('guild-A')).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears a pending reconnect timer when connect is called again', async () => {
+    vi.useFakeTimers();
+    try {
+      const { client } = makeClient();
+      const voice = await import('@discordjs/voice');
+      vi.mocked(voice.entersState).mockRejectedValueOnce(new Error('ready timeout'));
+
+      await expect(mod.connect(client as never, 'guild-A', 'chan-1')).rejects.toThrow();
+      // A retry timer is pending; an explicit reconnect must cancel it.
+      await mod.connect(client as never, 'guild-A', 'chan-2');
+      expect(mod.isConnected('guild-A')).toBe(true);
+
+      const joinsBefore = vi.mocked(voice.joinVoiceChannel).mock.calls.length;
+      await vi.advanceTimersByTimeAsync(60_000);
+      // The cancelled timer must not trigger a further join.
+      expect(vi.mocked(voice.joinVoiceChannel).mock.calls.length).toBe(joinsBefore);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('tears down and clears voice status when a live connection drops', async () => {
+    vi.useFakeTimers();
+    try {
+      const { client } = makeClient();
+      const voice = await import('@discordjs/voice');
+      const status = await import('../shared/statusStore.js');
+      await mod.connect(client as never, 'guild-A', 'chan-1');
+      expect(mod.isConnected('guild-A')).toBe(true);
+
+      const conn = createdConnections[0];
+      const dropHandler = conn.on.mock.calls.find(([e]) => e === 'disconnected')?.[1] as () => Promise<void>;
+      vi.mocked(status.setVoiceDisconnected).mockClear();
+      // The Signalling/Connecting recovery race fails → the connection is torn down.
+      vi.mocked(voice.entersState).mockRejectedValue(new Error('gone'));
+
+      await dropHandler();
+
+      expect(mod.isConnected('guild-A')).toBe(false);
+      expect(conn.destroy).toHaveBeenCalled();
+      expect(vi.mocked(status.setVoiceDisconnected)).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('shared audio player', () => {
+  it('Idle handler clears the playing flag and reports idle status', async () => {
+    const { client } = makeClient();
+    const voice = await import('@discordjs/voice');
+    const status = await import('../shared/statusStore.js');
+    const fakePlayer = { on: vi.fn(), stop: vi.fn(), play: vi.fn() };
+    vi.mocked(voice.createAudioPlayer).mockReturnValue(fakePlayer as never);
+
+    await mod.connect(client as never, 'guild-A', 'chan-1');
+    mod.startPlayback({} as never);
+    expect(mod.isPlaying()).toBe(true);
+
+    const idleHandler = fakePlayer.on.mock.calls.find(([e]) => e === 'idle')?.[1] as () => void;
+    idleHandler();
+
+    expect(mod.isPlaying()).toBe(false);
+    expect(vi.mocked(status.setVoiceIdle)).toHaveBeenCalled();
+  });
+
+  it('error handler resets the playing flag', async () => {
+    const { client } = makeClient();
+    const voice = await import('@discordjs/voice');
+    const fakePlayer = { on: vi.fn(), stop: vi.fn(), play: vi.fn() };
+    vi.mocked(voice.createAudioPlayer).mockReturnValue(fakePlayer as never);
+
+    await mod.connect(client as never, 'guild-A', 'chan-1');
+    mod.startPlayback({} as never);
+    expect(mod.isPlaying()).toBe(true);
+
+    const errorHandler = fakePlayer.on.mock.calls.find(([e]) => e === 'error')?.[1] as (err: Error) => void;
+    errorHandler(new Error('decode failed'));
+
+    expect(mod.isPlaying()).toBe(false);
   });
 });

--- a/src/audio/audioPlayer.test.ts
+++ b/src/audio/audioPlayer.test.ts
@@ -126,7 +126,7 @@ describe('connect', () => {
     // Treat the misconfiguration as permanent so no reconnect timer is scheduled.
     vi.mocked(utils.isPermanentVoiceMisconfigurationError).mockReturnValue(true);
 
-    await expect(mod.connect(client as never, '', 'chan-1')).rejects.toThrow('Missing guild ID or voice channel ID');
+    await expect(mod.connect(client as never, '', 'chan-1')).rejects.toThrow('Missing DISCORD_GUILD_ID or voice channel ID');
     expect(client.guilds.fetch).not.toHaveBeenCalled();
   });
 });

--- a/src/audio/audioPlayer.ts
+++ b/src/audio/audioPlayer.ts
@@ -189,7 +189,9 @@ export async function connect(client: Client, guildId: string, channelId?: strin
     const resolvedChannelId = channelId || DISCORD_VOICE_CHANNEL_ID;
 
     if (!guildId || !resolvedChannelId) {
-      throw new Error('Missing guild ID or voice channel ID');
+      // Message text must stay in sync with isPermanentVoiceMisconfigurationError
+      // so this is classified as permanent (not retried).
+      throw new Error('Missing DISCORD_GUILD_ID or voice channel ID');
     }
 
     // Fetching the channel from the target guild also validates that the channel

--- a/src/audio/audioPlayer.ts
+++ b/src/audio/audioPlayer.ts
@@ -320,7 +320,11 @@ export function getCurrentChannelId(guildId: string): string | null {
   return states.get(guildId)?.currentChannelId ?? null;
 }
 
-/** Marks playback as active and sends the resource to the shared audio player. */
+/**
+ * Marks playback as active and sends the resource to the shared audio player.
+ *
+ * @param resource - The audio resource to play.
+ */
 export function startPlayback(resource: AudioResource): void {
   playing = true;
   getPlayer().play(resource);

--- a/src/audio/audioPlayer.ts
+++ b/src/audio/audioPlayer.ts
@@ -93,6 +93,7 @@ const RECONNECT_BASE_DELAY_MS = 5_000;
 const RECONNECT_MAX_DELAY_MS = 60_000;
 const VOICE_CONNECT_TIMEOUT_MS = 30_000;
 
+/** Cancels and nulls any pending reconnect timer for the given guild state. */
 function clearReconnectTimer(state: GuildVoiceState): void {
   if (state.reconnectTimer) {
     clearTimeout(state.reconnectTimer);
@@ -100,6 +101,7 @@ function clearReconnectTimer(state: GuildVoiceState): void {
   }
 }
 
+/** Schedules an exponential-backoff voice reconnect for a guild, skipping if one is already pending. */
 function scheduleReconnect(state: GuildVoiceState, reason: string): void {
   if (!state.shouldAutoReconnect || !state.client || state.reconnectTimer || state.connection) return;
 
@@ -118,6 +120,7 @@ function scheduleReconnect(state: GuildVoiceState, reason: string): void {
   }, delay);
 }
 
+/** Returns the shared audio player, lazily creating it with idle and error handlers on first use. */
 function getPlayer(): DjsAudioPlayer {
   if (!player) {
     player = createAudioPlayer({
@@ -153,6 +156,7 @@ function tearDownGuild(state: GuildVoiceState): void {
   }
 }
 
+/** Builds the ConnectionHandlerDeps callbacks bound to a specific guild's mutable voice state. */
 function makeDeps(state: GuildVoiceState): ConnectionHandlerDeps {
   return {
     getAttemptId: () => state.currentAttemptId,

--- a/src/audio/audioPlayer.ts
+++ b/src/audio/audioPlayer.ts
@@ -9,15 +9,14 @@ import {
   type AudioResource,
   type VoiceConnection,
   type AudioPlayer as DjsAudioPlayer,
-  type DiscordGatewayAdapterCreator,
-  type DiscordGatewayAdapterLibraryMethods,
 } from '@discordjs/voice';
-import { Client, ChannelType, type VoiceBasedChannel } from 'discord.js';
+import { Client, ChannelType } from 'discord.js';
 import { DISCORD_VOICE_CHANNEL_ID } from '../shared/config';
 import { setVoiceConnected, setVoiceDisconnected, setVoiceIdle } from '../shared/statusStore';
 
 const log = createLogger('AudioPlayer');
 import { isPermanentVoiceMisconfigurationError } from '../discord/discordUtils';
+import { createVoiceAdapterFactory, type VoiceAdapterFactory } from './voiceAdapter';
 import {
   type ConnectionHandlerDeps,
   setupConnectionHandlers,
@@ -32,11 +31,12 @@ import {
 // by guild ID. The reconnect state machine (attempt IDs, timers, backoff) runs
 // independently per guild so a drop in one guild never disturbs another.
 //
-// NOTE: the @discordjs/voice AudioPlayer below is still a single shared instance
-// (Pitfall #7 in the plan): only one guild can play audio at a time, and a
-// resource sent to the player is heard on every connection currently subscribed.
-// That is acceptable for the single-guild deployment (one connection) and is
-// documented as an MVP limitation; true concurrency needs a per-guild player.
+// The @discordjs/voice AudioPlayer below is intentionally a single shared
+// instance (Pitfall #7 in the plan): only one guild can play audio at a time,
+// and a resource sent to the player is heard on every connection currently
+// subscribed. That is acceptable for the single-guild deployment (one
+// connection) and is documented as an MVP limitation; true concurrency needs a
+// per-guild player.
 
 interface GuildVoiceState {
   guildId: string;
@@ -48,8 +48,8 @@ interface GuildVoiceState {
   reconnectAttempts: number;
   shouldAutoReconnect: boolean;
   currentAttemptId: number;
-  // Cleanup for this guild's active raw-gateway adapter listener (see buildAdapter).
-  activeAdapterCleanup: (() => void) | null;
+  // Builds this guild's raw-gateway voice adapters and tracks their cleanup.
+  adapterFactory: VoiceAdapterFactory;
 }
 
 const states = new Map<string, GuildVoiceState>();
@@ -68,7 +68,7 @@ function getState(guildId: string): GuildVoiceState {
       reconnectAttempts: 0,
       shouldAutoReconnect: false,
       currentAttemptId: 0,
-      activeAdapterCleanup: null,
+      adapterFactory: createVoiceAdapterFactory(),
     };
     states.set(guildId, state);
   }
@@ -86,69 +86,6 @@ function anyConnected(): boolean {
 // Single shared audio player (see note above).
 let player: DjsAudioPlayer;
 let playing = false;
-
-// ─── Voice adapter ────────────────────────────────────────────────────────────
-// Bypasses discord.js's built-in voiceAdapterCreator to avoid type/version
-// incompatibilities with discord.js v14. Listens to raw gateway events instead.
-
-type RawPacket = { t: string; d: Record<string, unknown> };
-
-function makeOnRaw(methods: DiscordGatewayAdapterLibraryMethods): (packet: RawPacket) => void {
-  return function onRaw(packet: RawPacket): void {
-    if (packet.t === 'VOICE_STATE_UPDATE') {
-      methods.onVoiceStateUpdate(packet.d as unknown as Parameters<typeof methods.onVoiceStateUpdate>[0]);
-    }
-    if (packet.t === 'VOICE_SERVER_UPDATE') {
-      methods.onVoiceServerUpdate(packet.d as unknown as Parameters<typeof methods.onVoiceServerUpdate>[0]);
-    }
-  };
-}
-
-function makeAdapterCleanup(
-  channel: VoiceBasedChannel,
-  onRaw: (packet: RawPacket) => void,
-  originalMax: number,
-  state: GuildVoiceState,
-): () => void {
-  let cleanedUp = false;
-  return function cleanup(): void {
-    if (cleanedUp) return;
-    cleanedUp = true;
-    channel.client.off('raw', onRaw);
-    if (originalMax !== 0) channel.client.setMaxListeners(originalMax);
-    state.activeAdapterCleanup = null;
-  };
-}
-
-function buildAdapter(channel: VoiceBasedChannel, state: GuildVoiceState): DiscordGatewayAdapterCreator {
-  return (methods: DiscordGatewayAdapterLibraryMethods) => {
-    // Tear down this guild's previous adapter before registering a new one so
-    // raw-gateway listeners do not accumulate across reconnects.
-    if (state.activeAdapterCleanup) state.activeAdapterCleanup();
-
-    const onRaw = makeOnRaw(methods);
-    const originalMax = channel.client.getMaxListeners();
-    // 0 means unlimited — don't touch it.
-    if (originalMax !== 0) channel.client.setMaxListeners(originalMax + 1);
-    channel.client.on('raw', onRaw);
-
-    const cleanup = makeAdapterCleanup(channel, onRaw, originalMax, state);
-    state.activeAdapterCleanup = cleanup;
-
-    return {
-      sendPayload: (payload: unknown) => {
-        try {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          channel.guild.shard.send(payload as any);
-          return true;
-        } catch {
-          return false;
-        }
-      },
-      destroy: cleanup,
-    };
-  };
-}
 
 // ─── Reconnect ────────────────────────────────────────────────────────────────
 
@@ -270,7 +207,7 @@ export async function connect(client: Client, guildId: string, channelId?: strin
     nextConnection = joinVoiceChannel({
       channelId: channel.id,
       guildId: guild.id,
-      adapterCreator: buildAdapter(channel, state),
+      adapterCreator: state.adapterFactory.build(channel),
       selfDeaf: false,
       selfMute: false,
     });

--- a/src/audio/audioPlayer.ts
+++ b/src/audio/audioPlayer.ts
@@ -13,7 +13,7 @@ import {
   type DiscordGatewayAdapterLibraryMethods,
 } from '@discordjs/voice';
 import { Client, ChannelType, type VoiceBasedChannel } from 'discord.js';
-import { DISCORD_GUILD_ID, DISCORD_VOICE_CHANNEL_ID } from '../shared/config';
+import { DISCORD_VOICE_CHANNEL_ID } from '../shared/config';
 import { setVoiceConnected, setVoiceDisconnected, setVoiceIdle } from '../shared/statusStore';
 
 const log = createLogger('AudioPlayer');
@@ -25,24 +25,71 @@ import {
   cleanupFailedConnect,
 } from './audioConnectionHandlers';
 
-let connection: VoiceConnection | null = null;
+// ─── Per-guild voice state ──────────────────────────────────────────────────
+//
+// The bot can hold one voice connection per guild, so every connection-related
+// field that used to be a module singleton now lives in a per-guild record keyed
+// by guild ID. The reconnect state machine (attempt IDs, timers, backoff) runs
+// independently per guild so a drop in one guild never disturbs another.
+//
+// NOTE: the @discordjs/voice AudioPlayer below is still a single shared instance
+// (Pitfall #7 in the plan): only one guild can play audio at a time, and a
+// resource sent to the player is heard on every connection currently subscribed.
+// That is acceptable for the single-guild deployment (one connection) and is
+// documented as an MVP limitation; true concurrency needs a per-guild player.
+
+interface GuildVoiceState {
+  guildId: string;
+  connection: VoiceConnection | null;
+  currentChannelId: string | null;
+  targetChannelId: string | undefined;
+  client: Client | null;
+  reconnectTimer: NodeJS.Timeout | null;
+  reconnectAttempts: number;
+  shouldAutoReconnect: boolean;
+  currentAttemptId: number;
+  // Cleanup for this guild's active raw-gateway adapter listener (see buildAdapter).
+  activeAdapterCleanup: (() => void) | null;
+}
+
+const states = new Map<string, GuildVoiceState>();
+
+/** Returns the voice state for a guild, creating an empty record on first use. */
+function getState(guildId: string): GuildVoiceState {
+  let state = states.get(guildId);
+  if (!state) {
+    state = {
+      guildId,
+      connection: null,
+      currentChannelId: null,
+      targetChannelId: undefined,
+      client: null,
+      reconnectTimer: null,
+      reconnectAttempts: 0,
+      shouldAutoReconnect: false,
+      currentAttemptId: 0,
+      activeAdapterCleanup: null,
+    };
+    states.set(guildId, state);
+  }
+  return state;
+}
+
+/** True if any guild currently holds a live voice connection. */
+function anyConnected(): boolean {
+  for (const state of states.values()) {
+    if (state.connection) return true;
+  }
+  return false;
+}
+
+// Single shared audio player (see note above).
 let player: DjsAudioPlayer;
 let playing = false;
-let activeClient: Client | null = null;
-let reconnectTimer: NodeJS.Timeout | null = null;
-let reconnectAttempts = 0;
-let shouldAutoReconnect = false;
-let currentAttemptId = 0;
-let currentChannelId: string | null = null;
-let targetChannelId: string | undefined = undefined;
 
 // ─── Voice adapter ────────────────────────────────────────────────────────────
 // Bypasses discord.js's built-in voiceAdapterCreator to avoid type/version
 // incompatibilities with discord.js v14. Listens to raw gateway events instead.
-
-// Tracks the cleanup function for the currently active adapter so it can be
-// removed before a new one is registered, preventing listener accumulation.
-let activeAdapterCleanup: (() => void) | null = null;
 
 type RawPacket = { t: string; d: Record<string, unknown> };
 
@@ -61,6 +108,7 @@ function makeAdapterCleanup(
   channel: VoiceBasedChannel,
   onRaw: (packet: RawPacket) => void,
   originalMax: number,
+  state: GuildVoiceState,
 ): () => void {
   let cleanedUp = false;
   return function cleanup(): void {
@@ -68,13 +116,15 @@ function makeAdapterCleanup(
     cleanedUp = true;
     channel.client.off('raw', onRaw);
     if (originalMax !== 0) channel.client.setMaxListeners(originalMax);
-    activeAdapterCleanup = null;
+    state.activeAdapterCleanup = null;
   };
 }
 
-function buildAdapter(channel: VoiceBasedChannel): DiscordGatewayAdapterCreator {
+function buildAdapter(channel: VoiceBasedChannel, state: GuildVoiceState): DiscordGatewayAdapterCreator {
   return (methods: DiscordGatewayAdapterLibraryMethods) => {
-    if (activeAdapterCleanup) activeAdapterCleanup();
+    // Tear down this guild's previous adapter before registering a new one so
+    // raw-gateway listeners do not accumulate across reconnects.
+    if (state.activeAdapterCleanup) state.activeAdapterCleanup();
 
     const onRaw = makeOnRaw(methods);
     const originalMax = channel.client.getMaxListeners();
@@ -82,8 +132,8 @@ function buildAdapter(channel: VoiceBasedChannel): DiscordGatewayAdapterCreator 
     if (originalMax !== 0) channel.client.setMaxListeners(originalMax + 1);
     channel.client.on('raw', onRaw);
 
-    const cleanup = makeAdapterCleanup(channel, onRaw, originalMax);
-    activeAdapterCleanup = cleanup;
+    const cleanup = makeAdapterCleanup(channel, onRaw, originalMax, state);
+    state.activeAdapterCleanup = cleanup;
 
     return {
       sendPayload: (payload: unknown) => {
@@ -106,27 +156,27 @@ const RECONNECT_BASE_DELAY_MS = 5_000;
 const RECONNECT_MAX_DELAY_MS = 60_000;
 const VOICE_CONNECT_TIMEOUT_MS = 30_000;
 
-function clearReconnectTimer(): void {
-  if (reconnectTimer) {
-    clearTimeout(reconnectTimer);
-    reconnectTimer = null;
+function clearReconnectTimer(state: GuildVoiceState): void {
+  if (state.reconnectTimer) {
+    clearTimeout(state.reconnectTimer);
+    state.reconnectTimer = null;
   }
 }
 
-function scheduleReconnect(reason: string): void {
-  if (!shouldAutoReconnect || !activeClient || reconnectTimer || connection) return;
+function scheduleReconnect(state: GuildVoiceState, reason: string): void {
+  if (!state.shouldAutoReconnect || !state.client || state.reconnectTimer || state.connection) return;
 
-  const scheduledAttemptId = currentAttemptId;
-  const delay = Math.min(RECONNECT_BASE_DELAY_MS * 2 ** reconnectAttempts, RECONNECT_MAX_DELAY_MS);
-  reconnectAttempts += 1;
+  const scheduledAttemptId = state.currentAttemptId;
+  const delay = Math.min(RECONNECT_BASE_DELAY_MS * 2 ** state.reconnectAttempts, RECONNECT_MAX_DELAY_MS);
+  state.reconnectAttempts += 1;
 
-  log.warn(`Scheduling voice rejoin in ${delay}ms (${reason}).`);
-  reconnectTimer = setTimeout(() => {
-    reconnectTimer = null;
-    if (scheduledAttemptId !== currentAttemptId) return;
-    if (!shouldAutoReconnect || !activeClient || connection) return;
-    connect(activeClient, targetChannelId).catch((err) => {
-      log.error('Voice rejoin failed:', err);
+  log.warn(`Scheduling voice rejoin for guild ${state.guildId} in ${delay}ms (${reason}).`);
+  state.reconnectTimer = setTimeout(() => {
+    state.reconnectTimer = null;
+    if (scheduledAttemptId !== state.currentAttemptId) return;
+    if (!state.shouldAutoReconnect || !state.client || state.connection) return;
+    connect(state.client, state.guildId, state.targetChannelId).catch((err) => {
+      log.error(`Voice rejoin failed for guild ${state.guildId}:`, err);
     });
   }, delay);
 }
@@ -148,69 +198,84 @@ function getPlayer(): DjsAudioPlayer {
   return player;
 }
 
-function tearDownPlayer(): void {
-  try {
-    getPlayer().stop(true);
-  } catch {
-    // Ignore audio stop errors during disconnect cleanup.
+/**
+ * Releases a guild's playback footprint after its connection is gone. Only stops
+ * the shared player / clears the global playing status once no guild remains
+ * connected, so tearing down one guild never silences another.
+ */
+function tearDownGuild(state: GuildVoiceState): void {
+  state.currentChannelId = null;
+  if (!anyConnected()) {
+    try {
+      getPlayer().stop(true);
+    } catch {
+      // Ignore audio stop errors during disconnect cleanup.
+    }
+    playing = false;
+    setVoiceDisconnected();
   }
-  playing = false;
-  currentChannelId = null;
-  setVoiceDisconnected();
 }
 
-function makeDeps(): ConnectionHandlerDeps {
+function makeDeps(state: GuildVoiceState): ConnectionHandlerDeps {
   return {
-    getAttemptId: () => currentAttemptId,
-    getConnection: () => connection,
-    setConnection: (c) => { connection = c; },
-    tearDown: tearDownPlayer,
-    scheduleReconnect,
+    getAttemptId: () => state.currentAttemptId,
+    getConnection: () => state.connection,
+    setConnection: (c) => { state.connection = c; },
+    tearDown: () => tearDownGuild(state),
+    scheduleReconnect: (reason) => scheduleReconnect(state, reason),
   };
 }
 
 /**
- * Join the specified voice channel or the configured one and subscribe the audio player.
+ * Join a voice channel in the given guild and subscribe the audio player.
  * Should be called once the Discord client is ready.
+ *
+ * @param client - The ready Discord client.
+ * @param guildId - The guild whose voice channel to join (BIGINT snowflake string).
+ * @param channelId - Target voice channel ID; falls back to the legacy default when omitted.
+ * @returns Resolves once the connection is ready, or rejects if the join fails.
  */
-export async function connect(client: Client, channelId?: string): Promise<void> {
-  clearReconnectTimer();
-  const attemptId = ++currentAttemptId;
+export async function connect(client: Client, guildId: string, channelId?: string): Promise<void> {
+  const state = getState(guildId);
+  clearReconnectTimer(state);
+  const attemptId = ++state.currentAttemptId;
   let nextConnection: VoiceConnection | null = null;
 
-  activeClient = client;
-  targetChannelId = channelId;
-  shouldAutoReconnect = true;
+  state.client = client;
+  state.targetChannelId = channelId;
+  state.shouldAutoReconnect = true;
 
-  const previousConnection = connection;
-  const deps = makeDeps();
+  const previousConnection = state.connection;
+  const deps = makeDeps(state);
 
   try {
     const resolvedChannelId = channelId || DISCORD_VOICE_CHANNEL_ID;
 
-    if (!DISCORD_GUILD_ID || !resolvedChannelId) {
-      throw new Error('Missing DISCORD_GUILD_ID or voice channel ID');
+    if (!guildId || !resolvedChannelId) {
+      throw new Error('Missing guild ID or voice channel ID');
     }
 
-    const guild = await client.guilds.fetch(DISCORD_GUILD_ID);
-    if (attemptId !== currentAttemptId) return;
+    // Fetching the channel from the target guild also validates that the channel
+    // belongs to that guild — a channel from another guild resolves to null here.
+    const guild = await client.guilds.fetch(guildId);
+    if (attemptId !== state.currentAttemptId) return;
 
     const channel = await guild.channels.fetch(resolvedChannelId);
-    if (attemptId !== currentAttemptId) return;
+    if (attemptId !== state.currentAttemptId) return;
 
     if (!channel || channel.type !== ChannelType.GuildVoice) {
-      throw new Error(`Channel ${resolvedChannelId} is not a voice channel`);
+      throw new Error(`Channel ${resolvedChannelId} is not a voice channel in guild ${guildId}`);
     }
 
     nextConnection = joinVoiceChannel({
       channelId: channel.id,
       guildId: guild.id,
-      adapterCreator: buildAdapter(channel),
+      adapterCreator: buildAdapter(channel, state),
       selfDeaf: false,
       selfMute: false,
     });
 
-    if (attemptId !== currentAttemptId) {
+    if (attemptId !== state.currentAttemptId) {
       nextConnection.destroy();
       return;
     }
@@ -220,81 +285,103 @@ export async function connect(client: Client, channelId?: string): Promise<void>
 
     await entersState(joinedConnection, VoiceConnectionStatus.Ready, VOICE_CONNECT_TIMEOUT_MS);
 
-    if (attemptId !== currentAttemptId) {
+    if (attemptId !== state.currentAttemptId) {
       joinedConnection.destroy();
       return;
     }
 
     releasePreviousConnection(previousConnection, joinedConnection, deps);
-    connection = joinedConnection;
-    currentChannelId = channel.id;
+    state.connection = joinedConnection;
+    state.currentChannelId = channel.id;
 
-    clearReconnectTimer();
-    log.info('Voice connection ready.');
-    reconnectAttempts = 0;
+    clearReconnectTimer(state);
+    log.info(`Voice connection ready for guild ${guildId}.`);
+    state.reconnectAttempts = 0;
 
     joinedConnection.subscribe(getPlayer());
     setVoiceConnected(channel.name);
     log.info(`Joined voice channel: ${channel.name}`);
   } catch (err) {
-    if (attemptId === currentAttemptId) {
+    if (attemptId === state.currentAttemptId) {
       cleanupFailedConnect(previousConnection, nextConnection, deps);
     } else {
       nextConnection?.destroy();
     }
 
-    if (attemptId === currentAttemptId && shouldAutoReconnect && !isPermanentVoiceMisconfigurationError(err)) {
-      scheduleReconnect('connect failed');
+    if (attemptId === state.currentAttemptId && state.shouldAutoReconnect && !isPermanentVoiceMisconfigurationError(err)) {
+      scheduleReconnect(state, 'connect failed');
     }
 
     throw err;
   }
 }
 
-/**
- * Disconnect from the current voice channel, if connected.
- * Safe to call when already disconnected.
- */
-export function disconnect(): void {
-  currentAttemptId += 1;
-  shouldAutoReconnect = false;
-  activeClient = null;
-  targetChannelId = undefined;
-  clearReconnectTimer();
-  reconnectAttempts = 0;
-  currentChannelId = null;
+/** Tears down a single guild's voice connection and reconnect state. */
+function disconnectGuild(state: GuildVoiceState): void {
+  state.currentAttemptId += 1;
+  state.shouldAutoReconnect = false;
+  state.client = null;
+  state.targetChannelId = undefined;
+  clearReconnectTimer(state);
+  state.reconnectAttempts = 0;
+  state.currentChannelId = null;
 
-  const existingConnection = connection;
+  const existingConnection = state.connection;
   if (existingConnection) {
     existingConnection.destroy();
-    connection = null;
-    try {
-      getPlayer().stop(true);
-    } catch {
-      // Ignore audio stop errors during disconnect cleanup.
+    state.connection = null;
+    if (!anyConnected()) {
+      try {
+        getPlayer().stop(true);
+      } catch {
+        // Ignore audio stop errors during disconnect cleanup.
+      }
+      playing = false;
+      setVoiceDisconnected();
     }
-    playing = false;
-    setVoiceDisconnected();
-    log.info('Disconnected from voice channel.');
+    log.info(`Disconnected from voice channel for guild ${state.guildId}.`);
   }
 }
 
-/** Returns true if a sound is currently being played. */
+/**
+ * Disconnect from a guild's voice channel, or from every guild when no guild is
+ * given. Safe to call when already disconnected.
+ *
+ * @param guildId - Guild to disconnect; omit to disconnect all guilds (e.g. on shutdown).
+ */
+export function disconnect(guildId?: string): void {
+  if (guildId === undefined) {
+    for (const state of states.values()) disconnectGuild(state);
+    return;
+  }
+  disconnectGuild(getState(guildId));
+}
+
+/** Returns true if a sound is currently being played (shared across guilds). */
 export function isPlaying(): boolean {
   return playing;
 }
 
-/** Returns true if the bot is currently joined to a voice channel. */
-export function isConnected(): boolean {
-  return connection !== null;
+/**
+ * Returns true if the bot is joined to a voice channel.
+ *
+ * @param guildId - Restrict the check to one guild; omit to test whether any guild is connected.
+ */
+export function isConnected(guildId?: string): boolean {
+  if (guildId === undefined) return anyConnected();
+  return states.get(guildId)?.connection != null;
 }
 
-/** Returns the current voice channel ID if connected, null otherwise. */
-export function getCurrentChannelId(): string | null {
-  return currentChannelId;
+/**
+ * Returns the current voice channel ID for a guild, or null if not connected there.
+ *
+ * @param guildId - Guild to read the current channel for.
+ */
+export function getCurrentChannelId(guildId: string): string | null {
+  return states.get(guildId)?.currentChannelId ?? null;
 }
 
-/** Marks playback as active and sends the resource to the audio player. */
+/** Marks playback as active and sends the resource to the shared audio player. */
 export function startPlayback(resource: AudioResource): void {
   playing = true;
   getPlayer().play(resource);

--- a/src/audio/audioPlayer.ts
+++ b/src/audio/audioPlayer.ts
@@ -293,7 +293,8 @@ export function disconnect(guildId?: string): void {
     for (const state of states.values()) disconnectGuild(state);
     return;
   }
-  disconnectGuild(getState(guildId));
+  const state = states.get(guildId);
+  if (state) disconnectGuild(state);
 }
 
 /** Returns true if a sound is currently being played (shared across guilds). */

--- a/src/audio/voiceAdapter.test.ts
+++ b/src/audio/voiceAdapter.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createVoiceAdapterFactory } from './voiceAdapter';
+
+// Minimal fake voice channel exposing only what the adapter touches.
+function makeChannel() {
+  const shardSend = vi.fn();
+  const client = {
+    on: vi.fn(),
+    off: vi.fn(),
+    getMaxListeners: vi.fn(() => 10),
+    setMaxListeners: vi.fn(),
+  };
+  const channel = { client, guild: { shard: { send: shardSend } } };
+  return { channel, client, shardSend };
+}
+
+const methods = {
+  onVoiceStateUpdate: vi.fn(),
+  onVoiceServerUpdate: vi.fn(),
+} as never;
+
+describe('createVoiceAdapterFactory', () => {
+  it('registers a raw listener and raises the max-listener cap on build', () => {
+    const { channel, client } = makeChannel();
+    const factory = createVoiceAdapterFactory();
+
+    factory.build(channel as never)(methods);
+
+    expect(client.on).toHaveBeenCalledWith('raw', expect.any(Function));
+    expect(client.setMaxListeners).toHaveBeenCalledWith(11);
+  });
+
+  it('tears down the previous adapter before registering a new one (no listener accumulation)', () => {
+    const { channel, client } = makeChannel();
+    const factory = createVoiceAdapterFactory();
+
+    factory.build(channel as never)(methods);
+    expect(client.off).not.toHaveBeenCalled();
+
+    // Second build for the same guild must clean up the first listener.
+    factory.build(channel as never)(methods);
+    expect(client.off).toHaveBeenCalledWith('raw', expect.any(Function));
+    expect(client.setMaxListeners).toHaveBeenLastCalledWith(11);
+  });
+
+  it('destroy() removes the listener and restores the original cap', () => {
+    const { channel, client } = makeChannel();
+    const factory = createVoiceAdapterFactory();
+
+    const adapter = factory.build(channel as never)(methods);
+    adapter.destroy();
+
+    expect(client.off).toHaveBeenCalledWith('raw', expect.any(Function));
+    expect(client.setMaxListeners).toHaveBeenLastCalledWith(10);
+  });
+
+  it('sendPayload routes through the guild shard and reports success/failure', () => {
+    const { channel, shardSend } = makeChannel();
+    const factory = createVoiceAdapterFactory();
+    const adapter = factory.build(channel as never)(methods);
+
+    expect(adapter.sendPayload({ op: 4 })).toBe(true);
+    expect(shardSend).toHaveBeenCalledWith({ op: 4 });
+
+    shardSend.mockImplementationOnce(() => { throw new Error('shard down'); });
+    expect(adapter.sendPayload({ op: 4 })).toBe(false);
+  });
+
+  it('leaves an unlimited (0) max-listener cap untouched', () => {
+    const { channel, client } = makeChannel();
+    client.getMaxListeners.mockReturnValue(0);
+    const factory = createVoiceAdapterFactory();
+
+    factory.build(channel as never)(methods);
+
+    expect(client.setMaxListeners).not.toHaveBeenCalled();
+  });
+
+  it('forwards raw voice packets to the matching gateway method', () => {
+    const { channel, client } = makeChannel();
+    const factory = createVoiceAdapterFactory();
+    const localMethods = { onVoiceStateUpdate: vi.fn(), onVoiceServerUpdate: vi.fn() } as never;
+
+    factory.build(channel as never)(localMethods);
+    const onRaw = client.on.mock.calls[0][1] as (p: unknown) => void;
+
+    onRaw({ t: 'VOICE_STATE_UPDATE', d: { a: 1 } });
+    onRaw({ t: 'VOICE_SERVER_UPDATE', d: { b: 2 } });
+    onRaw({ t: 'SOMETHING_ELSE', d: {} });
+
+    expect((localMethods as { onVoiceStateUpdate: ReturnType<typeof vi.fn> }).onVoiceStateUpdate)
+      .toHaveBeenCalledWith({ a: 1 });
+    expect((localMethods as { onVoiceServerUpdate: ReturnType<typeof vi.fn> }).onVoiceServerUpdate)
+      .toHaveBeenCalledWith({ b: 2 });
+  });
+});

--- a/src/audio/voiceAdapter.test.ts
+++ b/src/audio/voiceAdapter.test.ts
@@ -2,13 +2,16 @@ import { describe, it, expect, vi } from 'vitest';
 import { createVoiceAdapterFactory } from './voiceAdapter';
 
 // Minimal fake voice channel exposing only what the adapter touches.
+// getMaxListeners/setMaxListeners are stateful so the incremental cap bookkeeping
+// can be tested accurately.
 function makeChannel() {
   const shardSend = vi.fn();
+  let cap = 10;
   const client = {
     on: vi.fn(),
     off: vi.fn(),
-    getMaxListeners: vi.fn(() => 10),
-    setMaxListeners: vi.fn(),
+    getMaxListeners: vi.fn(() => cap),
+    setMaxListeners: vi.fn((n: number) => { cap = n; }),
   };
   const channel = { client, guild: { shard: { send: shardSend } } };
   return { channel, client, shardSend };
@@ -74,6 +77,31 @@ describe('createVoiceAdapterFactory', () => {
     factory.build(channel as never)(methods);
 
     expect(client.setMaxListeners).not.toHaveBeenCalled();
+  });
+
+  it('two guild adapters sharing a client restore the baseline cap regardless of destroy order', () => {
+    let cap = 10;
+    const sharedClient = {
+      on: vi.fn(),
+      off: vi.fn(),
+      getMaxListeners: vi.fn(() => cap),
+      setMaxListeners: vi.fn((n: number) => { cap = n; }),
+    };
+    const channelA = { client: sharedClient, guild: { shard: { send: vi.fn() } } };
+    const channelB = { client: sharedClient, guild: { shard: { send: vi.fn() } } };
+
+    const factoryA = createVoiceAdapterFactory();
+    const factoryB = createVoiceAdapterFactory();
+    const adapterA = factoryA.build(channelA as never)(methods);
+    const adapterB = factoryB.build(channelB as never)(methods);
+    expect(cap).toBe(12);
+
+    // Destroy A first — the snapshot approach would leave cap at 11 after B also
+    // destroys (B's snapshot was 11, not the true baseline of 10).
+    adapterA.destroy();
+    expect(cap).toBe(11);
+    adapterB.destroy();
+    expect(cap).toBe(10);
   });
 
   it('forwards raw voice packets to the matching gateway method', () => {

--- a/src/audio/voiceAdapter.ts
+++ b/src/audio/voiceAdapter.ts
@@ -1,5 +1,6 @@
 import type {
   DiscordGatewayAdapterCreator,
+  DiscordGatewayAdapterImplementerMethods,
   DiscordGatewayAdapterLibraryMethods,
 } from '@discordjs/voice';
 import type { VoiceBasedChannel } from 'discord.js';
@@ -7,8 +8,16 @@ import type { VoiceBasedChannel } from 'discord.js';
 // ─── Voice adapter ────────────────────────────────────────────────────────────
 // Bypasses discord.js's built-in voiceAdapterCreator to avoid type/version
 // incompatibilities with discord.js v14. Listens to raw gateway events instead.
+//
+// The pieces are kept as flat module-level helpers (rather than closures nested
+// inside the factory) so each stays simple and independently testable.
 
 type RawPacket = { t: string; d: Record<string, unknown> };
+
+/** Tracks the cleanup for a guild's currently-registered adapter listener. */
+interface AdapterCleanupState {
+  activeCleanup: (() => void) | null;
+}
 
 function makeOnRaw(methods: DiscordGatewayAdapterLibraryMethods): (packet: RawPacket) => void {
   return function onRaw(packet: RawPacket): void {
@@ -19,6 +28,58 @@ function makeOnRaw(methods: DiscordGatewayAdapterLibraryMethods): (packet: RawPa
       methods.onVoiceServerUpdate(packet.d as unknown as Parameters<typeof methods.onVoiceServerUpdate>[0]);
     }
   };
+}
+
+/** Builds the idempotent cleanup that removes the raw listener and restores the cap. */
+function makeCleanup(
+  channel: VoiceBasedChannel,
+  onRaw: (packet: RawPacket) => void,
+  originalMax: number,
+  state: AdapterCleanupState,
+): () => void {
+  let cleanedUp = false;
+  return function cleanup(): void {
+    if (cleanedUp) return;
+    cleanedUp = true;
+    channel.client.off('raw', onRaw);
+    if (originalMax !== 0) channel.client.setMaxListeners(originalMax);
+    state.activeCleanup = null;
+  };
+}
+
+function makeSendPayload(channel: VoiceBasedChannel): (payload: unknown) => boolean {
+  return function sendPayload(payload: unknown): boolean {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      channel.guild.shard.send(payload as any);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+}
+
+/**
+ * Registers a raw-gateway adapter for one connection, tearing down the guild's
+ * previous adapter first so listeners do not accumulate across reconnects.
+ */
+function registerAdapter(
+  channel: VoiceBasedChannel,
+  methods: DiscordGatewayAdapterLibraryMethods,
+  state: AdapterCleanupState,
+): DiscordGatewayAdapterImplementerMethods {
+  if (state.activeCleanup) state.activeCleanup();
+
+  const onRaw = makeOnRaw(methods);
+  const originalMax = channel.client.getMaxListeners();
+  // 0 means unlimited — don't touch it.
+  if (originalMax !== 0) channel.client.setMaxListeners(originalMax + 1);
+  channel.client.on('raw', onRaw);
+
+  const cleanup = makeCleanup(channel, onRaw, originalMax, state);
+  state.activeCleanup = cleanup;
+
+  return { sendPayload: makeSendPayload(channel), destroy: cleanup };
 }
 
 /** Builds the gateway adapter creators for one guild's voice connections. */
@@ -35,43 +96,8 @@ export interface VoiceAdapterFactory {
  * @returns A factory whose `build` produces channel-bound adapter creators.
  */
 export function createVoiceAdapterFactory(): VoiceAdapterFactory {
-  let activeCleanup: (() => void) | null = null;
-
-  function build(channel: VoiceBasedChannel): DiscordGatewayAdapterCreator {
-    return (methods: DiscordGatewayAdapterLibraryMethods) => {
-      // Tear down the previous adapter before registering a new one.
-      if (activeCleanup) activeCleanup();
-
-      const onRaw = makeOnRaw(methods);
-      const originalMax = channel.client.getMaxListeners();
-      // 0 means unlimited — don't touch it.
-      if (originalMax !== 0) channel.client.setMaxListeners(originalMax + 1);
-      channel.client.on('raw', onRaw);
-
-      let cleanedUp = false;
-      const cleanup = (): void => {
-        if (cleanedUp) return;
-        cleanedUp = true;
-        channel.client.off('raw', onRaw);
-        if (originalMax !== 0) channel.client.setMaxListeners(originalMax);
-        activeCleanup = null;
-      };
-      activeCleanup = cleanup;
-
-      return {
-        sendPayload: (payload: unknown) => {
-          try {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            channel.guild.shard.send(payload as any);
-            return true;
-          } catch {
-            return false;
-          }
-        },
-        destroy: cleanup,
-      };
-    };
-  }
-
-  return { build };
+  const state: AdapterCleanupState = { activeCleanup: null };
+  return {
+    build: (channel) => (methods) => registerAdapter(channel, methods, state),
+  };
 }

--- a/src/audio/voiceAdapter.ts
+++ b/src/audio/voiceAdapter.ts
@@ -19,6 +19,7 @@ interface AdapterCleanupState {
   activeCleanup: (() => void) | null;
 }
 
+/** Creates the raw-gateway event handler that routes voice state and server update packets to the library. */
 function makeOnRaw(methods: DiscordGatewayAdapterLibraryMethods): (packet: RawPacket) => void {
   return function onRaw(packet: RawPacket): void {
     if (packet.t === 'VOICE_STATE_UPDATE') {
@@ -49,6 +50,7 @@ function makeCleanup(
   };
 }
 
+/** Creates the gateway payload sender that routes voice data through the channel's guild shard. */
 function makeSendPayload(channel: VoiceBasedChannel): (payload: unknown) => boolean {
   return function sendPayload(payload: unknown): boolean {
     try {

--- a/src/audio/voiceAdapter.ts
+++ b/src/audio/voiceAdapter.ts
@@ -30,11 +30,11 @@ function makeOnRaw(methods: DiscordGatewayAdapterLibraryMethods): (packet: RawPa
   };
 }
 
-/** Builds the idempotent cleanup that removes the raw listener and restores the cap. */
+/** Builds the idempotent cleanup that removes the raw listener and decrements the cap. */
 function makeCleanup(
   channel: VoiceBasedChannel,
   onRaw: (packet: RawPacket) => void,
-  originalMax: number,
+  increment: number,
   state: AdapterCleanupState,
 ): () => void {
   let cleanedUp = false;
@@ -42,7 +42,9 @@ function makeCleanup(
     if (cleanedUp) return;
     cleanedUp = true;
     channel.client.off('raw', onRaw);
-    if (originalMax !== 0) channel.client.setMaxListeners(originalMax);
+    // Decrement rather than restore to a snapshot so that cross-guild adapters
+    // sharing the same client do not race each other's cap bookkeeping.
+    if (increment > 0) channel.client.setMaxListeners(channel.client.getMaxListeners() - increment);
     state.activeCleanup = null;
   };
 }
@@ -71,12 +73,13 @@ function registerAdapter(
   if (state.activeCleanup) state.activeCleanup();
 
   const onRaw = makeOnRaw(methods);
-  const originalMax = channel.client.getMaxListeners();
+  const currentMax = channel.client.getMaxListeners();
   // 0 means unlimited — don't touch it.
-  if (originalMax !== 0) channel.client.setMaxListeners(originalMax + 1);
+  const increment = currentMax !== 0 ? 1 : 0;
+  if (increment > 0) channel.client.setMaxListeners(currentMax + 1);
   channel.client.on('raw', onRaw);
 
-  const cleanup = makeCleanup(channel, onRaw, originalMax, state);
+  const cleanup = makeCleanup(channel, onRaw, increment, state);
   state.activeCleanup = cleanup;
 
   return { sendPayload: makeSendPayload(channel), destroy: cleanup };

--- a/src/audio/voiceAdapter.ts
+++ b/src/audio/voiceAdapter.ts
@@ -84,7 +84,12 @@ function registerAdapter(
 
 /** Builds the gateway adapter creators for one guild's voice connections. */
 export interface VoiceAdapterFactory {
-  /** Returns an adapter creator bound to the given voice channel. */
+  /**
+   * Returns an adapter creator bound to the given voice channel.
+   *
+   * @param channel - The voice channel the adapter will relay gateway events for.
+   * @returns A `DiscordGatewayAdapterCreator` that can be passed to `joinVoiceChannel`.
+   */
   build(channel: VoiceBasedChannel): DiscordGatewayAdapterCreator;
 }
 

--- a/src/audio/voiceAdapter.ts
+++ b/src/audio/voiceAdapter.ts
@@ -1,0 +1,77 @@
+import type {
+  DiscordGatewayAdapterCreator,
+  DiscordGatewayAdapterLibraryMethods,
+} from '@discordjs/voice';
+import type { VoiceBasedChannel } from 'discord.js';
+
+// ─── Voice adapter ────────────────────────────────────────────────────────────
+// Bypasses discord.js's built-in voiceAdapterCreator to avoid type/version
+// incompatibilities with discord.js v14. Listens to raw gateway events instead.
+
+type RawPacket = { t: string; d: Record<string, unknown> };
+
+function makeOnRaw(methods: DiscordGatewayAdapterLibraryMethods): (packet: RawPacket) => void {
+  return function onRaw(packet: RawPacket): void {
+    if (packet.t === 'VOICE_STATE_UPDATE') {
+      methods.onVoiceStateUpdate(packet.d as unknown as Parameters<typeof methods.onVoiceStateUpdate>[0]);
+    }
+    if (packet.t === 'VOICE_SERVER_UPDATE') {
+      methods.onVoiceServerUpdate(packet.d as unknown as Parameters<typeof methods.onVoiceServerUpdate>[0]);
+    }
+  };
+}
+
+/** Builds the gateway adapter creators for one guild's voice connections. */
+export interface VoiceAdapterFactory {
+  /** Returns an adapter creator bound to the given voice channel. */
+  build(channel: VoiceBasedChannel): DiscordGatewayAdapterCreator;
+}
+
+/**
+ * Creates a per-guild adapter factory that tracks the active raw-gateway listener
+ * and tears down the previous one before registering a new adapter, so listeners
+ * never accumulate across that guild's reconnects.
+ *
+ * @returns A factory whose `build` produces channel-bound adapter creators.
+ */
+export function createVoiceAdapterFactory(): VoiceAdapterFactory {
+  let activeCleanup: (() => void) | null = null;
+
+  function build(channel: VoiceBasedChannel): DiscordGatewayAdapterCreator {
+    return (methods: DiscordGatewayAdapterLibraryMethods) => {
+      // Tear down the previous adapter before registering a new one.
+      if (activeCleanup) activeCleanup();
+
+      const onRaw = makeOnRaw(methods);
+      const originalMax = channel.client.getMaxListeners();
+      // 0 means unlimited — don't touch it.
+      if (originalMax !== 0) channel.client.setMaxListeners(originalMax + 1);
+      channel.client.on('raw', onRaw);
+
+      let cleanedUp = false;
+      const cleanup = (): void => {
+        if (cleanedUp) return;
+        cleanedUp = true;
+        channel.client.off('raw', onRaw);
+        if (originalMax !== 0) channel.client.setMaxListeners(originalMax);
+        activeCleanup = null;
+      };
+      activeCleanup = cleanup;
+
+      return {
+        sendPayload: (payload: unknown) => {
+          try {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            channel.guild.shard.send(payload as any);
+            return true;
+          } catch {
+            return false;
+          }
+        },
+        destroy: cleanup,
+      };
+    };
+  }
+
+  return { build };
+}

--- a/src/web/routes/api.test.ts
+++ b/src/web/routes/api.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../middleware', () => ({
+  requireAuth: (_req: any, _res: any, next: any) => next(),
+  requireMod: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock('../csrf', () => ({
+  csrfProtection: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock('../../shared/statusStore', () => ({
+  getStatus: vi.fn(),
+}));
+
+vi.mock('../../audio/audioPlayer', () => ({
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+  getCurrentChannelId: vi.fn(),
+}));
+
+vi.mock('../../discord/discordBot', () => ({
+  getDiscordClient: vi.fn(),
+}));
+
+vi.mock('../../discord/discordUtils', () => ({
+  getAvailableVoiceChannels: vi.fn(),
+}));
+
+vi.mock('../../shared/config', () => ({
+  DISCORD_GUILD_ID: 'guild-123',
+  DISCORD_VOICE_CHANNEL_ID: 'default-vc',
+}));
+
+vi.mock('./shared', () => ({
+  normalizeDiscordId: (s: string) => (/^\d{17,20}$/.test(s) ? s : null),
+}));
+
+vi.mock('../../shared/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+}));
+
+import express from 'express';
+import supertest from 'supertest';
+import router from './api';
+import { getStatus } from '../../shared/statusStore';
+import { connect, disconnect, getCurrentChannelId } from '../../audio/audioPlayer';
+import { getDiscordClient } from '../../discord/discordBot';
+import { getAvailableVoiceChannels } from '../../discord/discordUtils';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getStatus).mockReturnValue({ discord: {}, voice: {}, twitch: {}, tiktok: {} } as never);
+  vi.mocked(getDiscordClient).mockReturnValue({} as never);
+  vi.mocked(connect).mockResolvedValue(undefined);
+  vi.mocked(getCurrentChannelId).mockReturnValue('current-vc');
+  vi.mocked(getAvailableVoiceChannels).mockResolvedValue([]);
+});
+
+describe('GET /status', () => {
+  it('returns the status snapshot', async () => {
+    const res = await supertest(buildApp()).get('/status').expect(200);
+    expect(res.body).toEqual({ discord: {}, voice: {}, twitch: {}, tiktok: {} });
+  });
+});
+
+describe('GET /voice/channels', () => {
+  it('reports the current channel for the configured guild', async () => {
+    const res = await supertest(buildApp()).get('/voice/channels').expect(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      defaultChannelId: 'default-vc',
+      currentChannelId: 'current-vc',
+    });
+    expect(vi.mocked(getCurrentChannelId)).toHaveBeenCalledWith('guild-123');
+  });
+
+  it('returns 500 when channel lookup fails', async () => {
+    vi.mocked(getAvailableVoiceChannels).mockRejectedValue(new Error('Discord down'));
+    const res = await supertest(buildApp()).get('/voice/channels').expect(500);
+    expect(res.body).toMatchObject({ ok: false });
+  });
+});
+
+describe('POST /voice/join', () => {
+  it('disconnects then joins the requested channel for the configured guild', async () => {
+    const res = await supertest(buildApp())
+      .post('/voice/join')
+      .send({ channelId: '123456789012345678' })
+      .expect(200);
+
+    expect(res.body).toEqual({ ok: true });
+    expect(vi.mocked(disconnect)).toHaveBeenCalledWith('guild-123');
+    expect(vi.mocked(connect)).toHaveBeenCalledWith({}, 'guild-123', '123456789012345678');
+  });
+
+  it('falls back to the default channel when no channelId is given', async () => {
+    await supertest(buildApp()).post('/voice/join').send({}).expect(200);
+    expect(vi.mocked(connect)).toHaveBeenCalledWith({}, 'guild-123', undefined);
+  });
+
+  it('returns 400 for a non-string channelId', async () => {
+    await supertest(buildApp()).post('/voice/join').send({ channelId: 123 }).expect(400);
+    expect(vi.mocked(connect)).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for an invalid channel ID', async () => {
+    await supertest(buildApp()).post('/voice/join').send({ channelId: 'not-a-snowflake' }).expect(400);
+    expect(vi.mocked(connect)).not.toHaveBeenCalled();
+  });
+
+  it('returns 503 when the Discord client is not ready', async () => {
+    vi.mocked(getDiscordClient).mockReturnValue(null as never);
+    await supertest(buildApp()).post('/voice/join').send({ channelId: '123456789012345678' }).expect(503);
+    expect(vi.mocked(connect)).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when connect throws', async () => {
+    vi.mocked(connect).mockRejectedValue(new Error('No permission'));
+    const res = await supertest(buildApp())
+      .post('/voice/join')
+      .send({ channelId: '123456789012345678' })
+      .expect(500);
+    expect(res.body).toMatchObject({ ok: false });
+  });
+});
+
+describe('POST /voice/leave', () => {
+  it('disconnects the configured guild and returns ok', async () => {
+    const res = await supertest(buildApp()).post('/voice/leave').expect(200);
+    expect(res.body).toEqual({ ok: true });
+    expect(vi.mocked(disconnect)).toHaveBeenCalledWith('guild-123');
+  });
+});

--- a/src/web/routes/api.ts
+++ b/src/web/routes/api.ts
@@ -25,7 +25,7 @@ router.get('/voice/channels', requireMod, async (_req, res) => {
       ok: true,
       channels,
       defaultChannelId: DISCORD_VOICE_CHANNEL_ID,
-      currentChannelId: getCurrentChannelId(),
+      currentChannelId: getCurrentChannelId(DISCORD_GUILD_ID),
     });
   } catch (err) {
     log.error('Failed to list voice channels:', err);
@@ -53,8 +53,8 @@ router.post('/voice/join', requireMod, csrfProtection, async (req, res) => {
     }
     const resolvedChannelId = trimmedChannelId || undefined;
 
-    disconnect();
-    await connect(discordClient, resolvedChannelId);
+    disconnect(DISCORD_GUILD_ID);
+    await connect(discordClient, DISCORD_GUILD_ID, resolvedChannelId);
     res.json({ ok: true });
   } catch (err) {
     log.error('Voice rejoin failed:', err);
@@ -64,7 +64,7 @@ router.post('/voice/join', requireMod, csrfProtection, async (req, res) => {
 
 // Leave the voice channel — Mod and above
 router.post('/voice/leave', requireMod, csrfProtection, (_req, res) => {
-  disconnect();
+  disconnect(DISCORD_GUILD_ID);
   res.json({ ok: true });
 });
 

--- a/src/web/routes/streamdeck.test.ts
+++ b/src/web/routes/streamdeck.test.ts
@@ -303,6 +303,7 @@ describe('POST /voice/leave', () => {
     const res = await supertest(buildApp()).post('/voice/leave').expect(200);
 
     expect(res.body).toEqual({ ok: true });
-    expect(vi.mocked(disconnect)).toHaveBeenCalled();
+    // Leaving must be scoped to the configured guild, not an unscoped disconnect.
+    expect(vi.mocked(disconnect)).toHaveBeenCalledWith('guild-123');
   });
 });

--- a/src/web/routes/streamdeck.test.ts
+++ b/src/web/routes/streamdeck.test.ts
@@ -282,8 +282,8 @@ describe('POST /voice/join', () => {
       .expect(200);
 
     expect(res.body).toEqual({ ok: true });
-    expect(vi.mocked(disconnect)).toHaveBeenCalled();
-    expect(vi.mocked(connect)).toHaveBeenCalledWith({}, '123456789012345678');
+    expect(vi.mocked(disconnect)).toHaveBeenCalledWith('guild-123');
+    expect(vi.mocked(connect)).toHaveBeenCalledWith({}, 'guild-123', '123456789012345678');
   });
 
   it('returns 500 when connect throws', async () => {

--- a/src/web/routes/streamdeck.ts
+++ b/src/web/routes/streamdeck.ts
@@ -105,8 +105,8 @@ router.post('/voice/join', requireApiKey, async (req, res) => {
   }
 
   try {
-    disconnect();
-    await connect(discordClient, normalizedChannelId);
+    disconnect(DISCORD_GUILD_ID);
+    await connect(discordClient, DISCORD_GUILD_ID, normalizedChannelId);
     res.json({ ok: true });
   } catch (err) {
     log.error('Voice join failed:', err);
@@ -115,7 +115,7 @@ router.post('/voice/join', requireApiKey, async (req, res) => {
 });
 
 router.post('/voice/leave', requireApiKey, (_req, res) => {
-  disconnect();
+  disconnect(DISCORD_GUILD_ID);
   res.json({ ok: true });
 });
 


### PR DESCRIPTION
## Voice slice — per-guild connection map + explicit `guildId`

The focused follow-up to PR #273 (runtime guild-awareness), per the plan's "splitting valve": PR 2 → (runtime plumbing, merged) + (voice). This isolates the reconnect state machine — the riskiest file in the codebase — into its own change.

Like every multi-guild PR so far, this has **no observable effect on the single-guild bot**: `guildId` resolves to the one legacy guild everywhere.

### What changed

**`src/audio/audioPlayer.ts`** — module-singleton voice state → `Map<guildId, GuildVoiceState>`
- The bot can now hold one voice connection per guild, each with an **independent reconnect state machine** (attempt IDs, timers, backoff). A drop in one guild no longer disturbs another.
- `connect(client, guildId, channelId?)` — `guildId` is now explicit and required. Fetching the channel from the target guild also **validates the channel belongs to that guild** (a cross-guild channel ID resolves to null → rejected). Closes Security §4 for the voice join path.
- `disconnect(guildId?)` — disconnects one guild, or **every guild when called with no argument** (the shutdown path in `index.ts`).
- `isConnected(guildId?)` / `getCurrentChannelId(guildId)` are guild-aware. The shared/global voice status is only cleared once **no** guild remains connected.

**`src/web/routes/api.ts`, `src/web/routes/streamdeck.ts`** — thread the legacy guild id (`DISCORD_GUILD_ID`) through `connect` / `disconnect` / `getCurrentChannelId`. Behaviour identical on the single guild.

### Deliberately out of scope (deferred to PR 3)

- **Single shared `AudioPlayer`** retained — `isPlaying()` / `startPlayback()` stay global. Only one guild can play audio at a time, and a resource is heard on every currently-subscribed connection. This is the accepted MVP limitation from the plan (Pitfall #7); true concurrency needs a per-guild player. It is harmless today (one connection) and documented in-code.
- **`statusStore` voice/ready state stays global.** Per-guild voice status only becomes *useful* once `/status` is scoped to the session's `currentGuildId`, which requires the web-panel guild context landing in PR 3. Splitting it out now would be a speculative data-model change with no consumer (and would drag the guild-less Twitch/Streamdeck SFX path into the change). It is correct as-is for a single shared player.

### Tests

`src/audio/audioPlayer.test.ts` is **new** — the file previously had zero direct coverage. It exercises per-guild connect, default-channel fallback, non-voice-channel rejection, two-guild isolation, and selective vs. full disconnect (including that the global status is *not* cleared while another guild is still connected).

### Invariant

`npx tsc --noEmit && npm test` — green (1249 tests).

https://claude.ai/code/session_01QfGqskn817m3wmrwDjEqh3

---
_Generated by [Claude Code](https://claude.ai/code/session_01QfGqskn817m3wmrwDjEqh3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated, guild-scoped voice gateway adapter for raw packet handling.
* **Bug Fixes**
  * Improved voice connection, retry, and teardown so reconnect/disconnect effects are isolated to the targeted guild.
  * Playback state is now cleared reliably on voice player idle/error.
* **API Updates**
  * Voice connection controls are now guild-scoped; `getCurrentChannelId` requires a guild id, and routes pass the configured guild id.
* **Tests**
  * Added Vitest coverage for voice adapter behavior, per-guild connection/reconnect flows, and API/streamdeck route handling.
* **Documentation**
  * Added clarifying JSDoc for voice connection handler callbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->