### PR TITLE
Fix global rate-limit leak from companion auth route mount

### DIFF
--- a/src/web/rateLimits.ts
+++ b/src/web/rateLimits.ts
@@ -1,5 +1,21 @@
-import { ipKeyGenerator } from 'express-rate-limit';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import type { Request } from 'express';
+
+/**
+ * Tighter limit for auth endpoints to protect against OAuth quota exhaustion.
+ * Shared between `/auth/*` (mounted as a path-scoped middleware in server.ts) and
+ * the companion app's OAuth routes (applied per-route in companionAuth.ts, since
+ * that router is mounted at '/' and a blanket `.use()` there would rate-limit
+ * every request on the site, not just companion-auth ones).
+ */
+export const authLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: 10,
+  standardHeaders: 'draft-8',
+  legacyHeaders: false,
+  keyGenerator: ipKey,
+  message: 'Too many requests, please try again shortly.',
+});
 
 /**
  * Derives a rate-limit key from the request's IP address.

--- a/src/web/routes/companionAuth.rateLimit.test.ts
+++ b/src/web/routes/companionAuth.rateLimit.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../db', () => ({
+  exchangeCodeForToken: vi.fn(),
+}));
+vi.mock('../../shared/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+}));
+
+import express from 'express';
+import supertest from 'supertest';
+import router from './companionAuth';
+import { authLimiter } from '../rateLimits';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req: any, _res: any, next: any) => {
+    req.session = {};
+    next();
+  });
+  app.use(router);
+  return app;
+}
+
+// authLimiter is a process-wide singleton (shared with /auth's routes), so reset its
+// state for the test's IP between cases to keep this file's tests independent.
+beforeEach(() => {
+  void authLimiter.resetKey('::ffff:127.0.0.1');
+  void authLimiter.resetKey('127.0.0.1');
+  void authLimiter.resetKey('::1');
+});
+
+describe('companion auth routes rate limiting', () => {
+  it('is rate-limited (real authLimiter is wired to both companion routes, not skipped)', async () => {
+    const app = buildApp();
+    let sawRateLimited = false;
+    for (let i = 0; i < 15; i++) {
+      const res = await supertest(app).post('/api/companion/oauth/token').send({});
+      if (res.status === 429) {
+        sawRateLimited = true;
+        break;
+      }
+    }
+    expect(sawRateLimited).toBe(true);
+  });
+});

--- a/src/web/routes/companionAuth.rateLimit.test.ts
+++ b/src/web/routes/companionAuth.rateLimit.test.ts
@@ -32,11 +32,14 @@ beforeEach(() => {
 });
 
 describe('companion auth routes rate limiting', () => {
-  it('is rate-limited (real authLimiter is wired to both companion routes, not skipped)', async () => {
+  it.each([
+    ['POST', '/api/companion/oauth/token'] as const,
+    ['GET', '/companion/login?redirect_uri=http://127.0.0.1:9999/cb&state=abc'] as const,
+  ])('rate-limits repeated %s %s requests (authLimiter is wired, not skipped)', async (method, path) => {
     const app = buildApp();
     let sawRateLimited = false;
     for (let i = 0; i < 15; i++) {
-      const res = await supertest(app).post('/api/companion/oauth/token').send({});
+      const res = method === 'GET' ? await supertest(app).get(path) : await supertest(app).post(path).send({});
       if (res.status === 429) {
         sawRateLimited = true;
         break;

--- a/src/web/routes/companionAuth.test.ts
+++ b/src/web/routes/companionAuth.test.ts
@@ -6,6 +6,12 @@ vi.mock('../../db', () => ({
 vi.mock('../../shared/logger', () => ({
   createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
 }));
+// authLimiter is a process-wide singleton shared with /auth's routes (see
+// rateLimits.ts); stub it out here so the functional tests below aren't subject to
+// real rate limiting. Its wiring is verified separately in companionAuth.rateLimit.test.ts.
+vi.mock('../rateLimits', () => ({
+  authLimiter: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
 
 import express from 'express';
 import supertest from 'supertest';

--- a/src/web/routes/companionAuth.ts
+++ b/src/web/routes/companionAuth.ts
@@ -32,6 +32,7 @@ function isLoopbackRedirectUri(redirectUri: string): boolean {
  * Validates the loopback redirect_uri, stashes it (with the app's state) on the
  * session, then hands off to the existing Discord OAuth login; the callback
  * branches back here on success and redirects to redirectUri with a one-time code.
+ * Rate-limited by `authLimiter`, which responds 429 before this handler runs.
  * @param req.query.redirect_uri - Loopback URL the companion app is listening on.
  * @param req.query.state - Opaque value echoed back to the app for CSRF binding.
  */
