### PR TITLE
refactor(web): extract logAndRedirectError helper for POST catch blocks

### DIFF
--- a/src/web/routes/commandGuildOverrides.ts
+++ b/src/web/routes/commandGuildOverrides.ts
@@ -3,7 +3,7 @@ import { Router } from 'express';
 import { upsertOverride, removeOverride } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireMod, requireGuildContext } from '../middleware';
-import { parsePositiveIntId, trimField } from './shared';
+import { logAndRedirectError, parsePositiveIntId, trimField } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
@@ -35,8 +35,7 @@ router.post('/commands/guild-override', requireGuildContext, requireMod, csrfPro
     }
     res.redirect('/commands');
   } catch (err) {
-    log.error('Guild command override upsert failed:', err);
-    res.redirect('/commands?error=override_failed');
+    logAndRedirectError(res, log, 'Guild command override upsert failed:', err, '/commands', 'override_failed');
   }
 });
 
@@ -54,8 +53,7 @@ router.post('/commands/guild-override/reset', requireGuildContext, requireMod, c
     await removeOverride(guildId, commandId);
     res.redirect('/commands');
   } catch (err) {
-    log.error('Guild command override reset failed:', err);
-    res.redirect('/commands?error=override_reset_failed');
+    logAndRedirectError(res, log, 'Guild command override reset failed:', err, '/commands', 'override_reset_failed');
   }
 });
 

--- a/src/web/routes/commandGuildOverrides.ts
+++ b/src/web/routes/commandGuildOverrides.ts
@@ -35,7 +35,7 @@ router.post('/commands/guild-override', requireGuildContext, requireMod, csrfPro
     }
     res.redirect('/commands');
   } catch (err) {
-    logAndRedirectError(res, log, 'Guild command override upsert failed:', err, '/commands', 'override_failed');
+    logAndRedirectError({ res, log, logLabel: 'Guild command override upsert failed:', err, basePath: '/commands', errorCode: 'override_failed' });
   }
 });
 
@@ -53,7 +53,7 @@ router.post('/commands/guild-override/reset', requireGuildContext, requireMod, c
     await removeOverride(guildId, commandId);
     res.redirect('/commands');
   } catch (err) {
-    logAndRedirectError(res, log, 'Guild command override reset failed:', err, '/commands', 'override_reset_failed');
+    logAndRedirectError({ res, log, logLabel: 'Guild command override reset failed:', err, basePath: '/commands', errorCode: 'override_reset_failed' });
   }
 });
 

--- a/src/web/routes/commandMutations.ts
+++ b/src/web/routes/commandMutations.ts
@@ -88,7 +88,7 @@ router.post('/commands/add', requireMod, csrfProtection, async (req, res) => {
     commandId = await addCustomCommand(normalizedTriggerString, normalizedOutput, isDiscordEnabled, isMultiTwitch);
   } catch (err) {
     if (handleCommandWriteError(err, res)) return;
-    return logAndRedirectError(res, log, 'Add custom command error:', err, '/commands', 'add_failed');
+    return logAndRedirectError({ res, log, logLabel: 'Add custom command error:', err, basePath: '/commands', errorCode: 'add_failed' });
   }
 
   const rawDiscordIds = req.body.discord_ids;
@@ -136,7 +136,7 @@ router.post('/commands/update', requireMod, csrfProtection, async (req, res) => 
       return res.redirect('/commands?error=command_not_found');
     }
     if (handleCommandWriteError(err, res)) return;
-    return logAndRedirectError(res, log, 'Update custom command error:', err, '/commands', 'update_failed');
+    return logAndRedirectError({ res, log, logLabel: 'Update custom command error:', err, basePath: '/commands', errorCode: 'update_failed' });
   }
 
   res.redirect('/commands');
