### PR TITLE
Document overlay-admin route handlers with JSDoc

### DIFF
--- a/src/web/routes/overlayAdmin.ts
+++ b/src/web/routes/overlayAdmin.ts
@@ -36,7 +36,15 @@ async function fetchTwitchRewards(streamer: DbStreamerEventSub): Promise<TwitchC
   }
 }
 
-// GET /overlay/settings
+/**
+ * GET /overlay/settings — renders the overlay settings page with the user's
+ * uploaded videos, configured rewards, and live Twitch custom rewards (if the
+ * user is a streamer).
+ * @param req - Express request; reads `req.session.user`, `error`, and
+ *   `success` query params.
+ * @param res - Express response; renders the `overlayAdmin` view, or a 500
+ *   error page if loading settings fails.
+ */
 router.get('/settings', requireAuth, csrfProtection, async (req, res) => {
   try {
     const streamer = await getStreamerByDiscordId(req.session.user!.discordId);

--- a/src/web/routes/overlayAdminMutations.ts
+++ b/src/web/routes/overlayAdminMutations.ts
@@ -102,10 +102,21 @@ function uploadVideo(req: Request, res: Response, next: NextFunction): void {
   });
 }
 
-// POST /overlay/settings/videos/upload
-// csrfProtection runs BEFORE uploadVideo so a bad token is rejected before Multer
-// buffers the file. The client (overlayAdmin.js) sends the token in an X-CSRF-Token
-// header — available before body parsing and never placed in the URL.
+/**
+ * POST /overlay/settings/videos/upload — uploads a video file (webm/mp4,
+ * validated by magic bytes) for the requesting streamer. csrfProtection runs
+ * BEFORE uploadVideo so a bad token is rejected before Multer buffers the
+ * file; the client (overlayAdmin.js) sends the token in an X-CSRF-Token
+ * header — available before body parsing and never placed in the URL.
+ * @param req - Express request; reads `name` and the `video` file from
+ *   `req.body`/`req.file`.
+ * @param res - Express response; redirects to `/overlay/settings?success=video_uploaded`
+ *   on success, or to `/overlay/settings?error=<code>` if the requester isn't a
+ *   streamer (`not_a_streamer`), no file was uploaded or it failed magic-byte
+ *   validation (`invalid_file`), the resolved storage path is unsafe
+ *   (`invalid_path`), the file exceeds the size limit (`file_too_large`,
+ *   redirected by `handleUploadError`), or saving fails (`upload_failed`).
+ */
 router.post('/settings/videos/upload', requireAuth, csrfProtection, uploadVideo, async (req, res) => {
   try {
     const streamer = await requireStreamer(req, res);
@@ -123,7 +134,15 @@ router.post('/settings/videos/upload', requireAuth, csrfProtection, uploadVideo,
   }
 });
 
-// POST /overlay/settings/videos/:id/delete
+/**
+ * POST /overlay/settings/videos/:id/delete — deletes a video belonging to the
+ * requesting streamer, removing both its DB row and file on disk.
+ * @param req - Express request; reads the `id` route param.
+ * @param res - Express response; redirects to `/overlay/settings?success=video_deleted`
+ *   on success, or to `/overlay/settings?error=<code>` if the requester isn't a
+ *   streamer (`not_a_streamer`), `id` is malformed (`invalid_id`), or the delete
+ *   fails (`delete_failed`).
+ */
 router.post('/settings/videos/:id/delete', requireAuth, csrfProtection, async (req, res) => {
   try {
     const streamer = await requireStreamer(req, res);

--- a/src/web/routes/overlayAdminRewardMutations.ts
+++ b/src/web/routes/overlayAdminRewardMutations.ts
@@ -9,7 +9,17 @@ import { requireStreamer, toStringArray, parseWeight } from './overlayAdminShare
 const log = createLogger('OverlayAdminReward');
 export const router = Router();
 
-// POST /overlay/settings/rewards — create or update a reward assignment
+/**
+ * POST /overlay/settings/rewards — creates or updates a reward assignment,
+ * linking a Twitch custom reward (by UUID) to a weighted set of overlay videos.
+ * @param req - Express request; reads `twitch_reward_id`, `video_ids`, and
+ *   `weight_<videoId>` fields from `req.body`.
+ * @param res - Express response; redirects to `/overlay/settings?success=reward_saved`
+ *   on success, or to `/overlay/settings?error=<code>` if the requester isn't a
+ *   streamer (`not_a_streamer`), the reward ID isn't a valid UUID
+ *   (`invalid_reward_id`), no videos were selected (`no_videos_selected`), or
+ *   saving fails (`save_failed`).
+ */
 router.post('/settings/rewards', requireAuth, csrfProtection, async (req, res) => {
   try {
     const streamer = await requireStreamer(req, res);
@@ -40,7 +50,15 @@ router.post('/settings/rewards', requireAuth, csrfProtection, async (req, res) =
   }
 });
 
-// POST /overlay/settings/rewards/:id/delete
+/**
+ * POST /overlay/settings/rewards/:id/delete — deletes a reward assignment
+ * belonging to the requesting streamer.
+ * @param req - Express request; reads the `id` route param.
+ * @param res - Express response; redirects to `/overlay/settings?success=reward_deleted`
+ *   on success, or to `/overlay/settings?error=<code>` if the requester isn't a
+ *   streamer (`not_a_streamer`), `id` is malformed (`invalid_id`), or the delete
+ *   fails (`delete_failed`).
+ */
 router.post('/settings/rewards/:id/delete', requireAuth, csrfProtection, async (req, res) => {
   try {
     const streamer = await requireStreamer(req, res);


### PR DESCRIPTION
Documentation-only batch (5 of 6) adding JSDoc to Express route handlers per CLAUDE.md's docstring rule. No logic changes.

Follows #310, #311, #312, #313.

Routes documented:

**overlayAdmin.ts**
- `GET /overlay/settings`

**overlayAdminMutations.ts**
- `POST /overlay/settings/videos/upload`
- `POST /overlay/settings/videos/:id/delete`

**overlayAdminRewardMutations.ts**
- `POST /overlay/settings/rewards`
- `POST /overlay/settings/rewards/:id/delete`

`npx tsc --noEmit && npm test` pass (1412 tests).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwQ6zMzSUtcXPe3krsvDrx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded route documentation for overlay admin pages and reward actions.
  * Added clearer details on request inputs, response behavior, and possible success/error outcomes for video upload, video deletion, and reward create/update/delete flows.
  * Improved inline guidance for how these admin endpoints behave without changing any functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->