### PR TITLE
Document user-settings/eventsub route handlers with JSDoc

### DIFF
--- a/src/web/routes/eventsubAdmin.ts
+++ b/src/web/routes/eventsubAdmin.ts
@@ -11,6 +11,16 @@ const router = Router();
 
 // Admin-only emergency disconnect — e.g. if a streamer's OAuth token is compromised.
 // Normal connect/disconnect flows live in /user/settings.
+
+/**
+ * POST /admin/streams/twitch-disconnect/:streamerId — admin-only forced disconnect of
+ * a streamer's Twitch OAuth token, e.g. if it has been compromised. Clears the stored
+ * token and reloads EventSub subscriptions.
+ * @param req - Express request; reads the `streamerId` route param.
+ * @param res - Express response; redirects to `/admin/streams` on success, or to
+ *   `/admin/streams?error=<code>` if `streamerId` is not a valid positive integer
+ *   (`error=invalid_id`) or the disconnect fails (`error=eventsub_disconnect_failed`).
+ */
 router.post('/streams/twitch-disconnect/:streamerId', requireAdmin, csrfProtection, async (req, res) => {
   const streamerId = parsePositiveIntId(req.params.streamerId);
   if (streamerId === null) return res.redirect('/admin/streams?error=invalid_id');

--- a/src/web/routes/eventsubCallback.ts
+++ b/src/web/routes/eventsubCallback.ts
@@ -12,6 +12,24 @@ const router = Router();
 // GET /auth/twitch/eventsub/callback
 // No requireAuth — Twitch redirects here outside the normal session flow.
 // CSRF is handled via the session state set during OAuth initiation.
+
+/**
+ * GET /auth/twitch/eventsub/callback — completes the Twitch OAuth flow started by
+ * `/user/twitch-connect`. Validates the OAuth state and streamer ownership, exchanges
+ * the code for tokens, verifies the connecting Twitch account matches the expected
+ * streamer login, saves the token, initializes EventSub config, and reloads
+ * subscriptions.
+ * @param req - Express request; reads `code`/`state`/`error` query params and the
+ *   stored `eventsubOAuthState`/`eventsubStreamerId` session values.
+ * @param res - Express response; redirects to `/user/settings?success=twitch_connected`
+ *   on success, or to `/user/settings?error=<code>` if Twitch denied authorization
+ *   (`error=eventsub_oauth_denied`), the OAuth state/streamer is missing or mismatched
+ *   (`error=eventsub_oauth_state_mismatch`), config is missing (`error=eventsub_config_failed`),
+ *   the streamer record can't be found (`error=invalid_id`), the token exchange fails
+ *   (`error=eventsub_token_invalid`), the connecting account doesn't match the expected
+ *   streamer (`error=eventsub_wrong_account`), or any other error occurs
+ *   (`error=eventsub_config_failed`).
+ */
 router.get('/twitch/eventsub/callback', async (req, res) => {
   const { code, state, error } = req.query as Record<string, string | undefined>;
 

--- a/src/web/routes/userSettings.ts
+++ b/src/web/routes/userSettings.ts
@@ -44,6 +44,16 @@ function getFriendlyError(key: string): string {
 }
 
 // GET /user/settings
+
+/**
+ * GET /user/settings — renders the logged-in user's settings page, including their
+ * Twitch connection status, EventSub config, and any `error`/`success` query-param
+ * banner from a prior redirect.
+ * @param req - Express request; reads `req.session.user`, `error`, `success`, and
+ *   `expected` query params.
+ * @param res - Express response; renders the `userSettings` view, or a 500 error
+ *   page if loading the user/streamer record fails.
+ */
 router.get('/', requireAuth, csrfProtection, async (req, res) => {
   try {
     const discordId = req.session.user!.discordId;
@@ -86,6 +96,18 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
 });
 
 // GET /user/twitch-connect — initiates Twitch OAuth for the logged-in user
+
+/**
+ * GET /user/twitch-connect — starts the Twitch OAuth flow for the logged-in user's
+ * streamer record. Stores the OAuth state and streamer ID on the session, then
+ * redirects to Twitch's authorize URL.
+ * @param req - Express request; receives `eventsubOAuthState` and `eventsubStreamerId`
+ *   on its session.
+ * @param res - Express response; redirects to id.twitch.tv's OAuth2 authorize endpoint
+ *   on success, or to `/user/settings?error=<code>` if the user has no streamer record,
+ *   the Twitch bot isn't enabled for them, EventSub config is missing, or an
+ *   unexpected error occurs (`error=eventsub_config_failed`).
+ */
 router.get('/twitch-connect', requireAuth, async (req, res) => {
   try {
     const discordId = req.session.user!.discordId;
@@ -124,6 +146,15 @@ router.get('/twitch-connect', requireAuth, async (req, res) => {
 });
 
 // POST /user/twitch-disconnect
+
+/**
+ * POST /user/twitch-disconnect — clears the logged-in user's stored Twitch OAuth
+ * token and reloads EventSub subscriptions so the disconnect takes effect immediately.
+ * @param req - Express request; reads `req.session.user.discordId`.
+ * @param res - Express response; redirects to `/user/settings` on success, or to
+ *   `/user/settings?error=<code>` if the user has no streamer record
+ *   (`error=no_streamer_record`) or the token clear fails (`error=eventsub_disconnect_failed`).
+ */
 router.post('/twitch-disconnect', requireAuth, csrfProtection, async (req, res) => {
   try {
     const discordId = req.session.user!.discordId;
@@ -140,6 +171,20 @@ router.post('/twitch-disconnect', requireAuth, csrfProtection, async (req, res) 
 });
 
 // POST /user/eventsub-config
+
+/**
+ * POST /user/eventsub-config — saves the logged-in user's EventSub notification
+ * config (follow/sub/resub/giftsub/raid toggles and message templates), falling
+ * back to existing values for any field omitted from the body, then reloads
+ * EventSub subscriptions.
+ * @param req - Express request; reads `req.session.user.discordId` and the
+ *   notification-config fields from `req.body`.
+ * @param res - Express response; redirects to `/user/settings` on success, or to
+ *   `/user/settings?error=<code>` if the user has no streamer record
+ *   (`error=no_streamer_record`), the Twitch bot isn't enabled for them
+ *   (`error=eventsub_not_bot_enabled`), a message field exceeds the length limit, or
+ *   saving fails (`error=eventsub_config_failed`).
+ */
 router.post('/eventsub-config', requireAuth, csrfProtection, async (req, res) => {
   try {
     const discordId = req.session.user!.discordId;

--- a/src/web/routes/userSettings.ts
+++ b/src/web/routes/userSettings.ts
@@ -101,8 +101,8 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
  * GET /user/twitch-connect — starts the Twitch OAuth flow for the logged-in user's
  * streamer record. Stores the OAuth state and streamer ID on the session, then
  * redirects to Twitch's authorize URL.
- * @param req - Express request; receives `eventsubOAuthState` and `eventsubStreamerId`
- *   on its session.
+ * @param req - Express request; reads `req.session.user` and writes
+ *   `eventsubOAuthState` and `eventsubStreamerId` to the session for the callback.
  * @param res - Express response; redirects to id.twitch.tv's OAuth2 authorize endpoint
  *   on success, or to `/user/settings?error=<code>` if the user has no streamer record,
  *   the Twitch bot isn't enabled for them, EventSub config is missing, or an


### PR DESCRIPTION
Adds JSDoc to Express route handlers in `src/web/routes/` per CLAUDE.md's documentation rule. Second of several batched PRs covering all route files (first: #310).

Documentation only — no logic changes.

Routes documented:
- `src/web/routes/userSettings.ts`: `GET /user/`, `GET /user/twitch-connect`, `POST /user/twitch-disconnect`, `POST /user/eventsub-config`
- `src/web/routes/eventsubAdmin.ts`: `POST /admin/streams/twitch-disconnect/:streamerId`
- `src/web/routes/eventsubCallback.ts`: `GET /auth/twitch/eventsub/callback`


---
_Generated by [Claude Code](https://claude.ai/code/session_01XwQ6zMzSUtcXPe3krsvDrx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer route documentation for Twitch connection, disconnection, callback, and event subscription settings flows.
  * Improved in-code descriptions of request inputs, session/query handling, and redirect/error outcomes for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->