@@ -161,7 +161,7 @@ router.post('/commands/remove', requireMod, csrfProtection, async (req, res) => 
   try {
     await removeCustomCommand(parsedCommandId);
   } catch (err) {
-    return logAndRedirectError(res, log, 'Remove custom command error:', err, '/commands', 'remove_failed');
+    return logAndRedirectError({ res, log, logLabel: 'Remove custom command error:', err, basePath: '/commands', errorCode: 'remove_failed' });
   }
 
   res.redirect('/commands');

--- a/src/web/routes/commandMutations.ts
+++ b/src/web/routes/commandMutations.ts
@@ -15,6 +15,7 @@ import {
 import { csrfProtection } from '../csrf';
 import { requireMod } from '../middleware';
 import {
+  logAndRedirectError,
   normalizeRequiredText,
   normalizeSingleTokenRequiredText,
   parsePositiveIntId,
@@ -87,8 +88,7 @@ router.post('/commands/add', requireMod, csrfProtection, async (req, res) => {
     commandId = await addCustomCommand(normalizedTriggerString, normalizedOutput, isDiscordEnabled, isMultiTwitch);
   } catch (err) {
     if (handleCommandWriteError(err, res)) return;
-    log.error('Add custom command error:', err);
-    return res.redirect('/commands?error=add_failed');
+    return logAndRedirectError(res, log, 'Add custom command error:', err, '/commands', 'add_failed');
   }
 
   const rawDiscordIds = req.body.discord_ids;
@@ -136,8 +136,7 @@ router.post('/commands/update', requireMod, csrfProtection, async (req, res) => 
       return res.redirect('/commands?error=command_not_found');
     }
     if (handleCommandWriteError(err, res)) return;
-    log.error('Update custom command error:', err);
-    return res.redirect('/commands?error=update_failed');
+    return logAndRedirectError(res, log, 'Update custom command error:', err, '/commands', 'update_failed');
   }
 
   res.redirect('/commands');
@@ -162,8 +161,7 @@ router.post('/commands/remove', requireMod, csrfProtection, async (req, res) => 
   try {
     await removeCustomCommand(parsedCommandId);
   } catch (err) {
-    log.error('Remove custom command error:', err);
-    return res.redirect('/commands?error=remove_failed');
+    return logAndRedirectError(res, log, 'Remove custom command error:', err, '/commands', 'remove_failed');
   }
 
   res.redirect('/commands');

--- a/src/web/routes/companionKeys.ts
+++ b/src/web/routes/companionKeys.ts
@@ -2,7 +2,7 @@ import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import { issueToken, getTokenStatus, revokeToken } from '../../db';
 import { csrfProtection } from '../csrf';
-import { renderError, filterQueryParam, renderView } from './shared';
+import { logAndRedirectError, renderError, filterQueryParam, renderView } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
@@ -38,8 +38,7 @@ router.post('/companion-key/request', csrfProtection, async (req, res) => {
   try {
     plain = await issueToken(req.session.user!.discordId);
   } catch (err) {
-    log.error('Companion key request error:', err);
-    res.redirect('/companion-key?error=request_failed');
+    logAndRedirectError(res, log, 'Companion key request error:', err, '/companion-key', 'request_failed');
     return;
   }
 
@@ -66,8 +65,7 @@ router.post('/companion-key/revoke', csrfProtection, async (req, res) => {
     await revokeToken(req.session.user!.discordId);
     res.redirect('/companion-key');
   } catch (err) {
-    log.error('Companion key revoke error:', err);
-    res.redirect('/companion-key?error=revoke_failed');
+    logAndRedirectError(res, log, 'Companion key revoke error:', err, '/companion-key', 'revoke_failed');
   }
 });
 

--- a/src/web/routes/companionKeys.ts
+++ b/src/web/routes/companionKeys.ts
@@ -38,7 +38,7 @@ router.post('/companion-key/request', csrfProtection, async (req, res) => {
   try {
     plain = await issueToken(req.session.user!.discordId);
   } catch (err) {
-    logAndRedirectError(res, log, 'Companion key request error:', err, '/companion-key', 'request_failed');
+    logAndRedirectError({ res, log, logLabel: 'Companion key request error:', err, basePath: '/companion-key', errorCode: 'request_failed' });
     return;
   }
 
@@ -65,7 +65,7 @@ router.post('/companion-key/revoke', csrfProtection, async (req, res) => {
     await revokeToken(req.session.user!.discordId);
     res.redirect('/companion-key');
   } catch (err) {
-    logAndRedirectError(res, log, 'Companion key revoke error:', err, '/companion-key', 'revoke_failed');
+    logAndRedirectError({ res, log, logLabel: 'Companion key revoke error:', err, basePath: '/companion-key', errorCode: 'revoke_failed' });
   }
 });
 

--- a/src/web/routes/counters.ts
+++ b/src/web/routes/counters.ts
@@ -151,7 +151,7 @@ router.post('/counters/add', requireMod, csrfProtection, async (req, res) => {
     );
   } catch (err) {
     if (handleCounterWriteError(err, res)) return;
-    return logAndRedirectError(res, log, 'Add counter error:', err, '/counters', 'add_failed');
+    return logAndRedirectError({ res, log, logLabel: 'Add counter error:', err, basePath: '/counters', errorCode: 'add_failed' });
   }
 
   res.redirect('/counters');
@@ -203,7 +203,7 @@ router.post('/counters/update', requireMod, csrfProtection, async (req, res) => 
       return res.redirect('/counters?error=counter_not_found');
     }
     if (handleCounterWriteError(err, res)) return;
-    return logAndRedirectError(res, log, 'Update counter error:', err, '/counters', 'update_failed');
+    return logAndRedirectError({ res, log, logLabel: 'Update counter error:', err, basePath: '/counters', errorCode: 'update_failed' });
   }
 
   res.redirect('/counters');
@@ -231,7 +231,7 @@ router.post('/counters/remove', requireMod, csrfProtection, async (req, res) => 
       return res.redirect('/counters?error=counter_not_found');
     }
 
-    return logAndRedirectError(res, log, 'Remove counter error:', err, '/counters', 'remove_failed');
+    return logAndRedirectError({ res, log, logLabel: 'Remove counter error:', err, basePath: '/counters', errorCode: 'remove_failed' });
   }
 
   res.redirect('/counters');
@@ -259,7 +259,7 @@ router.post('/counters/reset/:id', requireManager, csrfProtection, async (req, r
       return res.redirect('/counters?error=counter_not_found');
     }
 
-    return logAndRedirectError(res, log, 'Reset counter error:', err, '/counters', 'reset_failed');
+    return logAndRedirectError({ res, log, logLabel: 'Reset counter error:', err, basePath: '/counters', errorCode: 'reset_failed' });
   }
 
   res.redirect('/counters?reset=1');

--- a/src/web/routes/counters.ts
+++ b/src/web/routes/counters.ts
@@ -16,6 +16,7 @@ import {
 import { csrfProtection } from '../csrf';
 import { requireAuth, requireMod, requireManager } from '../middleware';
 import {
+  logAndRedirectError,
   normalizeRequiredText,
   normalizeSingleTokenRequiredText,
   parsePositiveIntId,
@@ -150,8 +151,7 @@ router.post('/counters/add', requireMod, csrfProtection, async (req, res) => {
     );
   } catch (err) {
     if (handleCounterWriteError(err, res)) return;
-    log.error('Add counter error:', err);
-    return res.redirect('/counters?error=add_failed');
+    return logAndRedirectError(res, log, 'Add counter error:', err, '/counters', 'add_failed');
   }
 
   res.redirect('/counters');
@@ -203,8 +203,7 @@ router.post('/counters/update', requireMod, csrfProtection, async (req, res) => 
       return res.redirect('/counters?error=counter_not_found');
     }
     if (handleCounterWriteError(err, res)) return;
-    log.error('Update counter error:', err);
-    return res.redirect('/counters?error=update_failed');
+    return logAndRedirectError(res, log, 'Update counter error:', err, '/counters', 'update_failed');
   }
 
   res.redirect('/counters');
@@ -232,8 +231,7 @@ router.post('/counters/remove', requireMod, csrfProtection, async (req, res) => 
       return res.redirect('/counters?error=counter_not_found');
     }
 
-    log.error('Remove counter error:', err);
-    return res.redirect('/counters?error=remove_failed');
+    return logAndRedirectError(res, log, 'Remove counter error:', err, '/counters', 'remove_failed');
   }
 
   res.redirect('/counters');
@@ -261,8 +259,7 @@ router.post('/counters/reset/:id', requireManager, csrfProtection, async (req, r
       return res.redirect('/counters?error=counter_not_found');
     }
 
-    log.error('Reset counter error:', err);
-    return res.redirect('/counters?error=reset_failed');
+    return logAndRedirectError(res, log, 'Reset counter error:', err, '/counters', 'reset_failed');
   }
 
   res.redirect('/counters?reset=1');

--- a/src/web/routes/overlayAdminMutations.ts
+++ b/src/web/routes/overlayAdminMutations.ts
@@ -10,7 +10,7 @@ import { requireAuth } from '../middleware';
 import type { DbStreamerEventSub } from '../../db';
 import { addVideo, deleteVideo } from '../../db';
 import { OVERLAY_FOLDER, OVERLAY_MAX_FILE_MB } from '../../shared/config';
-import { parsePositiveIntId } from './shared';
+import { logAndRedirectError, parsePositiveIntId } from './shared';
 import { safeResolve } from '../../shared/pathUtils';
 import { requireStreamer } from './overlayAdminShared';
 
@@ -127,8 +127,7 @@ router.post('/settings/videos/upload', requireAuth, csrfProtection, uploadVideo,
     const code = err instanceof Error ? (err as NodeJS.ErrnoException).code : undefined;
     if (code === 'invalid_path') return res.redirect('/overlay/settings?error=invalid_path');
     if (code === 'invalid_file') return res.redirect('/overlay/settings?error=invalid_file');
-    log.error('Overlay video upload error:', err);
-    res.redirect('/overlay/settings?error=upload_failed');
+    logAndRedirectError(res, log, 'Overlay video upload error:', err, '/overlay/settings', 'upload_failed');
   }
 });
 
@@ -157,7 +156,6 @@ router.post('/settings/videos/:id/delete', requireAuth, csrfProtection, async (r
 
     res.redirect('/overlay/settings?success=video_deleted');
   } catch (err) {
-    log.error('Overlay video delete error:', err);
-    res.redirect('/overlay/settings?error=delete_failed');
+    logAndRedirectError(res, log, 'Overlay video delete error:', err, '/overlay/settings', 'delete_failed');
   }
 });

--- a/src/web/routes/overlayAdminMutations.ts
+++ b/src/web/routes/overlayAdminMutations.ts
@@ -127,7 +127,7 @@ router.post('/settings/videos/upload', requireAuth, csrfProtection, uploadVideo,
     const code = err instanceof Error ? (err as NodeJS.ErrnoException).code : undefined;
     if (code === 'invalid_path') return res.redirect('/overlay/settings?error=invalid_path');
     if (code === 'invalid_file') return res.redirect('/overlay/settings?error=invalid_file');
-    logAndRedirectError(res, log, 'Overlay video upload error:', err, '/overlay/settings', 'upload_failed');
+    logAndRedirectError({ res, log, logLabel: 'Overlay video upload error:', err, basePath: '/overlay/settings', errorCode: 'upload_failed' });
   }
 });
 
