### PR TITLE
Add renderView() safeguard against SSTI scanner findings

### DIFF
--- a/src/web/middleware.ts
+++ b/src/web/middleware.ts
@@ -10,6 +10,7 @@ import {
   getEffectiveAccessLevel,
   getGuildsForMember,
 } from '../db';
+import { renderView } from './routes/shared';
 
 /**
  * Ensures the request has a logged-in session user, redirecting to login otherwise.
@@ -93,13 +94,12 @@ export function requireManager(req: Request, res: Response, next: NextFunction):
   if (req.session.user && req.session.user.accessLevel >= AccessLevel.MANAGER) {
     next();
   } else {
-    res
-      .status(403)
-      .render('error', {
-        message: 'Access denied — Manager or above required.',
-        user: req.session.user ?? null,
-        csrfToken: req.session?.user ? ensureSessionCsrfToken(req) : '',
-      });
+    res.status(403);
+    renderView(res, 'error', {
+      message: 'Access denied — Manager or above required.',
+      user: req.session.user ?? null,
+      csrfToken: req.session?.user ? ensureSessionCsrfToken(req) : '',
+    });
   }
 }
 
@@ -114,13 +114,12 @@ export function requireMod(req: Request, res: Response, next: NextFunction): voi
   if (req.session.user && req.session.user.accessLevel >= AccessLevel.MOD) {
     next();
   } else {
-    res
-      .status(403)
-      .render('error', {
-        message: 'Access denied — Mod or above required.',
-        user: req.session.user ?? null,
-        csrfToken: req.session?.user ? ensureSessionCsrfToken(req) : '',
-      });
+    res.status(403);
+    renderView(res, 'error', {
+      message: 'Access denied — Mod or above required.',
+      user: req.session.user ?? null,
+      csrfToken: req.session?.user ? ensureSessionCsrfToken(req) : '',
+    });
   }
 }
 
@@ -195,12 +194,11 @@ export function requireAdmin(req: Request, res: Response, next: NextFunction): v
   if (req.session.user && req.session.user.accessLevel >= AccessLevel.ADMIN) {
     next();
   } else {
-    res
-      .status(403)
-      .render('error', {
-        message: 'Access denied — Admin required.',
-        user: req.session.user ?? null,
-        csrfToken: req.session?.user ? ensureSessionCsrfToken(req) : '',
-      });
+    res.status(403);
+    renderView(res, 'error', {
+      message: 'Access denied — Admin required.',
+      user: req.session.user ?? null,
+      csrfToken: req.session?.user ? ensureSessionCsrfToken(req) : '',
+    });
   }
 }

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -10,7 +10,7 @@ import {
 import { reloadGuildRegistry } from '../../discord/guildRegistry';
 import { csrfProtection } from '../csrf';
 import { requireManager, requireAdmin } from '../middleware';
-import { trimField, renderError, filterQueryParam } from './shared';
+import { trimField, renderError, filterQueryParam, renderView } from './shared';
 import { userMutationQueue } from './adminUserMutationQueue';
 import adminRefreshRouter, { getRefreshState } from './adminRefresh';
 import {
@@ -51,7 +51,7 @@ router.get('/users', requireManager, csrfProtection, async (req, res) => {
   const guildId = req.session.user!.currentGuildId!;
   try {
     const users = await getGuildMemberUsers(guildId);
-    res.render('admin', {
+    renderView(res, 'admin', {
       user: req.session.user,
       users,
       csrfToken: req.csrfToken(),

--- a/src/web/routes/auth.ts
+++ b/src/web/routes/auth.ts
@@ -15,7 +15,7 @@ import {
 import { fetchMemberDisplayName } from '../../discord/discordBot';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
-import { renderError, isLoopbackRedirectUri } from './shared';
+import { renderError, isLoopbackRedirectUri, renderView } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
@@ -217,7 +217,7 @@ router.post('/logout', requireAuth, csrfProtection, (req, res) => {
  */
 router.get('/login', (req, res) => {
   if (req.session.user) return res.redirect('/');
-  res.render('login', { user: null });
+  renderView(res, 'login', { user: null });
 });
 
 export default router;

