### PR TITLE
Document admin/command-admin route handlers with JSDoc

### DIFF
--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -38,6 +38,15 @@ const KNOWN_ERRORS = new Set([
   'self_edit_forbidden', 'self_remove_forbidden', 'target_above_level', 'invalid_twitch_state',
 ]);
 // View the current guild's members (Manager+)
+
+/**
+ * GET /admin/users — renders the member-management page for the current guild,
+ * listing every member with their access level and Twitch state.
+ * @param req - Express request; reads `req.session.user.currentGuildId` and the
+ *   `error` query param.
+ * @param res - Express response; renders the `admin` view, or a 500 error page if
+ *   loading members fails.
+ */
 router.get('/users', requireManager, csrfProtection, async (req, res) => {
   const guildId = req.session.user!.currentGuildId!;
   try {
@@ -68,6 +77,20 @@ async function reloadRegistrySafe(): Promise<void> {
 // Add a member to the current guild, or update their identity/level (Manager+;
 // managers may only assign levels below their own). Identity and Twitch are global;
 // the access level is written to guild_member for the current guild.
+
+/**
+ * POST /admin/users/add — adds a Discord user (creating/updating their global user
+ * row and Twitch identity) and grants them membership of the current guild at the
+ * requested access level. Reloads the guild registry afterwards, since a new member
+ * may provision a previously-inert guild.
+ * @param req - Express request; reads `discord_id`, `discord_name`, `access_level`,
+ *   `twitch_name`, and `clear_twitch_name` from `req.body`, plus the acting manager's
+ *   `req.session.user` and current guild.
+ * @param res - Express response; redirects to `/admin/users` on success, or to
+ *   `/admin/users?error=<code>` for validation failures (e.g. `invalid_discord_id`,
+ *   `invalid_access_level`, `access_level_too_high`, `invalid_twitch_name`,
+ *   `duplicate_twitch_name`) or a DB failure (`add_failed`).
+ */
 router.post('/users/add', requireManager, csrfProtection, async (req, res) => {
   const guildId = req.session.user!.currentGuildId!;
 
@@ -118,6 +141,15 @@ router.post('/users/add', requireManager, csrfProtection, async (req, res) => {
 
 // Update a member's access level within the current guild (Manager+; managers may
 // only set levels below their own and cannot modify members at their level or above)
+
+/**
+ * POST /admin/users/update — updates a member's access level within the current guild.
+ * @param req - Express request; reads `discord_id` and `access_level` from `req.body`.
+ * @param res - Express response; redirects to `/admin/users` on success, or to
+ *   `/admin/users?error=<code>` for validation failures (e.g. `invalid_discord_id`,
+ *   `invalid_access_level`, `access_level_too_high`, `target_above_level`) or a DB
+ *   failure (`update_failed`).
+ */
 router.post('/users/update', requireManager, csrfProtection, async (req, res) => {
   const guildId = req.session.user!.currentGuildId!;
 
@@ -142,6 +174,17 @@ router.post('/users/update', requireManager, csrfProtection, async (req, res) =>
 
 // Remove a member from the current guild (Admin only). The global user row and
 // Twitch identity are left intact — they may belong to other guilds.
+
+/**
+ * POST /admin/users/remove — removes a member from the current guild. Refuses to
+ * let an admin remove themselves, and reloads the guild registry afterwards since
+ * removing the last member un-provisions the guild.
+ * @param req - Express request; reads `discord_id` from `req.body`.
+ * @param res - Express response; redirects to `/admin/users` on success, or to
+ *   `/admin/users?error=<code>` if `discord_id` is invalid (`invalid_discord_id`),
+ *   the target is the acting admin (`self_remove_forbidden`), or removal fails
+ *   (`remove_failed`).
+ */
 router.post('/users/remove', requireAdmin, csrfProtection, async (req, res) => {
   const guildId = req.session.user!.currentGuildId!;
 
@@ -163,6 +206,16 @@ router.post('/users/remove', requireAdmin, csrfProtection, async (req, res) => {
 });
 
 // Toggle twitch bot participation for a user (Manager+)
+
+/**
+ * POST /admin/users/toggle-twitch — toggles whether a user participates in the
+ * Twitch bot.
+ * @param req - Express request; reads `discord_id` and `is_twitch_bot_enabled`
+ *   from `req.body`.
+ * @param res - Express response; redirects to `/admin/users` on success, or to
+ *   `/admin/users?error=<code>` for validation failures (e.g. `invalid_discord_id`,
+ *   `invalid_twitch_state`) or a DB failure (`toggle_failed`).
+ */
 router.post('/users/toggle-twitch', requireManager, csrfProtection, async (req, res) => {
   const guildId = req.session.user!.currentGuildId!;
 

--- a/src/web/routes/adminRefresh.ts
+++ b/src/web/routes/adminRefresh.ts
@@ -89,10 +89,26 @@ async function runDiscordNameRefresh(guildId: string): Promise<void> {
 const router = Router();
 
 // Mounted under /admin behind requireGuildContext, so currentGuildId is always set.
+
+/**
+ * GET /admin/users/refresh-status — polling endpoint for the current guild's
+ * in-progress (or most recent) Discord-name-refresh job.
+ * @param req - Express request; reads `req.session.user.currentGuildId`.
+ * @param res - Express response; always responds 200 with the guild's `RefreshState`
+ *   as JSON.
+ */
 router.get('/users/refresh-status', requireManager, (req, res) => {
   res.json(getRefreshState(req.session.user!.currentGuildId!));
 });
 
+/**
+ * POST /admin/users/refresh-names — kicks off a background job that re-fetches each
+ * guild member's Discord display name and updates it if changed. No-ops if a refresh
+ * is already running for the guild.
+ * @param req - Express request; reads `req.session.user.currentGuildId`.
+ * @param res - Express response; always redirects to `/admin/users` immediately —
+ *   the refresh itself runs asynchronously and is polled via `/users/refresh-status`.
+ */
 router.post('/users/refresh-names', requireManager, csrfProtection, async (req, res) => {
   const guildId = req.session.user!.currentGuildId!;
   if (getRefreshState(guildId).outcome === 'running') {

--- a/src/web/routes/commandAssignments.ts
+++ b/src/web/routes/commandAssignments.ts
@@ -14,6 +14,15 @@ import { parsePositiveIntId, normalizeDiscordId } from './shared';
 const log = createLogger('Web');
 const router = Router();
 
+/**
+ * POST /commands/assign — assigns a Twitch-linked Discord user to a custom command.
+ * @param req - Express request; reads `command_id` and `discord_id` from `req.body`.
+ * @param res - Express response; redirects to `/commands` on success, or to
+ *   `/commands?error=<code>` if fields are missing (`missing_fields`), IDs are
+ *   malformed (`invalid_id`), the user doesn't exist or has no linked Twitch name
+ *   (`invalid_assignment_user`), the command is already assigned (`command_taken`),
+ *   or the assignment write fails (`assign_failed`).
+ */
 router.post('/commands/assign', requireMod, csrfProtection, async (req, res) => {
   const { command_id, discord_id } = req.body as { command_id?: string; discord_id?: string };
   if (!command_id || !discord_id) {
@@ -46,6 +55,13 @@ router.post('/commands/assign', requireMod, csrfProtection, async (req, res) => 
   res.redirect('/commands');
 });
 
+/**
+ * POST /commands/unassign — removes a user's assignment from a custom command.
+ * @param req - Express request; reads `command_id` and `discord_id` from `req.body`.
+ * @param res - Express response; redirects to `/commands` on success, or to
+ *   `/commands?error=<code>` if fields are missing (`missing_fields`), IDs are
+ *   malformed (`invalid_id`), or the unassign write fails (`unassign_failed`).
+ */
 router.post('/commands/unassign', requireMod, csrfProtection, async (req, res) => {
   const { command_id, discord_id } = req.body as { command_id?: string; discord_id?: string };
   if (!command_id || !discord_id) {

--- a/src/web/routes/commandMonitor.ts
+++ b/src/web/routes/commandMonitor.ts
@@ -8,6 +8,13 @@ import { renderError } from './shared';
 const log = createLogger('Web');
 const router = Router();
 
+/**
+ * GET /command-monitor — renders the command monitor page showing recently
+ * triggered command test entries.
+ * @param req - Express request; reads `req.session.user`.
+ * @param res - Express response; renders the `command-monitor` view, or a 500
+ *   error page if loading recent entries fails.
+ */
 router.get('/command-monitor', requireManager, csrfProtection, (req, res) => {
   try {
     const recentEntries = getRecentCommandTestEntries();
@@ -22,6 +29,13 @@ router.get('/command-monitor', requireManager, csrfProtection, (req, res) => {
   }
 });
 
+/**
+ * GET /command-monitor/recent — polling endpoint returning recent command test
+ * entries as JSON, for live-refreshing the command monitor page.
+ * @param _req - Express request (unused).
+ * @param res - Express response; responds 200 with `{ entries }` on success, or
+ *   500 with `{ entries: [] }` if fetching entries fails.
+ */
 router.get('/command-monitor/recent', requireManager, (_req, res) => {
   try {
     res.json({ entries: getRecentCommandTestEntries() });

--- a/src/web/routes/commandMutations.ts
+++ b/src/web/routes/commandMutations.ts
@@ -59,6 +59,18 @@ async function assignUsersToNewCommand(commandId: number, discordIds: string[]):
   return null;
 }
 
+/**
+ * POST /commands/add — creates a custom command and optionally assigns it to one or
+ * more Twitch-linked Discord users. If any assignment fails, the just-created command
+ * is deleted to avoid a partially-assigned state.
+ * @param req - Express request; reads `trigger_string`, `output`, `is_discord_enabled`,
+ *   `is_multi_twitch`, and `discord_ids` from `req.body`.
+ * @param res - Express response; redirects to `/commands` on success, or to
+ *   `/commands?error=<code>` if required fields are missing (`missing_fields`), the
+ *   trigger is reserved (`reserved_command`) or already taken (`command_taken`), the
+ *   command insert fails (`add_failed`), or an assignment fails (`command_taken` or
+ *   `assign_failed`).
+ */
 router.post('/commands/add', requireMod, csrfProtection, async (req, res) => {
   const { trigger_string, output } = req.body as Record<string, string | undefined>;
   const isDiscordEnabled = req.body.is_discord_enabled === 'on';
@@ -90,6 +102,17 @@ router.post('/commands/add', requireMod, csrfProtection, async (req, res) => {
   res.redirect('/commands');
 });
 
+/**
+ * POST /commands/update — updates an existing custom command's trigger, output,
+ * and Discord/multi-Twitch flags.
+ * @param req - Express request; reads `command_id`, `trigger_string`, `output`,
+ *   `is_discord_enabled`, and `is_multi_twitch` from `req.body`.
+ * @param res - Express response; redirects to `/commands` on success, or to
+ *   `/commands?error=<code>` if required fields are missing (`missing_fields`),
+ *   `command_id` is malformed (`invalid_id`), the command no longer exists
+ *   (`command_not_found`), the trigger is reserved (`reserved_command`) or already
+ *   taken (`command_taken`), or the update fails (`update_failed`).
+ */
 router.post('/commands/update', requireMod, csrfProtection, async (req, res) => {
   const { command_id, trigger_string, output } = req.body as Record<string, string | undefined>;
   const isDiscordEnabled = req.body.is_discord_enabled === 'on';
@@ -120,6 +143,13 @@ router.post('/commands/update', requireMod, csrfProtection, async (req, res) => 
   res.redirect('/commands');
 });
 
+/**
+ * POST /commands/remove — deletes a custom command.
+ * @param req - Express request; reads `command_id` from `req.body`.
+ * @param res - Express response; redirects to `/commands` on success or if
+ *   `command_id` is absent, or to `/commands?error=<code>` if it's malformed
+ *   (`invalid_id`) or the delete fails (`remove_failed`).
+ */
 router.post('/commands/remove', requireMod, csrfProtection, async (req, res) => {
   const { command_id } = req.body as { command_id?: string };
   if (!command_id) return res.redirect('/commands');


### PR DESCRIPTION
Adds JSDoc to Express route handlers in `src/web/routes/` per CLAUDE.md's documentation rule. Third of several batched PRs covering all route files (previous: #310, #311).

Documentation only — no logic changes.

Routes documented:
- `src/web/routes/admin.ts`: `GET /admin/users`, `POST /admin/users/add`, `POST /admin/users/update`, `POST /admin/users/remove`, `POST /admin/users/toggle-twitch`
- `src/web/routes/adminRefresh.ts`: `GET /admin/users/refresh-status`, `POST /admin/users/refresh-names`
- `src/web/routes/commandMonitor.ts`: `GET /command-monitor`, `GET /command-monitor/recent`
- `src/web/routes/commandAssignments.ts`: `POST /commands/assign`, `POST /commands/unassign`
- `src/web/routes/commandMutations.ts`: `POST /commands/add`, `POST /commands/update`, `POST /commands/remove`


---
_Generated by [Claude Code](https://claude.ai/code/session_01XwQ6zMzSUtcXPe3krsvDrx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added and expanded route documentation across admin, command assignment, command monitoring, and command management endpoints.
  * Clarified expected inputs, success and failure redirects, polling responses, and error codes returned for common validation and database-related issues.
  * Improved descriptions of background refresh and recent-activity endpoints to make their behavior easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->