### PR TITLE
Require JSDoc on all functions, including anonymous handlers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,8 +58,7 @@ npm test      # Vitest
 
 ## Docstrings
 
-- Public functions (exported from a module) **must** have a JSDoc comment describing what they do, their parameters, and return value — one line is enough for simple cases.
-- Internal helpers only need a comment when the WHY is non-obvious (see general comment guidance).
+- All functions — including exported functions, internal helpers, and anonymous functions (e.g. inline Express route handlers) — **must** have a JSDoc comment describing what they do, their parameters, and return value — one line is enough for simple cases.
 - When you change a function's signature or behaviour, update its JSDoc to match — stale docs are worse than no docs.
 
 ---


### PR DESCRIPTION
## Summary
- Updates CLAUDE.md's docstring policy so JSDoc is required on **all** functions — exported, internal helper, and anonymous (e.g. inline Express route handlers) — instead of exempting unnamed/internal functions.
- Motivated by CodeRabbit's docstring-coverage check flagging low coverage on files where most functions are anonymous route handlers; aligning the project policy avoids permanent low-coverage scores on those files going forward.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (1339/1339)
- Docs-only change; no behavioral code touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_012HMbkgi6hughSpE7Df9Ypr)_