### PR TITLE
Document overlay-source and SFX route handlers with JSDoc

### DIFF
--- a/src/web/routes/overlaySource.ts
+++ b/src/web/routes/overlaySource.ts
@@ -38,19 +38,41 @@ export function pushOverlayEvent(login: string, videoPath: string): void {
   log.info(`Pushed overlay event to ${clients.size} client(s) for ${login}`);
 }
 
-// GET /overlay/controller — Forza/gamepad controller browser source (no auth, opened by OBS)
+/**
+ * GET /overlay/controller — renders the Forza/gamepad controller browser
+ * source page (no auth, opened directly by OBS).
+ * @param _req - Express request (unused).
+ * @param res - Express response; renders the `controllerOverlay` view.
+ */
 router.get('/controller', (_req, res) => {
   res.render('controllerOverlay');
 });
 
-// GET /overlay/:login — browser source HTML page (no auth, opened by OBS)
+/**
+ * GET /overlay/:login — renders the video-overlay browser source HTML page
+ * for a Twitch channel login (no auth, opened directly by OBS).
+ * @param req - Express request; reads the `login` route param.
+ * @param res - Express response; renders the `overlaySource` view, or calls
+ *   `next()` to fall through to later routes if `login` is malformed or
+ *   reserved (e.g. `settings`, `videos`, `controller`).
+ */
 router.get('/:login', (req, res, next) => {
   const { login } = req.params;
   if (!LOGIN_RE.test(login) || RESERVED_LOGINS.has(login.toLowerCase())) { next(); return; }
   res.render('overlaySource', { login: login.toLowerCase() });
 });
 
-// GET /overlay/:login/events — SSE endpoint
+/**
+ * GET /overlay/:login/events — SSE endpoint that streams `pushOverlayEvent`
+ * video notifications to a connected browser source for a channel login (no
+ * auth, opened directly by OBS).
+ * @param req - Express request; reads the `login` route param.
+ * @param res - Express response; on a valid login, upgrades to an
+ *   `text/event-stream` connection kept alive with periodic pings and torn
+ *   down on client disconnect; replies 429 if the channel's connection limit
+ *   (`MAX_SSE_CONNECTIONS_PER_CHANNEL`) is exceeded, or calls `next()` if
+ *   `login` is malformed or reserved.
+ */
 router.get('/:login/events', (req, res, next) => {
   const { login } = req.params;
   if (!LOGIN_RE.test(login) || RESERVED_LOGINS.has(login.toLowerCase())) { next(); return; }
@@ -95,7 +117,15 @@ router.get('/:login/events', (req, res, next) => {
   });
 });
 
-// GET /overlay/videos/:streamerId/:filename — serve video files (no auth)
+/**
+ * GET /overlay/videos/:streamerId/:filename — serves an overlay video file
+ * from disk (no auth; URLs are unguessable UUID filenames).
+ * @param req - Express request; reads the `streamerId` and `filename` route
+ *   params.
+ * @param res - Express response; sends the file on success, or replies 400 if
+ *   `streamerId`/`filename` are malformed or the resolved path is unsafe, or
+ *   404 if the file doesn't exist.
+ */
 router.get('/videos/:streamerId/:filename', async (req, res) => {
   const { streamerId, filename } = req.params;
 

--- a/src/web/routes/sfxPublic.ts
+++ b/src/web/routes/sfxPublic.ts
@@ -23,6 +23,13 @@ async function getCachedData(): Promise<PublicSfxTrigger[]> {
   return inFlight;
 }
 
+/**
+ * GET /sfx-list — renders the public SFX list page, served from a 5-minute
+ * in-memory cache (with single-flight dedup) to avoid repeated DB hits.
+ * @param req - Express request; reads `req.session.user`, used only if present.
+ * @param res - Express response; renders the `sfx-public` view, or a 500 error
+ *   page if loading triggers fails.
+ */
 router.get('/sfx-list', async (req, res) => {
   try {
     const triggers = await getCachedData();


### PR DESCRIPTION
Documentation-only batch (6 of 6, final) adding JSDoc to Express route handlers per CLAUDE.md's docstring rule. No logic changes.

Follows #310, #311, #312, #313, #314.

Routes documented:

**overlaySource.ts**
- `GET /overlay/controller`
- `GET /overlay/:login`
- `GET /overlay/:login/events`
- `GET /overlay/videos/:streamerId/:filename`

**sfxPublic.ts**
- `GET /sfx-list`

**sfx.ts** — dropped from this PR. Rebased onto main after `#319` ("Add SFX management for Mods+") landed, which rewrote `GET /sfx` and already added its own JSDoc. The new SFX mutation route files that PR introduced (`sfxTriggerMutations.ts`, `sfxFileMutations.ts`, `sfxFileUpload.ts`, `sfxCategoryMutations.ts`) also already have full JSDoc on every handler — verified, no gaps.

`npx tsc --noEmit && npm test` pass (1555 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved route documentation for overlay, event stream, video playback, and SFX listing endpoints.
  * Clarified request parameters, response behavior, fallback handling, and cache-related behavior for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->