### PR TITLE
Multi-server PR3c: voice scoped to session guild

### DIFF
--- a/src/audio/audioPlayer.test.ts
+++ b/src/audio/audioPlayer.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ─── Mocks ──────────────────────────────────────────────────────────────────
 
-vi.mock('../shared/config', () => ({ DISCORD_VOICE_CHANNEL_ID: 'default-vc' }));
+vi.mock('../shared/config', () => ({}));
 vi.mock('../shared/statusStore', () => ({
   setVoiceConnected: vi.fn(),
   setVoiceDisconnected: vi.fn(),
@@ -102,15 +102,12 @@ describe('connect', () => {
     expect(vi.mocked(status.setVoiceConnected)).toHaveBeenCalledWith('vc-chan-1');
   });
 
-  it('falls back to the default channel when none is given', async () => {
+  it('rejects when no channelId is given', async () => {
     const { client } = makeClient();
-    const voice = await import('@discordjs/voice');
+    const utils = await import('../discord/discordUtils.js');
+    vi.mocked(utils.isPermanentVoiceMisconfigurationError).mockReturnValue(true);
 
-    await mod.connect(client as never, 'guild-A');
-
-    expect(vi.mocked(voice.joinVoiceChannel)).toHaveBeenCalledWith(
-      expect.objectContaining({ channelId: 'default-vc' }),
-    );
+    await expect(mod.connect(client as never, 'guild-A', '')).rejects.toThrow('Missing guild ID or voice channel ID');
   });
 
   it('rejects and stays disconnected when the channel is not a voice channel', async () => {
@@ -136,7 +133,7 @@ describe('connect', () => {
     // Treat the misconfiguration as permanent so no reconnect timer is scheduled.
     vi.mocked(utils.isPermanentVoiceMisconfigurationError).mockReturnValue(true);
 
-    await expect(mod.connect(client as never, '', 'chan-1')).rejects.toThrow('Missing DISCORD_GUILD_ID or voice channel ID');
+    await expect(mod.connect(client as never, '', 'chan-1')).rejects.toThrow('Missing guild ID or voice channel ID');
     expect(client.guilds.fetch).not.toHaveBeenCalled();
   });
 });

--- a/src/audio/audioPlayer.ts
+++ b/src/audio/audioPlayer.ts
@@ -11,7 +11,6 @@ import {
   type AudioPlayer as DjsAudioPlayer,
 } from '@discordjs/voice';
 import { Client, ChannelType } from 'discord.js';
-import { DISCORD_VOICE_CHANNEL_ID } from '../shared/config';
 import { setVoiceConnected, setVoiceDisconnected, setVoiceIdle } from '../shared/statusStore';
 
 const log = createLogger('AudioPlayer');
@@ -113,7 +112,7 @@ function scheduleReconnect(state: GuildVoiceState, reason: string): void {
   state.reconnectTimer = setTimeout(() => {
     state.reconnectTimer = null;
     if (scheduledAttemptId !== state.currentAttemptId) return;
-    if (!state.shouldAutoReconnect || !state.client || state.connection) return;
+    if (!state.shouldAutoReconnect || !state.client || state.connection || !state.targetChannelId) return;
     connect(state.client, state.guildId, state.targetChannelId).catch((err) => {
       log.error(`Voice rejoin failed for guild ${state.guildId}:`, err);
     });
@@ -173,10 +172,10 @@ function makeDeps(state: GuildVoiceState): ConnectionHandlerDeps {
  *
  * @param client - The ready Discord client.
  * @param guildId - The guild whose voice channel to join (BIGINT snowflake string).
- * @param channelId - Target voice channel ID; falls back to the legacy default when omitted.
+ * @param channelId - Target voice channel ID (required).
  * @returns Resolves once the connection is ready, or rejects if the join fails.
  */
-export async function connect(client: Client, guildId: string, channelId?: string): Promise<void> {
+export async function connect(client: Client, guildId: string, channelId: string): Promise<void> {
   const state = getState(guildId);
   clearReconnectTimer(state);
   const attemptId = ++state.currentAttemptId;
@@ -190,12 +189,10 @@ export async function connect(client: Client, guildId: string, channelId?: strin
   const deps = makeDeps(state);
 
   try {
-    const resolvedChannelId = channelId || DISCORD_VOICE_CHANNEL_ID;
-
-    if (!guildId || !resolvedChannelId) {
+    if (!guildId || !channelId) {
       // Message text must stay in sync with isPermanentVoiceMisconfigurationError
       // so this is classified as permanent (not retried).
-      throw new Error('Missing DISCORD_GUILD_ID or voice channel ID');
+      throw new Error('Missing guild ID or voice channel ID');
     }
 
     // Fetching the channel from the target guild also validates that the channel
@@ -203,11 +200,11 @@ export async function connect(client: Client, guildId: string, channelId?: strin
     const guild = await client.guilds.fetch(guildId);
     if (attemptId !== state.currentAttemptId) return;
 
-    const channel = await guild.channels.fetch(resolvedChannelId);
+    const channel = await guild.channels.fetch(channelId);
     if (attemptId !== state.currentAttemptId) return;
 
     if (!channel || channel.type !== ChannelType.GuildVoice) {
-      throw new Error(`Channel ${resolvedChannelId} is not a voice channel in guild ${guildId}`);
+      throw new Error(`Channel ${channelId} is not a voice channel in guild ${guildId}`);
     }
 
     nextConnection = joinVoiceChannel({

--- a/src/discord/discordUtils.test.ts
+++ b/src/discord/discordUtils.test.ts
@@ -67,9 +67,15 @@ describe('isDiscordNotFoundError', () => {
 });
 
 describe('isPermanentVoiceMisconfigurationError', () => {
-  it('returns true for a missing-config message', () => {
+  it('returns true for the legacy missing-config message', () => {
     expect(isPermanentVoiceMisconfigurationError(
       new Error('Missing DISCORD_GUILD_ID or DISCORD_VOICE_CHANNEL_ID'),
+    )).toBe(true);
+  });
+
+  it('returns true for the current missing-config message', () => {
+    expect(isPermanentVoiceMisconfigurationError(
+      new Error('Missing guild ID or voice channel ID'),
     )).toBe(true);
   });
 

--- a/src/discord/discordUtils.ts
+++ b/src/discord/discordUtils.ts
@@ -12,6 +12,12 @@ export function isDiscordNotFoundError(err: unknown): boolean {
   );
 }
 
+/**
+ * Returns true when a voice-connect error is permanent and should not be retried.
+ *
+ * @param err - Caught error from voice connect/reconnect flow.
+ * @returns Whether the error indicates permanent misconfiguration/access/not-found.
+ */
 export function isPermanentVoiceMisconfigurationError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   const { message } = err;
@@ -21,6 +27,7 @@ export function isPermanentVoiceMisconfigurationError(err: unknown): boolean {
   const isConfigError =
     message.includes('Missing DISCORD_GUILD_ID or DISCORD_VOICE_CHANNEL_ID') ||
     message.includes('Missing DISCORD_GUILD_ID or voice channel ID') ||
+    message.includes('Missing guild ID or voice channel ID') ||
     message.includes('is not a voice channel');
   const isForbidden = status === 403 || code === RESTJSONErrorCodes.MissingAccess;
   return isConfigError || isForbidden || isDiscordNotFoundError(err);

--- a/src/web/routes/api.test.ts
+++ b/src/web/routes/api.test.ts
@@ -27,9 +27,8 @@ vi.mock('../../discord/discordUtils', () => ({
   getAvailableVoiceChannels: vi.fn(),
 }));
 
-vi.mock('../../shared/config', () => ({
-  DISCORD_GUILD_ID: 'guild-123',
-  DISCORD_VOICE_CHANNEL_ID: 'default-vc',
+vi.mock('../../db', () => ({
+  getGuildById: vi.fn(),
 }));
 
 vi.mock('./shared', () => ({
@@ -47,10 +46,18 @@ import { getStatus } from '../../shared/statusStore';
 import { connect, disconnect, getCurrentChannelId } from '../../audio/audioPlayer';
 import { getDiscordClient } from '../../discord/discordBot';
 import { getAvailableVoiceChannels } from '../../discord/discordUtils';
+import { getGuildById } from '../../db';
 
-function buildApp() {
+const GUILD_ID = '900000000000000001';
+
+// Injects a session with the current guild so the guild-scoped voice routes resolve.
+function buildApp(currentGuildId: string | null = GUILD_ID) {
   const app = express();
   app.use(express.json());
+  app.use((req: any, _res: any, next: any) => {
+    req.session = { user: { discordId: 'u1', currentGuildId } };
+    next();
+  });
   app.use(router);
   return app;
 }
@@ -62,6 +69,7 @@ beforeEach(() => {
   vi.mocked(connect).mockResolvedValue(undefined);
   vi.mocked(getCurrentChannelId).mockReturnValue('current-vc');
   vi.mocked(getAvailableVoiceChannels).mockResolvedValue([]);
+  vi.mocked(getGuildById).mockResolvedValue({ guild_id: GUILD_ID, name: 'Guild', voice_channel_id: 'default-vc' });
 });
 
 describe('GET /status', () => {
@@ -72,14 +80,26 @@ describe('GET /status', () => {
 });
 
 describe('GET /voice/channels', () => {
-  it('reports the current channel for the configured guild', async () => {
+  it('reports the current channel and DB default for the session guild', async () => {
     const res = await supertest(buildApp()).get('/voice/channels').expect(200);
     expect(res.body).toMatchObject({
       ok: true,
       defaultChannelId: 'default-vc',
       currentChannelId: 'current-vc',
     });
-    expect(vi.mocked(getCurrentChannelId)).toHaveBeenCalledWith('guild-123');
+    expect(vi.mocked(getCurrentChannelId)).toHaveBeenCalledWith(GUILD_ID);
+    expect(vi.mocked(getAvailableVoiceChannels)).toHaveBeenCalledWith(GUILD_ID);
+  });
+
+  it('returns null default when the guild has no configured voice channel', async () => {
+    vi.mocked(getGuildById).mockResolvedValue({ guild_id: GUILD_ID, name: 'Guild', voice_channel_id: null });
+    const res = await supertest(buildApp()).get('/voice/channels').expect(200);
+    expect(res.body.defaultChannelId).toBeNull();
+  });
+
+  it('returns 400 when no guild is selected', async () => {
+    const res = await supertest(buildApp(null)).get('/voice/channels').expect(400);
+    expect(res.body).toMatchObject({ ok: false });
   });
 
   it('returns 500 when channel lookup fails', async () => {
@@ -90,20 +110,32 @@ describe('GET /voice/channels', () => {
 });
 
 describe('POST /voice/join', () => {
-  it('disconnects then joins the requested channel for the configured guild', async () => {
+  it('disconnects then joins the requested channel for the session guild', async () => {
     const res = await supertest(buildApp())
       .post('/voice/join')
       .send({ channelId: '123456789012345678' })
       .expect(200);
 
     expect(res.body).toEqual({ ok: true });
-    expect(vi.mocked(disconnect)).toHaveBeenCalledWith('guild-123');
-    expect(vi.mocked(connect)).toHaveBeenCalledWith({}, 'guild-123', '123456789012345678');
+    expect(vi.mocked(disconnect)).toHaveBeenCalledWith(GUILD_ID);
+    expect(vi.mocked(connect)).toHaveBeenCalledWith({}, GUILD_ID, '123456789012345678');
   });
 
-  it('falls back to the default channel when no channelId is given', async () => {
+  it('falls back to the guild default channel when no channelId is given', async () => {
     await supertest(buildApp()).post('/voice/join').send({}).expect(200);
-    expect(vi.mocked(connect)).toHaveBeenCalledWith({}, 'guild-123', undefined);
+    expect(vi.mocked(connect)).toHaveBeenCalledWith({}, GUILD_ID, 'default-vc');
+  });
+
+  it('returns 400 when no channelId is given and guild has no default', async () => {
+    vi.mocked(getGuildById).mockResolvedValueOnce({ guild_id: GUILD_ID, name: 'Test', voice_channel_id: null } as any);
+    await supertest(buildApp()).post('/voice/join').send({}).expect(400);
+    expect(vi.mocked(disconnect)).not.toHaveBeenCalled();
+    expect(vi.mocked(connect)).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when no guild is selected', async () => {
+    await supertest(buildApp(null)).post('/voice/join').send({ channelId: '123456789012345678' }).expect(400);
+    expect(vi.mocked(connect)).not.toHaveBeenCalled();
   });
 
   it('returns 400 for a non-string channelId', async () => {
@@ -133,9 +165,14 @@ describe('POST /voice/join', () => {
 });
 
 describe('POST /voice/leave', () => {
-  it('disconnects the configured guild and returns ok', async () => {
+  it('disconnects the session guild and returns ok', async () => {
     const res = await supertest(buildApp()).post('/voice/leave').expect(200);
     expect(res.body).toEqual({ ok: true });
-    expect(vi.mocked(disconnect)).toHaveBeenCalledWith('guild-123');
+    expect(vi.mocked(disconnect)).toHaveBeenCalledWith(GUILD_ID);
+  });
+
+  it('returns 400 when no guild is selected', async () => {
+    await supertest(buildApp(null)).post('/voice/leave').expect(400);
+    expect(vi.mocked(disconnect)).not.toHaveBeenCalled();
   });
 });

--- a/src/web/routes/api.ts
+++ b/src/web/routes/api.ts
@@ -1,31 +1,53 @@
 import { createLogger } from '../../shared/logger';
-import { Router } from 'express';
+import { Router, type Request, type Response } from 'express';
 import { getStatus } from '../../shared/statusStore';
 import { requireAuth, requireMod } from '../middleware';
 import { connect, disconnect, getCurrentChannelId } from '../../audio/audioPlayer';
 import { getDiscordClient } from '../../discord/discordBot';
 import { csrfProtection } from '../csrf';
 import { getAvailableVoiceChannels } from '../../discord/discordUtils';
-import { DISCORD_GUILD_ID, DISCORD_VOICE_CHANNEL_ID } from '../../shared/config';
+import { getGuildById } from '../../db';
 import { normalizeDiscordId } from './shared';
 
 const log = createLogger('API');
 const router = Router();
+
+/**
+ * Resolves the guild the request acts in from the session, replying 400 when no
+ * guild is selected. Voice routes are guild-scoped — the bot can hold a separate
+ * connection per guild — and the guild is taken from the session (never the
+ * request body) so a Mod cannot drive another guild's voice connection.
+ *
+ * @returns The current guild ID, or null when the response has already been sent.
+ */
+function getSessionGuildId(req: Request, res: Response): string | null {
+  const guildId = req.session.user?.currentGuildId ?? null;
+  if (!guildId) {
+    res.status(400).json({ ok: false, error: 'No guild selected' });
+    return null;
+  }
+  return guildId;
+}
 
 // Live status JSON — polled by the dashboard frontend every few seconds
 router.get('/status', requireAuth, (_req, res) => {
   res.json(getStatus());
 });
 
-// Get available voice channels — Mod and above
-router.get('/voice/channels', requireMod, async (_req, res) => {
+// Get available voice channels for the current guild — Mod and above
+router.get('/voice/channels', requireMod, async (req, res) => {
+  const guildId = getSessionGuildId(req, res);
+  if (!guildId) return;
   try {
-    const channels = await getAvailableVoiceChannels(DISCORD_GUILD_ID);
+    const [channels, guild] = await Promise.all([
+      getAvailableVoiceChannels(guildId),
+      getGuildById(guildId),
+    ]);
     res.json({
       ok: true,
       channels,
-      defaultChannelId: DISCORD_VOICE_CHANNEL_ID,
-      currentChannelId: getCurrentChannelId(DISCORD_GUILD_ID),
+      defaultChannelId: guild?.voice_channel_id ?? null,
+      currentChannelId: getCurrentChannelId(guildId),
     });
   } catch (err) {
     log.error('Failed to list voice channels:', err);
@@ -33,8 +55,11 @@ router.get('/voice/channels', requireMod, async (_req, res) => {
   }
 });
 
-// Join a specific voice channel or the configured default — Mod and above
+// Join a specific voice channel, or the guild's configured default — Mod and above
 router.post('/voice/join', requireMod, csrfProtection, async (req, res) => {
+  const guildId = getSessionGuildId(req, res);
+  if (!guildId) return;
+
   const discordClient = getDiscordClient();
   if (!discordClient) {
     res.status(503).json({ ok: false, error: 'Discord client not ready' });
@@ -51,10 +76,15 @@ router.post('/voice/join', requireMod, csrfProtection, async (req, res) => {
       res.status(400).json({ ok: false, error: 'Invalid channel ID' });
       return;
     }
-    const resolvedChannelId = trimmedChannelId || undefined;
+    // Fall back to the guild's configured default channel when none is supplied.
+    const resolvedChannelId = trimmedChannelId || (await getGuildById(guildId))?.voice_channel_id || undefined;
+    if (!resolvedChannelId) {
+      res.status(400).json({ ok: false, error: 'No voice channel selected and no default configured' });
+      return;
+    }
 
-    disconnect(DISCORD_GUILD_ID);
-    await connect(discordClient, DISCORD_GUILD_ID, resolvedChannelId);
+    disconnect(guildId);
+    await connect(discordClient, guildId, resolvedChannelId);
     res.json({ ok: true });
   } catch (err) {
     log.error('Voice rejoin failed:', err);
@@ -62,9 +92,11 @@ router.post('/voice/join', requireMod, csrfProtection, async (req, res) => {
   }
 });
 
-// Leave the voice channel — Mod and above
-router.post('/voice/leave', requireMod, csrfProtection, (_req, res) => {
-  disconnect(DISCORD_GUILD_ID);
+// Leave the current guild's voice channel — Mod and above
+router.post('/voice/leave', requireMod, csrfProtection, (req, res) => {
+  const guildId = getSessionGuildId(req, res);
+  if (!guildId) return;
+  disconnect(guildId);
   res.json({ ok: true });
 });
 


### PR DESCRIPTION
## Summary

Stacked on #290 (PR3b — admin user-management). This chunk scopes voice connect/disconnect/channel-listing to the session's current guild instead of the single hardcoded `DISCORD_GUILD_ID`.

- `src/web/routes/api.ts`: `/voice/channels`, `/voice/join`, `/voice/leave` now resolve `guildId` from `req.session.user.currentGuildId` (never the request body), returning 400 if no guild is selected. The default voice channel comes from `guild.voice_channel_id` (DB) instead of the `DISCORD_VOICE_CHANNEL_ID` env var.
- `src/audio/audioPlayer.ts`: `connect(client, guildId, channelId)` now requires an explicit `channelId` — the implicit env-var fallback is removed. Auto-reconnect bails out if there's no `targetChannelId` instead of falling back.
- `src/discord/discordUtils.ts`: `isPermanentVoiceMisconfigurationError` recognizes the new "Missing guild ID or voice channel ID" message alongside the legacy one, so retry classification still works during rollout.

## Security note

This closes the cross-guild voice hijack risk identified in the multi-server plan (§4): a caller can no longer pass an arbitrary guild ID and channel ID combination from the request body — the guild always comes from the authenticated session.

## Behavioural change

None for the existing single-guild deployment — the session always resolves to the one seeded guild, and that guild's `voice_channel_id` is backfilled to match the old env var during the schema migration (already merged).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 1324/1324 passing
- [ ] Manual smoke test on staging: join/leave voice channel from the dashboard, confirm default channel still works

## Next steps

Streamdeck API key guild binding, per-guild command override UI, and removal of the legacy `DISCORD_GUILD_ID`/`DISCORD_VOICE_CHANNEL_ID` env vars.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QfGqskn817m3wmrwDjEqh3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Voice operations are now scoped to the selected guild in your session, allowing multi-guild voice management.
  * Added session-based guild selection for voice channel operations.

* **Bug Fixes**
  * Voice connectivity now requires explicit channel selection; removed fallback to legacy default channels.
  * Improved error messages for missing or invalid voice configuration.
  * Reconnect behavior now prevents attempts when destination channel is not set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->