### PR TITLE
Add Forza controller overlay browser source

### DIFF
--- a/public/controller-overlay.js
+++ b/public/controller-overlay.js
@@ -1,0 +1,105 @@
+const $ = id => document.getElementById(id);
+const statusEl = $('status');
+let gamepadIdx = null, polling = false;
+
+function setActive(id, on) {
+  const el = $(id); if (!el) return;
+  if (on) {
+    el.style.filter = 'brightness(3)';
+    el.setAttribute('fill', '#00d4ff');
+  } else {
+    el.style.filter = '';
+    el.setAttribute('fill', id === 'ls-ring' ? '#222' : '#272727');
+  }
+}
+
+function poll() {
+  const gps = navigator.getGamepads();
+  const gp = gps[gamepadIdx];
+  if (!gp) return;
+
+  // A button (index 0) — hand brake
+  setActive('btn-a', gp.buttons[0]?.pressed);
+
+  // Triggers
+  const ltVal = gp.buttons[6]?.value ?? 0;
+  const rtVal = gp.buttons[7]?.value ?? 0;
+  $('lt-fill').setAttribute('width', Math.round(140 * ltVal));
+  $('rt-fill').setAttribute('width', Math.round(140 * rtVal));
+
+  // Left stick
+  const lx = gp.axes[0] ?? 0, ly = gp.axes[1] ?? 0;
+  const R = 26;
+  const lDotX = 85 + lx * R, lDotY = 142 + ly * R;
+  $('ls-dot').setAttribute('cx', lDotX);
+  $('ls-dot').setAttribute('cy', lDotY);
+
+  const lM = Math.abs(lx) > 0.08 || Math.abs(ly) > 0.08;
+  const lsLine = $('ls-line'), lsDot = $('ls-dot'), lsRing = $('ls-ring');
+  if (lM) {
+    lsLine.setAttribute('x2', lDotX); lsLine.setAttribute('y2', lDotY);
+    lsLine.setAttribute('opacity', '0.7');
+    lsDot.setAttribute('fill', '#00d4ff');
+    lsDot.style.filter = 'brightness(1.4)';
+    if (!gp.buttons[10]?.pressed) lsRing.setAttribute('fill', '#0a2a3a');
+    lsRing.setAttribute('stroke', '#00d4ff');
+  } else {
+    lsLine.setAttribute('x2', 85); lsLine.setAttribute('y2', 142);
+    lsLine.setAttribute('opacity', '0');
+    lsDot.setAttribute('fill', '#3a3a3a');
+    lsDot.style.filter = '';
+    if (!gp.buttons[10]?.pressed) lsRing.setAttribute('fill', '#222');
+    lsRing.setAttribute('stroke', '#333');
+  }
+
+  // LS click
+  if (gp.buttons[10]?.pressed) {
+    lsRing.setAttribute('fill', '#00d4ff');
+    lsRing.style.filter = 'brightness(2)';
+  } else {
+    lsRing.style.filter = '';
+  }
+}
+
+function rafLoop() {
+  if (!polling) return;
+  poll();
+  requestAnimationFrame(rafLoop);
+}
+
+function startPolling() {
+  if (polling) return;
+  polling = true;
+  requestAnimationFrame(rafLoop);
+}
+
+function stopPolling() {
+  polling = false;
+}
+
+window.addEventListener('gamepadconnected', e => {
+  gamepadIdx = e.gamepad.index;
+  statusEl.textContent = ''; statusEl.className = 'connected';
+  startPolling();
+});
+
+window.addEventListener('gamepaddisconnected', e => {
+  if (e.gamepad.index === gamepadIdx) {
+    gamepadIdx = null;
+    statusEl.textContent = 'No controller connected'; statusEl.className = '';
+    stopPolling();
+  }
+});
+
+// Fallback poll for browsers that fire gamepadconnected late
+setInterval(() => {
+  if (gamepadIdx !== null) return;
+  const gps = navigator.getGamepads();
+  for (let i = 0; i < gps.length; i++) {
+    if (gps[i]) {
+      gamepadIdx = i;
+      statusEl.textContent = ''; statusEl.className = 'connected';
+      startPolling(); break;
+    }
+  }
+}, 500);

--- a/src/web/routes/overlaySource.test.ts
+++ b/src/web/routes/overlaySource.test.ts
@@ -18,6 +18,12 @@ import router, { MAX_SSE_CONNECTIONS_PER_CHANNEL, connections } from './overlayS
 
 function buildApp() {
   const app = express();
+  // Capture res.render calls as JSON so tests don't need a real view engine.
+  app.use((req, res, next) => {
+    (res as any).render = (view: string, locals?: Record<string, unknown>) =>
+      res.json({ view, ...(locals ?? {}) });
+    next();
+  });
   app.use(router);
   return app;
 }
