### PR TITLE
Add optional per-reward dynamic Channel Point pricing

### DIFF
--- a/DATABASE-SCHEMA.md
+++ b/DATABASE-SCHEMA.md
@@ -189,6 +189,38 @@ Per-streamer EventSub notification message configuration. Applied once the strea
 
 Created by `migrations/twitch_eventsub.sql`.
 
+## `reward_pricing`
+
+Dynamic Channel Point Pricing: per-reward config and demand state. Independent of `overlay_reward` — a reward can have dynamic pricing without overlay videos and vice versa. Optional/opt-in per reward via `enabled`.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | `INT` PK, auto-increment | |
+| `streamer_id` | `INT` | FK to `streamer.id` ON DELETE CASCADE |
+| `twitch_reward_id` | `VARCHAR(255)` | Twitch reward UUID; unique per `(streamer_id, twitch_reward_id)` |
+| `enabled` | `TINYINT(1)` | Whether dynamic pricing is active for this reward |
+| `base_cost` | `INT` | Minimum price |
+| `cooldown_seconds` | `INT` | Used to normalize demand decay/increment across rewards |
+| `max_multiplier` | `DECIMAL(6,3)` | Max price = `base_cost * (1 + max_multiplier)` |
+| `curve` | `DECIMAL(5,3)` | Exponent controlling how aggressively price rises with demand |
+| `demand` | `DECIMAL(9,6)` | Current demand, in `[0,1]` |
+| `demand_updated_at` | `BIGINT` | Epoch ms the `demand` value was last computed as of |
+| `last_pushed_cost` | `INT` NULL | Last cost actually pushed to Twitch; used to skip redundant Helix calls |
+
+Created by `migrations/reward_pricing.sql`.
+
+## `pricing_global_settings`
+
+Single global row (`id` pinned to 1) — bot-wide decay/increment settings shared by every `reward_pricing` row.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | `TINYINT` PK | Always `1` (enforced by a CHECK constraint) |
+| `decay_half_life_periods` | `DECIMAL(8,3)` | Cooldown-periods of inactivity for demand to halve |
+| `redemption_increment` | `DECIMAL(6,4)` | Flat demand increase applied per redemption |
+
+Created by `migrations/reward_pricing.sql`.
+
 ## `custom_command`
 
 Stores custom text commands managed through the admin panel. This is a **global catalog** shared across all guilds (no `guild_id`); per-guild deviations (disable / output override) live in `guild_command_override`. On Discord, every catalog command is enabled by default in every guild.

--- a/DATABASE-SCHEMA.md
+++ b/DATABASE-SCHEMA.md
@@ -206,6 +206,7 @@ Dynamic Channel Point Pricing: per-reward config and demand state. Independent o
 | `demand` | `DECIMAL(9,6)` | Current demand, in `[0,1]` |
 | `demand_updated_at` | `BIGINT` | Epoch ms the `demand` value was last computed as of |
 | `last_pushed_cost` | `INT` NULL | Last cost actually pushed to Twitch; used to skip redundant Helix calls |
+| `twitch_unsupported` | `TINYINT(1)` | Set (and `enabled` forced to 0) when Twitch returns 403 — the reward was created outside this app and can never be managed by it |
 
 Created by `migrations/reward_pricing.sql`.
 

--- a/migrations/reward_pricing.sql
+++ b/migrations/reward_pricing.sql
@@ -1,0 +1,27 @@
+-- Dynamic Channel Point Pricing: per-reward config/demand + bot-wide decay/increment settings.
+-- Independent of overlay_reward — a reward can have dynamic pricing without overlay videos and vice versa.
+CREATE TABLE reward_pricing (
+  id                INT          AUTO_INCREMENT PRIMARY KEY,
+  streamer_id       INT          NOT NULL,
+  twitch_reward_id  VARCHAR(255) NOT NULL,
+  enabled           TINYINT(1)   NOT NULL DEFAULT 0,
+  base_cost         INT          NOT NULL,
+  cooldown_seconds  INT          NOT NULL DEFAULT 60,
+  max_multiplier    DECIMAL(6,3) NOT NULL DEFAULT 1.000,
+  curve             DECIMAL(5,3) NOT NULL DEFAULT 1.000,
+  demand            DECIMAL(9,6) NOT NULL DEFAULT 0.000000,
+  demand_updated_at BIGINT       NOT NULL,
+  last_pushed_cost  INT          NULL,
+  UNIQUE KEY uq_reward_pricing (streamer_id, twitch_reward_id),
+  KEY idx_reward_pricing_enabled (enabled),
+  FOREIGN KEY (streamer_id) REFERENCES streamer(id) ON DELETE CASCADE
+);
+
+-- Single global row (id pinned to 1) — bot-wide decay/increment settings shared by every reward.
+CREATE TABLE pricing_global_settings (
+  id                       TINYINT      NOT NULL DEFAULT 1,
+  decay_half_life_periods DECIMAL(8,3) NOT NULL DEFAULT 3.000,
+  redemption_increment     DECIMAL(6,4) NOT NULL DEFAULT 0.1000,
+  PRIMARY KEY (id),
+  CONSTRAINT chk_pricing_global_settings_singleton CHECK (id = 1)
+);

--- a/migrations/reward_pricing.sql
+++ b/migrations/reward_pricing.sql
@@ -12,6 +12,9 @@ CREATE TABLE reward_pricing (
   demand            DECIMAL(9,6) NOT NULL DEFAULT 0.000000,
   demand_updated_at BIGINT       NOT NULL,
   last_pushed_cost  INT          NULL,
+  -- Set (and enabled forced to 0) when Twitch returns 403 on an update — the reward was
+  -- created outside this app (dashboard or another client_id) and can never be managed by it.
+  twitch_unsupported TINYINT(1)  NOT NULL DEFAULT 0,
   UNIQUE KEY uq_reward_pricing (streamer_id, twitch_reward_id),
   KEY idx_reward_pricing_enabled (enabled),
   FOREIGN KEY (streamer_id) REFERENCES streamer(id) ON DELETE CASCADE,

--- a/migrations/reward_pricing.sql
+++ b/migrations/reward_pricing.sql
@@ -14,8 +14,12 @@ CREATE TABLE reward_pricing (
   last_pushed_cost  INT          NULL,
   UNIQUE KEY uq_reward_pricing (streamer_id, twitch_reward_id),
   KEY idx_reward_pricing_enabled (enabled),
-  FOREIGN KEY (streamer_id) REFERENCES streamer(id) ON DELETE CASCADE
-);
+  FOREIGN KEY (streamer_id) REFERENCES streamer(id) ON DELETE CASCADE,
+  CONSTRAINT chk_reward_pricing_base_cost        CHECK (base_cost > 0),
+  CONSTRAINT chk_reward_pricing_cooldown_seconds CHECK (cooldown_seconds > 0),
+  CONSTRAINT chk_reward_pricing_max_multiplier   CHECK (max_multiplier >= 0),
+  CONSTRAINT chk_reward_pricing_curve            CHECK (curve > 0)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Single global row (id pinned to 1) — bot-wide decay/increment settings shared by every reward.
 CREATE TABLE pricing_global_settings (
@@ -24,4 +28,4 @@ CREATE TABLE pricing_global_settings (
   redemption_increment     DECIMAL(6,4) NOT NULL DEFAULT 0.1000,
   PRIMARY KEY (id),
   CONSTRAINT chk_pricing_global_settings_singleton CHECK (id = 1)
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/schema.sql
+++ b/schema.sql
@@ -283,7 +283,11 @@ CREATE TABLE IF NOT EXISTS reward_pricing (
   PRIMARY KEY (id),
   UNIQUE KEY uq_reward_pricing (streamer_id, twitch_reward_id),
   KEY idx_reward_pricing_enabled (enabled),
-  FOREIGN KEY (streamer_id) REFERENCES streamer(id) ON DELETE CASCADE
+  FOREIGN KEY (streamer_id) REFERENCES streamer(id) ON DELETE CASCADE,
+  CONSTRAINT chk_reward_pricing_base_cost        CHECK (base_cost > 0),
+  CONSTRAINT chk_reward_pricing_cooldown_seconds CHECK (cooldown_seconds > 0),
+  CONSTRAINT chk_reward_pricing_max_multiplier   CHECK (max_multiplier >= 0),
+  CONSTRAINT chk_reward_pricing_curve            CHECK (curve > 0)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ---------------------------------------------------------------------------

--- a/schema.sql
+++ b/schema.sql
@@ -280,6 +280,9 @@ CREATE TABLE IF NOT EXISTS reward_pricing (
   demand            DECIMAL(9,6) NOT NULL DEFAULT 0.000000,
   demand_updated_at BIGINT       NOT NULL,
   last_pushed_cost  INT          NULL,
+  -- Set (and enabled forced to 0) when Twitch returns 403 on an update — the reward was
+  -- created outside this app (dashboard or another client_id) and can never be managed by it.
+  twitch_unsupported TINYINT(1)  NOT NULL DEFAULT 0,
   PRIMARY KEY (id),
   UNIQUE KEY uq_reward_pricing (streamer_id, twitch_reward_id),
   KEY idx_reward_pricing_enabled (enabled),

--- a/schema.sql
+++ b/schema.sql
@@ -264,6 +264,42 @@ CREATE TABLE IF NOT EXISTS overlay_reward_video (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ---------------------------------------------------------------------------
+-- reward_pricing
+-- Dynamic Channel Point Pricing: per-reward config/demand. Independent of
+-- overlay_reward — a reward can have dynamic pricing without overlay videos.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS reward_pricing (
+  id                INT          NOT NULL AUTO_INCREMENT,
+  streamer_id       INT          NOT NULL,
+  twitch_reward_id  VARCHAR(255) NOT NULL,
+  enabled           TINYINT(1)   NOT NULL DEFAULT 0,
+  base_cost         INT          NOT NULL,
+  cooldown_seconds  INT          NOT NULL DEFAULT 60,
+  max_multiplier    DECIMAL(6,3) NOT NULL DEFAULT 1.000,
+  curve             DECIMAL(5,3) NOT NULL DEFAULT 1.000,
+  demand            DECIMAL(9,6) NOT NULL DEFAULT 0.000000,
+  demand_updated_at BIGINT       NOT NULL,
+  last_pushed_cost  INT          NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uq_reward_pricing (streamer_id, twitch_reward_id),
+  KEY idx_reward_pricing_enabled (enabled),
+  FOREIGN KEY (streamer_id) REFERENCES streamer(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ---------------------------------------------------------------------------
+-- pricing_global_settings
+-- Single global row (id pinned to 1) — bot-wide decay/increment settings
+-- shared by every reward_pricing row.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS pricing_global_settings (
+  id                       TINYINT      NOT NULL DEFAULT 1,
+  decay_half_life_periods DECIMAL(8,3) NOT NULL DEFAULT 3.000,
+  redemption_increment     DECIMAL(6,4) NOT NULL DEFAULT 0.1000,
+  PRIMARY KEY (id),
+  CONSTRAINT chk_pricing_global_settings_singleton CHECK (id = 1)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ---------------------------------------------------------------------------
 -- streamdeck_api_keys
 -- key_hash is a hex-encoded SHA-256 of the plain API key (64 chars).
 -- approved_by is nullable; SET NULL if the approver's user row is deleted.

--- a/src/db.ts
+++ b/src/db.ts
@@ -153,7 +153,7 @@ export {
 export type { RewardPricingRow, RewardPricingInput, GlobalPricingSettings } from './db/rewardPricing';
 export {
   getPricingForReward, getPricingConfigsForStreamer, getAllEnabledPricingRows,
-  upsertPricingConfig, recordPricingUpdate, deletePricingConfig,
+  upsertPricingConfig, recordPricingUpdate, deletePricingConfig, markPricingUnsupported,
   initGlobalPricingSettings, getGlobalPricingSettings, saveGlobalPricingSettings,
 } from './db/rewardPricing';
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -148,6 +148,15 @@ export {
   getVideosForReward,
 } from './db/overlayVideos';
 
+// ─── Channel point pricing ───────────────────────────────────────────────────
+
+export type { RewardPricingRow, RewardPricingInput, GlobalPricingSettings } from './db/rewardPricing';
+export {
+  getPricingForReward, getPricingConfigsForStreamer, getAllEnabledPricingRows,
+  upsertPricingConfig, recordPricingUpdate, deletePricingConfig,
+  initGlobalPricingSettings, getGlobalPricingSettings, saveGlobalPricingSettings,
+} from './db/rewardPricing';
+
 // ─── Streamdeck API keys ─────────────────────────────────────────────────────
 
 export type { StreamdeckKeyRow } from './db/streamdeckKeys';

--- a/src/db.ts
+++ b/src/db.ts
@@ -152,7 +152,7 @@ export {
 
 export type { RewardPricingRow, RewardPricingInput, GlobalPricingSettings } from './db/rewardPricing';
 export {
-  getPricingForReward, getPricingConfigsForStreamer, getAllEnabledPricingRows,
+  getPricingForReward, getPricingConfigById, getPricingConfigsForStreamer, getAllEnabledPricingRows,
   upsertPricingConfig, recordPricingUpdate, deletePricingConfig, markPricingUnsupported,
   initGlobalPricingSettings, getGlobalPricingSettings, saveGlobalPricingSettings,
 } from './db/rewardPricing';

--- a/src/db/rewardPricing.test.ts
+++ b/src/db/rewardPricing.test.ts
@@ -11,6 +11,7 @@ import {
   upsertPricingConfig,
   recordPricingUpdate,
   deletePricingConfig,
+  markPricingUnsupported,
   initGlobalPricingSettings,
   getGlobalPricingSettings,
   saveGlobalPricingSettings,
@@ -38,6 +39,7 @@ const sampleRow = {
   demand: '0.500000',
   demand_updated_at: '1700000000000',
   last_pushed_cost: 400,
+  twitch_unsupported: 0,
 };
 
 describe('getPricingForReward', () => {
@@ -61,6 +63,7 @@ describe('getPricingForReward', () => {
       demand: 0.5,
       demand_updated_at: '1700000000000',
       last_pushed_cost: 400,
+      twitch_unsupported: false,
     });
   });
 
@@ -117,6 +120,15 @@ describe('upsertPricingConfig', () => {
     expect(setClause).not.toContain('last_pushed_cost=');
   });
 
+  it('clears twitch_unsupported in the SET list, so an explicit save gives the reward another attempt', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await upsertPricingConfig(7, 'rwd-abc', { enabled: true, base_cost: 200, cooldown_seconds: 300, max_multiplier: 4, curve: 1.5 });
+    const sql: string = pool.execute.mock.calls[0][0];
+    const setClause = sql.split('ON DUPLICATE KEY UPDATE')[1];
+    expect(setClause).toContain('twitch_unsupported=0');
+  });
+
   it('passes converted enabled boolean and config fields', async () => {
     const pool = makePool();
     vi.mocked(getPool).mockReturnValue(pool as any);
@@ -147,6 +159,17 @@ describe('recordPricingUpdate', () => {
     vi.mocked(getPool).mockReturnValue(pool as any);
     await recordPricingUpdate(7, 'rwd-abc', 0.1, 1700000000000, null);
     expect(pool.execute.mock.calls[0][1]).toEqual([0.1, 1700000000000, null, 7, 'rwd-abc']);
+  });
+});
+
+describe('markPricingUnsupported', () => {
+  it('disables the row and sets twitch_unsupported, scoped by streamerId and twitchRewardId', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await markPricingUnsupported(7, 'rwd-abc');
+    const sql: string = pool.execute.mock.calls[0][0];
+    expect(sql).toContain('SET enabled = 0, twitch_unsupported = 1');
+    expect(pool.execute.mock.calls[0][1]).toEqual([7, 'rwd-abc']);
   });
 });
 

--- a/src/db/rewardPricing.test.ts
+++ b/src/db/rewardPricing.test.ts
@@ -6,6 +6,7 @@ vi.mock('mysql2/promise', () => ({ default: {} }));
 import { getPool } from './pool';
 import {
   getPricingForReward,
+  getPricingConfigById,
   getPricingConfigsForStreamer,
   getAllEnabledPricingRows,
   upsertPricingConfig,
@@ -78,6 +79,27 @@ describe('getPricingForReward', () => {
     vi.mocked(getPool).mockReturnValue(makePool([{ ...sampleRow, last_pushed_cost: null }]) as any);
     const row = await getPricingForReward(7, 'rwd-abc');
     expect(row!.last_pushed_cost).toBeNull();
+  });
+});
+
+describe('getPricingConfigById', () => {
+  it('returns null when no row found', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    expect(await getPricingConfigById(1, 7)).toBeNull();
+  });
+
+  it('returns the mapped row when found', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([sampleRow]) as any);
+    const row = await getPricingConfigById(1, 7);
+    expect(row!.id).toBe(1);
+    expect(row!.twitch_reward_id).toBe('rwd-abc');
+  });
+
+  it('queries with id and streamerId', async () => {
+    const pool = makePool([]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await getPricingConfigById(1, 7);
+    expect(pool.execute.mock.calls[0][1]).toEqual([1, 7]);
   });
 });
 

--- a/src/db/rewardPricing.test.ts
+++ b/src/db/rewardPricing.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./pool', () => ({ getPool: vi.fn() }));
+vi.mock('mysql2/promise', () => ({ default: {} }));
+
+import { getPool } from './pool';
+import {
+  getPricingForReward,
+  getPricingConfigsForStreamer,
+  getAllEnabledPricingRows,
+  upsertPricingConfig,
+  recordPricingUpdate,
+  deletePricingConfig,
+  initGlobalPricingSettings,
+  getGlobalPricingSettings,
+  saveGlobalPricingSettings,
+} from './rewardPricing';
+
+function makePool(rows: unknown[] = [], meta: unknown = {}) {
+  return {
+    execute: vi.fn().mockResolvedValue([[...rows], meta]),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const sampleRow = {
+  id: 1,
+  streamer_id: 7,
+  twitch_reward_id: 'rwd-abc',
+  enabled: 1,
+  base_cost: 200,
+  cooldown_seconds: 300,
+  max_multiplier: '4.000',
+  curve: '1.500',
+  demand: '0.500000',
+  demand_updated_at: '1700000000000',
+  last_pushed_cost: 400,
+};
+
+describe('getPricingForReward', () => {
+  it('returns null when no row found', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    expect(await getPricingForReward(7, 'rwd-abc')).toBeNull();
+  });
+
+  it('maps a found row, converting numeric strings and BIT columns', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([sampleRow]) as any);
+    const row = await getPricingForReward(7, 'rwd-abc');
+    expect(row).toEqual({
+      id: 1,
+      streamer_id: 7,
+      twitch_reward_id: 'rwd-abc',
+      enabled: true,
+      base_cost: 200,
+      cooldown_seconds: 300,
+      max_multiplier: 4,
+      curve: 1.5,
+      demand: 0.5,
+      demand_updated_at: '1700000000000',
+      last_pushed_cost: 400,
+    });
+  });
+
+  it('queries with streamerId and twitchRewardId', async () => {
+    const pool = makePool([]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await getPricingForReward(7, 'rwd-abc');
+    expect(pool.execute.mock.calls[0][1]).toEqual([7, 'rwd-abc']);
+  });
+
+  it('maps a null last_pushed_cost as null', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([{ ...sampleRow, last_pushed_cost: null }]) as any);
+    const row = await getPricingForReward(7, 'rwd-abc');
+    expect(row!.last_pushed_cost).toBeNull();
+  });
+});
+
+describe('getPricingConfigsForStreamer', () => {
+  it('returns all rows for the streamer', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([sampleRow, { ...sampleRow, id: 2 }]) as any);
+    const rows = await getPricingConfigsForStreamer(7);
+    expect(rows).toHaveLength(2);
+  });
+});
+
+describe('getAllEnabledPricingRows', () => {
+  it('returns all enabled rows without params', async () => {
+    const pool = makePool([sampleRow]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const rows = await getAllEnabledPricingRows();
+    expect(rows).toHaveLength(1);
+    expect(pool.execute.mock.calls[0][0]).toContain('enabled = 1');
+  });
+});
+
+describe('upsertPricingConfig', () => {
+  it('uses the row-alias ON DUPLICATE KEY UPDATE form', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await upsertPricingConfig(7, 'rwd-abc', { enabled: true, base_cost: 200, cooldown_seconds: 300, max_multiplier: 4, curve: 1.5 });
+    const sql: string = pool.execute.mock.calls[0][0];
+    expect(sql).toContain('AS new_row');
+    expect(sql).toContain('ON DUPLICATE KEY UPDATE');
+  });
+
+  it('does not touch demand, demand_updated_at, or last_pushed_cost in the SET list', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await upsertPricingConfig(7, 'rwd-abc', { enabled: true, base_cost: 200, cooldown_seconds: 300, max_multiplier: 4, curve: 1.5 });
+    const sql: string = pool.execute.mock.calls[0][0];
+    const setClause = sql.split('ON DUPLICATE KEY UPDATE')[1];
+    expect(setClause).not.toContain('demand=');
+    expect(setClause).not.toContain('demand_updated_at=');
+    expect(setClause).not.toContain('last_pushed_cost=');
+  });
+
+  it('passes converted enabled boolean and config fields', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await upsertPricingConfig(7, 'rwd-abc', { enabled: false, base_cost: 100, cooldown_seconds: 60, max_multiplier: 2, curve: 1 });
+    const params: unknown[] = pool.execute.mock.calls[0][1];
+    expect(params[0]).toBe(7);
+    expect(params[1]).toBe('rwd-abc');
+    expect(params[2]).toBe(0);
+    expect(params[3]).toBe(100);
+    expect(params[4]).toBe(60);
+    expect(params[5]).toBe(2);
+    expect(params[6]).toBe(1);
+  });
+});
+
+describe('recordPricingUpdate', () => {
+  it('updates exactly demand, demand_updated_at, and last_pushed_cost', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await recordPricingUpdate(7, 'rwd-abc', 0.75, 1700000000000, 350);
+    const sql: string = pool.execute.mock.calls[0][0];
+    expect(sql).toContain('SET demand = ?, demand_updated_at = ?, last_pushed_cost = ?');
+    expect(pool.execute.mock.calls[0][1]).toEqual([0.75, 1700000000000, 350, 7, 'rwd-abc']);
+  });
+
+  it('accepts a null lastPushedCost', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await recordPricingUpdate(7, 'rwd-abc', 0.1, 1700000000000, null);
+    expect(pool.execute.mock.calls[0][1]).toEqual([0.1, 1700000000000, null, 7, 'rwd-abc']);
+  });
+});
+
+describe('deletePricingConfig', () => {
+  it('scopes the DELETE by both id and streamerId', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await deletePricingConfig(3, 7);
+    expect(pool.execute.mock.calls[0][1]).toEqual([3, 7]);
+  });
+});
+
+describe('initGlobalPricingSettings', () => {
+  it('uses INSERT IGNORE with the default settings', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await initGlobalPricingSettings();
+    const sql: string = pool.execute.mock.calls[0][0];
+    expect(sql).toContain('INSERT IGNORE');
+    expect(pool.execute.mock.calls[0][1]).toEqual([3, 0.1]);
+  });
+});
+
+describe('getGlobalPricingSettings', () => {
+  it('returns defaults without throwing when the row is missing', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    const settings = await getGlobalPricingSettings();
+    expect(settings).toEqual({ decay_half_life_periods: 3, redemption_increment: 0.1 });
+  });
+
+  it('returns the stored row converted to numbers', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([{ decay_half_life_periods: '5.000', redemption_increment: '0.2000' }]) as any);
+    const settings = await getGlobalPricingSettings();
+    expect(settings).toEqual({ decay_half_life_periods: 5, redemption_increment: 0.2 });
+  });
+});
+
+describe('saveGlobalPricingSettings', () => {
+  it('uses the row-alias upsert form and passes the new settings', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await saveGlobalPricingSettings({ decay_half_life_periods: 4, redemption_increment: 0.15 });
+    const sql: string = pool.execute.mock.calls[0][0];
+    expect(sql).toContain('AS new_row');
+    expect(sql).toContain('ON DUPLICATE KEY UPDATE');
+    expect(pool.execute.mock.calls[0][1]).toEqual([4, 0.15]);
+  });
+});

