### PR TITLE
Fix deploy.sh dirty-tree false positive for untracked files

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -20,7 +20,7 @@ rollback() {
 }
 
 echo "==> Pulling latest code..."
-if ! git diff-index --quiet HEAD -- || [ -n "$(git ls-files --others --exclude-standard)" ]; then
+if ! git diff-index --quiet HEAD --; then
     echo "ERROR: Working directory has uncommitted changes or untracked files."
     echo "       Commit or stash changes before deploying."
     exit 1


### PR DESCRIPTION
## Summary
- Removes the `git ls-files --others --exclude-standard` check from the dirty-tree guard in `deploy.sh`
- `git pull` only modifies tracked files, so untracked files (logs, `.env`, `public/downloads/`) are never at risk — checking them caused false positives on an otherwise clean working tree

https://claude.ai/code/session_01EYfvYpB2NZqqZi1DEYPtso

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYfvYpB2NZqqZi1DEYPtso)_