--- a/src/web/routes/commandMonitor.test.ts
+++ b/src/web/routes/commandMonitor.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../commands/commandMonitorStore', () => ({
+  getRecentCommandTestEntries: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock('../csrf', () => ({
+  csrfProtection: (req: any, _res: any, next: any) => {
+    req.csrfToken = () => 'test-csrf-token';
+    next();
+  },
+}));
+
+vi.mock('../middleware', () => ({
+  requireManager: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock('../../shared/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+}));
+
+import express from 'express';
+import supertest from 'supertest';
+import router from './commandMonitor';
+import { getRecentCommandTestEntries } from '../../commands/commandMonitorStore';
+
+function buildApp() {
+  const app = express();
+  app.use((_req: any, res: any, next: any) => {
+    res.render = (view: string, locals: unknown) => res.json({ view, locals });
+    next();
+  });
+  app.use((req: any, _res: any, next: any) => {
+    req.session = { user: { discordId: '1', discordName: 'TestUser' } };
+    next();
+  });
+  app.use(router);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /command-monitor', () => {
+  it('renders the command-monitor view with recent entries', async () => {
+    const entries = [{ id: '1', source: 'discord', command: '!clap' }];
+    vi.mocked(getRecentCommandTestEntries).mockReturnValue(entries as any);
+
+    const res = await supertest(buildApp()).get('/command-monitor');
+
+    expect(res.status).toBe(200);
+    expect(res.body.view).toBe('command-monitor');
+    expect(res.body.locals.recentEntries).toEqual(entries);
+    expect(res.body.locals.csrfToken).toBe('test-csrf-token');
+  });
+
+  it('renders a 500 error page when loading entries throws', async () => {
+    vi.mocked(getRecentCommandTestEntries).mockImplementation(() => {
+      throw new Error('boom');
+    });
+
+    const res = await supertest(buildApp()).get('/command-monitor');
+
+    expect(res.status).toBe(500);
+    expect(res.body.view).toBe('error');
+  });
+});
+
+describe('GET /command-monitor/recent', () => {
+  it('returns recent entries as JSON', async () => {
+    const entries = [{ id: '1', source: 'twitch', command: '!hype' }];
+    vi.mocked(getRecentCommandTestEntries).mockReturnValue(entries as any);
+
+    const res = await supertest(buildApp()).get('/command-monitor/recent');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ entries });
+  });
+
+  it('returns 500 with an empty entries array when the store throws', async () => {
+    vi.mocked(getRecentCommandTestEntries).mockImplementation(() => {
+      throw new Error('boom');
+    });
+
+    const res = await supertest(buildApp()).get('/command-monitor/recent');
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ entries: [] });
+  });
+});

--- a/src/web/routes/commandMonitor.test.ts
+++ b/src/web/routes/commandMonitor.test.ts
@@ -24,6 +24,7 @@ import supertest from 'supertest';
 import router from './commandMonitor';
 import { getRecentCommandTestEntries } from '../../commands/commandMonitorStore';
 
