### PR TITLE
Fix mobile layout issues on settings and overlay pages

### DIFF
--- a/views/overlayAdmin.ejs
+++ b/views/overlayAdmin.ejs
@@ -57,7 +57,7 @@
         <div class="card-body">
           <p class="hint hint-compact">Add this URL as a Browser Source in OBS (1920×1080, transparent background):</p>
           <% const login = streamer.twitch_name ? streamer.twitch_name.toLowerCase() : ''; %>
-          <code class="mono" style="display:block;margin-top:0.4rem;user-select:all;"><%= baseUrl %>/overlay/<%= login %></code>
+          <code class="mono" style="display:block;margin-top:0.4rem;user-select:all;word-break:break-all;overflow-wrap:anywhere;"><%= baseUrl %>/overlay/<%= login %></code>
           <p class="hint" style="margin-top:0.5rem;">In OBS: Sources → Add → Browser → check "Local file" OFF, paste the URL above.</p>
         </div>
       </div>
@@ -69,7 +69,7 @@
       <div class="card">
         <div class="card-body">
           <p class="hint hint-compact">Add this URL as a Browser Source in OBS to display a gamepad input visualiser (throttle, brake, steering, handbrake):</p>
-          <code class="mono" style="display:block;margin-top:0.4rem;user-select:all;"><%= baseUrl %>/overlay/controller</code>
+          <code class="mono" style="display:block;margin-top:0.4rem;user-select:all;word-break:break-all;overflow-wrap:anywhere;"><%= baseUrl %>/overlay/controller</code>
           <p class="hint" style="margin-top:0.5rem;">Works with any Xbox / PlayStation / generic controller. Transparent background — native size is <strong>332&times;212px</strong> (set the OBS browser source to these dimensions, then scale to taste).</p>
         </div>
       </div>
@@ -108,7 +108,7 @@
       </div>
       <% } else { %>
       <div class="card">
-        <div class="card-body">
+        <div class="table-scroll">
           <table class="table" style="width:100%;">
             <thead>
               <tr>
@@ -209,7 +209,7 @@
           <div class="form-row-wrap" style="align-items:center;justify-content:space-between;">
             <div>
               <p class="hint hint-compact">Reward ID</p>
-              <code class="mono"><%= r.twitch_reward_id %></code>
+              <code class="mono" style="word-break:break-all;overflow-wrap:anywhere;"><%= r.twitch_reward_id %></code>
             </div>
             <form method="POST" action="/overlay/settings/rewards/<%= r.id %>/delete" style="margin:0;">
               <input type="hidden" name="_csrf" value="<%= csrfToken %>">
@@ -220,19 +220,21 @@
             </form>
           </div>
           <% if (r.videos.length > 0) { %>
-          <table class="table" style="width:100%;margin-top:0.75rem;">
-            <thead>
-              <tr><th>Video</th><th>Weight</th></tr>
-            </thead>
-            <tbody>
-              <% for (const v of r.videos) { %>
-              <tr>
-                <td><%= v.name %></td>
-                <td><%= v.weight %></td>
-              </tr>
-              <% } %>
-            </tbody>
-          </table>
+          <div class="table-scroll" style="margin-top:0.75rem;">
+            <table class="table" style="width:100%;">
+              <thead>
+                <tr><th>Video</th><th>Weight</th></tr>
+              </thead>
+              <tbody>
+                <% for (const v of r.videos) { %>
+                <tr>
+                  <td><%= v.name %></td>
+                  <td><%= v.weight %></td>
+                </tr>
+                <% } %>
+              </tbody>
+            </table>
+          </div>
           <% } else { %>
           <p class="hint" style="margin-top:0.5rem;">No videos assigned.</p>
           <% } %>

--- a/views/userSettings.ejs
+++ b/views/userSettings.ejs
@@ -107,7 +107,7 @@
                 Follow notifications <% if (!isConnected) { %><span class="hint">(requires Twitch connection)</span><% } %>
               </label>
               <p class="hint hint-compact">Variables: <code>{username} {display_name}</code></p>
-              <textarea class="input stream-textarea" name="follow_message" rows="1" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.follow_message) ? cfg.follow_message : 'Thanks {display_name} for the follow!' %></textarea>
+              <textarea class="input stream-textarea" name="follow_message" rows="2" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.follow_message) ? cfg.follow_message : 'Thanks {display_name} for the follow!' %></textarea>
             </div>
 
             <div class="form-subsection-gap">