--- a/src/db/rewardPricing.ts
+++ b/src/db/rewardPricing.ts
@@ -1,0 +1,209 @@
+import mysql from 'mysql2/promise';
+import { getPool } from './pool';
+import { fromBit } from './utils';
+
+/** A reward's dynamic-pricing configuration and current demand state. */
+export interface RewardPricingRow {
+  id: number;
+  streamer_id: number;
+  twitch_reward_id: string;
+  enabled: boolean;
+  base_cost: number;
+  cooldown_seconds: number;
+  max_multiplier: number;
+  curve: number;
+  demand: number;
+  /** Epoch ms as a string — BIGINT column; never coerce with Number() at this layer. */
+  demand_updated_at: string;
+  last_pushed_cost: number | null;
+}
+
+/** Config fields a streamer can edit for one reward via the admin UI. */
+export interface RewardPricingInput {
+  enabled: boolean;
+  base_cost: number;
+  cooldown_seconds: number;
+  max_multiplier: number;
+  curve: number;
+}
+
+/** Bot-wide settings shared by every reward's demand calculations. */
+export interface GlobalPricingSettings {
+  decay_half_life_periods: number;
+  redemption_increment: number;
+}
+
+const DEFAULT_GLOBAL_SETTINGS: GlobalPricingSettings = {
+  decay_half_life_periods: 3,
+  redemption_increment: 0.1,
+};
+
+function mapRow(r: mysql.RowDataPacket): RewardPricingRow {
+  return {
+    id: r.id,
+    streamer_id: r.streamer_id,
+    twitch_reward_id: r.twitch_reward_id,
+    enabled: fromBit(r.enabled),
+    base_cost: r.base_cost,
+    cooldown_seconds: r.cooldown_seconds,
+    max_multiplier: Number(r.max_multiplier),
+    curve: Number(r.curve),
+    demand: Number(r.demand),
+    demand_updated_at: String(r.demand_updated_at),
+    last_pushed_cost: r.last_pushed_cost == null ? null : Number(r.last_pushed_cost),
+  };
+}
+
+const REWARD_PRICING_SELECT = `
+  id, streamer_id, twitch_reward_id, enabled, base_cost, cooldown_seconds,
+  max_multiplier, curve, demand, demand_updated_at, last_pushed_cost`;
+
+/**
+ * Look up a single reward's pricing config/demand row, or null if not configured.
+ *
+ * @param streamerId - DB row ID of the owning streamer.
+ * @param twitchRewardId - Twitch reward UUID.
+ */
+export async function getPricingForReward(streamerId: number, twitchRewardId: string): Promise<RewardPricingRow | null> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT ${REWARD_PRICING_SELECT} FROM reward_pricing WHERE streamer_id = ? AND twitch_reward_id = ?`,
+    [streamerId, twitchRewardId],
+  );
+  return rows.length === 0 ? null : mapRow(rows[0]);
+}
+
+/**
+ * List every reward pricing row (configured or not yet enabled) belonging to a streamer.
+ *
+ * @param streamerId - DB row ID of the streamer.
+ */
+export async function getPricingConfigsForStreamer(streamerId: number): Promise<RewardPricingRow[]> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT ${REWARD_PRICING_SELECT} FROM reward_pricing WHERE streamer_id = ? ORDER BY id`,
+    [streamerId],
+  );
+  return rows.map(mapRow);
+}
+
+/**
+ * List every reward pricing row across all streamers where dynamic pricing is enabled.
+ * Used by the periodic decay scheduler to find rows that need a decay tick.
+ */
+export async function getAllEnabledPricingRows(): Promise<RewardPricingRow[]> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT ${REWARD_PRICING_SELECT} FROM reward_pricing WHERE enabled = 1 ORDER BY streamer_id`,
+  );
+  return rows.map(mapRow);
+}
+
+/**
+ * Create or update a reward's pricing config. Only touches the config columns
+ * (enabled/base_cost/cooldown_seconds/max_multiplier/curve) — demand, demand_updated_at,
+ * and last_pushed_cost are left untouched on an update so editing config never resets
+ * in-flight demand state. New rows start at demand=0 with demand_updated_at=now.
+ *
+ * @param streamerId - DB row ID of the owning streamer.
+ * @param twitchRewardId - Twitch reward UUID.
+ * @param input - The config fields to save.
+ */
+export async function upsertPricingConfig(
+  streamerId: number,
+  twitchRewardId: string,
+  input: RewardPricingInput,
+): Promise<void> {
+  await getPool().execute(
+    `INSERT INTO reward_pricing
+       (streamer_id, twitch_reward_id, enabled, base_cost, cooldown_seconds, max_multiplier, curve, demand_updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?) AS new_row
+     ON DUPLICATE KEY UPDATE
+       enabled=new_row.enabled, base_cost=new_row.base_cost, cooldown_seconds=new_row.cooldown_seconds,
+       max_multiplier=new_row.max_multiplier, curve=new_row.curve`,
+    [
+      streamerId, twitchRewardId,
+      input.enabled ? 1 : 0, input.base_cost, input.cooldown_seconds, input.max_multiplier, input.curve,
+      Date.now(),
+    ],
+  );
+}
+
+/**
+ * Persist a recalculated demand value (and, if it changed, the last cost pushed to Twitch).
+ * Shared by the redemption hook and the periodic decay scheduler — the only writer of
+ * demand state, keeping it separate from config edits (see upsertPricingConfig).
+ *
+ * @param streamerId - DB row ID of the owning streamer.
+ * @param twitchRewardId - Twitch reward UUID.
+ * @param demand - The newly computed demand value.
+ * @param demandUpdatedAtMs - Epoch ms this demand value was computed as of.
+ * @param lastPushedCost - The cost last pushed to Twitch, or null if none has been pushed yet.
+ */
+export async function recordPricingUpdate(
+  streamerId: number,
+  twitchRewardId: string,
+  demand: number,
+  demandUpdatedAtMs: number,
+  lastPushedCost: number | null,
+): Promise<void> {
+  await getPool().execute(
+    `UPDATE reward_pricing
+     SET demand = ?, demand_updated_at = ?, last_pushed_cost = ?
+     WHERE streamer_id = ? AND twitch_reward_id = ?`,
+    [demand, demandUpdatedAtMs, lastPushedCost, streamerId, twitchRewardId],
+  );
+}
+
+/**
+ * Delete a reward's pricing config, scoped to the owning streamer.
+ *
+ * @param id - Primary key of the `reward_pricing` row.
+ * @param streamerId - DB row ID of the owning streamer.
+ */
+export async function deletePricingConfig(id: number, streamerId: number): Promise<void> {
+  await getPool().execute(
+    `DELETE FROM reward_pricing WHERE id = ? AND streamer_id = ?`,
+    [id, streamerId],
+  );
+}
+
+/**
+ * Insert the default global pricing settings row (id=1) if one does not already exist.
+ * Safe to call multiple times; called once at bot startup.
+ */
+export async function initGlobalPricingSettings(): Promise<void> {
+  const s = DEFAULT_GLOBAL_SETTINGS;
+  await getPool().execute(
+    `INSERT IGNORE INTO pricing_global_settings (id, decay_half_life_periods, redemption_increment)
+     VALUES (1, ?, ?)`,
+    [s.decay_half_life_periods, s.redemption_increment],
+  );
+}
+
+/**
+ * Read the global pricing settings. Falls back to hardcoded defaults (without throwing)
+ * if the singleton row is missing, e.g. before initGlobalPricingSettings has run.
+ */
+export async function getGlobalPricingSettings(): Promise<GlobalPricingSettings> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT decay_half_life_periods, redemption_increment FROM pricing_global_settings WHERE id = 1`,
+  );
+  if (rows.length === 0) return { ...DEFAULT_GLOBAL_SETTINGS };
+  return {
+    decay_half_life_periods: Number(rows[0].decay_half_life_periods),
+    redemption_increment: Number(rows[0].redemption_increment),
+  };
+}
+
+/**
+ * Upsert the global pricing settings row (id=1).
+ *
+ * @param settings - The new global decay/increment settings.
+ */
+export async function saveGlobalPricingSettings(settings: GlobalPricingSettings): Promise<void> {
+  await getPool().execute(
+    `INSERT INTO pricing_global_settings (id, decay_half_life_periods, redemption_increment)
+     VALUES (1, ?, ?) AS new_row
+     ON DUPLICATE KEY UPDATE
+       decay_half_life_periods=new_row.decay_half_life_periods, redemption_increment=new_row.redemption_increment`,
+    [settings.decay_half_life_periods, settings.redemption_increment],
+  );
+}

--- a/src/db/rewardPricing.ts
+++ b/src/db/rewardPricing.ts
@@ -76,6 +76,21 @@ export async function getPricingForReward(streamerId: number, twitchRewardId: st
 }
 
 /**
+ * Look up a single reward's pricing config by its primary key, scoped to the owning
+ * streamer, or null if not found.
+ *
+ * @param id - Primary key of the `reward_pricing` row.
+ * @param streamerId - DB row ID of the owning streamer.
+ */
+export async function getPricingConfigById(id: number, streamerId: number): Promise<RewardPricingRow | null> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT ${REWARD_PRICING_SELECT} FROM reward_pricing WHERE id = ? AND streamer_id = ?`,
+    [id, streamerId],
+  );
+  return rows.length === 0 ? null : mapRow(rows[0]);
+}
+
+/**
  * List every reward pricing row (configured or not yet enabled) belonging to a streamer.
  *
  * @param streamerId - DB row ID of the streamer.

--- a/src/db/rewardPricing.ts
+++ b/src/db/rewardPricing.ts
@@ -16,6 +16,8 @@ export interface RewardPricingRow {
   /** Epoch ms as a string — BIGINT column; never coerce with Number() at this layer. */
   demand_updated_at: string;
   last_pushed_cost: number | null;
+  /** True once Twitch has returned 403 for this reward — it was created outside this app and can never be managed by it. */
+  twitch_unsupported: boolean;
 }
 
 /** Config fields a streamer can edit for one reward via the admin UI. */
@@ -51,12 +53,13 @@ function mapRow(r: mysql.RowDataPacket): RewardPricingRow {
     demand: Number(r.demand),
     demand_updated_at: String(r.demand_updated_at),
     last_pushed_cost: r.last_pushed_cost == null ? null : Number(r.last_pushed_cost),
+    twitch_unsupported: fromBit(r.twitch_unsupported),
   };
 }
 
 const REWARD_PRICING_SELECT = `
   id, streamer_id, twitch_reward_id, enabled, base_cost, cooldown_seconds,
-  max_multiplier, curve, demand, demand_updated_at, last_pushed_cost`;
+  max_multiplier, curve, demand, demand_updated_at, last_pushed_cost, twitch_unsupported`;
 
 /**
  * Look up a single reward's pricing config/demand row, or null if not configured.
@@ -101,6 +104,8 @@ export async function getAllEnabledPricingRows(): Promise<RewardPricingRow[]> {
  * (enabled/base_cost/cooldown_seconds/max_multiplier/curve) — demand, demand_updated_at,
  * and last_pushed_cost are left untouched on an update so editing config never resets
  * in-flight demand state. New rows start at demand=0 with demand_updated_at=now.
+ * Always clears `twitch_unsupported`, since an explicit save is the streamer opting back
+ * in and deserves another attempt (e.g. after recreating the reward via the bot).
  *
  * @param streamerId - DB row ID of the owning streamer.
  * @param twitchRewardId - Twitch reward UUID.
@@ -117,12 +122,26 @@ export async function upsertPricingConfig(
      VALUES (?, ?, ?, ?, ?, ?, ?, ?) AS new_row
      ON DUPLICATE KEY UPDATE
        enabled=new_row.enabled, base_cost=new_row.base_cost, cooldown_seconds=new_row.cooldown_seconds,
-       max_multiplier=new_row.max_multiplier, curve=new_row.curve`,
+       max_multiplier=new_row.max_multiplier, curve=new_row.curve, twitch_unsupported=0`,
     [
       streamerId, twitchRewardId,
       input.enabled ? 1 : 0, input.base_cost, input.cooldown_seconds, input.max_multiplier, input.curve,
       Date.now(),
     ],
+  );
+}
+
+/**
+ * Marks a reward as permanently unsupported by Twitch (403 on cost update — created outside
+ * this app) and disables it, so the decay scheduler and redemption hook stop retrying.
+ *
+ * @param streamerId - DB row ID of the owning streamer.
+ * @param twitchRewardId - Twitch reward UUID.
+ */
+export async function markPricingUnsupported(streamerId: number, twitchRewardId: string): Promise<void> {
+  await getPool().execute(
+    `UPDATE reward_pricing SET enabled = 0, twitch_unsupported = 1 WHERE streamer_id = ? AND twitch_reward_id = ?`,
+    [streamerId, twitchRewardId],
   );
 }
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -167,6 +167,10 @@ describe('startup — reward pricing scheduler', () => {
 
     expect(vi.mocked(db.initGlobalPricingSettings)).toHaveBeenCalledOnce();
     expect(vi.mocked(startRewardPricingScheduler)).toHaveBeenCalledOnce();
+
+    const [initCallOrder] = vi.mocked(db.initGlobalPricingSettings).mock.invocationCallOrder;
+    const [schedulerCallOrder] = vi.mocked(startRewardPricingScheduler).mock.invocationCallOrder;
+    expect(initCallOrder).toBeLessThan(schedulerCallOrder);
   });
 
   it('logs an error and continues starting up when initGlobalPricingSettings rejects', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -12,6 +12,7 @@ vi.mock('./db', () => ({
     }),
   })),
   closePool: vi.fn().mockResolvedValue(undefined),
