### PR TITLE
fix(counters): stop assuming all value&lt;year&gt; archive columns exist

### DIFF
--- a/src/db/counters.test.ts
+++ b/src/db/counters.test.ts
@@ -44,6 +44,7 @@ import {
   resetCounterCurrentValue,
   incrementCounter,
   archiveAndResetYearlyCounters,
+  invalidateArchiveColumnsCache,
   CounterNotFoundError,
 } from './counters';
 import { runSerializedCommandWrite } from './commandLocks';
@@ -68,6 +69,11 @@ function makePool(rows: unknown[] = [], meta: unknown = {}) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // The archive-columns cache is a module-level singleton (5-minute TTL in
+  // production) so it must be reset between tests, or a later test's
+  // getCounterHistory call would silently reuse an earlier test's cached columns
+  // instead of hitting its own `pool.query` mock.
+  invalidateArchiveColumnsCache();
 });
 
 // ─── CounterNotFoundError ────────────────────────────────────────────────────
@@ -199,6 +205,18 @@ describe('getCounterHistory', () => {
     const [sql] = pool.query.mock.calls[0];
     expect(sql).toContain('information_schema.COLUMNS');
     expect(sql).toContain("TABLE_NAME = 'counter'");
+  });
+
+  it('caches the existing-columns lookup so browsing multiple counters only queries information_schema once', async () => {
+    const pool = makePool([{ id: 1 }]);
+    pool.query.mockResolvedValue([[{ COLUMN_NAME: 'value2025' }], {}]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+
+    await getCounterHistory(1);
+    await getCounterHistory(2);
+    await getCounterHistory(3);
+
+    expect(pool.query).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/db/counters.test.ts
+++ b/src/db/counters.test.ts
@@ -60,6 +60,7 @@ function makePool(rows: unknown[] = [], meta: unknown = {}) {
   };
   return {
     execute: vi.fn().mockResolvedValue([[...rows], meta]),
+    query: vi.fn().mockResolvedValue([[], meta]),
     getConnection: vi.fn().mockResolvedValue(conn),
     _conn: conn,
   };
@@ -129,7 +130,12 @@ describe('getCounterHistory', () => {
       value2024: 20,
       value2025: null,
     };
-    vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
+    const pool = makePool([row]);
+    pool.query.mockResolvedValue([
+      [{ COLUMN_NAME: 'value2023' }, { COLUMN_NAME: 'value2024' }, { COLUMN_NAME: 'value2025' }],
+      {},
+    ]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
     const result = await getCounterHistory(1);
     expect(result).not.toBeNull();
     expect(result!.counter.id).toBe(1);
@@ -154,6 +160,45 @@ describe('getCounterHistory', () => {
     const result = await getCounterHistory(2);
     expect(result).not.toBeNull();
     expect(result!.history).toEqual([]);
+  });
+
+  it('only selects value<year> columns that actually exist on the table, ignoring the rest of the allowlist', async () => {
+    // Regression test: ARCHIVE_YEAR_COLUMNS spans 2020-2100 as an allowlist, but per
+    // DATABASE-SCHEMA.md the physical columns are added one year at a time — the schema
+    // may only have e.g. value2020..value2025. Querying the full allowlist blindly used
+    // to throw "Unknown column 'value2026' in 'field list'" in production.
+    const row = {
+      id: 3,
+      trigger_command: '!wins',
+      check_command: '!checkwins',
+      message: 'msg',
+      increment_message: 'inc',
+      reset_yearly: 1,
+      current_value: 1,
+      value2025: 7,
+    };
+    const pool = makePool([row]);
+    pool.query.mockResolvedValue([[{ COLUMN_NAME: 'value2025' }], {}]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+
+    const result = await getCounterHistory(3);
+
+    expect(result!.history).toEqual([{ year: 2025, value: 7 }]);
+    const [sql] = pool.execute.mock.calls[0];
+    expect(sql).toContain('`value2025`');
+    expect(sql).not.toContain('value2026');
+    expect(sql).not.toContain('value2100');
+  });
+
+  it('queries information_schema scoped to the counter table for existing archive columns', async () => {
+    const pool = makePool([]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+
+    await getCounterHistory(1);
+
+    const [sql] = pool.query.mock.calls[0];
+    expect(sql).toContain('information_schema.COLUMNS');
+    expect(sql).toContain("TABLE_NAME = 'counter'");
   });
 });
 

--- a/src/db/counters.test.ts
+++ b/src/db/counters.test.ts
@@ -218,6 +218,38 @@ describe('getCounterHistory', () => {
 
     expect(pool.query).toHaveBeenCalledTimes(1);
   });
+
+  it('excludes the current year (and any future year) even if the column exists and holds a non-null value', async () => {
+    // archiveAndResetYearlyCounters only ever writes into the *previous*
+    // completed year's column, so the current/future year can never have valid
+    // archived data — this must be excluded outright, not just via NULL-filtering.
+    const currentYear = new Date().getFullYear();
+    const lastYear = currentYear - 1;
+    const row: Record<string, unknown> = {
+      id: 4,
+      trigger_command: '!streak',
+      check_command: '!checkstreak',
+      message: 'msg',
+      increment_message: 'inc',
+      reset_yearly: 1,
+      current_value: 3,
+      [`value${lastYear}`]: 42,
+      [`value${currentYear}`]: 99, // stray non-null value; must never surface as history
+    };
+    const pool = makePool([row]);
+    pool.query.mockResolvedValue([
+      [{ COLUMN_NAME: `value${lastYear}` }, { COLUMN_NAME: `value${currentYear}` }],
+      {},
+    ]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+
+    const result = await getCounterHistory(4);
+
+    expect(result!.history).toEqual([{ year: lastYear, value: 42 }]);
+    const [sql] = pool.execute.mock.calls[0];
+    expect(sql).toContain(`\`value${lastYear}\``);
+    expect(sql).not.toContain(`value${currentYear}`);
+  });
 });
 
 // ─── addCounter ──────────────────────────────────────────────────────────────

--- a/src/db/counters.ts
+++ b/src/db/counters.ts
@@ -132,10 +132,21 @@ const archiveColumnsCacheState = createManagedLookupCache<ArchiveColumnsCache>({
       `SELECT COLUMN_NAME FROM information_schema.COLUMNS
        WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'counter' AND COLUMN_NAME LIKE 'value2%'`,
     );
-    const knownColumns = new Set(ARCHIVE_YEAR_COLUMNS.values());
+    // The current year (and any future year) can never have valid archived data —
+    // archiveAndResetYearlyCounters only ever writes into the *previous* completed
+    // year's column, on Jan 1. Exclude them even if the column already physically
+    // exists (e.g. pre-provisioned ahead of the year rolling over) and even if it
+    // somehow holds a non-null value, rather than relying solely on the NULL
+    // filter in getCounterHistory to hide it.
+    const currentYear = new Date().getFullYear();
+    const eligibleColumns = new Set(
+      Array.from(ARCHIVE_YEAR_COLUMNS.entries())
+        .filter(([year]) => year < currentYear)
+        .map(([, columnName]) => columnName),
+    );
     const columns = rows
       .map((row) => row.COLUMN_NAME as string)
-      .filter((columnName) => knownColumns.has(columnName));
+      .filter((columnName) => eligibleColumns.has(columnName));
     return { loadedAt: Date.now(), columns };
   },
 });
@@ -147,11 +158,14 @@ export function invalidateArchiveColumnsCache(): void {
 
 /**
  * Returns the `value<year>` archive columns that actually exist on the `counter`
- * table right now (cached for 5 minutes — see `archiveColumnsCacheState`). Per
- * `DATABASE-SCHEMA.md`, these columns are added incrementally over time (one per
- * year, as each year's archive becomes needed) — `ARCHIVE_YEAR_COLUMNS` is a
- * fixed allowlist of *theoretically valid* years, not a guarantee that every
- * column in it has been created yet, so callers must not assume the full range exists.
+ * table AND belong to a year strictly before the current calendar year (cached
+ * for 5 minutes — see `archiveColumnsCacheState`). Per `DATABASE-SCHEMA.md`,
+ * these columns are added incrementally over time (one per year, as each year's
+ * archive becomes needed) — `ARCHIVE_YEAR_COLUMNS` is a fixed allowlist of
+ * *theoretically valid* years, not a guarantee that every column in it has been
+ * created yet, so callers must not assume the full range exists. The current
+ * year and any future year are excluded outright, since they can never have
+ * valid archived data (see `archiveAndResetYearlyCounters`).
  */
 async function getExistingArchiveColumns(): Promise<string[]> {
   const cache = await archiveColumnsCacheState.getCache();

--- a/src/db/counters.ts
+++ b/src/db/counters.ts
@@ -110,13 +110,33 @@ export async function getAllCounters(): Promise<DbCounter[]> {
  * @returns The counter and its history (years with a non-null archived value, newest
  *   first), or `null` if no counter exists with the given id.
  */
+/**
+ * Returns the `value<year>` archive columns that actually exist on the `counter`
+ * table right now. Per `DATABASE-SCHEMA.md`, these columns are added incrementally
+ * over time (one per year, as each year's archive becomes needed) — `ARCHIVE_YEAR_COLUMNS`
+ * is a fixed allowlist of *theoretically valid* years, not a guarantee that every
+ * column in it has been created yet, so callers must not assume the full range exists.
+ */
+async function getExistingArchiveColumns(): Promise<string[]> {
+  const [rows] = await getPool().query<mysql.RowDataPacket[]>(
+    `SELECT COLUMN_NAME FROM information_schema.COLUMNS
+     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'counter' AND COLUMN_NAME LIKE 'value2%'`,
+  );
+  const knownColumns = new Set(ARCHIVE_YEAR_COLUMNS.values());
+  return rows
+    .map((row) => row.COLUMN_NAME as string)
+    .filter((columnName) => knownColumns.has(columnName));
+}
+
 export async function getCounterHistory(
   id: number,
 ): Promise<{ counter: DbCounter; history: CounterHistoryEntry[] } | null> {
-  const archiveColumns = Array.from(ARCHIVE_YEAR_COLUMNS.values());
+  const existingColumns = await getExistingArchiveColumns();
+  const selectColumns = existingColumns.length > 0
+    ? `, ${existingColumns.map((col) => `\`${col}\``).join(', ')}`
+    : '';
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    `SELECT id, trigger_command, check_command, message, increment_message, reset_yearly, current_value,
-            ${archiveColumns.map((col) => `\`${col}\``).join(', ')}
+    `SELECT id, trigger_command, check_command, message, increment_message, reset_yearly, current_value${selectColumns}
      FROM counter
      WHERE id = ?
      LIMIT 1`,
@@ -126,8 +146,9 @@ export async function getCounterHistory(
 
   const row = rows[0];
   const counter = mapCounter(row);
+  const existingColumnSet = new Set(existingColumns);
   const history: CounterHistoryEntry[] = Array.from(ARCHIVE_YEAR_COLUMNS.entries())
-    .filter(([, columnName]) => row[columnName] !== null && row[columnName] !== undefined)
+    .filter(([, columnName]) => existingColumnSet.has(columnName) && row[columnName] !== null && row[columnName] !== undefined)
     .map(([year, columnName]) => ({ year, value: row[columnName] as number }))
     .sort((a, b) => b.year - a.year);
 

--- a/src/db/counters.ts
+++ b/src/db/counters.ts
@@ -5,6 +5,7 @@ import { runSerializedCommandWrite } from './commandLocks';
 import { assertNotReservedCommand } from './reservedCommands';
 import { fromBit } from './utils';
 import { invalidateCounterLookupCache } from './counterCache';
+import { createManagedLookupCache, type RefreshingLookupCache } from './lookupCache';
 
 // ─── Archive column allowlist ─────────────────────────────────────────────────
 // MySQL does not support parameterised column names. Rather than building the
@@ -110,22 +111,51 @@ export async function getAllCounters(): Promise<DbCounter[]> {
  * @returns The counter and its history (years with a non-null archived value, newest
  *   first), or `null` if no counter exists with the given id.
  */
+// ─── Archive column existence cache ───────────────────────────────────────────
+// `value<year>` columns are only ever added via yearly migrations (see
+// DATABASE-SCHEMA.md), so a short TTL is enough to turn "one information_schema
+// round-trip per getCounterHistory call" into "one per 5 minutes", which matters
+// when an admin browses several counters' histories in one session.
+
+interface ArchiveColumnsCache extends RefreshingLookupCache {
+  columns: string[];
+}
+
+const archiveColumnsCacheState = createManagedLookupCache<ArchiveColumnsCache>({
+  cacheName: 'counter archive columns cache',
+  ttlMs: 300_000,
+  refreshFailureBackoffMs: 5_000,
+  refreshFailureMaxBackoffMs: 60_000,
+  createEmptyCache: () => ({ loadedAt: 0, columns: [] }),
+  loadCache: async () => {
+    const [rows] = await getPool().query<mysql.RowDataPacket[]>(
+      `SELECT COLUMN_NAME FROM information_schema.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'counter' AND COLUMN_NAME LIKE 'value2%'`,
+    );
+    const knownColumns = new Set(ARCHIVE_YEAR_COLUMNS.values());
+    const columns = rows
+      .map((row) => row.COLUMN_NAME as string)
+      .filter((columnName) => knownColumns.has(columnName));
+    return { loadedAt: Date.now(), columns };
+  },
+});
+
+/** Marks the archive-columns cache as stale so the next read re-queries `information_schema`. */
+export function invalidateArchiveColumnsCache(): void {
+  archiveColumnsCacheState.invalidate();
+}
+
 /**
  * Returns the `value<year>` archive columns that actually exist on the `counter`
- * table right now. Per `DATABASE-SCHEMA.md`, these columns are added incrementally
- * over time (one per year, as each year's archive becomes needed) — `ARCHIVE_YEAR_COLUMNS`
- * is a fixed allowlist of *theoretically valid* years, not a guarantee that every
+ * table right now (cached for 5 minutes — see `archiveColumnsCacheState`). Per
+ * `DATABASE-SCHEMA.md`, these columns are added incrementally over time (one per
+ * year, as each year's archive becomes needed) — `ARCHIVE_YEAR_COLUMNS` is a
+ * fixed allowlist of *theoretically valid* years, not a guarantee that every
  * column in it has been created yet, so callers must not assume the full range exists.
  */
 async function getExistingArchiveColumns(): Promise<string[]> {
-  const [rows] = await getPool().query<mysql.RowDataPacket[]>(
-    `SELECT COLUMN_NAME FROM information_schema.COLUMNS
-     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'counter' AND COLUMN_NAME LIKE 'value2%'`,
-  );
-  const knownColumns = new Set(ARCHIVE_YEAR_COLUMNS.values());
-  return rows
-    .map((row) => row.COLUMN_NAME as string)
-    .filter((columnName) => knownColumns.has(columnName));
+  const cache = await archiveColumnsCacheState.getCache();
+  return cache.columns;
 }
 
 /**

--- a/src/db/counters.ts
+++ b/src/db/counters.ts
@@ -128,6 +128,16 @@ async function getExistingArchiveColumns(): Promise<string[]> {
     .filter((columnName) => knownColumns.has(columnName));
 }
 
+/**
+ * Fetches a counter along with its archived yearly-reset history (the
+ * `value<year>` columns populated by `archiveAndResetYearlyCounters`). Only reads
+ * columns that actually exist on the `counter` table right now (see
+ * `getExistingArchiveColumns`), since not every year in `ARCHIVE_YEAR_COLUMNS` is
+ * guaranteed to be a physical column yet.
+ * @param id - The counter's numeric id.
+ * @returns The counter and its archived history (years with a non-null value,
+ *   newest first), or `null` if no counter exists with the given id.
+ */
 export async function getCounterHistory(
   id: number,
 ): Promise<{ counter: DbCounter; history: CounterHistoryEntry[] } | null> {


### PR DESCRIPTION
## Summary

Production incident: every request to `/counters/:id/history` (added in #340) was throwing a 500 —

```
[ERROR] [Web] Counter history page error: Unknown column 'value2026' in 'field list'
```

**Root cause:** `getCounterHistory` built its `SELECT` from every year in `ARCHIVE_YEAR_COLUMNS` (2020-2100). That map is an input-validation allowlist for safe SQL column-name construction (see the comment above its definition) — it is not a guarantee that all those columns physically exist. Per `DATABASE-SCHEMA.md`, `value<year>` columns are added to the `counter` table incrementally, one year at a time. Production only has `value2020`-`value2025`, so the query failed on the first year beyond that.

**Fix:** `getCounterHistory` now queries `information_schema.COLUMNS` for the `counter` table first, and only selects/reads columns that actually exist. No schema migration needed — this makes the code match the documented "added over time" model and is self-healing as future `valueYYYY` columns get added.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (106 files / 1793 tests)
- [x] New regression test reproducing the exact bug: asserts the generated SQL does not reference `value2026`/`value2100` when only `value2025` exists on the table
- [x] New test asserting the `information_schema.COLUMNS` lookup is scoped to the `counter` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbSyUedekQKAA5Q5SjW6ZW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an exported option to invalidate the cached discovery of archive-year columns for counter history.

* **Bug Fixes**
  * Improved counter history loading to select only archive-year columns that actually exist on the current counter table schema.
  * Ensures missing year columns don’t cause errors or inaccurate history.
  * Excludes the current and future years even when matching columns exist.

* **Tests**
  * Expanded coverage to validate schema-based column discovery, correct query scoping, and caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->