### PR TITLE
Add server-side deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -47,14 +47,18 @@ npm prune --omit=dev
 trap - ERR  # Rollback no longer needed — code is good.
 
 echo "==> Restarting bot in screen session '$SCREEN_SESSION'..."
-if screen -list | grep -Eq "[0-9]+\.$SCREEN_SESSION[[:space:]]"; then
+if screen -list | grep -Eq "[0-9]+\.${SCREEN_SESSION}[[:space:]]"; then
     screen -S "$SCREEN_SESSION" -X stuff $'\003'
 
     # Wait up to 15s for the node process to fully exit before restarting.
-    for i in {1..15}; do
+    for _ in {1..15}; do
         pgrep -f "node dist/index.js" > /dev/null 2>&1 || break
         sleep 1
     done
+
+    if pgrep -f "node dist/index.js" > /dev/null 2>&1; then
+        echo "WARNING: Node process did not stop within 15s. Attempting restart anyway..."
+    fi
 
     screen -S "$SCREEN_SESSION" -X stuff "npm start\n"
     echo "==> Bot restarted."

--- a/deploy.sh
+++ b/deploy.sh
@@ -29,9 +29,15 @@ echo "==> Pruning dev dependencies..."
 npm prune --omit=dev
 
 echo "==> Restarting bot in screen session '$SCREEN_SESSION'..."
-if screen -list | grep -q "$SCREEN_SESSION"; then
+if screen -list | grep -Eq "[0-9]+\.$SCREEN_SESSION[[:space:]]"; then
     screen -S "$SCREEN_SESSION" -X stuff $'\003'
-    sleep 2
+
+    # Wait up to 15s for the node process to fully exit before restarting.
+    for i in {1..15}; do
+        pgrep -f "node dist/index.js" > /dev/null 2>&1 || break
+        sleep 1
+    done
+
     screen -S "$SCREEN_SESSION" -X stuff "npm start\n"
     echo "==> Bot restarted."
 else

--- a/deploy.sh
+++ b/deploy.sh
@@ -10,8 +10,24 @@ cd "$(dirname "$0")"
 
 [ -f package.json ] || { echo "ERROR: Run this script from the repo root."; exit 1; }
 
+PREVIOUS_SHA=$(git rev-parse HEAD)
+
+# On any error after git pull, roll back to the previous commit.
+rollback() {
+    echo "ERROR: Deployment failed. Rolling back to $PREVIOUS_SHA..."
+    git reset --hard "$PREVIOUS_SHA"
+    exit 1
+}
+
 echo "==> Pulling latest code..."
+if ! git diff-index --quiet HEAD -- || [ -n "$(git ls-files --others --exclude-standard)" ]; then
+    echo "ERROR: Working directory has uncommitted changes or untracked files."
+    echo "       Commit or stash changes before deploying."
+    exit 1
+fi
 git pull origin main
+
+trap rollback ERR
 
 echo "==> Installing dependencies..."
 npm ci
@@ -27,6 +43,8 @@ npm test
 
 echo "==> Pruning dev dependencies..."
 npm prune --omit=dev
+
+trap - ERR  # Rollback no longer needed — code is good.
 
 echo "==> Restarting bot in screen session '$SCREEN_SESSION'..."
 if screen -list | grep -Eq "[0-9]+\.$SCREEN_SESSION[[:space:]]"; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── Config ───────────────────────────────────────────────────────────────────
+# Name of the screen session the bot runs in.
+SCREEN_SESSION="BCUK"
+# ─────────────────────────────────────────────────────────────────────────────
+
+cd "$(dirname "$0")"
+
+[ -f package.json ] || { echo "ERROR: Run this script from the repo root."; exit 1; }
+
+echo "==> Pulling latest code..."
+git pull origin main
+
+echo "==> Installing dependencies..."
+npm ci
+
+echo "==> Checking for vulnerabilities..."
+npm audit --audit-level=high
+
+echo "==> Building..."
+npm run build
+
+echo "==> Running tests..."
+npm test
+
+echo "==> Pruning dev dependencies..."
+npm prune --omit=dev
+
+echo "==> Restarting bot in screen session '$SCREEN_SESSION'..."
+if screen -list | grep -q "$SCREEN_SESSION"; then
+    screen -S "$SCREEN_SESSION" -X stuff $'\003'
+    sleep 2
+    screen -S "$SCREEN_SESSION" -X stuff "npm start\n"
+    echo "==> Bot restarted."
+else
+    echo "WARNING: Screen session '$SCREEN_SESSION' not found."
+    echo "         Start it manually: screen -S $SCREEN_SESSION npm start"
+fi
+
+echo "==> Deploy complete."

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "graphify:hook": "graphify hook install"
+    "graphify:hook": "graphify hook install",
+    "deploy": "bash deploy.sh"
   },
   "dependencies": {
     "@discordjs/voice": "^0.19.2",


### PR DESCRIPTION
## Summary

- Adds `deploy.sh` — a server-side script that automates the full deployment cycle: `git pull` → `npm ci` → security audit → build → test → prune devDeps → restart bot in the `BCUK` screen session
- Adds `"deploy": "bash deploy.sh"` to `package.json` scripts as a convenience alias
- `public/downloads/` (StreamDeck plugin) is never touched — gitignored files are invisible to `git pull`

## One-time server setup required

Before the script can be used, the repo needs to be cloned on the server. Since the repo is public, a simple HTTPS clone works — no deploy key needed:

1. Clone: `git clone https://github.com/Battle-Cattle/BCUK-Bot-4.git ~/bcuk-bot`
2. Copy `.env` and any existing `public/downloads/` files into the cloned directory

After that, a full deploy is just `bash deploy.sh` (or `npm run deploy`) from the repo directory.

## Test plan

- [ ] Clone repo on server and run `bash deploy.sh`
- [ ] Confirm git pull, audit, build, and tests all succeed
- [ ] Confirm BCUK screen session receives Ctrl-C then `npm start`
- [ ] Confirm `public/downloads/` is untouched after deploy
- [ ] Attach to screen session and verify bot is running

https://claude.ai/code/session_01EYfvYpB2NZqqZi1DEYPtso

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated end-to-end deployment script for the Node project with preflight checks, rollback-on-failure, and safe restart of the running service.
  * Introduced a new `deploy` command in the project scripts to run the deployment flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->