### PR TITLE
fix(validation): reject array form fields in parseWeight (overlay)

### DIFF
--- a/src/web/routes/overlayAdminRewardMutations.ts
+++ b/src/web/routes/overlayAdminRewardMutations.ts
@@ -40,7 +40,7 @@ router.post('/settings/rewards', requireAuth, csrfProtection, async (req, res) =
     await setRewardVideos(
       rewardId,
       streamer.id,
-      videoIds.map((videoId) => ({ videoId, weight: parseWeight(body[`weight_${videoId}`]) })),
+      videoIds.map((videoId) => ({ videoId, weight: parseWeight(body[`weight_${videoId}`]) ?? 1 })),
     );
 
     res.redirect('/overlay/settings?success=reward_saved');

--- a/src/web/routes/overlayAdminShared.test.ts
+++ b/src/web/routes/overlayAdminShared.test.ts
@@ -83,20 +83,20 @@ describe('toStringArray', () => {
 // ─── parseWeight ─────────────────────────────────────────────────────────────
 
 describe('parseWeight', () => {
-  it('returns 1 for undefined', () => {
-    expect(parseWeight(undefined)).toBe(1);
+  it('returns null for undefined', () => {
+    expect(parseWeight(undefined)).toBeNull();
   });
 
-  it('returns 1 for a non-numeric string', () => {
-    expect(parseWeight('abc')).toBe(1);
+  it('returns null for a non-numeric string', () => {
+    expect(parseWeight('abc')).toBeNull();
   });
 
-  it('returns 1 for zero', () => {
-    expect(parseWeight('0')).toBe(1);
+  it('returns null for zero', () => {
+    expect(parseWeight('0')).toBeNull();
   });
 
-  it('returns 1 for a negative number', () => {
-    expect(parseWeight('-5')).toBe(1);
+  it('returns null for a negative number', () => {
+    expect(parseWeight('-5')).toBeNull();
   });
 
   it('returns the parsed integer for a valid positive number', () => {
@@ -111,19 +111,23 @@ describe('parseWeight', () => {
     expect(parseWeight('2.99')).toBe(2);
   });
 
-  it('uses the first element of an array', () => {
-    expect(parseWeight(['7', '99'])).toBe(7);
+  it('returns null for an array (repeated field)', () => {
+    expect(parseWeight(['7', '99'])).toBeNull();
   });
 
-  it('returns 1 for an array with a non-numeric first element', () => {
-    expect(parseWeight(['abc'])).toBe(1);
+  it('returns null for an array with a non-numeric first element', () => {
+    expect(parseWeight(['abc'])).toBeNull();
   });
 
-  it('returns 1 for an empty array', () => {
-    expect(parseWeight([])).toBe(1);
+  it('returns null for an empty array', () => {
+    expect(parseWeight([])).toBeNull();
   });
 
-  it('returns 1 for Infinity (not finite)', () => {
-    expect(parseWeight('Infinity')).toBe(1);
+  it('returns null for Infinity (not finite)', () => {
+    expect(parseWeight('Infinity')).toBeNull();
+  });
+
+  it('returns null for a single-element array (repeated field)', () => {
+    expect(parseWeight(['7'])).toBeNull();
   });
 });

--- a/src/web/routes/overlayAdminShared.ts
+++ b/src/web/routes/overlayAdminShared.ts
@@ -16,7 +16,17 @@ export function toStringArray(value: string | string[] | undefined): string[] {
   return value ? [value] : [];
 }
 
-export function parseWeight(raw: string | string[] | undefined): number {
-  const n = Number(Array.isArray(raw) ? raw[0] : raw);
-  return Number.isFinite(n) && n >= 1 ? Math.floor(n) : 1;
+/**
+ * Parse a weight form field into a positive integer ≥ 1 (floored), or null when
+ * the value is missing, non-numeric, not positive, or an array (repeated field).
+ * Rejecting arrays is consistent with parsePositiveIntId — a duplicated weight
+ * field can't slip through silently.
+ * @param raw - Raw value from a form field.
+ * @returns A positive integer weight, or null when invalid.
+ */
+export function parseWeight(raw: string | string[] | undefined): number | null {
+  if (Array.isArray(raw)) return null;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 1) return null;
+  return Math.floor(n);
 }


### PR DESCRIPTION
## Summary

- `parseWeight` in `src/web/routes/overlayAdminShared.ts` previously accepted array form fields (e.g. `weight[]=5&weight[]=9999`) and silently used `raw[0]`, allowing a duplicated field to slip through undetected.
- The function now returns `number | null`, rejecting arrays (and other invalid input) with `null` — consistent with `parsePositiveIntId` in `shared.ts` and the `typeof value !== 'string'` guard already used in `sfxMutationsShared.ts`.
- The caller in `overlayAdminRewardMutations.ts` applies `?? 1` so invalid/array weights fall back to the minimum valid weight (1) rather than causing a runtime error. Legitimate weight submissions are unaffected.

**Severity:** Low — exploiting this required submitting a repeated form field, and the worst outcome was that a weight value submitted by a legitimate user could be ignored in favour of an attacker-supplied first element.

## Changes

- `src/web/routes/overlayAdminShared.ts` — `parseWeight` returns `number | null`; arrays short-circuit to `null`.
- `src/web/routes/overlayAdminRewardMutations.ts` — `parseWeight(...) ?? 1` fallback in the `setRewardVideos` mapping.
- `src/web/routes/overlayAdminShared.test.ts` — all "returns 1 for X" tests updated to "returns null for X"; array tests updated; new single-element-array test added.

## Test plan

- [x] `npx tsc --noEmit` passes with no errors
- [x] `npm test` — 1676 tests across 104 files, all passing
- [ ] Manual: submit the overlay reward form with a normal weight value and confirm it saves correctly
- [ ] Manual: confirm a crafted `weight[]=5&weight[]=9999` submission results in weight 1 being stored

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYjXbi9DN9P6k36ksqwgRo

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYjXbi9DN9P6k36ksqwgRo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reward weights now handle missing or invalid values more reliably, defaulting to a weight of 1 when no valid value is provided.
  * Validation for weight inputs has been tightened, so non-numeric, repeated, or out-of-range values are rejected consistently.
* **Tests**
  * Expanded coverage for weight parsing to verify the updated validation behavior across more input types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->