### PR TITLE
fix(deps): override undici to ^6.27.0 to clear audit vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -248,15 +248,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@discordjs/rest/node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
     "node_modules/@discordjs/util": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
@@ -562,9 +553,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -582,9 +570,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -602,9 +587,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -622,9 +604,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -642,9 +621,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -662,9 +638,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2100,15 +2073,6 @@
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
-    "node_modules/discord.js/node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
     "node_modules/dotenv": {
       "version": "17.4.2",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
@@ -3161,9 +3125,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3185,9 +3146,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3209,9 +3167,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3233,9 +3188,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4919,6 +4871,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "winston-daily-rotate-file": "^5.0.0"
   },
   "overrides": {
-    "ws": ">=8.21.0"
+    "ws": ">=8.21.0",
+    "undici": "^6.27.0"
   },
   "devDependencies": {
     "@types/ejs": "^3.1.5",


### PR DESCRIPTION
## Problem

Deploy failed at the `npm audit` gate with 4 vulnerabilities (1 high, 3 moderate), all in **undici `<=6.26.0`**, pulled in transitively via `discord.js` → `@discordjs/rest`:

- HTTP header injection via Set-Cookie percent-decoding (high)
- WebSocket client DoS via fragment count bypass
- HTTP response queue poisoning via keep-alive socket reuse
- Set-Cookie SameSite attribute downgrade

`npm audit fix --force` "resolves" these by **downgrading discord.js to v13** — a SemVer-major breaking change the codebase can't take (it's built on discord.js v14).

## Fix

Pin `undici` to `^6.27.0` (the patched release) via the existing `overrides` block in `package.json`. This keeps `discord.js` on **v14.26.4** while forcing the safe undici version everywhere it resolves.

```
`-- discord.js@14.26.4
  +-- @discordjs/rest@2.6.1
  | `-- undici@6.27.0 deduped
  `-- undici@6.27.0 overridden
```

## Verification

- `npm audit` → **found 0 vulnerabilities**
- `npx tsc --noEmit` → clean
- `npm test` → **1313 passed (81 files)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPTWeeKXemfphBek8HHqa9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management overrides for package compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->