### PR TITLE
Multi-server PR3e: per-guild command override UI

### DIFF
--- a/src/web/routes/commandGuildOverrides.test.ts
+++ b/src/web/routes/commandGuildOverrides.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../db', () => ({
+  upsertOverride: vi.fn().mockResolvedValue(undefined),
+  removeOverride: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../csrf', () => ({ csrfProtection: (_req: any, _res: any, next: any) => next() }));
+vi.mock('../middleware', () => ({
+  requireMod: (_req: any, _res: any, next: any) => next(),
+  requireGuildContext: (_req: any, _res: any, next: any) => next(),
+}));
+vi.mock('../../shared/logger', () => ({ createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }) }));
+
+import express from 'express';
+import supertest from 'supertest';
+import router from './commandGuildOverrides';
+import { upsertOverride, removeOverride } from '../../db';
+
+const GUILD_ID = '900000000000000001';
+
+/**
+ * Builds an Express test app with a mocked session, defaulting the session's
+ * current guild to GUILD_ID. Pass `null` to simulate no guild in session.
+ */
+function buildApp(currentGuildId: string | null = GUILD_ID) {
+  const app = express();
+  app.use(express.urlencoded({ extended: false }));
+  app.use((req: any, _res: any, next: any) => {
+    req.session = { user: { discordId: 'u1', currentGuildId } };
+    next();
+  });
+  app.use(router);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(upsertOverride).mockResolvedValue(undefined);
+  vi.mocked(removeOverride).mockResolvedValue(undefined);
+});
+
+// ─── POST /commands/guild-override ────────────────────────────────────────────
+
+describe('POST /commands/guild-override', () => {
+  it('calls upsertOverride with session guild and redirects to /commands', async () => {
+    const res = await supertest(buildApp())
+      .post('/commands/guild-override')
+      .send('command_id=5&is_disabled=1');
+    expect(res.headers.location).toBe('/commands');
+    expect(vi.mocked(upsertOverride)).toHaveBeenCalledWith(GUILD_ID, 5, {
+      isDisabled: true,
+      output: null,
+    });
+  });
+
+  it('stores a custom output when provided', async () => {
+    await supertest(buildApp())
+      .post('/commands/guild-override')
+      .send('command_id=5&output=Hello+there');
+    expect(vi.mocked(upsertOverride)).toHaveBeenCalledWith(GUILD_ID, 5, {
+      isDisabled: false,
+      output: 'Hello there',
+    });
+  });
+
+  it('removes the override instead of upserting when result is catalog default', async () => {
+    await supertest(buildApp())
+      .post('/commands/guild-override')
+      .send('command_id=5&output=Something&clear_output=1');
+    expect(vi.mocked(removeOverride)).toHaveBeenCalledWith(GUILD_ID, 5);
+    expect(vi.mocked(upsertOverride)).not.toHaveBeenCalled();
+  });
+
+  it('ignores guild_id from the request body and uses the session guild', async () => {
+    await supertest(buildApp())
+      .post('/commands/guild-override')
+      .send('command_id=5&guild_id=999999999999999999&is_disabled=1');
+    expect(vi.mocked(upsertOverride)).toHaveBeenCalledWith(GUILD_ID, 5, {
+      isDisabled: true,
+      output: null,
+    });
+  });
+
+  it('returns 302 to ?error=invalid_id for a non-integer command_id', async () => {
+    const res = await supertest(buildApp())
+      .post('/commands/guild-override')
+      .send('command_id=abc');
+    expect(res.headers.location).toBe('/commands?error=invalid_id');
+    expect(vi.mocked(upsertOverride)).not.toHaveBeenCalled();
+  });
+
+  it('redirects to ?error=override_failed when upsertOverride throws', async () => {
+    vi.mocked(upsertOverride).mockRejectedValue(new Error('DB error'));
+    const res = await supertest(buildApp())
+      .post('/commands/guild-override')
+      .send('command_id=5&is_disabled=1');
+    expect(res.headers.location).toBe('/commands?error=override_failed');
+  });
+
+  it('redirects to ?error=override_failed when removeOverride throws for a catalog-default result', async () => {
+    vi.mocked(removeOverride).mockRejectedValue(new Error('DB error'));
+    const res = await supertest(buildApp())
+      .post('/commands/guild-override')
+      .send('command_id=5');
+    expect(res.headers.location).toBe('/commands?error=override_failed');
+  });
+});
+
+// ─── POST /commands/guild-override/reset ─────────────────────────────────────
+
+describe('POST /commands/guild-override/reset', () => {
+  it('calls removeOverride with session guild and redirects to /commands', async () => {
+    const res = await supertest(buildApp())
+      .post('/commands/guild-override/reset')
+      .send('command_id=5');
+    expect(res.headers.location).toBe('/commands');
+    expect(vi.mocked(removeOverride)).toHaveBeenCalledWith(GUILD_ID, 5);
+  });
+
+  it('returns 302 to ?error=invalid_id for a non-integer command_id', async () => {
+    const res = await supertest(buildApp())
+      .post('/commands/guild-override/reset')
+      .send('command_id=abc');
+    expect(res.headers.location).toBe('/commands?error=invalid_id');
+    expect(vi.mocked(removeOverride)).not.toHaveBeenCalled();
+  });
+
+  it('redirects to ?error=override_reset_failed when removeOverride throws', async () => {
+    vi.mocked(removeOverride).mockRejectedValue(new Error('DB error'));
+    const res = await supertest(buildApp())
+      .post('/commands/guild-override/reset')
+      .send('command_id=5');
+    expect(res.headers.location).toBe('/commands?error=override_reset_failed');
+  });
+});

