### PR TITLE
Harden overlay video upload (CSRF in header, size-limit handling)

### DIFF
--- a/public/overlayAdmin.js
+++ b/public/overlayAdmin.js
@@ -43,7 +43,15 @@ function handleOverlayUploadSubmit(event) {
     body: new FormData(form),
   })
     .then(function (res) {
-      window.location.assign(res.url || '/overlay/settings');
+      // Only follow an actual server redirect (success/error → /overlay/settings?…).
+      // A non-redirect response (e.g. 403 CSRF, 500) keeps res.url at the POST-only
+      // upload route, so treat any non-OK response as a failure instead.
+      if (res.redirected && res.url) {
+        window.location.assign(res.url);
+        return;
+      }
+      if (!res.ok) throw new Error('Upload failed');
+      window.location.assign('/overlay/settings');
     })
     .catch(function () {
       window.location.assign('/overlay/settings?error=upload_failed');

--- a/public/overlayAdmin.js
+++ b/public/overlayAdmin.js
@@ -19,3 +19,35 @@ function handleOverlayAdminSubmit(event) {
 }
 
 document.addEventListener('submit', handleOverlayAdminSubmit);
+
+/**
+ * Submit the video upload form via fetch with the CSRF token in an X-CSRF-Token
+ * header, so the session token is never placed in the URL (history/Referer).
+ * csrfProtection validates the header before Multer parses the multipart body.
+ * fetch follows the server redirect; we then navigate to the resulting page.
+ * @param {SubmitEvent} event - The form submit event.
+ * @returns {void}
+ */
+function handleOverlayUploadSubmit(event) {
+  const form = event.target;
+  if (!(form instanceof HTMLFormElement) || !form.classList.contains('js-overlay-upload')) return;
+  event.preventDefault();
+
+  const token = (document.body && document.body.dataset.csrfToken) || '';
+  const submitBtn = form.querySelector('button[type="submit"]');
+  if (submitBtn) submitBtn.disabled = true;
+
+  fetch(form.action, {
+    method: 'POST',
+    headers: { 'X-CSRF-Token': token },
+    body: new FormData(form),
+  })
+    .then(function (res) {
+      window.location.assign(res.url || '/overlay/settings');
+    })
+    .catch(function () {
+      window.location.assign('/overlay/settings?error=upload_failed');
+    });
+}
+
+document.addEventListener('submit', handleOverlayUploadSubmit);

--- a/src/web/routes/overlayAdmin.ts
+++ b/src/web/routes/overlayAdmin.ts
@@ -18,6 +18,7 @@ const router = Router();
 const KNOWN_ERRORS = new Set([
   'not_a_streamer', 'invalid_file', 'upload_failed', 'delete_failed',
   'invalid_reward_id', 'no_videos_selected', 'save_failed', 'invalid_id', 'invalid_path',
+  'file_too_large',
 ]);
 const KNOWN_SUCCESSES = new Set([
   'video_uploaded', 'video_deleted', 'reward_saved', 'reward_deleted',

--- a/src/web/routes/overlayAdminMutations.test.ts
+++ b/src/web/routes/overlayAdminMutations.test.ts
@@ -1,4 +1,15 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+
+// Shrink the upload size limit to 1 MB before the route module reads
+// OVERLAY_MAX_FILE_MB at import time, so an oversized-upload test can trigger
+// Multer's LIMIT_FILE_SIZE with a small buffer. Existing tests use tiny buffers,
+// so they are unaffected. Restored in afterAll to avoid leaking to other files.
+vi.hoisted(() => {
+  process.env.OVERLAY_MAX_FILE_MB = '1';
+});
+afterAll(() => {
+  delete process.env.OVERLAY_MAX_FILE_MB;
+});
 
 vi.mock('../../shared/logger', () => ({
   createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
@@ -141,6 +152,19 @@ describe('POST /settings/videos/upload', () => {
       .attach('video', Buffer.from('not a real video'), { filename: 'evil.mp4', contentType: 'video/mp4' });
     expect(res.headers.location).toBe('/overlay/settings?error=invalid_file');
     expect(vi.mocked(fs.promises.writeFile)).not.toHaveBeenCalled();
+  });
+
+  // End-to-end: locks the uploadVideo → handleUploadError wiring so the route still
+  // redirects (rather than 500s) if the middleware chain or ordering ever changes.
+  it('redirects an oversized upload to file_too_large via the route middleware', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const oversized = Buffer.alloc(1024 * 1024 + 1024, 1); // > 1 MB limit set above
+    const res = await supertest(buildApp())
+      .post('/settings/videos/upload')
+      .attach('video', oversized, { filename: 'big.mp4', contentType: 'video/mp4' });
+    expect(res.headers.location).toBe('/overlay/settings?error=file_too_large');
+    expect(vi.mocked(fs.promises.writeFile)).not.toHaveBeenCalled();
+    expect(vi.mocked(addVideo)).not.toHaveBeenCalled();
   });
 });
 

--- a/src/web/routes/overlayAdminMutations.test.ts
+++ b/src/web/routes/overlayAdminMutations.test.ts
@@ -256,6 +256,7 @@ describe('detectVideoType', () => {
 // --- handleUploadError unit tests ---
 
 describe('handleUploadError', () => {
+  /** Minimal Express response stub capturing the redirect target. */
   function makeRes() {
     return { redirect: vi.fn() } as any;
   }

--- a/src/web/routes/overlayAdminMutations.test.ts
+++ b/src/web/routes/overlayAdminMutations.test.ts
@@ -40,7 +40,8 @@ vi.mock('fs', () => ({
 
 import express from 'express';
 import supertest from 'supertest';
-import { router, detectVideoType } from './overlayAdminMutations';
+import multer from 'multer';
+import { router, detectVideoType, handleUploadError } from './overlayAdminMutations';
 import { getStreamerByDiscordId, addVideo, deleteVideo } from '../../db';
 import { AccessLevel } from '../../db/users';
 import fs from 'fs';
@@ -249,5 +250,32 @@ describe('detectVideoType', () => {
 
   it('returns null for a buffer that is too short', () => {
     expect(detectVideoType(Buffer.from([0x1a, 0x45]))).toBeNull();
+  });
+});
+
+// --- handleUploadError unit tests ---
+
+describe('handleUploadError', () => {
+  function makeRes() {
+    return { redirect: vi.fn() } as any;
+  }
+
+  it('returns false and does not redirect when there is no error', () => {
+    const res = makeRes();
+    expect(handleUploadError(null, res)).toBe(false);
+    expect(res.redirect).not.toHaveBeenCalled();
+  });
+
+  it('redirects oversized files to file_too_large', () => {
+    const res = makeRes();
+    const err = new multer.MulterError('LIMIT_FILE_SIZE', 'video');
+    expect(handleUploadError(err, res)).toBe(true);
+    expect(res.redirect).toHaveBeenCalledWith('/overlay/settings?error=file_too_large');
+  });
+
+  it('redirects other multer/unknown errors to upload_failed', () => {
+    const res = makeRes();
+    expect(handleUploadError(new Error('boom'), res)).toBe(true);
+    expect(res.redirect).toHaveBeenCalledWith('/overlay/settings?error=upload_failed');
   });
 });

--- a/src/web/routes/overlayAdminMutations.ts
+++ b/src/web/routes/overlayAdminMutations.ts
@@ -87,8 +87,13 @@ export function handleUploadError(err: unknown, res: Response): boolean {
 }
 
 /**
- * Run Multer's single-file parser, redirecting on its errors (e.g. an oversized
- * file) instead of letting them fall through to the centralised error handler.
+ * Express middleware that runs Multer's single-file (`video`) parser and, on a
+ * Multer error (e.g. an oversized file), redirects via `handleUploadError`
+ * instead of letting it fall through to the centralised 500 handler.
+ * @param req - Express request carrying the multipart upload.
+ * @param res - Express response (used for the error redirect).
+ * @param next - Called to continue to the route handler when parsing succeeds.
+ * @returns {void}
  */
 function uploadVideo(req: Request, res: Response, next: NextFunction): void {
   upload.single('video')(req, res, (err: unknown) => {

--- a/src/web/routes/overlayAdminMutations.ts
+++ b/src/web/routes/overlayAdminMutations.ts
@@ -67,10 +67,13 @@ async function saveVideoFile(streamer: DbStreamerEventSub, file: Express.Multer.
 }
 
 /**
- * Translate a Multer error into a user-facing redirect. Returns true when it
- * handled `err` (so the caller should stop), false when there was no error.
- * An oversized file (`LIMIT_FILE_SIZE`) gets the `file_too_large` code; anything
- * else falls back to `upload_failed` rather than the generic 500 page.
+ * Translate a Multer error into a user-facing redirect, instead of letting it
+ * reach the centralised 500 handler. An oversized file (`LIMIT_FILE_SIZE`) gets
+ * the `file_too_large` code; any other error falls back to `upload_failed`.
+ * @param err - The error passed by Multer's callback, or null/undefined if none.
+ * @param res - Express response used to issue the redirect when an error occurred.
+ * @returns true when `err` was an error and a redirect was sent (caller should
+ *   stop); false when there was no error (caller should continue).
  */
 export function handleUploadError(err: unknown, res: Response): boolean {
   if (!err) return false;

--- a/src/web/routes/overlayAdminMutations.ts
+++ b/src/web/routes/overlayAdminMutations.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
+import type { Request, Response, NextFunction } from 'express';
 import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
@@ -65,10 +66,39 @@ async function saveVideoFile(streamer: DbStreamerEventSub, file: Express.Multer.
   log.info(`Overlay video uploaded for ${streamer.twitch_name}: ${filename}`);
 }
 
+/**
+ * Translate a Multer error into a user-facing redirect. Returns true when it
+ * handled `err` (so the caller should stop), false when there was no error.
+ * An oversized file (`LIMIT_FILE_SIZE`) gets the `file_too_large` code; anything
+ * else falls back to `upload_failed` rather than the generic 500 page.
+ */
+export function handleUploadError(err: unknown, res: Response): boolean {
+  if (!err) return false;
+  if (err instanceof multer.MulterError && err.code === 'LIMIT_FILE_SIZE') {
+    res.redirect('/overlay/settings?error=file_too_large');
+    return true;
+  }
+  log.error('Overlay upload middleware error:', err);
+  res.redirect('/overlay/settings?error=upload_failed');
+  return true;
+}
+
+/**
+ * Run Multer's single-file parser, redirecting on its errors (e.g. an oversized
+ * file) instead of letting them fall through to the centralised error handler.
+ */
+function uploadVideo(req: Request, res: Response, next: NextFunction): void {
+  upload.single('video')(req, res, (err: unknown) => {
+    if (handleUploadError(err, res)) return;
+    next();
+  });
+}
+
 // POST /overlay/settings/videos/upload
-// csrfProtection runs BEFORE upload.single so a bad token is rejected before Multer buffers the file.
-// The CSRF token is passed in the URL query string (?_csrf=…) so it is available before body parsing.
-router.post('/settings/videos/upload', requireAuth, csrfProtection, upload.single('video'), async (req, res) => {
+// csrfProtection runs BEFORE uploadVideo so a bad token is rejected before Multer
+// buffers the file. The client (overlayAdmin.js) sends the token in an X-CSRF-Token
+// header — available before body parsing and never placed in the URL.
+router.post('/settings/videos/upload', requireAuth, csrfProtection, uploadVideo, async (req, res) => {
   try {
     const streamer = await requireStreamer(req, res);
     if (!streamer) return;

--- a/views/overlayAdmin.ejs
+++ b/views/overlayAdmin.ejs
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/style.css">
   <%- include('partials/pwa-head') %>
 </head>
-<body>
+<body data-csrf-token="<%= csrfToken %>">
   <%- include('partials/nav') %>
 
   <main class="container">
@@ -23,6 +23,7 @@
         no_videos_selected:'Select at least one video to assign to the reward.',
         save_failed:      'Failed to save — please try again.',
         invalid_id:       'Invalid request.',
+        file_too_large:   `That file is too large (max ${maxFileMb} MB).`,
       }; %>
       <%= errorMessages[error] ?? `An error occurred (${error}).` %>
     </div>
@@ -81,7 +82,10 @@
 
       <div class="card card-spaced">
         <div class="card-body">
-          <form method="POST" action="/overlay/settings/videos/upload?_csrf=<%= encodeURIComponent(csrfToken) %>" enctype="multipart/form-data">
+          <!-- Submitted via fetch in overlayAdmin.js with the CSRF token in an
+               X-CSRF-Token header, so the session token is never placed in the URL
+               (browser history / Referer). -->
+          <form method="POST" action="/overlay/settings/videos/upload" enctype="multipart/form-data" class="js-overlay-upload">
             <div class="form-row-wrap" style="align-items:flex-end;">
               <div style="flex:1;">
                 <label class="hint hint-compact" for="video-name">Name</label>


### PR DESCRIPTION
## Summary

A CodeRabbit review on #319 flagged two issues on the new SFX upload route. The **same two issues already exist in the pre-existing overlay video upload** — this PR fixes them there for parity (opened separately per request, since they're out of scope for #319's feature).

The overlay upload uses `randomUUID()` filenames, so it has **no** equivalent of #319's third (TOCTOU collision) finding.

## What changed

- **CSRF token out of the URL.** The upload form placed the session-stable CSRF token in its action query string (`?_csrf=…`), where it can leak via browser history and `Referer` headers. It's now submitted via `fetch` with the token in an **`X-CSRF-Token` header** — which `csrfProtection` already accepts and which is available *before* Multer parses the multipart body, so the validate-before-buffer ordering is preserved and the token never enters the URL. The route's validation logic is unchanged.
  - `views/overlayAdmin.ejs`: drop `?_csrf=` from the form action, add `js-overlay-upload`, and expose the token via `<body data-csrf-token>`.
  - `public/overlayAdmin.js`: intercept the upload submit, POST via `fetch` with the header, then navigate to the server's redirect target.

- **Multer `LIMIT_FILE_SIZE` handled.** An oversized upload previously fell through to the centralised 500 page. `upload.single('video')` is now wrapped in `uploadVideo` + `handleUploadError`, redirecting oversized files to a new `file_too_large` error code (showing the max size) and other Multer errors to `upload_failed`.
  - `src/web/routes/overlayAdminMutations.ts`, `src/web/routes/overlayAdmin.ts` (known-error code), `views/overlayAdmin.ejs` (error message).

## Testing

- `npx tsc --noEmit` clean; full suite green (**1452 tests**).
- Added `handleUploadError` unit tests (oversized → `file_too_large`; other errors → `upload_failed`; no error → no redirect). Existing overlay upload route tests still pass.
- Verified `overlayAdmin.ejs` renders with the token no longer in the form action.

## Note

No-JS uploads now require JavaScript (the token is sent via header), consistent with the overlay admin UI already depending on JS. The same approach was applied to the SFX upload in #319.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BXACZwjUUtXY2Gv4TnkrLc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved client-side handling for overlay video uploads, including automatic redirect behavior after submissions.

* **Bug Fixes**
  * Added clearer, size-limit-specific feedback when an uploaded video exceeds the maximum file size.
  * Improved upload error handling so failures consistently redirect to the overlay settings page with the correct `error` code.
  * Updated CSRF handling to send the token via request headers rather than embedding it in the form action URL.

* **Tests**
  * Added deterministic and end-to-end coverage for oversized uploads and upload error redirect behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->