### PR TITLE
Fix stale live-state when Discord API calls fail during announcement lifecycle

### DIFF
--- a/src/twitch/monitor/twitchMonitorAnnouncements.test.ts
+++ b/src/twitch/monitor/twitchMonitorAnnouncements.test.ts
@@ -146,32 +146,23 @@ describe('editAnnouncement', () => {
     expect(setStreamerLive).toHaveBeenCalled();
   });
 
-  it('deletes old message and sends new one when delete_old_posts is true', async () => {
+  it('deletes old message via tryDeleteDiscordMessage and sends new one when delete_old_posts is true', async () => {
     const channel = makeTextChannel();
     vi.mocked(getDiscordClient).mockReturnValue(makeDiscordClient(channel) as any);
     const state = makeLiveState({ group: makeGroup({ delete_old_posts: true }) });
     await editAnnouncement(new Map(), state, makeStream(), 'live_message');
-    expect(channel._message.delete).toHaveBeenCalled();
+    expect(tryDeleteDiscordMessage).toHaveBeenCalledWith('ch1', 'msg1');
     expect(channel.send).toHaveBeenCalled();
     expect(setStreamerLive).toHaveBeenCalled();
   });
 
-  it('swallows DiscordNotFoundError when deleting old message', async () => {
-    const notFoundErr = new Error('Unknown Message');
-    const channel = makeTextChannel({ delete: vi.fn().mockRejectedValue(notFoundErr) });
+  it('logs and does not update state when tryDeleteDiscordMessage rejects', async () => {
+    vi.mocked(tryDeleteDiscordMessage).mockRejectedValueOnce(new Error('network'));
+    const channel = makeTextChannel();
     vi.mocked(getDiscordClient).mockReturnValue(makeDiscordClient(channel) as any);
-    vi.mocked(isDiscordNotFoundError).mockReturnValue(true);
     const state = makeLiveState({ group: makeGroup({ delete_old_posts: true }) });
     await expect(editAnnouncement(new Map(), state, makeStream(), 'live_message')).resolves.not.toThrow();
-  });
-
-  it('re-throws non-DiscordNotFoundError when deleting old message', async () => {
-    const channel = makeTextChannel({ delete: vi.fn().mockRejectedValue(new Error('network')) });
-    vi.mocked(getDiscordClient).mockReturnValue(makeDiscordClient(channel) as any);
-    vi.mocked(isDiscordNotFoundError).mockReturnValue(false);
-    const state = makeLiveState({ group: makeGroup({ delete_old_posts: true }) });
-    await expect(editAnnouncement(new Map(), state, makeStream(), 'live_message')).resolves.not.toThrow();
-    // Error is caught by outer try/catch and logged, not rethrown to caller
+    expect(setStreamerLive).not.toHaveBeenCalled();
   });
 
   it('updates state currentGame and title from stream', async () => {
@@ -182,6 +173,30 @@ describe('editAnnouncement', () => {
     await editAnnouncement(new Map(), state, newStream, 'new_game_message');
     expect(state.currentGame).toBe('Minecraft');
     expect(state.title).toBe('New Title');
+  });
+
+  it('posts a fresh message when the existing message is gone and delete_old_posts is false', async () => {
+    const notFoundErr = new Error('Unknown Message');
+    const channel = makeTextChannel();
+    channel.messages.fetch.mockRejectedValue(notFoundErr);
+    vi.mocked(getDiscordClient).mockReturnValue(makeDiscordClient(channel) as any);
+    vi.mocked(isDiscordNotFoundError).mockReturnValue(true);
+    const state = makeLiveState({ group: makeGroup({ delete_old_posts: false }) });
+    await editAnnouncement(new Map(), state, makeStream(), 'live_message');
+    expect(channel.send).toHaveBeenCalled();
+    expect(state.messageId).toBe('msg1');
+    expect(setStreamerLive).toHaveBeenCalled();
+  });
+
+  it('rethrows non-NotFound fetch errors when delete_old_posts is false', async () => {
+    const channel = makeTextChannel();
+    channel.messages.fetch.mockRejectedValue(new Error('network'));
+    vi.mocked(getDiscordClient).mockReturnValue(makeDiscordClient(channel) as any);
+    vi.mocked(isDiscordNotFoundError).mockReturnValue(false);
+    const state = makeLiveState({ group: makeGroup({ delete_old_posts: false }) });
+    await expect(editAnnouncement(new Map(), state, makeStream(), 'live_message')).resolves.not.toThrow();
+    // Error is caught by outer try/catch and logged; state is not updated.
+    expect(setStreamerLive).not.toHaveBeenCalled();
   });
 });
 
@@ -205,6 +220,15 @@ describe('deleteAnnouncement', () => {
     const liveStates = new Map([['k', makeLiveState({ messageId: 'msg1', channelId: 'ch1', streamerId: 10, groupId: 1 })]]);
     await deleteAnnouncement(liveStates, 'k');
     expect(tryDeleteDiscordMessage).toHaveBeenCalledWith('ch1', 'msg1');
+    expect(clearStreamerLive).toHaveBeenCalledWith(10);
+    expect(updateMultitwitch).toHaveBeenCalledWith(1, liveStates);
+    expect(liveStates.has('k')).toBe(false);
+  });
+
+  it('still clears DB and map state when tryDeleteDiscordMessage rejects', async () => {
+    vi.mocked(tryDeleteDiscordMessage).mockRejectedValueOnce(new Error('network'));
+    const liveStates = new Map([['k', makeLiveState({ messageId: 'msg1', channelId: 'ch1', streamerId: 10, groupId: 1 })]]);
+    await expect(deleteAnnouncement(liveStates, 'k')).resolves.not.toThrow();
     expect(clearStreamerLive).toHaveBeenCalledWith(10);
     expect(updateMultitwitch).toHaveBeenCalledWith(1, liveStates);
     expect(liveStates.has('k')).toBe(false);

--- a/src/twitch/monitor/twitchMonitorAnnouncements.test.ts
+++ b/src/twitch/monitor/twitchMonitorAnnouncements.test.ts
@@ -178,13 +178,14 @@ describe('editAnnouncement', () => {
   it('posts a fresh message when the existing message is gone and delete_old_posts is false', async () => {
     const notFoundErr = new Error('Unknown Message');
     const channel = makeTextChannel();
+    channel.send.mockResolvedValue({ id: 'msg2', channelId: 'ch1' });
     channel.messages.fetch.mockRejectedValue(notFoundErr);
     vi.mocked(getDiscordClient).mockReturnValue(makeDiscordClient(channel) as any);
     vi.mocked(isDiscordNotFoundError).mockReturnValue(true);
     const state = makeLiveState({ group: makeGroup({ delete_old_posts: false }) });
     await editAnnouncement(new Map(), state, makeStream(), 'live_message');
     expect(channel.send).toHaveBeenCalled();
-    expect(state.messageId).toBe('msg1');
+    expect(state.messageId).toBe('msg2');
     expect(setStreamerLive).toHaveBeenCalled();
   });
 

--- a/src/twitch/monitor/twitchMonitorAnnouncements.test.ts
+++ b/src/twitch/monitor/twitchMonitorAnnouncements.test.ts
@@ -156,13 +156,15 @@ describe('editAnnouncement', () => {
     expect(setStreamerLive).toHaveBeenCalled();
   });
 
-  it('logs and does not update state when tryDeleteDiscordMessage rejects', async () => {
+  it('treats old-message delete failure as best-effort and still commits the new message', async () => {
     vi.mocked(tryDeleteDiscordMessage).mockRejectedValueOnce(new Error('network'));
     const channel = makeTextChannel();
+    channel.send.mockResolvedValue({ id: 'msg2', channelId: 'ch1' });
     vi.mocked(getDiscordClient).mockReturnValue(makeDiscordClient(channel) as any);
     const state = makeLiveState({ group: makeGroup({ delete_old_posts: true }) });
     await expect(editAnnouncement(new Map(), state, makeStream(), 'live_message')).resolves.not.toThrow();
-    expect(setStreamerLive).not.toHaveBeenCalled();
+    expect(state.messageId).toBe('msg2');
+    expect(setStreamerLive).toHaveBeenCalled();
   });
 
   it('updates state currentGame and title from stream', async () => {

--- a/src/twitch/monitor/twitchMonitorAnnouncements.ts
+++ b/src/twitch/monitor/twitchMonitorAnnouncements.ts
@@ -85,8 +85,8 @@ export async function editAnnouncement(
     const textChannel = channel as TextChannel;
 
     if (group.delete_old_posts) {
-      await tryDeleteDiscordMessage(state.channelId, state.messageId);
       const msg = await textChannel.send({ content, embeds: [embed] });
+      await tryDeleteDiscordMessage(state.channelId, state.messageId);
       state.messageId = msg.id;
       state.channelId = msg.channelId;
     } else {

--- a/src/twitch/monitor/twitchMonitorAnnouncements.ts
+++ b/src/twitch/monitor/twitchMonitorAnnouncements.ts
@@ -86,7 +86,11 @@ export async function editAnnouncement(
 
     if (group.delete_old_posts) {
       const msg = await textChannel.send({ content, embeds: [embed] });
-      await tryDeleteDiscordMessage(state.channelId, state.messageId);
+      try {
+        await tryDeleteDiscordMessage(state.channelId, state.messageId);
+      } catch (err) {
+        log.error(`Failed to delete old announcement for ${state.login}, continuing:`, err);
+      }
       state.messageId = msg.id;
       state.channelId = msg.channelId;
     } else {

--- a/src/twitch/monitor/twitchMonitorAnnouncements.ts
+++ b/src/twitch/monitor/twitchMonitorAnnouncements.ts
@@ -10,6 +10,11 @@ import { LiveState, makeLiveState } from './twitchMonitorTypes';
 import { buildEmbed, fillTemplate, templateVars } from './twitchMonitorEmbed';
 import { updateMultitwitch } from './twitchMonitorMultitwitch';
 
+/**
+ * Posts a new "now live" announcement message for a streamer and records the
+ * resulting message location in both the in-memory live-state map and the DB.
+ * No-ops (storing a state with null message fields) if the Discord client isn't ready.
+ */
 export async function postAnnouncement(
   liveStates: Map<string, LiveState>,
   streamerData: DbStreamerFull,
@@ -47,6 +52,12 @@ export async function postAnnouncement(
   }
 }
 
+/**
+ * Updates an existing "now live" announcement in place (or replaces it, if the
+ * group is configured to delete old posts) to reflect a new game/title. If the
+ * previously-announced message is gone, falls back to posting a fresh one
+ * instead of silently failing on every subsequent call.
+ */
 export async function editAnnouncement(
   liveStates: Map<string, LiveState>,
   state: LiveState,
@@ -74,18 +85,20 @@ export async function editAnnouncement(
     const textChannel = channel as TextChannel;
 
     if (group.delete_old_posts) {
-      try {
-        const old = await textChannel.messages.fetch(state.messageId);
-        await old.delete();
-      } catch (err) {
-        if (!isDiscordNotFoundError(err)) throw err;
-      }
+      await tryDeleteDiscordMessage(state.channelId, state.messageId);
       const msg = await textChannel.send({ content, embeds: [embed] });
       state.messageId = msg.id;
       state.channelId = msg.channelId;
     } else {
-      const message = await textChannel.messages.fetch(state.messageId);
-      await message.edit({ content, embeds: [embed] });
+      try {
+        const message = await textChannel.messages.fetch(state.messageId);
+        await message.edit({ content, embeds: [embed] });
+      } catch (err) {
+        if (!isDiscordNotFoundError(err)) throw err;
+        const msg = await textChannel.send({ content, embeds: [embed] });
+        state.messageId = msg.id;
+        state.channelId = msg.channelId;
+      }
     }
 
     await setStreamerLive(state.streamerId, state.messageId!, state.channelId!, stream.game_name);
@@ -95,6 +108,13 @@ export async function editAnnouncement(
   }
 }
 
+/**
+ * Removes a streamer's "now live" announcement when they go offline: deletes
+ * the Discord message (best-effort) and clears live state from the DB and
+ * the in-memory map. DB/state cleanup always runs even if Discord message
+ * deletion fails, so a transient Discord API error can't leave the streamer
+ * stuck marked as live.
+ */
 export async function deleteAnnouncement(
   liveStates: Map<string, LiveState>,
   stateKey: string,
@@ -105,7 +125,11 @@ export async function deleteAnnouncement(
     return;
   }
 
-  await tryDeleteDiscordMessage(state.channelId, state.messageId);
+  try {
+    await tryDeleteDiscordMessage(state.channelId, state.messageId);
+  } catch (err) {
+    log.error(`Failed to delete announcement message for streamer ${state.streamerId}, continuing cleanup:`, err);
+  }
 
   await clearStreamerLive(state.streamerId);
   const groupId = state.groupId;


### PR DESCRIPTION
## Severity: Critical

## Issue
In `src/twitch/monitor/twitchMonitorAnnouncements.ts`:

1. **`deleteAnnouncement`** called `tryDeleteDiscordMessage` (which rethrows on any non-404 Discord error) with no surrounding try/catch. If Discord returns a transient error (rate limit, 5xx, network blip) while deleting the "now live" message, the function throws before reaching `clearStreamerLive`, `liveStates.delete`, and `updateMultitwitch`. The streamer is then permanently stuck marked as "live" in both the DB and in-memory state until the bot restarts.
2. **`editAnnouncement`**'s non-`delete_old_posts` branch fetched and edited the existing message with no recovery if the message had been deleted externally (e.g. by a moderator). Every subsequent game/title-change edit would silently fail forever, since there was no fallback to re-post.
3. The `delete_old_posts` branch in `editAnnouncement` duplicated the fetch+delete+swallow-404 logic that already exists in `tryDeleteDiscordMessage` (`src/discord/discordUtils.ts`), which CLAUDE.md calls out as the function to reuse rather than duplicate.

## Fix
- `deleteAnnouncement` now wraps the Discord delete call in try/catch, logs failures, and always proceeds with DB/state cleanup regardless of whether the Discord-side delete succeeded.
- `editAnnouncement`'s non-`delete_old_posts` branch now catches "not found" errors on fetch and falls back to posting a fresh message (mirroring the existing `delete_old_posts` recovery pattern), instead of failing silently on every call.
- The `delete_old_posts` branch now calls `tryDeleteDiscordMessage` directly instead of duplicating its fetch/delete/404-swallow logic.
- Added JSDoc to all three exported functions per CLAUDE.md's docstring requirement.
- Added/updated tests in `twitchMonitorAnnouncements.test.ts` covering: cleanup proceeding despite a delete failure, recovery-by-repost when the edited message is gone, and the new `tryDeleteDiscordMessage` usage path.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` — 85 files / 1414 tests pass

---
Found via an automated code-quality review of the repository.


---
_Generated by [Claude Code](https://claude.ai/code/session_014JwA6AR6AejwGAyyuTut3d)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated announcement editing to automatically post a replacement when the prior Discord message is missing, instead of failing.
  * Improved “delete old posts” flow to post the replacement first, then attempt deletion of the previous message safely.
  * Ensured live-stream state and multitwitch indicators are cleaned up even if Discord message deletion fails.
* **Documentation**
  * Refreshed JSDoc to reflect the new “now live” posting/updating and best-effort deletion behavior.
* **Tests**
  * Expanded coverage to validate replacement/update behavior and robust cleanup on deletion failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->