### PR TITLE
Skip file log transports during test runs

### DIFF
--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -3,6 +3,7 @@ import DailyRotateFile from 'winston-daily-rotate-file';
 
 const LOG_LEVEL = process.env.LOG_LEVEL ?? (process.env.NODE_ENV === 'production' ? 'info' : 'debug');
 const LOG_DIR = 'logs';
+const IS_TEST = !!process.env.VITEST;
 
 const fileFormat = format.combine(
   format.errors({ stack: true }),
@@ -26,25 +27,29 @@ const consoleFormat = format.combine(
 const rootLogger = winstonCreateLogger({
   level: LOG_LEVEL,
   transports: [
-    new DailyRotateFile({
-      dirname: LOG_DIR,
-      filename: 'combined-%DATE%.log',
-      datePattern: 'YYYY-MM-DD',
-      maxSize: '20m',
-      maxFiles: '14d',
-      zippedArchive: true,
-      format: fileFormat,
-    }),
-    new DailyRotateFile({
-      dirname: LOG_DIR,
-      filename: 'error-%DATE%.log',
-      datePattern: 'YYYY-MM-DD',
-      level: 'error',
-      maxSize: '20m',
-      maxFiles: '14d',
-      zippedArchive: true,
-      format: fileFormat,
-    }),
+    ...(!IS_TEST
+      ? [
+          new DailyRotateFile({
+            dirname: LOG_DIR,
+            filename: 'combined-%DATE%.log',
+            datePattern: 'YYYY-MM-DD',
+            maxSize: '20m',
+            maxFiles: '14d',
+            zippedArchive: true,
+            format: fileFormat,
+          }),
+          new DailyRotateFile({
+            dirname: LOG_DIR,
+            filename: 'error-%DATE%.log',
+            datePattern: 'YYYY-MM-DD',
+            level: 'error',
+            maxSize: '20m',
+            maxFiles: '14d',
+            zippedArchive: true,
+            format: fileFormat,
+          }),
+        ]
+      : []),
     new transports.Console({
       format: consoleFormat,
     }),


### PR DESCRIPTION
## Summary
- Checks for the `VITEST` environment variable in `src/shared/logger.ts`
- Skips both `DailyRotateFile` transports when running under Vitest — no log files created during tests
- Console transport is kept so log lines still appear in test output if needed
- Live logs on the server are completely unaffected

## Test plan
- [ ] Run `npm test` — confirm no `logs/` files are created
- [ ] Run the bot normally — confirm `logs/combined-*.log` and `logs/error-*.log` still appear

https://claude.ai/code/session_01EYfvYpB2NZqqZi1DEYPtso

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYfvYpB2NZqqZi1DEYPtso)_