### PR TITLE
Use Twitch EventSub to speed up live detection and keep Discord posts in sync

### DIFF
--- a/src/twitch/eventsub/twitchEventSubHandler.test.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.test.ts
@@ -7,7 +7,7 @@ vi.mock('../monitor/twitchMonitor', () => ({ triggerImmediateLiveCheck: vi.fn().
 
 import {
   handleFollow, handleSub, handleResub, handleGiftSub, handleRaid, handleRedemption,
-  handleStreamOnline, handleStreamOffline,
+  handleStreamOnline, handleStreamOffline, handleChannelUpdate,
   registerEventSubOverlayRuntime, registerEventSubTwitchRuntime,
 } from './twitchEventSubHandler';
 import { getVideosForReward } from '../../db';
@@ -285,6 +285,13 @@ describe('handleStreamOnline', () => {
 describe('handleStreamOffline', () => {
   it('triggers an immediate live-check for the broadcaster login', async () => {
     await handleStreamOffline('streamer');
+    expect(triggerImmediateLiveCheck).toHaveBeenCalledWith('streamer');
+  });
+});
+
+describe('handleChannelUpdate', () => {
+  it('triggers an immediate live-check for the broadcaster login', async () => {
+    await handleChannelUpdate('streamer');
     expect(triggerImmediateLiveCheck).toHaveBeenCalledWith('streamer');
   });
 });

--- a/src/twitch/eventsub/twitchEventSubHandler.test.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.test.ts
@@ -3,10 +3,16 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('../../db', () => ({ getVideosForReward: vi.fn() }));
 vi.mock('../../commands/soundSelector', () => ({ pickWeightedRandom: vi.fn() }));
 vi.mock('../../shared/logger', () => ({ createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }));
+vi.mock('../monitor/twitchMonitor', () => ({ triggerImmediateLiveCheck: vi.fn().mockResolvedValue(undefined) }));
 
-import { handleFollow, handleSub, handleResub, handleGiftSub, handleRaid, handleRedemption, registerEventSubOverlayRuntime, registerEventSubTwitchRuntime } from './twitchEventSubHandler';
+import {
+  handleFollow, handleSub, handleResub, handleGiftSub, handleRaid, handleRedemption,
+  handleStreamOnline, handleStreamOffline,
+  registerEventSubOverlayRuntime, registerEventSubTwitchRuntime,
+} from './twitchEventSubHandler';
 import { getVideosForReward } from '../../db';
 import { pickWeightedRandom } from '../../commands/soundSelector';
+import { triggerImmediateLiveCheck } from '../monitor/twitchMonitor';
 
 const mockSend = vi.fn<(channel: string, message: string) => Promise<void>>();
 registerEventSubTwitchRuntime({ send: mockSend });
@@ -263,5 +269,22 @@ describe('handleRedemption', () => {
     expect(getVideosForReward).toHaveBeenCalledWith('reward-abc', streamerId);
     expect(pickWeightedRandom).toHaveBeenCalledWith(videos);
     expect(mockPushOverlayEvent).toHaveBeenCalledWith('streamer', '/overlay/videos/7/clip2.mp4');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleStreamOnline / handleStreamOffline
+// ---------------------------------------------------------------------------
+describe('handleStreamOnline', () => {
+  it('triggers an immediate live-check for the broadcaster login', async () => {
+    await handleStreamOnline('streamer');
+    expect(triggerImmediateLiveCheck).toHaveBeenCalledWith('streamer');
+  });
+});
+
+describe('handleStreamOffline', () => {
+  it('triggers an immediate live-check for the broadcaster login', async () => {
+    await handleStreamOffline('streamer');
+    expect(triggerImmediateLiveCheck).toHaveBeenCalledWith('streamer');
   });
 });

--- a/src/twitch/eventsub/twitchEventSubHandler.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.ts
@@ -238,6 +238,7 @@ export async function handleRedemption(
  * here is harmless if it already caught the change first.
  *
  * @param login - Broadcaster login name.
+ * @returns Resolves after triggering the immediate live-check.
  */
 export async function handleStreamOnline(login: string): Promise<void> {
   await triggerImmediateLiveCheck(login);
@@ -250,6 +251,7 @@ export async function handleStreamOnline(login: string): Promise<void> {
  * `liveStates` map.
  *
  * @param login - Broadcaster login name.
+ * @returns Resolves after triggering the immediate live-check.
  */
 export async function handleStreamOffline(login: string): Promise<void> {
   await triggerImmediateLiveCheck(login);
@@ -262,6 +264,7 @@ export async function handleStreamOffline(login: string): Promise<void> {
  * on Discord without waiting for the next 60s poll.
  *
  * @param login - Broadcaster login name.
+ * @returns Resolves after triggering the immediate live-check.
  */
 export async function handleChannelUpdate(login: string): Promise<void> {
   await triggerImmediateLiveCheck(login);

--- a/src/twitch/eventsub/twitchEventSubHandler.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.ts
@@ -2,6 +2,7 @@ import type { EventSubConfig } from '../../db';
 import { getVideosForReward } from '../../db';
 import { pickWeightedRandom } from '../../commands/soundSelector';
 import { createLogger } from '../../shared/logger';
+import { triggerImmediateLiveCheck } from '../monitor/twitchMonitor';
 
 const log = createLogger('EventSubHandler');
 
@@ -228,4 +229,28 @@ export async function handleRedemption(
   const videoPath = `/overlay/videos/${streamerId}/${filename}`;
   _overlayRuntime?.pushOverlayEvent(login, videoPath);
   log.info(`Overlay triggered for ${login}: reward="${event.reward.title}" video=${filename}`);
+}
+
+/**
+ * Handle a stream.online EventSub notification by triggering an immediate live-check
+ * for the broadcaster, bypassing the Twitch monitor's 60s poll interval. The poller
+ * still runs as a fallback for streamers without EventSub connected, and re-checking
+ * here is harmless if it already caught the change first.
+ *
+ * @param login - Broadcaster login name.
+ */
+export async function handleStreamOnline(login: string): Promise<void> {
+  await triggerImmediateLiveCheck(login);
+}
+
+/**
+ * Handle a stream.offline EventSub notification by triggering an immediate live-check
+ * for the broadcaster. This starts the same 5-minute offline grace period the poller
+ * uses before removing the live announcement, since both paths share the same
+ * `liveStates` map.
+ *
+ * @param login - Broadcaster login name.
+ */
+export async function handleStreamOffline(login: string): Promise<void> {
+  await triggerImmediateLiveCheck(login);
 }

--- a/src/twitch/eventsub/twitchEventSubHandler.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.ts
@@ -254,3 +254,15 @@ export async function handleStreamOnline(login: string): Promise<void> {
 export async function handleStreamOffline(login: string): Promise<void> {
   await triggerImmediateLiveCheck(login);
 }
+
+/**
+ * Handle a channel.update EventSub notification (title/category change) by triggering
+ * an immediate live-check for the broadcaster. Reuses the same poll-and-decide logic
+ * as stream.online/offline, so a title or game change posted via Twitch is reflected
+ * on Discord without waiting for the next 60s poll.
+ *
+ * @param login - Broadcaster login name.
+ */
+export async function handleChannelUpdate(login: string): Promise<void> {
+  await triggerImmediateLiveCheck(login);
+}

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
@@ -22,6 +22,8 @@ vi.mock('./twitchEventSubHandler', () => ({
   handleGiftSub: vi.fn(),
   handleRaid: vi.fn(),
   handleRedemption: vi.fn(),
+  handleStreamOnline: vi.fn().mockResolvedValue(undefined),
+  handleStreamOffline: vi.fn().mockResolvedValue(undefined),
 }));
 
 import {
@@ -29,11 +31,13 @@ import {
   clearAuthFailedSubs,
   loadStreamersForEventSub,
   subscribeForStreamer,
+  dispatchNotification,
 } from './twitchEventSubSubscriptions';
 import { getAllEventSubStreamers } from '../../db';
 import { getValidToken, createEventSubSubscription, listEventSubSubscriptions, deleteEventSubSubscription, TwitchAuthError } from './twitchApiEventSub';
 import { getUsers } from '../twitchApi';
 import { getActiveChannels } from '../twitchChannelMembership';
+import { handleStreamOnline, handleStreamOffline } from './twitchEventSubHandler';
 
 // ---------------------------------------------------------------------------
 // hasAuthFailedSubs / clearAuthFailedSubs
@@ -218,5 +222,76 @@ describe('subscribeForStreamer', () => {
     });
 
     expect(deleteEventSubSubscription).toHaveBeenCalledWith('stale-sub', 'tok-z');
+  });
+
+  it('subscribes to stream.online and stream.offline whenever config and token are present', async () => {
+    vi.mocked(getActiveChannels).mockReturnValue(new Set(['botinchannel']));
+    vi.mocked(createEventSubSubscription).mockResolvedValue('sub-new');
+    vi.mocked(listEventSubSubscriptions).mockResolvedValue([]);
+
+    await subscribeForStreamer('sess-live', {
+      uid: 'uid-live',
+      token: 'tok-live',
+      name: 'botInChannel',
+      // No chat-alert features enabled — stream.online/offline should still subscribe.
+      config: { follow_enabled: false, sub_enabled: false, raid_enabled: false } as any,
+      streamerId: 22,
+    });
+
+    expect(createEventSubSubscription).toHaveBeenCalledWith(
+      'stream.online', '1', { broadcaster_user_id: 'uid-live' }, 'sess-live', 'tok-live',
+    );
+    expect(createEventSubSubscription).toHaveBeenCalledWith(
+      'stream.offline', '1', { broadcaster_user_id: 'uid-live' }, 'sess-live', 'tok-live',
+    );
+  });
+
+  it('does not subscribe to stream.online/offline when config is null', async () => {
+    vi.mocked(getActiveChannels).mockReturnValue(new Set(['botinchannel']));
+    vi.mocked(createEventSubSubscription).mockResolvedValue('sub-new');
+    vi.mocked(listEventSubSubscriptions).mockResolvedValue([]);
+
+    await subscribeForStreamer('sess-nocfg', {
+      uid: 'uid-nocfg',
+      token: 'tok-nocfg',
+      name: 'botInChannel',
+      config: null,
+      streamerId: 23,
+    });
+
+    expect(createEventSubSubscription).not.toHaveBeenCalledWith(
+      'stream.online', expect.anything(), expect.anything(), expect.anything(), expect.anything(),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dispatchNotification — stream.online / stream.offline routing
+// ---------------------------------------------------------------------------
+describe('dispatchNotification routes stream.online/offline', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    clearAuthFailedSubs('liveStreamer');
+    vi.mocked(getActiveChannels).mockReturnValue(new Set(['livestreamer']));
+    vi.mocked(createEventSubSubscription).mockResolvedValue('sub-id');
+    vi.mocked(listEventSubSubscriptions).mockResolvedValue([]);
+    // Populate streamerMap with a known config so dispatchNotification doesn't early-exit.
+    await subscribeForStreamer('sess-dispatch', {
+      uid: 'uid-dispatch',
+      token: 'tok-dispatch',
+      name: 'liveStreamer',
+      config: { follow_enabled: false, sub_enabled: false, raid_enabled: false } as any,
+      streamerId: 30,
+    });
+  });
+
+  it('calls handleStreamOnline for a stream.online notification', () => {
+    dispatchNotification('stream.online', {}, { broadcaster_user_id: 'uid-dispatch' });
+    expect(handleStreamOnline).toHaveBeenCalledWith('liveStreamer');
+  });
+
+  it('calls handleStreamOffline for a stream.offline notification', () => {
+    dispatchNotification('stream.offline', {}, { broadcaster_user_id: 'uid-dispatch' });
+    expect(handleStreamOffline).toHaveBeenCalledWith('liveStreamer');
   });
 });

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
@@ -24,6 +24,7 @@ vi.mock('./twitchEventSubHandler', () => ({
   handleRedemption: vi.fn(),
   handleStreamOnline: vi.fn().mockResolvedValue(undefined),
   handleStreamOffline: vi.fn().mockResolvedValue(undefined),
+  handleChannelUpdate: vi.fn().mockResolvedValue(undefined),
 }));
 
 import {
@@ -37,7 +38,7 @@ import { getAllEventSubStreamers } from '../../db';
 import { getValidToken, createEventSubSubscription, listEventSubSubscriptions, deleteEventSubSubscription, TwitchAuthError } from './twitchApiEventSub';
 import { getUsers } from '../twitchApi';
 import { getActiveChannels } from '../twitchChannelMembership';
-import { handleStreamOnline, handleStreamOffline } from './twitchEventSubHandler';
+import { handleStreamOnline, handleStreamOffline, handleChannelUpdate } from './twitchEventSubHandler';
 
 // ---------------------------------------------------------------------------
 // hasAuthFailedSubs / clearAuthFailedSubs
@@ -244,9 +245,12 @@ describe('subscribeForStreamer', () => {
     expect(createEventSubSubscription).toHaveBeenCalledWith(
       'stream.offline', '1', { broadcaster_user_id: 'uid-live' }, 'sess-live', 'tok-live',
     );
+    expect(createEventSubSubscription).toHaveBeenCalledWith(
+      'channel.update', '2', { broadcaster_user_id: 'uid-live' }, 'sess-live', 'tok-live',
+    );
   });
 
-  it('does not subscribe to stream.online/offline when config is null', async () => {
+  it('does not subscribe to stream.online/offline/channel.update when config is null', async () => {
     vi.mocked(getActiveChannels).mockReturnValue(new Set(['botinchannel']));
     vi.mocked(createEventSubSubscription).mockResolvedValue('sub-new');
     vi.mocked(listEventSubSubscriptions).mockResolvedValue([]);
@@ -261,6 +265,9 @@ describe('subscribeForStreamer', () => {
 
     expect(createEventSubSubscription).not.toHaveBeenCalledWith(
       'stream.online', expect.anything(), expect.anything(), expect.anything(), expect.anything(),
+    );
+    expect(createEventSubSubscription).not.toHaveBeenCalledWith(
+      'channel.update', expect.anything(), expect.anything(), expect.anything(), expect.anything(),
     );
   });
 });
@@ -293,5 +300,10 @@ describe('dispatchNotification routes stream.online/offline', () => {
   it('calls handleStreamOffline for a stream.offline notification', () => {
     dispatchNotification('stream.offline', {}, { broadcaster_user_id: 'uid-dispatch' });
     expect(handleStreamOffline).toHaveBeenCalledWith('liveStreamer');
+  });
+
+  it('calls handleChannelUpdate for a channel.update notification', () => {
+    dispatchNotification('channel.update', {}, { broadcaster_user_id: 'uid-dispatch' });
+    expect(handleChannelUpdate).toHaveBeenCalledWith('liveStreamer');
   });
 });

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
@@ -267,6 +267,9 @@ describe('subscribeForStreamer', () => {
       'stream.online', expect.anything(), expect.anything(), expect.anything(), expect.anything(),
     );
     expect(createEventSubSubscription).not.toHaveBeenCalledWith(
+      'stream.offline', expect.anything(), expect.anything(), expect.anything(), expect.anything(),
+    );
+    expect(createEventSubSubscription).not.toHaveBeenCalledWith(
       'channel.update', expect.anything(), expect.anything(), expect.anything(), expect.anything(),
     );
   });

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -7,7 +7,7 @@ import { normalizeTwitchChannelName } from '../twitchChannelName';
 import { createEventSubSubscription, listEventSubSubscriptions, deleteEventSubSubscription, getValidToken, TwitchAuthError } from './twitchApiEventSub';
 import {
   handleFollow, handleSub, handleResub, handleGiftSub, handleRaid, handleRedemption,
-  handleStreamOnline, handleStreamOffline,
+  handleStreamOnline, handleStreamOffline, handleChannelUpdate,
   FollowEvent, SubEvent, ResubEvent, GiftSubEvent, RaidEvent, RedemptionEvent,
 } from './twitchEventSubHandler';
 
@@ -49,6 +49,7 @@ const notificationHandlers = new Map<string, NotificationHandler>([
   ['channel.channel_points_custom_reward_redemption.add',  (l, e, c, sid) => handleRedemption(l, e as RedemptionEvent, c, sid)],
   ['stream.online',                                    (l) => handleStreamOnline(l)],
   ['stream.offline',                                   (l) => handleStreamOffline(l)],
+  ['channel.update',                                    (l) => handleChannelUpdate(l)],
 ]);
 
 async function deleteStaleSubscriptions(uid: string, desired: Set<string>, userToken: string | null): Promise<void> {
@@ -133,16 +134,18 @@ interface LiveEventsParams {
   sid: string; uid: string; token: string | null; config: EventSubConfig | null; name: string; desired: Set<string>;
 }
 
-// stream.online/offline require no scope beyond a valid token, so subscribe
-// whenever EventSub is connected at all — this drives an immediate live-check
+// stream.online/offline and channel.update require no scope beyond a valid token, so
+// subscribe whenever EventSub is connected at all — this drives an immediate live-check
 // that supplements (not replaces) the 60s poller.
 async function subscribeToLiveEvents(params: LiveEventsParams): Promise<void> {
   const { sid, uid, token, config, name, desired } = params;
   if (!config || !token) return;
   desired.add('stream.online');
   desired.add('stream.offline');
+  desired.add('channel.update');
   await subscribe(sid, { type: 'stream.online', version: '1', condition: { broadcaster_user_id: uid } }, token, name);
   await subscribe(sid, { type: 'stream.offline', version: '1', condition: { broadcaster_user_id: uid } }, token, name);
+  await subscribe(sid, { type: 'channel.update', version: '2', condition: { broadcaster_user_id: uid } }, token, name);
 }
 
 /** Data bundle passed to a StreamerConnection for setting up EventSub subscriptions. */

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -123,17 +123,21 @@ async function createSubscriptionsForStreamer(
     }, token, name);
   }
 
-  await subscribeToLiveEvents(sid, uid, token, config, name, desired);
+  await subscribeToLiveEvents({ sid, uid, token, config, name, desired });
 
   return desired;
+}
+
+/** Params bundle for {@link subscribeToLiveEvents} — groups the per-streamer subscription context into a single argument. */
+interface LiveEventsParams {
+  sid: string; uid: string; token: string | null; config: EventSubConfig | null; name: string; desired: Set<string>;
 }
 
 // stream.online/offline require no scope beyond a valid token, so subscribe
 // whenever EventSub is connected at all — this drives an immediate live-check
 // that supplements (not replaces) the 60s poller.
-async function subscribeToLiveEvents(
-  sid: string, uid: string, token: string | null, config: EventSubConfig | null, name: string, desired: Set<string>,
-): Promise<void> {
+async function subscribeToLiveEvents(params: LiveEventsParams): Promise<void> {
+  const { sid, uid, token, config, name, desired } = params;
   if (!config || !token) return;
   desired.add('stream.online');
   desired.add('stream.offline');

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -7,6 +7,7 @@ import { normalizeTwitchChannelName } from '../twitchChannelName';
 import { createEventSubSubscription, listEventSubSubscriptions, deleteEventSubSubscription, getValidToken, TwitchAuthError } from './twitchApiEventSub';
 import {
   handleFollow, handleSub, handleResub, handleGiftSub, handleRaid, handleRedemption,
+  handleStreamOnline, handleStreamOffline,
   FollowEvent, SubEvent, ResubEvent, GiftSubEvent, RaidEvent, RedemptionEvent,
 } from './twitchEventSubHandler';
 
@@ -46,6 +47,8 @@ const notificationHandlers = new Map<string, NotificationHandler>([
   ['channel.subscription.gift',                        (l, e, c) => handleGiftSub(l, e as GiftSubEvent, c)],
   ['channel.raid',                                     (l, e, c) => handleRaid(l, e as RaidEvent, c)],
   ['channel.channel_points_custom_reward_redemption.add',  (l, e, c, sid) => handleRedemption(l, e as RedemptionEvent, c, sid)],
+  ['stream.online',                                    (l) => handleStreamOnline(l)],
+  ['stream.offline',                                   (l) => handleStreamOffline(l)],
 ]);
 
 async function deleteStaleSubscriptions(uid: string, desired: Set<string>, userToken: string | null): Promise<void> {
@@ -118,6 +121,16 @@ async function createSubscriptionsForStreamer(
       version: '1',
       condition: { broadcaster_user_id: uid },
     }, token, name);
+  }
+
+  // stream.online/offline require no scope beyond a valid token, so subscribe
+  // whenever EventSub is connected at all — this drives an immediate live-check
+  // that supplements (not replaces) the 60s poller.
+  if (config && token) {
+    desired.add('stream.online');
+    desired.add('stream.offline');
+    await subscribe(sid, { type: 'stream.online', version: '1', condition: { broadcaster_user_id: uid } }, token, name);
+    await subscribe(sid, { type: 'stream.offline', version: '1', condition: { broadcaster_user_id: uid } }, token, name);
   }
 
   return desired;

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -123,17 +123,22 @@ async function createSubscriptionsForStreamer(
     }, token, name);
   }
 
-  // stream.online/offline require no scope beyond a valid token, so subscribe
-  // whenever EventSub is connected at all — this drives an immediate live-check
-  // that supplements (not replaces) the 60s poller.
-  if (config && token) {
-    desired.add('stream.online');
-    desired.add('stream.offline');
-    await subscribe(sid, { type: 'stream.online', version: '1', condition: { broadcaster_user_id: uid } }, token, name);
-    await subscribe(sid, { type: 'stream.offline', version: '1', condition: { broadcaster_user_id: uid } }, token, name);
-  }
+  await subscribeToLiveEvents(sid, uid, token, config, name, desired);
 
   return desired;
+}
+
+// stream.online/offline require no scope beyond a valid token, so subscribe
+// whenever EventSub is connected at all — this drives an immediate live-check
+// that supplements (not replaces) the 60s poller.
+async function subscribeToLiveEvents(
+  sid: string, uid: string, token: string | null, config: EventSubConfig | null, name: string, desired: Set<string>,
+): Promise<void> {
+  if (!config || !token) return;
+  desired.add('stream.online');
+  desired.add('stream.offline');
+  await subscribe(sid, { type: 'stream.online', version: '1', condition: { broadcaster_user_id: uid } }, token, name);
+  await subscribe(sid, { type: 'stream.offline', version: '1', condition: { broadcaster_user_id: uid } }, token, name);
 }
 
 /** Data bundle passed to a StreamerConnection for setting up EventSub subscriptions. */

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -124,28 +124,19 @@ async function createSubscriptionsForStreamer(
     }, token, name);
   }
 
-  await subscribeToLiveEvents({ sid, uid, token, config, name, desired });
+  // stream.online/offline and channel.update require no scope beyond a valid token, so
+  // subscribe whenever EventSub is connected at all — this drives an immediate live-check
+  // that supplements (not replaces) the 60s poller.
+  if (config && token) {
+    desired.add('stream.online');
+    desired.add('stream.offline');
+    desired.add('channel.update');
+    await subscribe(sid, { type: 'stream.online', version: '1', condition: { broadcaster_user_id: uid } }, token, name);
+    await subscribe(sid, { type: 'stream.offline', version: '1', condition: { broadcaster_user_id: uid } }, token, name);
+    await subscribe(sid, { type: 'channel.update', version: '2', condition: { broadcaster_user_id: uid } }, token, name);
+  }
 
   return desired;
-}
-
-/** Params bundle for {@link subscribeToLiveEvents} — groups the per-streamer subscription context into a single argument. */
-interface LiveEventsParams {
-  sid: string; uid: string; token: string | null; config: EventSubConfig | null; name: string; desired: Set<string>;
-}
-
-// stream.online/offline and channel.update require no scope beyond a valid token, so
-// subscribe whenever EventSub is connected at all — this drives an immediate live-check
-// that supplements (not replaces) the 60s poller.
-async function subscribeToLiveEvents(params: LiveEventsParams): Promise<void> {
-  const { sid, uid, token, config, name, desired } = params;
-  if (!config || !token) return;
-  desired.add('stream.online');
-  desired.add('stream.offline');
-  desired.add('channel.update');
-  await subscribe(sid, { type: 'stream.online', version: '1', condition: { broadcaster_user_id: uid } }, token, name);
-  await subscribe(sid, { type: 'stream.offline', version: '1', condition: { broadcaster_user_id: uid } }, token, name);
-  await subscribe(sid, { type: 'channel.update', version: '2', condition: { broadcaster_user_id: uid } }, token, name);
 }
 
 /** Data bundle passed to a StreamerConnection for setting up EventSub subscriptions. */

--- a/src/twitch/monitor/twitchMonitor.test.ts
+++ b/src/twitch/monitor/twitchMonitor.test.ts
@@ -167,6 +167,38 @@ describe('triggerImmediateLiveCheck', () => {
   });
 });
 
+// A login can map to multiple monitored streamer rows (the same Twitch name posted
+// to several Discord groups) — a failure for one must not skip the others.
+describe('triggerImmediateLiveCheck with multiple streamer rows for one login', () => {
+  const postAnnouncementSpy = vi.spyOn(twitchMonitorAnnouncements, 'postAnnouncement');
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.mocked(getAllStreamersWithGroups).mockResolvedValue([
+      makeStreamer({ id: 5, group: { id: 1, name: 'GroupA', discord_channel: '111', live_message: 'live', new_game_message: 'game', multi_twitch: false, delete_old_posts: false } }),
+      makeStreamer({ id: 6, group: { id: 2, name: 'GroupB', discord_channel: '222', live_message: 'live', new_game_message: 'game', multi_twitch: false, delete_old_posts: false } }),
+    ] as any);
+    vi.mocked(getUsers).mockResolvedValue([{ login: 'teststreamer', id: 'uid-5' }]);
+    vi.mocked(getDiscordClient).mockReturnValue(makeDiscordClient() as any);
+    await startTwitchMonitor();
+  });
+
+  afterEach(async () => {
+    await stopTwitchMonitor();
+  });
+
+  it('still processes the second streamer row after the first one fails', async () => {
+    vi.mocked(getStreams).mockResolvedValue([makeStream()] as any);
+    postAnnouncementSpy.mockRejectedValueOnce(new Error('discord down'));
+
+    await triggerImmediateLiveCheck('teststreamer');
+
+    expect(postAnnouncementSpy).toHaveBeenCalledTimes(2);
+    const states = getLiveStates();
+    expect(states.map((s) => s.streamerId)).toContain(6);
+  });
+});
+
 // Drives the 60s poll interval set up by startTwitchMonitor: pollStreams() dispatches
 // the full streamer list to dispatchStreamerPolls() on each tick, separately from the
 // single-streamer triggerImmediateLiveCheck() path exercised above.

--- a/src/twitch/monitor/twitchMonitor.test.ts
+++ b/src/twitch/monitor/twitchMonitor.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('../../shared/logger', () => ({ createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }));
 vi.mock('../../shared/statusStore', () => ({ setTwitchChannelLive: vi.fn() }));
-vi.mock('../../discord/discordBot', () => ({ getDiscordClient: vi.fn().mockReturnValue(null) }));
+vi.mock('../../discord/discordBot', () => ({ getDiscordClient: vi.fn() }));
 vi.mock('../../db', () => ({
   getAllStreamersWithGroups: vi.fn(),
   setStreamerLive: vi.fn().mockResolvedValue(undefined),
@@ -25,6 +25,22 @@ import { startTwitchMonitor, stopTwitchMonitor, triggerImmediateLiveCheck, getLi
 import { getAllStreamersWithGroups } from '../../db';
 import { getUsers, getStreams } from '../twitchApi';
 import { cancelOfflineTimersForLogin, handleStreamOffline } from './twitchMonitorOffline';
+import { getDiscordClient } from '../../discord/discordBot';
+import * as twitchMonitorAnnouncements from './twitchMonitorAnnouncements';
+
+function makeTextChannel(msgOverrides: Record<string, unknown> = {}) {
+  const message = { id: 'msg1', channelId: '111', delete: vi.fn().mockResolvedValue(undefined), edit: vi.fn().mockResolvedValue(undefined), ...msgOverrides };
+  return {
+    isTextBased: () => true,
+    send: vi.fn().mockResolvedValue({ id: 'msg1', channelId: '111' }),
+    messages: { fetch: vi.fn().mockResolvedValue(message) },
+    _message: message,
+  };
+}
+
+function makeDiscordClient(channel: ReturnType<typeof makeTextChannel> = makeTextChannel()) {
+  return { channels: { fetch: vi.fn().mockResolvedValue(channel) } };
+}
 
 function makeStreamer(overrides: Record<string, unknown> = {}) {
   return {
@@ -46,7 +62,7 @@ function makeStreamer(overrides: Record<string, unknown> = {}) {
 function makeStream(overrides: Record<string, unknown> = {}) {
   return {
     user_id: 'uid-5', user_login: 'teststreamer', game_name: 'Just Chatting',
-    title: 'hello', thumbnail_url: '', type: 'live',
+    title: 'hello', thumbnail_url: 'https://example.com/thumb-{width}x{height}.jpg', type: 'live',
     ...overrides,
   };
 }
@@ -55,10 +71,13 @@ function makeStream(overrides: Record<string, unknown> = {}) {
 // the same poll-and-decide logic the 60s poller uses for a single streamer, so EventSub
 // can short-circuit the poll interval without duplicating any announcement/grace-period code.
 describe('triggerImmediateLiveCheck', () => {
+  const editAnnouncementSpy = vi.spyOn(twitchMonitorAnnouncements, 'editAnnouncement');
+
   beforeEach(async () => {
     vi.clearAllMocks();
     vi.mocked(getAllStreamersWithGroups).mockResolvedValue([makeStreamer()] as any);
     vi.mocked(getUsers).mockResolvedValue([{ login: 'teststreamer', id: 'uid-5' }]);
+    vi.mocked(getDiscordClient).mockReturnValue(makeDiscordClient() as any);
     await startTwitchMonitor();
   });
 
@@ -112,5 +131,30 @@ describe('triggerImmediateLiveCheck', () => {
     await triggerImmediateLiveCheck('teststreamer'); // back online before grace period ends
 
     expect(cancelOfflineTimersForLogin).toHaveBeenCalledWith(expect.anything(), 'teststreamer');
+  });
+
+  it('edits the announcement with the live_message template on a title-only change', async () => {
+    vi.mocked(getStreams).mockResolvedValueOnce([makeStream()] as any);
+    await triggerImmediateLiveCheck('teststreamer'); // first check: goes live
+
+    vi.mocked(getStreams).mockResolvedValueOnce([makeStream({ title: 'New title' })] as any);
+    await triggerImmediateLiveCheck('teststreamer'); // second check: title changed, game unchanged
+
+    expect(editAnnouncementSpy).toHaveBeenCalledWith(
+      expect.anything(), expect.anything(), expect.objectContaining({ title: 'New title' }), 'live_message',
+    );
+    expect(getLiveStates()[0].title).toBe('New title');
+  });
+
+  it('edits the announcement with the new_game_message template on a game change', async () => {
+    vi.mocked(getStreams).mockResolvedValueOnce([makeStream()] as any);
+    await triggerImmediateLiveCheck('teststreamer'); // first check: goes live
+
+    vi.mocked(getStreams).mockResolvedValueOnce([makeStream({ game_name: 'Valorant' })] as any);
+    await triggerImmediateLiveCheck('teststreamer'); // second check: game changed
+
+    expect(editAnnouncementSpy).toHaveBeenCalledWith(
+      expect.anything(), expect.anything(), expect.objectContaining({ game_name: 'Valorant' }), 'new_game_message',
+    );
   });
 });

--- a/src/twitch/monitor/twitchMonitor.test.ts
+++ b/src/twitch/monitor/twitchMonitor.test.ts
@@ -157,4 +157,42 @@ describe('triggerImmediateLiveCheck', () => {
       expect.anything(), expect.anything(), expect.objectContaining({ game_name: 'Valorant' }), 'new_game_message',
     );
   });
+
+  it('logs and resolves without throwing when the Twitch API call fails', async () => {
+    vi.mocked(getStreams).mockRejectedValueOnce(new Error('API down'));
+
+    await expect(triggerImmediateLiveCheck('teststreamer')).resolves.toBeUndefined();
+
+    expect(getLiveStates()).toHaveLength(0);
+  });
+});
+
+// Drives the 60s poll interval set up by startTwitchMonitor: pollStreams() dispatches
+// the full streamer list to dispatchStreamerPolls() on each tick, separately from the
+// single-streamer triggerImmediateLiveCheck() path exercised above.
+describe('60s poll interval', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.mocked(getAllStreamersWithGroups).mockResolvedValue([makeStreamer()] as any);
+    vi.mocked(getUsers).mockResolvedValue([{ login: 'teststreamer', id: 'uid-5' }]);
+    vi.mocked(getDiscordClient).mockReturnValue(makeDiscordClient() as any);
+    await startTwitchMonitor();
+  });
+
+  afterEach(async () => {
+    await stopTwitchMonitor();
+    vi.useRealTimers();
+  });
+
+  it('polls every streamer on each tick and records newly-live streamers', async () => {
+    vi.mocked(getStreams).mockResolvedValue([makeStream()] as any);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(getStreams).toHaveBeenCalledWith(['uid-5']);
+    const states = getLiveStates();
+    expect(states).toHaveLength(1);
+    expect(states[0].login).toBe('teststreamer');
+  });
 });

--- a/src/twitch/monitor/twitchMonitor.test.ts
+++ b/src/twitch/monitor/twitchMonitor.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../shared/logger', () => ({ createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }));
+vi.mock('../../shared/statusStore', () => ({ setTwitchChannelLive: vi.fn() }));
+vi.mock('../../discord/discordBot', () => ({ getDiscordClient: vi.fn().mockReturnValue(null) }));
+vi.mock('../../db', () => ({
+  getAllStreamersWithGroups: vi.fn(),
+  setStreamerLive: vi.fn().mockResolvedValue(undefined),
+  clearStreamerLive: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../twitchApi', () => ({ getUsers: vi.fn(), getStreams: vi.fn() }));
+vi.mock('./twitchMonitorOffline', () => ({
+  cancelOfflineTimersForLogin: vi.fn(),
+  // Simulates the real module's effect (sets a non-null offlineTimer marker on matching
+  // entries) without scheduling a real 5-minute setTimeout that would leak past the test.
+  handleStreamOffline: vi.fn(async (liveStates: Map<string, { login: string; offlineTimer: unknown }>, _loginToUserId: unknown, login: string) => {
+    for (const state of liveStates.values()) {
+      if (state.login === login) state.offlineTimer = {};
+    }
+  }),
+}));
+vi.mock('./twitchMonitorStartup', () => ({ performStartupLiveCheck: vi.fn().mockResolvedValue(undefined) }));
+
+import { startTwitchMonitor, stopTwitchMonitor, triggerImmediateLiveCheck, getLiveStates } from './twitchMonitor';
+import { getAllStreamersWithGroups } from '../../db';
+import { getUsers, getStreams } from '../twitchApi';
+import { cancelOfflineTimersForLogin, handleStreamOffline } from './twitchMonitorOffline';
+
+function makeStreamer(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 5,
+    discord_id: 'd5',
+    twitch_name: 'teststreamer',
+    discord_message_id: null,
+    discord_channel_id: null,
+    live_game: null,
+    group: {
+      id: 1, name: 'Main', discord_channel: '111',
+      live_message: 'live', new_game_message: 'game',
+      multi_twitch: false, delete_old_posts: false,
+    },
+    ...overrides,
+  };
+}
+
+function makeStream(overrides: Record<string, unknown> = {}) {
+  return {
+    user_id: 'uid-5', user_login: 'teststreamer', game_name: 'Just Chatting',
+    title: 'hello', thumbnail_url: '', type: 'live',
+    ...overrides,
+  };
+}
+
+// Drives stream.online/offline EventSub notifications: triggerImmediateLiveCheck() re-runs
+// the same poll-and-decide logic the 60s poller uses for a single streamer, so EventSub
+// can short-circuit the poll interval without duplicating any announcement/grace-period code.
+describe('triggerImmediateLiveCheck', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.mocked(getAllStreamersWithGroups).mockResolvedValue([makeStreamer()] as any);
+    vi.mocked(getUsers).mockResolvedValue([{ login: 'teststreamer', id: 'uid-5' }]);
+    await startTwitchMonitor();
+  });
+
+  afterEach(async () => {
+    await stopTwitchMonitor();
+  });
+
+  it('no-ops without calling getStreams when the login is not monitored', async () => {
+    await triggerImmediateLiveCheck('unknownstreamer');
+    expect(getStreams).not.toHaveBeenCalled();
+  });
+
+  it('records the streamer as live on the first immediate check', async () => {
+    vi.mocked(getStreams).mockResolvedValue([makeStream()] as any);
+
+    await triggerImmediateLiveCheck('teststreamer');
+
+    expect(getStreams).toHaveBeenCalledWith(['uid-5']);
+    const states = getLiveStates();
+    expect(states).toHaveLength(1);
+    expect(states[0].login).toBe('teststreamer');
+    expect(states[0].currentGame).toBe('Just Chatting');
+  });
+
+  it('is case-insensitive on the login', async () => {
+    vi.mocked(getStreams).mockResolvedValue([makeStream()] as any);
+
+    await triggerImmediateLiveCheck('TestStreamer');
+
+    expect(getLiveStates()).toHaveLength(1);
+  });
+
+  it('starts the offline grace period when an already-live streamer is found offline', async () => {
+    vi.mocked(getStreams).mockResolvedValueOnce([makeStream()] as any);
+    await triggerImmediateLiveCheck('teststreamer'); // first check: goes live
+
+    vi.mocked(getStreams).mockResolvedValueOnce([]); // second check: offline
+    await triggerImmediateLiveCheck('teststreamer');
+
+    expect(handleStreamOffline).toHaveBeenCalledWith(expect.anything(), expect.anything(), 'teststreamer');
+  });
+
+  it('cancels the offline grace period when the streamer comes back during it', async () => {
+    vi.mocked(getStreams).mockResolvedValueOnce([makeStream()] as any);
+    await triggerImmediateLiveCheck('teststreamer'); // live
+
+    vi.mocked(getStreams).mockResolvedValueOnce([]);
+    await triggerImmediateLiveCheck('teststreamer'); // offline — grace period starts (mocked)
+
+    vi.mocked(getStreams).mockResolvedValueOnce([makeStream()] as any);
+    await triggerImmediateLiveCheck('teststreamer'); // back online before grace period ends
+
+    expect(cancelOfflineTimersForLogin).toHaveBeenCalledWith(expect.anything(), 'teststreamer');
+  });
+});

--- a/src/twitch/monitor/twitchMonitor.ts
+++ b/src/twitch/monitor/twitchMonitor.ts
@@ -15,7 +15,7 @@ import {
 } from './twitchMonitorMultitwitch';
 import { deleteAnnouncement } from './twitchMonitorAnnouncements';
 import { performStartupLiveCheck } from './twitchMonitorStartup';
-import { handlePollStreamer, dispatchStreamerPolls } from './twitchMonitorPoll';
+import { handlePollStreamer, dispatchStreamerPolls, withLoginLock } from './twitchMonitorPoll';
 
 const log = createLogger('TwitchMonitor');
 
@@ -60,9 +60,9 @@ async function pollStreams(): Promise<void> {
  * Immediately re-checks a single streamer's live status against the Twitch API,
  * bypassing the poll interval. Used by EventSub stream.online/offline notifications
  * to react faster than the 60s poll while reusing the same announcement and
- * offline-grace-period logic as the poller, so the two triggers can never disagree
- * on state — whichever fires first wins, the other is a no-op against the same
- * `liveStates` entry.
+ * offline-grace-period logic as the poller. The per-login `withLoginLock` ensures this
+ * never runs concurrently with a 60s poll tick (or another immediate check) for the same
+ * login, so the two triggers can't race on the same `liveStates` entry.
  *
  * @param login - Twitch login name of the streamer to check.
  */
@@ -79,7 +79,7 @@ export async function triggerImmediateLiveCheck(login: string): Promise<void> {
       streams.filter((s) => s.type === 'live').map((s) => [s.user_id, s]),
     );
     for (const streamer of matching) {
-      await handlePollStreamer(liveStates, loginToUserId, streamer, liveByUserId);
+      await withLoginLock(loginKey, () => handlePollStreamer(liveStates, loginToUserId, streamer, liveByUserId));
     }
   } catch (err) {
     log.error(`Immediate live check failed for ${loginKey}:`, err);

--- a/src/twitch/monitor/twitchMonitor.ts
+++ b/src/twitch/monitor/twitchMonitor.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '../../shared/logger';
 import { getAllStreamersWithGroups, DbStreamerFull } from '../../db';
-import { getUsers, getStreams, TwitchStream } from '../twitchApi';
+import { getUsers, getStreams } from '../twitchApi';
 import { LiveState } from './twitchMonitorTypes';
 import {
   DiscordMessagePreview,
@@ -13,17 +13,9 @@ import {
   buildMultiTwitchContext,
   getMultitwitchPreview,
 } from './twitchMonitorMultitwitch';
-import {
-  postAnnouncement,
-  editAnnouncement,
-  deleteAnnouncement,
-} from './twitchMonitorAnnouncements';
-import {
-  cancelOfflineTimersForLogin,
-  handleStreamOffline,
-} from './twitchMonitorOffline';
-import { setTwitchChannelLive } from '../../shared/statusStore';
+import { deleteAnnouncement } from './twitchMonitorAnnouncements';
 import { performStartupLiveCheck } from './twitchMonitorStartup';
+import { handlePollStreamer, dispatchStreamerPolls } from './twitchMonitorPoll';
 
 const log = createLogger('TwitchMonitor');
 
@@ -42,79 +34,6 @@ let currentPollPromise: Promise<void> = Promise.resolve();
 
 // ─── Polling ───────────────────────────────────────────────────────────────
 
-async function handlePollStreamer(
-  streamer: DbStreamerFull,
-  liveByUserId: Map<string, TwitchStream>,
-): Promise<void> {
-  const loginKey = streamer.twitch_name?.toLowerCase();
-  if (!loginKey) return;
-  const stateKey = String(streamer.id);
-  const userId = loginToUserId.get(loginKey);
-  if (!userId) return;
-
-  const pollStream = liveByUserId.get(userId);
-  const existing = liveStates.get(stateKey);
-
-  if (pollStream) {
-    if (existing?.offlineTimer) {
-      // Came back during grace period — cancel offline timers for all groups this login belongs to
-      cancelOfflineTimersForLogin(liveStates, loginKey);
-      log.info(`${loginKey} came back — offline timer(s) cancelled`);
-    }
-    setTwitchChannelLive(loginKey, true);
-    const isNew = !liveStates.has(stateKey);
-    if (isNew || (existing && !existing.messageId)) {
-      // Went live, or state exists with no Discord message (e.g. Discord wasn't ready at startup)
-      await postAnnouncement(liveStates, streamer, pollStream);
-      if (isNew) log.info(`${loginKey} went live in group ${streamer.group.name}`);
-    } else if (existing && existing.currentGame !== pollStream.game_name) {
-      // Game changed
-      await editAnnouncement(liveStates, existing, pollStream, 'new_game_message');
-      log.info(`${loginKey} game changed to ${pollStream.game_name}`);
-    } else if (existing && existing.title !== pollStream.title) {
-      // Title-only change — refresh the existing post without re-announcing a game change
-      await editAnnouncement(liveStates, existing, pollStream, 'live_message');
-      log.info(`${loginKey} title changed`);
-    } else if (existing) {
-      // Still live, nothing changed — keep currentStream in sync (e.g. thumbnail refresh)
-      existing.currentGame = pollStream.game_name;
-      existing.title = pollStream.title;
-      existing.currentStream = pollStream;
-    }
-  } else if (existing && !existing.offlineTimer) {
-    // Appears offline — start grace period (handleStreamOffline handles all groups for this login)
-    await handleStreamOffline(liveStates, loginToUserId, loginKey);
-  }
-}
-
-async function dispatchStreamerPolls(
-  streamers: DbStreamerFull[],
-  liveByUserId: Map<string, TwitchStream>,
-): Promise<void> {
-  // Group rows by login so same-login rows are serialized (shared offline-timer
-  // state); different logins run in parallel via Promise.allSettled.
-  const byLogin = new Map<string, DbStreamerFull[]>();
-  for (const streamer of streamers) {
-    const key = streamer.twitch_name?.toLowerCase() ?? '';
-    if (!key) continue;
-    const existing = byLogin.get(key);
-    if (existing) existing.push(streamer);
-    else byLogin.set(key, [streamer]);
-  }
-
-  await Promise.allSettled(
-    Array.from(byLogin.values()).map(async (group) => {
-      for (const streamer of group) {
-        try {
-          await handlePollStreamer(streamer, liveByUserId);
-        } catch (err) {
-          log.error(`Error handling streamer poll for ${streamer.twitch_name ?? 'unknown'} in group ${streamer.group.name}:`, err);
-        }
-      }
-    }),
-  );
-}
-
 async function pollStreams(): Promise<void> {
   if (pollRunning || streamersData.length === 0) return;
   pollRunning = true;
@@ -127,7 +46,7 @@ async function pollStreams(): Promise<void> {
       const liveByUserId = new Map(
         liveStreams.filter((s) => s.type === 'live').map((s) => [s.user_id, s]),
       );
-      await dispatchStreamerPolls(streamersData, liveByUserId);
+      await dispatchStreamerPolls(liveStates, loginToUserId, streamersData, liveByUserId);
     } catch (err) {
       log.error('Poll error:', err);
     } finally {
@@ -160,7 +79,7 @@ export async function triggerImmediateLiveCheck(login: string): Promise<void> {
       streams.filter((s) => s.type === 'live').map((s) => [s.user_id, s]),
     );
     for (const streamer of matching) {
-      await handlePollStreamer(streamer, liveByUserId);
+      await handlePollStreamer(liveStates, loginToUserId, streamer, liveByUserId);
     }
   } catch (err) {
     log.error(`Immediate live check failed for ${loginKey}:`, err);

--- a/src/twitch/monitor/twitchMonitor.ts
+++ b/src/twitch/monitor/twitchMonitor.ts
@@ -34,6 +34,7 @@ let currentPollPromise: Promise<void> = Promise.resolve();
 
 // ─── Polling ───────────────────────────────────────────────────────────────
 
+/** Polls the Twitch API for all monitored streamers' live status and dispatches the results. No-ops if a poll is already in flight or there are no streamers configured. */
 async function pollStreams(): Promise<void> {
   if (pollRunning || streamersData.length === 0) return;
   pollRunning = true;

--- a/src/twitch/monitor/twitchMonitor.ts
+++ b/src/twitch/monitor/twitchMonitor.ts
@@ -80,7 +80,11 @@ export async function triggerImmediateLiveCheck(login: string): Promise<void> {
       streams.filter((s) => s.type === 'live').map((s) => [s.user_id, s]),
     );
     for (const streamer of matching) {
-      await withLoginLock(loginKey, () => handlePollStreamer(liveStates, loginToUserId, streamer, liveByUserId));
+      try {
+        await withLoginLock(loginKey, () => handlePollStreamer(liveStates, loginToUserId, streamer, liveByUserId));
+      } catch (err) {
+        log.error(`Immediate live check failed for ${loginKey} in group ${streamer.group.name}:`, err);
+      }
     }
   } catch (err) {
     log.error(`Immediate live check failed for ${loginKey}:`, err);

--- a/src/twitch/monitor/twitchMonitor.ts
+++ b/src/twitch/monitor/twitchMonitor.ts
@@ -133,6 +133,36 @@ async function pollStreams(): Promise<void> {
   await currentPollPromise;
 }
 
+/**
+ * Immediately re-checks a single streamer's live status against the Twitch API,
+ * bypassing the poll interval. Used by EventSub stream.online/offline notifications
+ * to react faster than the 60s poll while reusing the same announcement and
+ * offline-grace-period logic as the poller, so the two triggers can never disagree
+ * on state — whichever fires first wins, the other is a no-op against the same
+ * `liveStates` entry.
+ *
+ * @param login - Twitch login name of the streamer to check.
+ */
+export async function triggerImmediateLiveCheck(login: string): Promise<void> {
+  const loginKey = login.toLowerCase();
+  const userId = loginToUserId.get(loginKey);
+  if (!userId) return;
+  const matching = streamersData.filter((s) => s.twitch_name?.toLowerCase() === loginKey);
+  if (matching.length === 0) return;
+
+  try {
+    const streams = await getStreams([userId]);
+    const liveByUserId = new Map(
+      streams.filter((s) => s.type === 'live').map((s) => [s.user_id, s]),
+    );
+    for (const streamer of matching) {
+      await handlePollStreamer(streamer, liveByUserId);
+    }
+  } catch (err) {
+    log.error(`Immediate live check failed for ${loginKey}:`, err);
+  }
+}
+
 // ─── Internal teardown ────────────────────────────────────────────────────────
 
 async function teardown(): Promise<void> {

--- a/src/twitch/monitor/twitchMonitor.ts
+++ b/src/twitch/monitor/twitchMonitor.ts
@@ -71,8 +71,12 @@ async function handlePollStreamer(
       // Game changed
       await editAnnouncement(liveStates, existing, pollStream, 'new_game_message');
       log.info(`${loginKey} game changed to ${pollStream.game_name}`);
+    } else if (existing && existing.title !== pollStream.title) {
+      // Title-only change — refresh the existing post without re-announcing a game change
+      await editAnnouncement(liveStates, existing, pollStream, 'live_message');
+      log.info(`${loginKey} title changed`);
     } else if (existing) {
-      // Still live — keep title in sync
+      // Still live, nothing changed — keep currentStream in sync (e.g. thumbnail refresh)
       existing.currentGame = pollStream.game_name;
       existing.title = pollStream.title;
       existing.currentStream = pollStream;

--- a/src/twitch/monitor/twitchMonitorPoll.test.ts
+++ b/src/twitch/monitor/twitchMonitorPoll.test.ts
@@ -11,7 +11,7 @@ vi.mock('./twitchMonitorOffline', () => ({
   handleStreamOffline: vi.fn().mockResolvedValue(undefined),
 }));
 
-import { handlePollStreamer, dispatchStreamerPolls } from './twitchMonitorPoll';
+import { handlePollStreamer, dispatchStreamerPolls, withLoginLock } from './twitchMonitorPoll';
 import { postAnnouncement, editAnnouncement } from './twitchMonitorAnnouncements';
 import { cancelOfflineTimersForLogin, handleStreamOffline } from './twitchMonitorOffline';
 import { setTwitchChannelLive } from '../../shared/statusStore';
@@ -159,5 +159,55 @@ describe('dispatchStreamerPolls', () => {
     const loginToUserId = new Map<string, string>();
     await dispatchStreamerPolls(liveStates, loginToUserId, [makeStreamer({ twitch_name: null })], new Map());
     expect(postAnnouncement).not.toHaveBeenCalled();
+  });
+});
+
+// ─── withLoginLock ────────────────────────────────────────────────────────────
+// Guards against the poll loop and triggerImmediateLiveCheck racing on the same
+// login's liveStates entry (CodeRabbit review finding on PR #303).
+
+describe('withLoginLock', () => {
+  it('serializes operations queued for the same login', async () => {
+    const order: string[] = [];
+    let releaseFirst!: () => void;
+    const first = withLoginLock('alice', () => new Promise<void>((resolve) => {
+      releaseFirst = () => { order.push('first'); resolve(); };
+    }));
+    const second = withLoginLock('alice', async () => { order.push('second'); });
+
+    await Promise.resolve(); // let microtasks settle without releasing the first op
+    expect(order).toEqual([]);
+
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(order).toEqual(['first', 'second']);
+  });
+
+  it('does not block operations queued for a different login', async () => {
+    const order: string[] = [];
+    let releaseFirst!: () => void;
+    const first = withLoginLock('alice', () => new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    }));
+    const second = withLoginLock('bob', async () => { order.push('bob'); });
+
+    await second;
+    expect(order).toEqual(['bob']);
+
+    releaseFirst();
+    await first;
+  });
+
+  it('still processes the next queued operation after a failure', async () => {
+    await expect(withLoginLock('alice', async () => { throw new Error('boom'); })).rejects.toThrow('boom');
+
+    const order: string[] = [];
+    await withLoginLock('alice', async () => { order.push('after-failure'); });
+    expect(order).toEqual(['after-failure']);
+  });
+
+  it('resolves with the wrapped function\'s return value', async () => {
+    const result = await withLoginLock('alice', async () => 42);
+    expect(result).toBe(42);
   });
 });

--- a/src/twitch/monitor/twitchMonitorPoll.test.ts
+++ b/src/twitch/monitor/twitchMonitorPoll.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../shared/logger', () => ({ createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }));
+vi.mock('../../shared/statusStore', () => ({ setTwitchChannelLive: vi.fn() }));
+vi.mock('./twitchMonitorAnnouncements', () => ({
+  postAnnouncement: vi.fn().mockResolvedValue(undefined),
+  editAnnouncement: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('./twitchMonitorOffline', () => ({
+  cancelOfflineTimersForLogin: vi.fn(),
+  handleStreamOffline: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { handlePollStreamer, dispatchStreamerPolls } from './twitchMonitorPoll';
+import { postAnnouncement, editAnnouncement } from './twitchMonitorAnnouncements';
+import { cancelOfflineTimersForLogin, handleStreamOffline } from './twitchMonitorOffline';
+import { setTwitchChannelLive } from '../../shared/statusStore';
+import type { DbStreamerFull, DbStreamGroup } from '../../db';
+import type { TwitchStream } from '../twitchApi';
+import type { LiveState } from './twitchMonitorTypes';
+
+function makeGroup(overrides: Partial<DbStreamGroup> = {}): DbStreamGroup {
+  return { id: 1, name: 'Main', discord_channel: 'ch1', live_message: 'live', new_game_message: 'game', multi_twitch: false, delete_old_posts: false, ...overrides };
+}
+
+function makeStreamer(overrides: Partial<DbStreamerFull> = {}): DbStreamerFull {
+  return { id: 5, discord_id: 'd5', twitch_name: 'teststreamer', discord_message_id: null, discord_channel_id: null, live_game: null, group: makeGroup(), ...overrides };
+}
+
+function makeStream(overrides: Partial<TwitchStream> = {}): TwitchStream {
+  return { user_id: 'uid-5', user_login: 'teststreamer', game_name: 'Just Chatting', title: 'hello', thumbnail_url: '', type: 'live', ...overrides };
+}
+
+function makeLiveState(overrides: Partial<LiveState> = {}): LiveState {
+  return {
+    streamerId: 5, login: 'teststreamer', groupId: 1, group: makeGroup(), currentGame: 'Just Chatting',
+    title: 'hello', messageId: 'msg1', channelId: 'ch1', currentStream: makeStream(), offlineTimer: null,
+    ...overrides,
+  } as LiveState;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ─── handlePollStreamer ───────────────────────────────────────────────────────
+
+describe('handlePollStreamer', () => {
+  it('does nothing when the streamer has no twitch_name', async () => {
+    const liveStates = new Map<string, LiveState>();
+    await handlePollStreamer(liveStates, new Map(), makeStreamer({ twitch_name: null }), new Map());
+    expect(postAnnouncement).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the login has no resolved user ID', async () => {
+    const liveStates = new Map<string, LiveState>();
+    await handlePollStreamer(liveStates, new Map(), makeStreamer(), new Map());
+    expect(postAnnouncement).not.toHaveBeenCalled();
+  });
+
+  it('posts a new announcement and marks the channel live when a new streamer goes live', async () => {
+    const liveStates = new Map<string, LiveState>();
+    const loginToUserId = new Map([['teststreamer', 'uid-5']]);
+    const liveByUserId = new Map([['uid-5', makeStream()]]);
+
+    await handlePollStreamer(liveStates, loginToUserId, makeStreamer(), liveByUserId);
+
+    expect(setTwitchChannelLive).toHaveBeenCalledWith('teststreamer', true);
+    expect(postAnnouncement).toHaveBeenCalledWith(liveStates, expect.objectContaining({ id: 5 }), expect.objectContaining({ user_id: 'uid-5' }));
+  });
+
+  it('cancels offline timers when a streamer with a running grace period comes back live', async () => {
+    const liveStates = new Map<string, LiveState>([['5', makeLiveState({ offlineTimer: {} as any })]]);
+    const loginToUserId = new Map([['teststreamer', 'uid-5']]);
+    const liveByUserId = new Map([['uid-5', makeStream()]]);
+
+    await handlePollStreamer(liveStates, loginToUserId, makeStreamer(), liveByUserId);
+
+    expect(cancelOfflineTimersForLogin).toHaveBeenCalledWith(liveStates, 'teststreamer');
+  });
+
+  it('edits with new_game_message when the game changes', async () => {
+    const liveStates = new Map<string, LiveState>([['5', makeLiveState({ messageId: 'msg1' })]]);
+    const loginToUserId = new Map([['teststreamer', 'uid-5']]);
+    const liveByUserId = new Map([['uid-5', makeStream({ game_name: 'Valorant' })]]);
+
+    await handlePollStreamer(liveStates, loginToUserId, makeStreamer(), liveByUserId);
+
+    expect(editAnnouncement).toHaveBeenCalledWith(liveStates, expect.anything(), expect.objectContaining({ game_name: 'Valorant' }), 'new_game_message');
+  });
+
+  it('edits with live_message when only the title changes', async () => {
+    const liveStates = new Map<string, LiveState>([['5', makeLiveState({ messageId: 'msg1' })]]);
+    const loginToUserId = new Map([['teststreamer', 'uid-5']]);
+    const liveByUserId = new Map([['uid-5', makeStream({ title: 'New title' })]]);
+
+    await handlePollStreamer(liveStates, loginToUserId, makeStreamer(), liveByUserId);
+
+    expect(editAnnouncement).toHaveBeenCalledWith(liveStates, expect.anything(), expect.objectContaining({ title: 'New title' }), 'live_message');
+  });
+
+  it('syncs currentStream without posting or editing when nothing changed', async () => {
+    const liveState = makeLiveState({ messageId: 'msg1' });
+    const liveStates = new Map<string, LiveState>([['5', liveState]]);
+    const loginToUserId = new Map([['teststreamer', 'uid-5']]);
+    const newStream = makeStream();
+    const liveByUserId = new Map([['uid-5', newStream]]);
+
+    await handlePollStreamer(liveStates, loginToUserId, makeStreamer(), liveByUserId);
+
+    expect(postAnnouncement).not.toHaveBeenCalled();
+    expect(editAnnouncement).not.toHaveBeenCalled();
+    expect(liveState.currentStream).toBe(newStream);
+  });
+
+  it('starts the offline grace period when a previously-live streamer is now offline', async () => {
+    const liveStates = new Map<string, LiveState>([['5', makeLiveState()]]);
+    const loginToUserId = new Map([['teststreamer', 'uid-5']]);
+
+    await handlePollStreamer(liveStates, loginToUserId, makeStreamer(), new Map());
+
+    expect(handleStreamOffline).toHaveBeenCalledWith(liveStates, loginToUserId, 'teststreamer');
+  });
+
+  it('does not restart the offline grace period when one is already running', async () => {
+    const liveStates = new Map<string, LiveState>([['5', makeLiveState({ offlineTimer: {} as any })]]);
+    const loginToUserId = new Map([['teststreamer', 'uid-5']]);
+
+    await handlePollStreamer(liveStates, loginToUserId, makeStreamer(), new Map());
+
+    expect(handleStreamOffline).not.toHaveBeenCalled();
+  });
+});
+
+// ─── dispatchStreamerPolls ────────────────────────────────────────────────────
+
+describe('dispatchStreamerPolls', () => {
+  it('dispatches each streamer and continues past a single failure', async () => {
+    vi.mocked(postAnnouncement).mockRejectedValueOnce(new Error('discord down')).mockResolvedValue(undefined);
+
+    const liveStates = new Map<string, LiveState>();
+    const loginToUserId = new Map([['streamera', 'uid-a'], ['streamerb', 'uid-b']]);
+    const streamers = [
+      makeStreamer({ id: 1, twitch_name: 'streamerA' }),
+      makeStreamer({ id: 2, twitch_name: 'streamerB' }),
+    ];
+    const liveByUserId = new Map([
+      ['uid-a', makeStream({ user_id: 'uid-a', user_login: 'streamera' })],
+      ['uid-b', makeStream({ user_id: 'uid-b', user_login: 'streamerb' })],
+    ]);
+
+    await dispatchStreamerPolls(liveStates, loginToUserId, streamers, liveByUserId);
+
+    expect(postAnnouncement).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips streamers with no twitch_name', async () => {
+    const liveStates = new Map<string, LiveState>();
+    const loginToUserId = new Map<string, string>();
+    await dispatchStreamerPolls(liveStates, loginToUserId, [makeStreamer({ twitch_name: null })], new Map());
+    expect(postAnnouncement).not.toHaveBeenCalled();
+  });
+});

--- a/src/twitch/monitor/twitchMonitorPoll.ts
+++ b/src/twitch/monitor/twitchMonitorPoll.ts
@@ -8,6 +8,23 @@ import { setTwitchChannelLive } from '../../shared/statusStore';
 
 const log = createLogger('TwitchMonitor');
 
+// Per-login chain of pending operations — ensures the poll loop and EventSub-triggered
+// immediate checks never call handlePollStreamer concurrently for the same login.
+const loginQueues = new Map<string, Promise<void>>();
+
+/**
+ * Runs `fn` after any previously queued operation for `login` has settled, so callers
+ * from different entrypoints (60s poll loop vs. triggerImmediateLiveCheck) never race on
+ * the same login's liveStates entry. A failure in `fn` rejects the caller's promise but
+ * does not block subsequent operations queued for the same login.
+ */
+export function withLoginLock<T>(login: string, fn: () => Promise<T>): Promise<T> {
+  const previous = loginQueues.get(login) ?? Promise.resolve();
+  const run = previous.then(() => fn());
+  loginQueues.set(login, run.then(() => undefined, () => undefined));
+  return run;
+}
+
 /** Params bundle for {@link handleLiveStreamer} — groups the per-streamer poll context into a single argument. */
 interface LiveStreamerParams {
   liveStates: Map<string, LiveState>;
@@ -89,10 +106,10 @@ export async function dispatchStreamerPolls(
   }
 
   await Promise.allSettled(
-    Array.from(byLogin.values()).map(async (group) => {
+    Array.from(byLogin.entries()).map(async ([loginKey, group]) => {
       for (const streamer of group) {
         try {
-          await handlePollStreamer(liveStates, loginToUserId, streamer, liveByUserId);
+          await withLoginLock(loginKey, () => handlePollStreamer(liveStates, loginToUserId, streamer, liveByUserId));
         } catch (err) {
           log.error(`Error handling streamer poll for ${streamer.twitch_name ?? 'unknown'} in group ${streamer.group.name}:`, err);
         }

--- a/src/twitch/monitor/twitchMonitorPoll.ts
+++ b/src/twitch/monitor/twitchMonitorPoll.ts
@@ -1,0 +1,98 @@
+import { createLogger } from '../../shared/logger';
+import { DbStreamerFull } from '../../db';
+import { TwitchStream } from '../twitchApi';
+import { LiveState } from './twitchMonitorTypes';
+import { postAnnouncement, editAnnouncement } from './twitchMonitorAnnouncements';
+import { cancelOfflineTimersForLogin, handleStreamOffline } from './twitchMonitorOffline';
+import { setTwitchChannelLive } from '../../shared/statusStore';
+
+const log = createLogger('TwitchMonitor');
+
+/** Posts, edits, or no-ops the Discord announcement for a streamer who is currently live. */
+async function handleLiveStreamer(
+  liveStates: Map<string, LiveState>,
+  streamer: DbStreamerFull,
+  stateKey: string,
+  loginKey: string,
+  existing: LiveState | undefined,
+  pollStream: TwitchStream,
+): Promise<void> {
+  const isNew = !liveStates.has(stateKey);
+  if (isNew || (existing && !existing.messageId)) {
+    // Went live, or state exists with no Discord message (e.g. Discord wasn't ready at startup)
+    await postAnnouncement(liveStates, streamer, pollStream);
+    if (isNew) log.info(`${loginKey} went live in group ${streamer.group.name}`);
+  } else if (existing && existing.currentGame !== pollStream.game_name) {
+    // Game changed
+    await editAnnouncement(liveStates, existing, pollStream, 'new_game_message');
+    log.info(`${loginKey} game changed to ${pollStream.game_name}`);
+  } else if (existing && existing.title !== pollStream.title) {
+    // Title-only change — refresh the existing post without re-announcing a game change
+    await editAnnouncement(liveStates, existing, pollStream, 'live_message');
+    log.info(`${loginKey} title changed`);
+  } else if (existing) {
+    // Still live, nothing changed — keep currentStream in sync (e.g. thumbnail refresh)
+    existing.currentGame = pollStream.game_name;
+    existing.title = pollStream.title;
+    existing.currentStream = pollStream;
+  }
+}
+
+/** Applies the live/offline/game/title transition for one streamer based on the latest poll result. */
+export async function handlePollStreamer(
+  liveStates: Map<string, LiveState>,
+  loginToUserId: Map<string, string>,
+  streamer: DbStreamerFull,
+  liveByUserId: Map<string, TwitchStream>,
+): Promise<void> {
+  const loginKey = streamer.twitch_name?.toLowerCase();
+  if (!loginKey) return;
+  const stateKey = String(streamer.id);
+  const userId = loginToUserId.get(loginKey);
+  if (!userId) return;
+
+  const pollStream = liveByUserId.get(userId);
+  const existing = liveStates.get(stateKey);
+
+  if (pollStream) {
+    if (existing?.offlineTimer) {
+      // Came back during grace period — cancel offline timers for all groups this login belongs to
+      cancelOfflineTimersForLogin(liveStates, loginKey);
+      log.info(`${loginKey} came back — offline timer(s) cancelled`);
+    }
+    setTwitchChannelLive(loginKey, true);
+    await handleLiveStreamer(liveStates, streamer, stateKey, loginKey, existing, pollStream);
+  } else if (existing && !existing.offlineTimer) {
+    // Appears offline — start grace period (handleStreamOffline handles all groups for this login)
+    await handleStreamOffline(liveStates, loginToUserId, loginKey);
+  }
+}
+
+/** Dispatches poll results to each streamer, serializing same-login rows (shared offline-timer state) and parallelizing across logins. */
+export async function dispatchStreamerPolls(
+  liveStates: Map<string, LiveState>,
+  loginToUserId: Map<string, string>,
+  streamers: DbStreamerFull[],
+  liveByUserId: Map<string, TwitchStream>,
+): Promise<void> {
+  const byLogin = new Map<string, DbStreamerFull[]>();
+  for (const streamer of streamers) {
+    const key = streamer.twitch_name?.toLowerCase() ?? '';
+    if (!key) continue;
+    const existing = byLogin.get(key);
+    if (existing) existing.push(streamer);
+    else byLogin.set(key, [streamer]);
+  }
+
+  await Promise.allSettled(
+    Array.from(byLogin.values()).map(async (group) => {
+      for (const streamer of group) {
+        try {
+          await handlePollStreamer(liveStates, loginToUserId, streamer, liveByUserId);
+        } catch (err) {
+          log.error(`Error handling streamer poll for ${streamer.twitch_name ?? 'unknown'} in group ${streamer.group.name}:`, err);
+        }
+      }
+    }),
+  );
+}

--- a/src/twitch/monitor/twitchMonitorPoll.ts
+++ b/src/twitch/monitor/twitchMonitorPoll.ts
@@ -8,15 +8,19 @@ import { setTwitchChannelLive } from '../../shared/statusStore';
 
 const log = createLogger('TwitchMonitor');
 
+/** Params bundle for {@link handleLiveStreamer} — groups the per-streamer poll context into a single argument. */
+interface LiveStreamerParams {
+  liveStates: Map<string, LiveState>;
+  streamer: DbStreamerFull;
+  loginKey: string;
+  existing: LiveState | undefined;
+  pollStream: TwitchStream;
+}
+
 /** Posts, edits, or no-ops the Discord announcement for a streamer who is currently live. */
-async function handleLiveStreamer(
-  liveStates: Map<string, LiveState>,
-  streamer: DbStreamerFull,
-  stateKey: string,
-  loginKey: string,
-  existing: LiveState | undefined,
-  pollStream: TwitchStream,
-): Promise<void> {
+async function handleLiveStreamer(params: LiveStreamerParams): Promise<void> {
+  const { liveStates, streamer, loginKey, existing, pollStream } = params;
+  const stateKey = String(streamer.id);
   const isNew = !liveStates.has(stateKey);
   if (isNew || (existing && !existing.messageId)) {
     // Went live, or state exists with no Discord message (e.g. Discord wasn't ready at startup)
@@ -61,7 +65,7 @@ export async function handlePollStreamer(
       log.info(`${loginKey} came back — offline timer(s) cancelled`);
     }
     setTwitchChannelLive(loginKey, true);
-    await handleLiveStreamer(liveStates, streamer, stateKey, loginKey, existing, pollStream);
+    await handleLiveStreamer({ liveStates, streamer, loginKey, existing, pollStream });
   } else if (existing && !existing.offlineTimer) {
     // Appears offline — start grace period (handleStreamOffline handles all groups for this login)
     await handleStreamOffline(liveStates, loginToUserId, loginKey);


### PR DESCRIPTION
## Summary
- Subscribe to `stream.online`/`stream.offline`/`channel.update` EventSub notifications for any streamer with an active EventSub connection (no extra OAuth scope needed — none of these subscription types require scopes beyond a valid token).
- New `triggerImmediateLiveCheck(login)` in `twitchMonitor.ts` re-runs the 60s poller's single-streamer logic on demand, reusing the same `liveStates` map, announcement posting, and 5-minute offline grace period — so EventSub just shortcuts the poll interval rather than becoming a second source of truth.
- The 60s poller is unchanged and keeps running for every streamer (including those without EventSub) as a fallback; all triggers funnel through the same state so there's no double-posting.
- Discord announcements now also get edited on a **title-only** change (previously only a game change triggered an edit), using the existing `live_message` template — `channel.update` notifications (and the poller) pick this up immediately.
- Extracted the poll/announcement decision logic (`handlePollStreamer`, `handleLiveStreamer`, `dispatchStreamerPolls`) out of `twitchMonitor.ts` into a new `twitchMonitorPoll.ts`, following the existing one-concern-per-file pattern (`twitchMonitorOffline.ts`, `twitchMonitorStartup.ts`) of passing `liveStates`/`loginToUserId` as explicit params — addresses a qlty "high total complexity" flag on `twitchMonitor.ts`.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — all 1370 tests pass, including new/updated tests for `triggerImmediateLiveCheck`, `handleStreamOnline`/`handleStreamOffline`/`handleChannelUpdate`, subscription creation, notification dispatch routing, title-change Discord edits, and the new `twitchMonitorPoll.ts` module

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01567aMEtm4N1KxYAHsak8SW

---
_Generated by [Claude Code](https://claude.ai/code/session_01567aMEtm4N1KxYAHsak8SW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Twitch EventSub handling for `stream.online`, `stream.offline`, and `channel.update`, routing each to the correct live-status update.
  * Introduced immediate live-state checks triggered by real-time events to reduce announcement latency.
* **Bug Fixes**
  * Improved reliability with case-insensitive streamer matching, safer behavior when stream lookups fail, and per-login serialization to prevent race conditions.
  * Enhanced offline grace handling and announcement edit logic for title vs game changes.
* **Tests**
  * Expanded Vitest coverage for EventSub routing/handlers and Twitch monitor polling, including concurrency and offline grace scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->