--- a/src/web/routes/commandGuildOverrides.ts
+++ b/src/web/routes/commandGuildOverrides.ts
@@ -1,0 +1,62 @@
+import { createLogger } from '../../shared/logger';
+import { Router } from 'express';
+import { upsertOverride, removeOverride } from '../../db';
+import { csrfProtection } from '../csrf';
+import { requireMod, requireGuildContext } from '../middleware';
+import { parsePositiveIntId, trimField } from './shared';
+
+const log = createLogger('Web');
+const router = Router();
+
+/**
+ * Sets or updates the per-guild override for a catalog command.
+ * Accepts `command_id`, `is_disabled` ("1" = disabled, absent = enabled),
+ * `output` (custom output text) and `clear_output` ("1" = remove any custom output).
+ * Guild ID is always taken from the session — never from the request body.
+ * If the resulting state is equivalent to the catalog default (not disabled,
+ * no custom output), the override row is removed instead of upserted.
+ */
+router.post('/commands/guild-override', requireGuildContext, requireMod, csrfProtection, async (req, res) => {
+  const guildId = req.session.user!.currentGuildId!;
+  const body = req.body as Record<string, unknown>;
+  const commandId = parsePositiveIntId(body.command_id as string | string[] | undefined);
+  if (!commandId) return res.redirect('/commands?error=invalid_id');
+
+  const isDisabled = body.is_disabled === '1';
+  const clearOutput = body.clear_output === '1';
+  const rawOutput = trimField(Array.isArray(body.output) ? (body.output as string[])[0] : body.output as string | undefined);
+  const output = clearOutput || !rawOutput ? null : rawOutput;
+
+  try {
+    if (!isDisabled && output === null) {
+      await removeOverride(guildId, commandId);
+    } else {
+      await upsertOverride(guildId, commandId, { isDisabled, output });
+    }
+    res.redirect('/commands');
+  } catch (err) {
+    log.error('Guild command override upsert failed:', err);
+    res.redirect('/commands?error=override_failed');
+  }
+});
+
+/**
+ * Removes the per-guild override for a catalog command, reverting it to the catalog default.
+ * Accepts `command_id`. Guild ID is always taken from the session.
+ */
+router.post('/commands/guild-override/reset', requireGuildContext, requireMod, csrfProtection, async (req, res) => {
+  const guildId = req.session.user!.currentGuildId!;
+  const body = req.body as Record<string, unknown>;
+  const commandId = parsePositiveIntId(body.command_id as string | string[] | undefined);
+  if (!commandId) return res.redirect('/commands?error=invalid_id');
+
+  try {
+    await removeOverride(guildId, commandId);
+    res.redirect('/commands');
+  } catch (err) {
+    log.error('Guild command override reset failed:', err);
+    res.redirect('/commands?error=override_reset_failed');
+  }
+});
+
+export default router;

