### PR TITLE
fix(upload): remove redundant MIME fileFilter from video upload

### DIFF
--- a/src/web/routes/overlayAdminMutations.ts
+++ b/src/web/routes/overlayAdminMutations.ts
@@ -24,13 +24,12 @@ const parsedMaxMb = parseInt(process.env.OVERLAY_MAX_FILE_MB ?? '100', 10);
 export const MAX_UPLOAD_MB = Number.isFinite(parsedMaxMb) && parsedMaxMb > 0 ? parsedMaxMb : 100;
 const MAX_FILE_BYTES = MAX_UPLOAD_MB * 1024 * 1024;
 
+// No fileFilter: client-supplied MIME type is unreliable (some browsers send
+// application/octet-stream). detectVideoType() validates via magic bytes instead,
+// mirroring the audio upload approach.
 export const upload = multer({
   storage: multer.memoryStorage(),
   limits: { fileSize: MAX_FILE_BYTES },
-  fileFilter: (_req, file, cb) => {
-    const allowed = ['video/webm', 'video/mp4'];
-    cb(null, allowed.includes(file.mimetype));
-  },
 });
 
 /**


### PR DESCRIPTION
## Summary

**Severity: Low**

The video upload used both multer's `fileFilter` (checking `video/webm` / `video/mp4` MIME type) AND `detectVideoType()` (magic-byte validation). The audio upload explicitly skips MIME filtering because client-supplied MIME types are unreliable — some browsers and platforms send `application/octet-stream` — making the video endpoint inconsistently strict. A valid webm file from such a client would be rejected before magic-byte validation even ran.

## Fix

Removed the `fileFilter` from the video upload multer config. `detectVideoType()` is now the sole gatekeeper, mirroring the existing audio upload approach. A comment explains why MIME filtering is intentionally omitted.

```diff
-export const upload = multer({
-  storage: multer.memoryStorage(),
-  limits: { fileSize: MAX_FILE_BYTES },
-  fileFilter: (_req, file, cb) => {
-    const allowed = ['video/webm', 'video/mp4'];
-    cb(null, allowed.includes(file.mimetype));
-  },
-});
+// No fileFilter: client-supplied MIME type is unreliable (some browsers send
+// application/octet-stream). detectVideoType() validates via magic bytes instead,
+// mirroring the audio upload approach.
+export const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: MAX_FILE_BYTES },
+});
```

## Test plan

- `npm test` passes — 104 files, 1676 tests
- `npx tsc --noEmit` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYjXbi9DN9P6k36ksqwgRo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video upload handling by validating file type on the server instead of trusting the browser-reported MIME type.
  * Uploads now accept only supported video formats after a more reliable content check, reducing failed or mislabeled uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->