@@ -156,6 +156,6 @@ router.post('/settings/videos/:id/delete', requireAuth, csrfProtection, async (r
 
     res.redirect('/overlay/settings?success=video_deleted');
   } catch (err) {
-    logAndRedirectError(res, log, 'Overlay video delete error:', err, '/overlay/settings', 'delete_failed');
+    logAndRedirectError({ res, log, logLabel: 'Overlay video delete error:', err, basePath: '/overlay/settings', errorCode: 'delete_failed' });
   }
 });

--- a/src/web/routes/overlayAdminRewardMutations.ts
+++ b/src/web/routes/overlayAdminRewardMutations.ts
@@ -3,7 +3,7 @@ import { Router } from 'express';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
 import { upsertReward, setRewardVideos, deleteReward } from '../../db';
-import { parsePositiveIntId } from './shared';
+import { logAndRedirectError, parsePositiveIntId } from './shared';
 import { requireStreamer, toStringArray, parseWeight } from './overlayAdminShared';
 
 const log = createLogger('OverlayAdminReward');
@@ -45,8 +45,7 @@ router.post('/settings/rewards', requireAuth, csrfProtection, async (req, res) =
 
     res.redirect('/overlay/settings?success=reward_saved');
   } catch (err) {
-    log.error('Overlay reward save error:', err);
-    res.redirect('/overlay/settings?error=save_failed');
+    logAndRedirectError(res, log, 'Overlay reward save error:', err, '/overlay/settings', 'save_failed');
   }
 });
 
@@ -70,7 +69,6 @@ router.post('/settings/rewards/:id/delete', requireAuth, csrfProtection, async (
     await deleteReward(rewardId, streamer.id);
     res.redirect('/overlay/settings?success=reward_deleted');
   } catch (err) {
-    log.error('Overlay reward delete error:', err);
-    res.redirect('/overlay/settings?error=delete_failed');
+    logAndRedirectError(res, log, 'Overlay reward delete error:', err, '/overlay/settings', 'delete_failed');
   }
 });

--- a/src/web/routes/overlayAdminRewardMutations.ts
+++ b/src/web/routes/overlayAdminRewardMutations.ts
@@ -45,7 +45,7 @@ router.post('/settings/rewards', requireAuth, csrfProtection, async (req, res) =
 
     res.redirect('/overlay/settings?success=reward_saved');
   } catch (err) {
-    logAndRedirectError(res, log, 'Overlay reward save error:', err, '/overlay/settings', 'save_failed');
+    logAndRedirectError({ res, log, logLabel: 'Overlay reward save error:', err, basePath: '/overlay/settings', errorCode: 'save_failed' });
   }
 });
 
@@ -69,6 +69,6 @@ router.post('/settings/rewards/:id/delete', requireAuth, csrfProtection, async (
     await deleteReward(rewardId, streamer.id);
     res.redirect('/overlay/settings?success=reward_deleted');
   } catch (err) {
-    logAndRedirectError(res, log, 'Overlay reward delete error:', err, '/overlay/settings', 'delete_failed');
+    logAndRedirectError({ res, log, logLabel: 'Overlay reward delete error:', err, basePath: '/overlay/settings', errorCode: 'delete_failed' });
   }
 });

--- a/src/web/routes/sfxCategoryMutations.ts
+++ b/src/web/routes/sfxCategoryMutations.ts
@@ -3,7 +3,7 @@ import { Router } from 'express';
 import { createCategory, renameCategory, deleteCategory } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireMod } from '../middleware';
