### PR TITLE
Add privacy/cookie notice page

### DIFF
--- a/src/web/routes/privacy.test.ts
+++ b/src/web/routes/privacy.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import express from 'express';
+import supertest from 'supertest';
+import privacyRouter from './privacy';
+
+function buildApp(sessionUser: unknown = null) {
+  const app = express();
+  app.use((req: any, _res: any, next: any) => {
+    req.session = { user: sessionUser };
+    next();
+  });
+  app.use((req: any, res: any, next: any) => {
+    res.render = (view: string, locals: unknown) => res.json({ view, locals });
+    next();
+  });
+  app.use(privacyRouter);
+  return app;
+}
+
+describe('GET /privacy', () => {
+  beforeEach(() => {
+    // no-op: each test builds its own app/session
+  });
+
+  it('renders the privacy page for anonymous visitors', async () => {
+    const res = await supertest(buildApp(null)).get('/privacy');
+    expect(res.status).toBe(200);
+    expect((res.body as any).view).toBe('privacy');
+    expect((res.body as any).locals.user).toBeNull();
+    expect((res.body as any).locals.csrfToken).toBe('');
+  });
+
+  it('renders the privacy page for signed-in users with a csrf token', async () => {
+    const user = { discordId: '42', discordName: 'Alice', accessLevel: 0 };
+    const res = await supertest(buildApp(user)).get('/privacy');
+    expect(res.status).toBe(200);
+    expect((res.body as any).view).toBe('privacy');
+    expect((res.body as any).locals.user).toEqual(user);
+    expect(typeof (res.body as any).locals.csrfToken).toBe('string');
+    expect((res.body as any).locals.csrfToken.length).toBeGreaterThan(0);
+  });
+});

--- a/src/web/routes/privacy.test.ts
+++ b/src/web/routes/privacy.test.ts
@@ -3,6 +3,7 @@ import express from 'express';
 import supertest from 'supertest';
 import privacyRouter from './privacy';
 