+/** Builds a minimal Express app wired with the command-monitor router and a fake session user. */
 function buildApp() {
   const app = express();
   app.use((_req: any, res: any, next: any) => {

--- a/src/web/routes/commandMonitor.ts
+++ b/src/web/routes/commandMonitor.ts
@@ -3,7 +3,7 @@ import { Router } from 'express';
 import { getRecentCommandTestEntries } from '../../commands/commandMonitorStore';
 import { csrfProtection } from '../csrf';
 import { requireManager } from '../middleware';
-import { renderError } from './shared';
+import { renderError, renderView } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
@@ -18,7 +18,7 @@ const router = Router();
 router.get('/command-monitor', requireManager, csrfProtection, (req, res) => {
   try {
     const recentEntries = getRecentCommandTestEntries();
-    res.render('command-monitor', {
+    renderView(res, 'command-monitor', {
       user: req.session.user,
       recentEntries,
       csrfToken: req.csrfToken(),

--- a/src/web/routes/commands.ts
+++ b/src/web/routes/commands.ts
@@ -10,7 +10,7 @@ import {
 } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
-import { renderError, filterQueryParam } from './shared';
+import { renderError, filterQueryParam, renderView } from './shared';
 import commandMutationsRouter from './commandMutations';
 import commandAssignmentsRouter from './commandAssignments';
 import commandGuildOverridesRouter from './commandGuildOverrides';
@@ -63,7 +63,7 @@ router.get('/commands', requireAuth, csrfProtection, async (req, res) => {
       };
     });
 
-    res.render('commands', {
+    renderView(res, 'commands', {
       user: req.session.user,
       commands: commandsForView,
       assignableUsers,

--- a/src/web/routes/companionKeys.ts
+++ b/src/web/routes/companionKeys.ts
@@ -2,7 +2,7 @@ import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import { issueToken, getTokenStatus, revokeToken } from '../../db';
 import { csrfProtection } from '../csrf';
-import { renderError, filterQueryParam } from './shared';
+import { renderError, filterQueryParam, renderView } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
@@ -13,7 +13,7 @@ const KNOWN_ERRORS = new Set(['request_failed', 'revoke_failed']);
 router.get('/companion-key', csrfProtection, async (req, res) => {
   try {
     const tokenStatus = await getTokenStatus(req.session.user!.discordId);
-    res.render('companion-keys', {
+    renderView(res, 'companion-keys', {
       user: req.session.user,
       csrfToken: req.csrfToken(),
       tokenStatus,
@@ -51,7 +51,7 @@ router.post('/companion-key/request', csrfProtection, async (req, res) => {
     tokenStatus = { hasToken: true, createdAt: new Date() };
   }
 
-  res.render('companion-keys', {
+  renderView(res, 'companion-keys', {
     user: req.session.user,
     csrfToken: req.csrfToken(),
     tokenStatus,

--- a/src/web/routes/counters.test.ts
+++ b/src/web/routes/counters.test.ts
@@ -41,6 +41,7 @@ import express from 'express';
 import supertest from 'supertest';
 import router from './counters';
 import {
+  getAllCounters,
   addCounter,
   updateCounter,
   removeCounter,
@@ -85,12 +86,36 @@ const VALID_UPDATE = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(getAllCounters).mockResolvedValue([]);
   vi.mocked(addCounter).mockResolvedValue(undefined);
   vi.mocked(updateCounter).mockResolvedValue(undefined);
   vi.mocked(removeCounter).mockResolvedValue(undefined);
   vi.mocked(resetCounterCurrentValue).mockResolvedValue(undefined);
   vi.mocked(isCounterCommandTaken).mockResolvedValue(false);
   vi.mocked(isMysqlDuplicateEntryError).mockReturnValue(false);
+});
+
+// --- GET /counters ---
+
+describe('GET /counters', () => {
+  it('renders the counters view with the loaded counters', async () => {
+    const counters = [{ id: 1, trigger_command: '!hits', check_command: '!count' }];
+    vi.mocked(getAllCounters).mockResolvedValue(counters as any);
+
+    const res = await supertest(buildApp()).get('/counters');
+
+    expect(res.status).toBe(200);
+    expect(res.text).toBe('rendered:counters');
+  });
+
+  it('renders a 500 error page when loading counters fails', async () => {
+    vi.mocked(getAllCounters).mockRejectedValue(new Error('db down'));
+
+    const res = await supertest(buildApp()).get('/counters');
+
+    expect(res.status).toBe(500);
+    expect(res.text).toBe('rendered:error');
+  });
 });
 
 // --- POST /counters/add ---

--- a/src/web/routes/counters.ts
+++ b/src/web/routes/counters.ts
@@ -21,6 +21,7 @@ import {
   parsePositiveIntId,
   renderError,
   filterQueryParam,
+  renderView,
 } from './shared';
 
 const log = createLogger('Web');
@@ -102,7 +103,7 @@ router.get('/counters', requireAuth, csrfProtection, async (req, res) => {
   try {
     const counters = await getAllCounters();
 
-    res.render('counters', {
+    renderView(res, 'counters', {
       user: req.session.user,
       counters,
       csrfToken: req.csrfToken(),

--- a/src/web/routes/dashboard.ts
+++ b/src/web/routes/dashboard.ts
@@ -4,7 +4,7 @@ import { getStatus } from '../../shared/statusStore';
 import { csrfProtection } from '../csrf';
 import { getStreamerByDiscordId } from '../../db';
 import { hasAuthFailedSubs } from '../../twitch/eventsub/twitchEventSubSubscriptions';
-import { renderError } from './shared';
+import { renderError, renderView } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
@@ -25,7 +25,7 @@ router.get('/', csrfProtection, async (req, res) => {
       const streamer = await getStreamerByDiscordId(req.session.user.discordId);
       needsReconnect = !!(streamer?.eventsub_access_token && streamer.twitch_name && hasAuthFailedSubs(streamer.twitch_name));
     }
-    res.render('dashboard', {
+    renderView(res, 'dashboard', {
       user: req.session.user,
       status,
       csrfToken: req.csrfToken(),

--- a/src/web/routes/guild.ts
+++ b/src/web/routes/guild.ts
@@ -3,7 +3,7 @@ import { Router } from 'express';
 import { AccessLevel, findUser, getAllGuilds, getEffectiveAccessLevel, getGuildsForMember } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
-import { normalizeDiscordId } from './shared';
+import { normalizeDiscordId, renderView } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
@@ -25,7 +25,7 @@ router.get('/select', requireAuth, csrfProtection, (req, res) => {
   if (user.guilds.length <= 1) {
     return res.redirect('/');
   }
-  res.render('guildSelect', {
+  renderView(res, 'guildSelect', {
     user,
     guilds: user.guilds,
     csrfToken: req.csrfToken(),

--- a/src/web/routes/overlayAdmin.ts
+++ b/src/web/routes/overlayAdmin.ts
@@ -8,7 +8,7 @@ import { getVideosForStreamer, getRewardsForStreamer } from '../../db';
 import { PUBLIC_URL } from '../../shared/config';
 import { getCustomRewards, TwitchCustomReward } from '../../twitch/twitchApi';
 import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
-import { filterQueryParam } from './shared';
+import { filterQueryParam, renderError, renderView } from './shared';
 import { router as mutationsRouter, MAX_UPLOAD_MB } from './overlayAdminMutations';
 import { router as rewardMutationsRouter } from './overlayAdminRewardMutations';
 
@@ -56,7 +56,7 @@ router.get('/settings', requireAuth, csrfProtection, async (req, res) => {
         ])
       : [[], [], []];
 
-    res.render('overlayAdmin', {
+    renderView(res, 'overlayAdmin', {
       user: req.session.user,
       csrfToken: req.csrfToken(),
       streamer: streamer ?? null,
@@ -70,7 +70,7 @@ router.get('/settings', requireAuth, csrfProtection, async (req, res) => {
     });
   } catch (err) {
     log.error('Overlay settings page error:', err);
-    res.status(500).render('error', { message: 'Failed to load overlay settings.', user: req.session.user ?? null, csrfToken: '' });
+    renderError(res, 500, 'Failed to load overlay settings.', req.session.user);
   }
 });
 

--- a/src/web/routes/overlaySource.test.ts
+++ b/src/web/routes/overlaySource.test.ts
@@ -51,6 +51,25 @@ describe('GET /controller', () => {
   });
 });
 
+describe('GET /:login', () => {
+  it('renders the overlaySource view with the lowercased login', async () => {
+    const res = await supertest(buildApp()).get('/SomeChannel');
+    expect(res.status).toBe(200);
+    expect(res.body.view).toBe('overlaySource');
+    expect(res.body.login).toBe('somechannel');
+  });
+
+  it('falls through (404) for a reserved login', async () => {
+    const res = await supertest(buildApp()).get('/settings');
+    expect(res.status).toBe(404);
+  });
+
+  it('falls through (404) for a malformed login', async () => {
+    const res = await supertest(buildApp()).get('/not-valid!');
+    expect(res.status).toBe(404);
+  });
+});
+
 describe('MAX_SSE_CONNECTIONS_PER_CHANNEL', () => {
   afterEach(() => {
     vi.unstubAllEnvs();

--- a/src/web/routes/overlaySource.test.ts
+++ b/src/web/routes/overlaySource.test.ts
@@ -9,7 +9,10 @@ vi.mock('../../shared/config', () => ({
 }));
 
 vi.mock('fs', () => ({
-  default: { promises: { access: vi.fn() } },
+  default: {
+    promises: { access: vi.fn() },
+    readdirSync: () => ['controllerOverlay.ejs', 'overlaySource.ejs'],
+  },
 }));
 
 import express from 'express';

--- a/src/web/routes/overlaySource.ts
+++ b/src/web/routes/overlaySource.ts
@@ -3,6 +3,7 @@ import { Router } from 'express';
 import fs from 'fs';
 import { OVERLAY_FOLDER } from '../../shared/config';
 import { safeResolve } from '../../shared/pathUtils';
+import { renderView } from './shared';
 
 const log = createLogger('OverlaySource');
 const router = Router();
@@ -45,7 +46,7 @@ export function pushOverlayEvent(login: string, videoPath: string): void {
  * @param res - Express response; renders the `controllerOverlay` view.
  */
 router.get('/controller', (_req, res) => {
-  res.render('controllerOverlay');
+  renderView(res, 'controllerOverlay');
 });
 
 /**
@@ -59,7 +60,7 @@ router.get('/controller', (_req, res) => {
 router.get('/:login', (req, res, next) => {
   const { login } = req.params;
   if (!LOGIN_RE.test(login) || RESERVED_LOGINS.has(login.toLowerCase())) { next(); return; }
-  res.render('overlaySource', { login: login.toLowerCase() });
+  renderView(res, 'overlaySource', { login: login.toLowerCase() });
 });
 
 /**

--- a/src/web/routes/privacy.ts
+++ b/src/web/routes/privacy.ts
@@ -1,11 +1,12 @@
 import { Router } from 'express';
 import { ensureSessionCsrfToken } from '../csrf';
+import { renderView } from './shared';
 
 const router = Router();
 
 /** Renders the public privacy/cookie notice page. Accessible whether or not the user is signed in. */
 router.get('/privacy', (req, res) => {
-  res.render('privacy', {
+  renderView(res, 'privacy', {
     user: req.session.user ?? null,
     csrfToken: req.session.user ? ensureSessionCsrfToken(req) : '',
   });

--- a/src/web/routes/sfx.ts
+++ b/src/web/routes/sfx.ts
@@ -4,7 +4,7 @@ import { getAllSfxTriggers, getAllCategories } from '../../db';
 import { csrfProtection } from '../csrf';
 import { SFX_MAX_FILE_MB } from '../../shared/config';
 import { AccessLevel } from '../../db/users';
-import { filterQueryParam, renderError } from './shared';
+import { filterQueryParam, renderError, renderView } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
@@ -44,7 +44,7 @@ router.get('/sfx', csrfProtection, async (req, res) => {
   try {
     const [triggers, categories] = await Promise.all([getAllSfxTriggers(), getAllCategories()]);
     const canManage = (req.session.user?.accessLevel ?? 0) >= AccessLevel.MOD;
-    res.render('sfx', {
+    renderView(res, 'sfx', {
       user: req.session.user,
       triggers,
       categories,

--- a/src/web/routes/sfxPublic.ts
+++ b/src/web/routes/sfxPublic.ts
@@ -2,7 +2,7 @@ import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import { getPublicSfxTriggers } from '../../db';
 import type { PublicSfxTrigger } from '../../db';
-import { renderError } from './shared';
+import { renderError, renderView } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
@@ -33,7 +33,7 @@ async function getCachedData(): Promise<PublicSfxTrigger[]> {
 router.get('/sfx-list', async (req, res) => {
   try {
     const triggers = await getCachedData();
-    res.render('sfx-public', {
+    renderView(res, 'sfx-public', {
       user: req.session.user ?? null,
       triggers,
     });

--- a/src/web/routes/shared.test.ts
+++ b/src/web/routes/shared.test.ts
@@ -12,6 +12,7 @@ import {
   normalizeSingleTokenRequiredText,
   normalizeDiscordId,
   renderError,
+  renderView,
   filterQueryParam,
 } from './shared';
 
@@ -165,11 +166,35 @@ describe('normalizeDiscordId', () => {
   });
 });
 
+describe('renderView', () => {
+  function mockRes() {
+    const render = vi.fn();
+    return { res: { render } as unknown as Response, render };
+  }
+
+  it('forwards a known view and data to res.render unchanged', () => {
+    const { res, render } = mockRes();
+    renderView(res, 'error', { message: 'hi' });
+    expect(render).toHaveBeenCalledWith('error', { message: 'hi' });
+  });
+
+  it('throws for a view name with no matching .ejs file under views/', () => {
+    const { res } = mockRes();
+    expect(() => renderView(res, 'not-a-real-view')).toThrow(/unknown view/);
+  });
+
+  it('does not call res.render when the view is unknown', () => {
+    const { res, render } = mockRes();
+    expect(() => renderView(res, '../../etc/passwd')).toThrow();
+    expect(render).not.toHaveBeenCalled();
+  });
+});
+
 describe('renderError', () => {
   function mockRes() {
     const render = vi.fn();
-    const status = vi.fn().mockReturnValue({ render });
-    return { res: { status } as unknown as Response, render, status };
+    const status = vi.fn();
+    return { res: { status, render } as unknown as Response, render, status };
   }
 
   it('calls res.status with the given status code', () => {

--- a/src/web/routes/shared.ts
+++ b/src/web/routes/shared.ts
@@ -1,5 +1,22 @@
+import fs from 'fs';
+import path from 'path';
 import type { Response } from 'express';
 import type { SessionUser } from '../../types/express';
+
+const VIEWS_DIR = path.join(__dirname, '../../../views');
+let knownViews: Set<string> | undefined;
+
+/** Lazily reads and caches the set of view names from the `.ejs` files under `views/`. */
+function getKnownViews(): Set<string> {
+  if (!knownViews) {
+    knownViews = new Set(
+      fs.readdirSync(VIEWS_DIR)
+        .filter((f) => f.endsWith('.ejs'))
+        .map((f) => f.slice(0, -'.ejs'.length)),
+    );
+  }
+  return knownViews;
+}
 
 /**
  * Parse a positive integer id form field. A repeated field (arriving as an array) is
@@ -69,6 +86,21 @@ export function normalizeDiscordId(value: string | undefined): string | null {
 }
 
 /**
+ * Renders an EJS view after checking `view` against the actual `.ejs` files present
+ * under `views/`. Throws if `view` isn't a real template, so a template name can never
+ * be attacker-controlled or silently mistyped.
+ * @param res - Express response object.
+ * @param view - Name of the view to render (without the `.ejs` extension).
+ * @param data - Template data, forwarded to `res.render` unchanged.
+ */
+export function renderView(res: Response, view: string, data?: Record<string, unknown>): void {
+  if (!getKnownViews().has(view)) {
+    throw new Error(`renderView: unknown view "${view}"`);
+  }
+  res.render(view, data);
+}
+
+/**
  * Renders the `error` EJS view with the given HTTP status and message.
  * @param res - Express response object.
  * @param status - HTTP status code to set.
@@ -81,7 +113,8 @@ export function renderError(
   message: string,
   sessionUser: SessionUser | undefined,
 ): void {
-  res.status(status).render('error', { message, user: sessionUser ?? null, csrfToken: '' });
+  res.status(status);
+  renderView(res, 'error', { message, user: sessionUser ?? null, csrfToken: '' });
 }
 
 /**

--- a/src/web/routes/streamdeckKeys.ts
+++ b/src/web/routes/streamdeckKeys.ts
@@ -12,7 +12,7 @@ import {
 import { csrfProtection } from '../csrf';
 import { requireAdmin } from '../middleware';
 import { WEB_PORT } from '../../shared/config';
-import { normalizeDiscordId, renderError, filterQueryParam } from './shared';
+import { normalizeDiscordId, renderError, filterQueryParam, renderView } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
@@ -25,7 +25,7 @@ const USER_KNOWN_ERRORS = new Set(['request_failed', 'revoke_failed']);
 router.get('/streamdeck-key', csrfProtection, async (req, res) => {
   try {
     const keyRow = await getApiKeyStatus(req.session.user!.discordId);
-    res.render('streamdeck-keys', {
+    renderView(res, 'streamdeck-keys', {
       user: req.session.user,
       csrfToken: req.csrfToken(),
       keyRow,
@@ -48,7 +48,7 @@ router.post('/streamdeck-key/request', csrfProtection, async (req, res) => {
       req.session.user!.currentGuildId!,
     );
     const keyRow = await getApiKeyStatus(req.session.user!.discordId);
-    res.render('streamdeck-keys', {
+    renderView(res, 'streamdeck-keys', {
       user: req.session.user,
       csrfToken: req.csrfToken(),
       keyRow,
@@ -81,7 +81,7 @@ const ADMIN_KNOWN_ERRORS = new Set(['approve_failed', 'deny_failed', 'revoke_fai
 router.get('/admin/streamdeck-keys', requireAdmin, csrfProtection, async (req, res) => {
   try {
     const [pending, all] = await Promise.all([getPendingRequests(), getAllApiKeys()]);
-    res.render('streamdeck-keys-admin', {
+    renderView(res, 'streamdeck-keys-admin', {
       user: req.session.user,
       csrfToken: req.csrfToken(),
       pending,

--- a/src/web/routes/streams.ts
+++ b/src/web/routes/streams.ts
@@ -17,7 +17,7 @@ import { csrfProtection } from '../csrf';
 import { requireManager } from '../middleware';
 import { restartTwitchMonitor, getLiveStates } from '../../twitch/monitor/twitchMonitor';
 import { AccessLevel } from '../../db';
-import { parsePositiveIntId, filterQueryParam, normalizeDiscordId } from './shared';
+import { parsePositiveIntId, filterQueryParam, normalizeDiscordId, renderView } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
@@ -79,7 +79,7 @@ router.get('/streams', requireManager, csrfProtection, async (req, res) => {
       (u) => u.twitch_name && !existingStreamerIds.has(u.discord_id),
     );
 
-    res.render('streams', {
+    renderView(res, 'streams', {
       user: req.session.user,
       groups,
       streamers,
@@ -93,7 +93,8 @@ router.get('/streams', requireManager, csrfProtection, async (req, res) => {
     });
   } catch (err) {
     log.error('Streams page error:', err);
-    res.status(500).render('error', { message: 'Failed to load streams page.', user: req.session.user ?? null });
+    res.status(500);
+    renderView(res, 'error', { message: 'Failed to load streams page.', user: req.session.user ?? null });
   }
 });
 

--- a/src/web/routes/streams.ts
+++ b/src/web/routes/streams.ts
@@ -17,7 +17,7 @@ import { csrfProtection } from '../csrf';
 import { requireManager } from '../middleware';
 import { restartTwitchMonitor, getLiveStates } from '../../twitch/monitor/twitchMonitor';
 import { AccessLevel } from '../../db';
-import { parsePositiveIntId, filterQueryParam, normalizeDiscordId, renderView } from './shared';
+import { parsePositiveIntId, filterQueryParam, normalizeDiscordId, renderView, renderError } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
@@ -93,8 +93,7 @@ router.get('/streams', requireManager, csrfProtection, async (req, res) => {
     });
   } catch (err) {
     log.error('Streams page error:', err);
-    res.status(500);
-    renderView(res, 'error', { message: 'Failed to load streams page.', user: req.session.user ?? null });
+    renderError(res, 500, 'Failed to load streams page.', req.session.user);
   }
 });
 

--- a/src/web/routes/tos.ts
+++ b/src/web/routes/tos.ts
@@ -1,11 +1,12 @@
 import { Router } from 'express';
 import { ensureSessionCsrfToken } from '../csrf';
+import { renderView } from './shared';
 
 const router = Router();
 
 /** Renders the public Terms of Service page. Accessible whether or not the user is signed in. */
 router.get('/tos', (req, res) => {
-  res.render('tos', {
+  renderView(res, 'tos', {
     user: req.session.user ?? null,
     csrfToken: req.session.user ? ensureSessionCsrfToken(req) : '',
   });

--- a/src/web/routes/userSettings.ts
+++ b/src/web/routes/userSettings.ts
@@ -4,7 +4,7 @@ import { randomBytes } from 'crypto';
 import { findUser, getStreamerByDiscordId, saveEventConfig, clearStreamerToken, EventSubConfig } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
-import { trimField, renderError, filterQueryParam } from './shared';
+import { trimField, renderError, filterQueryParam, renderView } from './shared';
 import { reloadEventSubSubscriptions } from '../../twitch/eventsub/twitchEventSub';
 import { hasAuthFailedSubs } from '../../twitch/eventsub/twitchEventSubSubscriptions';
 import { TWITCH_CLIENT_ID, TWITCH_EVENTSUB_REDIRECT_URI, EVENTSUB_TOKEN_SECRET } from '../../shared/config';
@@ -77,7 +77,7 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
 
     const needsReconnect = isConnected && !!(streamer?.twitch_name) && hasAuthFailedSubs(streamer.twitch_name);
 
-    res.render('userSettings', {
+    renderView(res, 'userSettings', {
       user: req.session.user,
       dbUser,
       streamer: safeStreamer,

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -44,18 +44,26 @@ vi.mock('./middleware', () => ({
   requireMod: vi.fn((_req: unknown, _res: unknown, next: () => void) => next()),
 }));
 
-// Each marker path is unique per router so a request only matches the router under
-// test, even though several real routers are mounted at the same '/' or '/admin' prefix.
+/** An empty router, standing in for a real route module whose internals aren't under test. */
 function emptyRouter() {
   return Router();
 }
+
+/**
+ * A router exposing a single `/__marker_${label}` route, so a request only matches the
+ * router under test even though several real routers are mounted at the same '/' or
+ * '/admin' prefix.
+ */
 function markerRouter(label: string) {
   const router = Router();
   router.get(`/__marker_${label}`, (_req, res) => res.json({ label }));
   return router;
 }
-// Exposes routes that hand an error to `next()`, to drive the csrfErrorHandler and
-// centralised error handler in server.ts without needing a real CSRF/unhandled failure.
+
+/**
+ * Exposes routes that hand an error to `next()`, to drive the csrfErrorHandler and
+ * centralised error handler in server.ts without needing a real CSRF/unhandled failure.
+ */
 function errorTriggerRouter() {
   const router = Router();
   router.get('/__trigger_csrf_error', (_req, _res, next) => {

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -54,14 +54,34 @@ function markerRouter(label: string) {
   router.get(`/__marker_${label}`, (_req, res) => res.json({ label }));
   return router;
 }
+// Exposes routes that hand an error to `next()`, to drive the csrfErrorHandler and
+// centralised error handler in server.ts without needing a real CSRF/unhandled failure.
+function errorTriggerRouter() {
+  const router = Router();
+  router.get('/__trigger_csrf_error', (_req, _res, next) => {
+    const err = Object.assign(new Error('invalid csrf token'), { code: 'EBADCSRFTOKEN' });
+    next(err);
+  });
+  router.get('/__trigger_error', (_req, _res, next) => {
+    next(new Error('boom'));
+  });
+  return router;
+}
 
 vi.mock('./routes/auth', () => ({ default: emptyRouter() }));
 vi.mock('./routes/guild', () => ({ default: markerRouter('guild') }));
 vi.mock('./routes/eventsubCallback', () => ({ default: emptyRouter() }));
 vi.mock('./routes/eventsubAdmin', () => ({ default: markerRouter('eventsubAdmin') }));
-vi.mock('./routes/dashboard', () => ({ default: markerRouter('dashboard') }));
+vi.mock('./routes/dashboard', () => ({
+  default: (() => {
+    const router = Router();
+    router.use(markerRouter('dashboard'));
+    router.use(errorTriggerRouter());
+    return router;
+  })(),
+}));
 vi.mock('./routes/admin', () => ({ default: markerRouter('admin') }));
-vi.mock('./routes/api', () => ({ default: emptyRouter() }));
+vi.mock('./routes/api', () => ({ default: errorTriggerRouter() }));
 vi.mock('./routes/sfx', () => ({ default: emptyRouter() }));
 vi.mock('./routes/sfxMutations', () => ({ default: emptyRouter() }));
 vi.mock('./routes/sfxPublic', () => ({ default: emptyRouter() }));
@@ -139,5 +159,36 @@ describe('server route wiring', () => {
       const res = await request(app).get('/__marker_dashboard');
       expect(res.status).toBe(200);
     }
+  });
+});
+
+describe('404 handler', () => {
+  it('renders the error view with a 404 status for an unmatched route', async () => {
+    const res = await request(app).get('/__this_route_does_not_exist');
+    expect(res.status).toBe(404);
+    expect(res.text).toContain('Page not found.');
+  });
+});
+
+describe('csrfErrorHandler', () => {
+  it('renders the error view with a 403 status for a CSRF failure outside /api', async () => {
+    const res = await request(app).get('/__trigger_csrf_error');
+    expect(res.status).toBe(403);
+    expect(res.text).toContain('Your form session expired');
+  });
+
+  it('responds with JSON for a CSRF failure under /api', async () => {
+    const res = await request(app).get('/api/__trigger_csrf_error');
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({
+      ok: false,
+      error: 'Your form session expired or the request could not be verified. Please reload the page and try again.',
+    });
+  });
+
+  it('forwards non-CSRF errors to the centralised error handler', async () => {
+    const res = await request(app).get('/__trigger_error');
+    expect(res.status).toBe(500);
+    expect(res.text).toContain('An unexpected error occurred.');
   });
 });

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -205,7 +205,11 @@ app.use('/admin', adminGuildRouter);
 app.use('/user/settings', requireAuth, userSettingsRouter);
 app.use('/overlay', requireAuth, overlayAdminRouter);
 
-// 404 handler
+/**
+ * 404 handler — catches any request that fell through every mounted router.
+ * @param req - Express request; reads `req.session.user` if present.
+ * @param res - Express response; renders the `error` view with a 404 status.
+ */
 app.use((req, res) => {
   res.status(404);
   renderView(res, 'error', {
@@ -215,6 +219,15 @@ app.use((req, res) => {
   });
 });
 
+/**
+ * Catches CSRF token validation failures raised by `csrfProtection` middleware.
+ * Responds with JSON for `/api` requests, or renders the `error` view otherwise.
+ * Delegates to `next(err)` for any other error type.
+ * @param err - The error thrown by the request pipeline.
+ * @param req - Express request; reads `req.originalUrl` and `req.session.user`.
+ * @param res - Express response; renders/responds with a 403 on a CSRF failure.
+ * @param next - Called with the original error when it isn't a CSRF failure.
+ */
 const csrfErrorHandler: ErrorRequestHandler = (err, req, res, next) => {
   if ((err as { code?: string } | undefined)?.code !== 'EBADCSRFTOKEN') {
     next(err);
@@ -241,7 +254,13 @@ const csrfErrorHandler: ErrorRequestHandler = (err, req, res, next) => {
 
 app.use(csrfErrorHandler);
 
-// Centralised error handler
+/**
+ * Centralised error handler — catches anything unhandled by earlier middleware/routes.
+ * @param err - The unhandled error.
+ * @param req - Express request; reads `req.session.user` if present.
+ * @param res - Express response; renders the `error` view with a 500 status.
+ * @param _next - Unused, but required for Express to recognize this as an error handler.
+ */
 app.use((err: unknown, req: express.Request, res: express.Response, _next: express.NextFunction) => {
   log.error('Unhandled error:', err);
   res.status(500);

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -37,6 +37,7 @@ import privacyRouter from './routes/privacy';
 import tosRouter from './routes/tos';
 import { requireAuth, requireGuildContext } from './middleware';
 import { ensureSessionCsrfToken } from './csrf';
+import { renderView } from './routes/shared';
 import {
   authLimiter,
   ipKey,
@@ -206,7 +207,8 @@ app.use('/overlay', requireAuth, overlayAdminRouter);
 
 // 404 handler
 app.use((req, res) => {
-  res.status(404).render('error', {
+  res.status(404);
+  renderView(res, 'error', {
     message: 'Page not found.',
     user: req.session.user ?? null,
     csrfToken: req.session.user ? ensureSessionCsrfToken(req) : '',
@@ -229,7 +231,8 @@ const csrfErrorHandler: ErrorRequestHandler = (err, req, res, next) => {
     return;
   }
 
-  res.status(403).render('error', {
+  res.status(403);
+  renderView(res, 'error', {
     message: 'Your form session expired or the request could not be verified. Please reload the page and try again.',
     user: req.session.user ?? null,
     csrfToken: req.session.user ? ensureSessionCsrfToken(req) : '',
@@ -241,7 +244,8 @@ app.use(csrfErrorHandler);
 // Centralised error handler
 app.use((err: unknown, req: express.Request, res: express.Response, _next: express.NextFunction) => {
   log.error('Unhandled error:', err);
-  res.status(500).render('error', {
+  res.status(500);
+  renderView(res, 'error', {
     message: 'An unexpected error occurred.',
     user: req.session.user ?? null,
     csrfToken: req.session.user ? ensureSessionCsrfToken(req) : '',


### PR DESCRIPTION
## Summary

An Aikido scan flagged "Server-Side Template Injection via untrusted input in `express.render()`" as High severity across ~13 route files. Investigation confirmed this is a scanner false positive — every `res.render()` call already uses a hardcoded template name, and request-derived query values (`error`, `success`, etc.) are already allowlisted via `filterQueryParam` before reaching the template data. No path exists where a template name is built from request input.

As a concrete code-level safeguard (rather than just dismissing the scanner finding), this PR adds `renderView()` to `src/web/routes/shared.ts`:

- Checks the requested view name against the actual `.ejs` files present under `views/` (read once, lazily cached), throwing if it doesn't match a real template.
- This is a genuine runtime allowlist check — the same pattern `filterQueryParam` already uses for query params — applied to the template-name argument, and it's self-maintaining: adding/removing a `.ejs` file under `views/` automatically updates what's allowed, with no list to hand-edit.
- Replaced every raw `res.render()` call in production code (route handlers, `middleware.ts`'s access-denied handlers, `server.ts`'s 404/CSRF/error handlers) with `renderView(...)`. `renderError()` now goes through it too.

No behavior changes for legitimate requests — this only adds a safety net against a template name ever becoming attacker-controlled or mistyped.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (1663 tests), including new `renderView` coverage in `shared.test.ts` (known view forwards correctly; unknown view throws without calling `res.render`)
- [x] Fixed `overlaySource.test.ts`'s `fs` mock, which previously stubbed only `promises.access` and broke once `shared.ts` needed `readdirSync`


---
_Generated by [Claude Code](https://claude.ai/code/session_01DKPmjbSMny95bztd9uE9Rm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized rendering for web pages and error responses across the app (including login, dashboard, privacy, settings, streams, admin, and overlays), improving consistency for both success and failure states.
  * Centralized error handling for 403/404/500 so users see the same messages and session/CSRF details in the HTML interface.
  * Added safer page rendering so only approved templates can be displayed.

* **Tests**
  * Expanded automated coverage for shared rendering behavior and updated route tests for overlays, counters, command monitor, and server error/CSRF paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->