-import { normalizeRequiredText, parsePositiveIntId } from './shared';
+import { logAndRedirectError, normalizeRequiredText, parsePositiveIntId } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
@@ -16,8 +16,7 @@ router.post('/sfx/category/add', requireMod, csrfProtection, async (req, res) =>
   try {
     await createCategory(name);
   } catch (err) {
-    log.error('Add SFX category error:', err);
-    return res.redirect('/sfx?error=add_failed');
+    return logAndRedirectError(res, log, 'Add SFX category error:', err, '/sfx', 'add_failed');
   }
 
   res.redirect('/sfx?success=category_added');
@@ -34,8 +33,7 @@ router.post('/sfx/category/rename', requireMod, csrfProtection, async (req, res)
     const renamed = await renameCategory(id, name);
     if (!renamed) return res.redirect('/sfx?error=invalid_id');
   } catch (err) {
-    log.error('Rename SFX category error:', err);
-    return res.redirect('/sfx?error=update_failed');
+    return logAndRedirectError(res, log, 'Rename SFX category error:', err, '/sfx', 'update_failed');
   }
 
   res.redirect('/sfx?success=category_updated');
@@ -50,8 +48,7 @@ router.post('/sfx/category/remove', requireMod, csrfProtection, async (req, res)
     const removed = await deleteCategory(id);
     if (!removed) return res.redirect('/sfx?error=invalid_id');
   } catch (err) {
-    log.error('Remove SFX category error:', err);
-    return res.redirect('/sfx?error=remove_failed');
+    return logAndRedirectError(res, log, 'Remove SFX category error:', err, '/sfx', 'remove_failed');
   }
 
   res.redirect('/sfx?success=category_removed');

--- a/src/web/routes/sfxCategoryMutations.ts
+++ b/src/web/routes/sfxCategoryMutations.ts
@@ -16,7 +16,7 @@ router.post('/sfx/category/add', requireMod, csrfProtection, async (req, res) =>
   try {
     await createCategory(name);
   } catch (err) {
-    return logAndRedirectError(res, log, 'Add SFX category error:', err, '/sfx', 'add_failed');
+    return logAndRedirectError({ res, log, logLabel: 'Add SFX category error:', err, basePath: '/sfx', errorCode: 'add_failed' });
   }
 
   res.redirect('/sfx?success=category_added');
@@ -33,7 +33,7 @@ router.post('/sfx/category/rename', requireMod, csrfProtection, async (req, res)
     const renamed = await renameCategory(id, name);
     if (!renamed) return res.redirect('/sfx?error=invalid_id');
   } catch (err) {
-    return logAndRedirectError(res, log, 'Rename SFX category error:', err, '/sfx', 'update_failed');
+    return logAndRedirectError({ res, log, logLabel: 'Rename SFX category error:', err, basePath: '/sfx', errorCode: 'update_failed' });
   }
 
   res.redirect('/sfx?success=category_updated');
@@ -48,7 +48,7 @@ router.post('/sfx/category/remove', requireMod, csrfProtection, async (req, res)
     const removed = await deleteCategory(id);
     if (!removed) return res.redirect('/sfx?error=invalid_id');
   } catch (err) {
-    return logAndRedirectError(res, log, 'Remove SFX category error:', err, '/sfx', 'remove_failed');
+    return logAndRedirectError({ res, log, logLabel: 'Remove SFX category error:', err, basePath: '/sfx', errorCode: 'remove_failed' });
   }
 
   res.redirect('/sfx?success=category_removed');

--- a/src/web/routes/sfxFileMutations.ts
+++ b/src/web/routes/sfxFileMutations.ts
@@ -3,7 +3,7 @@ import { Router } from 'express';
 import { updateSfxFile, deleteSfxFile } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireMod } from '../middleware';
-import { parsePositiveIntId } from './shared';
+import { logAndRedirectError, parsePositiveIntId } from './shared';
 import { removeSfxFiles, parseWeight } from './sfxMutationsShared';
 
 const log = createLogger('Web');
@@ -29,8 +29,7 @@ router.post('/sfx/file/update', requireMod, csrfProtection, async (req, res) => 
     const updated = await updateSfxFile(fileId, weight, hidden);
     if (!updated) return res.redirect('/sfx?error=invalid_id');
   } catch (err) {
-    log.error('Update SFX file error:', err);
-    return res.redirect('/sfx?error=update_failed');
+    return logAndRedirectError(res, log, 'Update SFX file error:', err, '/sfx', 'update_failed');
   }
 
   res.redirect('/sfx?success=file_updated');
@@ -52,8 +51,7 @@ router.post('/sfx/file/remove', requireMod, csrfProtection, async (req, res) => 
     if (file === null) return res.redirect('/sfx?error=invalid_id');
     await removeSfxFiles([file]);
   } catch (err) {
-    log.error('Remove SFX file error:', err);
-    return res.redirect('/sfx?error=remove_failed');
+    return logAndRedirectError(res, log, 'Remove SFX file error:', err, '/sfx', 'remove_failed');
   }
 
   res.redirect('/sfx?success=file_removed');

--- a/src/web/routes/sfxFileMutations.ts
+++ b/src/web/routes/sfxFileMutations.ts
@@ -29,7 +29,7 @@ router.post('/sfx/file/update', requireMod, csrfProtection, async (req, res) => 
     const updated = await updateSfxFile(fileId, weight, hidden);
     if (!updated) return res.redirect('/sfx?error=invalid_id');
   } catch (err) {
-    return logAndRedirectError(res, log, 'Update SFX file error:', err, '/sfx', 'update_failed');
+    return logAndRedirectError({ res, log, logLabel: 'Update SFX file error:', err, basePath: '/sfx', errorCode: 'update_failed' });
   }
 
   res.redirect('/sfx?success=file_updated');
@@ -51,7 +51,7 @@ router.post('/sfx/file/remove', requireMod, csrfProtection, async (req, res) => 
     if (file === null) return res.redirect('/sfx?error=invalid_id');
     await removeSfxFiles([file]);
   } catch (err) {
-    return logAndRedirectError(res, log, 'Remove SFX file error:', err, '/sfx', 'remove_failed');
+    return logAndRedirectError({ res, log, logLabel: 'Remove SFX file error:', err, basePath: '/sfx', errorCode: 'remove_failed' });
   }
 
   res.redirect('/sfx?success=file_removed');

--- a/src/web/routes/sfxTriggerMutations.ts
+++ b/src/web/routes/sfxTriggerMutations.ts
@@ -52,7 +52,7 @@ router.post('/sfx/trigger/add', requireMod, csrfProtection, async (req, res) => 
     await createSfxTrigger(command, categoryId, description, hidden);
   } catch (err) {
     if (isMysqlDuplicateEntryError(err)) return res.redirect('/sfx?error=command_taken');
-    return logAndRedirectError(res, log, 'Add SFX trigger error:', err, '/sfx', 'add_failed');
+    return logAndRedirectError({ res, log, logLabel: 'Add SFX trigger error:', err, basePath: '/sfx', errorCode: 'add_failed' });
   }
 
   res.redirect('/sfx?success=trigger_added');
@@ -79,7 +79,7 @@ router.post('/sfx/trigger/update', requireMod, csrfProtection, async (req, res) 
     if (!updated) return res.redirect('/sfx?error=invalid_id');
   } catch (err) {
     if (isMysqlDuplicateEntryError(err)) return res.redirect('/sfx?error=command_taken');
-    return logAndRedirectError(res, log, 'Update SFX trigger error:', err, '/sfx', 'update_failed');
+    return logAndRedirectError({ res, log, logLabel: 'Update SFX trigger error:', err, basePath: '/sfx', errorCode: 'update_failed' });
   }
 
   res.redirect('/sfx?success=trigger_updated');
@@ -95,7 +95,7 @@ router.post('/sfx/trigger/remove', requireMod, csrfProtection, async (req, res) 
     if (result === null) return res.redirect('/sfx?error=invalid_id');
     await removeSfxFiles(result.files);
   } catch (err) {
-    return logAndRedirectError(res, log, 'Remove SFX trigger error:', err, '/sfx', 'remove_failed');
+    return logAndRedirectError({ res, log, logLabel: 'Remove SFX trigger error:', err, basePath: '/sfx', errorCode: 'remove_failed' });
   }
 
   res.redirect('/sfx?success=trigger_removed');

--- a/src/web/routes/sfxTriggerMutations.ts
+++ b/src/web/routes/sfxTriggerMutations.ts
@@ -10,6 +10,7 @@ import {
 import { csrfProtection } from '../csrf';
 import { requireMod } from '../middleware';
 import {
+  logAndRedirectError,
   normalizeRequiredText,
   normalizeSingleTokenRequiredText,
   parsePositiveIntId,
@@ -51,8 +52,7 @@ router.post('/sfx/trigger/add', requireMod, csrfProtection, async (req, res) => 
     await createSfxTrigger(command, categoryId, description, hidden);
   } catch (err) {
     if (isMysqlDuplicateEntryError(err)) return res.redirect('/sfx?error=command_taken');
-    log.error('Add SFX trigger error:', err);
-    return res.redirect('/sfx?error=add_failed');
+    return logAndRedirectError(res, log, 'Add SFX trigger error:', err, '/sfx', 'add_failed');
   }
 
   res.redirect('/sfx?success=trigger_added');
@@ -79,8 +79,7 @@ router.post('/sfx/trigger/update', requireMod, csrfProtection, async (req, res) 
     if (!updated) return res.redirect('/sfx?error=invalid_id');
   } catch (err) {
     if (isMysqlDuplicateEntryError(err)) return res.redirect('/sfx?error=command_taken');
-    log.error('Update SFX trigger error:', err);
-    return res.redirect('/sfx?error=update_failed');
+    return logAndRedirectError(res, log, 'Update SFX trigger error:', err, '/sfx', 'update_failed');
   }
 
   res.redirect('/sfx?success=trigger_updated');
@@ -96,8 +95,7 @@ router.post('/sfx/trigger/remove', requireMod, csrfProtection, async (req, res) 
     if (result === null) return res.redirect('/sfx?error=invalid_id');
     await removeSfxFiles(result.files);
   } catch (err) {
-    log.error('Remove SFX trigger error:', err);
-    return res.redirect('/sfx?error=remove_failed');
+    return logAndRedirectError(res, log, 'Remove SFX trigger error:', err, '/sfx', 'remove_failed');
   }
 
   res.redirect('/sfx?success=trigger_removed');

--- a/src/web/routes/shared.test.ts
+++ b/src/web/routes/shared.test.ts
@@ -14,6 +14,7 @@ import {
   renderError,
   renderView,
   filterQueryParam,
+  logAndRedirectError,
 } from './shared';
 
 describe('parsePositiveIntId', () => {
@@ -279,5 +280,40 @@ describe('filterQueryParam', () => {
 
   it('returns null when the allowed set is empty', () => {
     expect(filterQueryParam('known_error', new Set())).toBeNull();
+  });
+});
+
+describe('logAndRedirectError', () => {
+  function mockRes() {
+    const redirect = vi.fn();
+    return { res: { redirect } as unknown as Response, redirect };
+  }
+
+  function mockLog() {
+    const error = vi.fn();
+    return { log: { error } as unknown as import('winston').Logger, error };
+  }
+
+  it('logs the error with the given label and forwards err unchanged', () => {
+    const { res } = mockRes();
+    const { log, error } = mockLog();
+    const err = new Error('boom');
+    logAndRedirectError(res, log, 'Add SFX category error:', err, '/sfx', 'add_failed');
+    expect(error).toHaveBeenCalledWith('Add SFX category error:', err);
+  });
+
+  it('redirects to basePath with the error query param', () => {
+    const { res, redirect } = mockRes();
+    const { log } = mockLog();
+    logAndRedirectError(res, log, 'Rename SFX category error:', new Error('x'), '/sfx', 'update_failed');
+    expect(redirect).toHaveBeenCalledWith('/sfx?error=update_failed');
+  });
+
+  it('works with a non-Error thrown value', () => {
+    const { res, redirect } = mockRes();
+    const { log, error } = mockLog();
+    logAndRedirectError(res, log, 'Remove error:', 'not an error object', '/counters', 'remove_failed');
+    expect(error).toHaveBeenCalledWith('Remove error:', 'not an error object');
+    expect(redirect).toHaveBeenCalledWith('/counters?error=remove_failed');
   });
 });

--- a/src/web/routes/shared.test.ts
+++ b/src/web/routes/shared.test.ts
@@ -298,21 +298,21 @@ describe('logAndRedirectError', () => {
     const { res } = mockRes();
     const { log, error } = mockLog();
     const err = new Error('boom');
-    logAndRedirectError(res, log, 'Add SFX category error:', err, '/sfx', 'add_failed');
+    logAndRedirectError({ res, log, logLabel: 'Add SFX category error:', err, basePath: '/sfx', errorCode: 'add_failed' });
     expect(error).toHaveBeenCalledWith('Add SFX category error:', err);
   });
 
   it('redirects to basePath with the error query param', () => {
     const { res, redirect } = mockRes();
     const { log } = mockLog();
-    logAndRedirectError(res, log, 'Rename SFX category error:', new Error('x'), '/sfx', 'update_failed');
+    logAndRedirectError({ res, log, logLabel: 'Rename SFX category error:', err: new Error('x'), basePath: '/sfx', errorCode: 'update_failed' });
     expect(redirect).toHaveBeenCalledWith('/sfx?error=update_failed');
   });
 
   it('works with a non-Error thrown value', () => {
     const { res, redirect } = mockRes();
     const { log, error } = mockLog();
-    logAndRedirectError(res, log, 'Remove error:', 'not an error object', '/counters', 'remove_failed');
+    logAndRedirectError({ res, log, logLabel: 'Remove error:', err: 'not an error object', basePath: '/counters', errorCode: 'remove_failed' });
     expect(error).toHaveBeenCalledWith('Remove error:', 'not an error object');
     expect(redirect).toHaveBeenCalledWith('/counters?error=remove_failed');
   });

--- a/src/web/routes/shared.ts
+++ b/src/web/routes/shared.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import type { Response } from 'express';
+import type { Logger } from 'winston';
 import type { SessionUser } from '../../types/express';
 
 const VIEWS_DIR = path.join(__dirname, '../../../views');
@@ -155,4 +156,27 @@ export function isLoopbackRedirectUri(redirectUri: string): boolean {
     return false;
   }
   return parsed.protocol === 'http:' && (parsed.hostname === '127.0.0.1' || parsed.hostname === 'localhost');
+}
+
+/**
+ * Logs a caught error and redirects to `basePath` with `?error=<errorCode>`.
+ * Standardizes the generic `catch (err) { log.error(...); return res.redirect(...); }` tail
+ * repeated across POST route handlers.
+ * @param res - Express response object.
+ * @param log - Logger to record the error on (module-scoped `createLogger` instance).
+ * @param logLabel - Message prefix passed to `log.error`, matching the handler's existing wording.
+ * @param err - The caught error value, forwarded to `log.error` unchanged.
+ * @param basePath - Path to redirect to, without query string (e.g. `/sfx`).
+ * @param errorCode - Value for the `error` query parameter (e.g. `add_failed`).
+ */
+export function logAndRedirectError(
+  res: Response,
+  log: Logger,
+  logLabel: string,
+  err: unknown,
+  basePath: string,
+  errorCode: string,
+): void {
+  log.error(logLabel, err);
+  res.redirect(`${basePath}?error=${errorCode}`);
 }

--- a/src/web/routes/shared.ts
+++ b/src/web/routes/shared.ts
@@ -158,25 +158,36 @@ export function isLoopbackRedirectUri(redirectUri: string): boolean {
   return parsed.protocol === 'http:' && (parsed.hostname === '127.0.0.1' || parsed.hostname === 'localhost');
 }
 
+/** Arguments for {@link logAndRedirectError}. */
+export interface LogAndRedirectErrorOptions {
+  /** Express response object. */
+  res: Response;
+  /** Logger to record the error on (module-scoped `createLogger` instance). */
+  log: Logger;
+  /** Message prefix passed to `log.error`, matching the handler's existing wording. */
+  logLabel: string;
+  /** The caught error value, forwarded to `log.error` unchanged. */
+  err: unknown;
+  /** Path to redirect to, without query string (e.g. `/sfx`). */
+  basePath: string;
+  /** Value for the `error` query parameter (e.g. `add_failed`). */
+  errorCode: string;
+}
+
 /**
  * Logs a caught error and redirects to `basePath` with `?error=<errorCode>`.
  * Standardizes the generic `catch (err) { log.error(...); return res.redirect(...); }` tail
  * repeated across POST route handlers.
- * @param res - Express response object.
- * @param log - Logger to record the error on (module-scoped `createLogger` instance).
- * @param logLabel - Message prefix passed to `log.error`, matching the handler's existing wording.
- * @param err - The caught error value, forwarded to `log.error` unchanged.
- * @param basePath - Path to redirect to, without query string (e.g. `/sfx`).
- * @param errorCode - Value for the `error` query parameter (e.g. `add_failed`).
+ * @param options - See {@link LogAndRedirectErrorOptions}.
  */
-export function logAndRedirectError(
-  res: Response,
-  log: Logger,
-  logLabel: string,
-  err: unknown,
-  basePath: string,
-  errorCode: string,
-): void {
+export function logAndRedirectError({
+  res,
+  log,
+  logLabel,
+  err,
+  basePath,
+  errorCode,
+}: LogAndRedirectErrorOptions): void {
   log.error(logLabel, err);
   res.redirect(`${basePath}?error=${errorCode}`);
 }

--- a/src/web/routes/streamdeckKeys.ts
+++ b/src/web/routes/streamdeckKeys.ts
@@ -12,7 +12,7 @@ import {
 import { csrfProtection } from '../csrf';
 import { requireAdmin } from '../middleware';
 import { WEB_PORT } from '../../shared/config';
-import { normalizeDiscordId, renderError, filterQueryParam, renderView } from './shared';
+import { logAndRedirectError, normalizeDiscordId, renderError, filterQueryParam, renderView } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
@@ -57,8 +57,7 @@ router.post('/streamdeck-key/request', csrfProtection, async (req, res) => {
       webPort: WEB_PORT,
     });
   } catch (err) {
-    log.error('Streamdeck key request error:', err);
-    res.redirect('/streamdeck-key?error=request_failed');
+    logAndRedirectError(res, log, 'Streamdeck key request error:', err, '/streamdeck-key', 'request_failed');
   }
 });
 
@@ -68,8 +67,7 @@ router.post('/streamdeck-key/revoke', csrfProtection, async (req, res) => {
     await revokeApiKey(req.session.user!.discordId);
     res.redirect('/streamdeck-key');
   } catch (err) {
-    log.error('Streamdeck key revoke error:', err);
-    res.redirect('/streamdeck-key?error=revoke_failed');
+    logAndRedirectError(res, log, 'Streamdeck key revoke error:', err, '/streamdeck-key', 'revoke_failed');
   }
 });
 
@@ -102,8 +100,7 @@ router.post('/admin/streamdeck-keys/approve', requireAdmin, csrfProtection, asyn
     await approveApiKey(validId, req.session.user!.discordId);
     res.redirect('/admin/streamdeck-keys');
   } catch (err) {
-    log.error('Streamdeck key approve error:', err);
-    res.redirect('/admin/streamdeck-keys?error=approve_failed');
+    logAndRedirectError(res, log, 'Streamdeck key approve error:', err, '/admin/streamdeck-keys', 'approve_failed');
   }
 });
 
