### PR TITLE
Multi-server PR3d: Streamdeck API key guild binding

### DIFF
--- a/src/db/streamdeckKeys.test.ts
+++ b/src/db/streamdeckKeys.test.ts
@@ -52,11 +52,12 @@ describe('findApprovedKeyByHash', () => {
 
   it('returns the mapped row when hash matches', async () => {
     const hash = sha256hex('mysecretkey');
-    const row = { discord_id: '42', key_hash: hash, status: 'approved', requested_at: new Date(), approved_at: new Date(), approved_by: '1' };
+    const row = { discord_id: '42', key_hash: hash, guild_id: 'g1', status: 'approved', requested_at: new Date(), approved_at: new Date(), approved_by: '1' };
     vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
     const result = await findApprovedKeyByHash(hash);
     expect(result).not.toBeNull();
     expect(result!.discord_id).toBe('42');
+    expect(result!.guild_id).toBe('g1');
     expect(result!.status).toBe('approved');
   });
 
@@ -83,6 +84,7 @@ describe('getApiKeyStatus', () => {
     const now = new Date();
     const row = {
       discord_id: '123',
+      guild_id: 'g1',
       status: 'pending',
       requested_at: now,
       approved_at: null,
@@ -93,15 +95,33 @@ describe('getApiKeyStatus', () => {
     vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
     const result = await getApiKeyStatus('123');
     expect(result!.discord_id).toBe('123');
+    expect(result!.guild_id).toBe('g1');
     expect(result!.status).toBe('pending');
     expect(result!.requested_at).toBe(now);
     expect(result!.approved_at).toBeNull();
     expect(result!.approved_by).toBeNull();
   });
 
+  it('preserves a null guild_id instead of stringifying it', async () => {
+    const row = {
+      discord_id: '123',
+      guild_id: null,
+      status: 'pending',
+      requested_at: new Date(),
+      approved_at: null,
+      approved_by: null,
+      user_name: null,
+      approver_name: null,
+    };
+    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const result = await getApiKeyStatus('123');
+    expect(result!.guild_id).toBeNull();
+  });
+
   it('maps a row with approver info', async () => {
     const row = {
       discord_id: '1',
+      guild_id: 'g1',
       status: 'approved',
       requested_at: new Date(),
       approved_at: new Date(),
@@ -111,6 +131,7 @@ describe('getApiKeyStatus', () => {
     };
     vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
     const result = await getApiKeyStatus('1');
+    expect(result!.guild_id).toBe('g1');
     expect(result!.approved_by).toBe('99');
     expect(result!.user_name).toBe('Alice');
     expect(result!.approver_name).toBe('Admin');
@@ -167,10 +188,11 @@ describe('getPendingRequests', () => {
   });
 
   it('maps pending rows', async () => {
-    const row = { discord_id: '1', status: 'pending', requested_at: new Date(), approved_at: null, approved_by: null, user_name: 'Alice', approver_name: null };
+    const row = { discord_id: '1', guild_id: 'g1', status: 'pending', requested_at: new Date(), approved_at: null, approved_by: null, user_name: 'Alice', approver_name: null };
     vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
     const result = await getPendingRequests();
     expect(result).toHaveLength(1);
+    expect(result[0].guild_id).toBe('g1');
     expect(result[0].status).toBe('pending');
     expect(result[0].user_name).toBe('Alice');
   });
@@ -187,13 +209,15 @@ describe('getAllApiKeys', () => {
 
   it('maps multiple rows with different statuses', async () => {
     const rows = [
-      { discord_id: '1', status: 'approved', requested_at: new Date(), approved_at: new Date(), approved_by: '2', user_name: 'Alice', approver_name: 'Admin' },
-      { discord_id: '3', status: 'revoked', requested_at: new Date(), approved_at: null, approved_by: null, user_name: 'Bob', approver_name: null },
+      { discord_id: '1', guild_id: 'g1', status: 'approved', requested_at: new Date(), approved_at: new Date(), approved_by: '2', user_name: 'Alice', approver_name: 'Admin' },
+      { discord_id: '3', guild_id: 'g2', status: 'revoked', requested_at: new Date(), approved_at: null, approved_by: null, user_name: 'Bob', approver_name: null },
     ];
     vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
     const result = await getAllApiKeys();
     expect(result).toHaveLength(2);
+    expect(result[0].guild_id).toBe('g1');
     expect(result[0].status).toBe('approved');
+    expect(result[1].guild_id).toBe('g2');
     expect(result[1].status).toBe('revoked');
   });
 });
@@ -202,10 +226,10 @@ describe('getAllApiKeys', () => {
 
 describe('requestApiKey', () => {
   it('throws when existing status is denied', async () => {
-    const row = { discord_id: '1', status: 'denied', requested_at: new Date(), approved_at: null, approved_by: null, user_name: null, approver_name: null };
+    const row = { discord_id: '1', guild_id: 'g1', status: 'denied', requested_at: new Date(), approved_at: null, approved_by: null, user_name: null, approver_name: null };
     const pool = makePool([row]);
     vi.mocked(getPool).mockReturnValue(pool as any);
-    await expect(requestApiKey('1', AccessLevel.USER)).rejects.toThrow('denied');
+    await expect(requestApiKey('1', AccessLevel.USER, 'g1')).rejects.toThrow('denied');
   });
 
   it('returns status=approved for MANAGER access level (2)', async () => {
@@ -215,13 +239,16 @@ describe('requestApiKey', () => {
         .mockResolvedValueOnce([[]])    // getApiKeyStatus initial
         .mockResolvedValueOnce([[]])    // INSERT
         .mockResolvedValueOnce([[{     // getApiKeyStatus after insert
-          discord_id: '1', status: 'approved', requested_at: new Date(), approved_at: new Date(), approved_by: '1', user_name: null, approver_name: null,
+          discord_id: '1', guild_id: 'g1', status: 'approved', requested_at: new Date(), approved_at: new Date(), approved_by: '1', user_name: null, approver_name: null,
         }]]),
     };
     vi.mocked(getPool).mockReturnValue(pool as any);
-    const result = await requestApiKey('1', AccessLevel.MANAGER);
+    const result = await requestApiKey('1', AccessLevel.MANAGER, 'g1');
     expect(result.status).toBe('approved');
     expect(result.plain).toHaveLength(64); // 32 bytes as hex
+    const [insertSql, insertParams] = pool.execute.mock.calls[1] as [string, unknown[]];
+    expect(insertSql).toContain('(discord_id, key_hash, guild_id, status, requested_at, approved_at, approved_by)');
+    expect(insertParams[2]).toBe('g1');
   });
 
   it('returns status=pending for USER access level (0)', async () => {
@@ -230,11 +257,11 @@ describe('requestApiKey', () => {
         .mockResolvedValueOnce([[]])   // getApiKeyStatus initial
         .mockResolvedValueOnce([[]])   // INSERT
         .mockResolvedValueOnce([[{    // getApiKeyStatus after insert
-          discord_id: '1', status: 'pending', requested_at: new Date(), approved_at: null, approved_by: null, user_name: null, approver_name: null,
+          discord_id: '1', guild_id: 'g1', status: 'pending', requested_at: new Date(), approved_at: null, approved_by: null, user_name: null, approver_name: null,
         }]]),
     };
     vi.mocked(getPool).mockReturnValue(pool as any);
-    const result = await requestApiKey('1', AccessLevel.USER);
+    const result = await requestApiKey('1', AccessLevel.USER, 'g1');
     expect(result.status).toBe('pending');
   });
 
@@ -244,11 +271,11 @@ describe('requestApiKey', () => {
         .mockResolvedValueOnce([[]])
         .mockResolvedValueOnce([[]])
         .mockResolvedValueOnce([[{
-          discord_id: '1', status: 'pending', requested_at: new Date(), approved_at: null, approved_by: null, user_name: null, approver_name: null,
+          discord_id: '1', guild_id: 'g1', status: 'pending', requested_at: new Date(), approved_at: null, approved_by: null, user_name: null, approver_name: null,
         }]]),
     };
     vi.mocked(getPool).mockReturnValue(pool as any);
-    const result = await requestApiKey('1', AccessLevel.MOD);
+    const result = await requestApiKey('1', AccessLevel.MOD, 'g1');
     expect(result.plain).toMatch(/^[0-9a-f]{64}$/);
   });
 });

--- a/src/db/streamdeckKeys.test.ts
+++ b/src/db/streamdeckKeys.test.ts
@@ -53,12 +53,15 @@ describe('findApprovedKeyByHash', () => {
   it('returns the mapped row when hash matches', async () => {
     const hash = sha256hex('mysecretkey');
     const row = { discord_id: '42', key_hash: hash, guild_id: 'g1', status: 'approved', requested_at: new Date(), approved_at: new Date(), approved_by: '1' };
-    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const pool = makePool([row]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
     const result = await findApprovedKeyByHash(hash);
     expect(result).not.toBeNull();
     expect(result!.discord_id).toBe('42');
     expect(result!.guild_id).toBe('g1');
     expect(result!.status).toBe('approved');
+    const [sql] = pool.execute.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('guild_id');
   });
 
   it('returns null when stored and incoming hash have different lengths', async () => {
@@ -92,7 +95,8 @@ describe('getApiKeyStatus', () => {
       user_name: null,
       approver_name: null,
     };
-    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const pool = makePool([row]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
     const result = await getApiKeyStatus('123');
     expect(result!.discord_id).toBe('123');
     expect(result!.guild_id).toBe('g1');
@@ -100,6 +104,8 @@ describe('getApiKeyStatus', () => {
     expect(result!.requested_at).toBe(now);
     expect(result!.approved_at).toBeNull();
     expect(result!.approved_by).toBeNull();
+    const [sql] = pool.execute.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('guild_id');
   });
 
   it('preserves a null guild_id instead of stringifying it', async () => {
@@ -189,12 +195,15 @@ describe('getPendingRequests', () => {
 
   it('maps pending rows', async () => {
     const row = { discord_id: '1', guild_id: 'g1', status: 'pending', requested_at: new Date(), approved_at: null, approved_by: null, user_name: 'Alice', approver_name: null };
-    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const pool = makePool([row]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
     const result = await getPendingRequests();
     expect(result).toHaveLength(1);
     expect(result[0].guild_id).toBe('g1');
     expect(result[0].status).toBe('pending');
     expect(result[0].user_name).toBe('Alice');
+    const [sql] = pool.execute.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('guild_id');
   });
 });
 
@@ -212,13 +221,16 @@ describe('getAllApiKeys', () => {
       { discord_id: '1', guild_id: 'g1', status: 'approved', requested_at: new Date(), approved_at: new Date(), approved_by: '2', user_name: 'Alice', approver_name: 'Admin' },
       { discord_id: '3', guild_id: 'g2', status: 'revoked', requested_at: new Date(), approved_at: null, approved_by: null, user_name: 'Bob', approver_name: null },
     ];
-    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const pool = makePool(rows);
+    vi.mocked(getPool).mockReturnValue(pool as any);
     const result = await getAllApiKeys();
     expect(result).toHaveLength(2);
     expect(result[0].guild_id).toBe('g1');
     expect(result[0].status).toBe('approved');
     expect(result[1].guild_id).toBe('g2');
     expect(result[1].status).toBe('revoked');
+    const [sql] = pool.execute.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('guild_id');
   });
 });
 
@@ -248,6 +260,7 @@ describe('requestApiKey', () => {
     expect(result.plain).toHaveLength(64); // 32 bytes as hex
     const [insertSql, insertParams] = pool.execute.mock.calls[1] as [string, unknown[]];
     expect(insertSql).toContain('(discord_id, key_hash, guild_id, status, requested_at, approved_at, approved_by)');
+    expect(insertSql).toMatch(/guild_id\s*=\s*IF\(status = 'denied', guild_id,\s*new_row\.guild_id\)/);
     expect(insertParams[2]).toBe('g1');
   });
 

--- a/src/db/streamdeckKeys.ts
+++ b/src/db/streamdeckKeys.ts
@@ -5,6 +5,8 @@ import { AccessLevel } from './users';
 
 export interface StreamdeckKeyRow {
   discord_id: string;
+  /** The guild this key acts on. */
+  guild_id: string | null;
   status: 'pending' | 'approved' | 'revoked' | 'denied';
   requested_at: Date;
   approved_at: Date | null;
@@ -16,6 +18,7 @@ export interface StreamdeckKeyRow {
 function mapRow(r: mysql.RowDataPacket): StreamdeckKeyRow {
   return {
     discord_id: String(r.discord_id),
+    guild_id: r.guild_id === null ? null : String(r.guild_id),
     status: r.status as StreamdeckKeyRow['status'],
     requested_at: r.requested_at,
     approved_at: r.approved_at ?? null,
@@ -25,9 +28,20 @@ function mapRow(r: mysql.RowDataPacket): StreamdeckKeyRow {
   };
 }
 
+/**
+ * Requests (or re-requests) a Streamdeck API key for a user, scoped to one guild.
+ * Manager+ access levels are auto-approved; everyone else is queued as pending.
+ * Throws if a previous request for this user was denied.
+ *
+ * @param discordId Requesting user's Discord snowflake.
+ * @param accessLevel The user's effective access level in `guildId`, used to decide auto-approval.
+ * @param guildId The guild the key will act on.
+ * @returns The plaintext key (only ever returned here — only the hash is stored) and its status.
+ */
 export async function requestApiKey(
   discordId: string,
   accessLevel: number,
+  guildId: string,
 ): Promise<{ plain: string; status: 'pending' | 'approved' }> {
   const existing = await getApiKeyStatus(discordId);
   if (existing?.status === 'denied') {
@@ -43,15 +57,16 @@ export async function requestApiKey(
 
   await getPool().execute(
     `INSERT INTO streamdeck_api_keys
-       (discord_id, key_hash, status, requested_at, approved_at, approved_by)
-     VALUES (?, ?, ?, ?, ?, ?) AS new_row
+       (discord_id, key_hash, guild_id, status, requested_at, approved_at, approved_by)
+     VALUES (?, ?, ?, ?, ?, ?, ?) AS new_row
      ON DUPLICATE KEY UPDATE
        key_hash     = IF(status = 'denied', key_hash,     new_row.key_hash),
+       guild_id     = IF(status = 'denied', guild_id,     new_row.guild_id),
        status       = IF(status = 'denied', status,       new_row.status),
        requested_at = IF(status = 'denied', requested_at, new_row.requested_at),
        approved_at  = IF(status = 'denied', approved_at,  new_row.approved_at),
        approved_by  = IF(status = 'denied', approved_by,  new_row.approved_by)`,
-    [discordId, hash, status, now, approvedAt, approvedBy],
+    [discordId, hash, guildId, status, now, approvedAt, approvedBy],
   );
 
   const after = await getApiKeyStatus(discordId);
@@ -64,7 +79,7 @@ export async function requestApiKey(
 
 export async function findApprovedKeyByHash(hash: string): Promise<StreamdeckKeyRow | null> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    `SELECT discord_id, key_hash, status, requested_at, approved_at, approved_by
+    `SELECT discord_id, key_hash, guild_id, status, requested_at, approved_at, approved_by
      FROM streamdeck_api_keys
      WHERE key_hash = ? AND status = 'approved'`,
     [hash],
@@ -78,7 +93,7 @@ export async function findApprovedKeyByHash(hash: string): Promise<StreamdeckKey
 
 export async function getApiKeyStatus(discordId: string): Promise<StreamdeckKeyRow | null> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    `SELECT discord_id, status, requested_at, approved_at, approved_by
+    `SELECT discord_id, guild_id, status, requested_at, approved_at, approved_by
      FROM streamdeck_api_keys
      WHERE discord_id = ?`,
     [discordId],
@@ -111,7 +126,7 @@ export async function revokeApiKey(discordId: string): Promise<void> {
 
 export async function getPendingRequests(): Promise<StreamdeckKeyRow[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    `SELECT k.discord_id, k.status, k.requested_at, k.approved_at, k.approved_by,
+    `SELECT k.discord_id, k.guild_id, k.status, k.requested_at, k.approved_at, k.approved_by,
             u.discord_name AS user_name, NULL AS approver_name
      FROM streamdeck_api_keys k
      LEFT JOIN \`user\` u ON u.discord_id = k.discord_id
@@ -123,7 +138,7 @@ export async function getPendingRequests(): Promise<StreamdeckKeyRow[]> {
 
 export async function getAllApiKeys(): Promise<StreamdeckKeyRow[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    `SELECT k.discord_id, k.status, k.requested_at, k.approved_at, k.approved_by,
+    `SELECT k.discord_id, k.guild_id, k.status, k.requested_at, k.approved_at, k.approved_by,
             u.discord_name AS user_name, a.discord_name AS approver_name
      FROM streamdeck_api_keys k
      LEFT JOIN \`user\` u ON u.discord_id = k.discord_id

--- a/src/db/streamdeckKeys.ts
+++ b/src/db/streamdeckKeys.ts
@@ -77,6 +77,12 @@ export async function requestApiKey(
   return { plain, status };
 }
 
+/**
+ * Finds an approved Streamdeck API key by its SHA-256 hash.
+ *
+ * @param hash SHA-256 hash of the submitted plaintext key.
+ * @returns The approved key row, including its guild binding, or null when not found.
+ */
 export async function findApprovedKeyByHash(hash: string): Promise<StreamdeckKeyRow | null> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
     `SELECT discord_id, key_hash, guild_id, status, requested_at, approved_at, approved_by
@@ -91,6 +97,12 @@ export async function findApprovedKeyByHash(hash: string): Promise<StreamdeckKey
   return mapRow(rows[0]);
 }
 
+/**
+ * Gets the current Streamdeck API key status for a Discord user.
+ *
+ * @param discordId Requesting user's Discord snowflake.
+ * @returns The key row, including its guild binding, or null when no request exists.
+ */
 export async function getApiKeyStatus(discordId: string): Promise<StreamdeckKeyRow | null> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
     `SELECT discord_id, guild_id, status, requested_at, approved_at, approved_by
@@ -124,6 +136,11 @@ export async function revokeApiKey(discordId: string): Promise<void> {
   );
 }
 
+/**
+ * Lists pending Streamdeck API key requests.
+ *
+ * @returns Pending key rows, including requester names and guild bindings, oldest first.
+ */
 export async function getPendingRequests(): Promise<StreamdeckKeyRow[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
     `SELECT k.discord_id, k.guild_id, k.status, k.requested_at, k.approved_at, k.approved_by,
@@ -136,6 +153,11 @@ export async function getPendingRequests(): Promise<StreamdeckKeyRow[]> {
   return rows.map(mapRow);
 }
 
+/**
+ * Lists all Streamdeck API keys.
+ *
+ * @returns Key rows, including requester/approver names and guild bindings.
+ */
 export async function getAllApiKeys(): Promise<StreamdeckKeyRow[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
     `SELECT k.discord_id, k.guild_id, k.status, k.requested_at, k.approved_at, k.approved_by,

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -39,6 +39,8 @@ declare module 'express-serve-static-core' {
   interface Request {
     csrfToken(): string;
     apiKeyOwner?: string;
+    /** The guild the Streamdeck API key is bound to, set by requireApiKey. */
+    apiKeyGuildId?: string | null;
   }
 }
 

--- a/src/web/middleware.test.ts
+++ b/src/web/middleware.test.ts
@@ -201,12 +201,13 @@ describe('requireApiKey', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-  it('sets req.apiKeyOwner and calls next() when key is valid', async () => {
-    vi.mocked(findApprovedKeyByHash).mockResolvedValue({ discord_id: 'user42' } as any);
+  it('sets req.apiKeyOwner, req.apiKeyGuildId, and calls next() when key is valid', async () => {
+    vi.mocked(findApprovedKeyByHash).mockResolvedValue({ discord_id: 'user42', guild_id: 'guild99' } as any);
     const req = makeReq({ headers: { authorization: 'Bearer validtoken' } });
     const res = makeRes();
     await requireApiKey(req, res, next);
     expect(req.apiKeyOwner).toBe('user42');
+    expect(req.apiKeyGuildId).toBe('guild99');
     expect(next).toHaveBeenCalled();
     expect(res.status).not.toHaveBeenCalled();
   });

--- a/src/web/middleware.ts
+++ b/src/web/middleware.ts
@@ -146,6 +146,7 @@ export async function requireApiKey(req: Request, res: Response, next: NextFunct
       return;
     }
     req.apiKeyOwner = row.discord_id;
+    req.apiKeyGuildId = row.guild_id;
     next();
   } catch {
     res.status(500).json({ ok: false, error: 'Internal server error' });

--- a/src/web/routes/streamdeck.test.ts
+++ b/src/web/routes/streamdeck.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { SfxTrigger, SfxFile } from '../../db';
 
+let mockApiKeyGuildId: string | null = 'guild-123';
 vi.mock('../middleware', () => ({
-  requireApiKey: (_req: any, _res: any, next: any) => next(),
+  requireApiKey: (req: any, _res: any, next: any) => {
+    req.apiKeyGuildId = mockApiKeyGuildId;
+    next();
+  },
 }));
 
 vi.mock('../../db', () => ({
@@ -43,10 +47,6 @@ vi.mock('../../shared/logger', () => ({
   createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
 }));
 
-vi.mock('../../shared/config', () => ({
-  DISCORD_GUILD_ID: 'guild-123',
-}));
-
 import express from 'express';
 import supertest from 'supertest';
 import router from './streamdeck';
@@ -79,6 +79,7 @@ function buildApp() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockApiKeyGuildId = 'guild-123';
   vi.mocked(getAllSfxTriggers).mockResolvedValue([]);
   vi.mocked(findTrigger).mockResolvedValue(null);
   vi.mocked(findSoundFiles).mockResolvedValue([]);
@@ -251,6 +252,14 @@ describe('GET /voice/channels', () => {
 
     expect(res.body).toMatchObject({ ok: false });
   });
+
+  it('returns 503 when the API key has no guild binding', async () => {
+    mockApiKeyGuildId = null;
+
+    const res = await supertest(buildApp()).get('/voice/channels').expect(503);
+
+    expect(res.body).toMatchObject({ ok: false });
+  });
 });
 
 describe('POST /voice/join', () => {
@@ -296,6 +305,17 @@ describe('POST /voice/join', () => {
 
     expect(res.body).toMatchObject({ ok: false });
   });
+
+  it('returns 503 when the API key has no guild binding', async () => {
+    mockApiKeyGuildId = null;
+
+    const res = await supertest(buildApp())
+      .post('/voice/join')
+      .send({ channelId: '123456789012345678' })
+      .expect(503);
+
+    expect(res.body).toMatchObject({ ok: false });
+  });
 });
 
 describe('POST /voice/leave', () => {
@@ -305,5 +325,13 @@ describe('POST /voice/leave', () => {
     expect(res.body).toEqual({ ok: true });
     // Leaving must be scoped to the configured guild, not an unscoped disconnect.
     expect(vi.mocked(disconnect)).toHaveBeenCalledWith('guild-123');
+  });
+
+  it('returns 503 when the API key has no guild binding', async () => {
+    mockApiKeyGuildId = null;
+
+    const res = await supertest(buildApp()).post('/voice/leave').expect(503);
+
+    expect(res.body).toMatchObject({ ok: false });
   });
 });

--- a/src/web/routes/streamdeck.ts
+++ b/src/web/routes/streamdeck.ts
@@ -14,8 +14,8 @@ const log = createLogger('Streamdeck');
 const router = Router();
 
 /**
- * Returns the guild ID the API key is bound to, or sends 503 and returns null
- * when `requireApiKey` did not populate it (should never happen in practice).
+ * Returns the guild ID the API key is bound to. Sends 503 and returns null
+ * if the key is not bound to a guild.
  */
 function getApiKeyGuildId(req: Request, res: Response): string | null {
   const guildId = req.apiKeyGuildId ?? null;

--- a/src/web/routes/streamdeck.ts
+++ b/src/web/routes/streamdeck.ts
@@ -1,10 +1,9 @@
 import { createLogger } from '../../shared/logger';
-import { Router } from 'express';
+import { Router, type Request, type Response } from 'express';
 import { findTrigger, findSoundFiles, getAllSfxTriggers } from '../../db';
 import { pickWeightedRandom } from '../../commands/soundSelector';
 import { playFile, VoiceNotConnectedError } from '../../audio/sfxPlayer';
 import { setVoicePlaying } from '../../shared/statusStore';
-import { DISCORD_GUILD_ID } from '../../shared/config';
 import { requireApiKey } from '../middleware';
 import { getAvailableVoiceChannels } from '../../discord/discordUtils';
 import { connect, disconnect } from '../../audio/audioPlayer';
@@ -13,6 +12,19 @@ import { normalizeDiscordId } from './shared';
 
 const log = createLogger('Streamdeck');
 const router = Router();
+
+/**
+ * Returns the guild ID the API key is bound to, or sends 503 and returns null
+ * when `requireApiKey` did not populate it (should never happen in practice).
+ */
+function getApiKeyGuildId(req: Request, res: Response): string | null {
+  const guildId = req.apiKeyGuildId ?? null;
+  if (!guildId) {
+    res.status(503).json({ ok: false, error: 'API key has no guild binding' });
+    return null;
+  }
+  return guildId;
+}
 
 router.get('/sfx', requireApiKey, async (_req, res) => {
   try {
@@ -76,9 +88,11 @@ router.post('/sfx', requireApiKey, async (req, res) => {
   }
 });
 
-router.get('/voice/channels', requireApiKey, async (_req, res) => {
+router.get('/voice/channels', requireApiKey, async (req, res) => {
+  const guildId = getApiKeyGuildId(req, res);
+  if (!guildId) return;
   try {
-    const channels = await getAvailableVoiceChannels(DISCORD_GUILD_ID);
+    const channels = await getAvailableVoiceChannels(guildId);
     res.json({ ok: true, channels });
   } catch (err) {
     log.error('Failed to list voice channels:', err);
@@ -87,6 +101,9 @@ router.get('/voice/channels', requireApiKey, async (_req, res) => {
 });
 
 router.post('/voice/join', requireApiKey, async (req, res) => {
+  const guildId = getApiKeyGuildId(req, res);
+  if (!guildId) return;
+
   const { channelId } = req.body as { channelId?: unknown };
   if (typeof channelId !== 'string') {
     res.status(400).json({ ok: false, error: 'Missing or invalid "channelId" field' });
@@ -105,8 +122,8 @@ router.post('/voice/join', requireApiKey, async (req, res) => {
   }
 
   try {
-    disconnect(DISCORD_GUILD_ID);
-    await connect(discordClient, DISCORD_GUILD_ID, normalizedChannelId);
+    disconnect(guildId);
+    await connect(discordClient, guildId, normalizedChannelId);
     res.json({ ok: true });
   } catch (err) {
     log.error('Voice join failed:', err);
@@ -114,8 +131,10 @@ router.post('/voice/join', requireApiKey, async (req, res) => {
   }
 });
 
-router.post('/voice/leave', requireApiKey, (_req, res) => {
-  disconnect(DISCORD_GUILD_ID);
+router.post('/voice/leave', requireApiKey, (req, res) => {
+  const guildId = getApiKeyGuildId(req, res);
+  if (!guildId) return;
+  disconnect(guildId);
   res.json({ ok: true });
 });
 

--- a/src/web/routes/streamdeckKeys.test.ts
+++ b/src/web/routes/streamdeckKeys.test.ts
@@ -30,7 +30,15 @@ import {
 } from '../../db';
 import { AccessLevel } from '../../db/users';
 
-const SESSION_USER = { discordId: '111222333444555666', discordName: 'Alice', accessLevel: AccessLevel.ADMIN };
+const GUILD_ID = '900000000000000001';
+const SESSION_USER = {
+  discordId: '111222333444555666',
+  discordName: 'Alice',
+  accessLevel: AccessLevel.ADMIN,
+  currentGuildId: GUILD_ID,
+  isOwner: false,
+  guilds: [{ guildId: GUILD_ID, name: 'Test Guild' }],
+};
 const VALID_DISCORD_ID = '123456789012345678';
 
 function buildApp(sessionUser = SESSION_USER) {
@@ -95,6 +103,11 @@ describe('POST /streamdeck-key/request', () => {
     const res = await supertest(buildApp()).post('/streamdeck-key/request');
     expect(res.status).toBe(200);
     expect((res.body as any).locals.newKey).toBeTruthy();
+    expect(vi.mocked(requestApiKey)).toHaveBeenCalledWith(
+      SESSION_USER.discordId,
+      SESSION_USER.accessLevel,
+      GUILD_ID,
+    );
   });
 
   it('redirects to ?error=request_failed on error', async () => {

--- a/src/web/routes/streamdeckKeys.ts
+++ b/src/web/routes/streamdeckKeys.ts
@@ -43,6 +43,7 @@ router.post('/streamdeck-key/request', csrfProtection, async (req, res) => {
     const { plain } = await requestApiKey(
       req.session.user!.discordId,
       req.session.user!.accessLevel,
+      req.session.user!.currentGuildId!,
     );
     const keyRow = await getApiKeyStatus(req.session.user!.discordId);
     res.render('streamdeck-keys', {

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -101,9 +101,9 @@ describe('server route wiring', () => {
     expect(res.body).toEqual({ label: 'streams' });
     // requireAuth also runs for the two earlier '/' mounts (streamdeckKeys, sfx) that match
     // every path, plus adminRouter's and streamsRouter's own '/admin' stacks: 2 + 2 = 4.
-    // requireGuildContext only runs for the two '/admin' stacks: 2.
+    // requireGuildContext runs for streamdeckKeys' '/' mount plus the two '/admin' stacks: 3.
     expect(requireAuth).toHaveBeenCalledTimes(4);
-    expect(requireGuildContext).toHaveBeenCalledTimes(2);
+    expect(requireGuildContext).toHaveBeenCalledTimes(3);
   });
 
   it('mounts the /admin eventsub router behind both requireAuth and requireGuildContext', async () => {
@@ -112,8 +112,9 @@ describe('server route wiring', () => {
     expect(res.body).toEqual({ label: 'eventsubAdmin' });
     // Same two leading '/' mounts, plus all three '/admin' stacks (admin, streams,
     // eventsubAdmin) run before the eventsubAdmin route responds: 2 + 3 = 5.
+    // requireGuildContext runs for streamdeckKeys' '/' mount plus all three '/admin' stacks: 4.
     expect(requireAuth).toHaveBeenCalledTimes(5);
-    expect(requireGuildContext).toHaveBeenCalledTimes(3);
+    expect(requireGuildContext).toHaveBeenCalledTimes(4);
   });
 
   it('mounts the dashboard root behind both requireAuth and requireGuildContext', async () => {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -160,7 +160,7 @@ app.use('/', sfxPublicRouter);
 app.use('/overlay', overlaySourceRouter);
 app.use('/guild', requireAuth, guildRouter);
 app.use('/api', requireAuth, apiRouter);
-app.use('/', requireAuth, streamdeckKeysRouter);
+app.use('/', requireAuth, requireGuildContext, streamdeckKeysRouter);
 app.use('/', requireAuth, sfxRouter);
 app.use('/admin', requireAuth, requireGuildContext, adminRouter);
 app.use('/admin', requireAuth, requireGuildContext, streamsRouter);


### PR DESCRIPTION
## Summary

Stacked on #291 (PR3c — voice scoped to session guild). This chunk binds each Streamdeck API key to the guild it was requested for, instead of implicitly acting against the single configured guild.

- `src/db/streamdeckKeys.ts`: `streamdeck_api_keys` gains a `guild_id` column; `StreamdeckKeyRow` and all read/write functions carry it through. `requestApiKey(discordId, accessLevel, guildId)` now requires the requesting guild.
- `src/web/middleware.ts`: `requireApiKey` sets `req.apiKeyGuildId = row.guild_id` from the approved key row (added alongside the existing `req.apiKeyOwner`).
- `src/types/express.d.ts`: adds the `apiKeyGuildId?: string | null` field to `Request`.
- `src/web/routes/streamdeck.ts`: guild-scoped lookups and voice actions use `req.apiKeyGuildId` — never a guild taken from the request body.
- `src/web/routes/streamdeckKeys.ts`: key requests pass the session's current guild through to `requestApiKey`.
- `src/web/server.ts`: `streamdeckKeysRouter` is now mounted behind `requireGuildContext` so there's always a current guild to bind a new key request to.

## Security note

Closes the Streamdeck cross-guild risk identified in the multi-server plan (§6): an API key's guild-scoped actions (e.g. voice join) can no longer be influenced by the request body — the guild always comes from the key's own `guild_id`, fixed at request time.

## Behavioural change

None for the existing single-guild deployment — all existing/new keys bind to the one seeded guild.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 1328/1328 passing
- [ ] Manual smoke test on staging: request a new Streamdeck key, approve it, confirm it still triggers SFX/voice actions correctly

## Next steps

Per-guild command override UI, and removal of the legacy `DISCORD_GUILD_ID`/`DISCORD_VOICE_CHANNEL_ID` env vars.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QfGqskn817m3wmrwDjEqh3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API keys can now be bound to a Discord guild, and the approved key’s guild is attached to authenticated requests.
  * Requesting a new Streamdeck API key now includes the user’s current guild context.
  * Voice endpoints now use the guild associated with the API key instead of a fixed guild.

* **Bug Fixes**
  * Voice endpoints now properly handle missing guild bindings by returning a service-unavailable error.
  * API-key database handling and related tests were updated to consistently preserve and return guild binding (`guild_id`), including null values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->