### PR TITLE
Fix repeated delete+repost of live announcements on title-only changes

### DIFF
--- a/src/twitch/monitor/twitchMonitorAnnouncements.test.ts
+++ b/src/twitch/monitor/twitchMonitorAnnouncements.test.ts
@@ -146,24 +146,35 @@ describe('editAnnouncement', () => {
     expect(setStreamerLive).toHaveBeenCalled();
   });
 
-  it('deletes old message via tryDeleteDiscordMessage and sends new one when delete_old_posts is true', async () => {
+  it('deletes old message via tryDeleteDiscordMessage and sends new one when delete_old_posts is true and game changed', async () => {
     const channel = makeTextChannel();
     vi.mocked(getDiscordClient).mockReturnValue(makeDiscordClient(channel) as any);
     const state = makeLiveState({ group: makeGroup({ delete_old_posts: true }) });
-    await editAnnouncement(new Map(), state, makeStream(), 'live_message');
+    await editAnnouncement(new Map(), state, makeStream(), 'new_game_message');
     expect(tryDeleteDiscordMessage).toHaveBeenCalledWith('ch1', 'msg1');
     expect(channel.send).toHaveBeenCalled();
     expect(setStreamerLive).toHaveBeenCalled();
   });
 
-  it('treats old-message delete failure as best-effort and still commits the new message', async () => {
+  it('treats old-message delete failure as best-effort and still commits the new message on a game change', async () => {
     vi.mocked(tryDeleteDiscordMessage).mockRejectedValueOnce(new Error('network'));
     const channel = makeTextChannel();
     channel.send.mockResolvedValue({ id: 'msg2', channelId: 'ch1' });
     vi.mocked(getDiscordClient).mockReturnValue(makeDiscordClient(channel) as any);
     const state = makeLiveState({ group: makeGroup({ delete_old_posts: true }) });
-    await expect(editAnnouncement(new Map(), state, makeStream(), 'live_message')).resolves.not.toThrow();
+    await expect(editAnnouncement(new Map(), state, makeStream(), 'new_game_message')).resolves.not.toThrow();
     expect(state.messageId).toBe('msg2');
+    expect(setStreamerLive).toHaveBeenCalled();
+  });
+
+  it('edits the existing message in place for a title-only change even when delete_old_posts is true', async () => {
+    const channel = makeTextChannel();
+    vi.mocked(getDiscordClient).mockReturnValue(makeDiscordClient(channel) as any);
+    const state = makeLiveState({ group: makeGroup({ delete_old_posts: true }) });
+    await editAnnouncement(new Map(), state, makeStream(), 'live_message');
+    expect(channel._message.edit).toHaveBeenCalled();
+    expect(channel.send).not.toHaveBeenCalled();
+    expect(tryDeleteDiscordMessage).not.toHaveBeenCalled();
     expect(setStreamerLive).toHaveBeenCalled();
   });
 

--- a/src/twitch/monitor/twitchMonitorAnnouncements.ts
+++ b/src/twitch/monitor/twitchMonitorAnnouncements.ts
@@ -53,10 +53,13 @@ export async function postAnnouncement(
 }
 
 /**
- * Updates an existing "now live" announcement in place (or replaces it, if the
- * group is configured to delete old posts) to reflect a new game/title. If the
- * previously-announced message is gone, falls back to posting a fresh one
- * instead of silently failing on every subsequent call.
+ * Updates an existing "now live" announcement to reflect a new game/title.
+ * Delete+repost (when the group has `delete_old_posts` enabled) is reserved
+ * for actual game changes (`templateKey === 'new_game_message'`) — title-only
+ * changes are always edited in place so a burst of Twitch `channel.update`
+ * notifications during stream start-up can't repeatedly delete and repost the
+ * announcement. If the previously-announced message is gone, falls back to
+ * posting a fresh one instead of silently failing on every subsequent call.
  */
 export async function editAnnouncement(
   liveStates: Map<string, LiveState>,
@@ -84,7 +87,7 @@ export async function editAnnouncement(
     if (!channel || !channel.isTextBased()) return;
     const textChannel = channel as TextChannel;
 
-    if (group.delete_old_posts) {
+    if (group.delete_old_posts && templateKey === 'new_game_message') {
       const msg = await textChannel.send({ content, embeds: [embed] });
       try {
         await tryDeleteDiscordMessage(state.channelId, state.messageId);


### PR DESCRIPTION
## Summary
- Investigated a report of a live announcement being deleted and reposted 3-4 times, ~1 minute apart. Confirmed the 5-minute offline grace period (shared correctly between the 60s poller and the new EventSub path) was not the cause — 1 minute is far too fast for that timer.
- Root cause: Twitch fires multiple `channel.update` EventSub notifications in quick succession when a stream starts (title/category settle separately). Each one reached `editAnnouncement`, which — for groups with `delete_old_posts` enabled — unconditionally deleted the old message and posted a new one, even for title-only changes.
- Fix: `editAnnouncement` now only does delete+repost for actual game changes (`templateKey === 'new_game_message'`). Title-only changes always edit the existing message in place, regardless of `delete_old_posts`.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — all 1556 tests pass (94 files)
- [x] Added a test confirming title-only changes edit in place even with `delete_old_posts: true`
- [x] Updated existing delete+repost tests to use `'new_game_message'` to reflect the game-change-only scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01U1NjT79BmWVzxJCdtaWNvo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Twitch announcement updates so title-only changes now edit the existing Discord post instead of deleting and reposting it.
  * Game changes can now replace the old announcement with a new one when configured to do so, while still recovering gracefully if the old message can’t be removed or found.
  * Kept live-state tracking consistent after announcement updates and reposts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->