### PR TITLE
Fix ambiguous status column in Streamdeck API key upsert

### DIFF
--- a/src/db/streamdeckKeys.test.ts
+++ b/src/db/streamdeckKeys.test.ts
@@ -260,7 +260,7 @@ describe('requestApiKey', () => {
     expect(result.plain).toHaveLength(64); // 32 bytes as hex
     const [insertSql, insertParams] = pool.execute.mock.calls[1] as [string, unknown[]];
     expect(insertSql).toContain('(discord_id, key_hash, guild_id, status, requested_at, approved_at, approved_by)');
-    expect(insertSql).toMatch(/guild_id\s*=\s*IF\(status = 'denied', guild_id,\s*new_row\.guild_id\)/);
+    expect(insertSql).toMatch(/guild_id\s*=\s*IF\(streamdeck_api_keys\.status = 'denied', streamdeck_api_keys\.guild_id,\s*new_row\.guild_id\)/);
     expect(insertParams[2]).toBe('g1');
   });
 
@@ -290,5 +290,25 @@ describe('requestApiKey', () => {
     vi.mocked(getPool).mockReturnValue(pool as any);
     const result = await requestApiKey('1', AccessLevel.MOD, 'g1');
     expect(result.plain).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('qualifies every bare column reference in the upsert IF() conditions to avoid ambiguity with new_row', async () => {
+    const pool = {
+      execute: vi.fn()
+        .mockResolvedValueOnce([[]])
+        .mockResolvedValueOnce([[]])
+        .mockResolvedValueOnce([[{
+          discord_id: '1', guild_id: 'g1', status: 'pending', requested_at: new Date(), approved_at: null, approved_by: null, user_name: null, approver_name: null,
+        }]]),
+    };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await requestApiKey('1', AccessLevel.USER, 'g1');
+    const [insertSql] = pool.execute.mock.calls[1] as [string, unknown[]];
+    const updateClause = insertSql.slice(insertSql.indexOf('ON DUPLICATE KEY UPDATE'));
+    // every "IF(" condition must reference the base table, not a bare column, to avoid
+    // "Column 'status' in field list is ambiguous" against the new_row alias
+    for (const match of updateClause.matchAll(/IF\(([^,]+),/g)) {
+      expect(match[1]).toContain('streamdeck_api_keys.');
+    }
   });
 });

--- a/src/db/streamdeckKeys.ts
+++ b/src/db/streamdeckKeys.ts
@@ -60,12 +60,12 @@ export async function requestApiKey(
        (discord_id, key_hash, guild_id, status, requested_at, approved_at, approved_by)
      VALUES (?, ?, ?, ?, ?, ?, ?) AS new_row
      ON DUPLICATE KEY UPDATE
-       key_hash     = IF(status = 'denied', key_hash,     new_row.key_hash),
-       guild_id     = IF(status = 'denied', guild_id,     new_row.guild_id),
-       status       = IF(status = 'denied', status,       new_row.status),
-       requested_at = IF(status = 'denied', requested_at, new_row.requested_at),
-       approved_at  = IF(status = 'denied', approved_at,  new_row.approved_at),
-       approved_by  = IF(status = 'denied', approved_by,  new_row.approved_by)`,
+       key_hash     = IF(streamdeck_api_keys.status = 'denied', streamdeck_api_keys.key_hash,     new_row.key_hash),
+       guild_id     = IF(streamdeck_api_keys.status = 'denied', streamdeck_api_keys.guild_id,     new_row.guild_id),
+       status       = IF(streamdeck_api_keys.status = 'denied', streamdeck_api_keys.status,       new_row.status),
+       requested_at = IF(streamdeck_api_keys.status = 'denied', streamdeck_api_keys.requested_at, new_row.requested_at),
+       approved_at  = IF(streamdeck_api_keys.status = 'denied', streamdeck_api_keys.approved_at,  new_row.approved_at),
+       approved_by  = IF(streamdeck_api_keys.status = 'denied', streamdeck_api_keys.approved_by,  new_row.approved_by)`,
     [discordId, hash, guildId, status, now, approvedAt, approvedBy],
   );
 


### PR DESCRIPTION
## Summary
- Production bug from #292: requesting a Streamdeck API key failed with `Error: Column 'status' in field list is ambiguous`.
- The `ON DUPLICATE KEY UPDATE` clause in `requestApiKey` referenced bare `status`/`guild_id`/etc. columns inside `IF()` conditions, which MySQL can't resolve between the existing row and the `new_row` alias introduced for the row-alias upsert syntax.
- Qualifies all existing-row column references with the table name (`streamdeck_api_keys.status`, etc.) to remove the ambiguity.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (added a regression test asserting every `IF()` condition in the upsert is table-qualified)
- [ ] Manually verify requesting/re-requesting a Streamdeck API key against a real MySQL instance


---
_Generated by [Claude Code](https://claude.ai/code/session_012HMbkgi6hughSpE7Df9Ypr)_