### PR TITLE
Refresh git index before dirty-tree check to avoid false positives

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -20,6 +20,7 @@ rollback() {
 }
 
 echo "==> Pulling latest code..."
+git update-index -q --refresh
 if ! git diff-index --quiet HEAD --; then
     echo "ERROR: Working directory has uncommitted changes or untracked files."
     echo "       Commit or stash changes before deploying."


### PR DESCRIPTION
## Summary
- Adds `git update-index -q --refresh` before the dirty-tree check in `deploy.sh`
- `git diff-index` uses cached stat data which can be stale after a fresh clone, causing false "dirty" reports even on a clean working tree — refreshing the index first prevents this

https://claude.ai/code/session_01EYfvYpB2NZqqZi1DEYPtso

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYfvYpB2NZqqZi1DEYPtso)_