### PR TITLE
Add {user}/{args}/{arg} placeholder substitution to custom commands

### DIFF
--- a/src/commands/commandUtils.test.ts
+++ b/src/commands/commandUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { extractCommand } from './commandUtils';
+import { extractCommand, extractArgs } from './commandUtils';
 
 describe('extractCommand', () => {
   it('returns null for an empty string', () => {
@@ -24,5 +24,31 @@ describe('extractCommand', () => {
 
   it('returns the full string lowercased when there is only one token', () => {
     expect(extractCommand('!321')).toBe('!321');
+  });
+});
+
+describe('extractArgs', () => {
+  it('returns an empty string for an empty message', () => {
+    expect(extractArgs('')).toBe('');
+  });
+
+  it('returns an empty string for a whitespace-only message', () => {
+    expect(extractArgs('   ')).toBe('');
+  });
+
+  it('returns an empty string when there are no args after the command', () => {
+    expect(extractArgs('!ding')).toBe('');
+  });
+
+  it('returns the trimmed text after the first token for multiple words', () => {
+    expect(extractArgs('!so @friend extra args')).toBe('@friend extra args');
+  });
+
+  it('trims extra leading/trailing whitespace around the args', () => {
+    expect(extractArgs('  !cmd   arg1  arg2   ')).toBe('arg1  arg2');
+  });
+
+  it('preserves original casing of the args', () => {
+    expect(extractArgs('!Cmd Hello World')).toBe('Hello World');
   });
 });

--- a/src/commands/commandUtils.ts
+++ b/src/commands/commandUtils.ts
@@ -1,5 +1,28 @@
+/**
+ * Extracts the command token from a raw message: the first whitespace-delimited
+ * token, lowercased. Leading/trailing whitespace is trimmed before splitting.
+ *
+ * @param rawMessage - Raw message text to extract the command from.
+ * @returns The lowercased first token, or null if the message is empty/whitespace-only.
+ */
 export function extractCommand(rawMessage: string): string | null {
   const trimmed = rawMessage.trim();
   if (!trimmed) return null;
   return trimmed.split(/\s+/)[0]?.toLowerCase() ?? null;
+}
+
+/**
+ * Extracts the argument text that follows the first token of a raw message.
+ * Leading/trailing whitespace is trimmed; the result preserves the original
+ * casing and internal spacing of the remaining text.
+ *
+ * @param rawMessage - Raw message text to extract arguments from.
+ * @returns The trimmed text after the first token, or '' if there is none.
+ */
+export function extractArgs(rawMessage: string): string {
+  const trimmed = rawMessage.trim();
+  if (!trimmed) return '';
+  const firstSpaceIndex = trimmed.search(/\s/);
+  if (firstSpaceIndex === -1) return '';
+  return trimmed.slice(firstSpaceIndex).trim();
 }

--- a/src/commands/customCommandHandler.test.ts
+++ b/src/commands/customCommandHandler.test.ts
@@ -129,6 +129,46 @@ describe('executeCustomCommandForDiscord', () => {
     expect(vi.mocked(getCustomCommandForDiscord)).not.toHaveBeenCalled();
     expect(msg.reply).not.toHaveBeenCalled();
   });
+
+  it('substitutes {user}, {args}, and {arg} in the response before replying and recording', async () => {
+    vi.mocked(getCustomCommandForDiscord).mockResolvedValue({
+      output: '{user} said {args} (first: {arg})',
+      is_multi_twitch: false,
+    } as any);
+    const msg = mockMsg('!hello foo bar');
+
+    await executeCustomCommandForDiscord(msg as any, 'viewer1');
+
+    const expected = 'viewer1 said foo bar (first: foo)';
+    expect(msg.reply).toHaveBeenCalledWith(expected);
+    expect(vi.mocked(recordCommandTestEntry)).toHaveBeenCalledWith(
+      expect.objectContaining({ response: expected }),
+    );
+  });
+
+  it('substitutes an unknown placeholder with an empty string', async () => {
+    vi.mocked(getCustomCommandForDiscord).mockResolvedValue({
+      output: 'Hi {user}, unknown: [{nope}]',
+      is_multi_twitch: false,
+    } as any);
+    const msg = mockMsg('!hello');
+
+    await executeCustomCommandForDiscord(msg as any, 'viewer1');
+
+    expect(msg.reply).toHaveBeenCalledWith('Hi viewer1, unknown: []');
+  });
+
+  it('substitutes {args} and {arg} as empty strings when no args are given', async () => {
+    vi.mocked(getCustomCommandForDiscord).mockResolvedValue({
+      output: 'args=[{args}] arg=[{arg}]',
+      is_multi_twitch: false,
+    } as any);
+    const msg = mockMsg('!hello');
+
+    await executeCustomCommandForDiscord(msg as any, 'viewer1');
+
+    expect(msg.reply).toHaveBeenCalledWith('args=[] arg=[]');
+  });
 });
 
 // ─── Twitch ───────────────────────────────────────────────────────────────────
@@ -190,6 +230,61 @@ describe('executeCustomCommandForTwitch', () => {
     // Falls back to source channel only
     expect(mockRuntime.send).toHaveBeenCalledTimes(1);
     expect(mockRuntime.send).toHaveBeenCalledWith('#a', 'Hi!');
+  });
+
+  it('substitutes {user}, {args}, and {arg} in the response before sending and recording', async () => {
+    vi.mocked(getCustomCommandForTwitchChannel).mockResolvedValue({
+      output: '{user} said {args} (first: {arg})',
+      is_multi_twitch: false,
+    } as any);
+
+    await executeCustomCommandForTwitch('#chan', '!hey foo bar', 'viewer1');
+
+    const expected = 'viewer1 said foo bar (first: foo)';
+    expect(mockRuntime.send).toHaveBeenCalledWith('#chan', expected);
+    expect(vi.mocked(recordCommandTestEntry)).toHaveBeenCalledWith(
+      expect.objectContaining({ response: expected }),
+    );
+  });
+
+  it('substitutes an unknown placeholder with an empty string', async () => {
+    vi.mocked(getCustomCommandForTwitchChannel).mockResolvedValue({
+      output: 'Hi {user}, unknown: [{nope}]',
+      is_multi_twitch: false,
+    } as any);
+
+    await executeCustomCommandForTwitch('#chan', '!hey', 'viewer1');
+
+    expect(mockRuntime.send).toHaveBeenCalledWith('#chan', 'Hi viewer1, unknown: []');
+  });
+
+  it('substitutes {args} and {arg} as empty strings when no args are given', async () => {
+    vi.mocked(getCustomCommandForTwitchChannel).mockResolvedValue({
+      output: 'args=[{args}] arg=[{arg}]',
+      is_multi_twitch: false,
+    } as any);
+
+    await executeCustomCommandForTwitch('#chan', '!hey', 'viewer1');
+
+    expect(mockRuntime.send).toHaveBeenCalledWith('#chan', 'args=[] arg=[]');
+  });
+
+  it('reuses the same filled response for every channel in a multi-twitch broadcast', async () => {
+    vi.mocked(getCustomCommandForTwitchChannel).mockResolvedValue({
+      output: '{user} said {args}',
+      is_multi_twitch: true,
+    } as any);
+    vi.mocked(getMultiTwitchDataForChannel).mockReturnValue({
+      url: 'multitwitch.tv/a/b',
+      participants: ['#a', '#b'],
+    } as any);
+    mockRuntime.getActiveChannels.mockReturnValue(new Set(['#a', '#b']));
+
+    await executeCustomCommandForTwitch('#a', '!multi hello there', 'viewer1');
+
+    const expected = 'viewer1 said hello there';
+    expect(mockRuntime.send).toHaveBeenCalledWith('#a', expected);
+    expect(mockRuntime.send).toHaveBeenCalledWith('#b', expected);
   });
 });
 

