### PR TITLE
fix(config): centralise overlay/SSE cap env vars in config.ts

### DIFF
--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -41,6 +41,15 @@ const _SFX_MAX_FILE_MB = Number(process.env.SFX_MAX_FILE_MB ?? '10');
 export const SFX_MAX_FILE_MB =
   Number.isInteger(_SFX_MAX_FILE_MB) && _SFX_MAX_FILE_MB > 0 ? _SFX_MAX_FILE_MB : 10;
 export const OVERLAY_FOLDER = process.env.OVERLAY_FOLDER ?? './overlay-videos';
+const _OVERLAY_MAX_FILE_MB = Number(process.env.OVERLAY_MAX_FILE_MB ?? '100');
+export const OVERLAY_MAX_FILE_MB =
+  Number.isInteger(_OVERLAY_MAX_FILE_MB) && _OVERLAY_MAX_FILE_MB > 0 ? _OVERLAY_MAX_FILE_MB : 100;
+const _COMPANION_MAX_SSE = Number(process.env.COMPANION_MAX_SSE_PER_TOKEN ?? '3');
+export const COMPANION_MAX_SSE_PER_TOKEN =
+  Number.isInteger(_COMPANION_MAX_SSE) && _COMPANION_MAX_SSE > 0 ? _COMPANION_MAX_SSE : 3;
+const _OVERLAY_MAX_SSE = Number(process.env.OVERLAY_MAX_SSE_PER_CHANNEL ?? '10');
+export const OVERLAY_MAX_SSE_PER_CHANNEL =
+  Number.isInteger(_OVERLAY_MAX_SSE) && _OVERLAY_MAX_SSE > 0 ? _OVERLAY_MAX_SSE : 10;
 const _COOLDOWN = parseInt(process.env.GLOBAL_COOLDOWN_MS ?? '3000', 10);
 if (Number.isNaN(_COOLDOWN)) throw new Error('Invalid GLOBAL_COOLDOWN_MS: must be a number');
 export const GLOBAL_COOLDOWN_MS = _COOLDOWN;

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -34,22 +34,19 @@ export const DB_USER = require_env('DB_USER');
 export const DB_PASSWORD = require_env('DB_PASSWORD');
 export const DB_NAME = require_env('DB_NAME');
 
-export const SFX_FOLDER = process.env.SFX_FOLDER ?? './sfx';
 // Use Number (not parseInt) so malformed values like `1024MB` or `1.5` fall back
 // to the safe default instead of being silently truncated to a valid-looking cap.
