### PR TITLE
fix(security): hash Streamdeck API token in rate-limit key store

### DIFF
--- a/src/web/rateLimits.test.ts
+++ b/src/web/rateLimits.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { describe, it, expect, vi } from 'vitest';
 import type { Request } from 'express';
 import type { SessionUser } from '../types/express';
@@ -134,8 +135,15 @@ describe('sessionLimiterKey', () => {
 // streamdeckLimiterKey
 // ---------------------------------------------------------------------------
 describe('streamdeckLimiterKey', () => {
-  it('returns the Bearer token when a valid Authorization header is present', () => {
-    expect(streamdeckLimiterKey(makeReq({ authHeader: 'Bearer my-secret-token' }))).toBe('my-secret-token');
+  it('returns the SHA-256 hash of the Bearer token when a valid Authorization header is present', () => {
+    const expected = createHash('sha256').update('my-secret-token').digest('hex');
+    expect(streamdeckLimiterKey(makeReq({ authHeader: 'Bearer my-secret-token' }))).toBe(expected);
+  });
+
+  it('keys different tokens to different hash buckets', () => {
+    const key1 = streamdeckLimiterKey(makeReq({ authHeader: 'Bearer token-a' }));
+    const key2 = streamdeckLimiterKey(makeReq({ authHeader: 'Bearer token-b' }));
+    expect(key1).not.toBe(key2);
   });
 
   it('falls back to req.ip when no Authorization header is present', () => {

--- a/src/web/rateLimits.ts
+++ b/src/web/rateLimits.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 import type { Request } from 'express';
 
@@ -63,12 +64,15 @@ export function sessionLimiterSkip(req: Request): boolean {
 /**
  * Generates a rate-limit key for the Streamdeck API.
  * Keys by Bearer token so each API key gets its own bucket regardless of IP.
+ * The token is SHA-256-hashed before use as the key so that plaintext API
+ * tokens are never stored in the rate-limit store (e.g. in memory dumps).
  * Falls back to IP-based keying when no Bearer token is present.
  * @param req - Express request object
- * @returns Bearer token value, or IP-based fallback key
+ * @returns SHA-256 hash of the Bearer token, or IP-based fallback key
  */
 export function streamdeckLimiterKey(req: Request): string {
   const auth = req.headers['authorization'];
   const token = auth?.startsWith('Bearer ') ? auth.slice(7) : null;
-  return token ?? ipKeyGenerator(req.ip ?? req.socket?.remoteAddress ?? 'unknown');
+  if (token) return createHash('sha256').update(token).digest('hex');
+  return ipKeyGenerator(req.ip ?? req.socket?.remoteAddress ?? 'unknown');
 }


### PR DESCRIPTION
## Problem

`streamdeckLimiterKey()` in `src/web/rateLimits.ts` was using the raw plaintext Bearer token as the key in the express-rate-limit in-memory store:

```ts
return token ?? ipKeyGenerator(req.ip ?? req.socket?.remoteAddress ?? 'unknown');
```

This means every authenticated Streamdeck API request caused the plaintext API token to be written into the rate-limit store held in process memory. A memory dump, heap snapshot, or debug capture of the Node.js process would expose raw API tokens for all active clients.

## Fix

The token is now SHA-256-hashed before being used as the bucket key:

```ts
if (token) return createHash('sha256').update(token).digest('hex');
```

- Same per-token bucketing behaviour is preserved — each unique token maps to a unique (deterministic) hash, so rate limiting continues to work correctly per API key.
- The plaintext token is never written to the rate-limit store.
- `import { createHash } from 'crypto'` uses Node's built-in module — no new dependency.

## Severity

**Low** — exploiting this requires process-level access (memory dump / heap snapshot), which already implies significant compromise. The fix is nonetheless cheap and eliminates an unnecessary residual exposure.

## Tests

- Updated existing test to assert the SHA-256 hex digest is returned (not the raw token).
- Added a second test verifying that different tokens produce different hash keys (bucket isolation).
- All 1681 tests pass; `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYjXbi9DN9P6k36ksqwgRo

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYjXbi9DN9P6k36ksqwgRo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rate limiting now uses a hashed value for bearer tokens instead of the raw token, improving how requests are grouped.
  * Requests with different bearer tokens are now placed into separate rate-limit buckets as expected.
  * Requests without a bearer token continue to use IP-based rate limiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->