@@ -115,8 +112,7 @@ router.post('/admin/streamdeck-keys/deny', requireAdmin, csrfProtection, async (
     await denyApiKey(validId);
     res.redirect('/admin/streamdeck-keys');
   } catch (err) {
-    log.error('Streamdeck key deny error:', err);
-    res.redirect('/admin/streamdeck-keys?error=deny_failed');
+    logAndRedirectError(res, log, 'Streamdeck key deny error:', err, '/admin/streamdeck-keys', 'deny_failed');
   }
 });
 
@@ -128,8 +124,7 @@ router.post('/admin/streamdeck-keys/revoke', requireAdmin, csrfProtection, async
     await revokeApiKey(validId);
     res.redirect('/admin/streamdeck-keys');
   } catch (err) {
-    log.error('Streamdeck key admin revoke error:', err);
-    res.redirect('/admin/streamdeck-keys?error=revoke_failed');
+    logAndRedirectError(res, log, 'Streamdeck key admin revoke error:', err, '/admin/streamdeck-keys', 'revoke_failed');
   }
 });
 

--- a/src/web/routes/streamdeckKeys.ts
+++ b/src/web/routes/streamdeckKeys.ts
@@ -57,7 +57,7 @@ router.post('/streamdeck-key/request', csrfProtection, async (req, res) => {
       webPort: WEB_PORT,
     });
   } catch (err) {
-    logAndRedirectError(res, log, 'Streamdeck key request error:', err, '/streamdeck-key', 'request_failed');
+    logAndRedirectError({ res, log, logLabel: 'Streamdeck key request error:', err, basePath: '/streamdeck-key', errorCode: 'request_failed' });
   }
 });
 
