### PR TITLE
fix: close open redirect in companion OAuth callback

### DIFF
--- a/src/web/routes/auth.test.ts
+++ b/src/web/routes/auth.test.ts
@@ -280,6 +280,39 @@ describe('GET /discord/callback', () => {
     expect(capturedSession.companionOAuth).toBeUndefined();
   });
 
+  it('renders error 400 when companionOAuth.redirectUri in session is not a loopback URL (defense-in-depth)', async () => {
+    mockFetch([
+      { ok: true, json: () => Promise.resolve({ access_token: 'tok' }) },
+      { ok: true, json: () => Promise.resolve({ id: '111', username: 'alice', avatar: null }) },
+    ]);
+    vi.mocked(findUser).mockResolvedValue({ discord_id: '111', discord_name: 'alice', is_twitch_bot_enabled: false, twitch_name: null, access_level: AccessLevel.USER, is_owner: false } as any);
+    vi.mocked(getGuildsForMember).mockResolvedValue([{ guild_id: '555', name: 'Guild', voice_channel_id: null }] as any);
+
+    const app = express();
+    app.use((req: any, _res: any, next: any) => {
+      req.session = {
+        oauthState: { value: 'state123', expiresAt: Date.now() + 60_000 },
+        companionOAuth: { redirectUri: 'https://evil.example/steal', appState: 'appstate1', expiresAt: Date.now() + 60_000 },
+        user: undefined,
+        destroy: vi.fn((cb: () => void) => cb()),
+        regenerate: vi.fn((cb: (err: null) => void) => cb(null)),
+        save: vi.fn((cb: (err: null) => void) => cb(null)),
+      };
+      next();
+    });
+    app.use((req: any, res: any, next: any) => {
+      res.render = (view: string, locals: unknown) =>
+        res.status((res as any).statusCode || 200).json({ view, locals });
+      next();
+    });
+    app.use(router);
+    const res = await supertest(app).get('/discord/callback?code=code&state=state123');
+
+    expect(res.status).toBe(400);
+    expect((res.body as any).view).toBe('error');
+    expect(createCode).not.toHaveBeenCalled();
+  });
+
   it('does not branch into the companion flow when companionOAuth is absent (existing dashboard-login behavior)', async () => {
     mockFetch([
       { ok: true, json: () => Promise.resolve({ access_token: 'tok' }) },

--- a/src/web/routes/auth.ts
+++ b/src/web/routes/auth.ts
@@ -15,7 +15,7 @@ import {
 import { fetchMemberDisplayName } from '../../discord/discordBot';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
-import { renderError } from './shared';
+import { renderError, isLoopbackRedirectUri } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
@@ -59,9 +59,10 @@ router.get('/discord', (req, res) => {
  *   `oauthState` session value.
  * @param res - Express response; redirects to `/` on success, or to the
  *   companion app's `redirectUri` for the loopback flow. Renders a 400 error
- *   page when the OAuth state is invalid or missing, a 403 error page when the
- *   user is not whitelisted or has no accessible guild, or a 500 error page if any
- *   step of the exchange/profile-fetch/session-save fails.
+ *   page when the OAuth state is invalid/missing or the companion redirectUri
+ *   fails the loopback re-validation check (defense-in-depth), a 403 error page
+ *   when the user is not whitelisted or has no accessible guild, or a 500 error
+ *   page if any step of the exchange/profile-fetch/session-save fails.
  */
 router.get('/discord/callback', async (req, res) => {
   const { code, state } = req.query as { code?: string; state?: string };
@@ -130,6 +131,10 @@ router.get('/discord/callback', async (req, res) => {
     const companionOAuth = req.session.companionOAuth;
     if (companionOAuth && Date.now() <= companionOAuth.expiresAt) {
       delete req.session.companionOAuth;
+      // Re-validate at point of use: defense-in-depth against session tampering.
+      if (!isLoopbackRedirectUri(companionOAuth.redirectUri)) {
+        return renderError(res, 400, 'Invalid companion redirect URI.', undefined);
+      }
       const authCode = await createCode(profile.id);
       const redirectUrl = new URL(companionOAuth.redirectUri);
       redirectUrl.searchParams.set('code', authCode);

--- a/src/web/routes/companionAuth.ts
+++ b/src/web/routes/companionAuth.ts
@@ -1,31 +1,13 @@
 import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import { exchangeCodeForToken } from '../../db';
-import { renderError } from './shared';
+import { renderError, isLoopbackRedirectUri } from './shared';
 import { authLimiter } from '../rateLimits';
 
 const log = createLogger('CompanionAuth');
 const router = Router();
 
 const COMPANION_OAUTH_TTL_MS = 10 * 60 * 1000;
-
-/**
- * Returns true if `redirectUri` is a loopback HTTP URL (127.0.0.1 or localhost,
- * any port). Per RFC 8252 §7.3, only loopback redirects are accepted for the
- * companion app's OAuth flow — anything else risks leaking the authorization
- * code to an attacker-controlled host.
- * @param redirectUri - The `redirect_uri` query parameter to validate.
- * @returns Whether the URI is a permitted loopback redirect target.
- */
-function isLoopbackRedirectUri(redirectUri: string): boolean {
-  let parsed: URL;
-  try {
-    parsed = new URL(redirectUri);
-  } catch {
-    return false;
-  }
-  return parsed.protocol === 'http:' && (parsed.hostname === '127.0.0.1' || parsed.hostname === 'localhost');
-}
 
 /**
  * GET /companion/login — entry point for the companion app's loopback OAuth flow.

--- a/src/web/routes/shared.ts
+++ b/src/web/routes/shared.ts
@@ -60,3 +60,21 @@ export function renderError(
 export function filterQueryParam(value: unknown, allowed: ReadonlySet<string>): string | null {
   return typeof value === 'string' && allowed.has(value) ? value : null;
 }
+
+/**
+ * Returns true if `redirectUri` is a loopback HTTP URL (127.0.0.1 or localhost,
+ * any port). Per RFC 8252 §7.3, only loopback redirects are accepted for the
+ * companion app's OAuth flow — anything else risks leaking the authorization
+ * code to an attacker-controlled host.
+ * @param redirectUri - The redirect URI string to validate.
+ * @returns Whether the URI is a permitted loopback redirect target.
+ */
+export function isLoopbackRedirectUri(redirectUri: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(redirectUri);
+  } catch {
+    return false;
+  }
+  return parsed.protocol === 'http:' && (parsed.hostname === '127.0.0.1' || parsed.hostname === 'localhost');
+}

--- a/src/web/routes/shared.ts
+++ b/src/web/routes/shared.ts
@@ -25,29 +25,56 @@ export function parsePositiveBigIntId(value: string | string[] | undefined): big
   return parsed > 0n ? parsed : null;
 }
 
+/**
+ * Returns `value` trimmed if it is a string, or an empty string otherwise.
+ * @param value - Any value from a form or request body.
+ * @returns Trimmed string, or `''` for non-string inputs.
+ */
 export function trimField(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
 }
 
+/**
+ * Trims `value` and returns it if non-empty, or `null` if blank/missing.
+ * @param value - Raw string from a form field.
+ * @returns Non-empty trimmed string, or `null`.
+ */
 export function normalizeRequiredText(value: string | undefined): string | null {
   if (typeof value !== 'string') return null;
   const normalized = value.trim();
   return normalized.length > 0 ? normalized : null;
 }
 
+/**
+ * Normalizes a required single-word (no whitespace) text field to lowercase.
+ * Returns `null` if the value is blank or contains whitespace.
+ * @param value - Raw string from a form field.
+ * @returns Lowercased single-token string, or `null`.
+ */
 export function normalizeSingleTokenRequiredText(value: string | undefined): string | null {
   const normalized = normalizeRequiredText(value);
   if (!normalized || /\s/.test(normalized)) return null;
   return normalized.toLowerCase();
 }
 
-// Discord snowflake IDs are always 17–20 digits.
+/**
+ * Validates and returns a Discord snowflake ID (17–20 digits), or `null` if invalid.
+ * @param value - Raw string from a form field.
+ * @returns The trimmed snowflake string, or `null`.
+ */
 export function normalizeDiscordId(value: string | undefined): string | null {
   if (typeof value !== 'string') return null;
   const trimmed = value.trim();
   return /^\d{17,20}$/.test(trimmed) ? trimmed : null;
 }
 
+/**
+ * Renders the `error` EJS view with the given HTTP status and message.
+ * @param res - Express response object.
+ * @param status - HTTP status code to set.
+ * @param message - Human-readable error message shown to the user.
+ * @param sessionUser - Current session user, or `undefined` if unauthenticated.
+ */
 export function renderError(
   res: Response,
   status: number,
@@ -57,6 +84,13 @@ export function renderError(
   res.status(status).render('error', { message, user: sessionUser ?? null, csrfToken: '' });
 }
 
+/**
+ * Returns `value` if it is a string present in `allowed`, otherwise `null`.
+ * Used to sanitize query parameters against an explicit allowlist.
+ * @param value - Raw query parameter value.
+ * @param allowed - Set of permitted string values.
+ * @returns The matched string, or `null`.
+ */
 export function filterQueryParam(value: unknown, allowed: ReadonlySet<string>): string | null {
   return typeof value === 'string' && allowed.has(value) ? value : null;
 }


### PR DESCRIPTION
## Summary

- The Discord OAuth callback (`auth.ts:137`) redirected to `companionOAuth.redirectUri` read from the session without re-validating it at the point of use. A tampered session could point the redirect to an arbitrary external host, leaking the one-time auth code.
- Adds a defense-in-depth call to `isLoopbackRedirectUri` immediately before building the redirect URL; returns a 400 error if the check fails.
- Moves `isLoopbackRedirectUri` from `companionAuth.ts` into `shared.ts` so both the entry point (where the URL is first received) and the callback (where it is used) share one canonical implementation.

## Changes

| File | Change |
|---|---|
| `src/web/routes/shared.ts` | Exported `isLoopbackRedirectUri` (moved from `companionAuth.ts`) |
| `src/web/routes/companionAuth.ts` | Removed local copy; imports from `shared.ts` |
| `src/web/routes/auth.ts` | Imports `isLoopbackRedirectUri`; re-validates `companionOAuth.redirectUri` before redirect |
| `src/web/routes/auth.test.ts` | New test: tampered session with non-loopback `redirectUri` → 400, `createCode` not called |

## Test plan

- [ ] `npx tsc --noEmit` passes (no type errors)
- [ ] `npm test` — all 1660 tests pass, including the new defense-in-depth test case
- [ ] New test: `renders error 400 when companionOAuth.redirectUri in session is not a loopback URL (defense-in-depth)` — verifies a session with `https://evil.example/steal` as the redirect URI is rejected with a 400 and never calls `createCode`

---
_Generated by [Claude Code](https://claude.ai/code/session_011JWgRcy71n7Ddv4mjsKnrV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened OAuth redirect validation so only loopback-based redirect targets are accepted, reducing the risk of invalid redirect handling.
  * Improved error handling in the callback flow: invalid or missing state now shows a 400 page, invalid redirect targets are rejected, and upstream failures return a 500 page.

* **Tests**
  * Added coverage for invalid redirect scenarios to ensure rejected requests do not proceed with code creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->