### PR TITLE
Document manager-dashboard route handlers with JSDoc

### DIFF
--- a/src/web/routes/api.ts
+++ b/src/web/routes/api.ts
@@ -29,12 +29,24 @@ function getSessionGuildId(req: Request, res: Response): string | null {
   return guildId;
 }
 
-// Live status JSON — polled by the dashboard frontend every few seconds
+/**
+ * GET /status — live bot status JSON, polled by the dashboard frontend every
+ * few seconds.
+ * @param _req - Express request (unused).
+ * @param res - Express response; returns `getStatus()`.
+ */
 router.get('/status', requireAuth, (_req, res) => {
   res.json(getStatus());
 });
 
-// Get available voice channels for the current guild — Mod and above
+/**
+ * GET /voice/channels — lists the current guild's available voice channels
+ * along with the configured default and currently-connected channel (Mod+).
+ * @param req - Express request; guild is taken from the session.
+ * @param res - Express response; JSON `{ ok: true, channels, defaultChannelId,
+ *   currentChannelId }` on success, 400 if no guild is selected, or 500 on
+ *   failure.
+ */
 router.get('/voice/channels', requireMod, async (req, res) => {
   const guildId = getSessionGuildId(req, res);
   if (!guildId) return;
@@ -55,7 +67,15 @@ router.get('/voice/channels', requireMod, async (req, res) => {
   }
 });
 
-// Join a specific voice channel, or the guild's configured default — Mod and above
+/**
+ * POST /voice/join — joins a specific voice channel, or the guild's configured
+ * default channel if none is supplied (Mod+).
+ * @param req - Express request; reads `channelId` from `req.body`; guild is
+ *   taken from the session.
+ * @param res - Express response; JSON `{ ok: true }` on success, 400 if no
+ *   guild is selected, `channelId` is malformed, or no channel is resolvable,
+ *   503 if the Discord client isn't ready, or 500 on failure.
+ */
 router.post('/voice/join', requireMod, csrfProtection, async (req, res) => {
   const guildId = getSessionGuildId(req, res);
   if (!guildId) return;
@@ -92,7 +112,13 @@ router.post('/voice/join', requireMod, csrfProtection, async (req, res) => {
   }
 });
 
-// Leave the current guild's voice channel — Mod and above
+/**
+ * POST /voice/leave — disconnects from the current guild's voice channel
+ * (Mod+).
+ * @param req - Express request; guild is taken from the session.
+ * @param res - Express response; JSON `{ ok: true }` on success, or 400 if no
+ *   guild is selected.
+ */
 router.post('/voice/leave', requireMod, csrfProtection, (req, res) => {
   const guildId = getSessionGuildId(req, res);
   if (!guildId) return;

--- a/src/web/routes/counters.ts
+++ b/src/web/routes/counters.ts
@@ -91,6 +91,13 @@ function validateAndNormalizeCounterForm(
   };
 }
 
+/**
+ * GET /counters — renders the counters page listing every counter.
+ * @param req - Express request; reads `req.session.user`, `error`, and `reset`
+ *   query params.
+ * @param res - Express response; renders the `counters` view, or a 500 error page
+ *   if loading counters fails.
+ */
 router.get('/counters', requireAuth, csrfProtection, async (req, res) => {
   try {
     const counters = await getAllCounters();
@@ -108,6 +115,16 @@ router.get('/counters', requireAuth, csrfProtection, async (req, res) => {
   }
 });
 
+/**
+ * POST /counters/add — creates a new counter with a trigger command, check command,
+ * increment/check messages, and yearly-reset flag.
+ * @param req - Express request; reads `trigger_command`, `check_command`, `message`,
+ *   `increment_message`, and `reset_yearly` from `req.body`.
+ * @param res - Express response; redirects to `/counters` on success, or to
+ *   `/counters?error=<code>` for validation failures (`missing_fields`,
+ *   `same_commands`, `duplicate_command`, `reserved_command`) or a DB failure
+ *   (`add_failed`).
+ */
 router.post('/counters/add', requireMod, csrfProtection, async (req, res) => {
   const form = validateAndNormalizeCounterForm(req.body as Record<string, string | undefined>);
   if (form.error) {
@@ -139,6 +156,17 @@ router.post('/counters/add', requireMod, csrfProtection, async (req, res) => {
   res.redirect('/counters');
 });
 
+/**
+ * POST /counters/update — updates an existing counter's commands, messages, and
+ * yearly-reset flag.
+ * @param req - Express request; reads `id`, `trigger_command`, `check_command`,
+ *   `message`, `increment_message`, and `reset_yearly` from `req.body`.
+ * @param res - Express response; redirects to `/counters` on success, or to
+ *   `/counters?error=<code>` for validation failures (`missing_fields`,
+ *   `same_commands`, `invalid_id`, `duplicate_command`, `reserved_command`), if the
+ *   counter no longer exists (`counter_not_found`), or the update fails
+ *   (`update_failed`).
+ */
 router.post('/counters/update', requireMod, csrfProtection, async (req, res) => {
   const { id } = req.body as Record<string, string | undefined>;
 
@@ -181,6 +209,13 @@ router.post('/counters/update', requireMod, csrfProtection, async (req, res) => 
   res.redirect('/counters');
 });
 
+/**
+ * POST /counters/remove — deletes a counter.
+ * @param req - Express request; reads `id` from `req.body`.
+ * @param res - Express response; redirects to `/counters` on success, or to
+ *   `/counters?error=<code>` if `id` is malformed (`invalid_id`), the counter
+ *   doesn't exist (`counter_not_found`), or the delete fails (`remove_failed`).
+ */
 router.post('/counters/remove', requireMod, csrfProtection, async (req, res) => {
   const { id } = req.body as { id?: string };
   const parsedId = parsePositiveIntId(id);
@@ -203,6 +238,14 @@ router.post('/counters/remove', requireMod, csrfProtection, async (req, res) => 
   res.redirect('/counters');
 });
 
+/**
+ * POST /counters/reset/:id — resets a counter's current value back to zero
+ * (Manager+).
+ * @param req - Express request; reads the `id` route param.
+ * @param res - Express response; redirects to `/counters?reset=1` on success, or
+ *   to `/counters?error=<code>` if `id` is malformed (`invalid_id`), the counter
+ *   doesn't exist (`counter_not_found`), or the reset fails (`reset_failed`).
+ */
 router.post('/counters/reset/:id', requireManager, csrfProtection, async (req, res) => {
   const rawId = req.params.id;
   const parsedId = parsePositiveIntId(typeof rawId === 'string' ? rawId : undefined);

--- a/src/web/routes/streams.ts
+++ b/src/web/routes/streams.ts
@@ -51,6 +51,14 @@ function getFriendlyError(key: string): string {
 
 // ─── View ─────────────────────────────────────────────────────────────────────
 
+/**
+ * GET /streams — renders the streams page with stream groups, streamers, and
+ * (admin only) EventSub status per streamer.
+ * @param req - Express request; reads `req.session.user`, `error`, and `success`
+ *   query params.
+ * @param res - Express response; renders the `streams` view, or a 500 error page
+ *   if loading streams data fails.
+ */
 router.get('/streams', requireManager, csrfProtection, async (req, res) => {
   try {
     const isAdmin = (req.session.user?.accessLevel ?? 0) >= AccessLevel.ADMIN;
@@ -91,12 +99,28 @@ router.get('/streams', requireManager, csrfProtection, async (req, res) => {
 
 // ─── Live state snapshot ──────────────────────────────────────────────────────
 
+/**
+ * GET /streams/live — JSON snapshot of current live states, polled by the
+ * streams page frontend.
+ * @param _req - Express request (unused).
+ * @param res - Express response; returns `{ streams }` from `getLiveStates()`.
+ */
 router.get('/streams/live', requireManager, (_req, res) => {
   res.json({ streams: getLiveStates() });
 });
 
 // ─── Groups ───────────────────────────────────────────────────────────────────
 
+/**
+ * POST /streams/groups/add — creates a new stream group (Discord channel, live
+ * and new-game messages, multi-twitch/delete-old-posts flags) and restarts the
+ * Twitch monitor.
+ * @param req - Express request; reads `name`, `discord_channel`, `live_message`,
+ *   `new_game_message`, `multi_twitch`, and `delete_old_posts` from `req.body`.
+ * @param res - Express response; redirects to `/admin/streams` on success, or to
+ *   `/admin/streams?error=<code>` for missing fields (`missing_fields`) or a DB
+ *   failure (`add_group_failed`).
+ */
 router.post('/streams/groups/add', requireManager, csrfProtection, async (req, res) => {
   const { name, discord_channel, live_message, new_game_message } = req.body as Record<string, string | undefined>;
   const multi_twitch = req.body.multi_twitch === 'on';
@@ -123,6 +147,16 @@ router.post('/streams/groups/add', requireManager, csrfProtection, async (req, r
   res.redirect('/admin/streams');
 });
 
+/**
+ * POST /streams/groups/update — updates an existing stream group's channel,
+ * messages, and flags, then restarts the Twitch monitor.
+ * @param req - Express request; reads `group_id`, `name`, `discord_channel`,
+ *   `live_message`, `new_game_message`, `multi_twitch`, and `delete_old_posts`
+ *   from `req.body`.
+ * @param res - Express response; redirects to `/admin/streams` on success, or to
+ *   `/admin/streams?error=<code>` for missing fields (`missing_fields`), a
+ *   malformed `group_id` (`invalid_id`), or a DB failure (`update_group_failed`).
+ */
 router.post('/streams/groups/update', requireManager, csrfProtection, async (req, res) => {
   const { group_id, name, discord_channel, live_message, new_game_message } = req.body as Record<string, string | undefined>;
   const multi_twitch = req.body.multi_twitch === 'on';
@@ -153,6 +187,14 @@ router.post('/streams/groups/update', requireManager, csrfProtection, async (req
   res.redirect('/admin/streams');
 });
 
+/**
+ * POST /streams/groups/remove — deletes a stream group, first removing its
+ * streamers to avoid FK constraint errors, then restarts the Twitch monitor.
+ * @param req - Express request; reads `group_id` from `req.body`.
+ * @param res - Express response; redirects to `/admin/streams` on success, or to
+ *   `/admin/streams?error=<code>` if `group_id` is malformed (`invalid_id`) or the
+ *   delete fails (`remove_group_failed`).
+ */
 router.post('/streams/groups/remove', requireManager, csrfProtection, async (req, res) => {
   const { group_id } = req.body as { group_id?: string };
   if (!group_id) return res.redirect('/admin/streams');
@@ -173,6 +215,16 @@ router.post('/streams/groups/remove', requireManager, csrfProtection, async (req
 
 // ─── Streamers ────────────────────────────────────────────────────────────────
 
+/**
+ * POST /streams/streamers/add — adds a user (who must already have a Twitch
+ * name) as a streamer in a stream group, then restarts the Twitch monitor.
+ * @param req - Express request; reads `discord_id` and `group_id` from
+ *   `req.body`.
+ * @param res - Express response; redirects to `/admin/streams` on success, or to
+ *   `/admin/streams?error=<code>` for missing/invalid fields or no Twitch name
+ *   (`missing_fields`), a malformed `group_id` (`invalid_id`), or a DB failure
+ *   (`add_streamer_failed`).
+ */
 router.post('/streams/streamers/add', requireManager, csrfProtection, async (req, res) => {
   const { discord_id, group_id } = req.body as { discord_id?: string | string[]; group_id?: string | string[] };
   const discordId = normalizeDiscordId(typeof discord_id === 'string' ? discord_id : undefined);
@@ -194,6 +246,14 @@ router.post('/streams/streamers/add', requireManager, csrfProtection, async (req
   res.redirect('/admin/streams');
 });
 
+/**
+ * POST /streams/streamers/remove — removes a streamer, then restarts the
+ * Twitch monitor.
+ * @param req - Express request; reads `streamer_id` from `req.body`.
+ * @param res - Express response; redirects to `/admin/streams` on success, or to
+ *   `/admin/streams?error=<code>` if `streamer_id` is malformed (`invalid_id`) or
+ *   the delete fails (`remove_streamer_failed`).
+ */
 router.post('/streams/streamers/remove', requireManager, csrfProtection, async (req, res) => {
   const { streamer_id } = req.body as { streamer_id?: string };
   if (!streamer_id) return res.redirect('/admin/streams');


### PR DESCRIPTION
Documentation-only batch (4 of 6) adding JSDoc to Express route handlers per CLAUDE.md's docstring rule. No logic changes.

Follows #310, #311, #312.

Routes documented:

**counters.ts**
- `GET /counters`
- `POST /counters/add`
- `POST /counters/update`
- `POST /counters/remove`
- `POST /counters/reset/:id`

**streams.ts**
- `GET /streams`
- `GET /streams/live`
- `POST /streams/groups/add`
- `POST /streams/groups/update`
- `POST /streams/groups/remove`
- `POST /streams/streamers/add`
- `POST /streams/streamers/remove`

**api.ts**
- `GET /status`
- `GET /voice/channels`
- `POST /voice/join`
- `POST /voice/leave`

`npx tsc --noEmit && npm test` pass (1412 tests).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwQ6zMzSUtcXPe3krsvDrx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded route documentation across API, counters, and streams endpoints.
  * Added clearer details on request inputs, response shapes, and possible error status codes.
  * Improved coverage for status, voice, counter management, stream listings, and admin actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->