### PR TITLE
Add test coverage for pool, eventsubAdmin, dashboard, test-utils, twitchEventSub

### DIFF
--- a/src/db/pool.test.ts
+++ b/src/db/pool.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const createPool = vi.fn();
+vi.mock('mysql2/promise', () => ({ default: { createPool: (...args: unknown[]) => createPool(...args) } }));
+vi.mock('../shared/config', () => ({
+  DB_HOST: 'test-host',
+  DB_PORT: 1234,
+  DB_USER: 'test-user',
+  DB_PASSWORD: 'test-password',
+  DB_NAME: 'test-db',
+}));
+
+import { getPool, closePool } from './pool';
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  createPool.mockReturnValue({ end: vi.fn().mockResolvedValue(undefined) });
+  // Reset the module-level singleton between tests.
+  await closePool();
+});
+
+describe('getPool', () => {
+  it('creates a pool with the configured connection settings', () => {
+    getPool();
+    expect(createPool).toHaveBeenCalledWith(
+      expect.objectContaining({
+        host: 'test-host',
+        port: 1234,
+        user: 'test-user',
+        password: 'test-password',
+        database: 'test-db',
+      }),
+    );
+  });
+
+  it('enables bigNumberStrings so BIGINT columns surface as strings', () => {
+    getPool();
+    expect(createPool).toHaveBeenCalledWith(
+      expect.objectContaining({ supportBigNumbers: true, bigNumberStrings: true }),
+    );
+  });
+
+  it('returns the same pool instance on repeated calls (singleton)', () => {
+    const first = getPool();
+    const second = getPool();
+    expect(second).toBe(first);
+    expect(createPool).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('closePool', () => {
+  it('ends the existing pool', async () => {
+    const mockPool = { end: vi.fn().mockResolvedValue(undefined) };
+    createPool.mockReturnValue(mockPool);
+    getPool();
+    await closePool();
+    expect(mockPool.end).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a no-op when no pool has been created yet', async () => {
+    await expect(closePool()).resolves.toBeUndefined();
+  });
+
+  it('allows a fresh pool to be created after closing', async () => {
+    getPool();
+    await closePool();
+    getPool();
+    expect(createPool).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/test-utils/deferredPromise.test.ts
+++ b/src/test-utils/deferredPromise.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+import { deferred } from './deferredPromise';
+
+describe('deferred', () => {
+  it('returns a promise that resolves with the value passed to resolve()', async () => {
+    const { promise, resolve } = deferred<string>();
+    resolve('done');
+    await expect(promise).resolves.toBe('done');
+  });
+
+  it('returns a promise that rejects with the reason passed to reject()', async () => {
+    const { promise, reject } = deferred();
+    reject(new Error('failed'));
+    await expect(promise).rejects.toThrow('failed');
+  });
+
+  it('does not settle until resolve or reject is called', async () => {
+    const { promise, resolve } = deferred<number>();
+    const onResolve = vi.fn();
+    promise.then(onResolve);
+    await Promise.resolve();
+    expect(onResolve).not.toHaveBeenCalled();
+    resolve(42);
+    await promise;
+    expect(onResolve).toHaveBeenCalledWith(42);
+  });
+
+  it('defaults to void value type, resolvable with no argument', async () => {
+    const { promise, resolve } = deferred();
+    resolve();
+    await expect(promise).resolves.toBeUndefined();
+  });
+});

--- a/src/test-utils/flushMicrotasks.test.ts
+++ b/src/test-utils/flushMicrotasks.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { flushMicrotasks } from './flushMicrotasks';
+
+describe('flushMicrotasks', () => {
+  it('resolves once all pending microtasks have settled', async () => {
+    let settled = false;
+    Promise.resolve().then(() => Promise.resolve()).then(() => { settled = true; });
+    await flushMicrotasks();
+    expect(settled).toBe(true);
+  });
+
+  it('resolves immediately when there is nothing pending', async () => {
+    await expect(flushMicrotasks()).resolves.toBeUndefined();
+  });
+});

--- a/src/twitch/eventsub/twitchEventSub.test.ts
+++ b/src/twitch/eventsub/twitchEventSub.test.ts
@@ -35,6 +35,7 @@ vi.mock('./twitchEventSubConnection', () => ({
 import { startEventSub, stopEventSub, reloadEventSubSubscriptions } from './twitchEventSub';
 import { loadStreamersForEventSub } from './twitchEventSubSubscriptions';
 
+/** Builds a minimal streamer fixture for the given uid, shaped like loadStreamersForEventSub's return value. */
 function makeStreamer(uid: string) {
   return { uid, token: 'token', name: uid, config: null, streamerId: 1 };
 }

--- a/src/twitch/eventsub/twitchEventSub.test.ts
+++ b/src/twitch/eventsub/twitchEventSub.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { flushMicrotasks } from '../../test-utils/flushMicrotasks';
+
+vi.mock('../../shared/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+}));
+
+vi.mock('./twitchEventSubSubscriptions', () => ({
+  loadStreamersForEventSub: vi.fn(),
+}));
+
+const connectionInstances: Array<{
+  uid: string;
+  start: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+  reload: ReturnType<typeof vi.fn>;
+  setSelfStopCallback: ReturnType<typeof vi.fn>;
+}> = [];
+
+vi.mock('./twitchEventSubConnection', () => ({
+  StreamerConnection: vi.fn().mockImplementation(function (data: { uid: string }) {
+    const instance = {
+      uid: data.uid,
+      start: vi.fn(),
+      stop: vi.fn(),
+      reload: vi.fn(),
+      setSelfStopCallback: vi.fn(),
+    };
+    connectionInstances.push(instance);
+    return instance;
+  }),
+}));
+
+import { startEventSub, stopEventSub, reloadEventSubSubscriptions } from './twitchEventSub';
+import { loadStreamersForEventSub } from './twitchEventSubSubscriptions';
+
+function makeStreamer(uid: string) {
+  return { uid, token: 'token', name: uid, config: null, streamerId: 1 };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  connectionInstances.length = 0;
+  vi.mocked(loadStreamersForEventSub).mockResolvedValue([]);
+  // Ensure no connections leak between tests regardless of prior test outcome.
+  stopEventSub();
+});
+
+describe('startEventSub', () => {
+  it('creates and starts a connection for each loaded streamer', async () => {
+    vi.mocked(loadStreamersForEventSub).mockResolvedValue([makeStreamer('uid-1'), makeStreamer('uid-2')]);
+    startEventSub();
+    await flushMicrotasks();
+
+    expect(connectionInstances).toHaveLength(2);
+    expect(connectionInstances[0].start).toHaveBeenCalledTimes(1);
+    expect(connectionInstances[1].start).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not create a duplicate connection for a uid that already exists', async () => {
+    vi.mocked(loadStreamersForEventSub).mockResolvedValue([makeStreamer('uid-1')]);
+    startEventSub();
+    await flushMicrotasks();
+    expect(connectionInstances).toHaveLength(1);
+
+    startEventSub();
+    await flushMicrotasks();
+    expect(connectionInstances).toHaveLength(1);
+  });
+
+  it('logs and swallows errors from loadStreamersForEventSub', async () => {
+    vi.mocked(loadStreamersForEventSub).mockRejectedValue(new Error('DB down'));
+    expect(() => startEventSub()).not.toThrow();
+    await flushMicrotasks();
+    expect(connectionInstances).toHaveLength(0);
+  });
+});
+
+describe('stopEventSub', () => {
+  it('stops and clears all active connections', async () => {
+    vi.mocked(loadStreamersForEventSub).mockResolvedValue([makeStreamer('uid-1'), makeStreamer('uid-2')]);
+    startEventSub();
+    await flushMicrotasks();
+    expect(connectionInstances).toHaveLength(2);
+
+    stopEventSub();
+    expect(connectionInstances[0].stop).toHaveBeenCalledTimes(1);
+    expect(connectionInstances[1].stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('prevents a subsequent reload from doing anything until startEventSub runs again', async () => {
+    stopEventSub();
+    vi.mocked(loadStreamersForEventSub).mockResolvedValue([makeStreamer('uid-1')]);
+    reloadEventSubSubscriptions();
+    await flushMicrotasks();
+    expect(loadStreamersForEventSub).not.toHaveBeenCalled();
+  });
+});
+
+describe('reloadEventSubSubscriptions', () => {
+  it('starts a new connection for a streamer added since the last load', async () => {
+    vi.mocked(loadStreamersForEventSub).mockResolvedValue([]);
+    startEventSub();
+    await flushMicrotasks();
+    expect(connectionInstances).toHaveLength(0);
+
+    vi.mocked(loadStreamersForEventSub).mockResolvedValue([makeStreamer('uid-new')]);
+    reloadEventSubSubscriptions();
+    await flushMicrotasks();
+
+    expect(connectionInstances).toHaveLength(1);
+    expect(connectionInstances[0].start).toHaveBeenCalledTimes(1);
+  });
+
+  it('reloads an existing connection rather than recreating it', async () => {
+    const streamer = makeStreamer('uid-1');
+    vi.mocked(loadStreamersForEventSub).mockResolvedValue([streamer]);
+    startEventSub();
+    await flushMicrotasks();
+    expect(connectionInstances).toHaveLength(1);
+
+    const updatedStreamer = { ...streamer, name: 'renamed' };
+    vi.mocked(loadStreamersForEventSub).mockResolvedValue([updatedStreamer]);
+    reloadEventSubSubscriptions();
+    await flushMicrotasks();
+
+    expect(connectionInstances).toHaveLength(1);
+    expect(connectionInstances[0].reload).toHaveBeenCalledWith(updatedStreamer);
+    expect(connectionInstances[0].start).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops and removes a connection whose streamer is no longer present', async () => {
+    vi.mocked(loadStreamersForEventSub).mockResolvedValue([makeStreamer('uid-1'), makeStreamer('uid-2')]);
+    startEventSub();
+    await flushMicrotasks();
+    expect(connectionInstances).toHaveLength(2);
+
+    vi.mocked(loadStreamersForEventSub).mockResolvedValue([makeStreamer('uid-2')]);
+    reloadEventSubSubscriptions();
+    await flushMicrotasks();
+
+    expect(connectionInstances[0].stop).toHaveBeenCalledTimes(1);
+    expect(connectionInstances[1].stop).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when stopped globally', async () => {
+    stopEventSub();
+    reloadEventSubSubscriptions();
+    await flushMicrotasks();
+    expect(loadStreamersForEventSub).not.toHaveBeenCalled();
+  });
+
+  it('logs and swallows errors during reload', async () => {
+    vi.mocked(loadStreamersForEventSub).mockResolvedValue([]);
+    startEventSub();
+    await flushMicrotasks();
+
+    vi.mocked(loadStreamersForEventSub).mockRejectedValue(new Error('DB down'));
+    expect(() => reloadEventSubSubscriptions()).not.toThrow();
+    await flushMicrotasks();
+  });
+
+  it('serialises concurrent reload calls through the reload chain', async () => {
+    vi.mocked(loadStreamersForEventSub).mockResolvedValue([]);
+    startEventSub();
+    await flushMicrotasks();
+
+    vi.mocked(loadStreamersForEventSub).mockResolvedValue([makeStreamer('uid-a')]);
+    reloadEventSubSubscriptions();
+    reloadEventSubSubscriptions();
+    await flushMicrotasks();
+
+    expect(connectionInstances).toHaveLength(1);
+  });
+});

--- a/src/twitch/eventsub/twitchEventSub.test.ts
+++ b/src/twitch/eventsub/twitchEventSub.test.ts
@@ -19,6 +19,11 @@ const connectionInstances: Array<{
 }> = [];
 
 vi.mock('./twitchEventSubConnection', () => ({
+  /**
+   * Fake StreamerConnection constructor that records each created instance for assertions.
+   * @param data - The streamer fixture passed to the real constructor.
+   * @returns A stub instance with spy methods, also pushed onto connectionInstances.
+   */
   StreamerConnection: vi.fn().mockImplementation(function (data: { uid: string }) {
     const instance = {
       uid: data.uid,
@@ -35,7 +40,11 @@ vi.mock('./twitchEventSubConnection', () => ({
 import { startEventSub, stopEventSub, reloadEventSubSubscriptions } from './twitchEventSub';
 import { loadStreamersForEventSub } from './twitchEventSubSubscriptions';
 
-/** Builds a minimal streamer fixture for the given uid, shaped like loadStreamersForEventSub's return value. */
+/**
+ * Builds a minimal streamer fixture, shaped like loadStreamersForEventSub's return value.
+ * @param uid - The Twitch user id to assign to the fixture.
+ * @returns A streamer-shaped object suitable for mocking loadStreamersForEventSub.
+ */
 function makeStreamer(uid: string) {
   return { uid, token: 'token', name: uid, config: null, streamerId: 1 };
 }

--- a/src/twitch/eventsub/twitchEventSub.test.ts
+++ b/src/twitch/eventsub/twitchEventSub.test.ts
@@ -169,6 +169,7 @@ describe('reloadEventSubSubscriptions', () => {
     vi.mocked(loadStreamersForEventSub).mockRejectedValue(new Error('DB down'));
     expect(() => reloadEventSubSubscriptions()).not.toThrow();
     await flushMicrotasks();
+    expect(connectionInstances).toHaveLength(0);
   });
 
   it('serialises concurrent reload calls through the reload chain', async () => {

--- a/src/twitch/eventsub/twitchEventSub.test.ts
+++ b/src/twitch/eventsub/twitchEventSub.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { flushMicrotasks } from '../../test-utils/flushMicrotasks';
+import { deferred } from '../../test-utils/deferredPromise';
 
 vi.mock('../../shared/logger', () => ({
   createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
@@ -165,9 +166,26 @@ describe('reloadEventSubSubscriptions', () => {
     startEventSub();
     await flushMicrotasks();
 
-    vi.mocked(loadStreamersForEventSub).mockResolvedValue([makeStreamer('uid-a')]);
+    // Gate both loads on deferred promises so we can prove the second reload's
+    // loadStreamersForEventSub call doesn't fire until the first one settles.
+    const first = deferred<ReturnType<typeof makeStreamer>[]>();
+    const second = deferred<ReturnType<typeof makeStreamer>[]>();
+    const loadCallOrder: number[] = [];
+    vi.mocked(loadStreamersForEventSub)
+      .mockImplementationOnce(() => { loadCallOrder.push(1); return first.promise; })
+      .mockImplementationOnce(() => { loadCallOrder.push(2); return second.promise; });
+
     reloadEventSubSubscriptions();
     reloadEventSubSubscriptions();
+    await flushMicrotasks();
+
+    expect(loadCallOrder).toEqual([1]);
+
+    first.resolve([]);
+    await flushMicrotasks();
+    expect(loadCallOrder).toEqual([1, 2]);
+
+    second.resolve([makeStreamer('uid-a')]);
     await flushMicrotasks();
 
     expect(connectionInstances).toHaveLength(1);

--- a/src/web/routes/dashboard.test.ts
+++ b/src/web/routes/dashboard.test.ts
@@ -32,6 +32,11 @@ import { hasAuthFailedSubs } from '../../twitch/eventsub/twitchEventSubSubscript
 
 const STATUS = { discord: { ready: true }, voice: {}, twitch: {}, tiktok: {} };
 
+/**
+ * Builds a minimal Express app with the dashboard router mounted, a stubbed session, and res.render captured as JSON.
+ * @param sessionUser - The session user to attach to each request, or undefined for an anonymous session.
+ * @returns The configured Express app, ready to be driven with supertest.
+ */
 function buildApp(sessionUser: any = undefined) {
   const app = express();
   app.use((req: any, res: any, next: any) => {

--- a/src/web/routes/dashboard.test.ts
+++ b/src/web/routes/dashboard.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../shared/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+}));
+
+vi.mock('../../shared/statusStore', () => ({
+  getStatus: vi.fn(),
+}));
+
+vi.mock('../../db', () => ({
+  getStreamerByDiscordId: vi.fn(),
+}));
+
+vi.mock('../../twitch/eventsub/twitchEventSubSubscriptions', () => ({
+  hasAuthFailedSubs: vi.fn(),
+}));
+
+vi.mock('../csrf', () => ({
+  csrfProtection: (req: any, _res: any, next: any) => {
+    req.csrfToken = () => 'test-csrf-token';
+    next();
+  },
+}));
+
+import express from 'express';
+import supertest from 'supertest';
+import router from './dashboard';
+import { getStatus } from '../../shared/statusStore';
+import { getStreamerByDiscordId } from '../../db';
+import { hasAuthFailedSubs } from '../../twitch/eventsub/twitchEventSubSubscriptions';
+
+const STATUS = { discord: { ready: true }, voice: {}, twitch: {}, tiktok: {} };
+
+function buildApp(sessionUser: any = undefined) {
+  const app = express();
+  app.use((req: any, res: any, next: any) => {
+    req.session = { user: sessionUser };
+    res.render = (view: string, locals?: any) => res.json({ view, ...locals });
+    next();
+  });
+  app.use(router);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getStatus).mockReturnValue(STATUS as any);
+});
+
+describe('GET /', () => {
+  it('renders the dashboard with needsReconnect false when no session user', async () => {
+    const res = await supertest(buildApp()).get('/');
+    expect(res.status).toBe(200);
+    expect(res.body.view).toBe('dashboard');
+    expect(res.body.status).toEqual(STATUS);
+    expect(res.body.needsReconnect).toBe(false);
+    expect(getStreamerByDiscordId).not.toHaveBeenCalled();
+  });
+
+  it('sets needsReconnect true when the streamer has auth-failed subs', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue({
+      eventsub_access_token: 'token',
+      twitch_name: 'streamer',
+    } as any);
+    vi.mocked(hasAuthFailedSubs).mockReturnValue(true);
+
+    const res = await supertest(buildApp({ discordId: '100' })).get('/');
+    expect(res.status).toBe(200);
+    expect(res.body.needsReconnect).toBe(true);
+    expect(hasAuthFailedSubs).toHaveBeenCalledWith('streamer');
+  });
+
+  it('sets needsReconnect false when the streamer has no access token', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue({
+      eventsub_access_token: null,
+      twitch_name: 'streamer',
+    } as any);
+    vi.mocked(hasAuthFailedSubs).mockReturnValue(true);
+
+    const res = await supertest(buildApp({ discordId: '100' })).get('/');
+    expect(res.body.needsReconnect).toBe(false);
+  });
+
+  it('sets needsReconnect false when the streamer has no twitch_name', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue({
+      eventsub_access_token: 'token',
+      twitch_name: null,
+    } as any);
+    vi.mocked(hasAuthFailedSubs).mockReturnValue(true);
+
+    const res = await supertest(buildApp({ discordId: '100' })).get('/');
+    expect(res.body.needsReconnect).toBe(false);
+  });
+
+  it('sets needsReconnect false when there is no streamer record', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
+
+    const res = await supertest(buildApp({ discordId: '100' })).get('/');
+    expect(res.body.needsReconnect).toBe(false);
+  });
+
+  it('renders a 500 error page when getStreamerByDiscordId throws', async () => {
+    vi.mocked(getStreamerByDiscordId).mockRejectedValue(new Error('DB down'));
+    const res = await supertest(buildApp({ discordId: '100' })).get('/');
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/web/routes/eventsubAdmin.test.ts
+++ b/src/web/routes/eventsubAdmin.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../shared/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+}));
+
+vi.mock('../../db', () => ({
+  clearStreamerToken: vi.fn(),
+}));
+
+vi.mock('../../twitch/eventsub/twitchEventSub', () => ({
+  reloadEventSubSubscriptions: vi.fn(),
+}));
+
+vi.mock('../csrf', () => ({
+  csrfProtection: (req: any, _res: any, next: any) => {
+    req.csrfToken = () => 'test-csrf-token';
+    next();
+  },
+}));
+
+vi.mock('../middleware', () => ({
+  requireAdmin: (req: any, res: any, next: any) => {
+    if (req.session.user?.accessLevel >= 3) return next();
+    res.status(403).render('error', { message: 'denied' });
+  },
+}));
+
+import express from 'express';
+import supertest from 'supertest';
+import router from './eventsubAdmin';
+import { clearStreamerToken } from '../../db';
+import { reloadEventSubSubscriptions } from '../../twitch/eventsub/twitchEventSub';
+
+function buildApp(accessLevel = 3) {
+  const app = express();
+  app.use((req: any, res: any, next: any) => {
+    req.session = { user: { discordId: '1', accessLevel } };
+    res.render = (view: string, locals?: any) => res.json({ view, ...locals });
+    next();
+  });
+  app.use(router);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(clearStreamerToken).mockResolvedValue(undefined);
+});
+
+describe('POST /streams/twitch-disconnect/:streamerId', () => {
+  it('redirects with invalid_id when streamerId is not a positive integer', async () => {
+    const res = await supertest(buildApp()).post('/streams/twitch-disconnect/not-a-number');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/admin/streams?error=invalid_id');
+    expect(clearStreamerToken).not.toHaveBeenCalled();
+  });
+
+  it('redirects with invalid_id for a zero/negative id', async () => {
+    const res = await supertest(buildApp()).post('/streams/twitch-disconnect/0');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/admin/streams?error=invalid_id');
+  });
+
+  it('clears the token and triggers a reload on success', async () => {
+    const res = await supertest(buildApp()).post('/streams/twitch-disconnect/42');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/admin/streams');
+    expect(clearStreamerToken).toHaveBeenCalledWith(42);
+    expect(reloadEventSubSubscriptions).toHaveBeenCalledTimes(1);
+  });
+
+  it('redirects with eventsub_disconnect_failed when clearStreamerToken throws', async () => {
+    vi.mocked(clearStreamerToken).mockRejectedValue(new Error('DB down'));
+    const res = await supertest(buildApp()).post('/streams/twitch-disconnect/42');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/admin/streams?error=eventsub_disconnect_failed');
+    expect(reloadEventSubSubscriptions).not.toHaveBeenCalled();
+  });
+
+  it('denies access below Admin level', async () => {
+    const res = await supertest(buildApp(2)).post('/streams/twitch-disconnect/42');
+    expect(res.status).toBe(403);
+    expect(clearStreamerToken).not.toHaveBeenCalled();
+  });
+});

--- a/src/web/routes/eventsubAdmin.test.ts
+++ b/src/web/routes/eventsubAdmin.test.ts
@@ -32,6 +32,11 @@ import router from './eventsubAdmin';
 import { clearStreamerToken } from '../../db';
 import { reloadEventSubSubscriptions } from '../../twitch/eventsub/twitchEventSub';
 
+/**
+ * Builds a minimal Express app with the eventsub admin router mounted, a stubbed session, and res.render captured as JSON.
+ * @param accessLevel - The access level to assign to the session user (defaults to Admin).
+ * @returns The configured Express app, ready to be driven with supertest.
+ */
 function buildApp(accessLevel = 3) {
   const app = express();
   app.use((req: any, res: any, next: any) => {

--- a/src/web/routes/eventsubAdmin.test.ts
+++ b/src/web/routes/eventsubAdmin.test.ts
@@ -56,8 +56,14 @@ describe('POST /streams/twitch-disconnect/:streamerId', () => {
     expect(clearStreamerToken).not.toHaveBeenCalled();
   });
 
-  it('redirects with invalid_id for a zero/negative id', async () => {
+  it('redirects with invalid_id for a zero id', async () => {
     const res = await supertest(buildApp()).post('/streams/twitch-disconnect/0');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/admin/streams?error=invalid_id');
+  });
+
+  it('redirects with invalid_id for a negative id', async () => {
+    const res = await supertest(buildApp()).post('/streams/twitch-disconnect/-1');
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/admin/streams?error=invalid_id');
   });


### PR DESCRIPTION
## Summary
- Adds Vitest coverage for five previously-untested areas: `src/db/pool.ts`, `src/web/routes/eventsubAdmin.ts`, `src/web/routes/dashboard.ts`, `src/test-utils/` (`deferredPromise.ts`, `flushMicrotasks.ts`), and `src/twitch/eventsub/twitchEventSub.ts`.
- `pool.test.ts`: singleton creation/config pass-through, `closePool` lifecycle and re-creation.
- `eventsubAdmin.test.ts`: admin disconnect route — id validation, success path (token clear + EventSub reload), failure redirect, access-level gating.
- `dashboard.test.ts`: `needsReconnect` derivation across missing session/streamer/token/twitch-name cases, plus 500 on DB error.
- `deferredPromise.test.ts` / `flushMicrotasks.test.ts`: behavior of the shared async test helpers.
- `twitchEventSub.test.ts`: `startEventSub`/`stopEventSub`/`reloadEventSubSubscriptions` orchestration (connection create/start/stop/reload, diffing on reload, error swallowing, serialised reload chain).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` — all 91 test files / 1446 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FDpv59F6Dr5soXsHxkgDUK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded Vitest coverage for database pooling behavior (singleton reuse, configured options, and safe shutdown/reopen).
  * Added tests for deferred promises and microtask flushing utilities.
  * Added Twitch EventSub lifecycle tests covering start/stop/reload behavior, connection reuse, cleanup for removed streamers, and serialized reload handling.
  * Added route tests for the dashboard and EventSub admin disconnect flow, including computed reconnect state, redirects, error handling, and admin access enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->