### PR TITLE
Add missing JSDoc and test coverage for customCommandHandler's session-cache logic

### DIFF
--- a/src/commands/customCommandHandler.test.ts
+++ b/src/commands/customCommandHandler.test.ts
@@ -307,12 +307,14 @@ describe('resolveSharedChatSessionId', () => {
     await resolveSharedChatSessionId('user-1');
     await Promise.resolve();
     await Promise.resolve();
+    const after = Date.now();
 
     const entry = sessionCache.get('user-1');
     expect(entry?.sessionId).toBe('stale');
-    // Pin the upper bound to the short retry window (5s), not just "before some later Date.now()",
-    // so this fails if the implementation falls back to the much longer normal cache TTL instead.
-    expect(entry!.expiry).toBeGreaterThan(before);
-    expect(entry!.expiry).toBeLessThanOrEqual(before + 5_000);
+    // Pin the bounds to the short retry window (5s) bracketed by [before, after], not just
+    // "before some later Date.now()", so this fails if the implementation falls back to the
+    // much longer normal cache TTL instead — while tolerating slow-CI timing jitter.
+    expect(entry!.expiry).toBeGreaterThanOrEqual(before + 5_000);
+    expect(entry!.expiry).toBeLessThanOrEqual(after + 5_000);
   });
 });

--- a/src/commands/customCommandHandler.test.ts
+++ b/src/commands/customCommandHandler.test.ts
@@ -303,12 +303,16 @@ describe('resolveSharedChatSessionId', () => {
     sessionCache.set('user-1', { sessionId: 'stale', expiry: Date.now() - 1 });
     vi.mocked(getSharedChatSession).mockRejectedValue(new Error('helix down'));
 
+    const before = Date.now();
     await resolveSharedChatSessionId('user-1');
     await Promise.resolve();
     await Promise.resolve();
 
     const entry = sessionCache.get('user-1');
     expect(entry?.sessionId).toBe('stale');
-    expect(entry!.expiry).toBeLessThanOrEqual(Date.now() + 5_000);
+    // Pin the upper bound to the short retry window (5s), not just "before some later Date.now()",
+    // so this fails if the implementation falls back to the much longer normal cache TTL instead.
+    expect(entry!.expiry).toBeGreaterThan(before);
+    expect(entry!.expiry).toBeLessThanOrEqual(before + 5_000);
   });
 });

--- a/src/commands/customCommandHandler.test.ts
+++ b/src/commands/customCommandHandler.test.ts
@@ -28,12 +28,14 @@ import {
   executeCustomCommandForTwitch,
   registerTwitchChatRuntime,
   purgeExpiredSessionCache,
+  resolveSharedChatSessionId,
   sessionCache,
 } from './customCommandHandler';
 import { getCustomCommandForDiscord, getCustomCommandForTwitchChannel } from '../db';
 import { recordCommandTestEntry } from './commandMonitorStore';
 import { isDiscordNotFoundError } from '../discord/discordUtils';
 import { getMultiTwitchDataForChannel } from '../twitch/monitor/twitchMonitor';