@@ -116,11 +116,11 @@
                 Sub/resub/gift notifications <% if (!isConnected) { %><span class="hint">(requires Twitch connection)</span><% } %>
               </label>
               <p class="hint hint-compact">New sub — variables: <code>{username} {display_name} {tier} {tier_name}</code></p>
-              <textarea class="input stream-textarea" name="sub_message" rows="1" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.sub_message) ? cfg.sub_message : 'Thanks {display_name} for subscribing! (Tier {tier})' %></textarea>
+              <textarea class="input stream-textarea" name="sub_message" rows="2" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.sub_message) ? cfg.sub_message : 'Thanks {display_name} for subscribing! (Tier {tier})' %></textarea>
               <p class="hint hint-compact" style="margin-top:0.4rem;">Resub — variables: <code>{username} {display_name} {tier} {tier_name} {months} {streak}</code></p>
-              <textarea class="input stream-textarea" name="resub_message" rows="1" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.resub_message) ? cfg.resub_message : 'Thanks {display_name} for {months} months! (Tier {tier})' %></textarea>
+              <textarea class="input stream-textarea" name="resub_message" rows="2" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.resub_message) ? cfg.resub_message : 'Thanks {display_name} for {months} months! (Tier {tier})' %></textarea>
               <p class="hint hint-compact" style="margin-top:0.4rem;">Gift sub — variables: <code>{gifter} {gifter_display} {count} {tier} {tier_name}</code></p>
-              <textarea class="input stream-textarea" name="giftsub_message" rows="1" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.giftsub_message) ? cfg.giftsub_message : '{gifter_display} gifted {count} sub(s) to the community!' %></textarea>
+              <textarea class="input stream-textarea" name="giftsub_message" rows="2" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.giftsub_message) ? cfg.giftsub_message : '{gifter_display} gifted {count} sub(s) to the community!' %></textarea>
             </div>
 
             <div class="form-subsection-gap">
@@ -129,7 +129,7 @@
                 Raid notifications <% if (!isConnected) { %><span class="hint">(requires Twitch connection)</span><% } %>
               </label>
               <p class="hint hint-compact">Variables: <code>{from_channel} {from_display} {viewers}</code></p>
-              <textarea class="input stream-textarea" name="raid_message" rows="1" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.raid_message) ? cfg.raid_message : 'Welcome raiders from {from_display}! Thank you for the {viewers} person raid!' %></textarea>
+              <textarea class="input stream-textarea" name="raid_message" rows="2" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.raid_message) ? cfg.raid_message : 'Welcome raiders from {from_display}! Thank you for the {viewers} person raid!' %></textarea>
             </div>
 
             <div class="button-row-wrap">


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Settings page**: notification message textareas had `rows="1"`, making them unreadably small with vertical scrollbars. Increased to `rows="2"` so the full message is visible without scrolling.
- **Overlay page – URLs**: the OBS browser source URL `<code>` blocks had no wrapping rules, causing long URLs to overflow the card and push the page wider than the viewport. Added `word-break: break-all; overflow-wrap: anywhere` inline.
- **Overlay page – tables**: the video library table and reward-assignment tables could also overflow on narrow screens. Wrapped both in `.table-scroll` so they scroll horizontally within their card rather than blowing out page width.

## Test plan

- [ ] On a narrow mobile viewport (~375px), open the Settings page → Twitch Notifications — textarea content should be visible without a vertical scrollbar
- [ ] On the Overlay admin page, the OBS URL and controller URL should wrap within the card (no horizontal page scroll)
- [ ] The video library table and reward assignment tables should scroll horizontally within their card if content is wide, not overflow the page

https://claude.ai/code/session_015Dz1aeQw7PFmHzr9WrtJDc
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Dz1aeQw7PFmHzr9WrtJDc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UI Updates**
  * Twitch notification message fields (follow, sub, resub, gift sub, raid) now use expandable multi-line text areas instead of single-line inputs.

* **Style**
  * Improved text wrapping for overlay display of URLs and reward IDs.
  * Enhanced table container styling and scrolling behavior in admin overlay panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->