--- a/src/web/routes/commands.test.ts
+++ b/src/web/routes/commands.test.ts
@@ -7,12 +7,15 @@ vi.mock('../../db', () => {
   return {
     getAllCustomCommandsWithAssignments: vi.fn().mockResolvedValue([]),
     getAllUsers: vi.fn().mockResolvedValue([]),
+    getOverridesForGuild: vi.fn().mockResolvedValue([]),
     addCustomCommand: vi.fn().mockResolvedValue(1),
     updateCustomCommand: vi.fn().mockResolvedValue(undefined),
     removeCustomCommand: vi.fn().mockResolvedValue(undefined),
     assignUserToCommand: vi.fn().mockResolvedValue(undefined),
     unassignUserFromCommand: vi.fn().mockResolvedValue(undefined),
     findUser: vi.fn().mockResolvedValue(null),
+    upsertOverride: vi.fn().mockResolvedValue(undefined),
+    removeOverride: vi.fn().mockResolvedValue(undefined),
     CommandConflictError,
     CommandNotFoundError,
     ReservedCommandError,
@@ -31,6 +34,7 @@ vi.mock('../middleware', () => ({
   requireAuth: (_req: any, _res: any, next: any) => next(),
   requireMod: (_req: any, _res: any, next: any) => next(),
   requireManager: (_req: any, _res: any, next: any) => next(),
+  requireGuildContext: (_req: any, _res: any, next: any) => next(),
 }));
 
 vi.mock('../../logger', () => ({
@@ -51,6 +55,7 @@ import {
   findUser,
   getAllCustomCommandsWithAssignments,
   getAllUsers,
+  getOverridesForGuild,
   isMysqlDuplicateEntryError,
   CommandConflictError,
   CommandNotFoundError,
@@ -77,6 +82,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(getAllCustomCommandsWithAssignments).mockResolvedValue([]);
   vi.mocked(getAllUsers).mockResolvedValue([]);
+  vi.mocked(getOverridesForGuild).mockResolvedValue([]);
   vi.mocked(addCustomCommand).mockResolvedValue(1);
   vi.mocked(updateCustomCommand).mockResolvedValue(undefined);
   vi.mocked(removeCustomCommand).mockResolvedValue(undefined);
@@ -512,6 +518,41 @@ describe('GET /commands', () => {
     app.use(router);
     const res = await supertest(app).get('/commands');
     expect(res.status).toBe(500);
+  });
+
+  it("36b. resolves the current guild's override onto the matching command and skips the lookup without a current guild", async () => {
+    vi.mocked(getAllCustomCommandsWithAssignments).mockResolvedValue([
+      { command_id: 1, trigger_string: '!hello', output: 'Hello!', is_discord_enabled: true, is_multi_twitch: false, assigned_users: [] } as any,
+      { command_id: 2, trigger_string: '!bye', output: 'Bye!', is_discord_enabled: true, is_multi_twitch: false, assigned_users: [] } as any,
+    ]);
+    vi.mocked(getOverridesForGuild).mockResolvedValue([
+      { guild_id: '900000000000000001', command_id: 1, is_disabled: true, output: null } as any,
+    ]);
+
+    let capturedLocals: any;
+    const app = express();
+    app.use(express.urlencoded({ extended: false }));
+    app.use((_req: any, res: any, next: any) => {
+      res.render = (_view: string, locals: any) => {
+        capturedLocals = locals;
+        res.send('ok');
+      };
+      next();
+    });
+    app.use((req: any, _res: any, next: any) => {
+      req.session = { user: { discord_id: '1', discord_name: 'TestUser', access_level: AccessLevel.MANAGER, currentGuildId: '900000000000000001' } };
+      next();
+    });
+    app.use(router);
+
+    await supertest(app).get('/commands');
+    expect(vi.mocked(getOverridesForGuild)).toHaveBeenCalledWith('900000000000000001');
+    expect(capturedLocals.commands[0].guildOverride).toMatchObject({ command_id: 1, is_disabled: true });
+    expect(capturedLocals.commands[1].guildOverride).toBeNull();
+
+    vi.mocked(getOverridesForGuild).mockClear();
+    await supertest(buildApp()).get('/commands');
+    expect(vi.mocked(getOverridesForGuild)).not.toHaveBeenCalled();
   });
 
   it('37. computes unassigned_users correctly when commands and users are present', async () => {

--- a/src/web/routes/commands.ts
+++ b/src/web/routes/commands.ts
@@ -2,15 +2,18 @@ import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import {
   DbCustomCommandWithAssignments,
+  DbGuildCommandOverride,
   DbUser,
   getAllCustomCommandsWithAssignments,
   getAllUsers,
+  getOverridesForGuild,
 } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
 import { renderError, filterQueryParam } from './shared';
 import commandMutationsRouter from './commandMutations';
 import commandAssignmentsRouter from './commandAssignments';
+import commandGuildOverridesRouter from './commandGuildOverrides';
 
 const log = createLogger('Web');
 const router = Router();
@@ -27,25 +30,36 @@ const KNOWN_ERRORS = new Set([
   'assign_failed',
   'unassign_failed',
   'invalid_assignment_user',
+  'override_failed',
+  'override_reset_failed',
 ]);
 
 interface CommandViewModel extends DbCustomCommandWithAssignments {
   unassigned_users: DbUser[];
+  /** Per-guild override row for the current guild, or null when at catalog default. */
+  guildOverride: DbGuildCommandOverride | null;
 }
 
+/**
+ * Renders the commands page: the global custom-command catalog plus, when a
+ * guild is in session, each command's per-guild override state.
+ */
 router.get('/commands', requireAuth, csrfProtection, async (req, res) => {
   try {
-    const [commands, users] = await Promise.all([
+    const guildId = req.session.user?.currentGuildId ?? null;
+    const [commands, users, overrides] = await Promise.all([
       getAllCustomCommandsWithAssignments(),
       getAllUsers(),
+      guildId ? getOverridesForGuild(guildId) : Promise.resolve([] as DbGuildCommandOverride[]),
     ]);
+    const overridesByCommandId = new Map(overrides.map((o) => [o.command_id, o]));
     const assignableUsers = users.filter((entry) => entry.twitch_name);
     const commandsForView: CommandViewModel[] = commands.map((command) => {
       const assignedDiscordIds = new Set(command.assigned_users.map((entry) => entry.discord_id));
-
       return {
         ...command,
         unassigned_users: assignableUsers.filter((entry) => !assignedDiscordIds.has(entry.discord_id)),
+        guildOverride: overridesByCommandId.get(command.command_id) ?? null,
       };
     });
 
@@ -64,5 +78,6 @@ router.get('/commands', requireAuth, csrfProtection, async (req, res) => {
 
 router.use(commandMutationsRouter);
 router.use(commandAssignmentsRouter);
+router.use(commandGuildOverridesRouter);
 
 export default router;

--- a/views/commands.ejs
+++ b/views/commands.ejs
@@ -26,6 +26,8 @@
         assign_failed: 'Failed to assign that user to the command.',
         unassign_failed: 'Failed to unassign that user from the command.',
         invalid_assignment_user: 'The selected user cannot be assigned to this command.',
+        override_failed: 'Failed to save the server override.',
+        override_reset_failed: 'Failed to reset the server override.',
       }; %>
       <div class="card card-alert-danger" role="alert" aria-live="assertive" aria-atomic="true">
         <span class="text-danger">&#9888; <%= errorMessages[error] || `Operation failed: ${error.replace(/_/g, ' ')}` %></span>
@@ -79,6 +81,7 @@
                 <th scope="col">Output</th>
                 <th scope="col">Discord</th>
                 <th scope="col">Multi-Twitch</th>
+                <th scope="col">This Server</th>
                 <th scope="col">Assigned Twitch Users</th>
                 <th scope="col">Actions</th>
               </tr>
@@ -102,6 +105,18 @@
                 <td class="command-output-cell"><%= command.output %></td>
                 <td><span class="badge <%= command.is_discord_enabled ? 'badge-active' : 'badge-offline' %>"><%= command.is_discord_enabled ? 'Enabled' : 'Off' %></span></td>
                 <td><span class="badge <%= command.is_multi_twitch ? 'badge-active' : 'badge-offline' %>"><%= command.is_multi_twitch ? 'Enabled' : 'Off' %></span></td>
+                <td>
+                  <% if (!user || !user.currentGuildId) { %>
+                    <span class="muted">—</span>
+                  <% } else if (command.guildOverride && command.guildOverride.is_disabled) { %>
+                    <span class="badge badge-offline">Disabled</span>
+                    <% if (command.guildOverride.output !== null) { %><span class="badge badge">Custom output</span><% } %>
+                  <% } else if (command.guildOverride && command.guildOverride.output !== null) { %>
+                    <span class="badge badge">Custom output</span>
+                  <% } else { %>
+                    <span class="muted">Catalog default</span>
+                  <% } %>
+                </td>
                 <td class="assigned-users-cell">
                   <% if (command.assigned_users.length > 0) { %>
                     <div class="badge-list-wrap">
@@ -133,7 +148,7 @@
                 </td>
               </tr>
               <tr class="files-row is-hidden" id="command-edit-<%= command.command_id %>">
-                <td colspan="6">
+                <td colspan="7">
                   <div class="command-edit-panel">
                     <form method="POST" action="/commands/update" class="stack-gap-md">
                       <input type="hidden" name="_csrf" value="<%= csrfToken %>">
@@ -201,13 +216,46 @@
                       <div class="empty-msg">No users with a Twitch name are available for assignment.</div>
                       <% } %>
                     </div>
+
+                    <% if (user && user.currentGuildId) { %>
+                    <div class="command-guild-override-shell">
+                      <h3 class="command-assignment-title">Server Override</h3>
+                      <% var guildOverride = command.guildOverride; %>
+                      <form method="POST" action="/commands/guild-override" class="stack-gap-md">
+                        <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                        <input type="hidden" name="command_id" value="<%= command.command_id %>">
+                        <div class="form-row-wrap">
+                          <label class="input checkbox-input-label">
+                            <input type="checkbox" name="is_disabled" value="1" <%= guildOverride && guildOverride.is_disabled ? 'checked' : '' %>> Disable for this server
+                          </label>
+                          <label class="input checkbox-input-label">
+                            <input type="checkbox" name="clear_output" value="1"> Clear custom output
+                          </label>
+                        </div>
+                        <div class="form-section-gap">
+                          <label for="guild_output_<%= command.command_id %>" class="form-label">Custom output for this server <span class="muted">(leave empty to use catalog output)</span></label>
+                          <textarea id="guild_output_<%= command.command_id %>" class="input stream-textarea" name="output" rows="2"><%= guildOverride && guildOverride.output !== null ? guildOverride.output : '' %></textarea>
+                        </div>
+                        <div class="button-row-wrap">
+                          <button type="submit" class="btn">Save Server Override</button>
+                        </div>
+                      </form>
+                      <% if (guildOverride) { %>
+                      <form method="POST" action="/commands/guild-override/reset" class="inline-form-sm">
+                        <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                        <input type="hidden" name="command_id" value="<%= command.command_id %>">
+                        <button type="submit" class="btn btn-ghost btn-sm">Reset to Catalog Default</button>
+                      </form>
+                      <% } %>
+                    </div>
+                    <% } %>
                   </div>
                 </td>
               </tr>
               <% }) %>
               <% if (commands.length === 0) { %>
               <tr>
-                <td colspan="6" class="empty-msg">No custom commands configured yet.</td>
+                <td colspan="7" class="empty-msg">No custom commands configured yet.</td>
               </tr>
               <% } %>
             </tbody>


### PR DESCRIPTION
## Summary

Stacked on #292 (PR3d — Streamdeck API key guild binding). This chunk adds the UI/route layer for the per-guild command override system (the `guild_command_override` table and its DB layer were already introduced in PR3a).

- New `src/web/routes/commandGuildOverrides.ts`: `POST /commands/guild-override` sets/updates a per-guild disable flag and/or output-text override for a catalog command; `POST /commands/guild-override/reset` clears it back to the catalog default. Mod+ only, CSRF-protected, guild ID always read from the session.
- `src/web/routes/commands.ts`: the commands list now fetches the current guild's overrides alongside the global catalog and attaches each command's effective `guildOverride` (or `null` for catalog default) to the view model.
- `views/commands.ejs`: renders each command's current-guild state and exposes controls to disable/override/reset it.

## Behavioural change

None for the existing single-guild deployment — with zero override rows, every command resolves to its catalog default exactly as before. The new controls let an admin start creating overrides, which is the actual point of this chunk.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 1337/1337 passing (81 test files)
- [ ] Manual smoke test on staging: disable a command for the guild, confirm it stops firing; set a custom output, confirm it's used; reset, confirm it reverts to catalog text

## Next steps

Final chunk: removal of the legacy `DISCORD_GUILD_ID`/`DISCORD_VOICE_CHANNEL_ID` env vars (depends on PR3c already being live).


---
_Generated by [Claude Code](https://claude.ai/code/session_01QfGqskn817m3wmrwDjEqh3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-server command overrides with the ability to enable/disable commands per server
  * Added server-specific custom output for commands, with clear-to-default behavior
  * Added “This Server” column to the Custom Commands UI to show current override status and manage server override settings
* **Tests**
  * Added coverage for guild override creation, reset, and input validation for the related endpoints and `/commands` rendering
<!-- end of auto-generated comment: release notes by coderabbit.ai -->