@@ -25,6 +31,21 @@ function buildApp() {
 beforeEach(() => {
   connections.clear();
   vi.clearAllMocks();
+});
+
+describe('GET /controller', () => {
+  it('returns 200 and renders the controllerOverlay view', async () => {
+    const res = await supertest(buildApp()).get('/controller');
+    expect(res.status).toBe(200);
+    expect(res.body.view).toBe('controllerOverlay');
+  });
+
+  it('is not caught by the :login route — "controller" is in RESERVED_LOGINS', async () => {
+    // /:login renders 'overlaySource'; /controller must render 'controllerOverlay'.
+    const res = await supertest(buildApp()).get('/controller');
+    expect(res.body.view).toBe('controllerOverlay');
+    expect(res.body.view).not.toBe('overlaySource');
+  });
 });
 
 describe('MAX_SSE_CONNECTIONS_PER_CHANNEL', () => {

--- a/src/web/routes/overlaySource.ts
+++ b/src/web/routes/overlaySource.ts
@@ -10,7 +10,7 @@ const router = Router();
 const LOGIN_RE = /^[a-zA-Z0-9_]{1,25}$/;
 const FILENAME_RE = /^[\w-]+\.(webm|mp4)$/i;
 // Words reserved for admin routes — must not be treated as channel logins.
-const RESERVED_LOGINS = new Set(['settings', 'videos']);
+const RESERVED_LOGINS = new Set(['settings', 'videos', 'controller']);
 
 // In-memory map of active SSE connections keyed by Twitch channel login (lowercase).
 export const connections = new Map<string, Set<import('express').Response>>();
@@ -37,6 +37,11 @@ export function pushOverlayEvent(login: string, videoPath: string): void {
   if (clients.size === 0) connections.delete(key);
   log.info(`Pushed overlay event to ${clients.size} client(s) for ${login}`);
 }
+
+// GET /overlay/controller — Forza/gamepad controller browser source (no auth, opened by OBS)
+router.get('/controller', (_req, res) => {
+  res.render('controllerOverlay');
+});
 
 // GET /overlay/:login — browser source HTML page (no auth, opened by OBS)
 router.get('/:login', (req, res, next) => {

--- a/views/controllerOverlay.ejs
+++ b/views/controllerOverlay.ejs
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Controller Overlay</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { background: transparent; }
+    #root { position: relative; display: inline-block; padding: 6px; font-family: 'Segoe UI', sans-serif; }
+    #status { position: absolute; z-index: 10; top: 50%; left: 50%; transform: translate(-50%, -50%); white-space: nowrap; text-align: center; font-size: 16px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: #ffffff; background: rgba(0,0,0,0.85); border: 1px solid rgba(255,255,255,0.15); padding: 10px 20px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.5); }
+    #status.connected { visibility: hidden; }
+  </style>
+</head>
+<body>
+<div id="root">
+  <div id="status">No controller connected</div>
+
+  <svg id="ctrl" viewBox="0 0 320 200" xmlns="http://www.w3.org/2000/svg" width="320" style="display:block">
+    <defs>
+      <clipPath id="lt-clip"><rect x="5" y="5" width="140" height="42" rx="8"/></clipPath>
+      <clipPath id="rt-clip"><rect x="175" y="5" width="140" height="42" rx="8"/></clipPath>
+    </defs>
+
+    <!-- LT / Brake -->
+    <rect x="5" y="5" width="140" height="42" rx="8" fill="#272727" stroke="#383838" stroke-width="1"/>
+    <rect id="lt-fill" x="5" y="5" width="0" height="42" rx="8" fill="#00d4ff" opacity="0.85" clip-path="url(#lt-clip)"/>
+    <text x="75" y="33" text-anchor="middle" font-family="'Segoe UI',sans-serif" font-size="16" font-weight="700" fill="#aaa">BRAKE</text>
+
+    <!-- RT / Throttle -->
+    <rect x="175" y="5" width="140" height="42" rx="8" fill="#272727" stroke="#383838" stroke-width="1"/>
+    <rect id="rt-fill" x="175" y="5" width="0" height="42" rx="8" fill="#00d4ff" opacity="0.85" clip-path="url(#rt-clip)"/>
+    <text x="245" y="33" text-anchor="middle" font-family="'Segoe UI',sans-serif" font-size="16" font-weight="700" fill="#aaa">THROTTLE</text>
+
+    <!-- Left Stick -->
+    <circle cx="85" cy="142" r="55" fill="#111" stroke="#2a2a2a" stroke-width="1.5"/>
+    <circle id="ls-ring" cx="85" cy="142" r="42" fill="#222" stroke="#333" stroke-width="1"/>
+    <line id="ls-line" x1="85" y1="142" x2="85" y2="142" stroke="#00d4ff" stroke-width="2.5" stroke-linecap="round" opacity="0"/>
+    <circle id="ls-dot" cx="85" cy="142" r="17" fill="#3a3a3a"/>
+    <text x="85" y="197" text-anchor="middle" font-family="'Segoe UI',sans-serif" font-size="13" font-weight="700" fill="#555">LS</text>
+
+    <!-- A Button / Hand Brake -->
+    <circle id="btn-a" cx="245" cy="142" r="50" fill="#272727" stroke="#3c3c3c" stroke-width="1"/>
+    <text text-anchor="middle" font-family="'Segoe UI',sans-serif" font-size="16" font-weight="700" fill="#33aa33">
+      <tspan x="245" dy="0" y="134">HAND</tspan>
+      <tspan x="245" dy="20">BRAKE</tspan>
+    </text>
+  </svg>
+</div>
+
+<script src="/controller-overlay.js"></script>
+</body>
+</html>

--- a/views/overlayAdmin.ejs
+++ b/views/overlayAdmin.ejs
@@ -70,7 +70,7 @@
         <div class="card-body">
           <p class="hint hint-compact">Add this URL as a Browser Source in OBS to display a gamepad input visualiser (throttle, brake, steering, handbrake):</p>
           <code class="mono" style="display:block;margin-top:0.4rem;user-select:all;"><%= baseUrl %>/overlay/controller</code>
-          <p class="hint" style="margin-top:0.5rem;">Works with any Xbox / PlayStation / generic controller. Transparent background — resize in OBS as needed.</p>
+          <p class="hint" style="margin-top:0.5rem;">Works with any Xbox / PlayStation / generic controller. Transparent background — native size is <strong>332&times;212px</strong> (set the OBS browser source to these dimensions, then scale to taste).</p>
         </div>
       </div>
     </section>

--- a/views/overlayAdmin.ejs
+++ b/views/overlayAdmin.ejs
@@ -63,6 +63,18 @@
       </div>
     </section>
 
+    <!-- ── Controller Overlay ────────────────────────────────────── -->
+    <section class="section">
+      <h2 class="section-title">Controller Overlay</h2>
+      <div class="card">
+        <div class="card-body">
+          <p class="hint hint-compact">Add this URL as a Browser Source in OBS to display a gamepad input visualiser (throttle, brake, steering, handbrake):</p>
+          <code class="mono" style="display:block;margin-top:0.4rem;user-select:all;"><%= baseUrl %>/overlay/controller</code>
+          <p class="hint" style="margin-top:0.5rem;">Works with any Xbox / PlayStation / generic controller. Transparent background — resize in OBS as needed.</p>
+        </div>
+      </div>
+    </section>
+
     <!-- ── Video Library ──────────────────────────────────────────── -->
     <section class="section">
       <h2 class="section-title">Video Library</h2>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a new unauthenticated route `GET /overlay/controller` that serves a transparent gamepad input visualiser designed to be added as an OBS browser source
- The overlay shows LT (brake), RT (throttle), left stick (steering), and A button (hand brake) — matching the Forza racing layout
- The browser source URL is surfaced in the Overlay settings page alongside the existing video overlay URL

## Implementation notes

- JS extracted to `public/controller-overlay.js` (static file) so it works within the existing `scriptSrc: 'self'` CSP — no inline scripts
- Web Worker timer from the original HTML removed; `requestAnimationFrame` loop alone is sufficient and avoids any `worker-src blob:` CSP issue
- `"controller"` added to `RESERVED_LOGINS` in `overlaySource.ts` so the new dedicated route is never shadowed by the `/:login` param route

## Test plan

- [ ] Navigate to `/overlay/settings` — confirm "Controller Overlay" section appears with the correct URL
- [ ] Open `/overlay/controller` in a browser — confirm transparent background, SVG widget renders
- [ ] Connect a controller — confirm inputs animate (triggers fill, stick moves, A button lights up)
- [ ] Add as OBS browser source, resize to taste

https://claude.ai/code/session_013vUumXeWsKQo8hFhdmmD6C
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_013vUumXeWsKQo8hFhdmmD6C)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a controller overlay that visualizes real-time gamepad input, including stick position, trigger/throttle bars, handbrake button status, and connection state indicators.
  * New configuration section in the overlay admin page with setup instructions and recommended dimensions (332×212px) for integrating the controller overlay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->