### PR TITLE
docs(twitch): clarify tmi.js private channel-list reset in onDisconnected

### DIFF
--- a/src/twitch/twitchBot.ts
+++ b/src/twitch/twitchBot.ts
@@ -77,12 +77,10 @@ function onConnected(addr: string, port: number): void {
 function onDisconnected(reason: string): void {
   connected = false;
   setConnected(false);
-  // Clear tmi.js's confirmed-channel list so it doesn't replay those
-  // channels in its auto-rejoin queue on the next connect. All joining
-  // is handled by reconcileJoinedChannels after 'connected' fires.
-  // tmi.js doesn't expose `channels` in its public types, but it is a real
-  // internal array. Clearing it prevents tmi.js from auto-rejoining stale
-  // channels on the next connect — all joins are handled by reconcileJoinedChannels.
+  // tmi.js ^1.8.5 does not clear its internal confirmed-channel list on
+  // disconnect, so without this reset the client would re-join every channel
+  // twice on reconnect (once from its own queue, once from reconcileJoinedChannels).
+  // `channels` is not part of the public type surface but is a real internal array.
   (client as any).channels = [];
   log.warn(`Disconnected: ${reason}`);
   getActiveChannels().forEach((ch) => { setTwitchChannel(ch, false); });


### PR DESCRIPTION
## Summary

**Severity: Low (documentation / maintenance)**

The `onDisconnected` handler in `src/twitch/twitchBot.ts` resets `(client as any).channels = []` directly on a private tmi.js internal. The existing comment explained what the code does but was redundant (said the same thing twice across six lines) and didn't record which tmi.js version the behaviour was verified against — a future maintainer bumping tmi.js would have no signal that this might break.

## Fix

Condensed the comment to a single clear explanation pinned to the tmi.js version:

```ts
// tmi.js ^1.8.5 does not clear its internal confirmed-channel list on
// disconnect, so without this reset the client would re-join every channel
// twice on reconnect (once from its own queue, once from reconcileJoinedChannels).
// `channels` is not part of the public type surface but is a real internal array.
(client as any).channels = [];
```

No behaviour change.

## Test plan

- `npm test` passes — 104 files, 1676 tests
- `npx tsc --noEmit` passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYjXbi9DN9P6k36ksqwgRo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the disconnect handling notes to better explain why the channel list is cleared after a bot disconnect.
  * No user-facing behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->