### PR TITLE
Multi-server (multi-guild) support — PR3: web panel guild context + config cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Discord (bot)
-DISCORD_GUILD_ID=your_guild_id_here
 DISCORD_TOKEN=your_discord_bot_token_here
-DISCORD_VOICE_CHANNEL_ID=your_voice_channel_id_here
+# Note: DISCORD_GUILD_ID and DISCORD_VOICE_CHANNEL_ID are no longer required.
+# Guild and voice channel configuration is now managed in the database (guild table).
 
 # Discord OAuth application (create at https://discord.com/developers/applications)
 # Under OAuth2 -> Redirects, add: http://localhost:3000/auth/discord/callback

--- a/package-lock.json
+++ b/package-lock.json
@@ -562,9 +562,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -582,9 +579,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -602,9 +596,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -622,9 +613,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -642,9 +630,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -662,9 +647,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3161,9 +3143,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3185,9 +3164,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3209,9 +3185,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3233,9 +3206,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/audio/audioPlayer.test.ts
+++ b/src/audio/audioPlayer.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ─── Mocks ──────────────────────────────────────────────────────────────────
 
-vi.mock('../shared/config', () => ({ DISCORD_VOICE_CHANNEL_ID: 'default-vc' }));
+vi.mock('../shared/config', () => ({}));
 vi.mock('../shared/statusStore', () => ({
   setVoiceConnected: vi.fn(),
   setVoiceDisconnected: vi.fn(),
@@ -102,15 +102,12 @@ describe('connect', () => {
     expect(vi.mocked(status.setVoiceConnected)).toHaveBeenCalledWith('vc-chan-1');
   });
 
-  it('falls back to the default channel when none is given', async () => {
+  it('rejects when no channelId is given', async () => {
     const { client } = makeClient();
-    const voice = await import('@discordjs/voice');
+    const utils = await import('../discord/discordUtils.js');
+    vi.mocked(utils.isPermanentVoiceMisconfigurationError).mockReturnValue(true);
 
-    await mod.connect(client as never, 'guild-A');
-
-    expect(vi.mocked(voice.joinVoiceChannel)).toHaveBeenCalledWith(
-      expect.objectContaining({ channelId: 'default-vc' }),
-    );
+    await expect(mod.connect(client as never, 'guild-A')).rejects.toThrow('Missing guild ID or voice channel ID');
   });
 
   it('rejects and stays disconnected when the channel is not a voice channel', async () => {
@@ -136,7 +133,7 @@ describe('connect', () => {
     // Treat the misconfiguration as permanent so no reconnect timer is scheduled.
     vi.mocked(utils.isPermanentVoiceMisconfigurationError).mockReturnValue(true);
 
-    await expect(mod.connect(client as never, '', 'chan-1')).rejects.toThrow('Missing DISCORD_GUILD_ID or voice channel ID');
+    await expect(mod.connect(client as never, '', 'chan-1')).rejects.toThrow('Missing guild ID or voice channel ID');
     expect(client.guilds.fetch).not.toHaveBeenCalled();
   });
 });

--- a/src/audio/audioPlayer.test.ts
+++ b/src/audio/audioPlayer.test.ts
@@ -107,7 +107,7 @@ describe('connect', () => {
     const utils = await import('../discord/discordUtils.js');
     vi.mocked(utils.isPermanentVoiceMisconfigurationError).mockReturnValue(true);
 
-    await expect(mod.connect(client as never, 'guild-A')).rejects.toThrow('Missing guild ID or voice channel ID');
+    await expect(mod.connect(client as never, 'guild-A', '')).rejects.toThrow('Missing guild ID or voice channel ID');
   });
 
   it('rejects and stays disconnected when the channel is not a voice channel', async () => {

--- a/src/audio/audioPlayer.ts
+++ b/src/audio/audioPlayer.ts
@@ -112,7 +112,7 @@ function scheduleReconnect(state: GuildVoiceState, reason: string): void {
   state.reconnectTimer = setTimeout(() => {
     state.reconnectTimer = null;
     if (scheduledAttemptId !== state.currentAttemptId) return;
-    if (!state.shouldAutoReconnect || !state.client || state.connection) return;
+    if (!state.shouldAutoReconnect || !state.client || state.connection || !state.targetChannelId) return;
     connect(state.client, state.guildId, state.targetChannelId).catch((err) => {
       log.error(`Voice rejoin failed for guild ${state.guildId}:`, err);
     });
@@ -172,10 +172,10 @@ function makeDeps(state: GuildVoiceState): ConnectionHandlerDeps {
  *
  * @param client - The ready Discord client.
  * @param guildId - The guild whose voice channel to join (BIGINT snowflake string).
- * @param channelId - Target voice channel ID; falls back to the legacy default when omitted.
+ * @param channelId - Target voice channel ID (required).
  * @returns Resolves once the connection is ready, or rejects if the join fails.
  */
-export async function connect(client: Client, guildId: string, channelId?: string): Promise<void> {
+export async function connect(client: Client, guildId: string, channelId: string): Promise<void> {
   const state = getState(guildId);
   clearReconnectTimer(state);
   const attemptId = ++state.currentAttemptId;

--- a/src/audio/audioPlayer.ts
+++ b/src/audio/audioPlayer.ts
@@ -11,7 +11,6 @@ import {
   type AudioPlayer as DjsAudioPlayer,
 } from '@discordjs/voice';
 import { Client, ChannelType } from 'discord.js';
-import { DISCORD_VOICE_CHANNEL_ID } from '../shared/config';
 import { setVoiceConnected, setVoiceDisconnected, setVoiceIdle } from '../shared/statusStore';
 
 const log = createLogger('AudioPlayer');
@@ -190,12 +189,10 @@ export async function connect(client: Client, guildId: string, channelId?: strin
   const deps = makeDeps(state);
 
   try {
-    const resolvedChannelId = channelId || DISCORD_VOICE_CHANNEL_ID;
-
-    if (!guildId || !resolvedChannelId) {
+    if (!guildId || !channelId) {
       // Message text must stay in sync with isPermanentVoiceMisconfigurationError
       // so this is classified as permanent (not retried).
-      throw new Error('Missing DISCORD_GUILD_ID or voice channel ID');
+      throw new Error('Missing guild ID or voice channel ID');
     }
 
     // Fetching the channel from the target guild also validates that the channel
@@ -203,11 +200,11 @@ export async function connect(client: Client, guildId: string, channelId?: strin
     const guild = await client.guilds.fetch(guildId);
     if (attemptId !== state.currentAttemptId) return;
 
-    const channel = await guild.channels.fetch(resolvedChannelId);
+    const channel = await guild.channels.fetch(channelId);
     if (attemptId !== state.currentAttemptId) return;
 
     if (!channel || channel.type !== ChannelType.GuildVoice) {
-      throw new Error(`Channel ${resolvedChannelId} is not a voice channel in guild ${guildId}`);
+      throw new Error(`Channel ${channelId} is not a voice channel in guild ${guildId}`);
     }
 
     nextConnection = joinVoiceChannel({

--- a/src/db.ts
+++ b/src/db.ts
@@ -23,7 +23,7 @@ export type { DbGuildCommandOverride } from './db/guildCommandOverrides';
 
 export {
   AccessLevel, ACCESS_LEVEL_LABELS,
-  findUser, findUserByTwitchName, getAllUsers,
+  findUser, findUserByTwitchName, getAllUsers, getGuildMemberUsers,
   updateDiscordName, getTwitchEnabledChannels, updateAccessLevel,
 } from './db/users';
 export type { AccessLevelValue, DbUser } from './db/users';

--- a/src/db.ts
+++ b/src/db.ts
@@ -4,7 +4,7 @@ export { getPool, closePool } from './db/pool';
 // ─── Guilds ──────────────────────────────────────────────────────────────────
 
 export {
-  getAllGuilds, getProvisionedGuilds, getGuildById, upsertGuild, setGuildVoiceChannel,
+  getAllGuilds, getProvisionedGuilds, getGuildById, getGuildsForMember, upsertGuild, setGuildVoiceChannel,
 } from './db/guilds';
 export type { DbGuild } from './db/guilds';
 

--- a/src/db/guildMembers.test.ts
+++ b/src/db/guildMembers.test.ts
@@ -90,24 +90,42 @@ describe('removeGuildMember', () => {
   });
 });
 
-describe('getEffectiveAccessLevel (PR 2 shim)', () => {
-  it('returns the legacy user.access_level regardless of guild', async () => {
-    vi.mocked(findUser).mockResolvedValueOnce({
-      discord_id: '222',
-      discord_name: 'Alice',
-      is_twitch_bot_enabled: false,
-      twitch_name: null,
-      access_level: 2,
-      is_owner: false,
-    });
+describe('getEffectiveAccessLevel', () => {
+  const baseUser = {
+    discord_id: '222',
+    discord_name: 'Alice',
+    is_twitch_bot_enabled: false,
+    twitch_name: null,
+    access_level: 0,
+    is_owner: false,
+  };
 
-    expect(await getEffectiveAccessLevel('any-guild', '222')).toBe(2);
-    // Shim must not touch guild_member yet.
+  it('defaults to USER (0) when the user is not whitelisted', async () => {
+    vi.mocked(findUser).mockResolvedValueOnce(null);
+    expect(await getEffectiveAccessLevel('g1', '999')).toBe(0);
+    // No guild_member lookup needed when there is no user row.
     expect(pool.execute).not.toHaveBeenCalled();
   });
 
-  it('defaults to USER (0) when the user has no row', async () => {
-    vi.mocked(findUser).mockResolvedValueOnce(null);
-    expect(await getEffectiveAccessLevel('any-guild', '999')).toBe(0);
+  it('returns ADMIN (3) for a bot owner regardless of membership', async () => {
+    vi.mocked(findUser).mockResolvedValueOnce({ ...baseUser, is_owner: true });
+    expect(await getEffectiveAccessLevel('g1', '222')).toBe(3);
+    // Owners short-circuit before any guild_member query.
+    expect(pool.execute).not.toHaveBeenCalled();
+  });
+
+  it('reads the per-guild level from guild_member for a non-owner', async () => {
+    vi.mocked(findUser).mockResolvedValueOnce({ ...baseUser });
+    pool.execute.mockResolvedValueOnce([[{ access_level: 2 }], []]);
+    expect(await getEffectiveAccessLevel('g1', '222')).toBe(2);
+    const [sql, params] = pool.execute.mock.calls[0];
+    expect(sql).toContain('FROM guild_member');
+    expect(params).toEqual(['g1', '222']);
+  });
+
+  it('defaults to USER (0) when a whitelisted non-owner has no membership in the guild', async () => {
+    vi.mocked(findUser).mockResolvedValueOnce({ ...baseUser });
+    pool.execute.mockResolvedValueOnce([[], []]);
+    expect(await getEffectiveAccessLevel('g1', '222')).toBe(0);
   });
 });

--- a/src/db/guildMembers.test.ts
+++ b/src/db/guildMembers.test.ts
@@ -98,6 +98,7 @@ describe('getEffectiveAccessLevel (PR 2 shim)', () => {
       is_twitch_bot_enabled: false,
       twitch_name: null,
       access_level: 2,
+      is_owner: false,
     });
 
     expect(await getEffectiveAccessLevel('any-guild', '222')).toBe(2);

--- a/src/db/guildMembers.ts
+++ b/src/db/guildMembers.ts
@@ -90,25 +90,24 @@ export async function removeGuildMember(guildId: string, discordId: string): Pro
   );
 }
 
-// ─── Effective access-level shim ───────────────────────────────────────────────
+// ─── Effective access-level resolution ─────────────────────────────────────────
 
 /**
- * Resolves a user's effective access level for a guild.
+ * Resolves a user's effective access level within a guild.
  *
- * COMPATIBILITY SHIM (PR 2): while only one guild exists and the web panel still
- * writes the legacy `user.access_level` column, this returns that legacy value so
- * every existing reader keeps behaving identically. It deliberately does NOT read
- * `guild_member` yet — that table is seeded from `access_level` at migration time
- * but would drift the moment an admin changes a level through the current UI.
+ * Resolution order (PR 3): a non-whitelisted user is User (0); a bot owner
+ * (`user.is_owner`) is Admin everywhere regardless of membership; otherwise the
+ * level comes from the user's `guild_member` row for that guild, defaulting to
+ * User (0) when they have no membership there. The web panel writes `guild_member`
+ * for the current guild, so this is the single source of truth for authorization.
  *
- * PR 3 flips the source to `guild_member` (per-guild) and adds the `is_owner`
- * short-circuit once the readers and the admin UI are migrated together.
- *
- * @param _guildId Accepted now so callers can thread guildId through; unused until PR 3.
- * @param discordId BIGINT snowflake as a string.
- * @returns The user's access level, or AccessLevel.USER (0) if they have no user row.
+ * @param guildId Guild snowflake as a string.
+ * @param discordId User snowflake as a string.
+ * @returns The user's access level (0–3) for the guild.
  */
-export async function getEffectiveAccessLevel(_guildId: string, discordId: string): Promise<number> {
+export async function getEffectiveAccessLevel(guildId: string, discordId: string): Promise<number> {
   const user = await findUser(discordId);
-  return user ? user.access_level : AccessLevel.USER;
+  if (!user) return AccessLevel.USER;
+  if (user.is_owner) return AccessLevel.ADMIN;
+  return (await getMemberAccessLevel(guildId, discordId)) ?? AccessLevel.USER;
 }

--- a/src/db/guilds.test.ts
+++ b/src/db/guilds.test.ts
@@ -4,7 +4,7 @@ vi.mock('./pool', () => ({ getPool: vi.fn() }));
 vi.mock('mysql2/promise', () => ({ default: {} }));
 
 import { getPool } from './pool';
-import { getAllGuilds, getProvisionedGuilds, getGuildById, upsertGuild, setGuildVoiceChannel } from './guilds';
+import { getAllGuilds, getProvisionedGuilds, getGuildById, getGuildsForMember, upsertGuild, setGuildVoiceChannel } from './guilds';
 
 function makePool() {
   return { execute: vi.fn().mockResolvedValue([[], []]) };
@@ -39,6 +39,27 @@ describe('getAllGuilds', () => {
   it('returns an empty array when no guilds exist', async () => {
     pool.execute.mockResolvedValueOnce([[], []]);
     expect(await getAllGuilds()).toEqual([]);
+  });
+});
+
+describe('getGuildsForMember', () => {
+  it('joins guild_member and maps BIGINT columns for the given user', async () => {
+    pool.execute.mockResolvedValueOnce([
+      [{ guild_id: 111n, name: 'Alpha', voice_channel_id: 222n }],
+      [],
+    ]);
+
+    const result = await getGuildsForMember('555');
+
+    expect(result).toEqual([{ guild_id: '111', name: 'Alpha', voice_channel_id: '222' }]);
+    const [sql, params] = pool.execute.mock.calls[0];
+    expect(sql).toContain('JOIN guild_member');
+    expect(params).toEqual(['555']);
+  });
+
+  it('returns an empty array when the user belongs to no guild', async () => {
+    pool.execute.mockResolvedValueOnce([[], []]);
+    expect(await getGuildsForMember('555')).toEqual([]);
   });
 });
 

--- a/src/db/guilds.ts
+++ b/src/db/guilds.ts
@@ -69,6 +69,25 @@ export async function getGuildById(guildId: string): Promise<DbGuild | null> {
   return rows.length === 0 ? null : mapGuild(rows[0]);
 }
 
+/**
+ * Returns the guilds a user is a member of (one row per guild_member), ordered by name.
+ * Used to build the web panel's guild switcher for non-owner users.
+ *
+ * @param discordId BIGINT snowflake as a string.
+ * @returns The user's member guilds; empty if they belong to none.
+ */
+export async function getGuildsForMember(discordId: string): Promise<DbGuild[]> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT g.guild_id, g.name, g.voice_channel_id
+     FROM guild g
+     JOIN guild_member gm ON gm.guild_id = g.guild_id
+     WHERE gm.discord_id = ?
+     ORDER BY g.name`,
+    [discordId],
+  );
+  return rows.map(mapGuild);
+}
+
 // ─── Mutations ─────────────────────────────────────────────────────────────────
 
 /**

--- a/src/db/streamdeckKeys.test.ts
+++ b/src/db/streamdeckKeys.test.ts
@@ -246,6 +246,9 @@ describe('requestApiKey', () => {
     const result = await requestApiKey('1', AccessLevel.MANAGER, 'g1');
     expect(result.status).toBe('approved');
     expect(result.plain).toHaveLength(64); // 32 bytes as hex
+    const [insertSql, insertParams] = pool.execute.mock.calls[1] as [string, unknown[]];
+    expect(insertSql).toContain('(discord_id, key_hash, guild_id, status, requested_at, approved_at, approved_by)');
+    expect(insertParams[2]).toBe('g1');
   });
 
   it('returns status=pending for USER access level (0)', async () => {

--- a/src/db/streamdeckKeys.test.ts
+++ b/src/db/streamdeckKeys.test.ts
@@ -52,11 +52,12 @@ describe('findApprovedKeyByHash', () => {
 
   it('returns the mapped row when hash matches', async () => {
     const hash = sha256hex('mysecretkey');
-    const row = { discord_id: '42', key_hash: hash, status: 'approved', requested_at: new Date(), approved_at: new Date(), approved_by: '1' };
+    const row = { discord_id: '42', key_hash: hash, guild_id: 'g1', status: 'approved', requested_at: new Date(), approved_at: new Date(), approved_by: '1' };
     vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
     const result = await findApprovedKeyByHash(hash);
     expect(result).not.toBeNull();
     expect(result!.discord_id).toBe('42');
+    expect(result!.guild_id).toBe('g1');
     expect(result!.status).toBe('approved');
   });
 
@@ -202,10 +203,10 @@ describe('getAllApiKeys', () => {
 
 describe('requestApiKey', () => {
   it('throws when existing status is denied', async () => {
-    const row = { discord_id: '1', status: 'denied', requested_at: new Date(), approved_at: null, approved_by: null, user_name: null, approver_name: null };
+    const row = { discord_id: '1', guild_id: 'g1', status: 'denied', requested_at: new Date(), approved_at: null, approved_by: null, user_name: null, approver_name: null };
     const pool = makePool([row]);
     vi.mocked(getPool).mockReturnValue(pool as any);
-    await expect(requestApiKey('1', AccessLevel.USER)).rejects.toThrow('denied');
+    await expect(requestApiKey('1', AccessLevel.USER, 'g1')).rejects.toThrow('denied');
   });
 
   it('returns status=approved for MANAGER access level (2)', async () => {
@@ -215,11 +216,11 @@ describe('requestApiKey', () => {
         .mockResolvedValueOnce([[]])    // getApiKeyStatus initial
         .mockResolvedValueOnce([[]])    // INSERT
         .mockResolvedValueOnce([[{     // getApiKeyStatus after insert
-          discord_id: '1', status: 'approved', requested_at: new Date(), approved_at: new Date(), approved_by: '1', user_name: null, approver_name: null,
+          discord_id: '1', guild_id: 'g1', status: 'approved', requested_at: new Date(), approved_at: new Date(), approved_by: '1', user_name: null, approver_name: null,
         }]]),
     };
     vi.mocked(getPool).mockReturnValue(pool as any);
-    const result = await requestApiKey('1', AccessLevel.MANAGER);
+    const result = await requestApiKey('1', AccessLevel.MANAGER, 'g1');
     expect(result.status).toBe('approved');
     expect(result.plain).toHaveLength(64); // 32 bytes as hex
   });
@@ -230,11 +231,11 @@ describe('requestApiKey', () => {
         .mockResolvedValueOnce([[]])   // getApiKeyStatus initial
         .mockResolvedValueOnce([[]])   // INSERT
         .mockResolvedValueOnce([[{    // getApiKeyStatus after insert
-          discord_id: '1', status: 'pending', requested_at: new Date(), approved_at: null, approved_by: null, user_name: null, approver_name: null,
+          discord_id: '1', guild_id: 'g1', status: 'pending', requested_at: new Date(), approved_at: null, approved_by: null, user_name: null, approver_name: null,
         }]]),
     };
     vi.mocked(getPool).mockReturnValue(pool as any);
-    const result = await requestApiKey('1', AccessLevel.USER);
+    const result = await requestApiKey('1', AccessLevel.USER, 'g1');
     expect(result.status).toBe('pending');
   });
 
@@ -244,11 +245,11 @@ describe('requestApiKey', () => {
         .mockResolvedValueOnce([[]])
         .mockResolvedValueOnce([[]])
         .mockResolvedValueOnce([[{
-          discord_id: '1', status: 'pending', requested_at: new Date(), approved_at: null, approved_by: null, user_name: null, approver_name: null,
+          discord_id: '1', guild_id: 'g1', status: 'pending', requested_at: new Date(), approved_at: null, approved_by: null, user_name: null, approver_name: null,
         }]]),
     };
     vi.mocked(getPool).mockReturnValue(pool as any);
-    const result = await requestApiKey('1', AccessLevel.MOD);
+    const result = await requestApiKey('1', AccessLevel.MOD, 'g1');
     expect(result.plain).toMatch(/^[0-9a-f]{64}$/);
   });
 });

--- a/src/db/streamdeckKeys.test.ts
+++ b/src/db/streamdeckKeys.test.ts
@@ -84,6 +84,7 @@ describe('getApiKeyStatus', () => {
     const now = new Date();
     const row = {
       discord_id: '123',
+      guild_id: 'g1',
       status: 'pending',
       requested_at: now,
       approved_at: null,
@@ -94,6 +95,7 @@ describe('getApiKeyStatus', () => {
     vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
     const result = await getApiKeyStatus('123');
     expect(result!.discord_id).toBe('123');
+    expect(result!.guild_id).toBe('g1');
     expect(result!.status).toBe('pending');
     expect(result!.requested_at).toBe(now);
     expect(result!.approved_at).toBeNull();
@@ -103,6 +105,7 @@ describe('getApiKeyStatus', () => {
   it('maps a row with approver info', async () => {
     const row = {
       discord_id: '1',
+      guild_id: 'g1',
       status: 'approved',
       requested_at: new Date(),
       approved_at: new Date(),
@@ -112,6 +115,7 @@ describe('getApiKeyStatus', () => {
     };
     vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
     const result = await getApiKeyStatus('1');
+    expect(result!.guild_id).toBe('g1');
     expect(result!.approved_by).toBe('99');
     expect(result!.user_name).toBe('Alice');
     expect(result!.approver_name).toBe('Admin');
@@ -168,10 +172,11 @@ describe('getPendingRequests', () => {
   });
 
   it('maps pending rows', async () => {
-    const row = { discord_id: '1', status: 'pending', requested_at: new Date(), approved_at: null, approved_by: null, user_name: 'Alice', approver_name: null };
+    const row = { discord_id: '1', guild_id: 'g1', status: 'pending', requested_at: new Date(), approved_at: null, approved_by: null, user_name: 'Alice', approver_name: null };
     vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
     const result = await getPendingRequests();
     expect(result).toHaveLength(1);
+    expect(result[0].guild_id).toBe('g1');
     expect(result[0].status).toBe('pending');
     expect(result[0].user_name).toBe('Alice');
   });
@@ -188,13 +193,15 @@ describe('getAllApiKeys', () => {
 
   it('maps multiple rows with different statuses', async () => {
     const rows = [
-      { discord_id: '1', status: 'approved', requested_at: new Date(), approved_at: new Date(), approved_by: '2', user_name: 'Alice', approver_name: 'Admin' },
-      { discord_id: '3', status: 'revoked', requested_at: new Date(), approved_at: null, approved_by: null, user_name: 'Bob', approver_name: null },
+      { discord_id: '1', guild_id: 'g1', status: 'approved', requested_at: new Date(), approved_at: new Date(), approved_by: '2', user_name: 'Alice', approver_name: 'Admin' },
+      { discord_id: '3', guild_id: 'g2', status: 'revoked', requested_at: new Date(), approved_at: null, approved_by: null, user_name: 'Bob', approver_name: null },
     ];
     vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
     const result = await getAllApiKeys();
     expect(result).toHaveLength(2);
+    expect(result[0].guild_id).toBe('g1');
     expect(result[0].status).toBe('approved');
+    expect(result[1].guild_id).toBe('g2');
     expect(result[1].status).toBe('revoked');
   });
 });

--- a/src/db/streamdeckKeys.test.ts
+++ b/src/db/streamdeckKeys.test.ts
@@ -102,6 +102,22 @@ describe('getApiKeyStatus', () => {
     expect(result!.approved_by).toBeNull();
   });
 
+  it('preserves a null guild_id instead of stringifying it', async () => {
+    const row = {
+      discord_id: '123',
+      guild_id: null,
+      status: 'pending',
+      requested_at: new Date(),
+      approved_at: null,
+      approved_by: null,
+      user_name: null,
+      approver_name: null,
+    };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const result = await getApiKeyStatus('123');
+    expect(result!.guild_id).toBeNull();
+  });
+
   it('maps a row with approver info', async () => {
     const row = {
       discord_id: '1',

--- a/src/db/streamdeckKeys.ts
+++ b/src/db/streamdeckKeys.ts
@@ -83,7 +83,7 @@ export async function findApprovedKeyByHash(hash: string): Promise<StreamdeckKey
 
 export async function getApiKeyStatus(discordId: string): Promise<StreamdeckKeyRow | null> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    `SELECT discord_id, status, requested_at, approved_at, approved_by
+    `SELECT discord_id, guild_id, status, requested_at, approved_at, approved_by
      FROM streamdeck_api_keys
      WHERE discord_id = ?`,
     [discordId],
@@ -116,7 +116,7 @@ export async function revokeApiKey(discordId: string): Promise<void> {
 
 export async function getPendingRequests(): Promise<StreamdeckKeyRow[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    `SELECT k.discord_id, k.status, k.requested_at, k.approved_at, k.approved_by,
+    `SELECT k.discord_id, k.guild_id, k.status, k.requested_at, k.approved_at, k.approved_by,
             u.discord_name AS user_name, NULL AS approver_name
      FROM streamdeck_api_keys k
      LEFT JOIN \`user\` u ON u.discord_id = k.discord_id
@@ -128,7 +128,7 @@ export async function getPendingRequests(): Promise<StreamdeckKeyRow[]> {
 
 export async function getAllApiKeys(): Promise<StreamdeckKeyRow[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    `SELECT k.discord_id, k.status, k.requested_at, k.approved_at, k.approved_by,
+    `SELECT k.discord_id, k.guild_id, k.status, k.requested_at, k.approved_at, k.approved_by,
             u.discord_name AS user_name, a.discord_name AS approver_name
      FROM streamdeck_api_keys k
      LEFT JOIN \`user\` u ON u.discord_id = k.discord_id

--- a/src/db/streamdeckKeys.ts
+++ b/src/db/streamdeckKeys.ts
@@ -6,7 +6,7 @@ import { AccessLevel } from './users';
 export interface StreamdeckKeyRow {
   discord_id: string;
   /** The guild this key acts on. */
-  guild_id: string;
+  guild_id: string | null;
   status: 'pending' | 'approved' | 'revoked' | 'denied';
   requested_at: Date;
   approved_at: Date | null;
@@ -18,7 +18,7 @@ export interface StreamdeckKeyRow {
 function mapRow(r: mysql.RowDataPacket): StreamdeckKeyRow {
   return {
     discord_id: String(r.discord_id),
-    guild_id: String(r.guild_id),
+    guild_id: r.guild_id === null ? null : String(r.guild_id),
     status: r.status as StreamdeckKeyRow['status'],
     requested_at: r.requested_at,
     approved_at: r.approved_at ?? null,

--- a/src/db/streamdeckKeys.ts
+++ b/src/db/streamdeckKeys.ts
@@ -5,6 +5,8 @@ import { AccessLevel } from './users';
 
 export interface StreamdeckKeyRow {
   discord_id: string;
+  /** The guild this key acts on. */
+  guild_id: string;
   status: 'pending' | 'approved' | 'revoked' | 'denied';
   requested_at: Date;
   approved_at: Date | null;
@@ -16,6 +18,7 @@ export interface StreamdeckKeyRow {
 function mapRow(r: mysql.RowDataPacket): StreamdeckKeyRow {
   return {
     discord_id: String(r.discord_id),
+    guild_id: String(r.guild_id),
     status: r.status as StreamdeckKeyRow['status'],
     requested_at: r.requested_at,
     approved_at: r.approved_at ?? null,
@@ -28,6 +31,7 @@ function mapRow(r: mysql.RowDataPacket): StreamdeckKeyRow {
 export async function requestApiKey(
   discordId: string,
   accessLevel: number,
+  guildId: string,
 ): Promise<{ plain: string; status: 'pending' | 'approved' }> {
   const existing = await getApiKeyStatus(discordId);
   if (existing?.status === 'denied') {
@@ -43,15 +47,16 @@ export async function requestApiKey(
 
   await getPool().execute(
     `INSERT INTO streamdeck_api_keys
-       (discord_id, key_hash, status, requested_at, approved_at, approved_by)
-     VALUES (?, ?, ?, ?, ?, ?) AS new_row
+       (discord_id, key_hash, guild_id, status, requested_at, approved_at, approved_by)
+     VALUES (?, ?, ?, ?, ?, ?, ?) AS new_row
      ON DUPLICATE KEY UPDATE
        key_hash     = IF(status = 'denied', key_hash,     new_row.key_hash),
+       guild_id     = IF(status = 'denied', guild_id,     new_row.guild_id),
        status       = IF(status = 'denied', status,       new_row.status),
        requested_at = IF(status = 'denied', requested_at, new_row.requested_at),
        approved_at  = IF(status = 'denied', approved_at,  new_row.approved_at),
        approved_by  = IF(status = 'denied', approved_by,  new_row.approved_by)`,
-    [discordId, hash, status, now, approvedAt, approvedBy],
+    [discordId, hash, guildId, status, now, approvedAt, approvedBy],
   );
 
   const after = await getApiKeyStatus(discordId);
@@ -64,7 +69,7 @@ export async function requestApiKey(
 
 export async function findApprovedKeyByHash(hash: string): Promise<StreamdeckKeyRow | null> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    `SELECT discord_id, key_hash, status, requested_at, approved_at, approved_by
+    `SELECT discord_id, key_hash, guild_id, status, requested_at, approved_at, approved_by
      FROM streamdeck_api_keys
      WHERE key_hash = ? AND status = 'approved'`,
     [hash],

--- a/src/db/streamdeckKeys.ts
+++ b/src/db/streamdeckKeys.ts
@@ -28,6 +28,16 @@ function mapRow(r: mysql.RowDataPacket): StreamdeckKeyRow {
   };
 }
 
+/**
+ * Requests (or re-requests) a Streamdeck API key for a user, scoped to one guild.
+ * Manager+ access levels are auto-approved; everyone else is queued as pending.
+ * Throws if a previous request for this user was denied.
+ *
+ * @param discordId Requesting user's Discord snowflake.
+ * @param accessLevel The user's effective access level in `guildId`, used to decide auto-approval.
+ * @param guildId The guild the key will act on.
+ * @returns The plaintext key (only ever returned here — only the hash is stored) and its status.
+ */
 export async function requestApiKey(
   discordId: string,
   accessLevel: number,

--- a/src/db/users.test.ts
+++ b/src/db/users.test.ts
@@ -88,6 +88,16 @@ describe('findUser', () => {
     const user = await findUser('999');
     expect(user!.discord_id).toBe('999');
   });
+
+  it('maps the is_owner bit column to a boolean', async () => {
+    const ownerRow = { discord_id: '1', discord_name: 'Owner', is_twitch_bot_enabled: 0, twitch_name: null, access_level: 3, is_owner: Buffer.from([1]) };
+    vi.mocked(getPool).mockReturnValue(makePool([[ownerRow]]) as any);
+    expect((await findUser('1'))!.is_owner).toBe(true);
+
+    const plainRow = { discord_id: '2', discord_name: 'User', is_twitch_bot_enabled: 0, twitch_name: null, access_level: 0, is_owner: 0 };
+    vi.mocked(getPool).mockReturnValue(makePool([[plainRow]]) as any);
+    expect((await findUser('2'))!.is_owner).toBe(false);
+  });
 });
 
 // ─── findUserByTwitchName ─────────────────────────────────────────────────────

--- a/src/db/users.test.ts
+++ b/src/db/users.test.ts
@@ -12,6 +12,7 @@ import {
   findUser,
   findUserByTwitchName,
   getAllUsers,
+  getGuildMemberUsers,
   upsertUserRecord,
   updateDiscordName,
   getTwitchEnabledChannels,
@@ -161,6 +162,32 @@ describe('getAllUsers', () => {
     expect(result).toHaveLength(2);
     expect(result[0].discord_id).toBe('1');
     expect(result[1].is_twitch_bot_enabled).toBe(true);
+  });
+});
+
+// ─── getGuildMemberUsers ──────────────────────────────────────────────────────
+
+describe('getGuildMemberUsers', () => {
+  it('returns an empty array when the guild has no members', async () => {
+    const pool = makePool([[]]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await getGuildMemberUsers('900000000000000001');
+    expect(result).toEqual([]);
+  });
+
+  it('queries guild_member filtered by guildId and maps access_level from it', async () => {
+    const rows = [
+      { discord_id: '1', discord_name: 'Alice', is_twitch_bot_enabled: 1, twitch_name: 'alice', access_level: 3, is_owner: 0 },
+    ];
+    const pool = makePool([rows]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await getGuildMemberUsers('900000000000000001');
+    expect(result).toHaveLength(1);
+    expect(result[0].discord_id).toBe('1');
+    expect(result[0].access_level).toBe(3);
+    const [sql, params] = vi.mocked(pool.execute).mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('guild_member');
+    expect(params).toEqual(['900000000000000001']);
   });
 });
 

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -81,6 +81,27 @@ export async function getAllUsers(): Promise<DbUser[]> {
   return rows.map(mapUser);
 }
 
+/**
+ * Returns the members of one guild as user records, with `access_level` sourced
+ * from the per-guild `guild_member` row (not the legacy global column). Backs the
+ * admin user list, which manages membership of the currently-selected guild.
+ *
+ * @param guildId Guild snowflake as a string.
+ * @returns The guild's members, highest access level first.
+ */
+export async function getGuildMemberUsers(guildId: string): Promise<DbUser[]> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT u.discord_id, u.discord_name, u.is_twitch_bot_enabled, u.twitch_name,
+            gm.access_level AS access_level, u.is_owner
+     FROM guild_member gm
+     JOIN \`user\` u ON u.discord_id = gm.discord_id
+     WHERE gm.guild_id = ?
+     ORDER BY gm.access_level DESC, u.discord_name ASC`,
+    [guildId],
+  );
+  return rows.map(mapUser);
+}
+
 // Short timeout so callers fail fast instead of hanging 50s under lock contention.
 async function withShortLockTimeout<T>(fn: (conn: mysql.PoolConnection) => Promise<T>): Promise<T> {
   const connection = await getPool().getConnection();

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -28,6 +28,8 @@ export interface DbUser {
   is_twitch_bot_enabled: boolean;
   twitch_name: string | null;
   access_level: number;
+  /** Bot-owner flag (global super-admin). Set only via direct DB access, never the web panel. */
+  is_owner: boolean;
 }
 
 function mapUser(r: mysql.RowDataPacket): DbUser {
@@ -37,12 +39,13 @@ function mapUser(r: mysql.RowDataPacket): DbUser {
     is_twitch_bot_enabled: fromBit(r.is_twitch_bot_enabled),
     twitch_name: r.twitch_name,
     access_level: r.access_level,
+    is_owner: fromBit(r.is_owner),
   };
 }
 
 export async function findUser(discordId: string): Promise<DbUser | null> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    'SELECT discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level FROM `user` WHERE discord_id = ?',
+    'SELECT discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level, is_owner FROM `user` WHERE discord_id = ?',
     [discordId],
   );
   return rows.length === 0 ? null : mapUser(rows[0]);
@@ -55,12 +58,12 @@ export async function findUserByTwitchName(twitchName: string, excludeDiscordId?
   }
 
   const sql = excludeDiscordId
-    ? `SELECT discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level
+    ? `SELECT discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level, is_owner
        FROM \`user\`
        WHERE twitch_name = ?
          AND discord_id <> ?
        LIMIT 1`
-    : `SELECT discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level
+    : `SELECT discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level, is_owner
        FROM \`user\`
        WHERE twitch_name = ?
        LIMIT 1`;
@@ -73,7 +76,7 @@ export async function findUserByTwitchName(twitchName: string, excludeDiscordId?
 
 export async function getAllUsers(): Promise<DbUser[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    'SELECT discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level FROM `user` ORDER BY access_level DESC, discord_name ASC',
+    'SELECT discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level, is_owner FROM `user` ORDER BY access_level DESC, discord_name ASC',
   );
   return rows.map(mapUser);
 }

--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -2,8 +2,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../shared/config', () => ({
   DISCORD_TOKEN: 'mock-token',
-  DISCORD_GUILD_ID: 'guild-id',
-  DISCORD_VOICE_CHANNEL_ID: 'vc-id',
   SFX_FOLDER: '/tmp/sfx',
   OVERLAY_FOLDER: '/tmp/overlay',
   GLOBAL_COOLDOWN_MS: 0,
@@ -18,7 +16,10 @@ vi.mock('./guildRegistry', () => ({
   isRegisteredGuild: vi.fn((id: string) => id === 'guild-id'),
   reloadGuildRegistry: vi.fn().mockResolvedValue(undefined),
 }));
-vi.mock('../db', () => ({ upsertGuild: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../db', () => ({
+  upsertGuild: vi.fn().mockResolvedValue(undefined),
+  getAllGuilds: vi.fn().mockResolvedValue([{ guild_id: 'guild-id', name: 'TestGuild', voice_channel_id: null }]),
+}));
 vi.mock('../shared/logger', () => ({ createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }));
 vi.mock('discord.js', () => ({
   Client: vi.fn(),
@@ -95,15 +96,15 @@ describe('getDiscordClient', () => {
 
 describe('fetchMemberDisplayName', () => {
   it('returns null when client is not ready', async () => {
-    expect(await mod.fetchMemberDisplayName('123')).toBeNull();
+    expect(await mod.fetchMemberDisplayName('123', false, 'guild-id')).toBeNull();
   });
 
   it('returns the member displayName when client is ready and fetch succeeds', async () => {
     mod.startDiscordBot();
     const readyCb = mockInstance.once.mock.calls.find(([event]: string[]) => event === 'clientReady')?.[1];
-    await readyCb(mockInstance);  // fires clientReady → sets client and cachedGuild
+    await readyCb(mockInstance);  // fires clientReady → sets client
 
-    const result = await mod.fetchMemberDisplayName('user123');
+    const result = await mod.fetchMemberDisplayName('user123', false, 'guild-id');
     expect(result).toBe('Alice');
   });
 
@@ -113,7 +114,7 @@ describe('fetchMemberDisplayName', () => {
     const readyCb = mockInstance.once.mock.calls.find(([event]: string[]) => event === 'clientReady')?.[1];
     await readyCb(mockInstance);
 
-    const result = await mod.fetchMemberDisplayName('missing');
+    const result = await mod.fetchMemberDisplayName('missing', false, 'guild-id');
     expect(result).toBeNull();
   });
 });

--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -196,8 +196,9 @@ describe('startDiscordBot — guildCreate handler', () => {
 // ─── startDiscordBot — clientReady error path ─────────────────────────────────
 
 describe('startDiscordBot — clientReady error path', () => {
-  it('catches guild fetch errors without crashing', async () => {
-    mockInstance.guilds.fetch.mockRejectedValueOnce(new Error('guild unavailable'));
+  it('catches getAllGuilds errors without crashing', async () => {
+    const db = await import('../db.js');
+    vi.mocked(db.getAllGuilds).mockRejectedValueOnce(new Error('guild unavailable'));
     mod.startDiscordBot();
     const readyCb = mockInstance.once.mock.calls.find(([event]: string[]) => event === 'clientReady')?.[1];
     await expect(readyCb(mockInstance)).resolves.toBeUndefined();

--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -203,6 +203,14 @@ describe('startDiscordBot — clientReady error path', () => {
     const readyCb = mockInstance.once.mock.calls.find(([event]: string[]) => event === 'clientReady')?.[1];
     await expect(readyCb(mockInstance)).resolves.toBeUndefined();
   });
+
+  it('sets ready state with DB guild names on clientReady success', async () => {
+    const status = await import('../shared/statusStore.js');
+    mod.startDiscordBot();
+    const readyCb = mockInstance.once.mock.calls.find(([event]: string[]) => event === 'clientReady')?.[1];
+    await readyCb(mockInstance);
+    expect(vi.mocked(status.setDiscordReady)).toHaveBeenCalledWith('Bot#1234', 'TestGuild');
+  });
 });
 
 // ─── startDiscordBot — error event ───────────────────────────────────────────

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -1,11 +1,11 @@
 import { Client, GatewayIntentBits, Guild } from 'discord.js';
-import { DISCORD_TOKEN, DISCORD_GUILD_ID } from '../shared/config';
+import { DISCORD_TOKEN } from '../shared/config';
 import { handleCommand } from '../commands/commandRouter';
 import { executeCustomCommandForDiscord } from '../commands/customCommandHandler';
 import { executeCounterCommandForDiscord } from '../commands/counterHandler';
 import { setDiscordReady } from '../shared/statusStore';
 import { isRegisteredGuild, reloadGuildRegistry } from './guildRegistry';
-import { upsertGuild } from '../db';
+import { upsertGuild, getAllGuilds } from '../db';
 import { createLogger } from '../shared/logger';
 
 const log = createLogger('Discord');
@@ -35,15 +35,13 @@ async function getGuild(guildId: string): Promise<Guild> {
  *
  * @param discordId - Discord user snowflake ID to look up.
  * @param force - When true, bypasses the guild member cache and fetches fresh from the API.
- * @param guildId - Guild to look the member up in. Defaults to the legacy configured guild
- *   so existing single-guild callers (e.g. web login) keep working until the web panel
- *   threads its own guild context through in a later phase.
+ * @param guildId - Guild to look the member up in.
  * @returns The member's server display name, or null on any failure.
  */
 export async function fetchMemberDisplayName(
   discordId: string,
   force = false,
-  guildId: string = DISCORD_GUILD_ID,
+  guildId: string,
 ): Promise<string | null> {
   if (!client) return null;
   try {
@@ -125,8 +123,9 @@ export function startDiscordBot(): void {
     client = c;
     log.info(`Logged in as ${c.user.tag}`);
     try {
-      const guild = await getGuild(DISCORD_GUILD_ID);
-      setDiscordReady(c.user.tag, guild.name);
+      const registeredGuilds = await getAllGuilds();
+      const names = registeredGuilds.map((g) => g.name).join(', ') || 'Unknown';
+      setDiscordReady(c.user.tag, names);
     } catch (err) {
       log.error('Failed to initialise:', err);
     }

--- a/src/discord/discordUtils.test.ts
+++ b/src/discord/discordUtils.test.ts
@@ -67,9 +67,15 @@ describe('isDiscordNotFoundError', () => {
 });
 
 describe('isPermanentVoiceMisconfigurationError', () => {
-  it('returns true for a missing-config message', () => {
+  it('returns true for the legacy missing-config message', () => {
     expect(isPermanentVoiceMisconfigurationError(
       new Error('Missing DISCORD_GUILD_ID or DISCORD_VOICE_CHANNEL_ID'),
+    )).toBe(true);
+  });
+
+  it('returns true for the current missing-config message', () => {
+    expect(isPermanentVoiceMisconfigurationError(
+      new Error('Missing guild ID or voice channel ID'),
     )).toBe(true);
   });
 

--- a/src/discord/discordUtils.ts
+++ b/src/discord/discordUtils.ts
@@ -21,6 +21,7 @@ export function isPermanentVoiceMisconfigurationError(err: unknown): boolean {
   const isConfigError =
     message.includes('Missing DISCORD_GUILD_ID or DISCORD_VOICE_CHANNEL_ID') ||
     message.includes('Missing DISCORD_GUILD_ID or voice channel ID') ||
+    message.includes('Missing guild ID or voice channel ID') ||
     message.includes('is not a voice channel');
   const isForbidden = status === 403 || code === RESTJSONErrorCodes.MissingAccess;
   return isConfigError || isForbidden || isDiscordNotFoundError(err);

--- a/src/discord/discordUtils.ts
+++ b/src/discord/discordUtils.ts
@@ -12,6 +12,12 @@ export function isDiscordNotFoundError(err: unknown): boolean {
   );
 }
 
+/**
+ * Returns true when a voice-connect error is permanent and should not be retried.
+ *
+ * @param err - Caught error from voice connect/reconnect flow.
+ * @returns Whether the error indicates permanent misconfiguration/access/not-found.
+ */
 export function isPermanentVoiceMisconfigurationError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   const { message } = err;

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -8,8 +8,6 @@ function require_env(name: string): string {
 }
 
 export const DISCORD_TOKEN = require_env('DISCORD_TOKEN');
-export const DISCORD_GUILD_ID = require_env('DISCORD_GUILD_ID');
-export const DISCORD_VOICE_CHANNEL_ID = require_env('DISCORD_VOICE_CHANNEL_ID');
 
 export const TWITCH_USERNAME = require_env('TWITCH_USERNAME');
 export const TWITCH_OAUTH_TOKEN = require_env('TWITCH_OAUTH_TOKEN');

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -38,6 +38,8 @@ declare module 'express-serve-static-core' {
   interface Request {
     csrfToken(): string;
     apiKeyOwner?: string;
+    /** The guild the Streamdeck API key is bound to, set by requireApiKey. */
+    apiKeyGuildId?: string;
   }
 }
 

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,11 +1,27 @@
 import 'express-session';
 import 'express-serve-static-core';
 
+/** A guild the logged-in user may act in, shown in the guild switcher. */
+export interface SessionGuildSummary {
+  guildId: string;
+  name: string;
+}
+
 export interface SessionUser {
   discordId: string;
   discordName: string;
   discordAvatar: string | null;
+  /** True for bot owners (user.is_owner): full access to every guild. */
+  isOwner: boolean;
+  /**
+   * Effective access level for `currentGuildId` (owners always resolve to Admin).
+   * Recomputed on login and on every guild switch — never trust it across guilds.
+   */
   accessLevel: 0 | 1 | 2 | 3;
+  /** The guild the session is currently acting in, or null until one is picked. */
+  currentGuildId: string | null;
+  /** Guilds this user may switch between (their memberships, or all guilds if owner). */
+  guilds: SessionGuildSummary[];
 }
 
 declare module 'express-session' {

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -39,7 +39,7 @@ declare module 'express-serve-static-core' {
     csrfToken(): string;
     apiKeyOwner?: string;
     /** The guild the Streamdeck API key is bound to, set by requireApiKey. */
-    apiKeyGuildId?: string;
+    apiKeyGuildId?: string | null;
   }
 }
 

--- a/src/web/middleware.test.ts
+++ b/src/web/middleware.test.ts
@@ -241,13 +241,14 @@ describe('requireGuildContext', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-  it('calls next() when a valid current guild is already selected', async () => {
-    const req = makeReq({
-      session: { user: { discordId: 'u1', currentGuildId: 'g1', accessLevel: 2, guilds: [{ guildId: 'g1', name: 'A' }] } },
-    });
+  it('calls next() when a valid current guild is already selected, refreshing the access level', async () => {
+    vi.mocked(getEffectiveAccessLevel).mockResolvedValue(3);
+    const user = { discordId: 'u1', currentGuildId: 'g1', accessLevel: 2, guilds: [{ guildId: 'g1', name: 'A' }] };
+    const req = makeReq({ session: { user } });
     await requireGuildContext(req, makeRes(), next);
     expect(next).toHaveBeenCalledOnce();
-    expect(vi.mocked(getEffectiveAccessLevel)).not.toHaveBeenCalled();
+    expect(vi.mocked(getEffectiveAccessLevel)).toHaveBeenCalledWith('g1', 'u1');
+    expect(user.accessLevel).toBe(3);
   });
 
   it('auto-selects and recomputes the level when the user has exactly one guild', async () => {

--- a/src/web/middleware.test.ts
+++ b/src/web/middleware.test.ts
@@ -198,12 +198,13 @@ describe('requireApiKey', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-  it('sets req.apiKeyOwner and calls next() when key is valid', async () => {
-    vi.mocked(findApprovedKeyByHash).mockResolvedValue({ discord_id: 'user42' } as any);
+  it('sets req.apiKeyOwner, req.apiKeyGuildId, and calls next() when key is valid', async () => {
+    vi.mocked(findApprovedKeyByHash).mockResolvedValue({ discord_id: 'user42', guild_id: 'guild99' } as any);
     const req = makeReq({ headers: { authorization: 'Bearer validtoken' } });
     const res = makeRes();
     await requireApiKey(req, res, next);
     expect(req.apiKeyOwner).toBe('user42');
+    expect(req.apiKeyGuildId).toBe('guild99');
     expect(next).toHaveBeenCalled();
     expect(res.status).not.toHaveBeenCalled();
   });

--- a/src/web/middleware.test.ts
+++ b/src/web/middleware.test.ts
@@ -2,14 +2,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../db', () => ({
   findApprovedKeyByHash: vi.fn(),
+  getEffectiveAccessLevel: vi.fn(),
   AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
 }));
 vi.mock('./csrf', () => ({
   ensureSessionCsrfToken: vi.fn().mockReturnValue('csrf-token'),
 }));
 
-import { requireAuth, requireManager, requireMod, requireAdmin, requireApiKey } from './middleware';
-import { findApprovedKeyByHash, AccessLevel } from '../db';
+import { requireAuth, requireManager, requireMod, requireAdmin, requireApiKey, requireGuildContext } from './middleware';
+import { findApprovedKeyByHash, getEffectiveAccessLevel, AccessLevel } from '../db';
 
 function makeReq(overrides: object = {}): any {
   return {
@@ -224,6 +225,59 @@ describe('requireApiKey', () => {
     await requireApiKey(req, res, next);
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.json).toHaveBeenCalledWith({ ok: false, error: 'Internal server error' });
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+// ─── requireGuildContext ────────────────────────────────────────────────────
+
+describe('requireGuildContext', () => {
+  it('redirects to login when no session user', async () => {
+    const req = makeReq({ session: {} });
+    const res = makeRes();
+    await requireGuildContext(req, res, next);
+    expect(res.redirect).toHaveBeenCalledWith('/auth/login');
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('calls next() when a valid current guild is already selected', async () => {
+    const req = makeReq({
+      session: { user: { discordId: 'u1', currentGuildId: 'g1', accessLevel: 2, guilds: [{ guildId: 'g1', name: 'A' }] } },
+    });
+    await requireGuildContext(req, makeRes(), next);
+    expect(next).toHaveBeenCalledOnce();
+    expect(vi.mocked(getEffectiveAccessLevel)).not.toHaveBeenCalled();
+  });
+
+  it('auto-selects and recomputes the level when the user has exactly one guild', async () => {
+    vi.mocked(getEffectiveAccessLevel).mockResolvedValue(3);
+    const user = { discordId: 'u1', currentGuildId: null, accessLevel: 0, guilds: [{ guildId: 'g1', name: 'A' }] };
+    const req = makeReq({ session: { user } });
+    await requireGuildContext(req, makeRes(), next);
+    expect(user.currentGuildId).toBe('g1');
+    expect(user.accessLevel).toBe(3);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('redirects to the picker when multiple guilds and none selected', async () => {
+    const req = makeReq({
+      session: { user: { discordId: 'u1', currentGuildId: null, accessLevel: 0, guilds: [{ guildId: 'g1', name: 'A' }, { guildId: 'g2', name: 'B' }] } },
+    });
+    const res = makeRes();
+    await requireGuildContext(req, res, next);
+    expect(res.redirect).toHaveBeenCalledWith('/guild/select');
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('drops a stale guild the user no longer belongs to and re-picks', async () => {
+    // currentGuildId points at a guild absent from the (now-reduced) membership list.
+    const req = makeReq({
+      session: { user: { discordId: 'u1', currentGuildId: 'gone', accessLevel: 3, guilds: [{ guildId: 'g1', name: 'A' }, { guildId: 'g2', name: 'B' }] } },
+    });
+    const res = makeRes();
+    await requireGuildContext(req, res, next);
+    expect(req.session.user.currentGuildId).toBeNull();
+    expect(res.redirect).toHaveBeenCalledWith('/guild/select');
     expect(next).not.toHaveBeenCalled();
   });
 });

--- a/src/web/middleware.ts
+++ b/src/web/middleware.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'crypto';
 import { Request, Response, NextFunction } from 'express';
 import { ensureSessionCsrfToken } from './csrf';
-import { AccessLevel, findApprovedKeyByHash } from '../db';
+import { AccessLevel, findApprovedKeyByHash, getEffectiveAccessLevel } from '../db';
 
 export function requireAuth(req: Request, res: Response, next: NextFunction): void {
   if (req.session.user) {
@@ -9,6 +9,40 @@ export function requireAuth(req: Request, res: Response, next: NextFunction): vo
   } else {
     res.redirect('/auth/login');
   }
+}
+
+/**
+ * Ensures the session has a current guild selected before a guild-scoped route runs.
+ * Assumes `requireAuth` ran first. Auto-selects when the user has exactly one guild
+ * (so single-guild deployments never see the picker); redirects to the picker when a
+ * choice is required; and re-validates that the stored guild is still one the user
+ * belongs to. The effective access level is recomputed for the resolved guild so
+ * authorization always reflects the current guild, never a stale login-time value.
+ */
+export async function requireGuildContext(req: Request, res: Response, next: NextFunction): Promise<void> {
+  const user = req.session.user;
+  if (!user) {
+    res.redirect('/auth/login');
+    return;
+  }
+
+  // A stored guild must still be one the user can act in (membership may have been
+  // revoked since login). Drop it and re-pick if not.
+  if (user.currentGuildId && !user.guilds.some((g) => g.guildId === user.currentGuildId)) {
+    user.currentGuildId = null;
+  }
+
+  if (!user.currentGuildId) {
+    if (user.guilds.length === 1) {
+      user.currentGuildId = user.guilds[0].guildId;
+      user.accessLevel = (await getEffectiveAccessLevel(user.currentGuildId, user.discordId)) as 0 | 1 | 2 | 3;
+    } else {
+      res.redirect('/guild/select');
+      return;
+    }
+  }
+
+  next();
 }
 
 export function requireManager(req: Request, res: Response, next: NextFunction): void {

--- a/src/web/middleware.ts
+++ b/src/web/middleware.ts
@@ -88,6 +88,7 @@ export async function requireApiKey(req: Request, res: Response, next: NextFunct
       return;
     }
     req.apiKeyOwner = row.discord_id;
+    req.apiKeyGuildId = row.guild_id;
     next();
   } catch {
     res.status(500).json({ ok: false, error: 'Internal server error' });

--- a/src/web/middleware.ts
+++ b/src/web/middleware.ts
@@ -35,12 +35,13 @@ export async function requireGuildContext(req: Request, res: Response, next: Nex
   if (!user.currentGuildId) {
     if (user.guilds.length === 1) {
       user.currentGuildId = user.guilds[0].guildId;
-      user.accessLevel = (await getEffectiveAccessLevel(user.currentGuildId, user.discordId)) as 0 | 1 | 2 | 3;
     } else {
       res.redirect('/guild/select');
       return;
     }
   }
+
+  user.accessLevel = (await getEffectiveAccessLevel(user.currentGuildId, user.discordId)) as 0 | 1 | 2 | 3;
 
   next();
 }

--- a/src/web/rateLimits.test.ts
+++ b/src/web/rateLimits.test.ts
@@ -13,7 +13,10 @@ const authedUser: SessionUser = {
   discordId: '123456789',
   discordName: 'TestUser',
   discordAvatar: null,
+  isOwner: false,
   accessLevel: 0,
+  currentGuildId: '999000999000999000',
+  guilds: [{ guildId: '999000999000999000', name: 'Test Guild' }],
 };
 
 function makeReq(overrides: Partial<{

--- a/src/web/routes/admin.test.ts
+++ b/src/web/routes/admin.test.ts
@@ -40,7 +40,7 @@ vi.mock('./adminRefresh', async () => {
   const { Router } = await import('express');
   return {
     default: Router(),
-    refreshState: { outcome: 'idle', updatedCount: 0, failureCount: 0, startedAt: null, finishedAt: null },
+    getRefreshState: vi.fn(() => ({ outcome: 'idle', updatedCount: 0, failureCount: 0, startedAt: null, finishedAt: null })),
   };
 });
 

--- a/src/web/routes/admin.test.ts
+++ b/src/web/routes/admin.test.ts
@@ -308,6 +308,11 @@ describe('POST /users/remove', () => {
 // --- POST /users/toggle-twitch ---
 
 describe('POST /users/toggle-twitch', () => {
+  beforeEach(() => {
+    // Target user is a member of the current guild by default.
+    vi.mocked(getMemberAccessLevel).mockResolvedValue(0);
+  });
+
   it('redirects to /admin/users when discord_id is missing', async () => {
     const res = await supertest(buildApp()).post('/users/toggle-twitch').type('form').send({ is_twitch_bot_enabled: 'true' });
     expect(res.headers.location).toBe('/admin/users');
@@ -317,6 +322,14 @@ describe('POST /users/toggle-twitch', () => {
     const res = await supertest(buildApp()).post('/users/toggle-twitch').type('form')
       .send({ discord_id: 'bad', is_twitch_bot_enabled: 'true' });
     expect(res.headers.location).toBe('/admin/users?error=invalid_discord_id');
+  });
+
+  it('redirects ?error=target_above_level when target is not a member of the current guild', async () => {
+    vi.mocked(getMemberAccessLevel).mockResolvedValue(null);
+    const res = await supertest(buildApp()).post('/users/toggle-twitch').type('form')
+      .send({ discord_id: VALID_ID, is_twitch_bot_enabled: 'true' });
+    expect(res.headers.location).toBe('/admin/users?error=target_above_level');
+    expect(vi.mocked(toggleTwitchMutation)).not.toHaveBeenCalled();
   });
 
   it('redirects ?error=invalid_twitch_state for an unrecognised value', async () => {

--- a/src/web/routes/admin.test.ts
+++ b/src/web/routes/admin.test.ts
@@ -2,10 +2,16 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../../db', () => ({
   findUser: vi.fn(),
-  getAllUsers: vi.fn(),
-  updateAccessLevel: vi.fn(),
+  getMemberAccessLevel: vi.fn(),
+  getGuildMemberUsers: vi.fn(),
+  setMemberAccessLevel: vi.fn(),
+  removeGuildMember: vi.fn(),
   ACCESS_LEVEL_LABELS: { 0: 'User', 1: 'Mod', 2: 'Manager', 3: 'Admin' },
   AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
+}));
+
+vi.mock('../../discord/guildRegistry', () => ({
+  reloadGuildRegistry: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('../csrf', () => ({
@@ -59,7 +65,8 @@ vi.mock('../../db/users', () => ({ AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, A
 import express from 'express';
 import supertest from 'supertest';
 import router from './admin';
-import { findUser, getAllUsers, updateAccessLevel } from '../../db';
+import { findUser, getMemberAccessLevel, getGuildMemberUsers, setMemberAccessLevel, removeGuildMember } from '../../db';
+import { reloadGuildRegistry } from '../../discord/guildRegistry';
 import { AccessLevel } from '../../db/users';
 import { normalizeTwitchChannelName } from '../../twitch/twitchChannelName';
 import {
@@ -67,14 +74,21 @@ import {
   isDuplicateTwitchNameDbError,
   isLockWaitTimeoutDbError,
   addOrUpdateUserMutation,
-  removeUserMutation,
   toggleTwitchMutation,
 } from './adminUserMutations';
 
-type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3 };
+type SessionUser = {
+  discordId: string;
+  discordName: string;
+  discordAvatar: string | null;
+  isOwner: boolean;
+  accessLevel: 0 | 1 | 2 | 3;
+  currentGuildId: string;
+};
 
-const ADMIN: SessionUser = { discordId: '100000000000000001', discordName: 'AdminUser', discordAvatar: null, accessLevel: AccessLevel.ADMIN };
-const MANAGER: SessionUser = { discordId: '200000000000000001', discordName: 'ManagerUser', discordAvatar: null, accessLevel: AccessLevel.MANAGER };
+const GUILD_ID = '900000000000000001';
+const ADMIN: SessionUser = { discordId: '100000000000000001', discordName: 'AdminUser', discordAvatar: null, isOwner: false, accessLevel: AccessLevel.ADMIN, currentGuildId: GUILD_ID };
+const MANAGER: SessionUser = { discordId: '200000000000000001', discordName: 'ManagerUser', discordAvatar: null, isOwner: false, accessLevel: AccessLevel.MANAGER, currentGuildId: GUILD_ID };
 const VALID_ID = '300000000000000001';
 
 function buildApp(sessionUser: SessionUser = ADMIN) {
@@ -91,11 +105,13 @@ function buildApp(sessionUser: SessionUser = ADMIN) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(getAllUsers).mockResolvedValue([]);
+  vi.mocked(getGuildMemberUsers).mockResolvedValue([]);
   vi.mocked(findUser).mockResolvedValue(null);
-  vi.mocked(updateAccessLevel).mockResolvedValue(undefined);
+  vi.mocked(getMemberAccessLevel).mockResolvedValue(null);
+  vi.mocked(setMemberAccessLevel).mockResolvedValue(undefined);
+  vi.mocked(removeGuildMember).mockResolvedValue(undefined);
+  vi.mocked(reloadGuildRegistry).mockResolvedValue(undefined);
   vi.mocked(addOrUpdateUserMutation).mockResolvedValue(undefined);
-  vi.mocked(removeUserMutation).mockResolvedValue(undefined);
   vi.mocked(toggleTwitchMutation).mockResolvedValue(undefined);
   vi.mocked(isLockWaitTimeoutDbError).mockReturnValue(false);
   vi.mocked(isDuplicateTwitchNameDbError).mockReturnValue(false);
@@ -125,8 +141,8 @@ describe('GET /users', () => {
     expect(res.body.error).toBeNull();
   });
 
-  it('returns 500 when getAllUsers throws', async () => {
-    vi.mocked(getAllUsers).mockRejectedValue(new Error('DB down'));
+  it('returns 500 when getGuildMemberUsers throws', async () => {
+    vi.mocked(getGuildMemberUsers).mockRejectedValue(new Error('DB down'));
     const res = await supertest(buildApp()).get('/users');
     expect(res.status).toBe(500);
   });
@@ -201,13 +217,15 @@ describe('POST /users/add', () => {
     expect(res.headers.location).toBe('/admin/users?error=add_failed');
   });
 
-  it('redirects to /admin/users on success', async () => {
+  it('redirects to /admin/users on success and grants guild membership', async () => {
     const res = await supertest(buildApp()).post('/users/add').type('form')
       .send({ discord_id: VALID_ID, discord_name: 'TestUser', access_level: '0', twitch_name: 'streamer' });
     expect(res.headers.location).toBe('/admin/users');
     expect(vi.mocked(addOrUpdateUserMutation)).toHaveBeenCalledWith(
       expect.objectContaining({ discordId: VALID_ID, discordName: 'TestUser', level: 0, normalizedTwitchName: 'streamer' }),
     );
+    expect(vi.mocked(setMemberAccessLevel)).toHaveBeenCalledWith(GUILD_ID, VALID_ID, 0);
+    expect(vi.mocked(reloadGuildRegistry)).toHaveBeenCalled();
   });
 });
 
@@ -230,22 +248,22 @@ describe('POST /users/update', () => {
   });
 
   it('redirects ?error=db_busy on lock timeout', async () => {
-    vi.mocked(updateAccessLevel).mockRejectedValue(new Error('lock'));
+    vi.mocked(setMemberAccessLevel).mockRejectedValue(new Error('lock'));
     vi.mocked(isLockWaitTimeoutDbError).mockReturnValue(true);
     const res = await supertest(buildApp()).post('/users/update').type('form').send({ discord_id: VALID_ID, access_level: '0' });
     expect(res.headers.location).toBe('/admin/users?error=db_busy');
   });
 
   it('redirects ?error=update_failed on unexpected DB error', async () => {
-    vi.mocked(updateAccessLevel).mockRejectedValue(new Error('unexpected'));
+    vi.mocked(setMemberAccessLevel).mockRejectedValue(new Error('unexpected'));
     const res = await supertest(buildApp()).post('/users/update').type('form').send({ discord_id: VALID_ID, access_level: '0' });
     expect(res.headers.location).toBe('/admin/users?error=update_failed');
   });
 
-  it('redirects to /admin/users on success', async () => {
+  it('redirects to /admin/users on success and writes the per-guild level', async () => {
     const res = await supertest(buildApp()).post('/users/update').type('form').send({ discord_id: VALID_ID, access_level: '1' });
     expect(res.headers.location).toBe('/admin/users');
-    expect(vi.mocked(updateAccessLevel)).toHaveBeenCalledWith(VALID_ID, 1);
+    expect(vi.mocked(setMemberAccessLevel)).toHaveBeenCalledWith(GUILD_ID, VALID_ID, 1);
   });
 });
 
@@ -268,22 +286,23 @@ describe('POST /users/remove', () => {
   });
 
   it('redirects ?error=db_busy on lock timeout', async () => {
-    vi.mocked(removeUserMutation).mockRejectedValue(new Error('lock'));
+    vi.mocked(removeGuildMember).mockRejectedValue(new Error('lock'));
     vi.mocked(isLockWaitTimeoutDbError).mockReturnValue(true);
     const res = await supertest(buildApp()).post('/users/remove').type('form').send({ discord_id: VALID_ID });
     expect(res.headers.location).toBe('/admin/users?error=db_busy');
   });
 
   it('redirects ?error=remove_failed on unexpected DB error', async () => {
-    vi.mocked(removeUserMutation).mockRejectedValue(new Error('unexpected'));
+    vi.mocked(removeGuildMember).mockRejectedValue(new Error('unexpected'));
     const res = await supertest(buildApp()).post('/users/remove').type('form').send({ discord_id: VALID_ID });
     expect(res.headers.location).toBe('/admin/users?error=remove_failed');
   });
 
-  it('redirects to /admin/users on success', async () => {
+  it('removes the member from the current guild and reloads the registry', async () => {
     const res = await supertest(buildApp()).post('/users/remove').type('form').send({ discord_id: VALID_ID });
     expect(res.headers.location).toBe('/admin/users');
-    expect(vi.mocked(removeUserMutation)).toHaveBeenCalledWith(VALID_ID);
+    expect(vi.mocked(removeGuildMember)).toHaveBeenCalledWith(GUILD_ID, VALID_ID);
+    expect(vi.mocked(reloadGuildRegistry)).toHaveBeenCalled();
   });
 });
 

--- a/src/web/routes/admin.test.ts
+++ b/src/web/routes/admin.test.ts
@@ -88,7 +88,6 @@ type SessionUser = {
 
 const GUILD_ID = '900000000000000001';
 const ADMIN: SessionUser = { discordId: '100000000000000001', discordName: 'AdminUser', discordAvatar: null, isOwner: false, accessLevel: AccessLevel.ADMIN, currentGuildId: GUILD_ID };
-const MANAGER: SessionUser = { discordId: '200000000000000001', discordName: 'ManagerUser', discordAvatar: null, isOwner: false, accessLevel: AccessLevel.MANAGER, currentGuildId: GUILD_ID };
 const VALID_ID = '300000000000000001';
 
 function buildApp(sessionUser: SessionUser = ADMIN) {

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -2,7 +2,6 @@ import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import {
   getGuildMemberUsers,
-  getMemberAccessLevel,
   setMemberAccessLevel,
   removeGuildMember,
   ACCESS_LEVEL_LABELS,
@@ -22,12 +21,12 @@ import {
 } from './adminUserMutations';
 import {
   accessLevelError,
-  parseTwitchEnabled,
   parseTwitchNameInput,
   checkManagerEditAuth,
   handleDbError,
   resolveGuildId,
   resolveValidDiscordId,
+  resolveToggleTwitchInputs,
 } from './adminUserValidation';
 
 const log = createLogger('Web');
@@ -185,12 +184,8 @@ router.post('/users/toggle-twitch', requireManager, csrfProtection, async (req, 
   const trimmedDiscordId = resolveValidDiscordId(res, discord_id);
   if (!trimmedDiscordId) return;
 
-  const nextEnabled = parseTwitchEnabled(is_twitch_bot_enabled);
-  if (nextEnabled === null) return res.redirect('/admin/users?error=invalid_twitch_state');
-
-  // Verify target is a member of the current guild before modifying their Twitch state.
-  const memberLevel = await getMemberAccessLevel(guildId, trimmedDiscordId);
-  if (memberLevel === null) return res.redirect('/admin/users?error=target_above_level');
+  const nextEnabled = await resolveToggleTwitchInputs(res, guildId, trimmedDiscordId, is_twitch_bot_enabled);
+  if (nextEnabled === null) return;
 
   try {
     await userMutationQueue.run(trimmedDiscordId, () => toggleTwitchMutation(trimmedDiscordId, nextEnabled));

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -20,12 +20,13 @@ import {
   toggleTwitchMutation,
 } from './adminUserMutations';
 import {
-  discordIdError,
   accessLevelError,
   parseTwitchEnabled,
   parseTwitchNameInput,
   checkManagerEditAuth,
   handleDbError,
+  resolveGuildId,
+  resolveValidDiscordId,
 } from './adminUserValidation';
 
 const log = createLogger('Web');
@@ -75,8 +76,8 @@ async function reloadRegistrySafe(): Promise<void> {
 // managers may only assign levels below their own). Identity and Twitch are global;
 // the access level is written to guild_member for the current guild.
 router.post('/users/add', requireManager, csrfProtection, async (req, res) => {
-  const guildId = req.session.user!.currentGuildId;
-  if (!guildId) return res.redirect('/guild/select');
+  const guildId = resolveGuildId(req, res);
+  if (!guildId) return;
 
   const { discord_id, discord_name, access_level, twitch_name, clear_twitch_name } = req.body as {
     discord_id?: string;
@@ -85,11 +86,9 @@ router.post('/users/add', requireManager, csrfProtection, async (req, res) => {
     twitch_name?: string;
     clear_twitch_name?: string;
   };
-  const trimmedDiscordId = trimField(discord_id);
-  if (!trimmedDiscordId || !access_level) return res.redirect('/admin/users');
-
-  const idErr = discordIdError(trimmedDiscordId);
-  if (idErr) return res.redirect(`/admin/users?error=${idErr}`);
+  const trimmedDiscordId = resolveValidDiscordId(res, discord_id);
+  if (!trimmedDiscordId) return;
+  if (!access_level) return res.redirect('/admin/users');
 
   const levelErr = accessLevelError(access_level);
   if (levelErr) return res.redirect(`/admin/users?error=${levelErr}`);
@@ -128,15 +127,13 @@ router.post('/users/add', requireManager, csrfProtection, async (req, res) => {
 // Update a member's access level within the current guild (Manager+; managers may
 // only set levels below their own and cannot modify members at their level or above)
 router.post('/users/update', requireManager, csrfProtection, async (req, res) => {
-  const guildId = req.session.user!.currentGuildId;
-  if (!guildId) return res.redirect('/guild/select');
+  const guildId = resolveGuildId(req, res);
+  if (!guildId) return;
 
   const { discord_id, access_level } = req.body as { discord_id?: string; access_level?: string };
-  const trimmedDiscordId = trimField(discord_id);
-  if (!trimmedDiscordId || access_level === undefined) return res.redirect('/admin/users');
-
-  const idErr = discordIdError(trimmedDiscordId);
-  if (idErr) return res.redirect(`/admin/users?error=${idErr}`);
+  if (access_level === undefined) return res.redirect('/admin/users');
+  const trimmedDiscordId = resolveValidDiscordId(res, discord_id);
+  if (!trimmedDiscordId) return;
 
   const levelErr = accessLevelError(access_level);
   if (levelErr) return res.redirect(`/admin/users?error=${levelErr}`);
@@ -155,15 +152,12 @@ router.post('/users/update', requireManager, csrfProtection, async (req, res) =>
 // Remove a member from the current guild (Admin only). The global user row and
 // Twitch identity are left intact — they may belong to other guilds.
 router.post('/users/remove', requireAdmin, csrfProtection, async (req, res) => {
-  const guildId = req.session.user!.currentGuildId;
-  if (!guildId) return res.redirect('/guild/select');
+  const guildId = resolveGuildId(req, res);
+  if (!guildId) return;
 
   const { discord_id } = req.body as { discord_id?: string };
-  const trimmedDiscordId = trimField(discord_id);
-  if (!trimmedDiscordId) return res.redirect('/admin/users');
-
-  const idErr = discordIdError(trimmedDiscordId);
-  if (idErr) return res.redirect(`/admin/users?error=${idErr}`);
+  const trimmedDiscordId = resolveValidDiscordId(res, discord_id);
+  if (!trimmedDiscordId) return;
 
   if (trimmedDiscordId === req.session.user!.discordId) {
     return res.redirect('/admin/users?error=self_remove_forbidden');
@@ -184,11 +178,8 @@ router.post('/users/toggle-twitch', requireManager, csrfProtection, async (req, 
     discord_id?: string;
     is_twitch_bot_enabled?: string;
   };
-  const trimmedDiscordId = trimField(discord_id);
-  if (!trimmedDiscordId) return res.redirect('/admin/users');
-
-  const idErr = discordIdError(trimmedDiscordId);
-  if (idErr) return res.redirect(`/admin/users?error=${idErr}`);
+  const trimmedDiscordId = resolveValidDiscordId(res, discord_id);
+  if (!trimmedDiscordId) return;
 
   const nextEnabled = parseTwitchEnabled(is_twitch_bot_enabled);
   if (nextEnabled === null) return res.redirect('/admin/users?error=invalid_twitch_state');

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -12,7 +12,7 @@ import { csrfProtection } from '../csrf';
 import { requireManager, requireAdmin } from '../middleware';
 import { trimField, renderError, filterQueryParam } from './shared';
 import { createMutationQueue } from '../../shared/mutationQueue';
-import adminRefreshRouter, { refreshState } from './adminRefresh';
+import adminRefreshRouter, { getRefreshState } from './adminRefresh';
 import {
   DuplicateTwitchNameError,
   isDuplicateTwitchNameDbError,
@@ -53,7 +53,7 @@ router.get('/users', requireManager, csrfProtection, async (req, res) => {
       csrfToken: req.csrfToken(),
       accessLevelLabels: ACCESS_LEVEL_LABELS,
       error: filterQueryParam(req.query.error, KNOWN_ERRORS),
-      refreshState,
+      refreshState: getRefreshState(guildId),
     });
   } catch (err) {
     log.error('Admin users error:', err);

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -24,7 +24,6 @@ import {
   parseTwitchNameInput,
   checkManagerEditAuth,
   handleDbError,
-  resolveGuildId,
   resolveValidDiscordId,
   resolveToggleTwitchInputs,
 } from './adminUserValidation';
@@ -45,8 +44,7 @@ const userMutationQueue = createMutationQueue();
 
 // View the current guild's members (Manager+)
 router.get('/users', requireManager, csrfProtection, async (req, res) => {
-  const guildId = req.session.user!.currentGuildId;
-  if (!guildId) return res.redirect('/guild/select');
+  const guildId = req.session.user!.currentGuildId!;
   try {
     const users = await getGuildMemberUsers(guildId);
     res.render('admin', {
@@ -76,8 +74,7 @@ async function reloadRegistrySafe(): Promise<void> {
 // managers may only assign levels below their own). Identity and Twitch are global;
 // the access level is written to guild_member for the current guild.
 router.post('/users/add', requireManager, csrfProtection, async (req, res) => {
-  const guildId = resolveGuildId(req, res);
-  if (!guildId) return;
+  const guildId = req.session.user!.currentGuildId!;
 
   const { discord_id, discord_name, access_level, twitch_name, clear_twitch_name } = req.body as {
     discord_id?: string;
@@ -127,8 +124,7 @@ router.post('/users/add', requireManager, csrfProtection, async (req, res) => {
 // Update a member's access level within the current guild (Manager+; managers may
 // only set levels below their own and cannot modify members at their level or above)
 router.post('/users/update', requireManager, csrfProtection, async (req, res) => {
-  const guildId = resolveGuildId(req, res);
-  if (!guildId) return;
+  const guildId = req.session.user!.currentGuildId!;
 
   const { discord_id, access_level } = req.body as { discord_id?: string; access_level?: string };
   if (access_level === undefined) return res.redirect('/admin/users');
@@ -152,8 +148,7 @@ router.post('/users/update', requireManager, csrfProtection, async (req, res) =>
 // Remove a member from the current guild (Admin only). The global user row and
 // Twitch identity are left intact — they may belong to other guilds.
 router.post('/users/remove', requireAdmin, csrfProtection, async (req, res) => {
-  const guildId = resolveGuildId(req, res);
-  if (!guildId) return;
+  const guildId = req.session.user!.currentGuildId!;
 
   const { discord_id } = req.body as { discord_id?: string };
   const trimmedDiscordId = resolveValidDiscordId(res, discord_id);
@@ -174,8 +169,7 @@ router.post('/users/remove', requireAdmin, csrfProtection, async (req, res) => {
 
 // Toggle twitch bot participation for a user (Manager+)
 router.post('/users/toggle-twitch', requireManager, csrfProtection, async (req, res) => {
-  const guildId = resolveGuildId(req, res);
-  if (!guildId) return;
+  const guildId = req.session.user!.currentGuildId!;
 
   const { discord_id, is_twitch_bot_enabled } = req.body as {
     discord_id?: string;

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -178,7 +178,7 @@ router.post('/users/toggle-twitch', requireManager, csrfProtection, async (req, 
   const trimmedDiscordId = resolveValidDiscordId(res, discord_id);
   if (!trimmedDiscordId) return;
 
-  const nextEnabled = await resolveToggleTwitchInputs(res, guildId, trimmedDiscordId, is_twitch_bot_enabled);
+  const nextEnabled = await resolveToggleTwitchInputs(res, req.session.user!, guildId, trimmedDiscordId, is_twitch_bot_enabled);
   if (nextEnabled === null) return;
 
   try {

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -2,6 +2,7 @@ import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import {
   getGuildMemberUsers,
+  getMemberAccessLevel,
   setMemberAccessLevel,
   removeGuildMember,
   ACCESS_LEVEL_LABELS,
@@ -174,6 +175,9 @@ router.post('/users/remove', requireAdmin, csrfProtection, async (req, res) => {
 
 // Toggle twitch bot participation for a user (Manager+)
 router.post('/users/toggle-twitch', requireManager, csrfProtection, async (req, res) => {
+  const guildId = resolveGuildId(req, res);
+  if (!guildId) return;
+
   const { discord_id, is_twitch_bot_enabled } = req.body as {
     discord_id?: string;
     is_twitch_bot_enabled?: string;
@@ -183,6 +187,10 @@ router.post('/users/toggle-twitch', requireManager, csrfProtection, async (req, 
 
   const nextEnabled = parseTwitchEnabled(is_twitch_bot_enabled);
   if (nextEnabled === null) return res.redirect('/admin/users?error=invalid_twitch_state');
+
+  // Verify target is a member of the current guild before modifying their Twitch state.
+  const memberLevel = await getMemberAccessLevel(guildId, trimmedDiscordId);
+  if (memberLevel === null) return res.redirect('/admin/users?error=target_above_level');
 
   try {
     await userMutationQueue.run(trimmedDiscordId, () => toggleTwitchMutation(trimmedDiscordId, nextEnabled));

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -1,11 +1,13 @@
 import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import {
-  getAllUsers,
-  updateAccessLevel,
+  getGuildMemberUsers,
+  setMemberAccessLevel,
+  removeGuildMember,
   ACCESS_LEVEL_LABELS,
   AccessLevelValue,
 } from '../../db';
+import { reloadGuildRegistry } from '../../discord/guildRegistry';
 import { csrfProtection } from '../csrf';
 import { requireManager, requireAdmin } from '../middleware';
 import { trimField, renderError, filterQueryParam } from './shared';
@@ -15,7 +17,6 @@ import {
   DuplicateTwitchNameError,
   isDuplicateTwitchNameDbError,
   addOrUpdateUserMutation,
-  removeUserMutation,
   toggleTwitchMutation,
 } from './adminUserMutations';
 import {
@@ -41,10 +42,12 @@ const KNOWN_ERRORS = new Set([
 // shared storage or a DB transaction/row lock before scaling out.
 const userMutationQueue = createMutationQueue();
 
-// View user list (Manager+)
+// View the current guild's members (Manager+)
 router.get('/users', requireManager, csrfProtection, async (req, res) => {
+  const guildId = req.session.user!.currentGuildId;
+  if (!guildId) return res.redirect('/guild/select');
   try {
-    const users = await getAllUsers();
+    const users = await getGuildMemberUsers(guildId);
     res.render('admin', {
       user: req.session.user,
       users,
@@ -59,8 +62,22 @@ router.get('/users', requireManager, csrfProtection, async (req, res) => {
   }
 });
 
-// Add or update a user (Manager+; managers may only assign levels below their own)
+/** Refresh the guild registry after a membership change; log but never fail the request. */
+async function reloadRegistrySafe(): Promise<void> {
+  try {
+    await reloadGuildRegistry();
+  } catch (err) {
+    log.error('Guild registry reload after membership change failed:', err);
+  }
+}
+
+// Add a member to the current guild, or update their identity/level (Manager+;
+// managers may only assign levels below their own). Identity and Twitch are global;
+// the access level is written to guild_member for the current guild.
 router.post('/users/add', requireManager, csrfProtection, async (req, res) => {
+  const guildId = req.session.user!.currentGuildId;
+  if (!guildId) return res.redirect('/guild/select');
+
   const { discord_id, discord_name, access_level, twitch_name, clear_twitch_name } = req.body as {
     discord_id?: string;
     discord_name?: string;
@@ -81,28 +98,39 @@ router.post('/users/add', requireManager, csrfProtection, async (req, res) => {
   const { normalizedTwitchName, shouldClearTwitchName, error: twitchErr } = parseTwitchNameInput(twitch_name, clear_twitch_name);
   if (twitchErr) return res.redirect(`/admin/users?error=${twitchErr}`);
 
-  const addAuthErr = await checkManagerEditAuth(req.session.user!, trimmedDiscordId, level);
+  const addAuthErr = await checkManagerEditAuth(req.session.user!, trimmedDiscordId, level, guildId);
   if (addAuthErr) return res.redirect(`/admin/users?error=${addAuthErr}`);
   try {
     const trimmedDiscordName = trimField(discord_name);
-    await userMutationQueue.run(trimmedDiscordId, () => addOrUpdateUserMutation({
-      discordId: trimmedDiscordId,
-      discordName: trimmedDiscordName,
-      level,
-      normalizedTwitchName,
-      shouldClearTwitchName,
-    }));
+    await userMutationQueue.run(trimmedDiscordId, async () => {
+      // Ensure the global user row (whitelist + Twitch identity) exists, then grant
+      // membership of the current guild at the chosen level.
+      await addOrUpdateUserMutation({
+        discordId: trimmedDiscordId,
+        discordName: trimmedDiscordName,
+        level,
+        normalizedTwitchName,
+        shouldClearTwitchName,
+      });
+      await setMemberAccessLevel(guildId, trimmedDiscordId, level);
+    });
   } catch (err) {
     if (err instanceof DuplicateTwitchNameError || isDuplicateTwitchNameDbError(err)) {
       return res.redirect('/admin/users?error=duplicate_twitch_name');
     }
     return handleDbError(err, res, 'add_failed', 'Add user');
   }
+  // A newly-added member may have provisioned a previously-inert guild.
+  await reloadRegistrySafe();
   res.redirect('/admin/users');
 });
 
-// Update access level (Manager+; managers may only set levels below their own and cannot modify users at their level or above)
+// Update a member's access level within the current guild (Manager+; managers may
+// only set levels below their own and cannot modify members at their level or above)
 router.post('/users/update', requireManager, csrfProtection, async (req, res) => {
+  const guildId = req.session.user!.currentGuildId;
+  if (!guildId) return res.redirect('/guild/select');
+
   const { discord_id, access_level } = req.body as { discord_id?: string; access_level?: string };
   const trimmedDiscordId = trimField(discord_id);
   if (!trimmedDiscordId || access_level === undefined) return res.redirect('/admin/users');
@@ -114,18 +142,22 @@ router.post('/users/update', requireManager, csrfProtection, async (req, res) =>
   if (levelErr) return res.redirect(`/admin/users?error=${levelErr}`);
 
   const level = Number(access_level);
-  const updateAuthErr = await checkManagerEditAuth(req.session.user!, trimmedDiscordId, level);
+  const updateAuthErr = await checkManagerEditAuth(req.session.user!, trimmedDiscordId, level, guildId);
   if (updateAuthErr) return res.redirect(`/admin/users?error=${updateAuthErr}`);
   try {
-    await userMutationQueue.run(trimmedDiscordId, () => updateAccessLevel(trimmedDiscordId, level));
+    await userMutationQueue.run(trimmedDiscordId, () => setMemberAccessLevel(guildId, trimmedDiscordId, level));
   } catch (err) {
     return handleDbError(err, res, 'update_failed', 'Update access level');
   }
   res.redirect('/admin/users');
 });
 
-// Remove a user (Admin only)
+// Remove a member from the current guild (Admin only). The global user row and
+// Twitch identity are left intact — they may belong to other guilds.
 router.post('/users/remove', requireAdmin, csrfProtection, async (req, res) => {
+  const guildId = req.session.user!.currentGuildId;
+  if (!guildId) return res.redirect('/guild/select');
+
   const { discord_id } = req.body as { discord_id?: string };
   const trimmedDiscordId = trimField(discord_id);
   if (!trimmedDiscordId) return res.redirect('/admin/users');
@@ -137,10 +169,12 @@ router.post('/users/remove', requireAdmin, csrfProtection, async (req, res) => {
     return res.redirect('/admin/users?error=self_remove_forbidden');
   }
   try {
-    await userMutationQueue.run(trimmedDiscordId, () => removeUserMutation(trimmedDiscordId));
+    await userMutationQueue.run(trimmedDiscordId, () => removeGuildMember(guildId, trimmedDiscordId));
   } catch (err) {
     return handleDbError(err, res, 'remove_failed', 'Remove user');
   }
+  // Removing the guild's last member un-provisions it; refresh the registry.
+  await reloadRegistrySafe();
   res.redirect('/admin/users');
 });
 

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -11,7 +11,7 @@ import { reloadGuildRegistry } from '../../discord/guildRegistry';
 import { csrfProtection } from '../csrf';
 import { requireManager, requireAdmin } from '../middleware';
 import { trimField, renderError, filterQueryParam } from './shared';
-import { createMutationQueue } from '../../shared/mutationQueue';
+import { userMutationQueue } from './adminUserMutationQueue';
 import adminRefreshRouter, { getRefreshState } from './adminRefresh';
 import {
   DuplicateTwitchNameError,
@@ -37,11 +37,6 @@ const KNOWN_ERRORS = new Set([
   'invalid_discord_id', 'invalid_access_level', 'access_level_too_high', 'invalid_twitch_name',
   'self_edit_forbidden', 'self_remove_forbidden', 'target_above_level', 'invalid_twitch_state',
 ]);
-// Twitch membership changes are serialized per user in-process because this bot
-// currently runs as a single web instance. If that changes, move this lock into
-// shared storage or a DB transaction/row lock before scaling out.
-const userMutationQueue = createMutationQueue();
-
 // View the current guild's members (Manager+)
 router.get('/users', requireManager, csrfProtection, async (req, res) => {
   const guildId = req.session.user!.currentGuildId!;

--- a/src/web/routes/adminRefresh.test.ts
+++ b/src/web/routes/adminRefresh.test.ts
@@ -182,6 +182,7 @@ describe('runDiscordNameRefresh outcomes', () => {
     expect(getRefreshState(GUILD_ID).outcome).toBe('noop');
     expect(getRefreshState(GUILD_ID).updatedCount).toBe(0);
     expect(updateDiscordName).not.toHaveBeenCalled();
+    expect(vi.mocked(fetchMemberDisplayName)).toHaveBeenCalledWith('1', true, GUILD_ID);
   });
 
   it('outcome is "partial" when some users succeed and some fail', async () => {
@@ -200,6 +201,8 @@ describe('runDiscordNameRefresh outcomes', () => {
     expect(getRefreshState(GUILD_ID).outcome).toBe('partial');
     expect(getRefreshState(GUILD_ID).updatedCount).toBe(1);
     expect(getRefreshState(GUILD_ID).failureCount).toBe(1);
+    expect(vi.mocked(fetchMemberDisplayName)).toHaveBeenCalledWith('1', true, GUILD_ID);
+    expect(vi.mocked(fetchMemberDisplayName)).toHaveBeenCalledWith('2', true, GUILD_ID);
   });
 
   it('outcome is "error" when all lookups fail', async () => {
@@ -215,6 +218,7 @@ describe('runDiscordNameRefresh outcomes', () => {
     expect(getRefreshState(GUILD_ID).outcome).toBe('error');
     expect(getRefreshState(GUILD_ID).updatedCount).toBe(0);
     expect(getRefreshState(GUILD_ID).failureCount).toBe(1);
+    expect(vi.mocked(fetchMemberDisplayName)).toHaveBeenCalledWith('1', true, GUILD_ID);
   });
 
   it('outcome is "error" when Discord client is not ready', async () => {
@@ -249,5 +253,6 @@ describe('runDiscordNameRefresh outcomes', () => {
     await waitForRefreshComplete();
     expect(getRefreshState(GUILD_ID).failureCount).toBe(1);
     expect(getRefreshState(GUILD_ID).outcome).toBe('error');
+    expect(vi.mocked(fetchMemberDisplayName)).toHaveBeenCalledWith('1', true, GUILD_ID);
   });
 });

--- a/src/web/routes/adminRefresh.test.ts
+++ b/src/web/routes/adminRefresh.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../../db', () => ({
-  getAllUsers: vi.fn(),
+  getGuildMemberUsers: vi.fn(),
   updateDiscordName: vi.fn(),
 }));
 vi.mock('../../discord/discordBot', () => ({
@@ -18,7 +18,7 @@ vi.mock('../../shared/logger', () => ({
   createLogger: () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn() }),
 }));
 
-import { getAllUsers, updateDiscordName } from '../../db';
+import { getGuildMemberUsers, updateDiscordName } from '../../db';
 import { getDiscordClient, fetchMemberDisplayName } from '../../discord/discordBot';
 import express from 'express';
 import supertest from 'supertest';
@@ -26,10 +26,16 @@ import supertest from 'supertest';
 // Import module last so mocks are in place before module-level code runs
 import router, { refreshState, type RefreshOutcome } from './adminRefresh';
 
+const GUILD_ID = '900000000000000001';
+
 function buildApp() {
   const app = express();
   app.use(express.json());
   app.use(express.urlencoded({ extended: false }));
+  app.use((req: any, _res: any, next: any) => {
+    req.session = { user: { discordId: 'u1', currentGuildId: GUILD_ID, accessLevel: 2 } };
+    next();
+  });
   app.use(router);
   return supertest(app);
 }
@@ -99,7 +105,7 @@ describe('GET /users/refresh-status', () => {
 describe('POST /users/refresh-names', () => {
   it('redirects to /admin/users immediately', async () => {
     vi.mocked(getDiscordClient).mockReturnValue({} as any);
-    vi.mocked(getAllUsers).mockResolvedValue([]);
+    vi.mocked(getGuildMemberUsers).mockResolvedValue([]);
     const app = buildApp();
     const res = await app.post('/users/refresh-names');
     expect(res.status).toBe(302);
@@ -111,7 +117,7 @@ describe('POST /users/refresh-names', () => {
     const app = buildApp();
     const res = await app.post('/users/refresh-names');
     expect(res.status).toBe(302);
-    expect(getAllUsers).not.toHaveBeenCalled();
+    expect(getGuildMemberUsers).not.toHaveBeenCalled();
   });
 });
 
@@ -120,7 +126,7 @@ describe('POST /users/refresh-names', () => {
 describe('runDiscordNameRefresh outcomes', () => {
   it('outcome is "noop" when discord client ready but no users need updating', async () => {
     vi.mocked(getDiscordClient).mockReturnValue({} as any);
-    vi.mocked(getAllUsers).mockResolvedValue([]);
+    vi.mocked(getGuildMemberUsers).mockResolvedValue([]);
     const app = buildApp();
     await app.post('/users/refresh-names');
     await waitForRefreshComplete();
@@ -132,7 +138,7 @@ describe('runDiscordNameRefresh outcomes', () => {
 
   it('outcome is "success" when all users are updated with no failures', async () => {
     vi.mocked(getDiscordClient).mockReturnValue({} as any);
-    vi.mocked(getAllUsers).mockResolvedValue([
+    vi.mocked(getGuildMemberUsers).mockResolvedValue([
       { discord_id: '1', discord_name: 'OldName1' },
       { discord_id: '2', discord_name: 'OldName2' },
     ] as any);
@@ -153,7 +159,7 @@ describe('runDiscordNameRefresh outcomes', () => {
 
   it('outcome is "noop" when display names have not changed', async () => {
     vi.mocked(getDiscordClient).mockReturnValue({} as any);
-    vi.mocked(getAllUsers).mockResolvedValue([
+    vi.mocked(getGuildMemberUsers).mockResolvedValue([
       { discord_id: '1', discord_name: 'UnchangedName' },
     ] as any);
     vi.mocked(fetchMemberDisplayName).mockResolvedValue('UnchangedName');
@@ -168,7 +174,7 @@ describe('runDiscordNameRefresh outcomes', () => {
 
   it('outcome is "partial" when some users succeed and some fail', async () => {
     vi.mocked(getDiscordClient).mockReturnValue({} as any);
-    vi.mocked(getAllUsers).mockResolvedValue([
+    vi.mocked(getGuildMemberUsers).mockResolvedValue([
       { discord_id: '1', discord_name: 'OldName1' },
       { discord_id: '2', discord_name: 'OldName2' },
     ] as any);
@@ -186,7 +192,7 @@ describe('runDiscordNameRefresh outcomes', () => {
 
   it('outcome is "error" when all lookups fail', async () => {
     vi.mocked(getDiscordClient).mockReturnValue({} as any);
-    vi.mocked(getAllUsers).mockResolvedValue([
+    vi.mocked(getGuildMemberUsers).mockResolvedValue([
       { discord_id: '1', discord_name: 'OldName1' },
     ] as any);
     vi.mocked(fetchMemberDisplayName).mockResolvedValue(null);
@@ -210,7 +216,7 @@ describe('runDiscordNameRefresh outcomes', () => {
 
   it('finishedAt is set after completion', async () => {
     vi.mocked(getDiscordClient).mockReturnValue({} as any);
-    vi.mocked(getAllUsers).mockResolvedValue([]);
+    vi.mocked(getGuildMemberUsers).mockResolvedValue([]);
 
     const before = Date.now();
     const app = buildApp();
@@ -221,7 +227,7 @@ describe('runDiscordNameRefresh outcomes', () => {
 
   it('individual user errors are caught and counted as failures', async () => {
     vi.mocked(getDiscordClient).mockReturnValue({} as any);
-    vi.mocked(getAllUsers).mockResolvedValue([
+    vi.mocked(getGuildMemberUsers).mockResolvedValue([
       { discord_id: '1', discord_name: 'OldName' },
     ] as any);
     vi.mocked(fetchMemberDisplayName).mockRejectedValue(new Error('Network error'));

--- a/src/web/routes/adminRefresh.test.ts
+++ b/src/web/routes/adminRefresh.test.ts
@@ -24,34 +24,27 @@ import express from 'express';
 import supertest from 'supertest';
 
 // Import module last so mocks are in place before module-level code runs
-import router, { refreshState, type RefreshOutcome } from './adminRefresh';
+import router, { refreshStates, getRefreshState } from './adminRefresh';
 
 const GUILD_ID = '900000000000000001';
+const OTHER_GUILD_ID = '900000000000000002';
 
-function buildApp() {
+function buildApp(currentGuildId: string = GUILD_ID) {
   const app = express();
   app.use(express.json());
   app.use(express.urlencoded({ extended: false }));
   app.use((req: any, _res: any, next: any) => {
-    req.session = { user: { discordId: 'u1', currentGuildId: GUILD_ID, accessLevel: 2 } };
+    req.session = { user: { discordId: 'u1', currentGuildId, accessLevel: 2 } };
     next();
   });
   app.use(router);
   return supertest(app);
 }
 
-function resetRefreshState() {
-  refreshState.outcome = 'idle';
-  refreshState.updatedCount = 0;
-  refreshState.failureCount = 0;
-  refreshState.startedAt = null;
-  refreshState.finishedAt = null;
-}
-
-/** Wait for refreshState to leave 'running'. */
-async function waitForRefreshComplete(timeoutMs = 2000): Promise<void> {
+/** Wait for a guild's refresh state to leave 'running'. */
+async function waitForRefreshComplete(guildId: string = GUILD_ID, timeoutMs = 2000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
-  while (refreshState.outcome === 'running') {
+  while (getRefreshState(guildId).outcome === 'running') {
     if (Date.now() > deadline) throw new Error('Timed out waiting for refresh to complete');
     await new Promise((r) => setTimeout(r, 10));
   }
@@ -59,25 +52,27 @@ async function waitForRefreshComplete(timeoutMs = 2000): Promise<void> {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  resetRefreshState();
+  refreshStates.clear();
 });
 
-// ─── refreshState initial values ─────────────────────────────────────────────
+// ─── getRefreshState defaults ────────────────────────────────────────────────
 
-describe('refreshState', () => {
-  it('starts in idle state', () => {
-    expect(refreshState.outcome).toBe('idle');
-    expect(refreshState.updatedCount).toBe(0);
-    expect(refreshState.failureCount).toBe(0);
-    expect(refreshState.startedAt).toBeNull();
-    expect(refreshState.finishedAt).toBeNull();
+describe('getRefreshState', () => {
+  it('returns idle defaults for a guild with no recorded refresh', () => {
+    expect(getRefreshState(GUILD_ID)).toEqual({
+      outcome: 'idle',
+      updatedCount: 0,
+      failureCount: 0,
+      startedAt: null,
+      finishedAt: null,
+    });
   });
 });
 
 // ─── GET /users/refresh-status ────────────────────────────────────────────────
 
 describe('GET /users/refresh-status', () => {
-  it('returns the current refreshState as JSON', async () => {
+  it('returns the current guild refresh state as JSON', async () => {
     const app = buildApp();
     const res = await app.get('/users/refresh-status');
     expect(res.status).toBe(200);
@@ -90,13 +85,16 @@ describe('GET /users/refresh-status', () => {
     });
   });
 
-  it('reflects state changes', async () => {
-    refreshState.outcome = 'success';
-    refreshState.updatedCount = 3;
-    const app = buildApp();
-    const res = await app.get('/users/refresh-status');
+  it('reflects state changes for the requesting guild only', async () => {
+    refreshStates.set(GUILD_ID, { outcome: 'success', updatedCount: 3, failureCount: 0, startedAt: 1, finishedAt: 2 });
+    refreshStates.set(OTHER_GUILD_ID, { outcome: 'error', updatedCount: 0, failureCount: 1, startedAt: 1, finishedAt: 2 });
+
+    const res = await buildApp(GUILD_ID).get('/users/refresh-status');
     expect(res.body.outcome).toBe('success');
     expect(res.body.updatedCount).toBe(3);
+
+    const otherRes = await buildApp(OTHER_GUILD_ID).get('/users/refresh-status');
+    expect(otherRes.body.outcome).toBe('error');
   });
 });
 
@@ -112,12 +110,24 @@ describe('POST /users/refresh-names', () => {
     expect(res.headers.location).toBe('/admin/users');
   });
 
-  it('redirects without starting a second refresh when one is already running', async () => {
-    refreshState.outcome = 'running';
+  it('redirects without starting a second refresh when one is already running for that guild', async () => {
+    refreshStates.set(GUILD_ID, { outcome: 'running', updatedCount: 0, failureCount: 0, startedAt: Date.now(), finishedAt: null });
     const app = buildApp();
     const res = await app.post('/users/refresh-names');
     expect(res.status).toBe(302);
     expect(getGuildMemberUsers).not.toHaveBeenCalled();
+  });
+
+  it('starting a refresh for one guild does not block a refresh for a different guild', async () => {
+    refreshStates.set(GUILD_ID, { outcome: 'running', updatedCount: 0, failureCount: 0, startedAt: Date.now(), finishedAt: null });
+    vi.mocked(getDiscordClient).mockReturnValue({} as any);
+    vi.mocked(getGuildMemberUsers).mockResolvedValue([]);
+
+    const res = await buildApp(OTHER_GUILD_ID).post('/users/refresh-names');
+    expect(res.status).toBe(302);
+    await waitForRefreshComplete(OTHER_GUILD_ID);
+    expect(getGuildMemberUsers).toHaveBeenCalledWith(OTHER_GUILD_ID);
+    expect(getRefreshState(GUILD_ID).outcome).toBe('running');
   });
 });
 
@@ -130,10 +140,10 @@ describe('runDiscordNameRefresh outcomes', () => {
     const app = buildApp();
     await app.post('/users/refresh-names');
     await waitForRefreshComplete();
-    expect(refreshState.outcome).toBe('noop');
-    expect(refreshState.updatedCount).toBe(0);
-    expect(refreshState.failureCount).toBe(0);
-    expect(refreshState.finishedAt).not.toBeNull();
+    expect(getRefreshState(GUILD_ID).outcome).toBe('noop');
+    expect(getRefreshState(GUILD_ID).updatedCount).toBe(0);
+    expect(getRefreshState(GUILD_ID).failureCount).toBe(0);
+    expect(getRefreshState(GUILD_ID).finishedAt).not.toBeNull();
   });
 
   it('outcome is "success" when all users are updated with no failures', async () => {
@@ -150,9 +160,9 @@ describe('runDiscordNameRefresh outcomes', () => {
     const app = buildApp();
     await app.post('/users/refresh-names');
     await waitForRefreshComplete();
-    expect(refreshState.outcome).toBe('success');
-    expect(refreshState.updatedCount).toBe(2);
-    expect(refreshState.failureCount).toBe(0);
+    expect(getRefreshState(GUILD_ID).outcome).toBe('success');
+    expect(getRefreshState(GUILD_ID).updatedCount).toBe(2);
+    expect(getRefreshState(GUILD_ID).failureCount).toBe(0);
     expect(vi.mocked(updateDiscordName)).toHaveBeenCalledWith('1', 'NewName1');
     expect(vi.mocked(updateDiscordName)).toHaveBeenCalledWith('2', 'NewName2');
     expect(vi.mocked(fetchMemberDisplayName)).toHaveBeenCalledWith('1', true, GUILD_ID);
@@ -169,8 +179,8 @@ describe('runDiscordNameRefresh outcomes', () => {
     const app = buildApp();
     await app.post('/users/refresh-names');
     await waitForRefreshComplete();
-    expect(refreshState.outcome).toBe('noop');
-    expect(refreshState.updatedCount).toBe(0);
+    expect(getRefreshState(GUILD_ID).outcome).toBe('noop');
+    expect(getRefreshState(GUILD_ID).updatedCount).toBe(0);
     expect(updateDiscordName).not.toHaveBeenCalled();
   });
 
@@ -187,9 +197,9 @@ describe('runDiscordNameRefresh outcomes', () => {
     const app = buildApp();
     await app.post('/users/refresh-names');
     await waitForRefreshComplete();
-    expect(refreshState.outcome).toBe('partial');
-    expect(refreshState.updatedCount).toBe(1);
-    expect(refreshState.failureCount).toBe(1);
+    expect(getRefreshState(GUILD_ID).outcome).toBe('partial');
+    expect(getRefreshState(GUILD_ID).updatedCount).toBe(1);
+    expect(getRefreshState(GUILD_ID).failureCount).toBe(1);
   });
 
   it('outcome is "error" when all lookups fail', async () => {
@@ -202,9 +212,9 @@ describe('runDiscordNameRefresh outcomes', () => {
     const app = buildApp();
     await app.post('/users/refresh-names');
     await waitForRefreshComplete();
-    expect(refreshState.outcome).toBe('error');
-    expect(refreshState.updatedCount).toBe(0);
-    expect(refreshState.failureCount).toBe(1);
+    expect(getRefreshState(GUILD_ID).outcome).toBe('error');
+    expect(getRefreshState(GUILD_ID).updatedCount).toBe(0);
+    expect(getRefreshState(GUILD_ID).failureCount).toBe(1);
   });
 
   it('outcome is "error" when Discord client is not ready', async () => {
@@ -213,7 +223,7 @@ describe('runDiscordNameRefresh outcomes', () => {
     const app = buildApp();
     await app.post('/users/refresh-names');
     await waitForRefreshComplete();
-    expect(refreshState.outcome).toBe('error');
+    expect(getRefreshState(GUILD_ID).outcome).toBe('error');
   });
 
   it('finishedAt is set after completion', async () => {
@@ -224,7 +234,7 @@ describe('runDiscordNameRefresh outcomes', () => {
     const app = buildApp();
     await app.post('/users/refresh-names');
     await waitForRefreshComplete();
-    expect(refreshState.finishedAt).toBeGreaterThanOrEqual(before);
+    expect(getRefreshState(GUILD_ID).finishedAt).toBeGreaterThanOrEqual(before);
   });
 
   it('individual user errors are caught and counted as failures', async () => {
@@ -237,7 +247,7 @@ describe('runDiscordNameRefresh outcomes', () => {
     const app = buildApp();
     await app.post('/users/refresh-names');
     await waitForRefreshComplete();
-    expect(refreshState.failureCount).toBe(1);
-    expect(refreshState.outcome).toBe('error');
+    expect(getRefreshState(GUILD_ID).failureCount).toBe(1);
+    expect(getRefreshState(GUILD_ID).outcome).toBe('error');
   });
 });

--- a/src/web/routes/adminRefresh.test.ts
+++ b/src/web/routes/adminRefresh.test.ts
@@ -155,6 +155,8 @@ describe('runDiscordNameRefresh outcomes', () => {
     expect(refreshState.failureCount).toBe(0);
     expect(vi.mocked(updateDiscordName)).toHaveBeenCalledWith('1', 'NewName1');
     expect(vi.mocked(updateDiscordName)).toHaveBeenCalledWith('2', 'NewName2');
+    expect(vi.mocked(fetchMemberDisplayName)).toHaveBeenCalledWith('1', true, GUILD_ID);
+    expect(vi.mocked(fetchMemberDisplayName)).toHaveBeenCalledWith('2', true, GUILD_ID);
   });
 
   it('outcome is "noop" when display names have not changed', async () => {

--- a/src/web/routes/adminRefresh.ts
+++ b/src/web/routes/adminRefresh.ts
@@ -7,31 +7,33 @@ import { getDiscordClient, fetchMemberDisplayName } from '../../discord/discordB
 
 export type RefreshOutcome = 'idle' | 'running' | 'success' | 'partial' | 'noop' | 'error';
 
-// This progress state is intentionally in-process because the web panel runs as
-// a single bot instance today. If the panel is ever scaled horizontally, move
-// this state into shared storage before relying on /users/refresh-status.
-export const refreshState: {
+export interface RefreshState {
   outcome: RefreshOutcome;
   updatedCount: number;
   failureCount: number;
   startedAt: number | null;
   finishedAt: number | null;
-} = {
-  outcome: 'idle',
-  updatedCount: 0,
-  failureCount: 0,
-  startedAt: null,
-  finishedAt: null,
-};
+}
+
+function idleRefreshState(): RefreshState {
+  return { outcome: 'idle', updatedCount: 0, failureCount: 0, startedAt: null, finishedAt: null };
+}
+
+// Per-guild progress state, intentionally in-process because the web panel runs as
+// a single bot instance today. If the panel is ever scaled horizontally, move this
+// state into shared storage before relying on /users/refresh-status.
+export const refreshStates = new Map<string, RefreshState>();
+
+/** Returns the Discord-name-refresh progress for a guild, defaulting to idle when no refresh has run yet. */
+export function getRefreshState(guildId: string): RefreshState {
+  return refreshStates.get(guildId) ?? idleRefreshState();
+}
 
 const log = createLogger('Web');
 
 async function runDiscordNameRefresh(guildId: string): Promise<void> {
-  refreshState.outcome = 'running';
-  refreshState.updatedCount = 0;
-  refreshState.failureCount = 0;
-  refreshState.startedAt = Date.now();
-  refreshState.finishedAt = null;
+  const state: RefreshState = { outcome: 'running', updatedCount: 0, failureCount: 0, startedAt: Date.now(), finishedAt: null };
+  refreshStates.set(guildId, state);
 
   try {
     if (!getDiscordClient()) {
@@ -47,7 +49,7 @@ async function runDiscordNameRefresh(guildId: string): Promise<void> {
         const name = await fetchMemberDisplayName(user.discord_id, true, guildId);
         if (name == null) {
           failureCount++;
-          refreshState.failureCount = failureCount;
+          state.failureCount = failureCount;
           log.error(`Failed to refresh Discord name for ${user.discord_id}: Discord lookup returned no display name`);
           await new Promise((resolve) => setTimeout(resolve, 200));
           continue;
@@ -57,42 +59,42 @@ async function runDiscordNameRefresh(guildId: string): Promise<void> {
         if (trimmedName && trimmedName !== user.discord_name) {
           await updateDiscordName(user.discord_id, trimmedName);
           updatedCount++;
-          refreshState.updatedCount = updatedCount;
+          state.updatedCount = updatedCount;
         }
       } catch (err) {
         failureCount++;
-        refreshState.failureCount = failureCount;
+        state.failureCount = failureCount;
         log.error(`Failed to refresh Discord name for ${user.discord_id}:`, err);
       }
       await new Promise((resolve) => setTimeout(resolve, 200));
     }
 
-    refreshState.updatedCount = updatedCount;
-    refreshState.failureCount = failureCount;
-    refreshState.outcome = updatedCount > 0
+    state.updatedCount = updatedCount;
+    state.failureCount = failureCount;
+    state.outcome = updatedCount > 0
       ? (failureCount > 0 ? 'partial' : 'success')
       : (failureCount > 0 ? 'error' : 'noop');
   } catch (err) {
-    refreshState.failureCount = Math.max(refreshState.failureCount, 1);
-    refreshState.outcome = 'error';
+    state.failureCount = Math.max(state.failureCount, 1);
+    state.outcome = 'error';
     log.error('Refresh Discord names failed:', err);
   } finally {
-    refreshState.finishedAt = Date.now();
+    state.finishedAt = Date.now();
   }
 }
 
 const router = Router();
 
-router.get('/users/refresh-status', requireManager, (_req, res) => {
-  res.json(refreshState);
+// Mounted under /admin behind requireGuildContext, so currentGuildId is always set.
+router.get('/users/refresh-status', requireManager, (req, res) => {
+  res.json(getRefreshState(req.session.user!.currentGuildId!));
 });
 
 router.post('/users/refresh-names', requireManager, csrfProtection, async (req, res) => {
-  if (refreshState.outcome === 'running') {
+  const guildId = req.session.user!.currentGuildId!;
+  if (getRefreshState(guildId).outcome === 'running') {
     return res.redirect('/admin/users');
   }
-  const guildId = req.session.user?.currentGuildId;
-  if (!guildId) return res.redirect('/guild/select');
   void runDiscordNameRefresh(guildId);
   return res.redirect('/admin/users');
 });

--- a/src/web/routes/adminRefresh.ts
+++ b/src/web/routes/adminRefresh.ts
@@ -4,11 +4,7 @@ import { getGuildMemberUsers, updateDiscordName } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireManager } from '../middleware';
 import { getDiscordClient, fetchMemberDisplayName } from '../../discord/discordBot';
-import { createMutationQueue } from '../../shared/mutationQueue';
-
-// A user can belong to multiple guilds, so refreshes for different guilds can run
-// concurrently and race on the same user row. Serialize writes per discord_id.
-const userMutationQueue = createMutationQueue();
+import { userMutationQueue } from './adminUserMutationQueue';
 
 export type RefreshOutcome = 'idle' | 'running' | 'success' | 'partial' | 'noop' | 'error';
 

--- a/src/web/routes/adminRefresh.ts
+++ b/src/web/routes/adminRefresh.ts
@@ -4,6 +4,11 @@ import { getGuildMemberUsers, updateDiscordName } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireManager } from '../middleware';
 import { getDiscordClient, fetchMemberDisplayName } from '../../discord/discordBot';
+import { createMutationQueue } from '../../shared/mutationQueue';
+
+// A user can belong to multiple guilds, so refreshes for different guilds can run
+// concurrently and race on the same user row. Serialize writes per discord_id.
+const userMutationQueue = createMutationQueue();
 
 export type RefreshOutcome = 'idle' | 'running' | 'success' | 'partial' | 'noop' | 'error';
 
@@ -57,7 +62,7 @@ async function runDiscordNameRefresh(guildId: string): Promise<void> {
 
         const trimmedName = name?.trim();
         if (trimmedName && trimmedName !== user.discord_name) {
-          await updateDiscordName(user.discord_id, trimmedName);
+          await userMutationQueue.run(user.discord_id, () => updateDiscordName(user.discord_id, trimmedName));
           updatedCount++;
           state.updatedCount = updatedCount;
         }

--- a/src/web/routes/adminRefresh.ts
+++ b/src/web/routes/adminRefresh.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
-import { getAllUsers, updateDiscordName } from '../../db';
+import { getGuildMemberUsers, updateDiscordName } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireManager } from '../middleware';
 import { getDiscordClient, fetchMemberDisplayName } from '../../discord/discordBot';
@@ -26,7 +26,7 @@ export const refreshState: {
 
 const log = createLogger('Web');
 
-async function runDiscordNameRefresh(): Promise<void> {
+async function runDiscordNameRefresh(guildId: string): Promise<void> {
   refreshState.outcome = 'running';
   refreshState.updatedCount = 0;
   refreshState.failureCount = 0;
@@ -38,13 +38,13 @@ async function runDiscordNameRefresh(): Promise<void> {
       throw new Error('Discord client is not ready');
     }
 
-    const users = await getAllUsers();
+    const users = await getGuildMemberUsers(guildId);
     let updatedCount = 0;
     let failureCount = 0;
 
     for (const user of users) {
       try {
-        const name = await fetchMemberDisplayName(user.discord_id, true);
+        const name = await fetchMemberDisplayName(user.discord_id, true, guildId);
         if (name == null) {
           failureCount++;
           refreshState.failureCount = failureCount;
@@ -87,11 +87,13 @@ router.get('/users/refresh-status', requireManager, (_req, res) => {
   res.json(refreshState);
 });
 
-router.post('/users/refresh-names', requireManager, csrfProtection, async (_req, res) => {
+router.post('/users/refresh-names', requireManager, csrfProtection, async (req, res) => {
   if (refreshState.outcome === 'running') {
     return res.redirect('/admin/users');
   }
-  void runDiscordNameRefresh();
+  const guildId = req.session.user?.currentGuildId;
+  if (!guildId) return res.redirect('/admin/users?error=no_guild');
+  void runDiscordNameRefresh(guildId);
   return res.redirect('/admin/users');
 });
 

--- a/src/web/routes/adminRefresh.ts
+++ b/src/web/routes/adminRefresh.ts
@@ -92,7 +92,7 @@ router.post('/users/refresh-names', requireManager, csrfProtection, async (req, 
     return res.redirect('/admin/users');
   }
   const guildId = req.session.user?.currentGuildId;
-  if (!guildId) return res.redirect('/admin/users?error=no_guild');
+  if (!guildId) return res.redirect('/guild/select');
   void runDiscordNameRefresh(guildId);
   return res.redirect('/admin/users');
 });

--- a/src/web/routes/adminUserMutationQueue.ts
+++ b/src/web/routes/adminUserMutationQueue.ts
@@ -1,0 +1,7 @@
+import { createMutationQueue } from '../../shared/mutationQueue';
+
+// A user can belong to multiple guilds, so admin mutations (add/edit/remove/toggle)
+// and the Discord-name refresh job can run concurrently and race on the same user
+// row. Shared by admin.ts and adminRefresh.ts so writes for the same discord_id
+// always serialize against each other, not just against writes from the same file.
+export const userMutationQueue = createMutationQueue();

--- a/src/web/routes/adminUserValidation.test.ts
+++ b/src/web/routes/adminUserValidation.test.ts
@@ -313,6 +313,8 @@ describe('resolveValidDiscordId', () => {
 describe('resolveToggleTwitchInputs', () => {
   const GUILD_ID = '900000000000000001';
   const TARGET_ID = '300000000000000001';
+  const ADMIN_USER = { accessLevel: AccessLevel.ADMIN, isOwner: false };
+  const MANAGER_USER = { accessLevel: AccessLevel.MANAGER, isOwner: false };
 
   function mockRes() {
     const redirect = vi.fn();
@@ -325,21 +327,21 @@ describe('resolveToggleTwitchInputs', () => {
 
   it('returns true when enabled flag is "true" and target is a guild member', async () => {
     const { res, redirect } = mockRes();
-    const result = await resolveToggleTwitchInputs(res, GUILD_ID, TARGET_ID, 'true');
+    const result = await resolveToggleTwitchInputs(res, ADMIN_USER, GUILD_ID, TARGET_ID, 'true');
     expect(result).toBe(true);
     expect(redirect).not.toHaveBeenCalled();
   });
 
   it('returns false when enabled flag is "false" and target is a guild member', async () => {
     const { res, redirect } = mockRes();
-    const result = await resolveToggleTwitchInputs(res, GUILD_ID, TARGET_ID, 'false');
+    const result = await resolveToggleTwitchInputs(res, ADMIN_USER, GUILD_ID, TARGET_ID, 'false');
     expect(result).toBe(false);
     expect(redirect).not.toHaveBeenCalled();
   });
 
   it('redirects ?error=invalid_twitch_state and returns null for an unrecognised flag', async () => {
     const { res, redirect } = mockRes();
-    const result = await resolveToggleTwitchInputs(res, GUILD_ID, TARGET_ID, 'maybe');
+    const result = await resolveToggleTwitchInputs(res, ADMIN_USER, GUILD_ID, TARGET_ID, 'maybe');
     expect(result).toBeNull();
     expect(redirect).toHaveBeenCalledWith('/admin/users?error=invalid_twitch_state');
   });
@@ -347,9 +349,25 @@ describe('resolveToggleTwitchInputs', () => {
   it('redirects ?error=target_above_level and returns null when target is not a guild member', async () => {
     vi.mocked(getMemberAccessLevel).mockResolvedValue(null);
     const { res, redirect } = mockRes();
-    const result = await resolveToggleTwitchInputs(res, GUILD_ID, TARGET_ID, 'true');
+    const result = await resolveToggleTwitchInputs(res, ADMIN_USER, GUILD_ID, TARGET_ID, 'true');
     expect(result).toBeNull();
     expect(redirect).toHaveBeenCalledWith('/admin/users?error=target_above_level');
+  });
+
+  it('redirects ?error=target_above_level when a non-admin actor targets a user at their own level', async () => {
+    vi.mocked(getMemberAccessLevel).mockResolvedValue(AccessLevel.MANAGER);
+    const { res, redirect } = mockRes();
+    const result = await resolveToggleTwitchInputs(res, MANAGER_USER, GUILD_ID, TARGET_ID, 'true');
+    expect(result).toBeNull();
+    expect(redirect).toHaveBeenCalledWith('/admin/users?error=target_above_level');
+  });
+
+  it('allows an admin actor to toggle a target at any level', async () => {
+    vi.mocked(getMemberAccessLevel).mockResolvedValue(AccessLevel.ADMIN);
+    const { res, redirect } = mockRes();
+    const result = await resolveToggleTwitchInputs(res, ADMIN_USER, GUILD_ID, TARGET_ID, 'true');
+    expect(result).toBe(true);
+    expect(redirect).not.toHaveBeenCalled();
   });
 });
 

--- a/src/web/routes/adminUserValidation.test.ts
+++ b/src/web/routes/adminUserValidation.test.ts
@@ -5,6 +5,7 @@ vi.mock('../../db/users', () => ({
 }));
 vi.mock('../../db', () => ({
   findUser: vi.fn(),
+  getMemberAccessLevel: vi.fn(),
   AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
 }));
 vi.mock('../../twitch/twitchChannelName', () => ({
@@ -20,7 +21,7 @@ vi.mock('../../shared/logger', () => ({
   createLogger: () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn() }),
 }));
 
-import { findUser } from '../../db';
+import { findUser, getMemberAccessLevel } from '../../db';
 import { AccessLevel } from '../../db/users';
 import { isLockWaitTimeoutDbError } from './adminUserMutations';
 import { normalizeTwitchChannelName } from '../../twitch/twitchChannelName';
@@ -183,63 +184,67 @@ describe('parseTwitchNameInput', () => {
 // ─── checkManagerEditAuth ────────────────────────────────────────────────────
 
 describe('checkManagerEditAuth', () => {
-  const ADMIN_SESSION = { discordId: '100000000000000001', accessLevel: AccessLevel.ADMIN };
-  const MANAGER_SESSION = { discordId: '200000000000000002', accessLevel: AccessLevel.MANAGER };
+  const GUILD_ID = '900000000000000001';
+  const ADMIN_SESSION = { discordId: '100000000000000001', accessLevel: AccessLevel.ADMIN, isOwner: false };
+  const MANAGER_SESSION = { discordId: '200000000000000002', accessLevel: AccessLevel.MANAGER, isOwner: false };
 
   beforeEach(() => {
     vi.mocked(findUser).mockResolvedValue(null);
+    vi.mocked(getMemberAccessLevel).mockResolvedValue(null);
   });
 
   it('returns "self_edit_forbidden" when editing own account', async () => {
     const result = await checkManagerEditAuth(
-      { discordId: '100000000000000001', accessLevel: AccessLevel.ADMIN },
+      { discordId: '100000000000000001', accessLevel: AccessLevel.ADMIN, isOwner: false },
       '100000000000000001',
       AccessLevel.USER,
+      GUILD_ID,
     );
     expect(result).toBe('self_edit_forbidden');
   });
 
+  it('returns "target_above_level" when a non-owner edits an owner', async () => {
+    vi.mocked(findUser).mockResolvedValue({ discord_id: '300000000000000003', is_owner: true } as any);
+    const result = await checkManagerEditAuth(ADMIN_SESSION, '300000000000000003', AccessLevel.USER, GUILD_ID);
+    expect(result).toBe('target_above_level');
+  });
+
   it('returns null for admin editing a lower-level user', async () => {
-    const result = await checkManagerEditAuth(ADMIN_SESSION, '300000000000000003', AccessLevel.USER);
+    const result = await checkManagerEditAuth(ADMIN_SESSION, '300000000000000003', AccessLevel.USER, GUILD_ID);
     expect(result).toBeNull();
   });
 
   it('returns null for admin editing a user at the same level', async () => {
-    const result = await checkManagerEditAuth(ADMIN_SESSION, '300000000000000003', AccessLevel.ADMIN);
+    const result = await checkManagerEditAuth(ADMIN_SESSION, '300000000000000003', AccessLevel.ADMIN, GUILD_ID);
     expect(result).toBeNull();
   });
 
   it('returns "access_level_too_high" when manager tries to set level >= their own', async () => {
-    const result = await checkManagerEditAuth(MANAGER_SESSION, '300000000000000003', AccessLevel.MANAGER);
+    const result = await checkManagerEditAuth(MANAGER_SESSION, '300000000000000003', AccessLevel.MANAGER, GUILD_ID);
     expect(result).toBe('access_level_too_high');
   });
 
   it('returns "access_level_too_high" when manager tries to set level above their own', async () => {
-    const result = await checkManagerEditAuth(MANAGER_SESSION, '300000000000000003', AccessLevel.ADMIN);
+    const result = await checkManagerEditAuth(MANAGER_SESSION, '300000000000000003', AccessLevel.ADMIN, GUILD_ID);
     expect(result).toBe('access_level_too_high');
   });
 
-  it('returns "target_above_level" when existing target user is at manager level', async () => {
-    vi.mocked(findUser).mockResolvedValue({
-      discord_id: '300000000000000003',
-      access_level: AccessLevel.MANAGER,
-    } as any);
-    const result = await checkManagerEditAuth(MANAGER_SESSION, '300000000000000003', AccessLevel.MOD);
+  it('returns "target_above_level" when the target is already at manager level in this guild', async () => {
+    vi.mocked(getMemberAccessLevel).mockResolvedValue(AccessLevel.MANAGER);
+    const result = await checkManagerEditAuth(MANAGER_SESSION, '300000000000000003', AccessLevel.MOD, GUILD_ID);
     expect(result).toBe('target_above_level');
+    expect(vi.mocked(getMemberAccessLevel)).toHaveBeenCalledWith(GUILD_ID, '300000000000000003');
   });
 
-  it('returns null when existing target is below manager level', async () => {
-    vi.mocked(findUser).mockResolvedValue({
-      discord_id: '300000000000000003',
-      access_level: AccessLevel.MOD,
-    } as any);
-    const result = await checkManagerEditAuth(MANAGER_SESSION, '300000000000000003', AccessLevel.MOD);
+  it('returns null when the target is below manager level in this guild', async () => {
+    vi.mocked(getMemberAccessLevel).mockResolvedValue(AccessLevel.MOD);
+    const result = await checkManagerEditAuth(MANAGER_SESSION, '300000000000000003', AccessLevel.MOD, GUILD_ID);
     expect(result).toBeNull();
   });
 
-  it('returns null when target user does not exist yet', async () => {
-    vi.mocked(findUser).mockResolvedValue(null);
-    const result = await checkManagerEditAuth(MANAGER_SESSION, '300000000000000003', AccessLevel.MOD);
+  it('returns null when target has no membership in this guild yet', async () => {
+    vi.mocked(getMemberAccessLevel).mockResolvedValue(null);
+    const result = await checkManagerEditAuth(MANAGER_SESSION, '300000000000000003', AccessLevel.MOD, GUILD_ID);
     expect(result).toBeNull();
   });
 });

--- a/src/web/routes/adminUserValidation.test.ts
+++ b/src/web/routes/adminUserValidation.test.ts
@@ -32,8 +32,10 @@ import {
   parseTwitchNameInput,
   checkManagerEditAuth,
   handleDbError,
+  resolveGuildId,
+  resolveValidDiscordId,
 } from './adminUserValidation';
-import type { Response } from 'express';
+import type { Request, Response } from 'express';
 
 const ACCESS_LEVEL_VALUES = [AccessLevel.USER, AccessLevel.MOD, AccessLevel.MANAGER, AccessLevel.ADMIN];
 
@@ -246,6 +248,62 @@ describe('checkManagerEditAuth', () => {
     vi.mocked(getMemberAccessLevel).mockResolvedValue(null);
     const result = await checkManagerEditAuth(MANAGER_SESSION, '300000000000000003', AccessLevel.MOD, GUILD_ID);
     expect(result).toBeNull();
+  });
+});
+
+// ─── resolveGuildId ──────────────────────────────────────────────────────────
+
+describe('resolveGuildId', () => {
+  function mockRes() {
+    const redirect = vi.fn();
+    return { res: { redirect } as unknown as Response, redirect };
+  }
+
+  it('returns the current guild id when one is set in the session', () => {
+    const { res, redirect } = mockRes();
+    const req = { session: { user: { currentGuildId: '900000000000000001' } } } as unknown as Request;
+    expect(resolveGuildId(req, res)).toBe('900000000000000001');
+    expect(redirect).not.toHaveBeenCalled();
+  });
+
+  it('redirects to /guild/select and returns null when no guild is set', () => {
+    const { res, redirect } = mockRes();
+    const req = { session: { user: { currentGuildId: undefined } } } as unknown as Request;
+    expect(resolveGuildId(req, res)).toBeNull();
+    expect(redirect).toHaveBeenCalledWith('/guild/select');
+  });
+});
+
+// ─── resolveValidDiscordId ───────────────────────────────────────────────────
+
+describe('resolveValidDiscordId', () => {
+  function mockRes() {
+    const redirect = vi.fn();
+    return { res: { redirect } as unknown as Response, redirect };
+  }
+
+  it('returns the trimmed id for a valid snowflake', () => {
+    const { res, redirect } = mockRes();
+    expect(resolveValidDiscordId(res, '  12345678901234567  ')).toBe('12345678901234567');
+    expect(redirect).not.toHaveBeenCalled();
+  });
+
+  it('redirects to /admin/users and returns null when the id is absent', () => {
+    const { res, redirect } = mockRes();
+    expect(resolveValidDiscordId(res, undefined)).toBeNull();
+    expect(redirect).toHaveBeenCalledWith('/admin/users');
+  });
+
+  it('redirects to /admin/users and returns null for a whitespace-only id', () => {
+    const { res, redirect } = mockRes();
+    expect(resolveValidDiscordId(res, '   ')).toBeNull();
+    expect(redirect).toHaveBeenCalledWith('/admin/users');
+  });
+
+  it('redirects to ?error=invalid_discord_id for a malformed id', () => {
+    const { res, redirect } = mockRes();
+    expect(resolveValidDiscordId(res, 'not-a-snowflake')).toBeNull();
+    expect(redirect).toHaveBeenCalledWith('/admin/users?error=invalid_discord_id');
   });
 });
 

--- a/src/web/routes/adminUserValidation.test.ts
+++ b/src/web/routes/adminUserValidation.test.ts
@@ -315,6 +315,7 @@ describe('resolveToggleTwitchInputs', () => {
   const TARGET_ID = '300000000000000001';
   const ADMIN_USER = { accessLevel: AccessLevel.ADMIN, isOwner: false };
   const MANAGER_USER = { accessLevel: AccessLevel.MANAGER, isOwner: false };
+  const OWNER_USER = { accessLevel: AccessLevel.ADMIN, isOwner: true };
 
   function mockRes() {
     const redirect = vi.fn();
@@ -323,6 +324,7 @@ describe('resolveToggleTwitchInputs', () => {
 
   beforeEach(() => {
     vi.mocked(getMemberAccessLevel).mockResolvedValue(0);
+    vi.mocked(findUser).mockResolvedValue(null);
   });
 
   it('returns true when enabled flag is "true" and target is a guild member', async () => {
@@ -366,6 +368,22 @@ describe('resolveToggleTwitchInputs', () => {
     vi.mocked(getMemberAccessLevel).mockResolvedValue(AccessLevel.ADMIN);
     const { res, redirect } = mockRes();
     const result = await resolveToggleTwitchInputs(res, ADMIN_USER, GUILD_ID, TARGET_ID, 'true');
+    expect(result).toBe(true);
+    expect(redirect).not.toHaveBeenCalled();
+  });
+
+  it('redirects ?error=target_above_level when a non-owner admin targets a bot owner', async () => {
+    vi.mocked(findUser).mockResolvedValue({ discord_id: TARGET_ID, is_owner: true } as any);
+    const { res, redirect } = mockRes();
+    const result = await resolveToggleTwitchInputs(res, ADMIN_USER, GUILD_ID, TARGET_ID, 'true');
+    expect(result).toBeNull();
+    expect(redirect).toHaveBeenCalledWith('/admin/users?error=target_above_level');
+  });
+
+  it('allows an owner to toggle another bot owner', async () => {
+    vi.mocked(findUser).mockResolvedValue({ discord_id: TARGET_ID, is_owner: true } as any);
+    const { res, redirect } = mockRes();
+    const result = await resolveToggleTwitchInputs(res, OWNER_USER, GUILD_ID, TARGET_ID, 'true');
     expect(result).toBe(true);
     expect(redirect).not.toHaveBeenCalled();
   });

--- a/src/web/routes/adminUserValidation.test.ts
+++ b/src/web/routes/adminUserValidation.test.ts
@@ -34,6 +34,7 @@ import {
   handleDbError,
   resolveGuildId,
   resolveValidDiscordId,
+  resolveToggleTwitchInputs,
 } from './adminUserValidation';
 import type { Request, Response } from 'express';
 
@@ -304,6 +305,51 @@ describe('resolveValidDiscordId', () => {
     const { res, redirect } = mockRes();
     expect(resolveValidDiscordId(res, 'not-a-snowflake')).toBeNull();
     expect(redirect).toHaveBeenCalledWith('/admin/users?error=invalid_discord_id');
+  });
+});
+
+// ─── resolveToggleTwitchInputs ───────────────────────────────────────────────
+
+describe('resolveToggleTwitchInputs', () => {
+  const GUILD_ID = '900000000000000001';
+  const TARGET_ID = '300000000000000001';
+
+  function mockRes() {
+    const redirect = vi.fn();
+    return { res: { redirect } as unknown as Response, redirect };
+  }
+
+  beforeEach(() => {
+    vi.mocked(getMemberAccessLevel).mockResolvedValue(0);
+  });
+
+  it('returns true when enabled flag is "true" and target is a guild member', async () => {
+    const { res, redirect } = mockRes();
+    const result = await resolveToggleTwitchInputs(res, GUILD_ID, TARGET_ID, 'true');
+    expect(result).toBe(true);
+    expect(redirect).not.toHaveBeenCalled();
+  });
+
+  it('returns false when enabled flag is "false" and target is a guild member', async () => {
+    const { res, redirect } = mockRes();
+    const result = await resolveToggleTwitchInputs(res, GUILD_ID, TARGET_ID, 'false');
+    expect(result).toBe(false);
+    expect(redirect).not.toHaveBeenCalled();
+  });
+
+  it('redirects ?error=invalid_twitch_state and returns null for an unrecognised flag', async () => {
+    const { res, redirect } = mockRes();
+    const result = await resolveToggleTwitchInputs(res, GUILD_ID, TARGET_ID, 'maybe');
+    expect(result).toBeNull();
+    expect(redirect).toHaveBeenCalledWith('/admin/users?error=invalid_twitch_state');
+  });
+
+  it('redirects ?error=target_above_level and returns null when target is not a guild member', async () => {
+    vi.mocked(getMemberAccessLevel).mockResolvedValue(null);
+    const { res, redirect } = mockRes();
+    const result = await resolveToggleTwitchInputs(res, GUILD_ID, TARGET_ID, 'true');
+    expect(result).toBeNull();
+    expect(redirect).toHaveBeenCalledWith('/admin/users?error=target_above_level');
   });
 });
 

--- a/src/web/routes/adminUserValidation.ts
+++ b/src/web/routes/adminUserValidation.ts
@@ -113,16 +113,20 @@ export async function checkManagerEditAuth(
 
 /**
  * Validates and resolves inputs for the toggle-twitch route.
- * Checks the enabled flag is parseable and that the target is a member of the current guild.
+ * Checks the enabled flag is parseable, that the target is a member of the current guild,
+ * and that the acting user outranks the target (mirrors `checkManagerEditAuth`'s rule: a
+ * non-Admin actor may not modify a target already at or above their own level).
  * Sends the appropriate error redirect and returns null on failure; returns the parsed boolean on success.
  *
  * @param res The response, used to redirect on error.
+ * @param sessionUser The acting user (current-guild access level + owner flag).
  * @param guildId The guild to verify membership in.
  * @param targetDiscordId The user whose Twitch state is being toggled.
  * @param isTwitchBotEnabled The raw form value for the enabled flag.
  */
 export async function resolveToggleTwitchInputs(
   res: Response,
+  sessionUser: { accessLevel: number; isOwner?: boolean },
   guildId: string,
   targetDiscordId: string,
   isTwitchBotEnabled: string | undefined,
@@ -134,6 +138,10 @@ export async function resolveToggleTwitchInputs(
   }
   const memberLevel = await getMemberAccessLevel(guildId, targetDiscordId);
   if (memberLevel === null) {
+    res.redirect('/admin/users?error=target_above_level');
+    return null;
+  }
+  if (!sessionUser.isOwner && sessionUser.accessLevel < AccessLevel.ADMIN && memberLevel >= sessionUser.accessLevel) {
     res.redirect('/admin/users?error=target_above_level');
     return null;
   }

--- a/src/web/routes/adminUserValidation.ts
+++ b/src/web/routes/adminUserValidation.ts
@@ -114,8 +114,9 @@ export async function checkManagerEditAuth(
 /**
  * Validates and resolves inputs for the toggle-twitch route.
  * Checks the enabled flag is parseable, that the target is a member of the current guild,
- * and that the acting user outranks the target (mirrors `checkManagerEditAuth`'s rule: a
- * non-Admin actor may not modify a target already at or above their own level).
+ * that only an owner may toggle another owner's Twitch state, and that the acting user
+ * outranks the target (mirrors `checkManagerEditAuth`'s rules: a non-Admin actor may not
+ * modify a target already at or above their own level).
  * Sends the appropriate error redirect and returns null on failure; returns the parsed boolean on success.
  *
  * @param res The response, used to redirect on error.
@@ -138,6 +139,12 @@ export async function resolveToggleTwitchInputs(
   }
   const memberLevel = await getMemberAccessLevel(guildId, targetDiscordId);
   if (memberLevel === null) {
+    res.redirect('/admin/users?error=target_above_level');
+    return null;
+  }
+  // Bot owners are global super-admins — only another owner may touch them, even an Admin.
+  const existingUser = await findUser(targetDiscordId);
+  if (existingUser?.is_owner && !sessionUser.isOwner) {
     res.redirect('/admin/users?error=target_above_level');
     return null;
   }

--- a/src/web/routes/adminUserValidation.ts
+++ b/src/web/routes/adminUserValidation.ts
@@ -1,6 +1,6 @@
 import { Response } from 'express';
 import { createLogger } from '../../shared/logger';
-import { findUser, AccessLevel } from '../../db';
+import { findUser, getMemberAccessLevel, AccessLevel } from '../../db';
 import { trimField } from './shared';
 import { normalizeTwitchChannelName } from '../../twitch/twitchChannelName';
 import { isLockWaitTimeoutDbError } from './adminUserMutations';
@@ -42,16 +42,34 @@ export function parseTwitchNameInput(
   return { error: null, normalizedTwitchName, shouldClearTwitchName };
 }
 
+/**
+ * Authorizes a Manager/Admin editing a user's access level within a guild.
+ * Returns an error code string, or null when the edit is permitted.
+ *
+ * Rules: nobody edits themselves through this form; only an owner may edit an
+ * owner; and a non-Admin actor may neither assign a level at or above their own
+ * nor modify a target who already sits at or above their own level **in this
+ * guild** (the target's level is read from `guild_member`, not the global column).
+ *
+ * @param sessionUser The acting user (current-guild access level + owner flag).
+ * @param targetDiscordId The user being edited.
+ * @param targetLevel The access level being assigned.
+ * @param guildId The guild the edit applies to.
+ */
 export async function checkManagerEditAuth(
-  sessionUser: { discordId: string; accessLevel: number },
+  sessionUser: { discordId: string; accessLevel: number; isOwner?: boolean },
   targetDiscordId: string,
   targetLevel: number,
+  guildId: string,
 ): Promise<string | null> {
   if (targetDiscordId === sessionUser.discordId) return 'self_edit_forbidden';
+  // Bot owners are global super-admins — only another owner may touch them.
+  const existingUser = await findUser(targetDiscordId);
+  if (existingUser?.is_owner && !sessionUser.isOwner) return 'target_above_level';
   if (sessionUser.accessLevel < AccessLevel.ADMIN) {
     if (targetLevel >= sessionUser.accessLevel) return 'access_level_too_high';
-    const existingUser = await findUser(targetDiscordId);
-    if (existingUser && existingUser.access_level >= sessionUser.accessLevel) return 'target_above_level';
+    const targetCurrentLevel = await getMemberAccessLevel(guildId, targetDiscordId);
+    if (targetCurrentLevel !== null && targetCurrentLevel >= sessionUser.accessLevel) return 'target_above_level';
   }
   return null;
 }

--- a/src/web/routes/adminUserValidation.ts
+++ b/src/web/routes/adminUserValidation.ts
@@ -1,4 +1,4 @@
-import { Response } from 'express';
+import { Request, Response } from 'express';
 import { createLogger } from '../../shared/logger';
 import { findUser, getMemberAccessLevel, AccessLevel } from '../../db';
 import { trimField } from './shared';
@@ -7,6 +7,43 @@ import { isLockWaitTimeoutDbError } from './adminUserMutations';
 
 const log = createLogger('Web');
 const DISCORD_ID_RE = /^\d{17,20}$/;
+
+/**
+ * Resolves the acting user's current guild from the session.
+ * Redirects to the guild picker and returns null when no guild is selected.
+ *
+ * @param req The incoming request (reads `session.user.currentGuildId`).
+ * @param res The response, used to redirect when no guild is set.
+ */
+export function resolveGuildId(req: Request, res: Response): string | null {
+  const guildId = req.session.user!.currentGuildId;
+  if (!guildId) {
+    res.redirect('/guild/select');
+    return null;
+  }
+  return guildId;
+}
+
+/**
+ * Trims and validates a submitted `discord_id` field. Returns the normalized ID,
+ * or redirects and returns null: to `/admin/users` when the field is absent, or
+ * to `?error=invalid_discord_id` when it is malformed.
+ *
+ * @param res The response, used to redirect on absent/invalid input.
+ * @param rawId The raw `discord_id` value from the request body.
+ */
+export function resolveValidDiscordId(res: Response, rawId: string | undefined): string | null {
+  const trimmed = trimField(rawId);
+  if (!trimmed) {
+    res.redirect('/admin/users');
+    return null;
+  }
+  if (discordIdError(trimmed)) {
+    res.redirect('/admin/users?error=invalid_discord_id');
+    return null;
+  }
+  return trimmed;
+}
 
 export function discordIdError(id: string): string | null {
   return DISCORD_ID_RE.test(id) ? null : 'invalid_discord_id';

--- a/src/web/routes/adminUserValidation.ts
+++ b/src/web/routes/adminUserValidation.ts
@@ -111,6 +111,35 @@ export async function checkManagerEditAuth(
   return null;
 }
 
+/**
+ * Validates and resolves inputs for the toggle-twitch route.
+ * Checks the enabled flag is parseable and that the target is a member of the current guild.
+ * Sends the appropriate error redirect and returns null on failure; returns the parsed boolean on success.
+ *
+ * @param res The response, used to redirect on error.
+ * @param guildId The guild to verify membership in.
+ * @param targetDiscordId The user whose Twitch state is being toggled.
+ * @param isTwitchBotEnabled The raw form value for the enabled flag.
+ */
+export async function resolveToggleTwitchInputs(
+  res: Response,
+  guildId: string,
+  targetDiscordId: string,
+  isTwitchBotEnabled: string | undefined,
+): Promise<boolean | null> {
+  const nextEnabled = parseTwitchEnabled(isTwitchBotEnabled);
+  if (nextEnabled === null) {
+    res.redirect('/admin/users?error=invalid_twitch_state');
+    return null;
+  }
+  const memberLevel = await getMemberAccessLevel(guildId, targetDiscordId);
+  if (memberLevel === null) {
+    res.redirect('/admin/users?error=target_above_level');
+    return null;
+  }
+  return nextEnabled;
+}
+
 export function handleDbError(err: unknown, res: Response, failCode: string, context: string): void {
   if (isLockWaitTimeoutDbError(err)) {
     log.warn(`${context} DB lock timeout`, err);

--- a/src/web/routes/api.test.ts
+++ b/src/web/routes/api.test.ts
@@ -126,6 +126,13 @@ describe('POST /voice/join', () => {
     expect(vi.mocked(connect)).toHaveBeenCalledWith({}, GUILD_ID, 'default-vc');
   });
 
+  it('returns 400 when no channelId is given and guild has no default', async () => {
+    vi.mocked(getGuildById).mockResolvedValueOnce({ guild_id: GUILD_ID, name: 'Test', voice_channel_id: null } as any);
+    await supertest(buildApp()).post('/voice/join').send({}).expect(400);
+    expect(vi.mocked(disconnect)).not.toHaveBeenCalled();
+    expect(vi.mocked(connect)).not.toHaveBeenCalled();
+  });
+
   it('returns 400 when no guild is selected', async () => {
     await supertest(buildApp(null)).post('/voice/join').send({ channelId: '123456789012345678' }).expect(400);
     expect(vi.mocked(connect)).not.toHaveBeenCalled();

--- a/src/web/routes/api.test.ts
+++ b/src/web/routes/api.test.ts
@@ -27,9 +27,8 @@ vi.mock('../../discord/discordUtils', () => ({
   getAvailableVoiceChannels: vi.fn(),
 }));
 
-vi.mock('../../shared/config', () => ({
-  DISCORD_GUILD_ID: 'guild-123',
-  DISCORD_VOICE_CHANNEL_ID: 'default-vc',
+vi.mock('../../db', () => ({
+  getGuildById: vi.fn(),
 }));
 
 vi.mock('./shared', () => ({
@@ -47,10 +46,18 @@ import { getStatus } from '../../shared/statusStore';
 import { connect, disconnect, getCurrentChannelId } from '../../audio/audioPlayer';
 import { getDiscordClient } from '../../discord/discordBot';
 import { getAvailableVoiceChannels } from '../../discord/discordUtils';
+import { getGuildById } from '../../db';
 
-function buildApp() {
+const GUILD_ID = '900000000000000001';
+
+// Injects a session with the current guild so the guild-scoped voice routes resolve.
+function buildApp(currentGuildId: string | null = GUILD_ID) {
   const app = express();
   app.use(express.json());
+  app.use((req: any, _res: any, next: any) => {
+    req.session = { user: { discordId: 'u1', currentGuildId } };
+    next();
+  });
   app.use(router);
   return app;
 }
@@ -62,6 +69,7 @@ beforeEach(() => {
   vi.mocked(connect).mockResolvedValue(undefined);
   vi.mocked(getCurrentChannelId).mockReturnValue('current-vc');
   vi.mocked(getAvailableVoiceChannels).mockResolvedValue([]);
+  vi.mocked(getGuildById).mockResolvedValue({ guild_id: GUILD_ID, name: 'Guild', voice_channel_id: 'default-vc' });
 });
 
 describe('GET /status', () => {
@@ -72,14 +80,26 @@ describe('GET /status', () => {
 });
 
 describe('GET /voice/channels', () => {
-  it('reports the current channel for the configured guild', async () => {
+  it('reports the current channel and DB default for the session guild', async () => {
     const res = await supertest(buildApp()).get('/voice/channels').expect(200);
     expect(res.body).toMatchObject({
       ok: true,
       defaultChannelId: 'default-vc',
       currentChannelId: 'current-vc',
     });
-    expect(vi.mocked(getCurrentChannelId)).toHaveBeenCalledWith('guild-123');
+    expect(vi.mocked(getCurrentChannelId)).toHaveBeenCalledWith(GUILD_ID);
+    expect(vi.mocked(getAvailableVoiceChannels)).toHaveBeenCalledWith(GUILD_ID);
+  });
+
+  it('returns null default when the guild has no configured voice channel', async () => {
+    vi.mocked(getGuildById).mockResolvedValue({ guild_id: GUILD_ID, name: 'Guild', voice_channel_id: null });
+    const res = await supertest(buildApp()).get('/voice/channels').expect(200);
+    expect(res.body.defaultChannelId).toBeNull();
+  });
+
+  it('returns 400 when no guild is selected', async () => {
+    const res = await supertest(buildApp(null)).get('/voice/channels').expect(400);
+    expect(res.body).toMatchObject({ ok: false });
   });
 
   it('returns 500 when channel lookup fails', async () => {
@@ -90,20 +110,25 @@ describe('GET /voice/channels', () => {
 });
 
 describe('POST /voice/join', () => {
-  it('disconnects then joins the requested channel for the configured guild', async () => {
+  it('disconnects then joins the requested channel for the session guild', async () => {
     const res = await supertest(buildApp())
       .post('/voice/join')
       .send({ channelId: '123456789012345678' })
       .expect(200);
 
     expect(res.body).toEqual({ ok: true });
-    expect(vi.mocked(disconnect)).toHaveBeenCalledWith('guild-123');
-    expect(vi.mocked(connect)).toHaveBeenCalledWith({}, 'guild-123', '123456789012345678');
+    expect(vi.mocked(disconnect)).toHaveBeenCalledWith(GUILD_ID);
+    expect(vi.mocked(connect)).toHaveBeenCalledWith({}, GUILD_ID, '123456789012345678');
   });
 
-  it('falls back to the default channel when no channelId is given', async () => {
+  it('falls back to the guild default channel when no channelId is given', async () => {
     await supertest(buildApp()).post('/voice/join').send({}).expect(200);
-    expect(vi.mocked(connect)).toHaveBeenCalledWith({}, 'guild-123', undefined);
+    expect(vi.mocked(connect)).toHaveBeenCalledWith({}, GUILD_ID, 'default-vc');
+  });
+
+  it('returns 400 when no guild is selected', async () => {
+    await supertest(buildApp(null)).post('/voice/join').send({ channelId: '123456789012345678' }).expect(400);
+    expect(vi.mocked(connect)).not.toHaveBeenCalled();
   });
 
   it('returns 400 for a non-string channelId', async () => {
@@ -133,9 +158,14 @@ describe('POST /voice/join', () => {
 });
 
 describe('POST /voice/leave', () => {
-  it('disconnects the configured guild and returns ok', async () => {
+  it('disconnects the session guild and returns ok', async () => {
     const res = await supertest(buildApp()).post('/voice/leave').expect(200);
     expect(res.body).toEqual({ ok: true });
-    expect(vi.mocked(disconnect)).toHaveBeenCalledWith('guild-123');
+    expect(vi.mocked(disconnect)).toHaveBeenCalledWith(GUILD_ID);
+  });
+
+  it('returns 400 when no guild is selected', async () => {
+    await supertest(buildApp(null)).post('/voice/leave').expect(400);
+    expect(vi.mocked(disconnect)).not.toHaveBeenCalled();
   });
 });

--- a/src/web/routes/api.ts
+++ b/src/web/routes/api.ts
@@ -78,6 +78,10 @@ router.post('/voice/join', requireMod, csrfProtection, async (req, res) => {
     }
     // Fall back to the guild's configured default channel when none is supplied.
     const resolvedChannelId = trimmedChannelId || (await getGuildById(guildId))?.voice_channel_id || undefined;
+    if (!resolvedChannelId) {
+      res.status(400).json({ ok: false, error: 'No voice channel selected and no default configured' });
+      return;
+    }
 
     disconnect(guildId);
     await connect(discordClient, guildId, resolvedChannelId);

--- a/src/web/routes/api.ts
+++ b/src/web/routes/api.ts
@@ -1,31 +1,53 @@
 import { createLogger } from '../../shared/logger';
-import { Router } from 'express';
+import { Router, type Request, type Response } from 'express';
 import { getStatus } from '../../shared/statusStore';
 import { requireAuth, requireMod } from '../middleware';
 import { connect, disconnect, getCurrentChannelId } from '../../audio/audioPlayer';
 import { getDiscordClient } from '../../discord/discordBot';
 import { csrfProtection } from '../csrf';
 import { getAvailableVoiceChannels } from '../../discord/discordUtils';
-import { DISCORD_GUILD_ID, DISCORD_VOICE_CHANNEL_ID } from '../../shared/config';
+import { getGuildById } from '../../db';
 import { normalizeDiscordId } from './shared';
 
 const log = createLogger('API');
 const router = Router();
+
+/**
+ * Resolves the guild the request acts in from the session, replying 400 when no
+ * guild is selected. Voice routes are guild-scoped — the bot can hold a separate
+ * connection per guild — and the guild is taken from the session (never the
+ * request body) so a Mod cannot drive another guild's voice connection.
+ *
+ * @returns The current guild ID, or null when the response has already been sent.
+ */
+function getSessionGuildId(req: Request, res: Response): string | null {
+  const guildId = req.session.user?.currentGuildId ?? null;
+  if (!guildId) {
+    res.status(400).json({ ok: false, error: 'No guild selected' });
+    return null;
+  }
+  return guildId;
+}
 
 // Live status JSON — polled by the dashboard frontend every few seconds
 router.get('/status', requireAuth, (_req, res) => {
   res.json(getStatus());
 });
 
-// Get available voice channels — Mod and above
-router.get('/voice/channels', requireMod, async (_req, res) => {
+// Get available voice channels for the current guild — Mod and above
+router.get('/voice/channels', requireMod, async (req, res) => {
+  const guildId = getSessionGuildId(req, res);
+  if (!guildId) return;
   try {
-    const channels = await getAvailableVoiceChannels(DISCORD_GUILD_ID);
+    const [channels, guild] = await Promise.all([
+      getAvailableVoiceChannels(guildId),
+      getGuildById(guildId),
+    ]);
     res.json({
       ok: true,
       channels,
-      defaultChannelId: DISCORD_VOICE_CHANNEL_ID,
-      currentChannelId: getCurrentChannelId(DISCORD_GUILD_ID),
+      defaultChannelId: guild?.voice_channel_id ?? null,
+      currentChannelId: getCurrentChannelId(guildId),
     });
   } catch (err) {
     log.error('Failed to list voice channels:', err);
@@ -33,8 +55,11 @@ router.get('/voice/channels', requireMod, async (_req, res) => {
   }
 });
 
-// Join a specific voice channel or the configured default — Mod and above
+// Join a specific voice channel, or the guild's configured default — Mod and above
 router.post('/voice/join', requireMod, csrfProtection, async (req, res) => {
+  const guildId = getSessionGuildId(req, res);
+  if (!guildId) return;
+
   const discordClient = getDiscordClient();
   if (!discordClient) {
     res.status(503).json({ ok: false, error: 'Discord client not ready' });
@@ -51,10 +76,11 @@ router.post('/voice/join', requireMod, csrfProtection, async (req, res) => {
       res.status(400).json({ ok: false, error: 'Invalid channel ID' });
       return;
     }
-    const resolvedChannelId = trimmedChannelId || undefined;
+    // Fall back to the guild's configured default channel when none is supplied.
+    const resolvedChannelId = trimmedChannelId || (await getGuildById(guildId))?.voice_channel_id || undefined;
 
-    disconnect(DISCORD_GUILD_ID);
-    await connect(discordClient, DISCORD_GUILD_ID, resolvedChannelId);
+    disconnect(guildId);
+    await connect(discordClient, guildId, resolvedChannelId);
     res.json({ ok: true });
   } catch (err) {
     log.error('Voice rejoin failed:', err);
@@ -62,9 +88,11 @@ router.post('/voice/join', requireMod, csrfProtection, async (req, res) => {
   }
 });
 
-// Leave the voice channel — Mod and above
-router.post('/voice/leave', requireMod, csrfProtection, (_req, res) => {
-  disconnect(DISCORD_GUILD_ID);
+// Leave the current guild's voice channel — Mod and above
+router.post('/voice/leave', requireMod, csrfProtection, (req, res) => {
+  const guildId = getSessionGuildId(req, res);
+  if (!guildId) return;
+  disconnect(guildId);
   res.json({ ok: true });
 });
 

--- a/src/web/routes/auth.test.ts
+++ b/src/web/routes/auth.test.ts
@@ -8,6 +8,9 @@ vi.mock('../../shared/config', () => ({
 vi.mock('../../db', () => ({
   findUser: vi.fn().mockResolvedValue(null),
   updateDiscordName: vi.fn().mockResolvedValue(undefined),
+  getAllGuilds: vi.fn().mockResolvedValue([]),
+  getGuildsForMember: vi.fn().mockResolvedValue([]),
+  getEffectiveAccessLevel: vi.fn().mockResolvedValue(0),
 }));
 vi.mock('../../discord/discordBot', () => ({
   fetchMemberDisplayName: vi.fn().mockResolvedValue(null),
@@ -25,7 +28,7 @@ vi.mock('../../shared/logger', () => ({
 import express from 'express';
 import supertest from 'supertest';
 import router from './auth';
-import { findUser, updateDiscordName } from '../../db';
+import { findUser, updateDiscordName, getGuildsForMember, getEffectiveAccessLevel } from '../../db';
 import { AccessLevel } from '../../db/users';
 import { fetchMemberDisplayName } from '../../discord/discordBot';
 
@@ -64,6 +67,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(findUser).mockResolvedValue(null);
   vi.mocked(fetchMemberDisplayName).mockResolvedValue(null);
+  vi.mocked(getGuildsForMember).mockResolvedValue([]);
+  vi.mocked(getEffectiveAccessLevel).mockResolvedValue(0);
 });
 
 // ─── GET /discord ─────────────────────────────────────────────────────────────
@@ -133,12 +138,25 @@ describe('GET /discord/callback', () => {
     expect(res.status).toBe(403);
   });
 
+  it('renders error 403 when the whitelisted user belongs to no guild', async () => {
+    mockFetch([
+      { ok: true, json: () => Promise.resolve({ access_token: 'tok' }) },
+      { ok: true, json: () => Promise.resolve({ id: '111', username: 'alice', avatar: null }) },
+    ]);
+    vi.mocked(findUser).mockResolvedValue({ discord_id: '111', discord_name: 'alice', is_twitch_bot_enabled: false, twitch_name: null, access_level: AccessLevel.USER, is_owner: false } as any);
+    vi.mocked(getGuildsForMember).mockResolvedValue([]);
+    const res = await supertest(buildApp({ oauthState: { value: 'state123', expiresAt: Date.now() + 60_000 } }))
+      .get('/discord/callback?code=code&state=state123');
+    expect(res.status).toBe(403);
+  });
+
   it('redirects to / on successful authentication', async () => {
     mockFetch([
       { ok: true, json: () => Promise.resolve({ access_token: 'tok' }) },
       { ok: true, json: () => Promise.resolve({ id: '111', username: 'alice', avatar: null }) },
     ]);
-    vi.mocked(findUser).mockResolvedValue({ discord_id: '111', discord_name: 'alice', is_twitch_bot_enabled: false, twitch_name: null, access_level: AccessLevel.USER } as any);
+    vi.mocked(findUser).mockResolvedValue({ discord_id: '111', discord_name: 'alice', is_twitch_bot_enabled: false, twitch_name: null, access_level: AccessLevel.USER, is_owner: false } as any);
+    vi.mocked(getGuildsForMember).mockResolvedValue([{ guild_id: '555', name: 'Guild', voice_channel_id: null }] as any);
     const res = await supertest(buildApp({ oauthState: { value: 'state123', expiresAt: Date.now() + 60_000 } }))
       .get('/discord/callback?code=code&state=state123');
     expect(res.status).toBe(302);
@@ -150,7 +168,8 @@ describe('GET /discord/callback', () => {
       { ok: true, json: () => Promise.resolve({ access_token: 'tok' }) },
       { ok: true, json: () => Promise.resolve({ id: '111', username: 'alice', avatar: null }) },
     ]);
-    vi.mocked(findUser).mockResolvedValue({ discord_id: '111', discord_name: 'OldName', is_twitch_bot_enabled: false, twitch_name: null, access_level: AccessLevel.USER } as any);
+    vi.mocked(findUser).mockResolvedValue({ discord_id: '111', discord_name: 'OldName', is_twitch_bot_enabled: false, twitch_name: null, access_level: AccessLevel.USER, is_owner: false } as any);
+    vi.mocked(getGuildsForMember).mockResolvedValue([{ guild_id: '555', name: 'Guild', voice_channel_id: null }] as any);
     vi.mocked(fetchMemberDisplayName).mockResolvedValue('NewDisplayName');
     const res = await supertest(buildApp({ oauthState: { value: 'state123', expiresAt: Date.now() + 60_000 } }))
       .get('/discord/callback?code=code&state=state123');

--- a/src/web/routes/auth.test.ts
+++ b/src/web/routes/auth.test.ts
@@ -11,6 +11,7 @@ vi.mock('../../db', () => ({
   getAllGuilds: vi.fn().mockResolvedValue([]),
   getGuildsForMember: vi.fn().mockResolvedValue([]),
   getEffectiveAccessLevel: vi.fn().mockResolvedValue(0),
+  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
 }));
 vi.mock('../../discord/discordBot', () => ({
   fetchMemberDisplayName: vi.fn().mockResolvedValue(null),
@@ -28,11 +29,11 @@ vi.mock('../../shared/logger', () => ({
 import express from 'express';
 import supertest from 'supertest';
 import router from './auth';
-import { findUser, updateDiscordName, getGuildsForMember, getEffectiveAccessLevel } from '../../db';
+import { findUser, updateDiscordName, getAllGuilds, getGuildsForMember, getEffectiveAccessLevel } from '../../db';
 import { AccessLevel } from '../../db/users';
 import { fetchMemberDisplayName } from '../../discord/discordBot';
 
-function buildApp(sessionOverrides: Record<string, unknown> = {}) {
+function buildApp(sessionOverrides: Record<string, unknown> = {}, captureSession?: (session: any) => void) {
   const app = express();
   app.use(express.urlencoded({ extended: false }));
   app.use((req: any, _res: any, next: any) => {
@@ -44,6 +45,7 @@ function buildApp(sessionOverrides: Record<string, unknown> = {}) {
       save: vi.fn((cb: (err: null) => void) => cb(null)),
       ...sessionOverrides,
     };
+    captureSession?.(req.session);
     next();
   });
   app.use((req: any, res: any, next: any) => {
@@ -161,6 +163,47 @@ describe('GET /discord/callback', () => {
       .get('/discord/callback?code=code&state=state123');
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/');
+  });
+
+  it('uses getAllGuilds (not getGuildsForMember) when the user is the bot owner', async () => {
+    mockFetch([
+      { ok: true, json: () => Promise.resolve({ access_token: 'tok' }) },
+      { ok: true, json: () => Promise.resolve({ id: '111', username: 'alice', avatar: null }) },
+    ]);
+    vi.mocked(findUser).mockResolvedValue({ discord_id: '111', discord_name: 'alice', is_twitch_bot_enabled: false, twitch_name: null, access_level: AccessLevel.USER, is_owner: true } as any);
+    vi.mocked(getAllGuilds).mockResolvedValue([
+      { guild_id: '555', name: 'Guild', voice_channel_id: null },
+      { guild_id: '556', name: 'Other Guild', voice_channel_id: null },
+    ] as any);
+    const res = await supertest(buildApp({ oauthState: { value: 'state123', expiresAt: Date.now() + 60_000 } }))
+      .get('/discord/callback?code=code&state=state123');
+    expect(res.status).toBe(302);
+    expect(getAllGuilds).toHaveBeenCalled();
+    expect(getGuildsForMember).not.toHaveBeenCalled();
+  });
+
+  it('stores discordId, accessLevel and currentGuildId on the session after successful auth', async () => {
+    mockFetch([
+      { ok: true, json: () => Promise.resolve({ access_token: 'tok' }) },
+      { ok: true, json: () => Promise.resolve({ id: '111', username: 'alice', avatar: null }) },
+    ]);
+    vi.mocked(findUser).mockResolvedValue({ discord_id: '111', discord_name: 'alice', is_twitch_bot_enabled: false, twitch_name: null, access_level: AccessLevel.USER, is_owner: false } as any);
+    vi.mocked(getGuildsForMember).mockResolvedValue([{ guild_id: '555', name: 'Guild', voice_channel_id: null }] as any);
+    vi.mocked(getEffectiveAccessLevel).mockResolvedValue(AccessLevel.MOD);
+
+    let capturedSession: any;
+    const app = buildApp(
+      { oauthState: { value: 'state123', expiresAt: Date.now() + 60_000 } },
+      (session) => { capturedSession = session; },
+    );
+    const res = await supertest(app).get('/discord/callback?code=code&state=state123');
+
+    expect(res.status).toBe(302);
+    expect(capturedSession.user).toMatchObject({
+      discordId: '111',
+      currentGuildId: '555',
+      accessLevel: AccessLevel.MOD,
+    });
   });
 
   it('updates discord name when fetchMemberDisplayName returns a value', async () => {

--- a/src/web/routes/auth.test.ts
+++ b/src/web/routes/auth.test.ts
@@ -175,11 +175,21 @@ describe('GET /discord/callback', () => {
       { guild_id: '555', name: 'Guild', voice_channel_id: null },
       { guild_id: '556', name: 'Other Guild', voice_channel_id: null },
     ] as any);
-    const res = await supertest(buildApp({ oauthState: { value: 'state123', expiresAt: Date.now() + 60_000 } }))
-      .get('/discord/callback?code=code&state=state123');
+
+    let capturedSession: any;
+    const app = buildApp(
+      { oauthState: { value: 'state123', expiresAt: Date.now() + 60_000 } },
+      (session) => { capturedSession = session; },
+    );
+    const res = await supertest(app).get('/discord/callback?code=code&state=state123');
+
     expect(res.status).toBe(302);
     expect(getAllGuilds).toHaveBeenCalled();
     expect(getGuildsForMember).not.toHaveBeenCalled();
+    expect(capturedSession.user).toMatchObject({
+      currentGuildId: null,
+      accessLevel: AccessLevel.USER,
+    });
   });
 
   it('stores discordId, accessLevel and currentGuildId on the session after successful auth', async () => {

--- a/src/web/routes/auth.ts
+++ b/src/web/routes/auth.ts
@@ -8,6 +8,7 @@ import {
   getAllGuilds,
   getGuildsForMember,
   getEffectiveAccessLevel,
+  AccessLevel,
   type DbGuild,
 } from '../../db';
 import { fetchMemberDisplayName } from '../../discord/discordBot';
@@ -117,7 +118,7 @@ router.get('/discord/callback', async (req, res) => {
     const currentGuildId = accessibleGuilds.length === 1 ? accessibleGuilds[0].guild_id : null;
     const accessLevel = currentGuildId
       ? ((await getEffectiveAccessLevel(currentGuildId, profile.id)) as 0 | 1 | 2 | 3)
-      : 0;
+      : AccessLevel.USER;
 
     // 5. Save to session — regenerate the session ID first to prevent session fixation.
     const rawAvatar = profile.avatar

--- a/src/web/routes/auth.ts
+++ b/src/web/routes/auth.ts
@@ -80,20 +80,6 @@ router.get('/discord/callback', async (req, res) => {
       return renderError(res, 403, 'You are not on the whitelist. Contact an admin to be added.', undefined);
     }
 
-    let syncedDiscordName = dbUser.discord_name?.trim() || profile.username;
-    try {
-      const displayName = await fetchMemberDisplayName(profile.id, true);
-      const trimmedDisplayName = displayName?.trim();
-      if (trimmedDisplayName) {
-        syncedDiscordName = trimmedDisplayName;
-      }
-      if (syncedDiscordName !== dbUser.discord_name) {
-        await updateDiscordName(profile.id, syncedDiscordName);
-      }
-    } catch (syncErr) {
-      log.warn('Non-blocking discord_name sync failed:', syncErr);
-    }
-
     // 4. Resolve the guilds this user may act in. Owners get every guild; everyone
     //    else gets the guilds they have a membership row in. No accessible guild
     //    means they have not been provisioned anywhere — deny rather than show an
@@ -108,6 +94,22 @@ router.get('/discord/callback', async (req, res) => {
         'You have not been added to any server yet. Contact the bot owner to be granted access.',
         undefined,
       );
+    }
+
+    // Sync display name using the first accessible guild (display names are per-guild
+    // in Discord; we use a best-effort lookup against one guild at login time).
+    let syncedDiscordName = dbUser.discord_name?.trim() || profile.username;
+    try {
+      const displayName = await fetchMemberDisplayName(profile.id, true, accessibleGuilds[0].guild_id);
+      const trimmedDisplayName = displayName?.trim();
+      if (trimmedDisplayName) {
+        syncedDiscordName = trimmedDisplayName;
+      }
+      if (syncedDiscordName !== dbUser.discord_name) {
+        await updateDiscordName(profile.id, syncedDiscordName);
+      }
+    } catch (syncErr) {
+      log.warn('Non-blocking discord_name sync failed:', syncErr);
     }
 
     // Auto-select when there is only one choice; otherwise force the guild picker

--- a/src/web/routes/auth.ts
+++ b/src/web/routes/auth.ts
@@ -2,7 +2,14 @@ import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import crypto from 'crypto';
 import { DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET, DISCORD_CALLBACK_URL } from '../../shared/config';
-import { findUser, updateDiscordName } from '../../db';
+import {
+  findUser,
+  updateDiscordName,
+  getAllGuilds,
+  getGuildsForMember,
+  getEffectiveAccessLevel,
+  type DbGuild,
+} from '../../db';
 import { fetchMemberDisplayName } from '../../discord/discordBot';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
@@ -87,7 +94,30 @@ router.get('/discord/callback', async (req, res) => {
       log.warn('Non-blocking discord_name sync failed:', syncErr);
     }
 
-    // 4. Save to session — regenerate the session ID first to prevent session fixation.
+    // 4. Resolve the guilds this user may act in. Owners get every guild; everyone
+    //    else gets the guilds they have a membership row in. No accessible guild
+    //    means they have not been provisioned anywhere — deny rather than show an
+    //    empty panel.
+    const accessibleGuilds: DbGuild[] = dbUser.is_owner
+      ? await getAllGuilds()
+      : await getGuildsForMember(profile.id);
+    if (accessibleGuilds.length === 0) {
+      return renderError(
+        res,
+        403,
+        'You have not been added to any server yet. Contact the bot owner to be granted access.',
+        undefined,
+      );
+    }
+
+    // Auto-select when there is only one choice; otherwise force the guild picker
+    // by leaving currentGuildId null (accessLevel stays 0 until a guild is chosen).
+    const currentGuildId = accessibleGuilds.length === 1 ? accessibleGuilds[0].guild_id : null;
+    const accessLevel = currentGuildId
+      ? ((await getEffectiveAccessLevel(currentGuildId, profile.id)) as 0 | 1 | 2 | 3)
+      : 0;
+
+    // 5. Save to session — regenerate the session ID first to prevent session fixation.
     const rawAvatar = profile.avatar
       ? `https://cdn.discordapp.com/avatars/${profile.id}/${profile.avatar}.png`
       : null;
@@ -95,7 +125,10 @@ router.get('/discord/callback', async (req, res) => {
       discordId: profile.id,
       discordName: syncedDiscordName,
       discordAvatar: rawAvatar?.startsWith('https://cdn.discordapp.com/') ? rawAvatar : null,
-      accessLevel: dbUser.access_level as 0 | 1 | 2 | 3,
+      isOwner: dbUser.is_owner,
+      accessLevel,
+      currentGuildId,
+      guilds: accessibleGuilds.map((g) => ({ guildId: g.guild_id, name: g.name })),
     };
 
     await new Promise<void>((resolve, reject) => {

--- a/src/web/routes/commandGuildOverrides.test.ts
+++ b/src/web/routes/commandGuildOverrides.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../db', () => ({
+  upsertOverride: vi.fn().mockResolvedValue(undefined),
+  removeOverride: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../csrf', () => ({ csrfProtection: (_req: any, _res: any, next: any) => next() }));
+vi.mock('../middleware', () => ({
+  requireMod: (_req: any, _res: any, next: any) => next(),
+  requireGuildContext: (_req: any, _res: any, next: any) => next(),
+}));
+vi.mock('../../shared/logger', () => ({ createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }) }));
+
+import express from 'express';
+import supertest from 'supertest';
+import router from './commandGuildOverrides';
+import { upsertOverride, removeOverride } from '../../db';
+
+const GUILD_ID = '900000000000000001';
+
+function buildApp(currentGuildId: string | null = GUILD_ID) {
+  const app = express();
+  app.use(express.urlencoded({ extended: false }));
+  app.use((req: any, _res: any, next: any) => {
+    req.session = { user: { discordId: 'u1', currentGuildId } };
+    next();
+  });
+  app.use(router);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(upsertOverride).mockResolvedValue(undefined);
+  vi.mocked(removeOverride).mockResolvedValue(undefined);
+});
+
+// ─── POST /commands/guild-override ────────────────────────────────────────────
+
+describe('POST /commands/guild-override', () => {
+  it('calls upsertOverride with session guild and redirects to /commands', async () => {
+    const res = await supertest(buildApp())
+      .post('/commands/guild-override')
+      .send('command_id=5&is_disabled=1');
+    expect(res.headers.location).toBe('/commands');
+    expect(vi.mocked(upsertOverride)).toHaveBeenCalledWith(GUILD_ID, 5, {
+      isDisabled: true,
+      output: null,
+    });
+  });
+
+  it('stores a custom output when provided', async () => {
+    await supertest(buildApp())
+      .post('/commands/guild-override')
+      .send('command_id=5&output=Hello+there');
+    expect(vi.mocked(upsertOverride)).toHaveBeenCalledWith(GUILD_ID, 5, {
+      isDisabled: false,
+      output: 'Hello there',
+    });
+  });
+
+  it('clears custom output when clear_output is set', async () => {
+    await supertest(buildApp())
+      .post('/commands/guild-override')
+      .send('command_id=5&output=Something&clear_output=1');
+    expect(vi.mocked(upsertOverride)).toHaveBeenCalledWith(GUILD_ID, 5, {
+      isDisabled: false,
+      output: null,
+    });
+  });
+
+  it('returns 302 to ?error=invalid_id for a non-integer command_id', async () => {
+    const res = await supertest(buildApp())
+      .post('/commands/guild-override')
+      .send('command_id=abc');
+    expect(res.headers.location).toBe('/commands?error=invalid_id');
+    expect(vi.mocked(upsertOverride)).not.toHaveBeenCalled();
+  });
+
+  it('redirects to ?error=override_failed when upsertOverride throws', async () => {
+    vi.mocked(upsertOverride).mockRejectedValue(new Error('DB error'));
+    const res = await supertest(buildApp())
+      .post('/commands/guild-override')
+      .send('command_id=5');
+    expect(res.headers.location).toBe('/commands?error=override_failed');
+  });
+});
+
+// ─── POST /commands/guild-override/reset ─────────────────────────────────────
+
+describe('POST /commands/guild-override/reset', () => {
+  it('calls removeOverride with session guild and redirects to /commands', async () => {
+    const res = await supertest(buildApp())
+      .post('/commands/guild-override/reset')
+      .send('command_id=5');
+    expect(res.headers.location).toBe('/commands');
+    expect(vi.mocked(removeOverride)).toHaveBeenCalledWith(GUILD_ID, 5);
+  });
+
+  it('returns 302 to ?error=invalid_id for a non-integer command_id', async () => {
+    const res = await supertest(buildApp())
+      .post('/commands/guild-override/reset')
+      .send('command_id=abc');
+    expect(res.headers.location).toBe('/commands?error=invalid_id');
+    expect(vi.mocked(removeOverride)).not.toHaveBeenCalled();
+  });
+
+  it('redirects to ?error=override_reset_failed when removeOverride throws', async () => {
+    vi.mocked(removeOverride).mockRejectedValue(new Error('DB error'));
+    const res = await supertest(buildApp())
+      .post('/commands/guild-override/reset')
+      .send('command_id=5');
+    expect(res.headers.location).toBe('/commands?error=override_reset_failed');
+  });
+});

--- a/src/web/routes/commandGuildOverrides.ts
+++ b/src/web/routes/commandGuildOverrides.ts
@@ -1,0 +1,56 @@
+import { createLogger } from '../../shared/logger';
+import { Router } from 'express';
+import { upsertOverride, removeOverride } from '../../db';
+import { csrfProtection } from '../csrf';
+import { requireMod, requireGuildContext } from '../middleware';
+import { parsePositiveIntId } from './shared';
+
+const log = createLogger('Web');
+const router = Router();
+
+/**
+ * Sets or updates the per-guild override for a catalog command.
+ * Accepts `command_id`, `is_disabled` ("1" = disabled, absent = enabled),
+ * `output` (custom output text) and `clear_output` ("1" = remove any custom output).
+ * Guild ID is always taken from the session — never from the request body.
+ */
+router.post('/commands/guild-override', requireMod, requireGuildContext, csrfProtection, async (req, res) => {
+  const guildId = req.session.user!.currentGuildId!;
+  const body = req.body as Record<string, string | undefined>;
+  const commandId = parsePositiveIntId(body.command_id);
+  if (!commandId) return res.redirect('/commands?error=invalid_id');
+
+  const isDisabled = body.is_disabled === '1';
+  const clearOutput = body.clear_output === '1';
+  const rawOutput = (body.output ?? '').trim();
+  const output = clearOutput || !rawOutput ? null : rawOutput;
+
+  try {
+    await upsertOverride(guildId, commandId, { isDisabled, output });
+    res.redirect('/commands');
+  } catch (err) {
+    log.error('Guild command override upsert failed:', err);
+    res.redirect('/commands?error=override_failed');
+  }
+});
+
+/**
+ * Removes the per-guild override for a catalog command, reverting it to the catalog default.
+ * Accepts `command_id`. Guild ID is always taken from the session.
+ */
+router.post('/commands/guild-override/reset', requireMod, requireGuildContext, csrfProtection, async (req, res) => {
+  const guildId = req.session.user!.currentGuildId!;
+  const body = req.body as Record<string, string | undefined>;
+  const commandId = parsePositiveIntId(body.command_id);
+  if (!commandId) return res.redirect('/commands?error=invalid_id');
+
+  try {
+    await removeOverride(guildId, commandId);
+    res.redirect('/commands');
+  } catch (err) {
+    log.error('Guild command override reset failed:', err);
+    res.redirect('/commands?error=override_reset_failed');
+  }
+});
+
+export default router;

--- a/src/web/routes/commandGuildOverrides.ts
+++ b/src/web/routes/commandGuildOverrides.ts
@@ -14,7 +14,7 @@ const router = Router();
  * `output` (custom output text) and `clear_output` ("1" = remove any custom output).
  * Guild ID is always taken from the session — never from the request body.
  */
-router.post('/commands/guild-override', requireMod, requireGuildContext, csrfProtection, async (req, res) => {
+router.post('/commands/guild-override', requireGuildContext, requireMod, csrfProtection, async (req, res) => {
   const guildId = req.session.user!.currentGuildId!;
   const body = req.body as Record<string, unknown>;
   const commandId = parsePositiveIntId(body.command_id as string | string[] | undefined);
@@ -38,7 +38,7 @@ router.post('/commands/guild-override', requireMod, requireGuildContext, csrfPro
  * Removes the per-guild override for a catalog command, reverting it to the catalog default.
  * Accepts `command_id`. Guild ID is always taken from the session.
  */
-router.post('/commands/guild-override/reset', requireMod, requireGuildContext, csrfProtection, async (req, res) => {
+router.post('/commands/guild-override/reset', requireGuildContext, requireMod, csrfProtection, async (req, res) => {
   const guildId = req.session.user!.currentGuildId!;
   const body = req.body as Record<string, unknown>;
   const commandId = parsePositiveIntId(body.command_id as string | string[] | undefined);

--- a/src/web/routes/commandGuildOverrides.ts
+++ b/src/web/routes/commandGuildOverrides.ts
@@ -3,7 +3,7 @@ import { Router } from 'express';
 import { upsertOverride, removeOverride } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireMod, requireGuildContext } from '../middleware';
-import { parsePositiveIntId } from './shared';
+import { parsePositiveIntId, trimField } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
@@ -16,13 +16,13 @@ const router = Router();
  */
 router.post('/commands/guild-override', requireMod, requireGuildContext, csrfProtection, async (req, res) => {
   const guildId = req.session.user!.currentGuildId!;
-  const body = req.body as Record<string, string | undefined>;
-  const commandId = parsePositiveIntId(body.command_id);
+  const body = req.body as Record<string, unknown>;
+  const commandId = parsePositiveIntId(body.command_id as string | string[] | undefined);
   if (!commandId) return res.redirect('/commands?error=invalid_id');
 
   const isDisabled = body.is_disabled === '1';
   const clearOutput = body.clear_output === '1';
-  const rawOutput = (body.output ?? '').trim();
+  const rawOutput = trimField(Array.isArray(body.output) ? (body.output as string[])[0] : body.output as string | undefined);
   const output = clearOutput || !rawOutput ? null : rawOutput;
 
   try {
@@ -40,8 +40,8 @@ router.post('/commands/guild-override', requireMod, requireGuildContext, csrfPro
  */
 router.post('/commands/guild-override/reset', requireMod, requireGuildContext, csrfProtection, async (req, res) => {
   const guildId = req.session.user!.currentGuildId!;
-  const body = req.body as Record<string, string | undefined>;
-  const commandId = parsePositiveIntId(body.command_id);
+  const body = req.body as Record<string, unknown>;
+  const commandId = parsePositiveIntId(body.command_id as string | string[] | undefined);
   if (!commandId) return res.redirect('/commands?error=invalid_id');
 
   try {

--- a/src/web/routes/commands.test.ts
+++ b/src/web/routes/commands.test.ts
@@ -55,6 +55,7 @@ import {
   findUser,
   getAllCustomCommandsWithAssignments,
   getAllUsers,
+  getOverridesForGuild,
   isMysqlDuplicateEntryError,
   CommandConflictError,
   CommandNotFoundError,
@@ -81,6 +82,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(getAllCustomCommandsWithAssignments).mockResolvedValue([]);
   vi.mocked(getAllUsers).mockResolvedValue([]);
+  vi.mocked(getOverridesForGuild).mockResolvedValue([]);
   vi.mocked(addCustomCommand).mockResolvedValue(1);
   vi.mocked(updateCustomCommand).mockResolvedValue(undefined);
   vi.mocked(removeCustomCommand).mockResolvedValue(undefined);
@@ -516,6 +518,41 @@ describe('GET /commands', () => {
     app.use(router);
     const res = await supertest(app).get('/commands');
     expect(res.status).toBe(500);
+  });
+
+  it("36b. resolves the current guild's override onto the matching command and skips the lookup without a current guild", async () => {
+    vi.mocked(getAllCustomCommandsWithAssignments).mockResolvedValue([
+      { command_id: 1, trigger_string: '!hello', output: 'Hello!', is_discord_enabled: true, is_multi_twitch: false, assigned_users: [] } as any,
+      { command_id: 2, trigger_string: '!bye', output: 'Bye!', is_discord_enabled: true, is_multi_twitch: false, assigned_users: [] } as any,
+    ]);
+    vi.mocked(getOverridesForGuild).mockResolvedValue([
+      { guild_id: '900000000000000001', command_id: 1, is_disabled: true, output: null } as any,
+    ]);
+
+    let capturedLocals: any;
+    const app = express();
+    app.use(express.urlencoded({ extended: false }));
+    app.use((_req: any, res: any, next: any) => {
+      res.render = (_view: string, locals: any) => {
+        capturedLocals = locals;
+        res.send('ok');
+      };
+      next();
+    });
+    app.use((req: any, _res: any, next: any) => {
+      req.session = { user: { discord_id: '1', discord_name: 'TestUser', access_level: AccessLevel.MANAGER, currentGuildId: '900000000000000001' } };
+      next();
+    });
+    app.use(router);
+
+    await supertest(app).get('/commands');
+    expect(vi.mocked(getOverridesForGuild)).toHaveBeenCalledWith('900000000000000001');
+    expect(capturedLocals.commands[0].guildOverride).toMatchObject({ command_id: 1, is_disabled: true });
+    expect(capturedLocals.commands[1].guildOverride).toBeNull();
+
+    vi.mocked(getOverridesForGuild).mockClear();
+    await supertest(buildApp()).get('/commands');
+    expect(vi.mocked(getOverridesForGuild)).not.toHaveBeenCalled();
   });
 
   it('37. computes unassigned_users correctly when commands and users are present', async () => {

--- a/src/web/routes/commands.test.ts
+++ b/src/web/routes/commands.test.ts
@@ -7,12 +7,15 @@ vi.mock('../../db', () => {
   return {
     getAllCustomCommandsWithAssignments: vi.fn().mockResolvedValue([]),
     getAllUsers: vi.fn().mockResolvedValue([]),
+    getOverridesForGuild: vi.fn().mockResolvedValue([]),
     addCustomCommand: vi.fn().mockResolvedValue(1),
     updateCustomCommand: vi.fn().mockResolvedValue(undefined),
     removeCustomCommand: vi.fn().mockResolvedValue(undefined),
     assignUserToCommand: vi.fn().mockResolvedValue(undefined),
     unassignUserFromCommand: vi.fn().mockResolvedValue(undefined),
     findUser: vi.fn().mockResolvedValue(null),
+    upsertOverride: vi.fn().mockResolvedValue(undefined),
+    removeOverride: vi.fn().mockResolvedValue(undefined),
     CommandConflictError,
     CommandNotFoundError,
     ReservedCommandError,
@@ -31,6 +34,7 @@ vi.mock('../middleware', () => ({
   requireAuth: (_req: any, _res: any, next: any) => next(),
   requireMod: (_req: any, _res: any, next: any) => next(),
   requireManager: (_req: any, _res: any, next: any) => next(),
+  requireGuildContext: (_req: any, _res: any, next: any) => next(),
 }));
 
 vi.mock('../../logger', () => ({

--- a/src/web/routes/commands.ts
+++ b/src/web/routes/commands.ts
@@ -2,15 +2,18 @@ import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import {
   DbCustomCommandWithAssignments,
+  DbGuildCommandOverride,
   DbUser,
   getAllCustomCommandsWithAssignments,
   getAllUsers,
+  getOverridesForGuild,
 } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
 import { renderError, filterQueryParam } from './shared';
 import commandMutationsRouter from './commandMutations';
 import commandAssignmentsRouter from './commandAssignments';
+import commandGuildOverridesRouter from './commandGuildOverrides';
 
 const log = createLogger('Web');
 const router = Router();
@@ -27,25 +30,32 @@ const KNOWN_ERRORS = new Set([
   'assign_failed',
   'unassign_failed',
   'invalid_assignment_user',
+  'override_failed',
+  'override_reset_failed',
 ]);
 
 interface CommandViewModel extends DbCustomCommandWithAssignments {
   unassigned_users: DbUser[];
+  /** Per-guild override row for the current guild, or null when at catalog default. */
+  guildOverride: DbGuildCommandOverride | null;
 }
 
 router.get('/commands', requireAuth, csrfProtection, async (req, res) => {
   try {
-    const [commands, users] = await Promise.all([
+    const guildId = req.session.user?.currentGuildId ?? null;
+    const [commands, users, overrides] = await Promise.all([
       getAllCustomCommandsWithAssignments(),
       getAllUsers(),
+      guildId ? getOverridesForGuild(guildId) : Promise.resolve([] as DbGuildCommandOverride[]),
     ]);
+    const overridesByCommandId = new Map(overrides.map((o) => [o.command_id, o]));
     const assignableUsers = users.filter((entry) => entry.twitch_name);
     const commandsForView: CommandViewModel[] = commands.map((command) => {
       const assignedDiscordIds = new Set(command.assigned_users.map((entry) => entry.discord_id));
-
       return {
         ...command,
         unassigned_users: assignableUsers.filter((entry) => !assignedDiscordIds.has(entry.discord_id)),
+        guildOverride: overridesByCommandId.get(command.command_id) ?? null,
       };
     });
 
@@ -64,5 +74,6 @@ router.get('/commands', requireAuth, csrfProtection, async (req, res) => {
 
 router.use(commandMutationsRouter);
 router.use(commandAssignmentsRouter);
+router.use(commandGuildOverridesRouter);
 
 export default router;

--- a/src/web/routes/guild.test.ts
+++ b/src/web/routes/guild.test.ts
@@ -3,6 +3,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('../../db', () => ({
   getEffectiveAccessLevel: vi.fn().mockResolvedValue(0),
 }));
+vi.mock('../../db/users', () => ({
+  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
+}));
 vi.mock('../csrf', () => ({
   csrfProtection: (_req: any, _res: any, next: any) => next(),
 }));
@@ -17,6 +20,7 @@ import express from 'express';
 import supertest from 'supertest';
 import router from './guild';
 import { getEffectiveAccessLevel } from '../../db';
+import { AccessLevel } from '../../db/users';
 
 const TWO_GUILDS = [
   { guildId: '100000000000000001', name: 'Alpha' },
@@ -41,7 +45,7 @@ function buildApp(sessionUser: unknown) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(getEffectiveAccessLevel).mockResolvedValue(0);
+  vi.mocked(getEffectiveAccessLevel).mockResolvedValue(AccessLevel.USER);
 });
 
 describe('GET /guild/select', () => {
@@ -63,8 +67,8 @@ describe('GET /guild/select', () => {
 
 describe('POST /guild/select', () => {
   it('selects a guild the user belongs to and recomputes the access level', async () => {
-    vi.mocked(getEffectiveAccessLevel).mockResolvedValue(2);
-    const user: any = { discordId: 'u1', currentGuildId: null, accessLevel: 0, guilds: TWO_GUILDS };
+    vi.mocked(getEffectiveAccessLevel).mockResolvedValue(AccessLevel.MANAGER);
+    const user: any = { discordId: 'u1', currentGuildId: null, accessLevel: AccessLevel.USER, guilds: TWO_GUILDS };
     const app = express();
     app.use(express.urlencoded({ extended: false }));
     app.use((req: any, _res: any, next: any) => {
@@ -82,12 +86,12 @@ describe('POST /guild/select', () => {
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/');
     expect(user.currentGuildId).toBe('100000000000000002');
-    expect(user.accessLevel).toBe(2);
+    expect(user.accessLevel).toBe(AccessLevel.MANAGER);
     expect(vi.mocked(getEffectiveAccessLevel)).toHaveBeenCalledWith('100000000000000002', 'u1');
   });
 
   it('rejects a guild the user does not belong to (cross-guild IDOR guard)', async () => {
-    const user: any = { discordId: 'u1', currentGuildId: null, accessLevel: 0, guilds: TWO_GUILDS };
+    const user: any = { discordId: 'u1', currentGuildId: null, accessLevel: AccessLevel.USER, guilds: TWO_GUILDS };
     const app = express();
     app.use(express.urlencoded({ extended: false }));
     app.use((req: any, _res: any, next: any) => {
@@ -109,7 +113,7 @@ describe('POST /guild/select', () => {
   });
 
   it('rejects a malformed guild ID', async () => {
-    const user: any = { discordId: 'u1', currentGuildId: null, accessLevel: 0, guilds: TWO_GUILDS };
+    const user: any = { discordId: 'u1', currentGuildId: null, accessLevel: AccessLevel.USER, guilds: TWO_GUILDS };
     const app = express();
     app.use(express.urlencoded({ extended: false }));
     app.use((req: any, _res: any, next: any) => {

--- a/src/web/routes/guild.test.ts
+++ b/src/web/routes/guild.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../db', () => ({
+  getEffectiveAccessLevel: vi.fn().mockResolvedValue(0),
+}));
+vi.mock('../csrf', () => ({
+  csrfProtection: (_req: any, _res: any, next: any) => next(),
+}));
+vi.mock('../middleware', () => ({
+  requireAuth: (_req: any, _res: any, next: any) => next(),
+}));
+vi.mock('../../shared/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+}));
+
+import express from 'express';
+import supertest from 'supertest';
+import router from './guild';
+import { getEffectiveAccessLevel } from '../../db';
+
+const TWO_GUILDS = [
+  { guildId: '100000000000000001', name: 'Alpha' },
+  { guildId: '100000000000000002', name: 'Beta' },
+];
+
+function buildApp(sessionUser: unknown) {
+  const app = express();
+  app.use(express.urlencoded({ extended: false }));
+  app.use((req: any, _res: any, next: any) => {
+    req.session = { user: sessionUser };
+    req.csrfToken = () => 'csrf-token';
+    next();
+  });
+  app.use((req: any, res: any, next: any) => {
+    res.render = (view: string, locals: unknown) => res.status(200).json({ view, locals });
+    next();
+  });
+  app.use('/guild', router);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getEffectiveAccessLevel).mockResolvedValue(0);
+});
+
+describe('GET /guild/select', () => {
+  it('renders the picker when the user has multiple guilds', async () => {
+    const res = await supertest(buildApp({ discordId: 'u1', currentGuildId: null, guilds: TWO_GUILDS }))
+      .get('/guild/select');
+    expect(res.status).toBe(200);
+    expect((res.body as any).view).toBe('guildSelect');
+    expect((res.body as any).locals.guilds).toHaveLength(2);
+  });
+
+  it('redirects to / when the user has a single guild', async () => {
+    const res = await supertest(buildApp({ discordId: 'u1', currentGuildId: '100000000000000001', guilds: [TWO_GUILDS[0]] }))
+      .get('/guild/select');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/');
+  });
+});
+
+describe('POST /guild/select', () => {
+  it('selects a guild the user belongs to and recomputes the access level', async () => {
+    vi.mocked(getEffectiveAccessLevel).mockResolvedValue(2);
+    const user: any = { discordId: 'u1', currentGuildId: null, accessLevel: 0, guilds: TWO_GUILDS };
+    const app = express();
+    app.use(express.urlencoded({ extended: false }));
+    app.use((req: any, _res: any, next: any) => {
+      req.session = { user };
+      req.csrfToken = () => 'csrf-token';
+      next();
+    });
+    app.use('/guild', router);
+
+    const res = await supertest(app)
+      .post('/guild/select')
+      .type('form')
+      .send({ guild_id: '100000000000000002' });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/');
+    expect(user.currentGuildId).toBe('100000000000000002');
+    expect(user.accessLevel).toBe(2);
+    expect(vi.mocked(getEffectiveAccessLevel)).toHaveBeenCalledWith('100000000000000002', 'u1');
+  });
+
+  it('rejects a guild the user does not belong to (cross-guild IDOR guard)', async () => {
+    const user: any = { discordId: 'u1', currentGuildId: null, accessLevel: 0, guilds: TWO_GUILDS };
+    const app = express();
+    app.use(express.urlencoded({ extended: false }));
+    app.use((req: any, _res: any, next: any) => {
+      req.session = { user };
+      req.csrfToken = () => 'csrf-token';
+      next();
+    });
+    app.use('/guild', router);
+
+    const res = await supertest(app)
+      .post('/guild/select')
+      .type('form')
+      .send({ guild_id: '999000999000999000' });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/guild/select');
+    expect(user.currentGuildId).toBeNull();
+    expect(vi.mocked(getEffectiveAccessLevel)).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed guild ID', async () => {
+    const user: any = { discordId: 'u1', currentGuildId: null, accessLevel: 0, guilds: TWO_GUILDS };
+    const app = express();
+    app.use(express.urlencoded({ extended: false }));
+    app.use((req: any, _res: any, next: any) => {
+      req.session = { user };
+      req.csrfToken = () => 'csrf-token';
+      next();
+    });
+    app.use('/guild', router);
+
+    const res = await supertest(app)
+      .post('/guild/select')
+      .type('form')
+      .send({ guild_id: 'not-a-snowflake' });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/guild/select');
+    expect(vi.mocked(getEffectiveAccessLevel)).not.toHaveBeenCalled();
+  });
+});

--- a/src/web/routes/guild.test.ts
+++ b/src/web/routes/guild.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../../db', () => ({
   getEffectiveAccessLevel: vi.fn().mockResolvedValue(0),
+  getAllGuilds: vi.fn(),
+  getGuildsForMember: vi.fn(),
 }));
 vi.mock('../../db/users', () => ({
   AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
@@ -19,12 +21,17 @@ vi.mock('../../shared/logger', () => ({
 import express from 'express';
 import supertest from 'supertest';
 import router from './guild';
-import { getEffectiveAccessLevel } from '../../db';
+import { getAllGuilds, getEffectiveAccessLevel, getGuildsForMember } from '../../db';
 import { AccessLevel } from '../../db/users';
 
 const TWO_GUILDS = [
   { guildId: '100000000000000001', name: 'Alpha' },
   { guildId: '100000000000000002', name: 'Beta' },
+];
+
+const TWO_DB_GUILDS = [
+  { guild_id: '100000000000000001', name: 'Alpha', voice_channel_id: null },
+  { guild_id: '100000000000000002', name: 'Beta', voice_channel_id: null },
 ];
 
 function buildApp(sessionUser: unknown) {
@@ -46,6 +53,8 @@ function buildApp(sessionUser: unknown) {
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(getEffectiveAccessLevel).mockResolvedValue(AccessLevel.USER);
+  vi.mocked(getGuildsForMember).mockResolvedValue(TWO_DB_GUILDS as any);
+  vi.mocked(getAllGuilds).mockResolvedValue(TWO_DB_GUILDS as any);
 });
 
 describe('GET /guild/select', () => {
@@ -110,6 +119,60 @@ describe('POST /guild/select', () => {
     expect(res.headers.location).toBe('/guild/select');
     expect(user.currentGuildId).toBeNull();
     expect(vi.mocked(getEffectiveAccessLevel)).not.toHaveBeenCalled();
+  });
+
+  it('rejects a guild present in the stale session list but no longer returned by getGuildsForMember', async () => {
+    // Membership was revoked after login; the session's cached guild list is stale,
+    // but the live DB lookup no longer includes it, so the guard must still reject.
+    vi.mocked(getGuildsForMember).mockResolvedValue([TWO_DB_GUILDS[0]] as any);
+    const user: any = { discordId: 'u1', currentGuildId: null, accessLevel: AccessLevel.USER, guilds: TWO_GUILDS };
+    const app = express();
+    app.use(express.urlencoded({ extended: false }));
+    app.use((req: any, _res: any, next: any) => {
+      req.session = { user };
+      req.csrfToken = () => 'csrf-token';
+      next();
+    });
+    app.use('/guild', router);
+
+    const res = await supertest(app)
+      .post('/guild/select')
+      .type('form')
+      .send({ guild_id: '100000000000000002' });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/guild/select');
+    expect(user.currentGuildId).toBeNull();
+    expect(vi.mocked(getEffectiveAccessLevel)).not.toHaveBeenCalled();
+  });
+
+  it('uses getAllGuilds (not getGuildsForMember) when the user is the bot owner', async () => {
+    const user: any = {
+      discordId: 'u1',
+      currentGuildId: null,
+      accessLevel: AccessLevel.USER,
+      isOwner: true,
+      guilds: TWO_GUILDS,
+    };
+    const app = express();
+    app.use(express.urlencoded({ extended: false }));
+    app.use((req: any, _res: any, next: any) => {
+      req.session = { user };
+      req.csrfToken = () => 'csrf-token';
+      next();
+    });
+    app.use('/guild', router);
+
+    const res = await supertest(app)
+      .post('/guild/select')
+      .type('form')
+      .send({ guild_id: '100000000000000002' });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/');
+    expect(user.currentGuildId).toBe('100000000000000002');
+    expect(vi.mocked(getAllGuilds)).toHaveBeenCalled();
+    expect(vi.mocked(getGuildsForMember)).not.toHaveBeenCalled();
   });
 
   it('rejects a malformed guild ID', async () => {

--- a/src/web/routes/guild.ts
+++ b/src/web/routes/guild.ts
@@ -1,0 +1,55 @@
+import { createLogger } from '../../shared/logger';
+import { Router } from 'express';
+import { getEffectiveAccessLevel } from '../../db';
+import { csrfProtection } from '../csrf';
+import { requireAuth } from '../middleware';
+import { normalizeDiscordId } from './shared';
+
+const log = createLogger('Web');
+const router = Router();
+
+// ─── Guild picker ──────────────────────────────────────────────────────────
+//
+// After Discord OAuth login a user may have access to more than one guild. This
+// page lets them choose which one the session acts in. Single-guild users never
+// reach it — requireGuildContext auto-selects their only guild.
+
+/** Render the guild picker. Users with a single guild are sent straight to the dashboard. */
+router.get('/select', requireAuth, csrfProtection, (req, res) => {
+  const user = req.session.user!;
+  if (user.guilds.length <= 1) {
+    return res.redirect('/');
+  }
+  res.render('guildSelect', {
+    user,
+    guilds: user.guilds,
+    csrfToken: req.csrfToken(),
+  });
+});
+
+/**
+ * Select the active guild. The requested guild ID is untrusted input: it must be
+ * one the user already belongs to (their session guild list), or the request is
+ * rejected. On success the effective access level is recomputed for that guild so
+ * authorization reflects the current guild, never the previous one.
+ */
+router.post('/select', requireAuth, csrfProtection, async (req, res) => {
+  const user = req.session.user!;
+  const { guild_id } = req.body as { guild_id?: unknown };
+  const requestedGuildId = typeof guild_id === 'string' ? normalizeDiscordId(guild_id) : null;
+
+  if (!requestedGuildId || !user.guilds.some((g) => g.guildId === requestedGuildId)) {
+    return res.redirect('/guild/select');
+  }
+
+  try {
+    user.currentGuildId = requestedGuildId;
+    user.accessLevel = (await getEffectiveAccessLevel(requestedGuildId, user.discordId)) as 0 | 1 | 2 | 3;
+  } catch (err) {
+    log.error('Guild select failed:', err);
+    return res.redirect('/guild/select');
+  }
+  res.redirect('/');
+});
+
+export default router;

--- a/src/web/routes/guild.ts
+++ b/src/web/routes/guild.ts
@@ -43,8 +43,9 @@ router.post('/select', requireAuth, csrfProtection, async (req, res) => {
   }
 
   try {
+    const accessLevel = (await getEffectiveAccessLevel(requestedGuildId, user.discordId)) as 0 | 1 | 2 | 3;
     user.currentGuildId = requestedGuildId;
-    user.accessLevel = (await getEffectiveAccessLevel(requestedGuildId, user.discordId)) as 0 | 1 | 2 | 3;
+    user.accessLevel = accessLevel;
   } catch (err) {
     log.error('Guild select failed:', err);
     return res.redirect('/guild/select');

--- a/src/web/routes/guild.ts
+++ b/src/web/routes/guild.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
-import { getEffectiveAccessLevel } from '../../db';
+import { getAllGuilds, getEffectiveAccessLevel, getGuildsForMember } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
 import { normalizeDiscordId } from './shared';
@@ -28,9 +28,10 @@ router.get('/select', requireAuth, csrfProtection, (req, res) => {
 });
 
 /**
- * Select the active guild. The requested guild ID is untrusted input: it must be
- * one the user already belongs to (their session guild list), or the request is
- * rejected. On success the effective access level is recomputed for that guild so
+ * Select the active guild. The requested guild ID is untrusted input: membership
+ * is re-checked against live `guild_member` data (not the session's cached guild
+ * list, which can be stale if membership was revoked after login) before it is
+ * accepted. On success the effective access level is recomputed for that guild so
  * authorization reflects the current guild, never the previous one.
  */
 router.post('/select', requireAuth, csrfProtection, async (req, res) => {
@@ -38,11 +39,16 @@ router.post('/select', requireAuth, csrfProtection, async (req, res) => {
   const { guild_id } = req.body as { guild_id?: unknown };
   const requestedGuildId = typeof guild_id === 'string' ? normalizeDiscordId(guild_id) : null;
 
-  if (!requestedGuildId || !user.guilds.some((g) => g.guildId === requestedGuildId)) {
+  if (!requestedGuildId) {
     return res.redirect('/guild/select');
   }
 
   try {
+    const liveGuilds = user.isOwner ? await getAllGuilds() : await getGuildsForMember(user.discordId);
+    if (!liveGuilds.some((g) => g.guild_id === requestedGuildId)) {
+      return res.redirect('/guild/select');
+    }
+    user.guilds = liveGuilds.map((g) => ({ guildId: g.guild_id, name: g.name }));
     const accessLevel = (await getEffectiveAccessLevel(requestedGuildId, user.discordId)) as 0 | 1 | 2 | 3;
     user.currentGuildId = requestedGuildId;
     user.accessLevel = accessLevel;

--- a/src/web/routes/shared.test.ts
+++ b/src/web/routes/shared.test.ts
@@ -198,7 +198,10 @@ describe('renderError', () => {
       discordId: '123456789012345678',
       discordName: 'TestUser',
       discordAvatar: null,
+      isOwner: false,
       accessLevel: AccessLevel.MOD,
+      currentGuildId: '999000999000999000',
+      guilds: [{ guildId: '999000999000999000', name: 'Test Guild' }],
     };
     renderError(res, 500, 'Server error', user);
     expect(render).toHaveBeenCalledWith('error', {

--- a/src/web/routes/streamdeck.test.ts
+++ b/src/web/routes/streamdeck.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { SfxTrigger, SfxFile } from '../../db';
 
 vi.mock('../middleware', () => ({
-  requireApiKey: (_req: any, _res: any, next: any) => next(),
+  requireApiKey: (req: any, _res: any, next: any) => {
+    req.apiKeyGuildId = 'guild-123';
+    next();
+  },
 }));
 
 vi.mock('../../db', () => ({
@@ -41,10 +44,6 @@ vi.mock('../../discord/discordBot', () => ({
 
 vi.mock('../../shared/logger', () => ({
   createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
-}));
-
-vi.mock('../../shared/config', () => ({
-  DISCORD_GUILD_ID: 'guild-123',
 }));
 
 import express from 'express';

--- a/src/web/routes/streamdeck.test.ts
+++ b/src/web/routes/streamdeck.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { SfxTrigger, SfxFile } from '../../db';
 
+let mockApiKeyGuildId: string | null = 'guild-123';
 vi.mock('../middleware', () => ({
   requireApiKey: (req: any, _res: any, next: any) => {
-    req.apiKeyGuildId = 'guild-123';
+    req.apiKeyGuildId = mockApiKeyGuildId;
     next();
   },
 }));
@@ -78,6 +79,7 @@ function buildApp() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockApiKeyGuildId = 'guild-123';
   vi.mocked(getAllSfxTriggers).mockResolvedValue([]);
   vi.mocked(findTrigger).mockResolvedValue(null);
   vi.mocked(findSoundFiles).mockResolvedValue([]);
@@ -250,6 +252,14 @@ describe('GET /voice/channels', () => {
 
     expect(res.body).toMatchObject({ ok: false });
   });
+
+  it('returns 503 when the API key has no guild binding', async () => {
+    mockApiKeyGuildId = null;
+
+    const res = await supertest(buildApp()).get('/voice/channels').expect(503);
+
+    expect(res.body).toMatchObject({ ok: false });
+  });
 });
 
 describe('POST /voice/join', () => {
@@ -295,6 +305,17 @@ describe('POST /voice/join', () => {
 
     expect(res.body).toMatchObject({ ok: false });
   });
+
+  it('returns 503 when the API key has no guild binding', async () => {
+    mockApiKeyGuildId = null;
+
+    const res = await supertest(buildApp())
+      .post('/voice/join')
+      .send({ channelId: '123456789012345678' })
+      .expect(503);
+
+    expect(res.body).toMatchObject({ ok: false });
+  });
 });
 
 describe('POST /voice/leave', () => {
@@ -304,5 +325,13 @@ describe('POST /voice/leave', () => {
     expect(res.body).toEqual({ ok: true });
     // Leaving must be scoped to the configured guild, not an unscoped disconnect.
     expect(vi.mocked(disconnect)).toHaveBeenCalledWith('guild-123');
+  });
+
+  it('returns 503 when the API key has no guild binding', async () => {
+    mockApiKeyGuildId = null;
+
+    const res = await supertest(buildApp()).post('/voice/leave').expect(503);
+
+    expect(res.body).toMatchObject({ ok: false });
   });
 });

--- a/src/web/routes/streamdeck.ts
+++ b/src/web/routes/streamdeck.ts
@@ -1,10 +1,9 @@
 import { createLogger } from '../../shared/logger';
-import { Router } from 'express';
+import { Router, type Request, type Response } from 'express';
 import { findTrigger, findSoundFiles, getAllSfxTriggers } from '../../db';
 import { pickWeightedRandom } from '../../commands/soundSelector';
 import { playFile, VoiceNotConnectedError } from '../../audio/sfxPlayer';
 import { setVoicePlaying } from '../../shared/statusStore';
-import { DISCORD_GUILD_ID } from '../../shared/config';
 import { requireApiKey } from '../middleware';
 import { getAvailableVoiceChannels } from '../../discord/discordUtils';
 import { connect, disconnect } from '../../audio/audioPlayer';
@@ -13,6 +12,19 @@ import { normalizeDiscordId } from './shared';
 
 const log = createLogger('Streamdeck');
 const router = Router();
+
+/**
+ * Returns the guild ID the API key is bound to, or sends 503 and returns null
+ * when `requireApiKey` did not populate it (should never happen in practice).
+ */
+function getApiKeyGuildId(req: Request, res: Response): string | null {
+  const guildId = req.apiKeyGuildId ?? null;
+  if (!guildId) {
+    res.status(503).json({ ok: false, error: 'API key has no guild binding' });
+    return null;
+  }
+  return guildId;
+}
 
 router.get('/sfx', requireApiKey, async (_req, res) => {
   try {
@@ -76,9 +88,11 @@ router.post('/sfx', requireApiKey, async (req, res) => {
   }
 });
 
-router.get('/voice/channels', requireApiKey, async (_req, res) => {
+router.get('/voice/channels', requireApiKey, async (req, res) => {
+  const guildId = getApiKeyGuildId(req, res);
+  if (!guildId) return;
   try {
-    const channels = await getAvailableVoiceChannels(DISCORD_GUILD_ID);
+    const channels = await getAvailableVoiceChannels(guildId);
     res.json({ ok: true, channels });
   } catch (err) {
     log.error('Failed to list voice channels:', err);
@@ -87,6 +101,9 @@ router.get('/voice/channels', requireApiKey, async (_req, res) => {
 });
 
 router.post('/voice/join', requireApiKey, async (req, res) => {
+  const guildId = getApiKeyGuildId(req, res);
+  if (!guildId) return;
+
   const { channelId } = req.body as { channelId?: unknown };
   if (typeof channelId !== 'string') {
     res.status(400).json({ ok: false, error: 'Missing or invalid "channelId" field' });
@@ -105,8 +122,8 @@ router.post('/voice/join', requireApiKey, async (req, res) => {
   }
 
   try {
-    disconnect(DISCORD_GUILD_ID);
-    await connect(discordClient, DISCORD_GUILD_ID, normalizedChannelId);
+    disconnect(guildId);
+    await connect(discordClient, guildId, normalizedChannelId);
     res.json({ ok: true });
   } catch (err) {
     log.error('Voice join failed:', err);
@@ -114,8 +131,10 @@ router.post('/voice/join', requireApiKey, async (req, res) => {
   }
 });
 
-router.post('/voice/leave', requireApiKey, (_req, res) => {
-  disconnect(DISCORD_GUILD_ID);
+router.post('/voice/leave', requireApiKey, (req, res) => {
+  const guildId = getApiKeyGuildId(req, res);
+  if (!guildId) return;
+  disconnect(guildId);
   res.json({ ok: true });
 });
 

--- a/src/web/routes/streamdeckKeys.test.ts
+++ b/src/web/routes/streamdeckKeys.test.ts
@@ -30,7 +30,15 @@ import {
 } from '../../db';
 import { AccessLevel } from '../../db/users';
 
-const SESSION_USER = { discordId: '111222333444555666', discordName: 'Alice', accessLevel: AccessLevel.ADMIN };
+const GUILD_ID = '900000000000000001';
+const SESSION_USER = {
+  discordId: '111222333444555666',
+  discordName: 'Alice',
+  accessLevel: AccessLevel.ADMIN,
+  currentGuildId: GUILD_ID,
+  isOwner: false,
+  guilds: [{ guildId: GUILD_ID, name: 'Test Guild' }],
+};
 const VALID_DISCORD_ID = '123456789012345678';
 
 function buildApp(sessionUser = SESSION_USER) {
@@ -95,6 +103,11 @@ describe('POST /streamdeck-key/request', () => {
     const res = await supertest(buildApp()).post('/streamdeck-key/request');
     expect(res.status).toBe(200);
     expect((res.body as any).locals.newKey).toBeTruthy();
+    expect(vi.mocked(requestApiKey)).toHaveBeenCalledWith(
+      SESSION_USER.discordId,
+      SESSION_USER.accessLevel,
+      GUILD_ID,
+    );
   });
 
   it('redirects to ?error=request_failed on error', async () => {

--- a/src/web/routes/streamdeckKeys.ts
+++ b/src/web/routes/streamdeckKeys.ts
@@ -43,6 +43,7 @@ router.post('/streamdeck-key/request', csrfProtection, async (req, res) => {
     const { plain } = await requestApiKey(
       req.session.user!.discordId,
       req.session.user!.accessLevel,
+      req.session.user!.currentGuildId!,
     );
     const keyRow = await getApiKeyStatus(req.session.user!.discordId);
     res.render('streamdeck-keys', {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -160,7 +160,7 @@ app.use('/', sfxPublicRouter);
 app.use('/overlay', overlaySourceRouter);
 app.use('/guild', requireAuth, guildRouter);
 app.use('/api', requireAuth, apiRouter);
-app.use('/', requireAuth, streamdeckKeysRouter);
+app.use('/', requireAuth, requireGuildContext, streamdeckKeysRouter);
 app.use('/', requireAuth, sfxRouter);
 app.use('/admin', requireAuth, requireGuildContext, adminRouter);
 app.use('/admin', requireAuth, streamsRouter);

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -12,6 +12,7 @@ const log = createLogger('Web');
 
 const isProduction = process.env.NODE_ENV === 'production';
 import authRouter from './routes/auth';
+import guildRouter from './routes/guild';
 import eventsubCallbackRouter from './routes/eventsubCallback';
 import eventsubAdminRouter from './routes/eventsubAdmin';
 import dashboardRouter from './routes/dashboard';
@@ -28,7 +29,7 @@ import streamdeckKeysRouter from './routes/streamdeckKeys';
 import userSettingsRouter from './routes/userSettings';
 import overlaySourceRouter from './routes/overlaySource';
 import overlayAdminRouter from './routes/overlayAdmin';
-import { requireAuth } from './middleware';
+import { requireAuth, requireGuildContext } from './middleware';
 import { ensureSessionCsrfToken } from './csrf';
 import {
   ipKey,
@@ -157,10 +158,11 @@ app.use('/auth', authLimiter, eventsubCallbackRouter);
 app.use('/api/streamdeck', streamdeckLimiter, streamdeckRouter);
 app.use('/', sfxPublicRouter);
 app.use('/overlay', overlaySourceRouter);
+app.use('/guild', requireAuth, guildRouter);
 app.use('/api', requireAuth, apiRouter);
 app.use('/', requireAuth, streamdeckKeysRouter);
 app.use('/', requireAuth, sfxRouter);
-app.use('/admin', requireAuth, adminRouter);
+app.use('/admin', requireAuth, requireGuildContext, adminRouter);
 app.use('/admin', requireAuth, streamsRouter);
 app.use('/admin', requireAuth, eventsubAdminRouter);
 app.use('/user/settings', requireAuth, userSettingsRouter);
@@ -168,7 +170,7 @@ app.use('/overlay', requireAuth, overlayAdminRouter);
 app.use('/', requireAuth, commandsRouter);
 app.use('/', requireAuth, countersRouter);
 app.use('/', requireAuth, commandMonitorRouter);
-app.use('/', requireAuth, dashboardRouter);
+app.use('/', requireAuth, requireGuildContext, dashboardRouter);
 
 // 404 handler
 app.use((req, res) => {

--- a/views/commands.ejs
+++ b/views/commands.ejs
@@ -236,15 +236,15 @@
                         </div>
                         <div class="button-row-wrap">
                           <button type="submit" class="btn">Save Server Override</button>
-                          <% if (guildOverride) { %>
-                          <form method="POST" action="/commands/guild-override/reset" class="inline-form-sm">
-                            <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-                            <input type="hidden" name="command_id" value="<%= command.command_id %>">
-                            <button type="submit" class="btn btn-ghost btn-sm">Reset to Catalog Default</button>
-                          </form>
-                          <% } %>
                         </div>
                       </form>
+                      <% if (guildOverride) { %>
+                      <form method="POST" action="/commands/guild-override/reset" class="inline-form-sm">
+                        <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                        <input type="hidden" name="command_id" value="<%= command.command_id %>">
+                        <button type="submit" class="btn btn-ghost btn-sm">Reset to Catalog Default</button>
+                      </form>
+                      <% } %>
                     </div>
                     <% } %>
                   </div>

--- a/views/commands.ejs
+++ b/views/commands.ejs
@@ -26,6 +26,8 @@
         assign_failed: 'Failed to assign that user to the command.',
         unassign_failed: 'Failed to unassign that user from the command.',
         invalid_assignment_user: 'The selected user cannot be assigned to this command.',
+        override_failed: 'Failed to save the server override.',
+        override_reset_failed: 'Failed to reset the server override.',
       }; %>
       <div class="card card-alert-danger" role="alert" aria-live="assertive" aria-atomic="true">
         <span class="text-danger">&#9888; <%= errorMessages[error] || `Operation failed: ${error.replace(/_/g, ' ')}` %></span>

--- a/views/commands.ejs
+++ b/views/commands.ejs
@@ -79,6 +79,7 @@
                 <th scope="col">Output</th>
                 <th scope="col">Discord</th>
                 <th scope="col">Multi-Twitch</th>
+                <th scope="col">This Server</th>
                 <th scope="col">Assigned Twitch Users</th>
                 <th scope="col">Actions</th>
               </tr>
@@ -102,6 +103,18 @@
                 <td class="command-output-cell"><%= command.output %></td>
                 <td><span class="badge <%= command.is_discord_enabled ? 'badge-active' : 'badge-offline' %>"><%= command.is_discord_enabled ? 'Enabled' : 'Off' %></span></td>
                 <td><span class="badge <%= command.is_multi_twitch ? 'badge-active' : 'badge-offline' %>"><%= command.is_multi_twitch ? 'Enabled' : 'Off' %></span></td>
+                <td>
+                  <% if (!user || !user.currentGuildId) { %>
+                    <span class="muted">—</span>
+                  <% } else if (command.guildOverride && command.guildOverride.is_disabled) { %>
+                    <span class="badge badge-offline">Disabled</span>
+                    <% if (command.guildOverride.output !== null) { %><span class="badge badge">Custom output</span><% } %>
+                  <% } else if (command.guildOverride && command.guildOverride.output !== null) { %>
+                    <span class="badge badge">Custom output</span>
+                  <% } else { %>
+                    <span class="muted">Catalog default</span>
+                  <% } %>
+                </td>
                 <td class="assigned-users-cell">
                   <% if (command.assigned_users.length > 0) { %>
                     <div class="badge-list-wrap">
@@ -133,7 +146,7 @@
                 </td>
               </tr>
               <tr class="files-row is-hidden" id="command-edit-<%= command.command_id %>">
-                <td colspan="6">
+                <td colspan="7">
                   <div class="command-edit-panel">
                     <form method="POST" action="/commands/update" class="stack-gap-md">
                       <input type="hidden" name="_csrf" value="<%= csrfToken %>">
@@ -201,13 +214,46 @@
                       <div class="empty-msg">No users with a Twitch name are available for assignment.</div>
                       <% } %>
                     </div>
+
+                    <% if (user && user.currentGuildId) { %>
+                    <div class="command-guild-override-shell">
+                      <h3 class="command-assignment-title">Server Override</h3>
+                      <% var guildOverride = command.guildOverride; %>
+                      <form method="POST" action="/commands/guild-override" class="stack-gap-md">
+                        <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                        <input type="hidden" name="command_id" value="<%= command.command_id %>">
+                        <div class="form-row-wrap">
+                          <label class="input checkbox-input-label">
+                            <input type="checkbox" name="is_disabled" value="1" <%= guildOverride && guildOverride.is_disabled ? 'checked' : '' %>> Disable for this server
+                          </label>
+                          <label class="input checkbox-input-label">
+                            <input type="checkbox" name="clear_output" value="1"> Clear custom output
+                          </label>
+                        </div>
+                        <div class="form-section-gap">
+                          <label for="guild_output_<%= command.command_id %>" class="form-label">Custom output for this server <span class="muted">(leave empty to use catalog output)</span></label>
+                          <textarea id="guild_output_<%= command.command_id %>" class="input stream-textarea" name="output" rows="2"><%= guildOverride && guildOverride.output !== null ? guildOverride.output : '' %></textarea>
+                        </div>
+                        <div class="button-row-wrap">
+                          <button type="submit" class="btn">Save Server Override</button>
+                          <% if (guildOverride) { %>
+                          <form method="POST" action="/commands/guild-override/reset" class="inline-form-sm">
+                            <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                            <input type="hidden" name="command_id" value="<%= command.command_id %>">
+                            <button type="submit" class="btn btn-ghost btn-sm">Reset to Catalog Default</button>
+                          </form>
+                          <% } %>
+                        </div>
+                      </form>
+                    </div>
+                    <% } %>
                   </div>
                 </td>
               </tr>
               <% }) %>
               <% if (commands.length === 0) { %>
               <tr>
-                <td colspan="6" class="empty-msg">No custom commands configured yet.</td>
+                <td colspan="7" class="empty-msg">No custom commands configured yet.</td>
               </tr>
               <% } %>
             </tbody>

--- a/views/guildSelect.ejs
+++ b/views/guildSelect.ejs
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BCUK Bot — Choose a Server</title>
+  <link rel="stylesheet" href="/style.css">
+  <%- include('partials/pwa-head') %>
+</head>
+<body>
+  <%- include('partials/nav') %>
+
+  <main class="container">
+    <section class="section">
+      <h2 class="section-title">Choose a Server</h2>
+      <p class="section-subtitle">You manage more than one server. Pick which one to work in.</p>
+
+      <div class="guild-list">
+        <% guilds.forEach(function (g) { %>
+        <form method="POST" action="/guild/select" class="guild-select-form">
+          <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+          <input type="hidden" name="guild_id" value="<%= g.guildId %>">
+          <button type="submit" class="btn btn-primary guild-select-btn">
+            <%= g.name %>
+          </button>
+        </form>
+        <% }); %>
+      </div>
+    </section>
+  </main>
+
+  <%- include('partials/pwa-register') %>
+</body>
+</html>

--- a/views/partials/nav.ejs
+++ b/views/partials/nav.ejs
@@ -34,6 +34,14 @@
       <% } %>
     </div>
     <div class="navbar-end">
+      <% if (user && user.guilds && user.guilds.length > 0) { %>
+      <% const currentGuild = user.guilds.find(function (g) { return g.guildId === user.currentGuildId; }); %>
+      <% if (user.guilds.length > 1) { %>
+      <a href="/guild/select" class="nav-item guild-switcher" title="Switch server">🏠 <%= currentGuild ? currentGuild.name : 'Choose server' %> ▾</a>
+      <% } else if (currentGuild) { %>
+      <span class="guild-name">🏠 <%= currentGuild.name %></span>
+      <% } %>
+      <% } %>
       <% if (user) { %>
       <% if (user.discordAvatar) { %>
       <img src="<%= user.discordAvatar %>?size=32" class="avatar" alt="">


### PR DESCRIPTION
## Summary

- **Guild picker & session context**: After OAuth login, users select their guild (auto-selected if only one). `currentGuildId` is stored in the session; `POST /guild/select` validates membership before writing it (IDOR guard, Security §2). `requireGuildContext` middleware enforces guild context on mutation routes.
- **Per-guild access levels**: `getEffectiveAccessLevel` is now called per-request from `currentGuildId`; `requireMod/Manager/Admin` read the current-guild level. `is_owner` short-circuits to full access everywhere.
- **Streamdeck API key guild binding**: `streamdeck_api_keys.guild_id` is wired through the DB layer, middleware (`req.apiKeyGuildId`), and routes so voice/SFX actions use the key's bound guild — never a global env var (Security §6).
- **Config cleanup**: `DISCORD_GUILD_ID` and `DISCORD_VOICE_CHANNEL_ID` removed from `require_env`; voice channel is now DB-driven (`guild.voice_channel_id`). `.env.example` updated.
- **Per-guild command overrides UI**: The commands page shows a "This Server" column and a Server Override edit panel (disable toggle, custom output textarea, reset to catalog default). New `commandGuildOverrides` router handles `POST /commands/guild-override` and `/reset`; guild always comes from the session.
- **Admin refresh scoped to current guild**: Discord name refresh now operates on the current guild's members only.
- **`fetchMemberDisplayName` requires explicit `guildId`**: No longer falls back to env var; callers supply the guild explicitly.

## Test plan

- [ ] `npx tsc --noEmit` — no type errors
- [ ] `npm test` — all 1309 tests pass
- [ ] Log in; verify guild picker shows correct guilds and auto-selects when only one
- [ ] Switch guild and confirm mod-gated routes reflect the new guild's access level
- [ ] As Mod, disable a catalog command for the current guild → confirm it stops firing in Discord for that guild but still fires in others
- [ ] As Mod, set a custom output override → confirm that guild sees the override text; other guilds see catalog text
- [ ] Reset override → command returns to catalog default
- [ ] Streamdeck API key request binds to `currentGuildId`; voice join uses the key's guild
- [ ] Confirm `DISCORD_GUILD_ID` and `DISCORD_VOICE_CHANNEL_ID` are no longer required in `.env`

https://claude.ai/code/session_01QfGqskn817m3wmrwDjEqh3

---
_Generated by [Claude Code](https://claude.ai/code/session_01QfGqskn817m3wmrwDjEqh3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Choose a Server” guild-selection flow with UI support for switching servers.
  * Enabled per-server command overrides (disable, custom output, reset to catalog default).
* **Configuration**
  * Removed server/voice channel IDs from environment configuration; server/voice setup is now driven by database guild records.
* **Bug Fixes / Behavior Changes**
  * Scoped OAuth, admin tools, voice, and stream deck operations to the selected server using guild-scoped access rules.
  * Improved error handling: voice join now validates guild/voice inputs more strictly; missing API-key guild binding returns a clear 503 response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->