### PR TITLE
build(deps-dev): bump @types/node from 24.13.2 to 26.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@types/express-mysql-session": "^3.0.8",
         "@types/express-session": "^1.19.0",
         "@types/multer": "^2.1.0",
-        "@types/node": "^24.13.2",
+        "@types/node": "^26.0.0",
         "@types/supertest": "^7.2.0",
         "@types/tmi.js": "^1.8.6",
         "@types/ws": "^8.18.1",
@@ -1252,12 +1252,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.13.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
-      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/qs": {
@@ -4883,9 +4883,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/express-mysql-session": "^3.0.8",
     "@types/express-session": "^1.19.0",
     "@types/multer": "^2.1.0",
-    "@types/node": "^24.13.2",
+    "@types/node": "^26.0.0",
     "@types/supertest": "^7.2.0",
     "@types/tmi.js": "^1.8.6",
     "@types/ws": "^8.18.1",


### PR DESCRIPTION
Closing — this duplicated #298. The task was to review #298, not open a competing PR. See #298 for the review.