### PR TITLE
Restrict CSP font-src to 'self'

### DIFF
--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -170,6 +170,15 @@ describe('server route wiring', () => {
   });
 });
 
+describe('CSP header', () => {
+  it('restricts font-src to self, without falling back to helmet defaults', async () => {
+    const res = await request(app).get('/__marker_dashboard');
+    const csp = res.headers['content-security-policy'];
+    expect(csp).toContain("font-src 'self'");
+    expect(csp).not.toMatch(/font-src[^;]*https:/);
+  });
+});
+
 describe('404 handler', () => {
   it('renders the error view with a 404 status for an unmatched route', async () => {
     const res = await request(app).get('/__this_route_does_not_exist');

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -55,12 +55,14 @@ app.use(
       ? { maxAge: 31536000, includeSubDomains: true }
       : false,
     contentSecurityPolicy: {
+      useDefaults: false,
       directives: {
         defaultSrc: ["'self'"],
         scriptSrc: ["'self'"],
         scriptSrcAttr: ["'none'"],
         styleSrc: ["'self'", "'unsafe-inline'"],
         imgSrc: ["'self'", 'data:', 'https://cdn.discordapp.com', 'https://static-cdn.jtvnw.net'],
+        fontSrc: ["'self'"],
         connectSrc: ["'self'"],
         mediaSrc: ["'self'"],
         objectSrc: ["'none'"],


### PR DESCRIPTION
## Summary

- Aikido flagged the CSP on `https://bcuk.expiredminotaur.com/tos` as "not restrictive enough". The reported header included `font-src 'self' https: data:`, but that directive wasn't actually set anywhere in `src/web/server.ts` — helmet was silently merging its default `font-src` (`'self' https: data:`) in for the one directive left unspecified, since every other directive in the config already matched the default it wanted.
- Added an explicit `fontSrc: ["'self'"]` directive — no fonts are loaded from a remote origin or `data:` URI anywhere in the app (only system font stacks like `'Segoe UI', sans-serif`), so `'self'` is sufficient.
- Set `useDefaults: false` on the helmet `contentSecurityPolicy` config so any directive left unset in the future can't silently pick up a permissive helmet default again.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (all 1677 tests pass, including a new assertion in `src/web/server.test.ts` that the `Content-Security-Policy` header contains `font-src 'self'` and does not contain `https:` in the `font-src` directive)


---
_Generated by [Claude Code](https://claude.ai/code/session_019HGFr5Zf68LzmuSdiiFx6A)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened the app’s Content Security Policy so browser security rules now follow the app’s intended settings more closely.
  * Improved CSP coverage for the dashboard route, ensuring font loading is restricted to the app’s own origin and no longer falls back to broader HTTPS sources.
  * Added a test to verify the security header stays correctly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->