### PR TITLE
cd to repo directory before starting bot in screen session

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -61,7 +61,8 @@ if screen -list | grep -Eq "[0-9]+\.${SCREEN_SESSION}[[:space:]]"; then
         echo "WARNING: Node process did not stop within 15s. Attempting restart anyway..."
     fi
 
-    screen -S "$SCREEN_SESSION" -X stuff "npm start\n"
+    REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+    screen -S "$SCREEN_SESSION" -X stuff "cd ${REPO_DIR} && npm start\n"
     echo "==> Bot restarted."
 else
     echo "WARNING: Screen session '$SCREEN_SESSION' not found."

--- a/deploy.sh
+++ b/deploy.sh
@@ -20,6 +20,7 @@ rollback() {
 }
 
 echo "==> Pulling latest code..."
+git update-index -q --refresh
 if ! git diff-index --quiet HEAD --; then
     echo "ERROR: Working directory has uncommitted changes or untracked files."
     echo "       Commit or stash changes before deploying."


### PR DESCRIPTION
## Summary
- Sends `cd <repo-dir> && npm start` to the screen session instead of just `npm start`
- Ensures the bot always starts from the correct directory regardless of where the screen session's working directory happens to be

https://claude.ai/code/session_01EYfvYpB2NZqqZi1DEYPtso

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYfvYpB2NZqqZi1DEYPtso)_