+  initGlobalPricingSettings: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock('./discord/discordBot', () => ({
   startDiscordBot: vi.fn(),
@@ -60,6 +61,10 @@ vi.mock('./web/routes/companionEvents', () => ({ pushCompanionEvent: vi.fn() }))
 vi.mock('./commands/counterScheduler', () => ({
   startCounterScheduler: vi.fn(),
   stopCounterScheduler: vi.fn(),
+}));
+vi.mock('./twitch/pricing/rewardPricingScheduler', () => ({
+  startRewardPricingScheduler: vi.fn(),
+  stopRewardPricingScheduler: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock('./shared/logger', () => ({
   createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -78,6 +78,11 @@ beforeEach(() => {
   // module cache but does not reset call counts. clearAllMocks() resets counts to 0
   // so failure-path assertions on mocks like startDiscordBot start from a clean slate.
   vi.clearAllMocks();
+  // Each import('./index.js') registers fresh SIGINT/SIGTERM listeners on the real
+  // process object; resetModules doesn't remove the old ones. Clear them so a test
+  // that emits a signal only triggers its own run's shutdown() closure.
+  process.removeAllListeners('SIGINT');
+  process.removeAllListeners('SIGTERM');
   // Throw on the first call so main() stops executing after a catch block calls
   // process.exit(1). Revert to a no-op on subsequent calls so the outer
   // main().catch() path — which also calls process.exit(1) after the inner throw
@@ -90,6 +95,8 @@ beforeEach(() => {
 
 afterEach(() => {
   exitSpy.mockRestore();
+  process.removeAllListeners('SIGINT');
+  process.removeAllListeners('SIGTERM');
 });
 
 /** Imports index.ts (which fires main() immediately) and waits for it to settle. */
@@ -146,5 +153,45 @@ describe('startup — guild registry preload', () => {
 
     expect(exitSpy).toHaveBeenCalledWith(1);
     expect(vi.mocked(startDiscordBot)).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Reward pricing scheduler startup/shutdown ────────────────────────────────
+
+describe('startup — reward pricing scheduler', () => {
+  it('starts the scheduler after initializing global pricing settings', async () => {
+    const db = await import('./db.js');
+    const { startRewardPricingScheduler } = await import('./twitch/pricing/rewardPricingScheduler.js');
+
+    await runMain();
+
+    expect(vi.mocked(db.initGlobalPricingSettings)).toHaveBeenCalledOnce();
+    expect(vi.mocked(startRewardPricingScheduler)).toHaveBeenCalledOnce();
+  });
+
+  it('logs an error and continues starting up when initGlobalPricingSettings rejects', async () => {
+    const db = await import('./db.js');
+    const { startRewardPricingScheduler } = await import('./twitch/pricing/rewardPricingScheduler.js');
+    const { startEventSub } = await import('./twitch/eventsub/twitchEventSub.js');
+    vi.mocked(db.initGlobalPricingSettings).mockRejectedValueOnce(new Error('db down'));
+
+    await runMain();
+
+    expect(vi.mocked(startRewardPricingScheduler)).not.toHaveBeenCalled();
+    // Startup continues past the failed try/catch to the rest of main() instead of aborting.
+    expect(vi.mocked(startEventSub)).toHaveBeenCalledOnce();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('shutdown', () => {
+  it('stops the reward pricing scheduler on SIGINT', async () => {
+    const { stopRewardPricingScheduler } = await import('./twitch/pricing/rewardPricingScheduler.js');
+
+    await runMain();
+    process.emit('SIGINT');
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(vi.mocked(stopRewardPricingScheduler)).toHaveBeenCalledOnce();
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -173,7 +173,7 @@ describe('startup — reward pricing scheduler', () => {
     expect(initCallOrder).toBeLessThan(schedulerCallOrder);
   });
 
-  it('logs an error and continues starting up when initGlobalPricingSettings rejects', async () => {
+  it('still starts the scheduler and continues startup when initGlobalPricingSettings rejects', async () => {
     const db = await import('./db.js');
     const { startRewardPricingScheduler } = await import('./twitch/pricing/rewardPricingScheduler.js');
     const { startEventSub } = await import('./twitch/eventsub/twitchEventSub.js');
@@ -181,8 +181,9 @@ describe('startup — reward pricing scheduler', () => {
 
     await runMain();
 
-    expect(vi.mocked(startRewardPricingScheduler)).not.toHaveBeenCalled();
-    // Startup continues past the failed try/catch to the rest of main() instead of aborting.
+    // A transient settings-bootstrap failure shouldn't disable decay for the process lifetime —
+    // the pricing read path falls back to defaults, so the scheduler starts regardless.
+    expect(vi.mocked(startRewardPricingScheduler)).toHaveBeenCalledOnce();
     expect(vi.mocked(startEventSub)).toHaveBeenCalledOnce();
     expect(exitSpy).not.toHaveBeenCalled();
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,10 +92,10 @@ async function main(): Promise<void> {
 
   try {
     await initGlobalPricingSettings();
-    startRewardPricingScheduler();
   } catch (err) {
-    log.error('RewardPricingScheduler startup error:', err);
+    log.error('initGlobalPricingSettings startup error:', err);
   }
+  startRewardPricingScheduler();
 
   startTwitchMonitor().catch((err) => log.error('TwitchMonitor startup error:', err));
   startEventSub();

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,10 @@ import { createLogger } from './shared/logger';
 
 const log = createLogger('Bot');
 
+/**
+ * Gracefully stops schedulers and bot connections, closes the DB pool, and exits the process.
+ * @param signal - The name of the signal that triggered shutdown (e.g. `SIGINT`).
+ */
 async function shutdown(signal: string): Promise<void> {
   log.info(`${signal} received — disconnecting from voice and shutting down.`);
   stopCounterScheduler();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import 'mediaplex'; // Must be imported first to register as Opus provider
-import { getPool, closePool } from './db';
+import { getPool, closePool, initGlobalPricingSettings } from './db';
 import { startTwitchBot, stopTwitchBot, sayInChannel } from './twitch/twitchBot';
 import { getActiveChannels, getActiveChannelUserIds, setChannelJoinedHook } from './twitch/twitchChannelMembership';
 import { startDiscordBot, stopDiscordBot } from './discord/discordBot';
@@ -18,6 +18,7 @@ import { registerEventSubOverlayRuntime, registerEventSubTwitchRuntime, register
 import { pushOverlayEvent } from './web/routes/overlaySource';
 import { pushCompanionEvent } from './web/routes/companionEvents';
 import { startCounterScheduler, stopCounterScheduler } from './commands/counterScheduler';
+import { startRewardPricingScheduler, stopRewardPricingScheduler } from './twitch/pricing/rewardPricingScheduler';
 import { createLogger } from './shared/logger';
 
 const log = createLogger('Bot');
@@ -25,6 +26,7 @@ const log = createLogger('Bot');
 async function shutdown(signal: string): Promise<void> {
   log.info(`${signal} received — disconnecting from voice and shutting down.`);
   stopCounterScheduler();
+  await stopRewardPricingScheduler();
   stopEventSub();
   await stopTwitchMonitor();
   stopTikTokBot();
@@ -83,6 +85,14 @@ async function main(): Promise<void> {
   await startTikTokBot();
   startWebPanel();
   startCounterScheduler();
+
+  try {
+    await initGlobalPricingSettings();
+    startRewardPricingScheduler();
+  } catch (err) {
+    log.error('RewardPricingScheduler startup error:', err);
+  }
+
   startTwitchMonitor().catch((err) => log.error('TwitchMonitor startup error:', err));
   startEventSub();
 }

--- a/src/twitch/eventsub/twitchEventSubHandler.test.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.test.ts
@@ -4,6 +4,7 @@ vi.mock('../../db', () => ({ getVideosForReward: vi.fn(), getStreamerById: vi.fn
 vi.mock('../../commands/soundSelector', () => ({ pickWeightedRandom: vi.fn() }));
 vi.mock('../../shared/logger', () => ({ createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }));
 vi.mock('../monitor/twitchMonitor', () => ({ triggerImmediateLiveCheck: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../pricing/rewardPricingService', () => ({ applyRedemptionPricing: vi.fn().mockResolvedValue(undefined) }));
 
 import {
   handleFollow, handleSub, handleResub, handleGiftSub, handleRaid, handleRedemption,
@@ -13,6 +14,7 @@ import {
 import { getVideosForReward, getStreamerById } from '../../db';
 import { pickWeightedRandom } from '../../commands/soundSelector';
 import { triggerImmediateLiveCheck } from '../monitor/twitchMonitor';
+import { applyRedemptionPricing } from '../pricing/rewardPricingService';
 
 const mockSend = vi.fn<(channel: string, message: string) => Promise<void>>();
 registerEventSubTwitchRuntime({ send: mockSend });
@@ -324,6 +326,25 @@ describe('handleRedemption', () => {
     await handleRedemption('streamer', event, makeConfig(), streamerId);
 
     expect(mockPushCompanionEvent).not.toHaveBeenCalled();
+    expect(mockPushOverlayEvent).toHaveBeenCalledWith('streamer', '/overlay/videos/7/clip1.mp4');
+  });
+
+  it('applies dynamic pricing for the redeemed reward', async () => {
+    vi.mocked(getVideosForReward).mockResolvedValue([]);
+
+    await handleRedemption('streamer', event, makeConfig(), streamerId);
+
+    expect(applyRedemptionPricing).toHaveBeenCalledWith(streamerId, 'reward-abc');
+  });
+
+  it('still triggers the overlay lookup when applyRedemptionPricing throws', async () => {
+    vi.mocked(applyRedemptionPricing).mockRejectedValueOnce(new Error('pricing failed'));
+    const videos = [{ file: 'clip1.mp4', weight: 1 }] as any[];
+    vi.mocked(getVideosForReward).mockResolvedValue(videos);
+    vi.mocked(pickWeightedRandom).mockReturnValue('clip1.mp4');
+
+    await handleRedemption('streamer', event, makeConfig(), streamerId);
+
     expect(mockPushOverlayEvent).toHaveBeenCalledWith('streamer', '/overlay/videos/7/clip1.mp4');
   });
 });

--- a/src/twitch/eventsub/twitchEventSubHandler.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.ts
@@ -231,13 +231,14 @@ export async function handleRaid(login: string, event: RaidEvent, config: EventS
 /**
  * Handle a channel.channel_points_custom_reward_redemption.add EventSub notification.
  * Unconditionally forwards the redemption to the streamer's companion app (if any device
- * is connected), applies dynamic pricing for the redeemed reward (a no-op if the reward
+ * is connected), fires off dynamic pricing for the redeemed reward (a no-op if the reward
  * doesn't have dynamic pricing enabled), then separately looks up videos configured for
  * the redeemed reward and triggers an overlay event if found. The overlay push still
  * no-ops when no videos are configured for the reward or `_overlayRuntime` is absent.
- * The companion push and the pricing update are each isolated in their own try/catch so a
- * failure in either (e.g. a DB error, or a failed Twitch price push) cannot prevent the
- * independent overlay-video logic below from running.
+ * The companion push is isolated in its own try/catch, and the pricing update is
+ * intentionally not awaited (its errors are caught via `.catch` instead), so a failure or
+ * network latency in either (e.g. a DB error, or a slow/failed Twitch price push) cannot
+ * delay or prevent the independent overlay-video logic below from running.
  *
  * @param login - Broadcaster login name.
  * @param event - Redemption event payload including reward ID and user details.
@@ -267,11 +268,11 @@ export async function handleRedemption(
     log.error('Failed to push companion event for redemption:', err);
   }
 
-  try {
-    await applyRedemptionPricing(streamerId, event.reward.id);
-  } catch (err) {
+  // Not awaited: applyRedemptionPricing drives a queued Twitch Helix call, and there's no
+  // correctness reason to make the overlay-trigger path below wait on that network latency.
+  applyRedemptionPricing(streamerId, event.reward.id).catch((err) => {
     log.error('Failed to apply dynamic pricing for redemption:', err);
-  }
+  });
 
   const videos = await getVideosForReward(event.reward.id, streamerId);
   if (videos.length === 0) return;

--- a/src/twitch/eventsub/twitchEventSubHandler.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.ts
@@ -4,6 +4,7 @@ import { pickWeightedRandom } from '../../commands/soundSelector';
 import { createLogger } from '../../shared/logger';
 import { triggerImmediateLiveCheck } from '../monitor/twitchMonitor';
 import { fillTemplate } from '../../shared/textTemplate';
+import { applyRedemptionPricing } from '../pricing/rewardPricingService';
 
 const log = createLogger('EventSubHandler');
 
@@ -230,11 +231,13 @@ export async function handleRaid(login: string, event: RaidEvent, config: EventS
 /**
  * Handle a channel.channel_points_custom_reward_redemption.add EventSub notification.
  * Unconditionally forwards the redemption to the streamer's companion app (if any device
- * is connected), then separately looks up videos configured for the redeemed reward and
- * triggers an overlay event if found. The overlay push still no-ops when no videos are
- * configured for the reward or `_overlayRuntime` is absent. The companion push is isolated
- * in its own try/catch so a failure there (e.g. a DB error from `getStreamerById`) cannot
- * prevent the independent overlay-video logic below from running.
+ * is connected), applies dynamic pricing for the redeemed reward (a no-op if the reward
+ * doesn't have dynamic pricing enabled), then separately looks up videos configured for
+ * the redeemed reward and triggers an overlay event if found. The overlay push still
+ * no-ops when no videos are configured for the reward or `_overlayRuntime` is absent.
+ * The companion push and the pricing update are each isolated in their own try/catch so a
+ * failure in either (e.g. a DB error, or a failed Twitch price push) cannot prevent the
+ * independent overlay-video logic below from running.
  *
  * @param login - Broadcaster login name.
  * @param event - Redemption event payload including reward ID and user details.
@@ -262,6 +265,12 @@ export async function handleRedemption(
     }
   } catch (err) {
     log.error('Failed to push companion event for redemption:', err);
+  }
+
+  try {
+    await applyRedemptionPricing(streamerId, event.reward.id);
+  } catch (err) {
+    log.error('Failed to apply dynamic pricing for redemption:', err);
   }
 
   const videos = await getVideosForReward(event.reward.id, streamerId);

--- a/src/twitch/pricing/rewardPricingMath.test.ts
+++ b/src/twitch/pricing/rewardPricingMath.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { computePrice, decayDemand, applyRedemption } from './rewardPricingMath';
+
+const config = { baseCost: 200, cooldownSeconds: 300, maxMultiplier: 4, curve: 1.5 };
+
+describe('computePrice', () => {
+  it('returns baseCost at demand=0', () => {
+    expect(computePrice(0, config)).toBe(200);
+  });
+
+  it('returns baseCost * (1 + maxMultiplier) at demand=1', () => {
+    expect(computePrice(1, config)).toBe(1000);
+  });
+
+  it('computes a curved mid-range value', () => {
+    // usage=0.5, curve=1.5 -> curved = 0.5^1.5 ≈ 0.353553
+    // price = round(200 * (1 + 0.353553*4)) = round(200 * 2.414214) = round(482.8427) = 483
+    expect(computePrice(0.5, config)).toBe(483);
+  });
+
+  it('rounds to the nearest integer', () => {
+    const c = { baseCost: 100, cooldownSeconds: 60, maxMultiplier: 1, curve: 1 };
+    // usage=0.006 -> price = round(100 * 1.006) = round(100.6) = 101
+    expect(computePrice(0.006, c)).toBe(101);
+  });
+
+  it('clamps demand above 1 before computing', () => {
+    expect(computePrice(5, config)).toBe(computePrice(1, config));
+  });
+
+  it('clamps demand below 0 before computing', () => {
+    expect(computePrice(-5, config)).toBe(computePrice(0, config));
+  });
+});
+
+describe('decayDemand', () => {
+  it('returns demand unchanged when elapsedSeconds is 0', () => {
+    expect(decayDemand(0.8, 0, 300, 3)).toBe(0.8);
+  });
+
+  it('halves demand exactly after one half-life worth of periods', () => {
+    // elapsedSeconds = cooldownSeconds * decayHalfLifePeriods -> periodsElapsed = decayHalfLifePeriods
+    const result = decayDemand(0.8, 300 * 3, 300, 3);
+    expect(result).toBeCloseTo(0.4, 10);
+  });
+
+  it('quarters demand after two half-lives worth of periods', () => {
+    const result = decayDemand(0.8, 300 * 6, 300, 3);
+    expect(result).toBeCloseTo(0.2, 10);
+  });
+
+  it('clamps to 0 for very large elapsed time', () => {
+    expect(decayDemand(1, 1e9, 300, 3)).toBe(0);
+  });
+
+  it('never goes negative', () => {
+    expect(decayDemand(0, 1000, 300, 3)).toBeGreaterThanOrEqual(0);
+  });
+
+  it('is a no-op when elapsedSeconds is negative (clock skew)', () => {
+    expect(decayDemand(0.5, -10, 300, 3)).toBe(0.5);
+  });
+
+  it('is a no-op when cooldownSeconds is non-positive', () => {
+    expect(decayDemand(0.5, 100, 0, 3)).toBe(0.5);
+  });
+
+  it('is a no-op when decayHalfLifePeriods is non-positive', () => {
+    expect(decayDemand(0.5, 100, 300, 0)).toBe(0.5);
+  });
+
+  it('still clamps an out-of-range demand even in the no-op path', () => {
+    expect(decayDemand(1.5, 0, 300, 3)).toBe(1);
+    expect(decayDemand(-1.5, 0, 300, 3)).toBe(0);
+  });
+});
+
+describe('applyRedemption', () => {
+  it('decays then adds the redemption increment', () => {
+    // decay(0.8, 300, 300, 3) ≈ 0.8 * 2^(-1/3) ≈ 0.635200
+    const result = applyRedemption(0.8, 300, 300, 3, 0.1);
+    expect(result).toBeCloseTo(0.6352 + 0.1, 3);
+  });
+
+  it('clamps to 1 when the result would overflow', () => {
+    expect(applyRedemption(0.95, 0, 300, 3, 0.5)).toBe(1);
+  });
+
+  it('applies decay before the increment (order matters)', () => {
+    // If increment were applied before decay, elapsed=huge would still decay demand+increment to ~0.
+    // Applying decay first means the increment survives even after demand fully decays.
+    const result = applyRedemption(1, 1e9, 300, 3, 0.2);
+    expect(result).toBeCloseTo(0.2, 10);
+  });
+});
+
+describe('cooldown normalization — comparable rates across different cooldowns', () => {
+  it('two rewards with different cooldowns redeemed at their own max frequency converge to the same steady-state demand', () => {
+    const decayHalfLifePeriods = 3;
+    const redemptionIncrement = 0.1;
+
+    function simulate(cooldownSeconds: number, iterations: number): number {
+      let demand = 0;
+      for (let i = 0; i < iterations; i++) {
+        demand = applyRedemption(demand, cooldownSeconds, cooldownSeconds, decayHalfLifePeriods, redemptionIncrement);
+      }
+      return demand;
+    }
+
+    const shortCooldown = simulate(30, 200);
+    const longCooldown = simulate(300, 200);
+
+    expect(Math.abs(shortCooldown - longCooldown)).toBeLessThan(1e-6);
+
+    const r = Math.pow(2, -1 / decayHalfLifePeriods);
+    const expectedSteadyState = redemptionIncrement / (1 - r);
+    expect(shortCooldown).toBeCloseTo(Math.min(1, expectedSteadyState), 6);
+  });
+});

--- a/src/twitch/pricing/rewardPricingMath.ts
+++ b/src/twitch/pricing/rewardPricingMath.ts
@@ -1,0 +1,69 @@
+/** Per-reward pricing parameters used by the price/demand calculations below. */
+export interface RewardPricingConfig {
+  baseCost: number;
+  cooldownSeconds: number;
+  maxMultiplier: number;
+  curve: number;
+}
+
+/**
+ * Computes the current redemption price from demand and a reward's pricing config.
+ * price = round(baseCost * (1 + clamp(demand,0,1)^curve * maxMultiplier)).
+ *
+ * @param demand - Current demand value; clamped to [0,1] before use.
+ * @param config - The reward's pricing configuration.
+ * @returns The rounded price, bounded to [baseCost, baseCost*(1+maxMultiplier)].
+ */
+export function computePrice(demand: number, config: RewardPricingConfig): number {
+  const usage = Math.min(1, Math.max(0, demand));
+  const curved = Math.pow(usage, config.curve);
+  return Math.round(config.baseCost * (1 + curved * config.maxMultiplier));
+}
+
+/**
+ * Decays demand continuously over elapsed time, normalized by the reward's own cooldown
+ * so rewards with different cooldowns decay at comparable relative rates. Guards against
+ * non-positive cooldown/half-life or negative elapsed time by treating them as a no-op
+ * rather than throwing or producing NaN/Infinity.
+ *
+ * @param demand - Demand value before decay.
+ * @param elapsedSeconds - Real seconds elapsed since the demand value was last updated.
+ * @param cooldownSeconds - The reward's configured cooldown, used to normalize elapsed time.
+ * @param decayHalfLifePeriods - Global setting: number of cooldown-periods for demand to halve.
+ * @returns The decayed demand, clamped to [0,1].
+ */
+export function decayDemand(
+  demand: number,
+  elapsedSeconds: number,
+  cooldownSeconds: number,
+  decayHalfLifePeriods: number,
+): number {
+  if (elapsedSeconds <= 0 || cooldownSeconds <= 0 || decayHalfLifePeriods <= 0) {
+    return Math.min(1, Math.max(0, demand));
+  }
+  const periodsElapsed = elapsedSeconds / cooldownSeconds;
+  const decayed = demand * Math.pow(2, -periodsElapsed / decayHalfLifePeriods);
+  return Math.min(1, Math.max(0, decayed));
+}
+
+/**
+ * Applies a single redemption to demand: first decays for elapsed time, then adds the
+ * global redemption increment, then clamps to [0,1].
+ *
+ * @param demand - Demand value before this redemption.
+ * @param elapsedSeconds - Real seconds elapsed since the demand value was last updated.
+ * @param cooldownSeconds - The reward's configured cooldown, used to normalize decay.
+ * @param decayHalfLifePeriods - Global setting: number of cooldown-periods for demand to halve.
+ * @param redemptionIncrement - Global setting: flat demand increase applied per redemption.
+ * @returns The updated demand, clamped to [0,1].
+ */
+export function applyRedemption(
+  demand: number,
+  elapsedSeconds: number,
+  cooldownSeconds: number,
+  decayHalfLifePeriods: number,
+  redemptionIncrement: number,
+): number {
+  const decayed = decayDemand(demand, elapsedSeconds, cooldownSeconds, decayHalfLifePeriods);
+  return Math.min(1, Math.max(0, decayed + redemptionIncrement));
+}

--- a/src/twitch/pricing/rewardPricingScheduler.test.ts
+++ b/src/twitch/pricing/rewardPricingScheduler.test.ts
@@ -90,6 +90,20 @@ describe('startRewardPricingScheduler / stopRewardPricingScheduler', () => {
     expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(2);
   });
 
+  it('does not leak the interval when started twice without stopping', async () => {
+    vi.mocked(getAllEnabledPricingRows).mockResolvedValue([]);
+    startRewardPricingScheduler();
+    startRewardPricingScheduler(); // second call should no-op, not replace the tracked handle
+
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    // If the second call had leaked a duplicate interval, this would be 2.
+    expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(1);
+
+    await stopRewardPricingScheduler();
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(1); // fully stopped, no orphaned timer still firing
+  });
+
   it('stop prevents further ticks', async () => {
     vi.mocked(getAllEnabledPricingRows).mockResolvedValue([]);
     startRewardPricingScheduler();

--- a/src/twitch/pricing/rewardPricingScheduler.test.ts
+++ b/src/twitch/pricing/rewardPricingScheduler.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../shared/logger', () => ({ createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) }));
+vi.mock('../../db', () => ({ getAllEnabledPricingRows: vi.fn() }));
+vi.mock('./rewardPricingService', () => ({ applyDecayTick: vi.fn() }));
+
+import { getAllEnabledPricingRows } from '../../db';
+import { applyDecayTick } from './rewardPricingService';
+import { runDecayTick, startRewardPricingScheduler, stopRewardPricingScheduler } from './rewardPricingScheduler';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+});
+
+afterEach(async () => {
+  await stopRewardPricingScheduler();
+  vi.useRealTimers();
+});
+
+describe('runDecayTick', () => {
+  it('calls applyDecayTick for every enabled row', async () => {
+    vi.mocked(getAllEnabledPricingRows).mockResolvedValue([
+      { streamer_id: 1, twitch_reward_id: 'r1' },
+      { streamer_id: 2, twitch_reward_id: 'r2' },
+    ] as any);
+    vi.mocked(applyDecayTick).mockResolvedValue(undefined);
+
+    await runDecayTick();
+
+    expect(applyDecayTick).toHaveBeenCalledWith(1, 'r1');
+    expect(applyDecayTick).toHaveBeenCalledWith(2, 'r2');
+  });
+
+  it('continues to the next row when one fails', async () => {
+    vi.mocked(getAllEnabledPricingRows).mockResolvedValue([
+      { streamer_id: 1, twitch_reward_id: 'r1' },
+      { streamer_id: 2, twitch_reward_id: 'r2' },
+    ] as any);
+    vi.mocked(applyDecayTick).mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce(undefined);
+
+    await expect(runDecayTick()).resolves.toBeUndefined();
+    expect(applyDecayTick).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not throw when loading rows fails', async () => {
+    vi.mocked(getAllEnabledPricingRows).mockRejectedValue(new Error('db down'));
+    await expect(runDecayTick()).resolves.toBeUndefined();
+  });
+});
+
+describe('startRewardPricingScheduler / stopRewardPricingScheduler', () => {
+  it('fires runDecayTick on the configured interval', async () => {
+    vi.mocked(getAllEnabledPricingRows).mockResolvedValue([]);
+    startRewardPricingScheduler();
+
+    expect(getAllEnabledPricingRows).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(2);
+  });
+
+  it('stop prevents further ticks', async () => {
+    vi.mocked(getAllEnabledPricingRows).mockResolvedValue([]);
+    startRewardPricingScheduler();
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(1);
+
+    await stopRewardPricingScheduler();
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(1);
+  });
+
+  it('a reentrancy guard prevents overlapping ticks', async () => {
+    let resolveFirst!: () => void;
+    const gate = new Promise<void>((resolve) => { resolveFirst = resolve; });
+    vi.mocked(getAllEnabledPricingRows).mockImplementation(async () => {
+      await gate;
+      return [];
+    });
+
+    const first = runDecayTick();
+    const second = runDecayTick(); // should not trigger a second getAllEnabledPricingRows call
+
+    resolveFirst();
+    await Promise.all([first, second]);
+
+    expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/twitch/pricing/rewardPricingScheduler.test.ts
+++ b/src/twitch/pricing/rewardPricingScheduler.test.ts
@@ -47,6 +47,34 @@ describe('runDecayTick', () => {
     vi.mocked(getAllEnabledPricingRows).mockRejectedValue(new Error('db down'));
     await expect(runDecayTick()).resolves.toBeUndefined();
   });
+
+  it('processes rows concurrently rather than waiting for each to finish in turn', async () => {
+    vi.mocked(getAllEnabledPricingRows).mockResolvedValue([
+      { streamer_id: 1, twitch_reward_id: 'r1' },
+      { streamer_id: 2, twitch_reward_id: 'r2' },
+    ] as any);
+
+    let resolveFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => { resolveFirst = resolve; });
+    let secondStarted = false;
+
+    vi.mocked(applyDecayTick).mockImplementation(async (streamerId) => {
+      if (streamerId === 1) {
+        await firstGate; // blocks the first row until released below
+      } else {
+        secondStarted = true; // only reachable if the second row didn't wait for the first
+      }
+    });
+
+    const tick = runDecayTick();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(secondStarted).toBe(true); // second row started without waiting for the first to resolve
+
+    resolveFirst();
+    await tick;
+  });
 });
 
 describe('startRewardPricingScheduler / stopRewardPricingScheduler', () => {

--- a/src/twitch/pricing/rewardPricingScheduler.ts
+++ b/src/twitch/pricing/rewardPricingScheduler.ts
@@ -41,8 +41,12 @@ export async function runDecayTick(): Promise<void> {
   return currentTickPromise;
 }
 
-/** Starts the periodic decay-tick interval. Call once at bot startup. */
+/**
+ * Starts the periodic decay-tick interval. Call once at bot startup.
+ * No-ops if already started, so a second call can't leak the original interval handle.
+ */
 export function startRewardPricingScheduler(): void {
+  if (tickTimer) return;
   tickTimer = setInterval(() => {
     runDecayTick().catch((err) => log.error('Decay tick error:', err));
   }, DECAY_POLL_INTERVAL_MS);

--- a/src/twitch/pricing/rewardPricingScheduler.ts
+++ b/src/twitch/pricing/rewardPricingScheduler.ts
@@ -13,6 +13,9 @@ let currentTickPromise: Promise<void> = Promise.resolve();
 /**
  * Applies a decay-only pricing sync to every reward with dynamic pricing enabled, across
  * all streamers, pushing an updated Twitch cost for any reward whose price has drifted.
+ * Rows are processed concurrently — `applyDecayTick` already serializes work per reward via
+ * its own mutation queue, so different rows are independent and don't need to wait on each
+ * other, keeping tick duration from growing linearly with the number of enabled rewards.
  * No-ops (re-uses the in-flight promise) if a tick is already running, so a slow tick
  * can't overlap with the next interval firing.
  */
@@ -22,13 +25,13 @@ export async function runDecayTick(): Promise<void> {
   currentTickPromise = (async () => {
     try {
       const rows = await getAllEnabledPricingRows();
-      for (const row of rows) {
-        try {
-          await applyDecayTick(row.streamer_id, row.twitch_reward_id);
-        } catch (err) {
-          log.error(`Decay tick failed for reward ${row.twitch_reward_id} (streamer ${row.streamer_id}):`, err);
-        }
-      }
+      await Promise.allSettled(
+        rows.map((row) =>
+          applyDecayTick(row.streamer_id, row.twitch_reward_id).catch((err) => {
+            log.error(`Decay tick failed for reward ${row.twitch_reward_id} (streamer ${row.streamer_id}):`, err);
+          }),
+        ),
+      );
     } catch (err) {
       log.error('Failed to load enabled pricing rows:', err);
     } finally {

--- a/src/twitch/pricing/rewardPricingScheduler.ts
+++ b/src/twitch/pricing/rewardPricingScheduler.ts
@@ -1,0 +1,53 @@
+import { createLogger } from '../../shared/logger';
+import { getAllEnabledPricingRows } from '../../db';
+import { applyDecayTick } from './rewardPricingService';
+
+const log = createLogger('RewardPricingScheduler');
+
+const DECAY_POLL_INTERVAL_MS = 5 * 60_000;
+
+let tickTimer: ReturnType<typeof setInterval> | null = null;
+let tickRunning = false;
+let currentTickPromise: Promise<void> = Promise.resolve();
+
+/**
+ * Applies a decay-only pricing sync to every reward with dynamic pricing enabled, across
+ * all streamers, pushing an updated Twitch cost for any reward whose price has drifted.
+ * No-ops (re-uses the in-flight promise) if a tick is already running, so a slow tick
+ * can't overlap with the next interval firing.
+ */
+export async function runDecayTick(): Promise<void> {
+  if (tickRunning) return currentTickPromise;
+  tickRunning = true;
+  currentTickPromise = (async () => {
+    try {
+      const rows = await getAllEnabledPricingRows();
+      for (const row of rows) {
+        try {
+          await applyDecayTick(row.streamer_id, row.twitch_reward_id);
+        } catch (err) {
+          log.error(`Decay tick failed for reward ${row.twitch_reward_id} (streamer ${row.streamer_id}):`, err);
+        }
+      }
+    } catch (err) {
+      log.error('Failed to load enabled pricing rows:', err);
+    } finally {
+      tickRunning = false;
+    }
+  })();
+  return currentTickPromise;
+}
+
+/** Starts the periodic decay-tick interval. Call once at bot startup. */
+export function startRewardPricingScheduler(): void {
+  tickTimer = setInterval(() => {
+    runDecayTick().catch((err) => log.error('Decay tick error:', err));
+  }, DECAY_POLL_INTERVAL_MS);
+  log.info(`Started — decay tick every ${DECAY_POLL_INTERVAL_MS / 1000}s`);
+}
+
+/** Stops the periodic decay-tick interval and awaits any in-flight tick before returning. */
+export async function stopRewardPricingScheduler(): Promise<void> {
+  if (tickTimer) { clearInterval(tickTimer); tickTimer = null; }
+  await currentTickPromise;
+}

--- a/src/twitch/pricing/rewardPricingService.test.ts
+++ b/src/twitch/pricing/rewardPricingService.test.ts
@@ -6,6 +6,7 @@ vi.mock('../../db', () => ({
   getPricingForReward: vi.fn(),
   recordPricingUpdate: vi.fn(),
   markPricingUnsupported: vi.fn(),
+  deletePricingConfig: vi.fn(),
   getGlobalPricingSettings: vi.fn(),
   getStreamerById: vi.fn(),
 }));
@@ -17,11 +18,12 @@ vi.mock('../twitchApi', () => {
 });
 
 import {
-  getPricingForReward, recordPricingUpdate, markPricingUnsupported, getGlobalPricingSettings, getStreamerById,
+  getPricingForReward, recordPricingUpdate, markPricingUnsupported, deletePricingConfig,
+  getGlobalPricingSettings, getStreamerById,
 } from '../../db';
 import { getValidToken } from '../eventsub/twitchApiEventSub';
 import { updateRewardCost, TwitchRewardUnsupportedError } from '../twitchApi';
-import { applyRedemptionPricing, applyDecayTick } from './rewardPricingService';
+import { applyRedemptionPricing, applyDecayTick, resetAndDeletePricing } from './rewardPricingService';
 
 const settings = { decay_half_life_periods: 3, redemption_increment: 0.1 };
 const streamer = { id: 1, twitch_user_id: 'bc1', eventsub_access_token: 'tok' } as any;
@@ -49,6 +51,7 @@ beforeEach(() => {
   vi.mocked(getGlobalPricingSettings).mockResolvedValue(settings);
   vi.mocked(getStreamerById).mockResolvedValue(streamer);
   vi.mocked(getValidToken).mockResolvedValue('user-token');
+  vi.mocked(deletePricingConfig).mockResolvedValue(undefined);
 });
 
 describe('applyRedemptionPricing', () => {
@@ -156,5 +159,69 @@ describe('applyDecayTick', () => {
     const [, , demandArg] = vi.mocked(recordPricingUpdate).mock.calls[0];
     // decay(0.5, 300, 300, 3) = 0.5 * 2^(-1/3) ≈ 0.39700
     expect(demandArg).toBeCloseTo(0.397, 2);
+  });
+});
+
+describe('resetAndDeletePricing', () => {
+  it('resets the Twitch cost to base_cost, then deletes the config', async () => {
+    vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ base_cost: 200 }));
+    await resetAndDeletePricing(42, 1, 'rwd1');
+    expect(updateRewardCost).toHaveBeenCalledWith('bc1', 'rwd1', 200, 'user-token');
+    expect(deletePricingConfig).toHaveBeenCalledWith(42, 1);
+    const [resetOrder] = vi.mocked(updateRewardCost).mock.invocationCallOrder;
+    const [deleteOrder] = vi.mocked(deletePricingConfig).mock.invocationCallOrder;
+    expect(resetOrder).toBeLessThan(deleteOrder);
+  });
+
+  it('skips the reset (but still deletes) when the reward is marked unsupported', async () => {
+    vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ twitch_unsupported: true }));
+    await resetAndDeletePricing(42, 1, 'rwd1');
+    expect(updateRewardCost).not.toHaveBeenCalled();
+    expect(deletePricingConfig).toHaveBeenCalledWith(42, 1);
+  });
+
+  it('skips the reset (but still deletes) when the row no longer exists', async () => {
+    vi.mocked(getPricingForReward).mockResolvedValue(null);
+    await resetAndDeletePricing(42, 1, 'rwd1');
+    expect(updateRewardCost).not.toHaveBeenCalled();
+    expect(deletePricingConfig).toHaveBeenCalledWith(42, 1);
+  });
+
+  it('still deletes when the Twitch reset fails', async () => {
+    vi.mocked(getPricingForReward).mockResolvedValue(makeRow());
+    vi.mocked(updateRewardCost).mockRejectedValueOnce(new Error('twitch down'));
+    await expect(resetAndDeletePricing(42, 1, 'rwd1')).resolves.toBeUndefined();
+    expect(deletePricingConfig).toHaveBeenCalledWith(42, 1);
+  });
+
+  it('serializes with a concurrent applyDecayTick on the same reward key', async () => {
+    const order: string[] = [];
+    let resolveFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => { resolveFirst = resolve; });
+
+    vi.mocked(getPricingForReward).mockImplementation(async () => {
+      order.push('read');
+      if (order.filter((o) => o === 'read').length === 1) {
+        await firstGate; // the decay tick's read blocks here until released
+      }
+      return makeRow();
+    });
+    vi.mocked(deletePricingConfig).mockImplementation(async () => {
+      order.push('delete');
+    });
+    vi.mocked(recordPricingUpdate).mockImplementation(async () => {
+      order.push('write');
+    });
+
+    const decayTick = applyDecayTick(1, 'rwd1');
+    const del = resetAndDeletePricing(42, 1, 'rwd1'); // same key — must wait for the decay tick to finish
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(order).toEqual(['read']); // the delete's read hasn't happened yet — it's queued behind the decay tick
+
+    resolveFirst();
+    await Promise.all([decayTick, del]);
+    expect(order).toEqual(['read', 'write', 'read', 'delete']);
   });
 });

--- a/src/twitch/pricing/rewardPricingService.test.ts
+++ b/src/twitch/pricing/rewardPricingService.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../shared/logger', () => ({ createLogger: () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn() }) }));
+
+vi.mock('../../db', () => ({
+  getPricingForReward: vi.fn(),
+  recordPricingUpdate: vi.fn(),
+  getGlobalPricingSettings: vi.fn(),
+  getStreamerById: vi.fn(),
+}));
+
+vi.mock('../eventsub/twitchApiEventSub', () => ({ getValidToken: vi.fn() }));
+vi.mock('../twitchApi', () => ({ updateRewardCost: vi.fn() }));
+
+import {
+  getPricingForReward, recordPricingUpdate, getGlobalPricingSettings, getStreamerById,
+} from '../../db';
+import { getValidToken } from '../eventsub/twitchApiEventSub';
+import { updateRewardCost } from '../twitchApi';
+import { applyRedemptionPricing, applyDecayTick } from './rewardPricingService';
+
+const settings = { decay_half_life_periods: 3, redemption_increment: 0.1 };
+const streamer = { id: 1, twitch_user_id: 'bc1', eventsub_access_token: 'tok' } as any;
+
+function makeRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 1,
+    streamer_id: 1,
+    twitch_reward_id: 'rwd1',
+    enabled: true,
+    base_cost: 200,
+    cooldown_seconds: 300,
+    max_multiplier: 4,
+    curve: 1.5,
+    demand: 0,
+    demand_updated_at: String(Date.now()),
+    last_pushed_cost: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getGlobalPricingSettings).mockResolvedValue(settings);
+  vi.mocked(getStreamerById).mockResolvedValue(streamer);
+  vi.mocked(getValidToken).mockResolvedValue('user-token');
+});
+
+describe('applyRedemptionPricing', () => {
+  it('no-ops (no DB write, no Twitch call) when no pricing config exists', async () => {
+    vi.mocked(getPricingForReward).mockResolvedValue(null);
+    await applyRedemptionPricing(1, 'rwd1');
+    expect(updateRewardCost).not.toHaveBeenCalled();
+    expect(recordPricingUpdate).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when pricing is disabled for the reward', async () => {
+    vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ enabled: false }));
+    await applyRedemptionPricing(1, 'rwd1');
+    expect(updateRewardCost).not.toHaveBeenCalled();
+    expect(recordPricingUpdate).not.toHaveBeenCalled();
+  });
+
+  it('pushes the new cost to Twitch when it differs from last_pushed_cost', async () => {
+    vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
+    await applyRedemptionPricing(1, 'rwd1');
+    expect(updateRewardCost).toHaveBeenCalledWith('bc1', 'rwd1', expect.any(Number), 'user-token');
+    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), expect.any(Number));
+  });
+
+  it('skips the Twitch call when the recomputed price equals last_pushed_cost', async () => {
+    // demand pinned at 1 (max), last_pushed_cost already at the max price -> redemption increment
+    // still saturates at demand=1, so price stays the same as last_pushed_cost.
+    const maxPrice = Math.round(200 * (1 + Math.pow(1, 1.5) * 4)); // 1000
+    vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 1, demand_updated_at: String(Date.now()), last_pushed_cost: maxPrice }));
+    await applyRedemptionPricing(1, 'rwd1');
+    expect(updateRewardCost).not.toHaveBeenCalled();
+    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), maxPrice);
+  });
+
+  it('swallows a Twitch push failure but still persists the recalculated demand', async () => {
+    vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
+    vi.mocked(updateRewardCost).mockRejectedValue(new Error('Twitch down'));
+    await expect(applyRedemptionPricing(1, 'rwd1')).resolves.toBeUndefined();
+    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), null);
+  });
+
+  it('skips the push (but still persists demand) when no valid token is available', async () => {
+    vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
+    vi.mocked(getValidToken).mockResolvedValue(null);
+    await applyRedemptionPricing(1, 'rwd1');
+    expect(updateRewardCost).not.toHaveBeenCalled();
+    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), null);
+  });
+
+  it('serializes two concurrent calls on the same reward key', async () => {
+    const order: string[] = [];
+    let resolveFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => { resolveFirst = resolve; });
+
+    vi.mocked(getPricingForReward).mockImplementation(async () => {
+      order.push('read');
+      if (order.filter((o) => o === 'read').length === 1) {
+        await firstGate; // first call blocks here until released
+      }
+      return makeRow({ demand: 0, last_pushed_cost: null });
+    });
+    vi.mocked(recordPricingUpdate).mockImplementation(async () => {
+      order.push('write');
+    });
+
+    const first = applyRedemptionPricing(1, 'rwd1');
+    const second = applyRedemptionPricing(1, 'rwd1'); // same key — must wait for first to finish
+
+    // Give the second call a chance to run if it were (incorrectly) not serialized.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(order).toEqual(['read']); // second call's read hasn't happened yet — it's queued behind the first
+
+    resolveFirst();
+    await Promise.all([first, second]);
+    expect(order).toEqual(['read', 'write', 'read', 'write']);
+  });
+
+  it('does not serialize calls on different reward keys', async () => {
+    vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
+    await Promise.all([
+      applyRedemptionPricing(1, 'rwd1'),
+      applyRedemptionPricing(1, 'rwd2'),
+    ]);
+    expect(recordPricingUpdate).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('applyDecayTick', () => {
+  it('applies decay without the redemption increment', async () => {
+    vi.mocked(getPricingForReward).mockResolvedValue(makeRow({
+      demand: 0.5,
+      demand_updated_at: String(Date.now() - 300_000), // 300s elapsed, cooldown=300s -> 1 period of decay
+      last_pushed_cost: null,
+    }));
+    await applyDecayTick(1, 'rwd1');
+    const [, , demandArg] = vi.mocked(recordPricingUpdate).mock.calls[0];
+    // decay(0.5, 300, 300, 3) = 0.5 * 2^(-1/3) ≈ 0.39700
+    expect(demandArg).toBeCloseTo(0.397, 2);
+  });
+});

--- a/src/twitch/pricing/rewardPricingService.test.ts
+++ b/src/twitch/pricing/rewardPricingService.test.ts
@@ -5,18 +5,22 @@ vi.mock('../../shared/logger', () => ({ createLogger: () => ({ warn: vi.fn(), er
 vi.mock('../../db', () => ({
   getPricingForReward: vi.fn(),
   recordPricingUpdate: vi.fn(),
+  markPricingUnsupported: vi.fn(),
   getGlobalPricingSettings: vi.fn(),
   getStreamerById: vi.fn(),
 }));
 
 vi.mock('../eventsub/twitchApiEventSub', () => ({ getValidToken: vi.fn() }));
-vi.mock('../twitchApi', () => ({ updateRewardCost: vi.fn() }));
+vi.mock('../twitchApi', () => {
+  class TwitchRewardUnsupportedError extends Error {}
+  return { updateRewardCost: vi.fn(), TwitchRewardUnsupportedError };
+});
 
 import {
-  getPricingForReward, recordPricingUpdate, getGlobalPricingSettings, getStreamerById,
+  getPricingForReward, recordPricingUpdate, markPricingUnsupported, getGlobalPricingSettings, getStreamerById,
 } from '../../db';
 import { getValidToken } from '../eventsub/twitchApiEventSub';
-import { updateRewardCost } from '../twitchApi';
+import { updateRewardCost, TwitchRewardUnsupportedError } from '../twitchApi';
 import { applyRedemptionPricing, applyDecayTick } from './rewardPricingService';
 
 const settings = { decay_half_life_periods: 3, redemption_increment: 0.1 };
@@ -35,6 +39,7 @@ function makeRow(overrides: Partial<Record<string, unknown>> = {}) {
     demand: 0,
     demand_updated_at: String(Date.now()),
     last_pushed_cost: null,
+    twitch_unsupported: false,
     ...overrides,
   };
 }
@@ -66,6 +71,14 @@ describe('applyRedemptionPricing', () => {
     await applyRedemptionPricing(1, 'rwd1');
     expect(updateRewardCost).toHaveBeenCalledWith('bc1', 'rwd1', expect.any(Number), 'user-token');
     expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), expect.any(Number));
+  });
+
+  it('marks the reward unsupported and disables it on a 403, without recording demand', async () => {
+    vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
+    vi.mocked(updateRewardCost).mockRejectedValue(new TwitchRewardUnsupportedError('403'));
+    await applyRedemptionPricing(1, 'rwd1');
+    expect(markPricingUnsupported).toHaveBeenCalledWith(1, 'rwd1');
+    expect(recordPricingUpdate).not.toHaveBeenCalled();
   });
 
   it('skips the Twitch call when the recomputed price equals last_pushed_cost', async () => {

--- a/src/twitch/pricing/rewardPricingService.ts
+++ b/src/twitch/pricing/rewardPricingService.ts
@@ -1,0 +1,91 @@
+import { createMutationQueue } from '../../shared/mutationQueue';
+import {
+  getPricingForReward, recordPricingUpdate, getGlobalPricingSettings, getStreamerById,
+} from '../../db';
+import { getValidToken } from '../eventsub/twitchApiEventSub';
+import { updateRewardCost } from '../twitchApi';
+import { computePrice, decayDemand, applyRedemption } from './rewardPricingMath';
+import { createLogger } from '../../shared/logger';
+
+const log = createLogger('RewardPricing');
+
+// Serializes read-modify-write cycles per reward, so a redemption and a concurrent
+// decay-scheduler tick on the same reward never race each other. Different rewards
+// (different keys) run fully concurrently.
+const pricingQueue = createMutationQueue<string>();
+
+function queueKey(streamerId: number, twitchRewardId: string): string {
+  return `${streamerId}:${twitchRewardId}`;
+}
+
+/**
+ * Recomputes demand and price for one reward and persists the result, pushing the new
+ * cost to Twitch only when it differs from the last pushed cost. No-ops entirely (no DB
+ * write, no Twitch call) when the reward has no pricing config or dynamic pricing is
+ * disabled for it — this is where "optional per reward" is enforced. A failure resolving
+ * the streamer's token or pushing to Twitch is caught and logged; the recalculated demand
+ * is still persisted so the price is simply retried on the next redemption/decay tick.
+ *
+ * @param streamerId - DB row ID of the owning streamer.
+ * @param twitchRewardId - Twitch reward UUID.
+ * @param applyIncrement - True for a redemption (decay + increment); false for a decay-only tick.
+ */
+async function syncRewardPrice(streamerId: number, twitchRewardId: string, applyIncrement: boolean): Promise<void> {
+  const row = await getPricingForReward(streamerId, twitchRewardId);
+  if (!row || !row.enabled) return;
+
+  const settings = await getGlobalPricingSettings();
+  const elapsedSeconds = Math.max(0, (Date.now() - Number(row.demand_updated_at)) / 1000);
+  const newDemand = applyIncrement
+    ? applyRedemption(row.demand, elapsedSeconds, row.cooldown_seconds, settings.decay_half_life_periods, settings.redemption_increment)
+    : decayDemand(row.demand, elapsedSeconds, row.cooldown_seconds, settings.decay_half_life_periods);
+
+  const newCost = computePrice(newDemand, {
+    baseCost: row.base_cost,
+    cooldownSeconds: row.cooldown_seconds,
+    maxMultiplier: row.max_multiplier,
+    curve: row.curve,
+  });
+
+  let lastPushedCost = row.last_pushed_cost;
+  if (newCost !== row.last_pushed_cost) {
+    try {
+      const streamer = await getStreamerById(streamerId);
+      const token = streamer ? await getValidToken(streamer) : null;
+      if (streamer?.twitch_user_id && token) {
+        await updateRewardCost(streamer.twitch_user_id, twitchRewardId, newCost, token);
+        lastPushedCost = newCost;
+      } else {
+        log.warn(`No valid broadcaster token for streamer ${streamerId} — skipping Twitch price push for reward ${twitchRewardId}`);
+      }
+    } catch (err) {
+      log.error(`Failed to push new price for reward ${twitchRewardId}:`, err);
+    }
+  }
+
+  await recordPricingUpdate(streamerId, twitchRewardId, newDemand, Date.now(), lastPushedCost);
+}
+
+/**
+ * Applies a single redemption to a reward's dynamic pricing: decays for elapsed time,
+ * adds the global redemption increment, and pushes the new price to Twitch if it changed.
+ * Called from the EventSub redemption handler.
+ *
+ * @param streamerId - DB row ID of the owning streamer.
+ * @param twitchRewardId - Twitch reward UUID that was redeemed.
+ */
+export async function applyRedemptionPricing(streamerId: number, twitchRewardId: string): Promise<void> {
+  await pricingQueue.run(queueKey(streamerId, twitchRewardId), () => syncRewardPrice(streamerId, twitchRewardId, true));
+}
+
+/**
+ * Applies decay-only (no redemption increment) to a reward's dynamic pricing and pushes
+ * the new price to Twitch if it changed. Called by the periodic decay scheduler, and as a
+ * best-effort immediate resync after an admin edits a reward's pricing config.
+ *
+ * @param streamerId - DB row ID of the owning streamer.
+ * @param twitchRewardId - Twitch reward UUID.
+ */
+export async function applyDecayTick(streamerId: number, twitchRewardId: string): Promise<void> {
+  await pricingQueue.run(queueKey(streamerId, twitchRewardId), () => syncRewardPrice(streamerId, twitchRewardId, false));
+}

--- a/src/twitch/pricing/rewardPricingService.ts
+++ b/src/twitch/pricing/rewardPricingService.ts
@@ -1,9 +1,9 @@
 import { createMutationQueue } from '../../shared/mutationQueue';
 import {
-  getPricingForReward, recordPricingUpdate, getGlobalPricingSettings, getStreamerById,
+  getPricingForReward, recordPricingUpdate, markPricingUnsupported, getGlobalPricingSettings, getStreamerById,
 } from '../../db';
 import { getValidToken } from '../eventsub/twitchApiEventSub';
-import { updateRewardCost } from '../twitchApi';
+import { updateRewardCost, TwitchRewardUnsupportedError } from '../twitchApi';
 import { computePrice, decayDemand, applyRedemption } from './rewardPricingMath';
 import { createLogger } from '../../shared/logger';
 
@@ -22,9 +22,12 @@ function queueKey(streamerId: number, twitchRewardId: string): string {
  * Recomputes demand and price for one reward and persists the result, pushing the new
  * cost to Twitch only when it differs from the last pushed cost. No-ops entirely (no DB
  * write, no Twitch call) when the reward has no pricing config or dynamic pricing is
- * disabled for it — this is where "optional per reward" is enforced. A failure resolving
- * the streamer's token or pushing to Twitch is caught and logged; the recalculated demand
- * is still persisted so the price is simply retried on the next redemption/decay tick.
+ * disabled for it — this is where "optional per reward" is enforced. A transient failure
+ * resolving the streamer's token or pushing to Twitch is caught and logged; the recalculated
+ * demand is still persisted so the price is simply retried on the next redemption/decay tick.
+ * A 403 from Twitch (the reward was created outside this app and can never be managed by it)
+ * is treated as permanent instead: the row is disabled via `markPricingUnsupported` and demand
+ * is intentionally not persisted, since the row won't be read again until re-enabled.
  *
  * @param streamerId - DB row ID of the owning streamer.
  * @param twitchRewardId - Twitch reward UUID.
@@ -59,6 +62,11 @@ async function syncRewardPrice(streamerId: number, twitchRewardId: string, apply
         log.warn(`No valid broadcaster token for streamer ${streamerId} — skipping Twitch price push for reward ${twitchRewardId}`);
       }
     } catch (err) {
+      if (err instanceof TwitchRewardUnsupportedError) {
+        log.warn(`Reward ${twitchRewardId} (streamer ${streamerId}) can't be managed by this app — disabling dynamic pricing:`, err);
+        await markPricingUnsupported(streamerId, twitchRewardId);
+        return; // markPricingUnsupported already disabled the row; no need to also record demand.
+      }
       log.error(`Failed to push new price for reward ${twitchRewardId}:`, err);
     }
   }

--- a/src/twitch/pricing/rewardPricingService.ts
+++ b/src/twitch/pricing/rewardPricingService.ts
@@ -1,6 +1,7 @@
 import { createMutationQueue } from '../../shared/mutationQueue';
 import {
-  getPricingForReward, recordPricingUpdate, markPricingUnsupported, getGlobalPricingSettings, getStreamerById,
+  getPricingForReward, recordPricingUpdate, markPricingUnsupported, deletePricingConfig,
+  getGlobalPricingSettings, getStreamerById,
 } from '../../db';
 import { getValidToken } from '../eventsub/twitchApiEventSub';
 import { updateRewardCost, TwitchRewardUnsupportedError } from '../twitchApi';
@@ -96,4 +97,34 @@ export async function applyRedemptionPricing(streamerId: number, twitchRewardId:
  */
 export async function applyDecayTick(streamerId: number, twitchRewardId: string): Promise<void> {
   await pricingQueue.run(queueKey(streamerId, twitchRewardId), () => syncRewardPrice(streamerId, twitchRewardId, false));
+}
+
+/**
+ * Resets a reward's Twitch-side cost to its base_cost, then deletes its pricing config —
+ * both inside the same queued operation as `applyRedemptionPricing`/`applyDecayTick` for this
+ * reward, so a concurrent redemption or decay tick can never push a new price into the gap
+ * between the reset and the delete (which would otherwise leave Twitch at a stale cost with
+ * no config left to ever reconcile it). Skips the reset (but still deletes) when the reward
+ * was marked unsupported, since Twitch would just reject the reset too.
+ *
+ * @param id - Primary key of the `reward_pricing` row to delete.
+ * @param streamerId - DB row ID of the owning streamer.
+ * @param twitchRewardId - Twitch reward UUID.
+ */
+export async function resetAndDeletePricing(id: number, streamerId: number, twitchRewardId: string): Promise<void> {
+  await pricingQueue.run(queueKey(streamerId, twitchRewardId), async () => {
+    const row = await getPricingForReward(streamerId, twitchRewardId);
+    if (row && !row.twitch_unsupported) {
+      try {
+        const streamer = await getStreamerById(streamerId);
+        const token = streamer ? await getValidToken(streamer) : null;
+        if (streamer?.twitch_user_id && token) {
+          await updateRewardCost(streamer.twitch_user_id, twitchRewardId, row.base_cost, token);
+        }
+      } catch (err) {
+        log.warn(`Failed to reset Twitch reward cost before deleting pricing config for reward ${twitchRewardId}:`, err);
+      }
+    }
+    await deletePricingConfig(id, streamerId);
+  });
 }

--- a/src/twitch/pricing/rewardPricingService.ts
+++ b/src/twitch/pricing/rewardPricingService.ts
@@ -39,7 +39,8 @@ async function syncRewardPrice(streamerId: number, twitchRewardId: string, apply
   if (!row || !row.enabled) return;
 
   const settings = await getGlobalPricingSettings();
-  const elapsedSeconds = Math.max(0, (Date.now() - Number(row.demand_updated_at)) / 1000);
+  const now = Date.now();
+  const elapsedSeconds = Math.max(0, (now - Number(row.demand_updated_at)) / 1000);
   const newDemand = applyIncrement
     ? applyRedemption(row.demand, elapsedSeconds, row.cooldown_seconds, settings.decay_half_life_periods, settings.redemption_increment)
     : decayDemand(row.demand, elapsedSeconds, row.cooldown_seconds, settings.decay_half_life_periods);
@@ -72,7 +73,7 @@ async function syncRewardPrice(streamerId: number, twitchRewardId: string, apply
     }
   }
 
-  await recordPricingUpdate(streamerId, twitchRewardId, newDemand, Date.now(), lastPushedCost);
+  await recordPricingUpdate(streamerId, twitchRewardId, newDemand, now, lastPushedCost);
 }
 
 /**

--- a/src/twitch/twitchApi.test.ts
+++ b/src/twitch/twitchApi.test.ts
@@ -6,7 +6,10 @@ vi.mock('../shared/config', () => ({
   TWITCH_CLIENT_SECRET: 'test-client-secret',
 }));
 
-import { getUsers, getStreams, getChannelInfo, getSharedChatSession, getAppToken, updateRewardCost } from './twitchApi';
+import {
+  getUsers, getStreams, getChannelInfo, getSharedChatSession, getAppToken,
+  updateRewardCost, TwitchRewardUnsupportedError,
+} from './twitchApi';
 
 const TOKEN_RESPONSE = { access_token: 'test-token', expires_in: 3600 };
 
@@ -174,5 +177,15 @@ describe('updateRewardCost', () => {
     vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(500, {}));
     await expect(updateRewardCost('bc1', 'rwd1', 500, 'user-token')).rejects.toThrow();
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws TwitchRewardUnsupportedError specifically on a 403 response', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(403, {}));
+    await expect(updateRewardCost('bc1', 'rwd1', 500, 'user-token')).rejects.toBeInstanceOf(TwitchRewardUnsupportedError);
+  });
+
+  it('does not throw TwitchRewardUnsupportedError for other non-OK statuses', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(400, {}));
+    await expect(updateRewardCost('bc1', 'rwd1', 500, 'user-token')).rejects.not.toBeInstanceOf(TwitchRewardUnsupportedError);
   });
 });

--- a/src/twitch/twitchApi.test.ts
+++ b/src/twitch/twitchApi.test.ts
@@ -6,7 +6,7 @@ vi.mock('../shared/config', () => ({
   TWITCH_CLIENT_SECRET: 'test-client-secret',
 }));
 
-import { getUsers, getStreams, getChannelInfo, getSharedChatSession, getAppToken } from './twitchApi';
+import { getUsers, getStreams, getChannelInfo, getSharedChatSession, getAppToken, updateRewardCost } from './twitchApi';
 
 const TOKEN_RESPONSE = { access_token: 'test-token', expires_in: 3600 };
 
@@ -149,5 +149,30 @@ describe('getSharedChatSession', () => {
     vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(200, TOKEN_RESPONSE));
     await getAppToken();
     expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('updateRewardCost', () => {
+  it('sends a PATCH with broadcaster_id and id query params and the new cost in the body', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(200, {}));
+    await updateRewardCost('bc1', 'rwd1', 500, 'user-token');
+
+    const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+    expect(String(url)).toContain('broadcaster_id=bc1');
+    expect(String(url)).toContain('id=rwd1');
+    expect(init?.method).toBe('PATCH');
+    expect(init?.body).toBe(JSON.stringify({ cost: 500 }));
+    expect((init?.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+  });
+
+  it('throws with the response status on a non-OK response', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(400, {}));
+    await expect(updateRewardCost('bc1', 'rwd1', 500, 'user-token')).rejects.toThrow('updateRewardCost failed: 400');
+  });
+
+  it('does not retry on failure (single fetch call)', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(500, {}));
+    await expect(updateRewardCost('bc1', 'rwd1', 500, 'user-token')).rejects.toThrow();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/twitch/twitchApi.ts
+++ b/src/twitch/twitchApi.ts
@@ -181,6 +181,29 @@ export async function getCustomRewards(broadcasterId: string, userToken: string)
   return data.data;
 }
 
+/**
+ * Updates a custom reward's cost on Twitch via Helix. Requires a broadcaster user token
+ * (app tokens cannot manage custom rewards). Not wrapped in fetchHelixWithRetry — the
+ * caller (dynamic pricing sync) already tolerates a failed push by retrying on the next
+ * redemption/decay tick, so retrying here would just duplicate that behaviour.
+ *
+ * @param broadcasterId - Twitch user ID of the reward's broadcaster.
+ * @param rewardId - Twitch reward UUID to update.
+ * @param cost - The new channel-point cost.
+ * @param userToken - Broadcaster OAuth user token with the channel:manage:redemptions scope.
+ */
+export async function updateRewardCost(broadcasterId: string, rewardId: string, cost: number, userToken: string): Promise<void> {
+  const res = await twitchFetch(
+    `https://api.twitch.tv/helix/channel_points/custom_rewards?broadcaster_id=${encodeURIComponent(broadcasterId)}&id=${encodeURIComponent(rewardId)}`,
+    {
+      method: 'PATCH',
+      headers: { ...authHeaders(userToken), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ cost }),
+    },
+  );
+  if (!res.ok) throw new Error(`[TwitchAPI] updateRewardCost failed: ${res.status}`);
+}
+
 export interface SharedChatParticipant {
   broadcaster_id: string;
   broadcaster_login: string;

--- a/src/twitch/twitchApi.ts
+++ b/src/twitch/twitchApi.ts
@@ -182,6 +182,18 @@ export async function getCustomRewards(broadcasterId: string, userToken: string)
 }
 
 /**
+ * Thrown when Twitch returns 403 for a reward cost update — Twitch only allows the app that
+ * created a reward to manage it, so this is permanent for a given reward, not a transient
+ * failure worth retrying.
+ */
+export class TwitchRewardUnsupportedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TwitchRewardUnsupportedError';
+  }
+}
+
+/**
  * Updates a custom reward's cost on Twitch via Helix. Requires a broadcaster user token
  * (app tokens cannot manage custom rewards). Not wrapped in fetchHelixWithRetry — the
  * caller (dynamic pricing sync) already tolerates a failed push by retrying on the next
@@ -191,6 +203,8 @@ export async function getCustomRewards(broadcasterId: string, userToken: string)
  * @param rewardId - Twitch reward UUID to update.
  * @param cost - The new channel-point cost.
  * @param userToken - Broadcaster OAuth user token with the channel:manage:redemptions scope.
+ * @throws {TwitchRewardUnsupportedError} When Twitch returns 403 (reward created by a
+ *   different client_id, or channel points aren't available for the broadcaster).
  */
 export async function updateRewardCost(broadcasterId: string, rewardId: string, cost: number, userToken: string): Promise<void> {
   const res = await twitchFetch(
@@ -201,6 +215,7 @@ export async function updateRewardCost(broadcasterId: string, rewardId: string, 
       body: JSON.stringify({ cost }),
     },
   );
+  if (res.status === 403) throw new TwitchRewardUnsupportedError(`[TwitchAPI] updateRewardCost: reward ${rewardId} cannot be managed by this app (403)`);
   if (!res.ok) throw new Error(`[TwitchAPI] updateRewardCost failed: ${res.status}`);
 }
 

--- a/src/web/routes/pricingAdmin.test.ts
+++ b/src/web/routes/pricingAdmin.test.ts
@@ -97,6 +97,15 @@ describe('GET /', () => {
     expect(res.body.rewards[0].previewPrice).toBe(1000);
   });
 
+  it('renders with an empty reward list when getCustomRewards throws', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(getCustomRewards).mockRejectedValue(new Error('Twitch down'));
+
+    const res = await supertest(buildApp()).get('/');
+    expect(res.status).toBe(200);
+    expect(res.body.rewards).toEqual([]);
+  });
+
   it('leaves config/previewPrice null for a reward with no pricing config yet', async () => {
     vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
     vi.mocked(getCustomRewards).mockResolvedValue([{ id: 'rwd1', title: 'Cool Reward', cost: 200, is_enabled: true }]);

--- a/src/web/routes/pricingAdmin.test.ts
+++ b/src/web/routes/pricingAdmin.test.ts
@@ -106,6 +106,34 @@ describe('GET /', () => {
     expect(res.body.rewards).toEqual([]);
   });
 
+  it('renders with an empty reward list (not a 500) when getValidToken throws', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(getValidToken).mockRejectedValue(new Error('token refresh failed'));
+
+    const res = await supertest(buildApp()).get('/');
+    expect(res.status).toBe(200);
+    expect(res.body.rewards).toEqual([]);
+    expect(getCustomRewards).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a pricing config as an unlinked row when its reward no longer appears on Twitch', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(getCustomRewards).mockResolvedValue([]); // reward no longer listed by Twitch
+    vi.mocked(getPricingConfigsForStreamer).mockResolvedValue([{
+      id: 1, streamer_id: 123, twitch_reward_id: 'orphaned-rwd', enabled: true,
+      base_cost: 200, cooldown_seconds: 300, max_multiplier: 4, curve: 1.5,
+      demand: 0.5, demand_updated_at: '1700000000000', last_pushed_cost: 300,
+    }] as any);
+
+    const res = await supertest(buildApp()).get('/');
+    expect(res.status).toBe(200);
+    expect(res.body.rewards).toHaveLength(1);
+    expect(res.body.rewards[0].twitchReward).toBeNull();
+    expect(res.body.rewards[0].rewardId).toBe('orphaned-rwd');
+    expect(res.body.rewards[0].config.id).toBe(1);
+    expect(res.body.rewards[0].previewPrice).not.toBeNull();
+  });
+
   it('leaves config/previewPrice null for a reward with no pricing config yet', async () => {
     vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
     vi.mocked(getCustomRewards).mockResolvedValue([{ id: 'rwd1', title: 'Cool Reward', cost: 200, is_enabled: true }]);

--- a/src/web/routes/pricingAdmin.test.ts
+++ b/src/web/routes/pricingAdmin.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../db', () => ({
+  getStreamerByDiscordId: vi.fn(),
+  getPricingConfigsForStreamer: vi.fn(),
+  getGlobalPricingSettings: vi.fn(),
+}));
+
+vi.mock('../csrf', () => ({
+  csrfProtection: (req: any, _res: any, next: any) => {
+    req.csrfToken = () => 'test-csrf-token';
+    next();
+  },
+}));
+
+vi.mock('../middleware', () => ({
+  requireAuth: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock('../../twitch/twitchApi', () => ({
+  getCustomRewards: vi.fn(),
+}));
+
+vi.mock('../../twitch/eventsub/twitchApiEventSub', () => ({
+  getValidToken: vi.fn(),
+}));
+
+vi.mock('../../shared/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+}));
+
+vi.mock('./pricingAdminMutations', async () => {
+  const { Router } = await import('express');
+  return { router: Router() };
+});
+
+import express from 'express';
+import supertest from 'supertest';
+import router from './pricingAdmin';
+import { getStreamerByDiscordId, getPricingConfigsForStreamer, getGlobalPricingSettings } from '../../db';
+import { getCustomRewards } from '../../twitch/twitchApi';
+import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
+
+type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3; isOwner: boolean };
+const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: 0, isOwner: false };
+const OWNER: SessionUser = { ...USER, discordId: '200000000000000002', isOwner: true };
+
+const MOCK_STREAMER = { id: 123, twitch_user_id: 'twitch123', twitch_name: 'teststreamer', discord_id: USER.discordId };
+
+function buildApp(sessionUser: SessionUser = USER) {
+  const app = express();
+  app.use(express.urlencoded({ extended: false }));
+  app.use((req: any, res: any, next: any) => {
+    req.session = { user: sessionUser };
+    res.render = (view: string, locals?: any) => res.json({ view, ...locals });
+    next();
+  });
+  app.use(router);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
+  vi.mocked(getPricingConfigsForStreamer).mockResolvedValue([]);
+  vi.mocked(getCustomRewards).mockResolvedValue([]);
+  vi.mocked(getValidToken).mockResolvedValue('token');
+  vi.mocked(getGlobalPricingSettings).mockResolvedValue({ decay_half_life_periods: 3, redemption_increment: 0.1 });
+});
+
+describe('GET /', () => {
+  it('renders with streamer=null when the user is not a streamer', async () => {
+    const res = await supertest(buildApp()).get('/');
+    expect(res.status).toBe(200);
+    expect(res.body.streamer).toBeNull();
+  });
+
+  it('returns 500 when getStreamerByDiscordId throws', async () => {
+    vi.mocked(getStreamerByDiscordId).mockRejectedValue(new Error('DB down'));
+    const res = await supertest(buildApp()).get('/');
+    expect(res.status).toBe(500);
+  });
+
+  it('merges live Twitch rewards with existing pricing config and computes a preview price', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(getCustomRewards).mockResolvedValue([{ id: 'rwd1', title: 'Cool Reward', cost: 200, is_enabled: true }]);
+    vi.mocked(getPricingConfigsForStreamer).mockResolvedValue([{
+      id: 1, streamer_id: 123, twitch_reward_id: 'rwd1', enabled: true,
+      base_cost: 200, cooldown_seconds: 300, max_multiplier: 4, curve: 1.5,
+      demand: 1, demand_updated_at: '1700000000000', last_pushed_cost: 1000,
+    }] as any);
+
+    const res = await supertest(buildApp()).get('/');
+    expect(res.status).toBe(200);
+    expect(res.body.rewards).toHaveLength(1);
+    expect(res.body.rewards[0].config.id).toBe(1);
+    expect(res.body.rewards[0].previewPrice).toBe(1000);
+  });
+
+  it('leaves config/previewPrice null for a reward with no pricing config yet', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(getCustomRewards).mockResolvedValue([{ id: 'rwd1', title: 'Cool Reward', cost: 200, is_enabled: true }]);
+
+    const res = await supertest(buildApp()).get('/');
+    expect(res.body.rewards[0].config).toBeNull();
+    expect(res.body.rewards[0].previewPrice).toBeNull();
+  });
+
+  it('does not include global settings for a non-owner', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp(USER)).get('/');
+    expect(res.body.isOwner).toBe(false);
+    expect(res.body.globalSettings).toBeNull();
+    expect(getGlobalPricingSettings).not.toHaveBeenCalled();
+  });
+
+  it('includes global settings for the bot owner', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp(OWNER)).get('/');
+    expect(res.body.isOwner).toBe(true);
+    expect(res.body.globalSettings).toEqual({ decay_half_life_periods: 3, redemption_increment: 0.1 });
+  });
+});

--- a/src/web/routes/pricingAdmin.test.ts
+++ b/src/web/routes/pricingAdmin.test.ts
@@ -87,7 +87,7 @@ describe('GET /', () => {
     vi.mocked(getPricingConfigsForStreamer).mockResolvedValue([{
       id: 1, streamer_id: 123, twitch_reward_id: 'rwd1', enabled: true,
       base_cost: 200, cooldown_seconds: 300, max_multiplier: 4, curve: 1.5,
-      demand: 1, demand_updated_at: '1700000000000', last_pushed_cost: 1000,
+      demand: 1, demand_updated_at: '1700000000000', last_pushed_cost: 1000, twitch_unsupported: false,
     }] as any);
 
     const res = await supertest(buildApp()).get('/');
@@ -122,7 +122,7 @@ describe('GET /', () => {
     vi.mocked(getPricingConfigsForStreamer).mockResolvedValue([{
       id: 1, streamer_id: 123, twitch_reward_id: 'orphaned-rwd', enabled: true,
       base_cost: 200, cooldown_seconds: 300, max_multiplier: 4, curve: 1.5,
-      demand: 0.5, demand_updated_at: '1700000000000', last_pushed_cost: 300,
+      demand: 0.5, demand_updated_at: '1700000000000', last_pushed_cost: 300, twitch_unsupported: false,
     }] as any);
 
     const res = await supertest(buildApp()).get('/');
@@ -132,6 +132,20 @@ describe('GET /', () => {
     expect(res.body.rewards[0].rewardId).toBe('orphaned-rwd');
     expect(res.body.rewards[0].config.id).toBe(1);
     expect(res.body.rewards[0].previewPrice).not.toBeNull();
+  });
+
+  it('passes through twitch_unsupported so the view can show the disabled-by-Twitch message', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(getCustomRewards).mockResolvedValue([{ id: 'rwd1', title: 'Cool Reward', cost: 200, is_enabled: true }]);
+    vi.mocked(getPricingConfigsForStreamer).mockResolvedValue([{
+      id: 1, streamer_id: 123, twitch_reward_id: 'rwd1', enabled: false,
+      base_cost: 200, cooldown_seconds: 300, max_multiplier: 4, curve: 1.5,
+      demand: 0.2, demand_updated_at: '1700000000000', last_pushed_cost: null, twitch_unsupported: true,
+    }] as any);
+
+    const res = await supertest(buildApp()).get('/');
+    expect(res.body.rewards[0].config.twitch_unsupported).toBe(true);
+    expect(res.body.rewards[0].config.enabled).toBe(false);
   });
 
   it('leaves config/previewPrice null for a reward with no pricing config yet', async () => {

--- a/src/web/routes/pricingAdmin.ts
+++ b/src/web/routes/pricingAdmin.ts
@@ -5,6 +5,7 @@ import { requireAuth } from '../middleware';
 import { getStreamerByDiscordId } from '../../db';
 import type { DbStreamerEventSub } from '../../db';
 import { getPricingConfigsForStreamer, getGlobalPricingSettings } from '../../db';
+import type { RewardPricingRow } from '../../db';
 import { getCustomRewards, TwitchCustomReward } from '../../twitch/twitchApi';
 import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
 import { computePrice } from '../../twitch/pricing/rewardPricingMath';
@@ -20,12 +21,20 @@ const KNOWN_ERRORS = new Set([
 ]);
 const KNOWN_SUCCESSES = new Set(['pricing_saved', 'pricing_deleted', 'global_settings_saved']);
 
-/** Fetches the streamer's live Twitch custom rewards, or an empty list if not connected. */
+/** One row on the pricing admin page: a live Twitch reward, an "unlinked" orphaned config, or both merged. */
+interface PricingRewardRow {
+  rewardId: string;
+  twitchReward: TwitchCustomReward | null;
+  config: RewardPricingRow | null;
+  previewPrice: number | null;
+}
+
+/** Fetches the streamer's live Twitch custom rewards, or an empty list if not connected or on any failure. */
 async function fetchTwitchRewards(streamer: DbStreamerEventSub): Promise<TwitchCustomReward[]> {
   if (!streamer.twitch_user_id) return [];
-  const token = await getValidToken(streamer);
-  if (!token) return [];
   try {
+    const token = await getValidToken(streamer);
+    if (!token) return [];
     return await getCustomRewards(streamer.twitch_user_id, token);
   } catch (err) {
     log.warn('Failed to fetch Twitch custom rewards:', err);
@@ -48,7 +57,9 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
       : [[], []];
 
     const configByRewardId = new Map(pricingConfigs.map((c) => [c.twitch_reward_id, c]));
-    const rewards = twitchRewards.map((tr) => {
+    const matchedRewardIds = new Set(twitchRewards.map((tr) => tr.id));
+
+    const rewards: PricingRewardRow[] = twitchRewards.map((tr) => {
       const config = configByRewardId.get(tr.id) ?? null;
       const previewPrice = config
         ? computePrice(config.demand, {
@@ -58,8 +69,26 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
             curve: config.curve,
           })
         : null;
-      return { twitchReward: tr, config, previewPrice };
+      return { rewardId: tr.id, twitchReward: tr, config, previewPrice };
     });
+
+    // Configs whose reward no longer appears on Twitch (deleted, or the streamer's token
+    // lacks the scope to list it) still get processed by the decay scheduler — surface them
+    // as "unlinked" rows so they aren't invisible/unmanageable from this page.
+    for (const config of pricingConfigs) {
+      if (matchedRewardIds.has(config.twitch_reward_id)) continue;
+      rewards.push({
+        rewardId: config.twitch_reward_id,
+        twitchReward: null,
+        config,
+        previewPrice: computePrice(config.demand, {
+          baseCost: config.base_cost,
+          cooldownSeconds: config.cooldown_seconds,
+          maxMultiplier: config.max_multiplier,
+          curve: config.curve,
+        }),
+      });
+    }
 
     const isOwner = req.session.user?.isOwner ?? false;
     const globalSettings = isOwner ? await getGlobalPricingSettings() : null;

--- a/src/web/routes/pricingAdmin.ts
+++ b/src/web/routes/pricingAdmin.ts
@@ -29,6 +29,16 @@ interface PricingRewardRow {
   previewPrice: number | null;
 }
 
+/** Computes the live preview price for a reward's current demand, from its pricing config. */
+function previewPriceFor(config: RewardPricingRow): number {
+  return computePrice(config.demand, {
+    baseCost: config.base_cost,
+    cooldownSeconds: config.cooldown_seconds,
+    maxMultiplier: config.max_multiplier,
+    curve: config.curve,
+  });
+}
+
 /** Fetches the streamer's live Twitch custom rewards, or an empty list if not connected or on any failure. */
 async function fetchTwitchRewards(streamer: DbStreamerEventSub): Promise<TwitchCustomReward[]> {
   if (!streamer.twitch_user_id) return [];
@@ -61,15 +71,7 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
 
     const rewards: PricingRewardRow[] = twitchRewards.map((tr) => {
       const config = configByRewardId.get(tr.id) ?? null;
-      const previewPrice = config
-        ? computePrice(config.demand, {
-            baseCost: config.base_cost,
-            cooldownSeconds: config.cooldown_seconds,
-            maxMultiplier: config.max_multiplier,
-            curve: config.curve,
-          })
-        : null;
-      return { rewardId: tr.id, twitchReward: tr, config, previewPrice };
+      return { rewardId: tr.id, twitchReward: tr, config, previewPrice: config ? previewPriceFor(config) : null };
     });
 
     // Configs whose reward no longer appears on Twitch (deleted, or the streamer's token
@@ -77,17 +79,7 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
     // as "unlinked" rows so they aren't invisible/unmanageable from this page.
     for (const config of pricingConfigs) {
       if (matchedRewardIds.has(config.twitch_reward_id)) continue;
-      rewards.push({
-        rewardId: config.twitch_reward_id,
-        twitchReward: null,
-        config,
-        previewPrice: computePrice(config.demand, {
-          baseCost: config.base_cost,
-          cooldownSeconds: config.cooldown_seconds,
-          maxMultiplier: config.max_multiplier,
-          curve: config.curve,
-        }),
-      });
+      rewards.push({ rewardId: config.twitch_reward_id, twitchReward: null, config, previewPrice: previewPriceFor(config) });
     }
 
     const isOwner = req.session.user?.isOwner ?? false;

--- a/src/web/routes/pricingAdmin.ts
+++ b/src/web/routes/pricingAdmin.ts
@@ -1,0 +1,85 @@
+import { createLogger } from '../../shared/logger';
+import { Router } from 'express';
+import { csrfProtection } from '../csrf';
+import { requireAuth } from '../middleware';
+import { getStreamerByDiscordId } from '../../db';
+import type { DbStreamerEventSub } from '../../db';
+import { getPricingConfigsForStreamer, getGlobalPricingSettings } from '../../db';
+import { getCustomRewards, TwitchCustomReward } from '../../twitch/twitchApi';
+import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
+import { computePrice } from '../../twitch/pricing/rewardPricingMath';
+import { filterQueryParam, renderError, renderView } from './shared';
+import { router as pricingMutationsRouter } from './pricingAdminMutations';
+
+const log = createLogger('PricingAdmin');
+const router = Router();
+
+const KNOWN_ERRORS = new Set([
+  'not_a_streamer', 'invalid_reward_id', 'invalid_config', 'save_failed', 'invalid_id',
+  'delete_failed', 'not_owner', 'invalid_settings',
+]);
+const KNOWN_SUCCESSES = new Set(['pricing_saved', 'pricing_deleted', 'global_settings_saved']);
+
+/** Fetches the streamer's live Twitch custom rewards, or an empty list if not connected. */
+async function fetchTwitchRewards(streamer: DbStreamerEventSub): Promise<TwitchCustomReward[]> {
+  if (!streamer.twitch_user_id) return [];
+  const token = await getValidToken(streamer);
+  if (!token) return [];
+  try {
+    return await getCustomRewards(streamer.twitch_user_id, token);
+  } catch (err) {
+    log.warn('Failed to fetch Twitch custom rewards:', err);
+    return [];
+  }
+}
+
+/**
+ * GET /pricing — renders the dynamic pricing admin page: the streamer's live Twitch
+ * rewards merged with any existing pricing config (including a live price preview),
+ * and — only for the bot owner — the bot-wide decay/increment settings.
+ * @param req - Express request; reads `req.session.user`, `error`, and `success` query params.
+ * @param res - Express response; renders the `pricingAdmin` view, or a 500 error page on failure.
+ */
+router.get('/', requireAuth, csrfProtection, async (req, res) => {
+  try {
+    const streamer = await getStreamerByDiscordId(req.session.user!.discordId);
+    const [pricingConfigs, twitchRewards] = streamer
+      ? await Promise.all([getPricingConfigsForStreamer(streamer.id), fetchTwitchRewards(streamer)])
+      : [[], []];
+
+    const configByRewardId = new Map(pricingConfigs.map((c) => [c.twitch_reward_id, c]));
+    const rewards = twitchRewards.map((tr) => {
+      const config = configByRewardId.get(tr.id) ?? null;
+      const previewPrice = config
+        ? computePrice(config.demand, {
+            baseCost: config.base_cost,
+            cooldownSeconds: config.cooldown_seconds,
+            maxMultiplier: config.max_multiplier,
+            curve: config.curve,
+          })
+        : null;
+      return { twitchReward: tr, config, previewPrice };
+    });
+
+    const isOwner = req.session.user?.isOwner ?? false;
+    const globalSettings = isOwner ? await getGlobalPricingSettings() : null;
+
+    renderView(res, 'pricingAdmin', {
+      user: req.session.user,
+      csrfToken: req.csrfToken(),
+      streamer: streamer ?? null,
+      rewards,
+      isOwner,
+      globalSettings,
+      error: filterQueryParam(req.query.error, KNOWN_ERRORS),
+      success: filterQueryParam(req.query.success, KNOWN_SUCCESSES),
+    });
+  } catch (err) {
+    log.error('Pricing settings page error:', err);
+    renderError(res, 500, 'Failed to load pricing settings.', req.session.user);
+  }
+});
+
+router.use(pricingMutationsRouter);
+
+export default router;

--- a/src/web/routes/pricingAdminMutations.test.ts
+++ b/src/web/routes/pricingAdminMutations.test.ts
@@ -6,6 +6,8 @@ vi.mock('../../shared/logger', () => ({
 
 vi.mock('../../db', () => ({
   getStreamerByDiscordId: vi.fn(),
+  getStreamerById: vi.fn(),
+  getPricingConfigById: vi.fn(),
   upsertPricingConfig: vi.fn(),
   deletePricingConfig: vi.fn(),
   saveGlobalPricingSettings: vi.fn(),
@@ -23,12 +25,18 @@ vi.mock('../middleware', () => ({
 }));
 
 vi.mock('../../twitch/pricing/rewardPricingService', () => ({ applyDecayTick: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../../twitch/eventsub/twitchApiEventSub', () => ({ getValidToken: vi.fn() }));
+vi.mock('../../twitch/twitchApi', () => ({ updateRewardCost: vi.fn() }));
 
 import express from 'express';
 import supertest from 'supertest';
 import { router } from './pricingAdminMutations';
-import { getStreamerByDiscordId, upsertPricingConfig, deletePricingConfig, saveGlobalPricingSettings } from '../../db';
+import {
+  getStreamerByDiscordId, getStreamerById, getPricingConfigById, upsertPricingConfig, deletePricingConfig, saveGlobalPricingSettings,
+} from '../../db';
 import { applyDecayTick } from '../../twitch/pricing/rewardPricingService';
+import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
+import { updateRewardCost } from '../../twitch/twitchApi';
 
 type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3; isOwner: boolean };
 const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: 0, isOwner: false };
@@ -52,6 +60,10 @@ function buildApp(sessionUser: SessionUser = USER) {
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
+  vi.mocked(getStreamerById).mockResolvedValue(MOCK_STREAMER as any);
+  vi.mocked(getPricingConfigById).mockResolvedValue(null);
+  vi.mocked(getValidToken).mockResolvedValue('user-token');
+  vi.mocked(updateRewardCost).mockResolvedValue(undefined);
   vi.mocked(upsertPricingConfig).mockResolvedValue(undefined);
   vi.mocked(deletePricingConfig).mockResolvedValue(undefined);
   vi.mocked(saveGlobalPricingSettings).mockResolvedValue(undefined);
@@ -151,6 +163,58 @@ describe('POST /settings/rewards/:id/delete', () => {
     vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
     const res = await supertest(buildApp()).post('/settings/rewards/5/delete');
     expect(res.headers.location).toBe('/pricing?success=pricing_deleted');
+    expect(deletePricingConfig).toHaveBeenCalledWith(5, MOCK_STREAMER.id);
+  });
+
+  it('resets the Twitch reward cost to base_cost before deleting', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(getPricingConfigById).mockResolvedValue({
+      id: 5, twitch_reward_id: VALID_REWARD_ID, base_cost: 200, twitch_unsupported: false,
+    } as any);
+
+    const res = await supertest(buildApp()).post('/settings/rewards/5/delete');
+
+    expect(res.headers.location).toBe('/pricing?success=pricing_deleted');
+    expect(updateRewardCost).toHaveBeenCalledWith(MOCK_STREAMER.twitch_user_id, VALID_REWARD_ID, 200, 'user-token');
+    expect(deletePricingConfig).toHaveBeenCalledWith(5, MOCK_STREAMER.id);
+    const [resetCallOrder] = vi.mocked(updateRewardCost).mock.invocationCallOrder;
+    const [deleteCallOrder] = vi.mocked(deletePricingConfig).mock.invocationCallOrder;
+    expect(resetCallOrder).toBeLessThan(deleteCallOrder);
+  });
+
+  it('skips the Twitch reset for a reward already marked unsupported', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(getPricingConfigById).mockResolvedValue({
+      id: 5, twitch_reward_id: VALID_REWARD_ID, base_cost: 200, twitch_unsupported: true,
+    } as any);
+
+    await supertest(buildApp()).post('/settings/rewards/5/delete');
+
+    expect(updateRewardCost).not.toHaveBeenCalled();
+    expect(deletePricingConfig).toHaveBeenCalledWith(5, MOCK_STREAMER.id);
+  });
+
+  it('still deletes when the Twitch reset fails', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(getPricingConfigById).mockResolvedValue({
+      id: 5, twitch_reward_id: VALID_REWARD_ID, base_cost: 200, twitch_unsupported: false,
+    } as any);
+    vi.mocked(updateRewardCost).mockRejectedValueOnce(new Error('twitch down'));
+
+    const res = await supertest(buildApp()).post('/settings/rewards/5/delete');
+
+    expect(res.headers.location).toBe('/pricing?success=pricing_deleted');
+    expect(deletePricingConfig).toHaveBeenCalledWith(5, MOCK_STREAMER.id);
+  });
+
+  it('skips the Twitch reset (but still deletes) when no config is found', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(getPricingConfigById).mockResolvedValue(null);
+
+    const res = await supertest(buildApp()).post('/settings/rewards/5/delete');
+
+    expect(res.headers.location).toBe('/pricing?success=pricing_deleted');
+    expect(updateRewardCost).not.toHaveBeenCalled();
     expect(deletePricingConfig).toHaveBeenCalledWith(5, MOCK_STREAMER.id);
   });
 

--- a/src/web/routes/pricingAdminMutations.test.ts
+++ b/src/web/routes/pricingAdminMutations.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../shared/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+}));
+
+vi.mock('../../db', () => ({
+  getStreamerByDiscordId: vi.fn(),
+  upsertPricingConfig: vi.fn(),
+  deletePricingConfig: vi.fn(),
+  saveGlobalPricingSettings: vi.fn(),
+}));
+
+vi.mock('../csrf', () => ({
+  csrfProtection: (req: any, _res: any, next: any) => {
+    req.csrfToken = () => 'test-csrf-token';
+    next();
+  },
+}));
+
+vi.mock('../middleware', () => ({
+  requireAuth: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock('../../twitch/pricing/rewardPricingService', () => ({ applyDecayTick: vi.fn().mockResolvedValue(undefined) }));
+
+import express from 'express';
+import supertest from 'supertest';
+import { router } from './pricingAdminMutations';
+import { getStreamerByDiscordId, upsertPricingConfig, deletePricingConfig, saveGlobalPricingSettings } from '../../db';
+import { applyDecayTick } from '../../twitch/pricing/rewardPricingService';
+
+type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3; isOwner: boolean };
+const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: 0, isOwner: false };
+const OWNER: SessionUser = { ...USER, discordId: '200000000000000002', isOwner: true };
+
+const MOCK_STREAMER = { id: 123, twitch_user_id: 'twitch123', twitch_name: 'teststreamer', discord_id: USER.discordId };
+
+const VALID_REWARD_ID = '12345678-1234-1234-8234-123456789abc';
+
+function buildApp(sessionUser: SessionUser = USER) {
+  const app = express();
+  app.use(express.urlencoded({ extended: false }));
+  app.use((req: any, _res: any, next: any) => {
+    req.session = { user: sessionUser };
+    next();
+  });
+  app.use(router);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
+  vi.mocked(upsertPricingConfig).mockResolvedValue(undefined);
+  vi.mocked(deletePricingConfig).mockResolvedValue(undefined);
+  vi.mocked(saveGlobalPricingSettings).mockResolvedValue(undefined);
+});
+
+describe('POST /settings/rewards', () => {
+  it('redirects with error when user is not a streamer', async () => {
+    const res = await supertest(buildApp())
+      .post('/settings/rewards')
+      .type('form')
+      .send({ twitch_reward_id: VALID_REWARD_ID, base_cost: '200', cooldown_seconds: '300', max_multiplier: '4', curve: '1.5' });
+    expect(res.headers.location).toBe('/pricing?error=not_a_streamer');
+  });
+
+  it('redirects with error for an invalid reward id', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp())
+      .post('/settings/rewards')
+      .type('form')
+      .send({ twitch_reward_id: 'not-a-uuid', base_cost: '200', cooldown_seconds: '300', max_multiplier: '4', curve: '1.5' });
+    expect(res.headers.location).toBe('/pricing?error=invalid_reward_id');
+  });
+
+  it.each([
+    ['base_cost', { base_cost: '0' }],
+    ['cooldown_seconds', { cooldown_seconds: '0' }],
+    ['max_multiplier', { max_multiplier: '-1' }],
+    ['curve', { curve: '0' }],
+  ])('redirects with invalid_config when %s is invalid', async (_name, override) => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp())
+      .post('/settings/rewards')
+      .type('form')
+      .send({
+        twitch_reward_id: VALID_REWARD_ID,
+        base_cost: '200', cooldown_seconds: '300', max_multiplier: '4', curve: '1.5',
+        ...override,
+      });
+    expect(res.headers.location).toBe('/pricing?error=invalid_config');
+  });
+
+  it('saves the config, best-effort resyncs, and redirects to success', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp())
+      .post('/settings/rewards')
+      .type('form')
+      .send({
+        twitch_reward_id: VALID_REWARD_ID,
+        enabled: 'on',
+        base_cost: '200', cooldown_seconds: '300', max_multiplier: '4', curve: '1.5',
+      });
+    expect(res.headers.location).toBe('/pricing?success=pricing_saved');
+    expect(upsertPricingConfig).toHaveBeenCalledWith(MOCK_STREAMER.id, VALID_REWARD_ID, {
+      enabled: true, base_cost: 200, cooldown_seconds: 300, max_multiplier: 4, curve: 1.5,
+    });
+    expect(applyDecayTick).toHaveBeenCalledWith(MOCK_STREAMER.id, VALID_REWARD_ID);
+  });
+
+  it('treats a missing enabled checkbox as false', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    await supertest(buildApp())
+      .post('/settings/rewards')
+      .type('form')
+      .send({ twitch_reward_id: VALID_REWARD_ID, base_cost: '200', cooldown_seconds: '300', max_multiplier: '4', curve: '1.5' });
+    expect(upsertPricingConfig).toHaveBeenCalledWith(MOCK_STREAMER.id, VALID_REWARD_ID, expect.objectContaining({ enabled: false }));
+  });
+
+  it('still redirects to success when the best-effort resync throws', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(applyDecayTick).mockRejectedValueOnce(new Error('twitch down'));
+    const res = await supertest(buildApp())
+      .post('/settings/rewards')
+      .type('form')
+      .send({ twitch_reward_id: VALID_REWARD_ID, base_cost: '200', cooldown_seconds: '300', max_multiplier: '4', curve: '1.5' });
+    expect(res.headers.location).toBe('/pricing?success=pricing_saved');
+  });
+});
+
+describe('POST /settings/rewards/:id/delete', () => {
+  it('redirects with error for an invalid id', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp()).post('/settings/rewards/invalid/delete');
+    expect(res.headers.location).toBe('/pricing?error=invalid_id');
+  });
+
+  it('deletes and redirects to success', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp()).post('/settings/rewards/5/delete');
+    expect(res.headers.location).toBe('/pricing?success=pricing_deleted');
+    expect(deletePricingConfig).toHaveBeenCalledWith(5, MOCK_STREAMER.id);
+  });
+});
+
+describe('POST /settings/global', () => {
+  it('rejects a non-owner even without checking guild access level', async () => {
+    const res = await supertest(buildApp(USER))
+      .post('/settings/global')
+      .type('form')
+      .send({ decay_half_life_periods: '3', redemption_increment: '0.1' });
+    expect(res.headers.location).toBe('/pricing?error=not_owner');
+    expect(saveGlobalPricingSettings).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid decay_half_life_periods for an owner', async () => {
+    const res = await supertest(buildApp(OWNER))
+      .post('/settings/global')
+      .type('form')
+      .send({ decay_half_life_periods: '0', redemption_increment: '0.1' });
+    expect(res.headers.location).toBe('/pricing?error=invalid_settings');
+  });
+
+  it('rejects a redemption_increment above 1', async () => {
+    const res = await supertest(buildApp(OWNER))
+      .post('/settings/global')
+      .type('form')
+      .send({ decay_half_life_periods: '3', redemption_increment: '1.5' });
+    expect(res.headers.location).toBe('/pricing?error=invalid_settings');
+  });
+
+  it('saves and redirects to success for an owner', async () => {
+    const res = await supertest(buildApp(OWNER))
+      .post('/settings/global')
+      .type('form')
+      .send({ decay_half_life_periods: '4', redemption_increment: '0.2' });
+    expect(res.headers.location).toBe('/pricing?success=global_settings_saved');
+    expect(saveGlobalPricingSettings).toHaveBeenCalledWith({ decay_half_life_periods: 4, redemption_increment: 0.2 });
+  });
+});

--- a/src/web/routes/pricingAdminMutations.test.ts
+++ b/src/web/routes/pricingAdminMutations.test.ts
@@ -6,7 +6,6 @@ vi.mock('../../shared/logger', () => ({
 
 vi.mock('../../db', () => ({
   getStreamerByDiscordId: vi.fn(),
-  getStreamerById: vi.fn(),
   getPricingConfigById: vi.fn(),
   upsertPricingConfig: vi.fn(),
   deletePricingConfig: vi.fn(),
@@ -24,19 +23,18 @@ vi.mock('../middleware', () => ({
   requireAuth: (_req: any, _res: any, next: any) => next(),
 }));
 
-vi.mock('../../twitch/pricing/rewardPricingService', () => ({ applyDecayTick: vi.fn().mockResolvedValue(undefined) }));
-vi.mock('../../twitch/eventsub/twitchApiEventSub', () => ({ getValidToken: vi.fn() }));
-vi.mock('../../twitch/twitchApi', () => ({ updateRewardCost: vi.fn() }));
+vi.mock('../../twitch/pricing/rewardPricingService', () => ({
+  applyDecayTick: vi.fn().mockResolvedValue(undefined),
+  resetAndDeletePricing: vi.fn().mockResolvedValue(undefined),
+}));
 
 import express from 'express';
 import supertest from 'supertest';
 import { router } from './pricingAdminMutations';
 import {
-  getStreamerByDiscordId, getStreamerById, getPricingConfigById, upsertPricingConfig, deletePricingConfig, saveGlobalPricingSettings,
+  getStreamerByDiscordId, getPricingConfigById, upsertPricingConfig, deletePricingConfig, saveGlobalPricingSettings,
 } from '../../db';
-import { applyDecayTick } from '../../twitch/pricing/rewardPricingService';
-import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
-import { updateRewardCost } from '../../twitch/twitchApi';
+import { applyDecayTick, resetAndDeletePricing } from '../../twitch/pricing/rewardPricingService';
 
 type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3; isOwner: boolean };
 const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: 0, isOwner: false };
@@ -60,13 +58,12 @@ function buildApp(sessionUser: SessionUser = USER) {
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
-  vi.mocked(getStreamerById).mockResolvedValue(MOCK_STREAMER as any);
   vi.mocked(getPricingConfigById).mockResolvedValue(null);
-  vi.mocked(getValidToken).mockResolvedValue('user-token');
-  vi.mocked(updateRewardCost).mockResolvedValue(undefined);
   vi.mocked(upsertPricingConfig).mockResolvedValue(undefined);
   vi.mocked(deletePricingConfig).mockResolvedValue(undefined);
   vi.mocked(saveGlobalPricingSettings).mockResolvedValue(undefined);
+  vi.mocked(applyDecayTick).mockResolvedValue(undefined);
+  vi.mocked(resetAndDeletePricing).mockResolvedValue(undefined);
 });
 
 describe('POST /settings/rewards', () => {
@@ -166,7 +163,7 @@ describe('POST /settings/rewards/:id/delete', () => {
     expect(deletePricingConfig).toHaveBeenCalledWith(5, MOCK_STREAMER.id);
   });
 
-  it('resets the Twitch reward cost to base_cost before deleting', async () => {
+  it('delegates the reset-and-delete to resetAndDeletePricing when a config exists', async () => {
     vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
     vi.mocked(getPricingConfigById).mockResolvedValue({
       id: 5, twitch_reward_id: VALID_REWARD_ID, base_cost: 200, twitch_unsupported: false,
@@ -175,52 +172,34 @@ describe('POST /settings/rewards/:id/delete', () => {
     const res = await supertest(buildApp()).post('/settings/rewards/5/delete');
 
     expect(res.headers.location).toBe('/pricing?success=pricing_deleted');
-    expect(updateRewardCost).toHaveBeenCalledWith(MOCK_STREAMER.twitch_user_id, VALID_REWARD_ID, 200, 'user-token');
-    expect(deletePricingConfig).toHaveBeenCalledWith(5, MOCK_STREAMER.id);
-    const [resetCallOrder] = vi.mocked(updateRewardCost).mock.invocationCallOrder;
-    const [deleteCallOrder] = vi.mocked(deletePricingConfig).mock.invocationCallOrder;
-    expect(resetCallOrder).toBeLessThan(deleteCallOrder);
+    expect(resetAndDeletePricing).toHaveBeenCalledWith(5, MOCK_STREAMER.id, VALID_REWARD_ID);
+    expect(deletePricingConfig).not.toHaveBeenCalled();
   });
 
-  it('skips the Twitch reset for a reward already marked unsupported', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    vi.mocked(getPricingConfigById).mockResolvedValue({
-      id: 5, twitch_reward_id: VALID_REWARD_ID, base_cost: 200, twitch_unsupported: true,
-    } as any);
-
-    await supertest(buildApp()).post('/settings/rewards/5/delete');
-
-    expect(updateRewardCost).not.toHaveBeenCalled();
-    expect(deletePricingConfig).toHaveBeenCalledWith(5, MOCK_STREAMER.id);
-  });
-
-  it('still deletes when the Twitch reset fails', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    vi.mocked(getPricingConfigById).mockResolvedValue({
-      id: 5, twitch_reward_id: VALID_REWARD_ID, base_cost: 200, twitch_unsupported: false,
-    } as any);
-    vi.mocked(updateRewardCost).mockRejectedValueOnce(new Error('twitch down'));
-
-    const res = await supertest(buildApp()).post('/settings/rewards/5/delete');
-
-    expect(res.headers.location).toBe('/pricing?success=pricing_deleted');
-    expect(deletePricingConfig).toHaveBeenCalledWith(5, MOCK_STREAMER.id);
-  });
-
-  it('skips the Twitch reset (but still deletes) when no config is found', async () => {
+  it('deletes directly (no resetAndDeletePricing) when no config is found', async () => {
     vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
     vi.mocked(getPricingConfigById).mockResolvedValue(null);
 
     const res = await supertest(buildApp()).post('/settings/rewards/5/delete');
 
     expect(res.headers.location).toBe('/pricing?success=pricing_deleted');
-    expect(updateRewardCost).not.toHaveBeenCalled();
+    expect(resetAndDeletePricing).not.toHaveBeenCalled();
     expect(deletePricingConfig).toHaveBeenCalledWith(5, MOCK_STREAMER.id);
   });
 
   it('redirects with delete_failed when deletePricingConfig throws', async () => {
     vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
     vi.mocked(deletePricingConfig).mockRejectedValueOnce(new Error('DB down'));
+    const res = await supertest(buildApp()).post('/settings/rewards/5/delete');
+    expect(res.headers.location).toBe('/pricing?error=delete_failed');
+  });
+
+  it('redirects with delete_failed when resetAndDeletePricing throws', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(getPricingConfigById).mockResolvedValue({
+      id: 5, twitch_reward_id: VALID_REWARD_ID, base_cost: 200, twitch_unsupported: false,
+    } as any);
+    vi.mocked(resetAndDeletePricing).mockRejectedValueOnce(new Error('DB down'));
     const res = await supertest(buildApp()).post('/settings/rewards/5/delete');
     expect(res.headers.location).toBe('/pricing?error=delete_failed');
   });

--- a/src/web/routes/pricingAdminMutations.test.ts
+++ b/src/web/routes/pricingAdminMutations.test.ts
@@ -128,6 +128,16 @@ describe('POST /settings/rewards', () => {
       .send({ twitch_reward_id: VALID_REWARD_ID, base_cost: '200', cooldown_seconds: '300', max_multiplier: '4', curve: '1.5' });
     expect(res.headers.location).toBe('/pricing?success=pricing_saved');
   });
+
+  it('redirects with save_failed when upsertPricingConfig throws', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(upsertPricingConfig).mockRejectedValueOnce(new Error('DB down'));
+    const res = await supertest(buildApp())
+      .post('/settings/rewards')
+      .type('form')
+      .send({ twitch_reward_id: VALID_REWARD_ID, base_cost: '200', cooldown_seconds: '300', max_multiplier: '4', curve: '1.5' });
+    expect(res.headers.location).toBe('/pricing?error=save_failed');
+  });
 });
 
 describe('POST /settings/rewards/:id/delete', () => {
@@ -142,6 +152,13 @@ describe('POST /settings/rewards/:id/delete', () => {
     const res = await supertest(buildApp()).post('/settings/rewards/5/delete');
     expect(res.headers.location).toBe('/pricing?success=pricing_deleted');
     expect(deletePricingConfig).toHaveBeenCalledWith(5, MOCK_STREAMER.id);
+  });
+
+  it('redirects with delete_failed when deletePricingConfig throws', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(deletePricingConfig).mockRejectedValueOnce(new Error('DB down'));
+    const res = await supertest(buildApp()).post('/settings/rewards/5/delete');
+    expect(res.headers.location).toBe('/pricing?error=delete_failed');
   });
 });
 
@@ -178,5 +195,14 @@ describe('POST /settings/global', () => {
       .send({ decay_half_life_periods: '4', redemption_increment: '0.2' });
     expect(res.headers.location).toBe('/pricing?success=global_settings_saved');
     expect(saveGlobalPricingSettings).toHaveBeenCalledWith({ decay_half_life_periods: 4, redemption_increment: 0.2 });
+  });
+
+  it('redirects with save_failed when saveGlobalPricingSettings throws', async () => {
+    vi.mocked(saveGlobalPricingSettings).mockRejectedValueOnce(new Error('DB down'));
+    const res = await supertest(buildApp(OWNER))
+      .post('/settings/global')
+      .type('form')
+      .send({ decay_half_life_periods: '4', redemption_increment: '0.2' });
+    expect(res.headers.location).toBe('/pricing?error=save_failed');
   });
 });

--- a/src/web/routes/pricingAdminMutations.ts
+++ b/src/web/routes/pricingAdminMutations.ts
@@ -1,0 +1,116 @@
+import { createLogger } from '../../shared/logger';
+import { Router } from 'express';
+import { csrfProtection } from '../csrf';
+import { requireAuth } from '../middleware';
+import { upsertPricingConfig, deletePricingConfig, saveGlobalPricingSettings } from '../../db';
+import { logAndRedirectError, parsePositiveIntId } from './shared';
+import {
+  requireStreamer, parsePositiveIntField, parseNonNegativeNumberField, parsePositiveNumberField,
+} from './pricingAdminShared';
+import { applyDecayTick } from '../../twitch/pricing/rewardPricingService';
+
+const log = createLogger('PricingAdminMutations');
+export const router = Router();
+
+const REWARD_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * POST /pricing/settings/rewards — creates or updates a reward's dynamic pricing config.
+ * @param req - Express request; reads `twitch_reward_id`, `enabled`, `base_cost`,
+ *   `cooldown_seconds`, `max_multiplier`, and `curve` from `req.body`.
+ * @param res - Express response; redirects to `/pricing?success=pricing_saved` on success,
+ *   or to `/pricing?error=<code>` if the requester isn't a streamer (`not_a_streamer`),
+ *   the reward ID isn't a valid UUID (`invalid_reward_id`), any config field is invalid
+ *   (`invalid_config`), or saving fails (`save_failed`).
+ */
+router.post('/settings/rewards', requireAuth, csrfProtection, async (req, res) => {
+  try {
+    const streamer = await requireStreamer(req, res);
+    if (!streamer) return;
+
+    const body = req.body as Record<string, string | string[] | undefined>;
+    const twitchRewardId = (typeof body.twitch_reward_id === 'string' ? body.twitch_reward_id : '').trim();
+    if (!REWARD_ID_RE.test(twitchRewardId)) return res.redirect('/pricing?error=invalid_reward_id');
+
+    const baseCost = parsePositiveIntField(body.base_cost);
+    const cooldownSeconds = parsePositiveIntField(body.cooldown_seconds);
+    const maxMultiplier = parseNonNegativeNumberField(body.max_multiplier);
+    const curve = parsePositiveNumberField(body.curve);
+    if (baseCost === null || cooldownSeconds === null || maxMultiplier === null || curve === null) {
+      return res.redirect('/pricing?error=invalid_config');
+    }
+
+    const enabled = !Array.isArray(body.enabled) && body.enabled === 'on';
+
+    await upsertPricingConfig(streamer.id, twitchRewardId, {
+      enabled, base_cost: baseCost, cooldown_seconds: cooldownSeconds, max_multiplier: maxMultiplier, curve,
+    });
+
+    // Best-effort immediate resync so the reward's Twitch-side cost reflects the new
+    // config right away instead of waiting for the next redemption/decay tick.
+    try {
+      await applyDecayTick(streamer.id, twitchRewardId);
+    } catch (err) {
+      log.warn('Immediate pricing resync after save failed:', err);
+    }
+
+    res.redirect('/pricing?success=pricing_saved');
+  } catch (err) {
+    logAndRedirectError({ res, log, logLabel: 'Pricing config save error:', err, basePath: '/pricing', errorCode: 'save_failed' });
+  }
+});
+
+/**
+ * POST /pricing/settings/rewards/:id/delete — deletes a reward's pricing config
+ * belonging to the requesting streamer.
+ * @param req - Express request; reads the `id` route param.
+ * @param res - Express response; redirects to `/pricing?success=pricing_deleted` on success,
+ *   or to `/pricing?error=<code>` if the requester isn't a streamer (`not_a_streamer`),
+ *   `id` is malformed (`invalid_id`), or the delete fails (`delete_failed`).
+ */
+router.post('/settings/rewards/:id/delete', requireAuth, csrfProtection, async (req, res) => {
+  try {
+    const streamer = await requireStreamer(req, res);
+    if (!streamer) return;
+
+    const id = parsePositiveIntId(req.params.id);
+    if (id === null) return res.redirect('/pricing?error=invalid_id');
+
+    await deletePricingConfig(id, streamer.id);
+    res.redirect('/pricing?success=pricing_deleted');
+  } catch (err) {
+    logAndRedirectError({ res, log, logLabel: 'Pricing config delete error:', err, basePath: '/pricing', errorCode: 'delete_failed' });
+  }
+});
+
+/**
+ * POST /pricing/settings/global — updates the bot-wide decay/increment settings shared by
+ * every reward's demand calculations. Restricted to the bot owner (`req.session.user.isOwner`)
+ * since this setting is not scoped to any single guild or streamer.
+ * @param req - Express request; reads `decay_half_life_periods` and `redemption_increment`
+ *   from `req.body`.
+ * @param res - Express response; redirects to `/pricing?success=global_settings_saved` on
+ *   success, or to `/pricing?error=<code>` if the requester isn't the bot owner (`not_owner`),
+ *   a field is invalid (`invalid_settings`), or saving fails (`save_failed`).
+ */
+router.post('/settings/global', requireAuth, csrfProtection, async (req, res) => {
+  try {
+    if (!req.session.user?.isOwner) return res.redirect('/pricing?error=not_owner');
+
+    const body = req.body as Record<string, string | string[] | undefined>;
+    const decayHalfLifePeriods = parsePositiveNumberField(body.decay_half_life_periods);
+    const redemptionIncrement = parseNonNegativeNumberField(body.redemption_increment);
+    if (decayHalfLifePeriods === null || redemptionIncrement === null || redemptionIncrement > 1) {
+      return res.redirect('/pricing?error=invalid_settings');
+    }
+
+    await saveGlobalPricingSettings({
+      decay_half_life_periods: decayHalfLifePeriods,
+      redemption_increment: redemptionIncrement,
+    });
+
+    res.redirect('/pricing?success=global_settings_saved');
+  } catch (err) {
+    logAndRedirectError({ res, log, logLabel: 'Global pricing settings save error:', err, basePath: '/pricing', errorCode: 'save_failed' });
+  }
+});

--- a/src/web/routes/pricingAdminMutations.ts
+++ b/src/web/routes/pricingAdminMutations.ts
@@ -2,12 +2,16 @@ import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
-import { upsertPricingConfig, deletePricingConfig, saveGlobalPricingSettings } from '../../db';
+import {
+  upsertPricingConfig, deletePricingConfig, getPricingConfigById, getStreamerById, saveGlobalPricingSettings,
+} from '../../db';
 import { logAndRedirectError, parsePositiveIntId } from './shared';
 import {
   requireStreamer, parsePositiveIntField, parseNonNegativeNumberField, parsePositiveNumberField,
 } from './pricingAdminShared';
 import { applyDecayTick } from '../../twitch/pricing/rewardPricingService';
+import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
+import { updateRewardCost } from '../../twitch/twitchApi';
 
 const log = createLogger('PricingAdminMutations');
 export const router = Router();
@@ -62,7 +66,10 @@ router.post('/settings/rewards', requireAuth, csrfProtection, async (req, res) =
 
 /**
  * POST /pricing/settings/rewards/:id/delete — deletes a reward's pricing config
- * belonging to the requesting streamer.
+ * belonging to the requesting streamer. Best-effort resets the reward's Twitch-side
+ * cost back to its base_cost first (skipped if the reward was marked unsupported),
+ * since deleting the DB row alone would otherwise leave Twitch permanently stuck at
+ * whatever price dynamic pricing last pushed.
  * @param req - Express request; reads the `id` route param.
  * @param res - Express response; redirects to `/pricing?success=pricing_deleted` on success,
  *   or to `/pricing?error=<code>` if the requester isn't a streamer (`not_a_streamer`),
@@ -75,6 +82,19 @@ router.post('/settings/rewards/:id/delete', requireAuth, csrfProtection, async (
 
     const id = parsePositiveIntId(req.params.id);
     if (id === null) return res.redirect('/pricing?error=invalid_id');
+
+    const config = await getPricingConfigById(id, streamer.id);
+    if (config && !config.twitch_unsupported) {
+      try {
+        const owner = await getStreamerById(streamer.id);
+        const token = owner ? await getValidToken(owner) : null;
+        if (owner?.twitch_user_id && token) {
+          await updateRewardCost(owner.twitch_user_id, config.twitch_reward_id, config.base_cost, token);
+        }
+      } catch (err) {
+        log.warn('Failed to reset Twitch reward cost before deleting pricing config:', err);
+      }
+    }
 
     await deletePricingConfig(id, streamer.id);
     res.redirect('/pricing?success=pricing_deleted');

--- a/src/web/routes/pricingAdminMutations.ts
+++ b/src/web/routes/pricingAdminMutations.ts
@@ -3,15 +3,13 @@ import { Router } from 'express';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
 import {
-  upsertPricingConfig, deletePricingConfig, getPricingConfigById, getStreamerById, saveGlobalPricingSettings,
+  upsertPricingConfig, deletePricingConfig, getPricingConfigById, saveGlobalPricingSettings,
 } from '../../db';
 import { logAndRedirectError, parsePositiveIntId } from './shared';
 import {
   requireStreamer, parsePositiveIntField, parseNonNegativeNumberField, parsePositiveNumberField,
 } from './pricingAdminShared';
-import { applyDecayTick } from '../../twitch/pricing/rewardPricingService';
-import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
-import { updateRewardCost } from '../../twitch/twitchApi';
+import { applyDecayTick, resetAndDeletePricing } from '../../twitch/pricing/rewardPricingService';
 
 const log = createLogger('PricingAdminMutations');
 export const router = Router();
@@ -69,7 +67,9 @@ router.post('/settings/rewards', requireAuth, csrfProtection, async (req, res) =
  * belonging to the requesting streamer. Best-effort resets the reward's Twitch-side
  * cost back to its base_cost first (skipped if the reward was marked unsupported),
  * since deleting the DB row alone would otherwise leave Twitch permanently stuck at
- * whatever price dynamic pricing last pushed.
+ * whatever price dynamic pricing last pushed. The reset and delete run inside the
+ * same queued pricing operation as a concurrent redemption/decay tick for this
+ * reward, so neither can race the other into leaving a stale, unreconcilable cost.
  * @param req - Express request; reads the `id` route param.
  * @param res - Express response; redirects to `/pricing?success=pricing_deleted` on success,
  *   or to `/pricing?error=<code>` if the requester isn't a streamer (`not_a_streamer`),
@@ -84,19 +84,12 @@ router.post('/settings/rewards/:id/delete', requireAuth, csrfProtection, async (
     if (id === null) return res.redirect('/pricing?error=invalid_id');
 
     const config = await getPricingConfigById(id, streamer.id);
-    if (config && !config.twitch_unsupported) {
-      try {
-        const owner = await getStreamerById(streamer.id);
-        const token = owner ? await getValidToken(owner) : null;
-        if (owner?.twitch_user_id && token) {
-          await updateRewardCost(owner.twitch_user_id, config.twitch_reward_id, config.base_cost, token);
-        }
-      } catch (err) {
-        log.warn('Failed to reset Twitch reward cost before deleting pricing config:', err);
-      }
+    if (config) {
+      await resetAndDeletePricing(id, streamer.id, config.twitch_reward_id);
+    } else {
+      await deletePricingConfig(id, streamer.id);
     }
 
-    await deletePricingConfig(id, streamer.id);
     res.redirect('/pricing?success=pricing_deleted');
   } catch (err) {
     logAndRedirectError({ res, log, logLabel: 'Pricing config delete error:', err, basePath: '/pricing', errorCode: 'delete_failed' });

--- a/src/web/routes/pricingAdminShared.test.ts
+++ b/src/web/routes/pricingAdminShared.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../db', () => ({ getStreamerByDiscordId: vi.fn() }));
+
+import { getStreamerByDiscordId } from '../../db';
+import {
+  requireStreamer, parsePositiveIntField, parseNonNegativeNumberField, parsePositiveNumberField,
+} from './pricingAdminShared';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('requireStreamer', () => {
+  function makeReqRes(discordId = '123') {
+    const req = { session: { user: { discordId } } } as any;
+    const res = { redirect: vi.fn() } as any;
+    return { req, res };
+  }
+
+  it('returns the streamer when found', async () => {
+    const streamer = { id: 1 };
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(streamer as any);
+    const { req, res } = makeReqRes();
+    const result = await requireStreamer(req, res);
+    expect(result).toBe(streamer);
+    expect(res.redirect).not.toHaveBeenCalled();
+  });
+
+  it('redirects to /pricing?error=not_a_streamer and returns null when not found', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
+    const { req, res } = makeReqRes();
+    const result = await requireStreamer(req, res);
+    expect(result).toBeNull();
+    expect(res.redirect).toHaveBeenCalledWith('/pricing?error=not_a_streamer');
+  });
+});
+
+describe('parsePositiveIntField', () => {
+  it('accepts a positive integer string', () => {
+    expect(parsePositiveIntField('200')).toBe(200);
+  });
+
+  it('rejects an array (repeated field)', () => {
+    expect(parsePositiveIntField(['1', '2'])).toBeNull();
+  });
+
+  it('rejects zero', () => {
+    expect(parsePositiveIntField('0')).toBeNull();
+  });
+
+  it('rejects non-numeric input', () => {
+    expect(parsePositiveIntField('abc')).toBeNull();
+  });
+
+  it('rejects a decimal', () => {
+    expect(parsePositiveIntField('1.5')).toBeNull();
+  });
+
+  it('rejects undefined', () => {
+    expect(parsePositiveIntField(undefined)).toBeNull();
+  });
+
+  it('rejects an empty string', () => {
+    expect(parsePositiveIntField('')).toBeNull();
+  });
+});
+
+describe('parseNonNegativeNumberField', () => {
+  it('accepts zero', () => {
+    expect(parseNonNegativeNumberField('0')).toBe(0);
+  });
+
+  it('accepts a positive decimal', () => {
+    expect(parseNonNegativeNumberField('4.5')).toBe(4.5);
+  });
+
+  it('rejects a negative number', () => {
+    expect(parseNonNegativeNumberField('-1')).toBeNull();
+  });
+
+  it('rejects an array (repeated field)', () => {
+    expect(parseNonNegativeNumberField(['1', '2'])).toBeNull();
+  });
+
+  it('rejects undefined', () => {
+    expect(parseNonNegativeNumberField(undefined)).toBeNull();
+  });
+
+  it('rejects an empty string instead of silently coercing to 0', () => {
+    expect(parseNonNegativeNumberField('')).toBeNull();
+  });
+
+  it('rejects a whitespace-only string instead of silently coercing to 0', () => {
+    expect(parseNonNegativeNumberField('   ')).toBeNull();
+  });
+});
+
+describe('parsePositiveNumberField', () => {
+  it('accepts a positive decimal', () => {
+    expect(parsePositiveNumberField('1.5')).toBe(1.5);
+  });
+
+  it('rejects zero', () => {
+    expect(parsePositiveNumberField('0')).toBeNull();
+  });
+
+  it('rejects a negative number', () => {
+    expect(parsePositiveNumberField('-1')).toBeNull();
+  });
+
+  it('rejects an array (repeated field)', () => {
+    expect(parsePositiveNumberField(['1', '2'])).toBeNull();
+  });
+
+  it('rejects undefined', () => {
+    expect(parsePositiveNumberField(undefined)).toBeNull();
+  });
+
+  it('rejects an empty string instead of silently coercing to 0', () => {
+    expect(parsePositiveNumberField('')).toBeNull();
+  });
+
+  it('rejects a whitespace-only string instead of silently coercing to 0', () => {
+    expect(parsePositiveNumberField('   ')).toBeNull();
+  });
+});

--- a/src/web/routes/pricingAdminShared.ts
+++ b/src/web/routes/pricingAdminShared.ts
@@ -1,0 +1,48 @@
+import type { Request, Response } from 'express';
+import { getStreamerByDiscordId } from '../../db';
+import type { DbStreamerEventSub } from '../../db';
+
+/**
+ * Loads the requesting user's streamer record, redirecting to `/pricing?error=not_a_streamer`
+ * if they aren't one. Kept separate from overlayAdminShared's requireStreamer (which redirects
+ * to `/overlay/settings`), so the two admin pages stay fully decoupled.
+ */
+export async function requireStreamer(req: Request, res: Response): Promise<DbStreamerEventSub | null> {
+  const streamer = await getStreamerByDiscordId(req.session.user!.discordId);
+  if (!streamer) {
+    res.redirect('/pricing?error=not_a_streamer');
+    return null;
+  }
+  return streamer;
+}
+
+/**
+ * Parses a required positive integer form field (e.g. base_cost, cooldown_seconds).
+ * Rejects arrays (repeated fields), non-numeric input, and non-positive values.
+ */
+export function parsePositiveIntField(value: string | string[] | undefined): number | null {
+  if (Array.isArray(value)) return null;
+  if (typeof value !== 'string' || !/^\d+$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+/**
+ * Parses a required non-negative decimal form field (e.g. max_multiplier, redemption_increment).
+ * Rejects arrays (repeated fields), non-numeric input, and negative values.
+ */
+export function parseNonNegativeNumberField(value: string | string[] | undefined): number | null {
+  if (Array.isArray(value)) return null;
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 0 ? n : null;
+}
+
+/**
+ * Parses a required strictly-positive decimal form field (e.g. curve, decay_half_life_periods).
+ * Rejects arrays (repeated fields), non-numeric input, and non-positive values.
+ */
+export function parsePositiveNumberField(value: string | string[] | undefined): number | null {
+  if (Array.isArray(value)) return null;
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}

--- a/src/web/routes/pricingAdminShared.ts
+++ b/src/web/routes/pricingAdminShared.ts
@@ -29,20 +29,22 @@ export function parsePositiveIntField(value: string | string[] | undefined): num
 
 /**
  * Parses a required non-negative decimal form field (e.g. max_multiplier, redemption_increment).
- * Rejects arrays (repeated fields), non-numeric input, and negative values.
+ * Rejects arrays (repeated fields), empty/whitespace input, non-numeric input, and negative values.
  */
 export function parseNonNegativeNumberField(value: string | string[] | undefined): number | null {
   if (Array.isArray(value)) return null;
+  if (typeof value !== 'string' || value.trim() === '') return null;
   const n = Number(value);
   return Number.isFinite(n) && n >= 0 ? n : null;
 }
 
 /**
  * Parses a required strictly-positive decimal form field (e.g. curve, decay_half_life_periods).
- * Rejects arrays (repeated fields), non-numeric input, and non-positive values.
+ * Rejects arrays (repeated fields), empty/whitespace input, non-numeric input, and non-positive values.
  */
 export function parsePositiveNumberField(value: string | string[] | undefined): number | null {
   if (Array.isArray(value)) return null;
+  if (typeof value !== 'string' || value.trim() === '') return null;
   const n = Number(value);
   return Number.isFinite(n) && n > 0 ? n : null;
 }

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -103,6 +103,7 @@ vi.mock('./routes/streamdeckKeys', () => ({ default: emptyRouter() }));
 vi.mock('./routes/userSettings', () => ({ default: emptyRouter() }));
 vi.mock('./routes/overlaySource', () => ({ default: emptyRouter() }));
 vi.mock('./routes/overlayAdmin', () => ({ default: emptyRouter() }));
+vi.mock('./routes/pricingAdmin', () => ({ default: emptyRouter() }));
 vi.mock('./routes/companionAuth', () => ({ default: emptyRouter() }));
 vi.mock('./routes/companionEvents', () => ({ default: emptyRouter() }));
 vi.mock('./routes/companionKeys', () => ({ default: emptyRouter() }));

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -34,6 +34,7 @@ import companionKeysRouter from './routes/companionKeys';
 import userSettingsRouter from './routes/userSettings';
 import overlaySourceRouter from './routes/overlaySource';
 import overlayAdminRouter from './routes/overlayAdmin';
+import pricingAdminRouter from './routes/pricingAdmin';
 import privacyRouter from './routes/privacy';
 import tosRouter from './routes/tos';
 import { requireAuth, requireGuildContext } from './middleware';
@@ -208,6 +209,7 @@ app.use('/admin', adminGuildRouter);
 
 app.use('/user/settings', requireAuth, userSettingsRouter);
 app.use('/overlay', requireAuth, overlayAdminRouter);
+app.use('/pricing', requireAuth, pricingAdminRouter);
 
 /**
  * 404 handler — catches any request that fell through every mounted router.

--- a/views/partials/nav.ejs
+++ b/views/partials/nav.ejs
@@ -36,6 +36,7 @@
       <% } %>
       <% if (user) { %>
       <a href="/overlay/settings" class="nav-item">Overlay</a>
+      <a href="/pricing" class="nav-item">Pricing</a>
       <a href="/user/settings" class="nav-item">Settings</a>
       <% } %>
     </div>

--- a/views/pricingAdmin.ejs
+++ b/views/pricingAdmin.ejs
@@ -17,7 +17,7 @@
       <% const errorMessages = {
         not_a_streamer:   'You are not configured as a monitored streamer.',
         invalid_reward_id:'Invalid reward ID format.',
-        invalid_config:   'Base cost, cooldown, max multiplier, and curve must all be valid, positive numbers.',
+        invalid_config:   'Base cost, cooldown, and curve must be positive numbers, and max multiplier must be zero or greater.',
         save_failed:      'Failed to save — please try again.',
         invalid_id:       'Invalid request.',
         delete_failed:    'Delete failed — please try again.',
@@ -131,23 +131,23 @@
                 Enabled
               </label>
               <div>
-                <label class="hint hint-compact">Base cost</label>
-                <input class="input" type="number" min="1" name="base_cost" style="width:7rem;"
+                <label class="hint hint-compact" for="base-cost-<%= r.rewardId %>">Base cost</label>
+                <input id="base-cost-<%= r.rewardId %>" class="input" type="number" min="1" name="base_cost" style="width:7rem;"
                   value="<%= r.config ? r.config.base_cost : r.twitchReward.cost %>" required>
               </div>
               <div>
-                <label class="hint hint-compact">Cooldown (s)</label>
-                <input class="input" type="number" min="1" name="cooldown_seconds" style="width:7rem;"
+                <label class="hint hint-compact" for="cooldown-<%= r.rewardId %>">Cooldown (s)</label>
+                <input id="cooldown-<%= r.rewardId %>" class="input" type="number" min="1" name="cooldown_seconds" style="width:7rem;"
                   value="<%= r.config ? r.config.cooldown_seconds : 60 %>" required>
               </div>
               <div>
-                <label class="hint hint-compact">Max multiplier</label>
-                <input class="input" type="number" step="0.1" min="0" name="max_multiplier" style="width:7rem;"
+                <label class="hint hint-compact" for="max-mult-<%= r.rewardId %>">Max multiplier</label>
+                <input id="max-mult-<%= r.rewardId %>" class="input" type="number" step="0.1" min="0" name="max_multiplier" style="width:7rem;"
                   value="<%= r.config ? r.config.max_multiplier : 1 %>" required>
               </div>
               <div>
-                <label class="hint hint-compact">Curve</label>
-                <input class="input" type="number" step="0.1" min="0.1" name="curve" style="width:7rem;"
+                <label class="hint hint-compact" for="curve-<%= r.rewardId %>">Curve</label>
+                <input id="curve-<%= r.rewardId %>" class="input" type="number" step="0.1" min="0.1" name="curve" style="width:7rem;"
                   value="<%= r.config ? r.config.curve : 1 %>" required>
               </div>
               <div>

--- a/views/pricingAdmin.ejs
+++ b/views/pricingAdmin.ejs
@@ -107,7 +107,9 @@
               <strong>Unlinked reward</strong>
               <p class="hint hint-compact">No longer found on Twitch (deleted, or not visible with the current connection) — reward ID: <code class="mono"><%= r.rewardId %></code></p>
               <% } %>
-              <% if (r.config) { %>
+              <% if (r.config && r.config.twitch_unsupported) { %>
+              <p class="hint hint-compact" style="color:var(--danger, #c0392b);">This reward can't be managed by the bot — it was created via the Twitch dashboard (or another app), and Twitch only allows the app that created a reward to change its cost. Dynamic pricing has been disabled.</p>
+              <% } else if (r.config) { %>
               <p class="hint hint-compact">Demand: <%= (r.config.demand * 100).toFixed(1) %>% — computed price (may take up to 5 min to sync to Twitch): <%= r.previewPrice.toLocaleString() %> pts</p>
               <% } %>
             </div>

--- a/views/pricingAdmin.ejs
+++ b/views/pricingAdmin.ejs
@@ -132,12 +132,12 @@
               </label>
               <div>
                 <label class="hint hint-compact" for="base-cost-<%= r.rewardId %>">Base cost</label>
-                <input id="base-cost-<%= r.rewardId %>" class="input" type="number" min="1" name="base_cost" style="width:7rem;"
+                <input id="base-cost-<%= r.rewardId %>" class="input" type="number" min="1" step="1" name="base_cost" style="width:7rem;"
                   value="<%= r.config ? r.config.base_cost : r.twitchReward.cost %>" required>
               </div>
               <div>
                 <label class="hint hint-compact" for="cooldown-<%= r.rewardId %>">Cooldown (s)</label>
-                <input id="cooldown-<%= r.rewardId %>" class="input" type="number" min="1" name="cooldown_seconds" style="width:7rem;"
+                <input id="cooldown-<%= r.rewardId %>" class="input" type="number" min="1" step="1" name="cooldown_seconds" style="width:7rem;"
                   value="<%= r.config ? r.config.cooldown_seconds : 60 %>" required>
               </div>
               <div>

--- a/views/pricingAdmin.ejs
+++ b/views/pricingAdmin.ejs
@@ -100,10 +100,15 @@
         <div class="card-body">
           <div class="form-row-wrap" style="align-items:center;justify-content:space-between;">
             <div>
+              <% if (r.twitchReward) { %>
               <strong><%= r.twitchReward.title %></strong>
               <p class="hint hint-compact">Twitch cost: <%= r.twitchReward.cost.toLocaleString() %> pts<%= r.twitchReward.is_enabled ? '' : ' · disabled' %></p>
+              <% } else { %>
+              <strong>Unlinked reward</strong>
+              <p class="hint hint-compact">No longer found on Twitch (deleted, or not visible with the current connection) — reward ID: <code class="mono"><%= r.rewardId %></code></p>
+              <% } %>
               <% if (r.config) { %>
-              <p class="hint hint-compact">Demand: <%= (r.config.demand * 100).toFixed(1) %>% — current dynamic price: <%= r.previewPrice.toLocaleString() %> pts</p>
+              <p class="hint hint-compact">Demand: <%= (r.config.demand * 100).toFixed(1) %>% — computed price (may take up to 5 min to sync to Twitch): <%= r.previewPrice.toLocaleString() %> pts</p>
               <% } %>
             </div>
             <% if (r.config) { %>
@@ -114,9 +119,10 @@
             <% } %>
           </div>
 
+          <% if (r.twitchReward) { %>
           <form method="POST" action="/pricing/settings/rewards" style="margin-top:0.75rem;">
             <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-            <input type="hidden" name="twitch_reward_id" value="<%= r.twitchReward.id %>">
+            <input type="hidden" name="twitch_reward_id" value="<%= r.rewardId %>">
             <div class="form-row-wrap" style="align-items:flex-end;">
               <label style="display:flex;align-items:center;gap:0.4rem;">
                 <input type="checkbox" name="enabled" <%= r.config && r.config.enabled ? 'checked' : '' %>>
@@ -147,6 +153,7 @@
               </div>
             </div>
           </form>
+          <% } %>
         </div>
       </div>
       <% } %>

--- a/views/pricingAdmin.ejs
+++ b/views/pricingAdmin.ejs
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BCUK Bot — Dynamic Pricing</title>
+  <link rel="stylesheet" href="/style.css">
+  <%- include('partials/pwa-head') %>
+</head>
+<body data-csrf-token="<%= csrfToken %>">
+  <%- include('partials/nav') %>
+
+  <main class="container">
+
+    <% if (error) { %>
+    <div class="card card-alert-danger">
+      <% const errorMessages = {
+        not_a_streamer:   'You are not configured as a monitored streamer.',
+        invalid_reward_id:'Invalid reward ID format.',
+        invalid_config:   'Base cost, cooldown, max multiplier, and curve must all be valid, positive numbers.',
+        save_failed:      'Failed to save — please try again.',
+        invalid_id:       'Invalid request.',
+        delete_failed:    'Delete failed — please try again.',
+        not_owner:        'Only the bot owner can change the global pricing settings.',
+        invalid_settings: 'Decay half-life must be positive, and the redemption increment must be between 0 and 1.',
+      }; %>
+      <%= errorMessages[error] ?? `An error occurred (${error}).` %>
+    </div>
+    <% } %>
+
+    <% if (success) { %>
+    <div class="card card-alert-success">
+      <% const successMessages = {
+        pricing_saved:          'Pricing config saved.',
+        pricing_deleted:        'Pricing config removed.',
+        global_settings_saved:  'Global pricing settings saved.',
+      }; %>
+      <%= successMessages[success] ?? 'Done.' %>
+    </div>
+    <% } %>
+
+    <% if (!streamer) { %>
+    <section class="section">
+      <div class="card">
+        <div class="card-body">
+          <p class="hint">You are not configured as a monitored streamer. Contact a Manager or Admin.</p>
+        </div>
+      </div>
+    </section>
+    <% } else { %>
+
+    <% if (isOwner) { %>
+    <!-- ── Global Settings (bot owner only) ───────────────────────── -->
+    <section class="section">
+      <h2 class="section-title">Global Pricing Settings</h2>
+      <p class="hint" style="margin-bottom:0.75rem;">
+        Shared by every reward's demand calculation, across all streamers.
+      </p>
+      <div class="card">
+        <div class="card-body">
+          <form method="POST" action="/pricing/settings/global">
+            <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+            <div class="form-row-wrap" style="align-items:flex-end;">
+              <div>
+                <label class="hint hint-compact" for="decay-half-life">Decay half-life (cooldown periods)</label>
+                <input id="decay-half-life" class="input" type="number" step="0.1" min="0.1" name="decay_half_life_periods"
+                  value="<%= globalSettings.decay_half_life_periods %>" required>
+              </div>
+              <div>
+                <label class="hint hint-compact" for="redemption-increment">Redemption increment (0–1)</label>
+                <input id="redemption-increment" class="input" type="number" step="0.01" min="0" max="1" name="redemption_increment"
+                  value="<%= globalSettings.redemption_increment %>" required>
+              </div>
+              <div>
+                <button type="submit" class="btn">Save</button>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+    </section>
+    <% } %>
+
+    <!-- ── Reward Pricing ──────────────────────────────────────────── -->
+    <section class="section">
+      <h2 class="section-title">Dynamic Channel Point Pricing</h2>
+      <p class="hint" style="margin-bottom:0.75rem;">
+        Turn this on per reward to have its channel point cost automatically rise with usage and decay when idle.
+      </p>
+
+      <% if (rewards.length === 0) { %>
+      <div class="card">
+        <div class="card-body">
+          <p class="hint">No Twitch custom rewards found. Connect your Twitch account in <a href="/user/settings">User Settings</a>, or create a reward on your Twitch dashboard first.</p>
+        </div>
+      </div>
+      <% } else { %>
+      <% for (const r of rewards) { %>
+      <div class="card card-spaced">
+        <div class="card-body">
+          <div class="form-row-wrap" style="align-items:center;justify-content:space-between;">
+            <div>
+              <strong><%= r.twitchReward.title %></strong>
+              <p class="hint hint-compact">Twitch cost: <%= r.twitchReward.cost.toLocaleString() %> pts<%= r.twitchReward.is_enabled ? '' : ' · disabled' %></p>
+              <% if (r.config) { %>
+              <p class="hint hint-compact">Demand: <%= (r.config.demand * 100).toFixed(1) %>% — current dynamic price: <%= r.previewPrice.toLocaleString() %> pts</p>
+              <% } %>
+            </div>
+            <% if (r.config) { %>
+            <form method="POST" action="/pricing/settings/rewards/<%= r.config.id %>/delete" style="margin:0;">
+              <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+              <button type="submit" class="btn btn-ghost btn-sm">Remove</button>
+            </form>
+            <% } %>
+          </div>
+
+          <form method="POST" action="/pricing/settings/rewards" style="margin-top:0.75rem;">
+            <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+            <input type="hidden" name="twitch_reward_id" value="<%= r.twitchReward.id %>">
+            <div class="form-row-wrap" style="align-items:flex-end;">
+              <label style="display:flex;align-items:center;gap:0.4rem;">
+                <input type="checkbox" name="enabled" <%= r.config && r.config.enabled ? 'checked' : '' %>>
+                Enabled
+              </label>
+              <div>
+                <label class="hint hint-compact">Base cost</label>
+                <input class="input" type="number" min="1" name="base_cost" style="width:7rem;"
+                  value="<%= r.config ? r.config.base_cost : r.twitchReward.cost %>" required>
+              </div>
+              <div>
+                <label class="hint hint-compact">Cooldown (s)</label>
+                <input class="input" type="number" min="1" name="cooldown_seconds" style="width:7rem;"
+                  value="<%= r.config ? r.config.cooldown_seconds : 60 %>" required>
+              </div>
+              <div>
+                <label class="hint hint-compact">Max multiplier</label>
+                <input class="input" type="number" step="0.1" min="0" name="max_multiplier" style="width:7rem;"
+                  value="<%= r.config ? r.config.max_multiplier : 1 %>" required>
+              </div>
+              <div>
+                <label class="hint hint-compact">Curve</label>
+                <input class="input" type="number" step="0.1" min="0.1" name="curve" style="width:7rem;"
+                  value="<%= r.config ? r.config.curve : 1 %>" required>
+              </div>
+              <div>
+                <button type="submit" class="btn">Save</button>
+              </div>
+            </div>
+          </form>
+        </div>
+      </div>
+      <% } %>
+      <% } %>
+    </section>
+
+    <% } %>
+
+  </main>
+
+  <%- include('partials/pwa-register') %>
+  <%- include('partials/footer') %>
+  <script src="/utils.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Implements the uploaded Dynamic Channel Point Pricing spec: a Twitch Channel Point reward's cost automatically rises with redemption demand and decays when idle, configurable per reward and **opt-in per reward** (an `enabled` toggle — nothing changes unless a streamer explicitly turns it on for a given reward).

- New `reward_pricing` table stores per-reward config (`base_cost`, `cooldown_seconds`, `max_multiplier`, `curve`) and persistent demand state (`demand`, `demand_updated_at`, `last_pushed_cost`), independent of the existing `overlay_reward` table.
- New `pricing_global_settings` singleton table holds two bot-wide knobs: `decay_half_life_periods` and `redemption_increment`.
- Pure math module (`rewardPricingMath.ts`) implements the spec's price formula plus demand decay/increment, with decay **normalized by each reward's own cooldown** so rewards with different cooldowns move toward saturation at comparable relative rates when each is redeemed at its own max frequency.
- New Helix `updateRewardCost` call (previously only a read existed) pushes the recalculated price to Twitch — on every redemption (via a new hook in `handleRedemption`) and via a new periodic decay-tick scheduler (every 5 min), skipping the Helix call when the price hasn't changed.
- New standalone `/pricing` admin page for streamers to configure/enable pricing per reward, with a bot-owner-only section for the two global settings (gated by `isOwner`, not guild-scoped `accessLevel`, since these settings aren't per-guild).
- Concurrent updates to the same reward's demand (a redemption racing a decay tick) are serialized via the existing `mutationQueue` pattern.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` — all 113 test files / 1890 tests pass, including new coverage for the math (incl. the cooldown-normalization steady-state case), DB layer, orchestration service (concurrency, no-op-when-disabled, Twitch-push skip-when-unchanged), scheduler, redemption hook wiring, new Helix call, and the new admin routes (validation, owner-only gating)
- [ ] Manual walkthrough on a real Twitch account: enable pricing on a test reward, redeem it, confirm demand/price rise and drift back down over time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151M3CDRw5g2c8UUxk15YD8

---
_Generated by [Claude Code](https://claude.ai/code/session_0151M3CDRw5g2c8UUxk15YD8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Pricing admin page for dynamic Twitch Channel Points pricing, including per-reward configuration and bot-wide global settings.
  * Introduced automated demand decay and dynamic cost updates on redemptions, plus live preview pricing.
  * Added admin endpoints to save/delete reward pricing and update global pricing settings.
  * Added a “Pricing” navigation link for authenticated users.
* **Bug Fixes**
  * Improved scheduler startup/shutdown reliability and made redemption pricing non-blocking while keeping overlay pushes working.
* **Tests**
  * Added coverage for pricing math, scheduler behavior, DB helpers, Twitch synchronization, and admin UI/routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->