### PR TITLE
fix(security): restrict trigger names to alphanumeric/prefix allowlist

### DIFF
--- a/src/web/routes/shared.test.ts
+++ b/src/web/routes/shared.test.ts
@@ -130,6 +130,22 @@ describe('normalizeSingleTokenRequiredText', () => {
   it('trims surrounding whitespace before checking for tokens', () => {
     expect(normalizeSingleTokenRequiredText('  !cmd  ')).toBe('!cmd');
   });
+
+  it('returns null for a trigger containing angle brackets', () => {
+    expect(normalizeSingleTokenRequiredText('!<test>')).toBeNull();
+  });
+
+  it('returns null for a trigger containing an ampersand', () => {
+    expect(normalizeSingleTokenRequiredText('!test&me')).toBeNull();
+  });
+
+  it('returns null for a trigger with only a prefix character', () => {
+    expect(normalizeSingleTokenRequiredText('!')).toBeNull();
+  });
+
+  it('allows valid triggers with hyphens and underscores', () => {
+    expect(normalizeSingleTokenRequiredText('!my-cmd_1')).toBe('!my-cmd_1');
+  });
 });
 
 describe('normalizeDiscordId', () => {

--- a/src/web/routes/shared.test.ts
+++ b/src/web/routes/shared.test.ts
@@ -146,6 +146,11 @@ describe('normalizeSingleTokenRequiredText', () => {
   it('allows valid triggers with hyphens and underscores', () => {
     expect(normalizeSingleTokenRequiredText('!my-cmd_1')).toBe('!my-cmd_1');
   });
+
+  it('returns null for a trigger containing quote characters', () => {
+    expect(normalizeSingleTokenRequiredText("!it's")).toBeNull();
+    expect(normalizeSingleTokenRequiredText('!say"hi"')).toBeNull();
+  });
 });
 
 describe('normalizeDiscordId', () => {

--- a/src/web/routes/shared.ts
+++ b/src/web/routes/shared.ts
@@ -63,15 +63,26 @@ export function normalizeRequiredText(value: string | undefined): string | null 
 }
 
 /**
- * Normalizes a required single-word (no whitespace) text field to lowercase.
- * Returns `null` if the value is blank or contains whitespace.
+ * Allowlist regex for valid trigger strings (e.g. `!clap`, `!my-cmd_1`).
+ * Permits an optional single-char prefix (`!`, `?`, `#`, `@`), then one alphanumeric
+ * character, followed by zero or more alphanumeric, underscore, or hyphen characters.
+ * Rejects HTML-special characters such as `<`, `>`, `&`, and `"`.
+ */
+const TRIGGER_RE = /^[!?#@]?[a-z0-9][a-z0-9_-]*$/;
+
+/**
+ * Normalizes a required single-word (no whitespace) text field to lowercase and
+ * validates it against the trigger-name allowlist (`TRIGGER_RE`).
+ * Returns `null` if the value is blank, contains whitespace, or contains characters
+ * outside the safe allowlist (e.g. HTML-special chars like `<`, `>`, `&`, `"`).
  * @param value - Raw string from a form field.
- * @returns Lowercased single-token string, or `null`.
+ * @returns Lowercased, allowlist-validated single-token string, or `null`.
  */
 export function normalizeSingleTokenRequiredText(value: string | undefined): string | null {
   const normalized = normalizeRequiredText(value);
   if (!normalized || /\s/.test(normalized)) return null;
-  return normalized.toLowerCase();
+  const lower = normalized.toLowerCase();
+  return TRIGGER_RE.test(lower) ? lower : null;
 }
 
 /**


### PR DESCRIPTION
## Summary

**Severity: Low**

`normalizeSingleTokenRequiredText` previously rejected only whitespace in trigger names, permitting HTML-special characters such as `<`, `>`, `&`, and `"`. Trigger names flow into `status.voice.lastCommand`, the command monitor store, and EJS templates, so this created a defence-in-depth gap.

## Fix

Added a character allowlist regex (`TRIGGER_RE`) to `normalizeSingleTokenRequiredText`:

```
/^[!?#@]?[a-z0-9][a-z0-9_-]*$/
```

This permits the optional prefix (`!`, `?`, `#`, `@`), one mandatory alphanumeric character, and zero or more alphanumeric/underscore/hyphen characters. HTML-special characters (`<`, `>`, `&`, `"`) are rejected before reaching any template.

All existing trigger patterns (`!clap`, `!so`, `!cmd-name`, `!321`) still pass. A JSDoc comment on `TRIGGER_RE` documents the intent.

## Test plan

- `normalizeSingleTokenRequiredText('!<test>')` → `null`
- `normalizeSingleTokenRequiredText('!test&me')` → `null`
- `normalizeSingleTokenRequiredText('!')` → `null` (prefix-only, no body)
- `normalizeSingleTokenRequiredText('!my-cmd_1')` → `'!my-cmd_1'` (valid)
- All 4 new test cases added to `shared.test.ts`; full test suite passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYjXbi9DN9P6k36ksqwgRo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trigger text validation to accept only supported characters.
  * Trigger inputs now reject invalid symbols like angle brackets and ampersands, while still allowing lowercase normalization.
  * Triggers with hyphens and underscores are now accepted as valid.
  * A trigger made up of only the prefix character is now rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->