--- a/src/commands/customCommandHandler.ts
+++ b/src/commands/customCommandHandler.ts
@@ -5,9 +5,10 @@ import { getCustomCommandForDiscord, getCustomCommandForTwitchChannel } from '..
 const log = createLogger('CustomCmd');
 import { recordCommandTestEntry } from './commandMonitorStore';
 import { getSharedChatSession } from '../twitch/twitchApi';
-import { extractCommand } from './commandUtils';
+import { extractCommand, extractArgs } from './commandUtils';
 import { isDiscordNotFoundError } from '../discord/discordUtils';
 import { getMultiTwitchDataForChannel } from '../twitch/monitor/twitchMonitor';
+import { fillTemplate } from '../shared/textTemplate';
 
 // ─── Twitch runtime (registered from index.ts before startTwitchBot) ─────────
 //
@@ -172,8 +173,15 @@ async function broadcastToActiveChannels(sourceChannel: string, command: string,
  * are skipped; output overrides replace the catalog text). Discord not-found errors
  * (e.g. message deleted before the reply lands) are silently swallowed.
  *
+ * Before sending, the matched response is run through {@link fillTemplate} with
+ * `{user}` (the invoking username), `{args}` (the raw text after the command token),
+ * and `{arg}` (the first whitespace-delimited word of `{args}`) substituted in —
+ * unknown placeholders resolve to an empty string. The filled text is what's both
+ * sent and recorded via `recordCommandTestEntry`, so the monitor panel shows the
+ * resolved response rather than the raw template.
+ *
  * @param message - The Discord message to inspect and, if matched, reply to.
