### PR TITLE
Fix CSP violations breaking inline event handlers across web views

### DIFF
--- a/public/dashboard-reconnect.js
+++ b/public/dashboard-reconnect.js
@@ -1,0 +1,15 @@
+(function () {
+  if (sessionStorage.getItem('twitch_reconnect_dismissed')) {
+    var modal = document.getElementById('reconnect-modal');
+    if (modal) modal.style.display = 'none';
+  }
+})();
+
+var dismissReconnectBtn = document.getElementById('dismiss-reconnect-modal');
+if (dismissReconnectBtn) {
+  dismissReconnectBtn.addEventListener('click', function () {
+    sessionStorage.setItem('twitch_reconnect_dismissed', '1');
+    var modal = document.getElementById('reconnect-modal');
+    if (modal) modal.style.display = 'none';
+  });
+}

--- a/public/dashboard-reconnect.js
+++ b/public/dashboard-reconnect.js
@@ -1,3 +1,4 @@
+/** Hides the reconnect modal on load if the user already dismissed it earlier this session. */
 (function () {
   if (sessionStorage.getItem('twitch_reconnect_dismissed')) {
     var modal = document.getElementById('reconnect-modal');
@@ -7,6 +8,7 @@
 
 var dismissReconnectBtn = document.getElementById('dismiss-reconnect-modal');
 if (dismissReconnectBtn) {
+  /** Persists the reconnect-modal dismissal for this session and hides the modal. */
   dismissReconnectBtn.addEventListener('click', function () {
     sessionStorage.setItem('twitch_reconnect_dismissed', '1');
     var modal = document.getElementById('reconnect-modal');

--- a/public/overlayAdmin.js
+++ b/public/overlayAdmin.js
@@ -8,8 +8,14 @@ function getDeleteRewardConfirmationMessage() {
   return 'Remove this reward assignment?';
 }
 
-/** Confirms destructive deletions before allowing the video/reward-assignment delete forms to submit. */
-document.addEventListener('submit', function (event) {
+/**
+ * Confirms destructive deletions before allowing the video/reward-assignment delete forms to submit.
+ * @param {SubmitEvent} event - The form submit event.
+ * @returns {void}
+ */
+function handleOverlayAdminSubmit(event) {
   if (confirmSubmit(event, 'js-confirm-delete-video', getDeleteVideoConfirmationMessage)) return;
   confirmSubmit(event, 'js-confirm-delete-reward', getDeleteRewardConfirmationMessage);
-});
+}
+
+document.addEventListener('submit', handleOverlayAdminSubmit);

--- a/public/overlayAdmin.js
+++ b/public/overlayAdmin.js
@@ -1,0 +1,8 @@
+document.addEventListener('submit', function (event) {
+  if (confirmSubmit(event, 'js-confirm-delete-video', function () {
+    return 'Delete this video? Any reward assignments using it will be removed.';
+  })) return;
+  confirmSubmit(event, 'js-confirm-delete-reward', function () {
+    return 'Remove this reward assignment?';
+  });
+});

--- a/public/overlayAdmin.js
+++ b/public/overlayAdmin.js
@@ -1,8 +1,15 @@
+/** Returns the confirmation message for deleting an overlay video. */
+function getDeleteVideoConfirmationMessage() {
+  return 'Delete this video? Any reward assignments using it will be removed.';
+}
+
+/** Returns the confirmation message for removing a reward assignment. */
+function getDeleteRewardConfirmationMessage() {
+  return 'Remove this reward assignment?';
+}
+
+/** Confirms destructive deletions before allowing the video/reward-assignment delete forms to submit. */
 document.addEventListener('submit', function (event) {
-  if (confirmSubmit(event, 'js-confirm-delete-video', function () {
-    return 'Delete this video? Any reward assignments using it will be removed.';
-  })) return;
-  confirmSubmit(event, 'js-confirm-delete-reward', function () {
-    return 'Remove this reward assignment?';
-  });
+  if (confirmSubmit(event, 'js-confirm-delete-video', getDeleteVideoConfirmationMessage)) return;
+  confirmSubmit(event, 'js-confirm-delete-reward', getDeleteRewardConfirmationMessage);
 });

--- a/public/streamdeck-keys-admin.js
+++ b/public/streamdeck-keys-admin.js
@@ -1,0 +1,8 @@
+document.addEventListener('submit', function (event) {
+  if (confirmSubmit(event, 'js-confirm-deny-key', function () {
+    return 'Are you sure you want to deny this request?';
+  })) return;
+  confirmSubmit(event, 'js-confirm-revoke-key-admin', function () {
+    return 'Revoke this key? It will stop working immediately.';
+  });
+});

--- a/public/streamdeck-keys-admin.js
+++ b/public/streamdeck-keys-admin.js
@@ -1,8 +1,15 @@
+/** Returns the confirmation message for denying a pending Streamdeck key request. */
+function getDenyKeyConfirmationMessage() {
+  return 'Are you sure you want to deny this request?';
+}
+
+/** Returns the confirmation message for revoking an approved Streamdeck key. */
+function getRevokeKeyConfirmationMessage() {
+  return 'Revoke this key? It will stop working immediately.';
+}
+
+/** Confirms deny/revoke actions before allowing the admin Streamdeck key forms to submit. */
 document.addEventListener('submit', function (event) {
-  if (confirmSubmit(event, 'js-confirm-deny-key', function () {
-    return 'Are you sure you want to deny this request?';
-  })) return;
-  confirmSubmit(event, 'js-confirm-revoke-key-admin', function () {
-    return 'Revoke this key? It will stop working immediately.';
-  });
+  if (confirmSubmit(event, 'js-confirm-deny-key', getDenyKeyConfirmationMessage)) return;
+  confirmSubmit(event, 'js-confirm-revoke-key-admin', getRevokeKeyConfirmationMessage);
 });

--- a/public/streamdeck-keys.js
+++ b/public/streamdeck-keys.js
@@ -1,10 +1,18 @@
-function copyKey(event) {
-  const key = document.getElementById('new-key').textContent;
-  navigator.clipboard.writeText(key).then(() => {
-    const btn = event.currentTarget;
-    btn.textContent = 'Copied!';
-    setTimeout(() => { btn.textContent = 'Copy'; }, 2000);
-  }).catch(() => { alert('Could not copy automatically — please copy the key manually.'); });
+document.addEventListener('submit', function (event) {
+  confirmSubmit(event, 'js-confirm-revoke-key', function () {
+    return 'Revoke your API key? It will stop working immediately.';
+  });
+});
+
+const copyBtn = document.getElementById('copy-key-btn');
+if (copyBtn) {
+  copyBtn.addEventListener('click', function () {
+    const key = document.getElementById('new-key').textContent;
+    navigator.clipboard.writeText(key).then(() => {
+      copyBtn.textContent = 'Copied!';
+      setTimeout(() => { copyBtn.textContent = 'Copy'; }, 2000);
+    }).catch(() => { alert('Could not copy automatically — please copy the key manually.'); });
+  });
 }
 
 const hostCell = document.getElementById('sd-host-cell');

--- a/public/streamdeck-keys.js
+++ b/public/streamdeck-keys.js
@@ -1,13 +1,23 @@
+/** Returns the confirmation message for revoking the current user's Streamdeck API key. */
+function getRevokeKeyConfirmationMessage() {
+  return 'Revoke your API key? It will stop working immediately.';
+}
+
+/** Confirms revocation before allowing the Streamdeck key revoke form to submit. */
 document.addEventListener('submit', function (event) {
-  confirmSubmit(event, 'js-confirm-revoke-key', function () {
-    return 'Revoke your API key? It will stop working immediately.';
-  });
+  confirmSubmit(event, 'js-confirm-revoke-key', getRevokeKeyConfirmationMessage);
 });
 
 const copyBtn = document.getElementById('copy-key-btn');
 if (copyBtn) {
+  /** Copies the newly generated Streamdeck API key to the clipboard and shows brief feedback on the button. */
   copyBtn.addEventListener('click', function () {
-    const key = document.getElementById('new-key').textContent;
+    const keyEl = document.getElementById('new-key');
+    const key = keyEl ? keyEl.textContent : '';
+    if (!navigator.clipboard || typeof navigator.clipboard.writeText !== 'function') {
+      alert('Could not copy automatically — please copy the key manually.');
+      return;
+    }
     navigator.clipboard.writeText(key).then(() => {
       copyBtn.textContent = 'Copied!';
       setTimeout(() => { copyBtn.textContent = 'Copy'; }, 2000);

--- a/public/streams-live-poll.js
+++ b/public/streams-live-poll.js
@@ -31,6 +31,11 @@ document.addEventListener('click', function (event) {
   }
 });
 
+/** Returns the confirmation message for disconnecting a streamer's Twitch connection. */
+function getDisconnectTwitchConfirmationMessage(t) {
+  return 'Disconnect Twitch for ' + (t.dataset.twitchName || 'this streamer') + '?';
+}
+
 document.addEventListener('submit', function (event) {
   if (confirmSubmit(event, 'js-confirm-remove-group', function (t) {
     return 'Remove group "' + (t.dataset.groupName || 'this group') + '" and all its streamers?';
@@ -38,9 +43,7 @@ document.addEventListener('submit', function (event) {
   if (confirmSubmit(event, 'js-confirm-remove-streamer', function (t) {
     return 'Remove streamer "' + (t.dataset.streamerName || 'this streamer') + '"?';
   })) return;
-  confirmSubmit(event, 'js-confirm-disconnect-twitch', function (t) {
-    return 'Disconnect Twitch for ' + (t.dataset.twitchName || 'this streamer') + '?';
-  });
+  confirmSubmit(event, 'js-confirm-disconnect-twitch', getDisconnectTwitchConfirmationMessage);
 });
 
 var liveNowInflight = false;

--- a/public/streams-live-poll.js
+++ b/public/streams-live-poll.js
@@ -35,8 +35,11 @@ document.addEventListener('submit', function (event) {
   if (confirmSubmit(event, 'js-confirm-remove-group', function (t) {
     return 'Remove group "' + (t.dataset.groupName || 'this group') + '" and all its streamers?';
   })) return;
-  confirmSubmit(event, 'js-confirm-remove-streamer', function (t) {
+  if (confirmSubmit(event, 'js-confirm-remove-streamer', function (t) {
     return 'Remove streamer "' + (t.dataset.streamerName || 'this streamer') + '"?';
+  })) return;
+  confirmSubmit(event, 'js-confirm-disconnect-twitch', function (t) {
+    return 'Disconnect Twitch for ' + (t.dataset.twitchName || 'this streamer') + '?';
   });
 });
 

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -99,21 +99,11 @@
       <p style="color:var(--muted);font-size:0.875rem;margin-bottom:1.5rem;">Please reconnect your Twitch account to restore full functionality.</p>
       <div style="display:flex;gap:0.75rem;justify-content:center;flex-wrap:wrap;">
         <a href="/user/settings/twitch-connect" class="btn">Reconnect Twitch</a>
-        <button onclick="dismissReconnectModal()" class="btn btn-ghost">Dismiss</button>
+        <button id="dismiss-reconnect-modal" class="btn btn-ghost">Dismiss</button>
       </div>
     </div>
   </div>
-  <script>
-    (function () {
-      if (sessionStorage.getItem('twitch_reconnect_dismissed')) {
-        document.getElementById('reconnect-modal').style.display = 'none';
-      }
-    })();
-    function dismissReconnectModal() {
-      sessionStorage.setItem('twitch_reconnect_dismissed', '1');
-      document.getElementById('reconnect-modal').style.display = 'none';
-    }
-  </script>
+  <script src="/dashboard-reconnect.js"></script>
   <% } %>
 </body>
 </html>

--- a/views/overlayAdmin.ejs
+++ b/views/overlayAdmin.ejs
@@ -125,10 +125,9 @@
                 <td class="mono" style="font-size:0.8em;"><%= v.filename %></td>
                 <td><%= new Date(v.created_at).toLocaleDateString() %></td>
                 <td>
-                  <form method="POST" action="/overlay/settings/videos/<%= v.id %>/delete" style="margin:0;">
+                  <form method="POST" action="/overlay/settings/videos/<%= v.id %>/delete" style="margin:0;" class="js-confirm-delete-video">
                     <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-                    <button type="submit" class="btn btn-ghost btn-sm"
-                      onclick="return confirm('Delete this video? Any reward assignments using it will be removed.')">
+                    <button type="submit" class="btn btn-ghost btn-sm">
                       Delete
                     </button>
                   </form>
@@ -211,10 +210,9 @@
               <p class="hint hint-compact">Reward ID</p>
               <code class="mono" style="word-break:break-all;overflow-wrap:anywhere;"><%= r.twitch_reward_id %></code>
             </div>
-            <form method="POST" action="/overlay/settings/rewards/<%= r.id %>/delete" style="margin:0;">
+            <form method="POST" action="/overlay/settings/rewards/<%= r.id %>/delete" style="margin:0;" class="js-confirm-delete-reward">
               <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-              <button type="submit" class="btn btn-ghost btn-sm"
-                onclick="return confirm('Remove this reward assignment?')">
+              <button type="submit" class="btn btn-ghost btn-sm">
                 Remove
               </button>
             </form>
@@ -249,5 +247,7 @@
   </main>
 
   <%- include('partials/pwa-register') %>
+  <script src="/utils.js"></script>
+  <script src="/overlayAdmin.js"></script>
 </body>
 </html>

--- a/views/streamdeck-keys-admin.ejs
+++ b/views/streamdeck-keys-admin.ejs
@@ -54,10 +54,10 @@
                       <input type="hidden" name="discord_id" value="<%= row.discord_id %>">
                       <button type="submit" class="btn btn-sm">Approve</button>
                     </form>
-                    <form method="POST" action="/admin/streamdeck-keys/deny" class="inline-form-sm">
+                    <form method="POST" action="/admin/streamdeck-keys/deny" class="inline-form-sm js-confirm-deny-key">
                       <input type="hidden" name="_csrf" value="<%= csrfToken %>">
                       <input type="hidden" name="discord_id" value="<%= row.discord_id %>">
-                      <button type="submit" class="btn btn-sm btn-ghost" onclick="return confirm('Are you sure you want to deny this request?')">Deny</button>
+                      <button type="submit" class="btn btn-sm btn-ghost">Deny</button>
                     </form>
                   </div>
                 </td>
@@ -125,17 +125,17 @@
                       <input type="hidden" name="discord_id" value="<%= row.discord_id %>">
                       <button type="submit" class="btn btn-sm">Approve</button>
                     </form>
-                    <form method="POST" action="/admin/streamdeck-keys/deny" class="inline-form-sm">
+                    <form method="POST" action="/admin/streamdeck-keys/deny" class="inline-form-sm js-confirm-deny-key">
                       <input type="hidden" name="_csrf" value="<%= csrfToken %>">
                       <input type="hidden" name="discord_id" value="<%= row.discord_id %>">
-                      <button type="submit" class="btn btn-sm btn-ghost" onclick="return confirm('Are you sure you want to deny this request?')">Deny</button>
+                      <button type="submit" class="btn btn-sm btn-ghost">Deny</button>
                     </form>
                   </div>
                   <% } else if (row.status === 'approved') { %>
-                  <form method="POST" action="/admin/streamdeck-keys/revoke" class="inline-form-sm">
+                  <form method="POST" action="/admin/streamdeck-keys/revoke" class="inline-form-sm js-confirm-revoke-key-admin">
                     <input type="hidden" name="_csrf" value="<%= csrfToken %>">
                     <input type="hidden" name="discord_id" value="<%= row.discord_id %>">
-                    <button type="submit" class="btn btn-sm btn-ghost" onclick="return confirm('Revoke this key? It will stop working immediately.')">Revoke</button>
+                    <button type="submit" class="btn btn-sm btn-ghost">Revoke</button>
                   </form>
                   <% } else { %>
                   <em class="muted">—</em>
@@ -151,5 +151,7 @@
     </section>
   </main>
   <%- include('partials/pwa-register') %>
+  <script src="/utils.js"></script>
+  <script src="/streamdeck-keys-admin.js"></script>
 </body>
 </html>

--- a/views/streamdeck-keys.ejs
+++ b/views/streamdeck-keys.ejs
@@ -29,7 +29,7 @@
         <p><strong>&#10003; Your API key has been generated.</strong> Copy it now — it will not be shown again.</p>
         <div style="margin-top:.75rem;display:flex;gap:.5rem;align-items:center;flex-wrap:wrap;">
           <code class="mono" id="new-key" style="font-size:.85rem;word-break:break-all;flex:1;min-width:0;"><%= newKey %></code>
-          <button type="button" class="btn btn-sm" onclick="copyKey(event)">Copy</button>
+          <button type="button" class="btn btn-sm" id="copy-key-btn">Copy</button>
         </div>
         <% if (keyRow && keyRow.status === 'pending') { %>
         <p style="margin-top:.75rem;" class="muted">Your key is pending admin approval. It will become active once an Admin approves your request.</p>
@@ -79,9 +79,9 @@
             <input type="hidden" name="_csrf" value="<%= csrfToken %>">
             <button type="submit" class="btn btn-sm">Generate New Key</button>
           </form>
-          <form method="POST" action="/streamdeck-key/revoke">
+          <form method="POST" action="/streamdeck-key/revoke" class="js-confirm-revoke-key">
             <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-            <button type="submit" class="btn btn-sm btn-ghost" onclick="return confirm('Revoke your API key? It will stop working immediately.')">Revoke Key</button>
+            <button type="submit" class="btn btn-sm btn-ghost">Revoke Key</button>
           </form>
         </div>
 
@@ -143,6 +143,7 @@
     </section>
   </main>
   <%- include('partials/pwa-register') %>
+  <script src="/utils.js"></script>
   <script src="/streamdeck-keys.js"></script>
 </body>
 </html>

--- a/views/streams.ejs
+++ b/views/streams.ejs
@@ -213,9 +213,9 @@
               <td>
                 <div class="actions">
                   <% if (isAdmin && isConnected) { %>
-                  <form method="POST" action="/admin/streams/twitch-disconnect/<%= s.id %>" class="inline-form-sm">
+                  <form method="POST" action="/admin/streams/twitch-disconnect/<%= s.id %>" class="inline-form-sm js-confirm-disconnect-twitch" data-twitch-name="<%= s.twitch_name %>">
                     <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-                    <button type="submit" class="btn btn-ghost btn-sm" onclick="return confirm('Disconnect Twitch for <%= s.twitch_name %>?')">Disconnect</button>
+                    <button type="submit" class="btn btn-ghost btn-sm">Disconnect</button>
                   </form>
                   <% } %>
                   <form method="POST" action="/admin/streams/streamers/remove" class="inline-form-sm js-confirm-remove-streamer" data-streamer-name="<%= s.twitch_name ?? s.discord_id %>">


### PR DESCRIPTION
## Summary
- The site's CSP sets `script-src-attr 'none'`, which blocks inline `onclick` attributes. The streamdeck pages used `onclick="copyKey(event)"` and `onclick="return confirm(...)"`, so the browser blocked them — including the reported broken Copy button on `/streamdeck-key`.
- While fixing the streamdeck pages, found the same problem in several other views and fixed those too:
  - `views/streams.ejs` — Disconnect-Twitch confirm button.
  - `views/dashboard.ejs` — the reconnect-modal Dismiss button, plus the inline `<script>` block driving it. That block had no `src`, so it's also blocked outright by `script-src 'self'` (no `unsafe-inline`/nonce) — a stricter violation than the attribute case.
  - `views/overlayAdmin.ejs` — Delete-video and remove-reward-assignment confirms (this page had no `<script>` tags at all before).
  - `views/streamdeck-keys-admin.ejs` — Deny/Revoke confirms (same issue as the user-facing streamdeck-keys page).
- All of these were moved to `addEventListener` calls in external scripts, reusing the existing `confirmSubmit` class-based pattern already used in `counters.js`/`admin.js`/`streams-live-poll.js`. New files: `public/streamdeck-keys-admin.js`, `public/overlayAdmin.js`, `public/dashboard-reconnect.js`.
- Scanned all of `views/` afterward for any remaining inline event-handler attributes or `<script>` blocks without `src` — none remain.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (all 1344 tests pass)
- [ ] Manually verify on `/streamdeck-key`: generate a key, click Copy, confirm it copies with no CSP console error; click Revoke and confirm the dialog fires.
- [ ] Manually verify admin streamdeck-keys, streams, dashboard (reconnect modal), and overlay admin pages: confirm dialogs and the reconnect dismiss button work with no CSP console errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Moved confirmation dialogs and submit-blocking behavior from inline prompts to centralized client-side handling across the dashboard and admin panels.

* **New Features**
  * Added persistent Twitch reconnect modal dismissal (stays dismissed after you choose “Dismiss”).
  * Improved Streamdeck API key copy flow with “Copied!” feedback and a graceful fallback if clipboard access isn’t available.
  * Added/standardized confirmation prompts for destructive actions: video deletion, reward removal, key deny/revoke, and Twitch disconnect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->