-const _SFX_MAX_FILE_MB = Number(process.env.SFX_MAX_FILE_MB ?? '10');
-export const SFX_MAX_FILE_MB =
-  Number.isInteger(_SFX_MAX_FILE_MB) && _SFX_MAX_FILE_MB > 0 ? _SFX_MAX_FILE_MB : 10;
+function parsePositiveIntEnv(envVar: string | undefined, fallback: number): number {
+  const parsed = Number(envVar);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export const SFX_FOLDER = process.env.SFX_FOLDER ?? './sfx';
+export const SFX_MAX_FILE_MB = parsePositiveIntEnv(process.env.SFX_MAX_FILE_MB, 10);
 export const OVERLAY_FOLDER = process.env.OVERLAY_FOLDER ?? './overlay-videos';
-const _OVERLAY_MAX_FILE_MB = Number(process.env.OVERLAY_MAX_FILE_MB ?? '100');
-export const OVERLAY_MAX_FILE_MB =
-  Number.isInteger(_OVERLAY_MAX_FILE_MB) && _OVERLAY_MAX_FILE_MB > 0 ? _OVERLAY_MAX_FILE_MB : 100;
-const _COMPANION_MAX_SSE = Number(process.env.COMPANION_MAX_SSE_PER_TOKEN ?? '3');
-export const COMPANION_MAX_SSE_PER_TOKEN =
-  Number.isInteger(_COMPANION_MAX_SSE) && _COMPANION_MAX_SSE > 0 ? _COMPANION_MAX_SSE : 3;
-const _OVERLAY_MAX_SSE = Number(process.env.OVERLAY_MAX_SSE_PER_CHANNEL ?? '10');
-export const OVERLAY_MAX_SSE_PER_CHANNEL =
-  Number.isInteger(_OVERLAY_MAX_SSE) && _OVERLAY_MAX_SSE > 0 ? _OVERLAY_MAX_SSE : 10;
+export const OVERLAY_MAX_FILE_MB = parsePositiveIntEnv(process.env.OVERLAY_MAX_FILE_MB, 100);
+export const COMPANION_MAX_SSE_PER_TOKEN = parsePositiveIntEnv(process.env.COMPANION_MAX_SSE_PER_TOKEN, 3);
+export const OVERLAY_MAX_SSE_PER_CHANNEL = parsePositiveIntEnv(process.env.OVERLAY_MAX_SSE_PER_CHANNEL, 10);
 const _COOLDOWN = parseInt(process.env.GLOBAL_COOLDOWN_MS ?? '3000', 10);
 if (Number.isNaN(_COOLDOWN)) throw new Error('Invalid GLOBAL_COOLDOWN_MS: must be a number');
 export const GLOBAL_COOLDOWN_MS = _COOLDOWN;

--- a/src/web/routes/companionEvents.test.ts
+++ b/src/web/routes/companionEvents.test.ts
@@ -7,6 +7,10 @@ vi.mock('../../shared/logger', () => ({
 // Stub auth: tests drive it via the `x-test-discord-id` header instead of a real token,
 // so SSE route behaviour can be exercised without re-testing requireCompanionKey itself
 // (that's covered in middleware.test.ts).
+vi.mock('../../shared/config', () => ({
+  COMPANION_MAX_SSE_PER_TOKEN: 3,
+}));
+
 vi.mock('../middleware', () => ({
   requireCompanionKey: (req: any, res: any, next: any) => {
     const id = req.headers['x-test-discord-id'];

--- a/src/web/routes/companionEvents.ts
+++ b/src/web/routes/companionEvents.ts
@@ -1,6 +1,7 @@
 import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import { requireCompanionKey } from '../middleware';
+import { COMPANION_MAX_SSE_PER_TOKEN } from '../../shared/config';
 
 const log = createLogger('CompanionEvents');
 const router = Router();
@@ -19,9 +20,7 @@ export interface CompanionEvent {
 // In-memory map of active SSE connections keyed by Discord ID.
 export const connections = new Map<string, Set<import('express').Response>>();
 
-const parsedMaxSse = parseInt(process.env.COMPANION_MAX_SSE_PER_TOKEN ?? '3', 10);
-export const MAX_SSE_CONNECTIONS_PER_TOKEN =
-  Number.isFinite(parsedMaxSse) && parsedMaxSse > 0 ? parsedMaxSse : 3;
+export const MAX_SSE_CONNECTIONS_PER_TOKEN = COMPANION_MAX_SSE_PER_TOKEN;
 
 /** Push a companion event to all of a Discord user's connected companion app instances. */
 export function pushCompanionEvent(discordId: string, event: CompanionEvent): void {

--- a/src/web/routes/overlayAdminMutations.test.ts
+++ b/src/web/routes/overlayAdminMutations.test.ts
@@ -1,15 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
-
-// Shrink the upload size limit to 1 MB before the route module reads
-// OVERLAY_MAX_FILE_MB at import time, so an oversized-upload test can trigger
-// Multer's LIMIT_FILE_SIZE with a small buffer. Existing tests use tiny buffers,
-// so they are unaffected. Restored in afterAll to avoid leaking to other files.
-vi.hoisted(() => {
-  process.env.OVERLAY_MAX_FILE_MB = '1';
-});
-afterAll(() => {
-  delete process.env.OVERLAY_MAX_FILE_MB;
-});
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../../shared/logger', () => ({
   createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
@@ -37,6 +26,8 @@ vi.mock('../middleware', () => ({
 
 vi.mock('../../shared/config', () => ({
   OVERLAY_FOLDER: '/app/overlay-videos',
+  // Use 1 MB so the oversized-upload test can trigger Multer's LIMIT_FILE_SIZE with a small buffer.
+  OVERLAY_MAX_FILE_MB: 1,
 }));
 
 vi.mock('fs', () => ({

--- a/src/web/routes/overlayAdminMutations.ts
+++ b/src/web/routes/overlayAdminMutations.ts
@@ -9,7 +9,7 @@ import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
 import type { DbStreamerEventSub } from '../../db';
 import { addVideo, deleteVideo } from '../../db';
-import { OVERLAY_FOLDER } from '../../shared/config';
+import { OVERLAY_FOLDER, OVERLAY_MAX_FILE_MB } from '../../shared/config';
 import { parsePositiveIntId } from './shared';
 import { safeResolve } from '../../shared/pathUtils';
 import { requireStreamer } from './overlayAdminShared';
@@ -19,9 +19,8 @@ export { requireStreamer, toStringArray, parseWeight } from './overlayAdminShare
 const log = createLogger('OverlayAdmin');
 export const router = Router();
 
-const parsedMaxMb = parseInt(process.env.OVERLAY_MAX_FILE_MB ?? '100', 10);
 /** Maximum upload size in megabytes, passed to templates to avoid direct process.env access in EJS. */
-export const MAX_UPLOAD_MB = Number.isFinite(parsedMaxMb) && parsedMaxMb > 0 ? parsedMaxMb : 100;
+export const MAX_UPLOAD_MB = OVERLAY_MAX_FILE_MB;
 const MAX_FILE_BYTES = MAX_UPLOAD_MB * 1024 * 1024;
 
 export const upload = multer({

--- a/src/web/routes/overlaySource.test.ts
+++ b/src/web/routes/overlaySource.test.ts
@@ -6,6 +6,7 @@ vi.mock('../../shared/logger', () => ({
 
 vi.mock('../../shared/config', () => ({
   OVERLAY_FOLDER: '/app/overlay-videos',
+  OVERLAY_MAX_SSE_PER_CHANNEL: 10,
 }));
 
 vi.mock('fs', () => ({
@@ -71,16 +72,8 @@ describe('GET /:login', () => {
 });
 
 describe('MAX_SSE_CONNECTIONS_PER_CHANNEL', () => {
-  afterEach(() => {
-    vi.unstubAllEnvs();
-    vi.resetModules();
-  });
-
-  it('defaults to 10', async () => {
-    vi.stubEnv('OVERLAY_MAX_SSE_PER_CHANNEL', '');
-    vi.resetModules();
-    const { MAX_SSE_CONNECTIONS_PER_CHANNEL: limit } = await import('./overlaySource.js');
-    expect(limit).toBe(10);
+  it('re-exports the value from config', () => {
+    expect(MAX_SSE_CONNECTIONS_PER_CHANNEL).toBe(10);
   });
 });
 

--- a/src/web/routes/overlaySource.ts
+++ b/src/web/routes/overlaySource.ts
@@ -1,7 +1,7 @@
 import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import fs from 'fs';
-import { OVERLAY_FOLDER } from '../../shared/config';
+import { OVERLAY_FOLDER, OVERLAY_MAX_SSE_PER_CHANNEL } from '../../shared/config';
 import { safeResolve } from '../../shared/pathUtils';
 import { renderView } from './shared';
 
@@ -16,9 +16,7 @@ const RESERVED_LOGINS = new Set(['settings', 'videos', 'controller']);
 // In-memory map of active SSE connections keyed by Twitch channel login (lowercase).
 export const connections = new Map<string, Set<import('express').Response>>();
 
-const parsedMaxSse = parseInt(process.env.OVERLAY_MAX_SSE_PER_CHANNEL ?? '10', 10);
-export const MAX_SSE_CONNECTIONS_PER_CHANNEL =
-  Number.isFinite(parsedMaxSse) && parsedMaxSse > 0 ? parsedMaxSse : 10;
+export const MAX_SSE_CONNECTIONS_PER_CHANNEL = OVERLAY_MAX_SSE_PER_CHANNEL;
 
 /** Push a video URL to all browser sources connected for this channel. */
 export function pushOverlayEvent(login: string, videoPath: string): void {


### PR DESCRIPTION
## Summary

**Severity: Low**

`OVERLAY_MAX_FILE_MB`, `COMPANION_MAX_SSE_PER_TOKEN`, and `OVERLAY_MAX_SSE_PER_CHANNEL` were parsed individually in three route files. Malformed values fell back to defaults silently without the consistent validation that other config vars (e.g. `SFX_MAX_FILE_MB`) receive in `src/shared/config.ts`.

## Fix

Moved all three constants into `src/shared/config.ts` using the same `Number()` + `Number.isInteger` + fallback pattern as `SFX_MAX_FILE_MB`:

```ts
const _OVERLAY_MAX_FILE_MB = Number(process.env.OVERLAY_MAX_FILE_MB ?? '100');
export const OVERLAY_MAX_FILE_MB =
  Number.isInteger(_OVERLAY_MAX_FILE_MB) && _OVERLAY_MAX_FILE_MB > 0 ? _OVERLAY_MAX_FILE_MB : 100;
// … COMPANION_MAX_SSE_PER_TOKEN (3), OVERLAY_MAX_SSE_PER_CHANNEL (10) …
```

Route files now import and re-export the validated constants instead of parsing `process.env` directly.

## Test plan

- `overlayAdminMutations.test.ts`: replaced the `vi.hoisted` env-var trick with `OVERLAY_MAX_FILE_MB: 1` in the config mock — cleaner and equivalent
- `overlaySource.test.ts`: updated config mock to include `OVERLAY_MAX_SSE_PER_CHANNEL: 10`; rewrote the "defaults to 10" test to assert the constant re-exports what the config provides
- `companionEvents.test.ts`: added `vi.mock('../../shared/config', …)` with `COMPANION_MAX_SSE_PER_TOKEN: 3`
- Full test suite passes — 104 files, 1676 tests

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYjXbi9DN9P6k36ksqwgRo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized, configurable limits for overlay uploads and SSE connections, including new shared settings for overlay and companion connection caps with safe defaults.
* **Bug Fixes**
  * Improved numeric parsing/validation for limit settings to ensure only valid positive integers are used (avoids misinterpreting malformed values).
  * Overlay and companion routes now read the same shared configuration for consistent enforcement.
* **Tests**
  * Updated tests to mock shared configuration values for predictable upload and SSE limit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->