@@ -67,7 +67,7 @@ router.post('/streamdeck-key/revoke', csrfProtection, async (req, res) => {
     await revokeApiKey(req.session.user!.discordId);
     res.redirect('/streamdeck-key');
   } catch (err) {
-    logAndRedirectError(res, log, 'Streamdeck key revoke error:', err, '/streamdeck-key', 'revoke_failed');
+    logAndRedirectError({ res, log, logLabel: 'Streamdeck key revoke error:', err, basePath: '/streamdeck-key', errorCode: 'revoke_failed' });
   }
 });
 
@@ -100,7 +100,7 @@ router.post('/admin/streamdeck-keys/approve', requireAdmin, csrfProtection, asyn
     await approveApiKey(validId, req.session.user!.discordId);
     res.redirect('/admin/streamdeck-keys');
   } catch (err) {
-    logAndRedirectError(res, log, 'Streamdeck key approve error:', err, '/admin/streamdeck-keys', 'approve_failed');
+    logAndRedirectError({ res, log, logLabel: 'Streamdeck key approve error:', err, basePath: '/admin/streamdeck-keys', errorCode: 'approve_failed' });
   }
 });
 
@@ -112,7 +112,7 @@ router.post('/admin/streamdeck-keys/deny', requireAdmin, csrfProtection, async (
     await denyApiKey(validId);
     res.redirect('/admin/streamdeck-keys');
   } catch (err) {
-    logAndRedirectError(res, log, 'Streamdeck key deny error:', err, '/admin/streamdeck-keys', 'deny_failed');
+    logAndRedirectError({ res, log, logLabel: 'Streamdeck key deny error:', err, basePath: '/admin/streamdeck-keys', errorCode: 'deny_failed' });
   }
 });
 