+import { getSharedChatSession } from '../twitch/twitchApi';
 
 function mockMsg(content: string) {
   return {
@@ -227,5 +229,86 @@ describe('purgeExpiredSessionCache', () => {
     purgeExpiredSessionCache();
 
     expect(sessionCache.size).toBe(0);
+  });
+});
+
+// ─── resolveSharedChatSessionId ───────────────────────────────────────────────
+
+describe('resolveSharedChatSessionId', () => {
+  beforeEach(() => {
+    sessionCache.clear();
+    vi.mocked(getSharedChatSession).mockReset();
+  });
+
+  it('fetches and caches the session id on a cold cache', async () => {
+    vi.mocked(getSharedChatSession).mockResolvedValue({ session_id: 'sess-1' } as any);
+
+    const result = await resolveSharedChatSessionId('user-1');
+
+    expect(result).toBe('sess-1');
+    expect(getSharedChatSession).toHaveBeenCalledWith('user-1');
+    expect(sessionCache.get('user-1')?.sessionId).toBe('sess-1');
+  });
+
+  it('caches a null session id and retries sooner on fetch failure', async () => {
+    vi.mocked(getSharedChatSession).mockRejectedValue(new Error('helix down'));
+
+    const result = await resolveSharedChatSessionId('user-1');
+
+    expect(result).toBeNull();
+    expect(sessionCache.get('user-1')?.sessionId).toBeNull();
+  });
+
+  it('returns the cached value without fetching while still fresh', async () => {
+    sessionCache.set('user-1', { sessionId: 'cached', expiry: Date.now() + 60_000 });
+
+    const result = await resolveSharedChatSessionId('user-1');
+
+    expect(result).toBe('cached');
+    expect(getSharedChatSession).not.toHaveBeenCalled();
+  });
+
+  it('serves the stale cached value immediately and refreshes in the background', async () => {
+    sessionCache.set('user-1', { sessionId: 'stale', expiry: Date.now() - 1 });
+    let resolveFetch: (v: any) => void;
+    vi.mocked(getSharedChatSession).mockReturnValue(
+      new Promise((resolve) => { resolveFetch = resolve; }),
+    );
+
+    const result = await resolveSharedChatSessionId('user-1');
+
+    expect(result).toBe('stale');
+    expect(getSharedChatSession).toHaveBeenCalledWith('user-1');
+
+    resolveFetch!({ session_id: 'fresh' });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(sessionCache.get('user-1')?.sessionId).toBe('fresh');
+  });
+
+  it('coalesces concurrent background refreshes for the same user into one call', async () => {
+    sessionCache.set('user-1', { sessionId: 'stale', expiry: Date.now() - 1 });
+    vi.mocked(getSharedChatSession).mockResolvedValue({ session_id: 'fresh' } as any);
+
+    await Promise.all([
+      resolveSharedChatSessionId('user-1'),
+      resolveSharedChatSessionId('user-1'),
+    ]);
+
+    expect(getSharedChatSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the last known value but shortens the retry window when a background refresh fails', async () => {
+    sessionCache.set('user-1', { sessionId: 'stale', expiry: Date.now() - 1 });
+    vi.mocked(getSharedChatSession).mockRejectedValue(new Error('helix down'));
+
+    await resolveSharedChatSessionId('user-1');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const entry = sessionCache.get('user-1');
+    expect(entry?.sessionId).toBe('stale');
+    expect(entry!.expiry).toBeLessThanOrEqual(Date.now() + 5_000);
   });
 });

--- a/src/commands/customCommandHandler.ts
+++ b/src/commands/customCommandHandler.ts
@@ -22,6 +22,7 @@ interface TwitchChatRuntime {
 
 let _twitchRuntime: TwitchChatRuntime | null = null;
 
+/** Stores the concrete Twitch chat runtime (send/getActiveChannels/getLoginUserIds) so Twitch custom commands can be sent and broadcast. Call once from index.ts after the Twitch bot is ready. */
 export function registerTwitchChatRuntime(runtime: TwitchChatRuntime): void {
   _twitchRuntime = runtime;
 }
@@ -33,6 +34,7 @@ interface LookupResult {
   isMultiTwitch: boolean;
 }
 
+/** Looks up `command` via the supplied platform-specific finder and returns its response/multi-twitch flag, or null if no custom command matches. */
 async function lookupCommand(
   command: string,
   findCustomCommand: (cmd: string) => Promise<{ output: string; is_multi_twitch: boolean } | null>,
@@ -69,6 +71,13 @@ export function purgeExpiredSessionCache(): void {
 // Purge expired entries so the cache does not grow without bound over long uptimes.
 setInterval(purgeExpiredSessionCache, SESSION_CACHE_TTL_MS).unref();
 
+/**
+ * Resolves the shared-chat session ID for a Twitch user, caching results for
+ * SESSION_CACHE_TTL_MS. A cache hit past its TTL is still returned immediately
+ * (stale-while-revalidate) and triggers at most one background refresh per
+ * user via `inFlightRefreshes`; a failed refresh keeps the last known value
+ * but shortens the retry window to SHORT_RETRY_TTL_MS.
+ */
 export async function resolveSharedChatSessionId(userId: string): Promise<string | null> {
   const now = Date.now();
   const cached = sessionCache.get(userId);
@@ -98,6 +107,13 @@ export async function resolveSharedChatSessionId(userId: string): Promise<string
   }
 }
 
+/**
+ * Sends a multi-twitch custom command's output to every active channel that has the
+ * command registered and is part of the source channel's multi-twitch group (falling
+ * back to the source channel only if it isn't currently in a group). Channels that
+ * share a Twitch shared-chat session are de-duplicated so only one message is sent
+ * per session. Returns true if at least one channel received the message.
+ */
 async function broadcastToActiveChannels(sourceChannel: string, command: string, output: string): Promise<boolean> {
   if (!_twitchRuntime) return false;
 
@@ -195,6 +211,16 @@ export async function executeCustomCommandForDiscord(
   }
 }
 
+/**
+ * Checks a Twitch chat message against the custom command catalog for `channel`
+ * and, if matched, sends the response — broadcasting to other active channels
+ * sharing a multi-twitch group when the command is flagged multi-twitch.
+ *
+ * @param channel - Twitch channel login the message was received on.
+ * @param rawMessage - Raw chat message text.
+ * @param username - Display name for the monitoring entry; null or omitted if unknown.
+ * @returns Resolves when the command is handled (or skipped).
+ */
 export async function executeCustomCommandForTwitch(
   channel: string,
   rawMessage: string,


### PR DESCRIPTION
## Severity: High (docs) / Medium (test gap)

## Issue
In `src/commands/customCommandHandler.ts`:
- `registerTwitchChatRuntime`, `lookupCommand`, `broadcastToActiveChannels`, `resolveSharedChatSessionId`, and `executeCustomCommandForTwitch` had no JSDoc, violating CLAUDE.md's requirement that every function (including internal helpers) document what it does.
- `resolveSharedChatSessionId` — the function owning the session cache's stale-while-revalidate behavior, single-flight background refresh (`inFlightRefreshes`), and error-fallback-to-last-known-value logic — had zero direct test coverage. Only its indirect callers and the cache-purge helper were tested.

## Fix
- Added JSDoc to all five functions describing behavior, parameters, and return values.
- Added 6 new tests for `resolveSharedChatSessionId` covering: cold-cache fetch, fetch failure, fresh-cache hit (no refetch), stale-cache-serves-immediately-and-refreshes-in-background, concurrent-call de-duplication via `inFlightRefreshes`, and the shortened retry window on a failed background refresh.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` — 85 files / 1418 tests pass

---
Found via an automated code-quality review of the repository.


---
_Generated by [Claude Code](https://claude.ai/code/session_014JwA6AR6AejwGAyyuTut3d)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved in-app developer-facing comments to better explain command handling, chat session caching, and multi-channel message behavior.
* **Tests**
  * Expanded automated coverage for shared chat session lookup, including cache hits, stale-data refreshes, failed requests, and concurrent access handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->