### PR TITLE
Add test coverage for EventSub StreamerConnection lifecycle/reconnect

### DIFF
--- a/src/twitch/eventsub/twitchEventSubConnection.test.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.test.ts
@@ -381,9 +381,26 @@ describe('StreamerConnection lifecycle', () => {
     conn.start();
     await (conn as any).handleMessage(makeWelcomeMsg('sess-live'));
 
+    // First reload's subscribeForStreamer call stays pending until resolveFirst() fires,
+    // so we can prove the second reload's call doesn't start until the first one settles.
+    let resolveFirst!: (value: number) => void;
+    const firstDeferred = new Promise<number>((resolve) => { resolveFirst = resolve; });
+    vi.mocked(subscribeForStreamer)
+      .mockImplementationOnce(() => firstDeferred)
+      .mockResolvedValueOnce(1);
+
     conn.reload(makeStreamerData());
     conn.reload(makeStreamerData());
-    // 1 call from the welcome handshake above + 1 per reload() = 3
+
+    // Flush pending microtasks so the first reload's doReload() has had a chance to run.
+    await Promise.resolve();
+    await Promise.resolve();
+    // Only the welcome handshake + first reload have fired — the second reload is still
+    // chained behind the first's unresolved promise. If reloadChain didn't serialise the
+    // calls, the second reload would have fired immediately too, making this 3.
+    expect(subscribeForStreamer).toHaveBeenCalledTimes(2);
+
+    resolveFirst(1);
     await vi.waitFor(() => expect(subscribeForStreamer).toHaveBeenCalledTimes(3));
   });
 });

--- a/src/twitch/eventsub/twitchEventSubConnection.test.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.test.ts
@@ -20,6 +20,7 @@ import {
   subscribeForStreamer,
   dispatchNotification,
   handleRevocation,
+  removeStreamerFromMap,
 } from './twitchEventSubSubscriptions';
 
 // ---------------------------------------------------------------------------
@@ -159,8 +160,12 @@ function makeWelcomeMsg(sessionId = 'sess-1', msgId?: string): EventSubMessage {
 }
 
 // Suppress WebSocket construction in tests — we test handleMessage directly.
+// Listeners are captured by event name so lifecycle tests can invoke them manually.
 class MockWebSocket {
-  addEventListener = vi.fn();
+  listeners = new Map<string, (...args: any[]) => void>();
+  addEventListener = vi.fn((event: string, cb: (...args: any[]) => void) => {
+    this.listeners.set(event, cb);
+  });
   close = vi.fn();
 }
 