@@ -124,7 +124,7 @@ router.post('/admin/streamdeck-keys/revoke', requireAdmin, csrfProtection, async
     await revokeApiKey(validId);
     res.redirect('/admin/streamdeck-keys');
   } catch (err) {
-    logAndRedirectError(res, log, 'Streamdeck key admin revoke error:', err, '/admin/streamdeck-keys', 'revoke_failed');
+    logAndRedirectError({ res, log, logLabel: 'Streamdeck key admin revoke error:', err, basePath: '/admin/streamdeck-keys', errorCode: 'revoke_failed' });
   }
 });
 

--- a/src/web/routes/streams.ts
+++ b/src/web/routes/streams.ts
@@ -141,7 +141,7 @@ router.post('/streams/groups/add', requireManager, csrfProtection, async (req, r
     });
     triggerRestart();
   } catch (err) {
-    return logAndRedirectError(res, log, 'Add stream group error:', err, '/admin/streams', 'add_group_failed');
+    return logAndRedirectError({ res, log, logLabel: 'Add stream group error:', err, basePath: '/admin/streams', errorCode: 'add_group_failed' });
   }
   res.redirect('/admin/streams');
 });
@@ -180,7 +180,7 @@ router.post('/streams/groups/update', requireManager, csrfProtection, async (req
     });
     triggerRestart();
   } catch (err) {
-    return logAndRedirectError(res, log, 'Update stream group error:', err, '/admin/streams', 'update_group_failed');
+    return logAndRedirectError({ res, log, logLabel: 'Update stream group error:', err, basePath: '/admin/streams', errorCode: 'update_group_failed' });
   }
   res.redirect('/admin/streams');
 });
@@ -205,7 +205,7 @@ router.post('/streams/groups/remove', requireManager, csrfProtection, async (req
     await removeStreamGroup(parsedGroupId);
     triggerRestart();
   } catch (err) {
-    return logAndRedirectError(res, log, 'Remove stream group error:', err, '/admin/streams', 'remove_group_failed');
+    return logAndRedirectError({ res, log, logLabel: 'Remove stream group error:', err, basePath: '/admin/streams', errorCode: 'remove_group_failed' });
   }
   res.redirect('/admin/streams');
 });
@@ -237,7 +237,7 @@ router.post('/streams/streamers/add', requireManager, csrfProtection, async (req
     await addStreamer(discordId, parsedGroupId);
     triggerRestart();
   } catch (err) {
-    return logAndRedirectError(res, log, 'Add streamer error:', err, '/admin/streams', 'add_streamer_failed');
+    return logAndRedirectError({ res, log, logLabel: 'Add streamer error:', err, basePath: '/admin/streams', errorCode: 'add_streamer_failed' });
   }
   res.redirect('/admin/streams');
 });
@@ -260,7 +260,7 @@ router.post('/streams/streamers/remove', requireManager, csrfProtection, async (
     await removeStreamer(parsedStreamerId);
     triggerRestart();
   } catch (err) {
-    return logAndRedirectError(res, log, 'Remove streamer error:', err, '/admin/streams', 'remove_streamer_failed');
+    return logAndRedirectError({ res, log, logLabel: 'Remove streamer error:', err, basePath: '/admin/streams', errorCode: 'remove_streamer_failed' });
   }
   res.redirect('/admin/streams');
 });

--- a/src/web/routes/streams.ts
+++ b/src/web/routes/streams.ts
@@ -17,7 +17,7 @@ import { csrfProtection } from '../csrf';
 import { requireManager } from '../middleware';
 import { restartTwitchMonitor, getLiveStates } from '../../twitch/monitor/twitchMonitor';
 import { AccessLevel } from '../../db';
-import { parsePositiveIntId, filterQueryParam, normalizeDiscordId, renderView, renderError } from './shared';
+import { logAndRedirectError, parsePositiveIntId, filterQueryParam, normalizeDiscordId, renderView, renderError } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
@@ -141,8 +141,7 @@ router.post('/streams/groups/add', requireManager, csrfProtection, async (req, r
     });
     triggerRestart();
   } catch (err) {
-    log.error('Add stream group error:', err);
-    return res.redirect('/admin/streams?error=add_group_failed');
+    return logAndRedirectError(res, log, 'Add stream group error:', err, '/admin/streams', 'add_group_failed');
   }
   res.redirect('/admin/streams');
 });
@@ -181,8 +180,7 @@ router.post('/streams/groups/update', requireManager, csrfProtection, async (req
     });
     triggerRestart();
   } catch (err) {
-    log.error('Update stream group error:', err);
-    return res.redirect('/admin/streams?error=update_group_failed');
+    return logAndRedirectError(res, log, 'Update stream group error:', err, '/admin/streams', 'update_group_failed');
   }
   res.redirect('/admin/streams');
 });
@@ -207,8 +205,7 @@ router.post('/streams/groups/remove', requireManager, csrfProtection, async (req
     await removeStreamGroup(parsedGroupId);
     triggerRestart();
   } catch (err) {
-    log.error('Remove stream group error:', err);
-    return res.redirect('/admin/streams?error=remove_group_failed');
+    return logAndRedirectError(res, log, 'Remove stream group error:', err, '/admin/streams', 'remove_group_failed');
   }
   res.redirect('/admin/streams');
 });