+/** Builds a minimal Express app wired with the privacy router, a fake session, and a `res.render` stub that echoes its arguments as JSON instead of rendering EJS. */
 function buildApp(sessionUser: unknown = null) {
   const app = express();
   app.use((req: any, _res: any, next: any) => {
@@ -18,6 +19,7 @@ function buildApp(sessionUser: unknown = null) {
 }
 
 describe('GET /privacy', () => {
+  /** No shared state to reset; each test builds its own app/session via buildApp. */
   beforeEach(() => {
     // no-op: each test builds its own app/session
   });

--- a/src/web/routes/privacy.ts
+++ b/src/web/routes/privacy.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import { ensureSessionCsrfToken } from '../csrf';
+
+const router = Router();
+
+/** Renders the public privacy/cookie notice page. Accessible whether or not the user is signed in. */
+router.get('/privacy', (req, res) => {
+  res.render('privacy', {
+    user: req.session.user ?? null,
+    csrfToken: req.session.user ? ensureSessionCsrfToken(req) : '',
+  });
+});
+
+export default router;

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -29,6 +29,7 @@ import streamdeckKeysRouter from './routes/streamdeckKeys';
 import userSettingsRouter from './routes/userSettings';
 import overlaySourceRouter from './routes/overlaySource';
 import overlayAdminRouter from './routes/overlayAdmin';
+import privacyRouter from './routes/privacy';
 import { requireAuth, requireGuildContext } from './middleware';
 import { ensureSessionCsrfToken } from './csrf';
 import {
@@ -157,6 +158,7 @@ app.use('/auth', authLimiter, authRouter);
 app.use('/auth', authLimiter, eventsubCallbackRouter);
 app.use('/api/streamdeck', streamdeckLimiter, streamdeckRouter);
 app.use('/', sfxPublicRouter);
+app.use('/', privacyRouter);
 app.use('/overlay', overlaySourceRouter);
 app.use('/guild', requireAuth, guildRouter);
 app.use('/api', requireAuth, apiRouter);

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -19,6 +19,7 @@
       Login with Discord
     </a>
     <p class="login-note">Access is restricted to whitelisted users only.</p>
+    <p class="login-note"><a href="/privacy">Privacy &amp; Cookies</a></p>
   </div>
   <%- include('partials/pwa-register') %>
 </body>

--- a/views/partials/nav.ejs
+++ b/views/partials/nav.ejs
@@ -53,6 +53,7 @@
         <button type="submit" class="btn btn-ghost btn-sm">Logout</button>
       </form>
       <% } %>
+      <a href="/privacy" class="nav-item">Privacy</a>
     </div>
   </div>
 </nav>

--- a/views/privacy.ejs
+++ b/views/privacy.ejs
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BCUK Bot — Privacy &amp; Cookies</title>
+  <link rel="stylesheet" href="/style.css">
+  <%- include('partials/pwa-head') %>
+</head>
+<body>
+  <% if (user) { %><%- include('partials/nav') %><% } %>
+  <main class="container">
+    <section class="section">
+      <h2 class="section-title">Privacy &amp; Cookies</h2>
+
+      <div class="card card-spaced">
+        <div class="card-header"><span class="card-icon">🍪</span><span class="card-label">Cookies</span></div>
+        <div class="card-body">
+          <p>This site sets a single cookie, <code>connect.sid</code>, which keeps you signed in between
+            page loads. It does not track you across other sites, and we don't use it for analytics or
+            advertising.</p>
+          <p>This cookie is <strong>strictly necessary</strong> — it only exists to keep your login session
+            and protect against cross-site request forgery (CSRF) once you sign in. Strictly necessary
+            cookies are exempt from cookie consent requirements under UK PECR/GDPR, so you won't see a
+            cookie consent banner here. The cookie expires automatically after 24 hours, is marked
+            <code>HttpOnly</code> (inaccessible to page scripts) and is sent over HTTPS only in production.</p>
+          <p>We don't use any analytics, advertising, or third-party tracking cookies anywhere on this site.</p>
+        </div>
+      </div>
+
+      <div class="card card-spaced">
+        <div class="card-header"><span class="card-icon">📋</span><span class="card-label">What we collect</span></div>
+        <div class="card-body">
+          <p>When you sign in with Discord, we receive and store your Discord ID, display name, and avatar
+            so you can use the control panel. We also store the access level assigned to you in each Discord
+            server the bot is added to.</p>
+          <p>If you connect a Twitch account for stream notifications, we store your Twitch user ID and the
+            OAuth access/refresh tokens needed to receive that data. Those tokens are encrypted at rest and
+            are never stored in plain text.</p>
+          <p>If you generate a Streamdeck API key, we store only a one-way hash of it — never the key itself.</p>
+          <p>We do not record or transcribe voice channel audio, and we do not store the content of Discord
+            messages or chat logs. A short list of the most recent bot command executions is kept in memory
+            for moderators to review, but it is not written to a database and is lost on restart.</p>
+        </div>
+      </div>
+
+      <div class="card card-spaced">
+        <div class="card-header"><span class="card-icon">🔗</span><span class="card-label">Third parties</span></div>
+        <div class="card-body">
+          <p>To provide the service we exchange data with Discord (for login and avatars) and Twitch (for
+            stream notifications you opt into). We don't share your data with any analytics, advertising, or
+            marketing services — we don't use any.</p>
+        </div>
+      </div>
+
+      <div class="card card-spaced">
+        <div class="card-header"><span class="card-icon">🗑️</span><span class="card-label">Retention &amp; deletion</span></div>
+        <div class="card-body">
+          <p>Login sessions expire after 24 hours of being issued. Server logs are kept for 14 days and then
+            deleted. If your account is removed from the system, your stored Discord/Twitch data — including
+            any encrypted Twitch tokens and API key records — is deleted along with it.</p>
+          <p>To request deletion of your data, contact a server administrator.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+  <%- include('partials/pwa-register') %>
+</body>
+</html>

--- a/views/privacy.ejs
+++ b/views/privacy.ejs
@@ -58,7 +58,8 @@
         <div class="card-body">
           <p>Login sessions expire after 24 hours of being issued. Server logs are kept for 14 days and then
             deleted. If your account is removed from the system, your stored Discord/Twitch data — including
-            any encrypted Twitch tokens and API key records — is deleted along with it.</p>
+            any encrypted Twitch tokens — is deleted along with it. Any Streamdeck API key you generated is
+            not automatically deleted; contact a server administrator to have it revoked.</p>
           <p>To request deletion of your data, contact a server administrator.</p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- The site only sets one cookie — `connect.sid` (express-session: httpOnly, sameSite=lax, secure in prod, 24h expiry) — used solely for login sessions, CSRF tokens, and OAuth state. Strictly-necessary cookies like this are exempt from consent requirements under UK PECR/GDPR, so **no consent popup is needed**.
- PECR's transparency rule still expects users to be told what's collected, even when exempt from consent. There was no privacy/cookie notice anywhere in the repo.
- Adds a public `/privacy` page (`views/privacy.ejs`, `src/web/routes/privacy.ts`) covering: the session cookie, Discord/Twitch data collected, third parties, and retention/deletion. Linked from the nav bar and the login screen.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — all 1416 tests pass, including new `src/web/routes/privacy.test.ts`
- [x] Rendered `privacy.ejs` directly for both anonymous and signed-in sessions to confirm the nav include and content render correctly
- [x] Confirmed `/privacy` link appears on `login.ejs` and in `partials/nav.ejs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TA3tcQ53CsnUtBcWdMdsoC

---
_Generated by [Claude Code](https://claude.ai/code/session_01TA3tcQ53CsnUtBcWdMdsoC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Privacy & Cookies page with details about data use, cookies, retention, and deletion.
  * Added Privacy links in the main navigation and on the login page for easier access.
* **Bug Fixes**
  * Improved the privacy page experience for both signed-in and anonymous visitors, showing the correct page content and session state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->