### PR TITLE
Reduce redundant requireAuth/requireGuildContext execution in server.ts

### DIFF
--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -103,24 +103,22 @@ describe('server route wiring', () => {
     const res = await request(app).get('/admin/__marker_streams');
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ label: 'streams' });
-    // requireAuth also runs for the three earlier '/' mounts (streamdeckKeys, sfx, sfxMutations)
-    // that match every path, plus adminRouter's and streamsRouter's own '/admin' stacks: 3 + 2 = 5.
-    // requireGuildContext runs for the streamdeckKeys and sfxMutations '/' mounts plus the
-    // two '/admin' stacks: 2 + 2 = 4.
-    expect(requireAuth).toHaveBeenCalledTimes(5);
-    expect(requireGuildContext).toHaveBeenCalledTimes(4);
+    // The '/'-mounted group runs once (requireAuth, then requireGuildContext when none
+    // of its requireAuth-only routers match), then the '/admin' group runs once more
+    // (requireAuth + requireGuildContext together) before streamsRouter responds: 2 + 2.
+    expect(requireAuth).toHaveBeenCalledTimes(2);
+    expect(requireGuildContext).toHaveBeenCalledTimes(2);
   });
 
   it('mounts the /admin eventsub router behind both requireAuth and requireGuildContext', async () => {
     const res = await request(app).get('/admin/__marker_eventsubAdmin');
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ label: 'eventsubAdmin' });
-    // Same three leading '/' mounts, plus all three '/admin' stacks (admin, streams,
-    // eventsubAdmin) run before the eventsubAdmin route responds: 3 + 3 = 6.
-    // requireGuildContext runs for the streamdeckKeys and sfxMutations '/' mounts plus
-    // all three '/admin' stacks: 2 + 3 = 5.
-    expect(requireAuth).toHaveBeenCalledTimes(6);
-    expect(requireGuildContext).toHaveBeenCalledTimes(5);
+    // Same as above: which '/admin' sub-router ends up matching doesn't add extra
+    // requireAuth/requireGuildContext calls, since the group's middleware runs once
+    // before dispatching to admin/streams/eventsubAdmin in turn.
+    expect(requireAuth).toHaveBeenCalledTimes(2);
+    expect(requireGuildContext).toHaveBeenCalledTimes(2);
   });
 
   it('mounts the dashboard root behind both requireAuth and requireGuildContext', async () => {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -161,21 +161,43 @@ app.use('/', sfxPublicRouter);
 app.use('/overlay', overlaySourceRouter);
 app.use('/guild', requireAuth, guildRouter);
 app.use('/api', requireAuth, apiRouter);
-app.use('/', requireAuth, requireGuildContext, streamdeckKeysRouter);
-app.use('/', requireAuth, sfxRouter);
+
+// All of the routers below share the same '/' mount point, so registering each one
+// behind its own app.use(path, ...middleware, router) call made requireAuth (and, for
+// some, requireGuildContext) run once per sibling mount per request — not once per
+// request — since every '/'-mounted layer matches every path and falls through via
+// next() until a route inside actually matches. Nesting them under shared Router()
+// instances collapses that to one middleware pass per group.
+//
 // requireGuildContext refreshes req.session.user.accessLevel for the current guild;
-// the mutation routers gate on requireMod, which reads that level, so it must run
-// here (not just requireAuth) or a stale/missing level could bypass the Mod check.
-app.use('/', requireAuth, requireGuildContext, sfxMutationsRouter);
-app.use('/admin', requireAuth, requireGuildContext, adminRouter);
-app.use('/admin', requireAuth, requireGuildContext, streamsRouter);
-app.use('/admin', requireAuth, requireGuildContext, eventsubAdminRouter);
+// sfxMutationsRouter gates on requireMod, which reads that level, so it must run
+// behind requireGuildContext (not just requireAuth) or a stale/missing level could
+// bypass the Mod check.
+const rootGuildRouter = express.Router();
+rootGuildRouter.use(requireGuildContext);
+rootGuildRouter.use(streamdeckKeysRouter);
+rootGuildRouter.use(dashboardRouter);
+rootGuildRouter.use(sfxMutationsRouter);
+
+const rootAuthedRouter = express.Router();
+rootAuthedRouter.use(requireAuth);
+rootAuthedRouter.use(sfxRouter);
+rootAuthedRouter.use(commandsRouter);
+rootAuthedRouter.use(countersRouter);
+rootAuthedRouter.use(commandMonitorRouter);
+rootAuthedRouter.use(rootGuildRouter);
+app.use('/', rootAuthedRouter);
+
+// Same redundancy as above for the '/admin'-mounted routers.
+const adminGuildRouter = express.Router();
+adminGuildRouter.use(requireAuth, requireGuildContext);
+adminGuildRouter.use(adminRouter);
+adminGuildRouter.use(streamsRouter);
+adminGuildRouter.use(eventsubAdminRouter);
+app.use('/admin', adminGuildRouter);
+
 app.use('/user/settings', requireAuth, userSettingsRouter);
 app.use('/overlay', requireAuth, overlayAdminRouter);
-app.use('/', requireAuth, commandsRouter);
-app.use('/', requireAuth, countersRouter);
-app.use('/', requireAuth, commandMonitorRouter);
-app.use('/', requireAuth, requireGuildContext, dashboardRouter);
 
 // 404 handler
 app.use((req, res) => {


### PR DESCRIPTION
## Summary
- Each `'/'`- and `'/admin'`-scoped router was mounted with its own `app.use(path, ...middleware, router)` call. Since every layer at the same prefix matches and falls through via `next()` until a route inside actually matches, `requireAuth` (and, for several routers, `requireGuildContext`) ran once per sibling mount per request — not once per request.
- `requireGuildContext` does several sequential DB-backed lookups per call (`findUser`, then `getAllGuilds`/`getGuildsForMember`, then `getEffectiveAccessLevel`), so this redundancy scales with router count for every request reaching that prefix.
- Nest the `'/'`-mounted routers (sfx, commands, counters, commandMonitor, streamdeckKeys, dashboard) and the `'/admin'`-mounted routers (admin, streams, eventsubAdmin) under shared `Router()` instances, so the middleware runs once per group instead of once per individual router. Worst case drops from 5 `requireAuth`/4 `requireGuildContext` calls down to 2/2 per request.
- No route-matching changes — confirmed no path collisions between the regrouped routers, and relative mount order between groups is preserved where it could affect behavior (`/guild`/`/api` still run before the `/` group; `/user/settings`/`/overlay` admin mounts are unaffected).

This was surfaced as a review comment on #319 (SFX management) but is a pre-existing, codebase-wide pattern, so it's addressed here as a standalone fix rather than folded into that PR.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (1453 tests passing)
- [x] Updated `src/web/server.test.ts` assertions to reflect the new, reduced middleware call counts for the `/admin/streams` and `/admin/eventsubAdmin` marker routes


---
_Generated by [Claude Code](https://claude.ai/code/session_01X4YGbj88cs24VXiLoJMKYb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route handling so authenticated and guild-aware pages load through a more consistent path.
  * Fixed admin-related routes to apply the expected access checks before reaching the destination page.
* **Tests**
  * Updated route coverage to reflect the new middleware execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->