@@ -240,8 +237,7 @@ router.post('/streams/streamers/add', requireManager, csrfProtection, async (req
     await addStreamer(discordId, parsedGroupId);
     triggerRestart();
   } catch (err) {
-    log.error('Add streamer error:', err);
-    return res.redirect('/admin/streams?error=add_streamer_failed');
+    return logAndRedirectError(res, log, 'Add streamer error:', err, '/admin/streams', 'add_streamer_failed');
   }
   res.redirect('/admin/streams');
 });
@@ -264,8 +260,7 @@ router.post('/streams/streamers/remove', requireManager, csrfProtection, async (
     await removeStreamer(parsedStreamerId);
     triggerRestart();
   } catch (err) {
-    log.error('Remove streamer error:', err);
-    return res.redirect('/admin/streams?error=remove_streamer_failed');
+    return logAndRedirectError(res, log, 'Remove streamer error:', err, '/admin/streams', 'remove_streamer_failed');
   }
   res.redirect('/admin/streams');
 });

--- a/src/web/routes/userSettings.ts
+++ b/src/web/routes/userSettings.ts
@@ -140,7 +140,7 @@ router.get('/twitch-connect', requireAuth, async (req, res) => {
 
     res.redirect(`https://id.twitch.tv/oauth2/authorize?${params.toString()}`);
   } catch (err) {
-    logAndRedirectError(res, log, 'Twitch connect error:', err, '/user/settings', 'eventsub_config_failed');
+    logAndRedirectError({ res, log, logLabel: 'Twitch connect error:', err, basePath: '/user/settings', errorCode: 'eventsub_config_failed' });
   }
 });
 
@@ -164,7 +164,7 @@ router.post('/twitch-disconnect', requireAuth, csrfProtection, async (req, res) 
     reloadEventSubSubscriptions();
     res.redirect('/user/settings');
   } catch (err) {
-    logAndRedirectError(res, log, 'EventSub disconnect error:', err, '/user/settings', 'eventsub_disconnect_failed');
+    logAndRedirectError({ res, log, logLabel: 'EventSub disconnect error:', err, basePath: '/user/settings', errorCode: 'eventsub_disconnect_failed' });
   }
 });
 
@@ -226,7 +226,7 @@ router.post('/eventsub-config', requireAuth, csrfProtection, async (req, res) =>
     reloadEventSubSubscriptions();
     res.redirect('/user/settings');
   } catch (err) {
-    logAndRedirectError(res, log, 'EventSub config save error:', err, '/user/settings', 'eventsub_config_failed');
+    logAndRedirectError({ res, log, logLabel: 'EventSub config save error:', err, basePath: '/user/settings', errorCode: 'eventsub_config_failed' });
   }
 });
 

--- a/src/web/routes/userSettings.ts
+++ b/src/web/routes/userSettings.ts
@@ -4,7 +4,7 @@ import { randomBytes } from 'crypto';
 import { findUser, getStreamerByDiscordId, saveEventConfig, clearStreamerToken, EventSubConfig } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
-import { trimField, renderError, filterQueryParam, renderView } from './shared';
+import { logAndRedirectError, trimField, renderError, filterQueryParam, renderView } from './shared';
 import { reloadEventSubSubscriptions } from '../../twitch/eventsub/twitchEventSub';
 import { hasAuthFailedSubs } from '../../twitch/eventsub/twitchEventSubSubscriptions';
 import { TWITCH_CLIENT_ID, TWITCH_EVENTSUB_REDIRECT_URI, EVENTSUB_TOKEN_SECRET } from '../../shared/config';
@@ -140,8 +140,7 @@ router.get('/twitch-connect', requireAuth, async (req, res) => {
 
     res.redirect(`https://id.twitch.tv/oauth2/authorize?${params.toString()}`);
   } catch (err) {
-    log.error('Twitch connect error:', err);
-    res.redirect('/user/settings?error=eventsub_config_failed');
+    logAndRedirectError(res, log, 'Twitch connect error:', err, '/user/settings', 'eventsub_config_failed');
   }
 });
 
@@ -165,8 +164,7 @@ router.post('/twitch-disconnect', requireAuth, csrfProtection, async (req, res) 
     reloadEventSubSubscriptions();
     res.redirect('/user/settings');
   } catch (err) {
-    log.error('EventSub disconnect error:', err);
-    res.redirect('/user/settings?error=eventsub_disconnect_failed');
+    logAndRedirectError(res, log, 'EventSub disconnect error:', err, '/user/settings', 'eventsub_disconnect_failed');
   }
 });
 
@@ -228,8 +226,7 @@ router.post('/eventsub-config', requireAuth, csrfProtection, async (req, res) =>
     reloadEventSubSubscriptions();
     res.redirect('/user/settings');
   } catch (err) {
-    log.error('EventSub config save error:', err);
-    res.redirect('/user/settings?error=eventsub_config_failed');
+    logAndRedirectError(res, log, 'EventSub config save error:', err, '/user/settings', 'eventsub_config_failed');
   }
 });
 


### PR DESCRIPTION
## Summary
- Adds `logAndRedirectError(res, log, logLabel, err, basePath, errorCode)` to `src/web/routes/shared.ts`, standardizing the repeated `catch (err) { log.error(...); return res.redirect(...); }` tail found across POST route handlers.
- Applies the helper in `sfxCategoryMutations.ts`, `sfxTriggerMutations.ts`, `sfxFileMutations.ts`, `counters.ts`, `streams.ts`, `commandMutations.ts`, `commandGuildOverrides.ts`, `overlayAdminMutations.ts`, `overlayAdminRewardMutations.ts`, `streamdeckKeys.ts`, `userSettings.ts`, and `companionKeys.ts`. Route-specific `instanceof(err)`/error-code branches (e.g. `isMysqlDuplicateEntryError` checks in `sfxTriggerMutations.ts`) are left inline — only the generic catch-all tail is replaced.
- `adminUserMutations.ts` was in scope per the task but has no matching catch blocks: its catches are internal rollback logic that logs and rethrows, never calling `res.redirect`, so it was intentionally left unmodified.
- GET handlers that render a 500 error page via `renderError` (a different pattern per `CLAUDE.md` — "Never render errors from a POST handler") are untouched.
- Adds a `logAndRedirectError` test case to `src/web/routes/shared.test.ts`; all existing route tests pass unmodified.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (105 test files, 1784 tests)
- [x] Manually diffed each touched catch block to confirm identical log messages and redirect targets/error codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HbSyUedekQKAA5Q5SjW6ZW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling across several admin and settings pages so failed actions now redirect with consistent error messages.
  * Applied this to command, counter, SFX, overlay, stream, key, and user settings flows.

* **Tests**
  * Added coverage for the shared error-handling behavior to confirm logging and redirects work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->