@@ -56,7 +57,8 @@ router.get('/companion/login', authLimiter, (req, res) => {
  * The exchange runs in a single DB transaction (see `exchangeCodeForToken`), so a
  * failure issuing the token doesn't permanently burn the one-time code.
  * @param req.body.code - Plaintext one-time code from the loopback redirect.
- * @returns `{ token }` on success, or a 400/500 JSON error response.
+ * @returns `{ token }` on success, or a 400/429/500 JSON error response —
+ *   429 comes from `authLimiter` and short-circuits before this handler runs.
  */
 router.post('/api/companion/oauth/token', authLimiter, async (req, res) => {
   const { code } = req.body as { code?: string };

--- a/src/web/routes/companionAuth.ts
+++ b/src/web/routes/companionAuth.ts
@@ -2,6 +2,7 @@ import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import { exchangeCodeForToken } from '../../db';
 import { renderError } from './shared';
+import { authLimiter } from '../rateLimits';
 
 const log = createLogger('CompanionAuth');
 const router = Router();
@@ -34,7 +35,7 @@ function isLoopbackRedirectUri(redirectUri: string): boolean {
  * @param req.query.redirect_uri - Loopback URL the companion app is listening on.
  * @param req.query.state - Opaque value echoed back to the app for CSRF binding.
  */
-router.get('/companion/login', (req, res) => {
+router.get('/companion/login', authLimiter, (req, res) => {
   const { redirect_uri: redirectUri, state } = req.query as { redirect_uri?: string; state?: string };
   if (!redirectUri || !state || !isLoopbackRedirectUri(redirectUri)) {
     return renderError(res, 400, 'Invalid or missing loopback redirect_uri/state.', undefined);
@@ -57,7 +58,7 @@ router.get('/companion/login', (req, res) => {
  * @param req.body.code - Plaintext one-time code from the loopback redirect.
  * @returns `{ token }` on success, or a 400/500 JSON error response.
  */
-router.post('/api/companion/oauth/token', async (req, res) => {
+router.post('/api/companion/oauth/token', authLimiter, async (req, res) => {
   const { code } = req.body as { code?: string };
   if (!code || typeof code !== 'string') {
     res.status(400).json({ ok: false, error: 'Missing code' });

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -131,4 +131,14 @@ describe('server route wiring', () => {
     expect(requireAuth).toHaveBeenCalled();
     expect(requireGuildContext).toHaveBeenCalled();
   });
+
+  it('does not apply the 10/min auth rate limiter to unrelated routes mounted at "/"', async () => {
+    // companionAuthRouter is mounted at '/', so authLimiter must live inside that
+    // router (applied per-route) rather than on the app.use('/', ...) call itself —
+    // otherwise it rate-limits every request on the site after only 10/min.
+    for (let i = 0; i < 15; i++) {
+      const res = await request(app).get('/__marker_dashboard');
+      expect(res.status).toBe(200);
+    }
+  });
 });

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -38,6 +38,7 @@ import tosRouter from './routes/tos';
 import { requireAuth, requireGuildContext } from './middleware';
 import { ensureSessionCsrfToken } from './csrf';
 import {
+  authLimiter,
   ipKey,
   generalLimiterSkip,
   sessionLimiterKey,
@@ -87,15 +88,6 @@ const generalLimiter = rateLimit({
   legacyHeaders: false,
   keyGenerator: ipKey,
   skip: generalLimiterSkip,
-});
-// Tighter limit for auth endpoints to protect against OAuth quota exhaustion
-const authLimiter = rateLimit({
-  windowMs: 60 * 1000,
-  limit: 10,
-  standardHeaders: 'draft-8',
-  legacyHeaders: false,
-  keyGenerator: ipKey,
-  message: 'Too many requests, please try again shortly.',
 });
 // Generous limit for the Streamdeck API — keyed by Bearer token so each API key gets
 // its own bucket regardless of which IP the request originates from.
@@ -166,7 +158,10 @@ app.use('/', sfxPublicRouter);
 app.use('/', privacyRouter);
 app.use('/', tosRouter);
 app.use('/overlay', overlaySourceRouter);
-app.use('/', authLimiter, companionAuthRouter);
+// authLimiter is applied per-route inside companionAuthRouter, not here — this
+// router is mounted at '/', so a blanket limiter here would rate-limit every
+// request on the site, not just the companion app's OAuth routes.
+app.use('/', companionAuthRouter);
 app.use('/api/companion', companionEventsRouter);
 app.use('/guild', requireAuth, guildRouter);
 app.use('/api', requireAuth, apiRouter);


### PR DESCRIPTION
## Summary

- `companionAuthRouter` is mounted at `'/'` in `server.ts` (`app.use('/', authLimiter, companionAuthRouter)`). Since `'/'` matches every path, Express ran the 10 req/min `authLimiter` middleware on **every request** that reached that point in the middleware chain — not just companion-auth requests — so ordinary page navigation (e.g. clicking the dashboard link a few times, which fires a couple of background fetches per load) could exhaust the bucket and trigger "Too many requests, please try again shortly."
- Moved `authLimiter` into `src/web/rateLimits.ts` (shared singleton, still used for `/auth/*` via its path-scoped mount) and applied it **per-route** inside `companionAuth.ts` (`GET /companion/login`, `POST /api/companion/oauth/token`) instead of as a blanket middleware on the `'/'` mount.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (1622 tests)
- [x] Added a regression test in `server.test.ts` asserting 15 rapid requests to an unrelated `'/'`-mounted route are never rate-limited
- [x] Added `companionAuth.rateLimit.test.ts` confirming the real `authLimiter` is still wired to the companion routes (rate-limits after repeated requests)
- [x] Stubbed `authLimiter` in `companionAuth.test.ts`'s functional tests so they aren't affected by the shared rate-limit bucket

https://claude.ai/code/session_01Wrrvw7YWMGtn9F3SRHmA61


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wrrvw7YWMGtn9F3SRHmA61)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rate limiting for companion login and token exchange requests to help protect auth-related endpoints.
* **Bug Fixes**
  * Scoped rate limiting so it no longer affects unrelated site routes.
  * Kept existing companion auth behavior intact while applying the new request limits.
* **Tests**
  * Added coverage for auth endpoint throttling.
  * Added regression checks to confirm other routes continue to respond normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->