- * @param username - Display name for the monitoring entry; null or omitted if unknown.
+ * @param username - Display name for the monitoring entry and `{user}` substitution; null or omitted if unknown.
  * @param guildId - Explicit guild ID for override-aware lookup; falls back to message.guildId.
  * @returns Resolves when the command is handled (or skipped).
  */
@@ -193,16 +201,23 @@ export async function executeCustomCommandForDiscord(
   const result = await lookupCommand(command, (cmd) => getCustomCommandForDiscord(cmd, resolvedGuildId));
   if (!result) return;
 
+  const args = extractArgs(message.content);
+  const filledResponse = fillTemplate(result.response, {
+    user: username ?? '',
+    args,
+    arg: args.split(/\s+/)[0] ?? '',
+  });
+
   recordCommandTestEntry({
     source: 'discord',
     command,
-    response: result.response,
+    response: filledResponse,
     channel: null,
     user: username ?? null,
   });
 
   try {
-    await message.reply(result.response);
+    await message.reply(filledResponse);
     log.info(`[Discord] Sent custom command '${command}' (recorded for monitoring).`);
   } catch (err) {
     if (!isDiscordNotFoundError(err)) {
@@ -216,9 +231,16 @@ export async function executeCustomCommandForDiscord(
  * and, if matched, sends the response — broadcasting to other active channels
  * sharing a multi-twitch group when the command is flagged multi-twitch.
  *
+ * Before sending, the matched response is run through {@link fillTemplate} with
+ * `{user}` (the invoking username), `{args}` (the raw text after the command token),
+ * and `{arg}` (the first whitespace-delimited word of `{args}`) substituted in —
+ * unknown placeholders resolve to an empty string. The filled text is what's
+ * recorded via `recordCommandTestEntry` and what's sent; for multi-twitch broadcasts
+ * the same filled string is reused for every target channel (no per-channel re-fill).
+ *
  * @param channel - Twitch channel login the message was received on.
  * @param rawMessage - Raw chat message text.
- * @param username - Display name for the monitoring entry; null or omitted if unknown.
+ * @param username - Display name for the monitoring entry and `{user}` substitution; null or omitted if unknown.
  * @returns Resolves when the command is handled (or skipped).
  */
 export async function executeCustomCommandForTwitch(
@@ -232,10 +254,17 @@ export async function executeCustomCommandForTwitch(
   const result = await lookupCommand(command, (cmd) => getCustomCommandForTwitchChannel(channel, cmd));
   if (!result) return;
 
+  const args = extractArgs(rawMessage);
+  const filledResponse = fillTemplate(result.response, {
+    user: username ?? '',
+    args,
+    arg: args.split(/\s+/)[0] ?? '',
+  });
+
   recordCommandTestEntry({
     source: 'twitch',
     command,
-    response: result.response,
+    response: filledResponse,
     channel,
     user: username ?? null,
   });
@@ -244,7 +273,7 @@ export async function executeCustomCommandForTwitch(
   if (runtime) {
     if (result.isMultiTwitch) {
       try {
-        const sent = await broadcastToActiveChannels(channel, command, result.response);
+        const sent = await broadcastToActiveChannels(channel, command, filledResponse);
         if (sent) {
           log.info(`[Twitch] Sent custom command '${command}' in ${channel} (recorded for monitoring).`);
         } else {
@@ -255,7 +284,7 @@ export async function executeCustomCommandForTwitch(
       }
     } else {
       try {
-        await runtime.send(channel, result.response);
+        await runtime.send(channel, filledResponse);
         log.info(`[Twitch] Sent custom command '${command}' in ${channel} (recorded for monitoring).`);
       } catch (err) {
         log.error(`[Twitch] Failed to send custom command '${command}' in ${channel}:`, err);

--- a/src/commands/customCommandHandler.ts
+++ b/src/commands/customCommandHandler.ts
@@ -50,6 +50,22 @@ async function lookupCommand(
   return null;
 }
 
+/**
+ * Extracts args from `rawMessage` and runs `rawResponse` through {@link fillTemplate}
+ * with `{user}` (the invoking username), `{args}` (the raw text after the command
+ * token), and `{arg}` (the first whitespace-delimited word of `{args}`) substituted
+ * in. Shared by both the Discord and Twitch execute paths so the placeholder set
+ * stays in sync between them.
+ */
+function buildFilledResponse(rawResponse: string, rawMessage: string, username?: string | null): string {
+  const args = extractArgs(rawMessage);
+  return fillTemplate(rawResponse, {
+    user: username ?? '',
+    args,
+    arg: args.split(/\s+/)[0] ?? '',
+  });
+}
+
 // ─── Multi-twitch broadcast ───────────────────────────────────────────────────
 
 interface SessionCacheEntry {
@@ -201,12 +217,7 @@ export async function executeCustomCommandForDiscord(
   const result = await lookupCommand(command, (cmd) => getCustomCommandForDiscord(cmd, resolvedGuildId));
   if (!result) return;
 
-  const args = extractArgs(message.content);
-  const filledResponse = fillTemplate(result.response, {
-    user: username ?? '',
-    args,
-    arg: args.split(/\s+/)[0] ?? '',
-  });
+  const filledResponse = buildFilledResponse(result.response, message.content, username);
 
   recordCommandTestEntry({
     source: 'discord',
@@ -254,12 +265,7 @@ export async function executeCustomCommandForTwitch(
   const result = await lookupCommand(command, (cmd) => getCustomCommandForTwitchChannel(channel, cmd));
   if (!result) return;
 
-  const args = extractArgs(rawMessage);
-  const filledResponse = fillTemplate(result.response, {
-    user: username ?? '',
-    args,
-    arg: args.split(/\s+/)[0] ?? '',
-  });
+  const filledResponse = buildFilledResponse(result.response, rawMessage, username);
 
   recordCommandTestEntry({
     source: 'twitch',

--- a/src/shared/textTemplate.test.ts
+++ b/src/shared/textTemplate.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { fillTemplate } from './textTemplate';
+
+describe('fillTemplate', () => {
+  it('substitutes a single placeholder', () => {
+    expect(fillTemplate('Hello {user}!', { user: 'alice' })).toBe('Hello alice!');
+  });
+
+  it('substitutes multiple distinct placeholders', () => {
+    expect(fillTemplate('{user} said {args}', { user: 'bob', args: 'hi there' })).toBe('bob said hi there');
+  });
+
+  it('substitutes repeated occurrences of the same placeholder', () => {
+    expect(fillTemplate('{user}-{user}', { user: 'x' })).toBe('x-x');
+  });
+
+  it('replaces unknown placeholders with an empty string', () => {
+    expect(fillTemplate('Hi {unknown}!', {})).toBe('Hi !');
+  });
+
+  it('returns the template unchanged when it has no placeholders', () => {
+    expect(fillTemplate('no placeholders here', { user: 'alice' })).toBe('no placeholders here');
+  });
+
+  it('returns an empty string for an empty template', () => {
+    expect(fillTemplate('', { user: 'alice' })).toBe('');
+  });
+});

--- a/src/shared/textTemplate.ts
+++ b/src/shared/textTemplate.ts
@@ -1,0 +1,11 @@
+/**
+ * Substitutes `{key}` placeholders in `template` with values from `vars`.
+ * Unknown placeholders (keys not present in `vars`) are replaced with an empty string.
+ *
+ * @param template - Template string containing zero or more `{key}` placeholders.
+ * @param vars - Map of placeholder names to their substitution values.
+ * @returns The template with all placeholders substituted.
+ */
+export function fillTemplate(template: string, vars: Record<string, string>): string {
+  return template.replace(/\{(\w+)\}/g, (_, k: string) => vars[k] ?? '');
+}

--- a/src/twitch/eventsub/twitchEventSubHandler.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.ts
@@ -3,6 +3,7 @@ import { getVideosForReward, getStreamerById } from '../../db';
 import { pickWeightedRandom } from '../../commands/soundSelector';
 import { createLogger } from '../../shared/logger';
 import { triggerImmediateLiveCheck } from '../monitor/twitchMonitor';
+import { fillTemplate } from '../../shared/textTemplate';
 
 const log = createLogger('EventSubHandler');
 
@@ -123,10 +124,6 @@ export interface RedemptionEvent {
   user_input: string;
 }
 
-function fill(template: string, vars: Record<string, string>): string {
-  return template.replace(/\{(\w+)\}/g, (_, k: string) => vars[k] ?? '');
-}
-
 function tierName(tier: string): string {
   return ({ '1000': 'Tier 1', '2000': 'Tier 2', '3000': 'Tier 3' } as Record<string, string>)[tier] ?? tier;
 }
@@ -142,7 +139,7 @@ function tierName(tier: string): string {
  */
 export async function handleFollow(login: string, event: FollowEvent, config: EventSubConfig): Promise<void> {
   if (!config.follow_enabled) return;
-  const msg = fill(config.follow_message, {
+  const msg = fillTemplate(config.follow_message, {
     username: event.user_login,
     display_name: event.user_name,
   });
@@ -159,7 +156,7 @@ export async function handleFollow(login: string, event: FollowEvent, config: Ev
  */
 export async function handleSub(login: string, event: SubEvent, config: EventSubConfig): Promise<void> {
   if (!config.sub_enabled || event.is_gift) return;
-  const msg = fill(config.sub_message, {
+  const msg = fillTemplate(config.sub_message, {
     username: event.user_login,
     display_name: event.user_name,
     tier: event.tier,
@@ -178,7 +175,7 @@ export async function handleSub(login: string, event: SubEvent, config: EventSub
  */
 export async function handleResub(login: string, event: ResubEvent, config: EventSubConfig): Promise<void> {
   if (!config.sub_enabled) return;
-  const msg = fill(config.resub_message, {
+  const msg = fillTemplate(config.resub_message, {
     username: event.user_login,
     display_name: event.user_name,
     tier: event.tier,
@@ -202,7 +199,7 @@ export async function handleGiftSub(login: string, event: GiftSubEvent, config: 
   if (!config.sub_enabled) return;
   const gifter = event.is_anonymous ? 'anonymous' : event.user_login;
   const gifterDisplay = event.is_anonymous ? 'Anonymous' : event.user_name;
-  const msg = fill(config.giftsub_message, {
+  const msg = fillTemplate(config.giftsub_message, {
     gifter,
     gifter_display: gifterDisplay,
     count: String(event.total),
@@ -222,7 +219,7 @@ export async function handleGiftSub(login: string, event: GiftSubEvent, config: 
  */
 export async function handleRaid(login: string, event: RaidEvent, config: EventSubConfig): Promise<void> {
   if (!config.raid_enabled) return;
-  const msg = fill(config.raid_message, {
+  const msg = fillTemplate(config.raid_message, {
     from_channel: event.from_broadcaster_user_login,
     from_display: event.from_broadcaster_user_name,
     viewers: String(event.viewers),

--- a/views/commands.ejs
+++ b/views/commands.ejs
@@ -54,6 +54,7 @@
             <div class="form-section-gap">
               <label for="output" class="form-label">Output</label>
               <p class="hint hint-compact">Reply text to send when the trigger matches.</p>
+              <p class="hint hint-compact">Variables: <code>{user} {args} {arg}</code></p>
               <textarea id="output" class="input stream-textarea" name="output" rows="3" placeholder="Hello chat!" required></textarea>
             </div>
             <% if (assignableUsers.length > 0) { %>
@@ -167,6 +168,7 @@
                       </div>
                       <div class="form-section-gap">
                         <label for="output_<%= command.command_id %>" class="form-label">Output</label>
+                        <p class="hint hint-compact">Variables: <code>{user} {args} {arg}</code></p>
                         <textarea id="output_<%= command.command_id %>" class="input stream-textarea" name="output" rows="3" required><%= command.output %></textarea>
                       </div>
                       <div class="button-row-wrap">


### PR DESCRIPTION
## Summary
- Custom commands previously ignored all arguments and supported no placeholders. This adds `{user}`, `{args}`, and `{arg}` substitution to command responses.
- Extracted the existing private `fill()` regex helper out of `src/twitch/eventsub/twitchEventSubHandler.ts` into a new shared `fillTemplate()` (`src/shared/textTemplate.ts`), with `twitchEventSubHandler.ts` now importing it (pure relocate, no behavior change).
- Added `extractArgs(rawMessage)` alongside the existing `extractCommand` in `src/commands/commandUtils.ts`, returning the trimmed text after the first token (or `''`).
- Wired `extractArgs` + `fillTemplate` into both `executeCustomCommandForDiscord` and `executeCustomCommandForTwitch` in `src/commands/customCommandHandler.ts`, substituting `{user}` (invoking username), `{args}` (raw args text), and `{arg}` (first arg word) into the response before it's sent and before it's recorded via `recordCommandTestEntry` (so the monitor panel shows resolved text). The multi-twitch broadcast path reuses the same filled string per channel.
- Added a "Variables: `{user} {args} {arg}`" hint to both the add and edit forms in `views/commands.ejs`, matching the existing hint style in `views/userSettings.ejs`.
- Added JSDoc to `extractCommand` (previously undocumented) and all new/changed functions.

## Test plan
- [x] New `src/shared/textTemplate.test.ts` covering `fillTemplate` (single/multiple/repeated placeholders, unknown placeholder → empty string, no placeholders, empty template).
- [x] New `extractArgs` test cases in `src/commands/commandUtils.test.ts` (empty/whitespace-only, no args, multiple words, extra whitespace, casing preserved).
- [x] New placeholder substitution test cases in `src/commands/customCommandHandler.test.ts` for both Discord and Twitch paths, including unknown-placeholder-stays-empty, no-args case, and multi-twitch broadcast reuse of the same filled string.
- [x] Confirmed existing `src/twitch/eventsub/twitchEventSubHandler.test.ts` still passes unchanged after the `fill()` → `fillTemplate()` relocate.
- [x] `npx tsc --noEmit && npm test` — 106 test files / 1800 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbSyUedekQKAA5Q5SjW6ZW

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbSyUedekQKAA5Q5SjW6ZW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added template variables for custom commands, including `{user}`, `{args}`, and `{arg}`.
  * Custom command responses are now dynamically filled before being sent and recorded, including Twitch multi-broadcasts.
  * Added a visible “Variables: {user} {args} {arg}” hint to command add/edit forms.

* **Bug Fixes**
  * Unknown placeholders now resolve to blank text instead of showing literally.
  * Improved argument parsing: trimming and consistent `{args}`/`{arg}` extraction, preserving expected internal spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->