@@ -263,5 +268,122 @@ describe('StreamerConnection.handleMessage', () => {
     expect(() => (conn as any).handleMessage(msg)).not.toThrow();
     expect(dispatchNotification).not.toHaveBeenCalled();
     expect(handleRevocation).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// StreamerConnection lifecycle: connect/stop/reload/reconnect
+// ---------------------------------------------------------------------------
+
+describe('StreamerConnection lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(subscribeForStreamer).mockResolvedValue(1);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('start() opens a WebSocket and registers the four lifecycle listeners', () => {
+    const conn = new StreamerConnection(makeStreamerData());
+    conn.start();
+    const ws = (conn as any).ws as MockWebSocket;
+    expect(ws.listeners.has('open')).toBe(true);
+    expect(ws.listeners.has('message')).toBe(true);
+    expect(ws.listeners.has('close')).toBe(true);
+    expect(ws.listeners.has('error')).toBe(true);
+  });
+
+  it('stop() closes the socket, clears timers, and removes the streamer from the map', () => {
+    const conn = new StreamerConnection(makeStreamerData());
+    conn.start();
+    const ws = (conn as any).ws as MockWebSocket;
+
+    conn.stop();
+
+    expect(ws.close).toHaveBeenCalledWith(1000, 'shutdown');
+    expect((conn as any).ws).toBeNull();
+    expect(removeStreamerFromMap).toHaveBeenCalledWith('uid-123');
+  });
+
+  it('does not reconnect after a close once stopped', () => {
+    const conn = new StreamerConnection(makeStreamerData());
+    conn.start();
+    const ws = (conn as any).ws as MockWebSocket;
+    conn.stop();
+
+    ws.listeners.get('close')!({ code: 1000, reason: 'shutdown' } as any);
+    vi.advanceTimersByTime(60_000);
+
+    expect((conn as any).ws).toBeNull();
+    expect((conn as any).reconnectTimer).toBeNull();
+  });
+
+  it('schedules a reconnect with exponential backoff when the socket closes unexpectedly', () => {
+    const conn = new StreamerConnection(makeStreamerData());
+    conn.start();
+    const firstWs = (conn as any).ws as MockWebSocket;
+
+    firstWs.listeners.get('close')!({ code: 1006, reason: 'abnormal' } as any);
+    expect((conn as any).reconnectAttempts).toBe(1);
+
+    vi.advanceTimersByTime(1_000);
+    const secondWs = (conn as any).ws as MockWebSocket;
+    expect(secondWs).not.toBe(firstWs);
+
+    secondWs.listeners.get('close')!({ code: 1006, reason: 'abnormal' } as any);
+    vi.advanceTimersByTime(1_999);
+    expect((conn as any).ws).toBeNull();
+    vi.advanceTimersByTime(1);
+    expect((conn as any).ws).not.toBeNull();
+  });
+
+  it('ignores a close event from a stale socket replaced during session migration', () => {
+    const conn = new StreamerConnection(makeStreamerData());
+    conn.start();
+    const staleWs = (conn as any).ws as MockWebSocket;
+
+    // Simulate a session_reconnect: a new socket is opened, the old one is left dangling.
+    conn.connect('wss://eventsub.wss.twitch.tv/ws?session_id=new');
+    const currentWs = (conn as any).ws as MockWebSocket;
+    expect(currentWs).not.toBe(staleWs);
+
+    staleWs.listeners.get('close')!({ code: 1000, reason: 'reconnect' } as any);
+
+    expect((conn as any).ws).toBe(currentWs);
+  });
+
+  it('reload() connects immediately when there is no live session', () => {
+    const conn = new StreamerConnection(makeStreamerData());
+    const connectSpy = vi.spyOn(conn, 'connect');
+
+    conn.reload(makeStreamerData());
+
+    return vi.waitFor(() => expect(connectSpy).toHaveBeenCalled());
+  });
+
+  it('reload() re-subscribes on the live session and stops when no subscriptions remain', async () => {
+    const conn = new StreamerConnection(makeStreamerData());
+    conn.start();
+    await (conn as any).handleMessage(makeWelcomeMsg('sess-live'));
+    vi.mocked(subscribeForStreamer).mockResolvedValue(0);
+
+    conn.reload(makeStreamerData());
+    await vi.waitFor(() => expect(removeStreamerFromMap).toHaveBeenCalled());
+
+    expect(subscribeForStreamer).toHaveBeenCalledWith('sess-live', expect.objectContaining({ uid: 'uid-123' }));
+  });
+
+  it('serialises overlapping reload() calls through the reload chain', async () => {
+    const conn = new StreamerConnection(makeStreamerData());
+    conn.start();
+    await (conn as any).handleMessage(makeWelcomeMsg('sess-live'));
+
+    conn.reload(makeStreamerData());
+    conn.reload(makeStreamerData());
+    // 1 call from the welcome handshake above + 1 per reload() = 3
+    await vi.waitFor(() => expect(subscribeForStreamer).toHaveBeenCalledTimes(3));
   });
 });


### PR DESCRIPTION
**Severity: Medium**

## Issue

`twitchEventSubConnection.test.ts` already covered `handleMessage` dispatch, message dedup, and the reconnect-URL allowlist, but had zero coverage of `StreamerConnection`'s actual connection lifecycle:

- `start()` / `stop()` and the timer/listener cleanup they're responsible for
- `scheduleReconnect()`'s exponential backoff after an unexpected close
- the `this.ws !== socket` guard in `onClose` that exists specifically to ignore a stale/dangling socket's close event during a session migration (`handleSessionReconnect` deliberately leaves the old socket open for `SESSION_MIGRATION_CLOSE_DELAY_MS` before closing it)
- `reload()` / `doReload()`'s `reloadChain` promise serialisation, which exists to prevent overlapping reload calls from racing each other's `subscribeForStreamer` calls

These are exactly the kind of paths that regress silently — a broken stale-socket guard would cause a spurious reconnect loop, and a broken `reloadChain` would let concurrent reloads issue out-of-order subscription updates.

## Fix

Added a `StreamerConnection lifecycle` describe block (8 tests):

- `start()` registers all four WebSocket listeners
- `stop()` closes the socket, clears timers, and calls `removeStreamerFromMap`
- no reconnect is scheduled after a close once `stop()` has run
- exponential backoff across repeated unexpected closes (1s, then growing)
- a close event from a stale socket (replaced via `connect()` during migration) is ignored — the current socket is left untouched
- `reload()` connects immediately when there's no live session, re-subscribes and stops on zero subscriptions when there is one, and serialises two overlapping `reload()` calls through the chain

Also fixed the existing `MockWebSocket` test helper to actually capture registered listeners (previously `addEventListener` was a no-op `vi.fn()`), so lifecycle tests can trigger `open`/`close` manually.

## Test plan

- `npx tsc --noEmit` passes
- `npx vitest run src/twitch/eventsub/twitchEventSubConnection.test.ts` — 35/35 passing
- `npm test` — full suite (86 files / 1438 tests) passing, no regressions

Found via an automated code-quality review of the repository.

---
_Generated by [Claude Code](https://claude.ai/code/session_014JwA6AR6AejwGAyyuTut3d)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection handling for live updates, including safer reconnect behavior after unexpected disconnects.
  * Prevented stale connection events from affecting newer sessions.
  * Made reload behavior more reliable, especially when updates happen back-to-back or when no active session is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->