### PR TITLE
Add price history graph to the pricing admin page

### DIFF
--- a/DATABASE-SCHEMA.md
+++ b/DATABASE-SCHEMA.md
@@ -225,7 +225,7 @@ Created by `migrations/reward_pricing.sql`.
 
 ## `reward_pricing_history`
 
-Time-series log of computed price/demand per reward, powering the price history graph on `/pricing`. Bounded to roughly the largest selectable time range (24h) — `recordPricingHistory()` prunes older rows for the same reward on every insert, so this table never grows unbounded.
+Time-series log of computed price/demand per reward, powering the price history graph on `/channel-points`. Bounded to roughly the largest selectable time range (24h) — `recordPricingHistory()` prunes older rows for the same reward on every insert, so this table never grows unbounded.
 
 | Column | Type | Notes |
 | --- | --- | --- |

--- a/DATABASE-SCHEMA.md
+++ b/DATABASE-SCHEMA.md
@@ -223,6 +223,20 @@ Single global row (`id` pinned to 1) — bot-wide decay/increment settings share
 
 Created by `migrations/reward_pricing.sql`.
 
+## `reward_pricing_history`
+
+Time-series log of computed price/demand per reward, powering the price history graph on `/pricing`. Bounded to roughly the largest selectable time range (24h) — `recordPricingHistory()` prunes older rows for the same reward on every insert, so this table never grows unbounded.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | `INT` PK, auto-increment | |
+| `reward_pricing_id` | `INT` | FK to `reward_pricing.id` ON DELETE CASCADE |
+| `recorded_at` | `BIGINT` | Epoch ms this point was recorded at |
+| `cost` | `INT` | Computed price at `recorded_at` |
+| `demand` | `DECIMAL(9,6)` | Demand at `recorded_at`, in `[0,1]` |
+
+Created by `migrations/reward_pricing_history.sql`.
+
 ## `custom_command`
 
 Stores custom text commands managed through the admin panel. This is a **global catalog** shared across all guilds (no `guild_id`); per-guild deviations (disable / output override) live in `guild_command_override`. On Discord, every catalog command is enabled by default in every guild.

--- a/migrations/reward_pricing_history.sql
+++ b/migrations/reward_pricing_history.sql
@@ -1,4 +1,4 @@
--- Time-series log of computed price/demand for the /pricing admin page's history graph.
+-- Time-series log of computed price/demand for the /channel-points admin page's history graph.
 -- Bounded to roughly the largest selectable time range (24h) — recordPricingHistory()
 -- prunes older rows for the same reward on every insert, so this never grows unbounded.
 CREATE TABLE reward_pricing_history (

--- a/migrations/reward_pricing_history.sql
+++ b/migrations/reward_pricing_history.sql
@@ -1,0 +1,12 @@
+-- Time-series log of computed price/demand for the /pricing admin page's history graph.
+-- Bounded to roughly the largest selectable time range (24h) — recordPricingHistory()
+-- prunes older rows for the same reward on every insert, so this never grows unbounded.
+CREATE TABLE reward_pricing_history (
+  id                INT    AUTO_INCREMENT PRIMARY KEY,
+  reward_pricing_id INT    NOT NULL,
+  recorded_at       BIGINT NOT NULL,
+  cost              INT    NOT NULL,
+  demand            DECIMAL(9,6) NOT NULL,
+  KEY idx_reward_pricing_history_reward_time (reward_pricing_id, recorded_at),
+  FOREIGN KEY (reward_pricing_id) REFERENCES reward_pricing(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/public/priceHistoryChart.js
+++ b/public/priceHistoryChart.js
@@ -1,0 +1,98 @@
+/**
+ * Finds the data point nearest to a given time value.
+ * @param {Array<[number, number]>} points - `[time, cost]` pairs, sorted ascending by time.
+ * @param {number} targetT - The time to find the nearest point to.
+ * @returns {[number, number] | undefined} The nearest point, or undefined if `points` is empty.
+ */
+function findNearestPoint(points, targetT) {
+  let nearest = points[0];
+  let nearestDelta = Infinity;
+  for (const point of points) {
+    const delta = Math.abs(point[0] - targetT);
+    if (delta < nearestDelta) {
+      nearest = point;
+      nearestDelta = delta;
+    }
+  }
+  return nearest;
+}
+
+/**
+ * Formats an epoch-ms timestamp as a short local time string for the tooltip.
+ * @param {number} t - Epoch ms.
+ * @returns {string} Formatted time, e.g. "2:34 PM".
+ */
+function formatTooltipTime(t) {
+  return new Date(t).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+}
+
+/**
+ * Updates a chart's crosshair line/dot and tooltip to the nearest point at a given
+ * client X position, or hides them when `clientX` is null.
+ * @param {SVGSVGElement} svg - The chart's root SVG element.
+ * @param {HTMLElement} tooltip - The floating tooltip element to position/fill.
+ * @param {number | null} clientX - Pointer X in viewport coordinates, or null to hide.
+ * @returns {void}
+ */
+function updateCrosshair(svg, tooltip, clientX) {
+  const crosshair = svg.querySelector('.price-history-crosshair');
+  if (clientX === null) {
+    if (crosshair) crosshair.style.display = 'none';
+    tooltip.style.display = 'none';
+    return;
+  }
+
+  const points = JSON.parse(svg.dataset.points || '[]');
+  if (points.length === 0) return;
+
+  const rect = svg.getBoundingClientRect();
+  const viewBoxWidth = svg.viewBox.baseVal.width || 480;
+  const plotLeft = Number(svg.dataset.plotLeft);
+  const plotRight = Number(svg.dataset.plotRight);
+  const rangeStart = Number(svg.dataset.rangeStart);
+  const rangeEnd = Number(svg.dataset.rangeEnd);
+
+  const svgX = ((clientX - rect.left) / rect.width) * viewBoxWidth;
+  const clampedX = Math.min(plotRight, Math.max(plotLeft, svgX));
+  const targetT = rangeStart + ((clampedX - plotLeft) / (plotRight - plotLeft)) * (rangeEnd - rangeStart);
+
+  const [t, cost] = findNearestPoint(points, targetT);
+  const pointX = plotLeft + ((t - rangeStart) / (rangeEnd - rangeStart)) * (plotRight - plotLeft);
+
+  if (crosshair) {
+    crosshair.style.display = '';
+    const line = crosshair.querySelector('.price-history-crosshair-line');
+    const dot = crosshair.querySelector('.price-history-crosshair-dot');
+    if (line) { line.setAttribute('x1', String(pointX)); line.setAttribute('x2', String(pointX)); }
+    if (dot) dot.setAttribute('cx', String(pointX));
+  }
+
+  tooltip.textContent = '';
+  const valueEl = document.createElement('strong');
+  valueEl.textContent = `${cost.toLocaleString()} pts`;
+  const timeEl = document.createElement('span');
+  timeEl.textContent = ` — ${formatTooltipTime(t)}`;
+  tooltip.appendChild(valueEl);
+  tooltip.appendChild(timeEl);
+  tooltip.style.display = '';
+  tooltip.style.left = `${clientX + 12}px`;
+  tooltip.style.top = `${rect.top + window.scrollY - 8}px`;
+}
+
+/** Wires up hover/focus crosshair+tooltip behavior for every `.price-history-chart` on the page. */
+function initPriceHistoryCharts() {
+  const charts = document.querySelectorAll('.price-history-chart');
+  if (charts.length === 0) return;
+
+  const tooltip = document.createElement('div');
+  tooltip.className = 'price-history-tooltip';
+  tooltip.style.display = 'none';
+  document.body.appendChild(tooltip);
+
+  charts.forEach((svg) => {
+    svg.addEventListener('pointermove', (event) => updateCrosshair(svg, tooltip, event.clientX));
+    svg.addEventListener('pointerleave', () => updateCrosshair(svg, tooltip, null));
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initPriceHistoryCharts);

--- a/public/style.css
+++ b/public/style.css
@@ -347,3 +347,14 @@ textarea.input, .stream-textarea { width: 100%; resize: vertical; font-family: v
   .section-header { flex-wrap: wrap; gap: .5rem; }
   .search-input { width: 100%; }
 }
+
+/* ── Price history chart (pricing admin) ──────────────── */
+.price-history-tick, .price-history-end-label { font-size: 9px; fill: var(--muted); }
+.price-history-chart { display: block; cursor: crosshair; touch-action: none; }
+.price-history-tooltip {
+  position: absolute; z-index: 20; pointer-events: none;
+  background: var(--bg-card); border: 1px solid var(--border); border-radius: 6px;
+  padding: .35rem .6rem; font-size: .78rem; color: var(--text); white-space: nowrap;
+}
+.price-history-tooltip strong { color: var(--primary); }
+.price-history-tooltip span { color: var(--muted); }

--- a/schema.sql
+++ b/schema.sql
@@ -308,6 +308,23 @@ CREATE TABLE IF NOT EXISTS pricing_global_settings (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ---------------------------------------------------------------------------
+-- reward_pricing_history
+-- Time-series log of computed price/demand for the /pricing admin page's
+-- history graph. Bounded to roughly the largest selectable time range (24h) —
+-- recordPricingHistory() prunes older rows for the same reward on every insert.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS reward_pricing_history (
+  id                INT    NOT NULL AUTO_INCREMENT,
+  reward_pricing_id INT    NOT NULL,
+  recorded_at       BIGINT NOT NULL,
+  cost              INT    NOT NULL,
+  demand            DECIMAL(9,6) NOT NULL,
+  PRIMARY KEY (id),
+  KEY idx_reward_pricing_history_reward_time (reward_pricing_id, recorded_at),
+  FOREIGN KEY (reward_pricing_id) REFERENCES reward_pricing(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ---------------------------------------------------------------------------
 -- streamdeck_api_keys
 -- key_hash is a hex-encoded SHA-256 of the plain API key (64 chars).
 -- approved_by is nullable; SET NULL if the approver's user row is deleted.

--- a/schema.sql
+++ b/schema.sql
@@ -309,7 +309,7 @@ CREATE TABLE IF NOT EXISTS pricing_global_settings (
 
 -- ---------------------------------------------------------------------------
 -- reward_pricing_history
--- Time-series log of computed price/demand for the /pricing admin page's
+-- Time-series log of computed price/demand for the /channel-points admin page's
 -- history graph. Bounded to roughly the largest selectable time range (24h) —
 -- recordPricingHistory() prunes older rows for the same reward on every insert.
 -- ---------------------------------------------------------------------------

--- a/src/db.ts
+++ b/src/db.ts
@@ -157,6 +157,9 @@ export {
   initGlobalPricingSettings, getGlobalPricingSettings, saveGlobalPricingSettings,
 } from './db/rewardPricing';
 
+export type { RewardPricingHistoryPoint } from './db/rewardPricingHistory';
+export { recordPricingHistory, getPricingHistory } from './db/rewardPricingHistory';
+
 // ─── Streamdeck API keys ─────────────────────────────────────────────────────
 
 export type { StreamdeckKeyRow } from './db/streamdeckKeys';

--- a/src/db/rewardPricingHistory.test.ts
+++ b/src/db/rewardPricingHistory.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./pool', () => ({ getPool: vi.fn() }));
+vi.mock('mysql2/promise', () => ({ default: {} }));
+
+import { getPool } from './pool';
+import { recordPricingHistory, getPricingHistory } from './rewardPricingHistory';
+
+function makePool(rows: unknown[] = [], meta: unknown = {}) {
+  return {
+    execute: vi.fn().mockResolvedValue([[...rows], meta]),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('recordPricingHistory', () => {
+  it('inserts the point and prunes points older than the retention window', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+
+    await recordPricingHistory(5, 350, 0.42, 1_700_100_000_000);
+
+    expect(pool.execute).toHaveBeenCalledTimes(2);
+    const [insertSql, insertParams] = pool.execute.mock.calls[0];
+    expect(insertSql).toContain('INSERT INTO reward_pricing_history');
+    expect(insertParams).toEqual([5, 1_700_100_000_000, 350, 0.42]);
+
+    const [deleteSql, deleteParams] = pool.execute.mock.calls[1];
+    expect(deleteSql).toContain('DELETE FROM reward_pricing_history');
+    expect(deleteParams[0]).toBe(5);
+    expect(deleteParams[1]).toBe(1_700_100_000_000 - 25 * 60 * 60 * 1000);
+  });
+});
+
+describe('getPricingHistory', () => {
+  it('returns an empty array when no points are found', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    expect(await getPricingHistory(5, 1_700_000_000_000)).toEqual([]);
+  });
+
+  it('maps rows, converting recorded_at to a string and demand to a number', async () => {
+    const rows = [{ recorded_at: '1700100000000', cost: 350, demand: '0.420000' }];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const points = await getPricingHistory(5, 1_700_000_000_000);
+    expect(points).toEqual([{ recorded_at: '1700100000000', cost: 350, demand: 0.42 }]);
+  });
+
+  it('queries with rewardPricingId and sinceMs, ordered ascending', async () => {
+    const pool = makePool([]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await getPricingHistory(5, 1_700_000_000_000);
+    expect(pool.execute.mock.calls[0][1]).toEqual([5, 1_700_000_000_000]);
+    expect(pool.execute.mock.calls[0][0]).toContain('ORDER BY recorded_at ASC');
+  });
+});

--- a/src/db/rewardPricingHistory.ts
+++ b/src/db/rewardPricingHistory.ts
@@ -9,7 +9,7 @@ export interface RewardPricingHistoryPoint {
   demand: number;
 }
 
-// Slightly larger than the largest selectable range on /pricing (24h), so a
+// Slightly larger than the largest selectable range on /channel-points (24h), so a
 // full 24h history is always available regardless of when within the retention
 // window the last prune ran.
 const RETENTION_MS = 25 * 60 * 60 * 1000;
@@ -17,7 +17,8 @@ const RETENTION_MS = 25 * 60 * 60 * 1000;
 /**
  * Records a price/demand point for a reward, then prunes points older than the
  * retention window for that same reward so the table stays bounded to roughly the
- * largest selectable history range.
+ * largest selectable history range. The insert and prune are independent of each
+ * other, so they run concurrently rather than as two sequential round-trips.
  *
  * @param rewardPricingId - Primary key of the `reward_pricing` row this point belongs to.
  * @param cost - The computed price at `recordedAtMs`.
@@ -30,14 +31,16 @@ export async function recordPricingHistory(
   demand: number,
   recordedAtMs: number,
 ): Promise<void> {
-  await getPool().execute(
-    `INSERT INTO reward_pricing_history (reward_pricing_id, recorded_at, cost, demand) VALUES (?, ?, ?, ?)`,
-    [rewardPricingId, recordedAtMs, cost, demand],
-  );
-  await getPool().execute(
-    `DELETE FROM reward_pricing_history WHERE reward_pricing_id = ? AND recorded_at < ?`,
-    [rewardPricingId, recordedAtMs - RETENTION_MS],
-  );
+  await Promise.all([
+    getPool().execute(
+      `INSERT INTO reward_pricing_history (reward_pricing_id, recorded_at, cost, demand) VALUES (?, ?, ?, ?)`,
+      [rewardPricingId, recordedAtMs, cost, demand],
+    ),
+    getPool().execute(
+      `DELETE FROM reward_pricing_history WHERE reward_pricing_id = ? AND recorded_at < ?`,
+      [rewardPricingId, recordedAtMs - RETENTION_MS],
+    ),
+  ]);
 }
 
 /**

--- a/src/db/rewardPricingHistory.ts
+++ b/src/db/rewardPricingHistory.ts
@@ -1,0 +1,61 @@
+import mysql from 'mysql2/promise';
+import { getPool } from './pool';
+
+/** One recorded price/demand point for a reward, at a point in time. */
+export interface RewardPricingHistoryPoint {
+  /** Epoch ms as a string — BIGINT column; never coerce with Number() at this layer. */
+  recorded_at: string;
+  cost: number;
+  demand: number;
+}
+
+// Slightly larger than the largest selectable range on /pricing (24h), so a
+// full 24h history is always available regardless of when within the retention
+// window the last prune ran.
+const RETENTION_MS = 25 * 60 * 60 * 1000;
+
+/**
+ * Records a price/demand point for a reward, then prunes points older than the
+ * retention window for that same reward so the table stays bounded to roughly the
+ * largest selectable history range.
+ *
+ * @param rewardPricingId - Primary key of the `reward_pricing` row this point belongs to.
+ * @param cost - The computed price at `recordedAtMs`.
+ * @param demand - The demand value at `recordedAtMs`.
+ * @param recordedAtMs - Epoch ms this point was computed as of.
+ */
+export async function recordPricingHistory(
+  rewardPricingId: number,
+  cost: number,
+  demand: number,
+  recordedAtMs: number,
+): Promise<void> {
+  await getPool().execute(
+    `INSERT INTO reward_pricing_history (reward_pricing_id, recorded_at, cost, demand) VALUES (?, ?, ?, ?)`,
+    [rewardPricingId, recordedAtMs, cost, demand],
+  );
+  await getPool().execute(
+    `DELETE FROM reward_pricing_history WHERE reward_pricing_id = ? AND recorded_at < ?`,
+    [rewardPricingId, recordedAtMs - RETENTION_MS],
+  );
+}
+
+/**
+ * Returns recorded price/demand points for a reward at or after `sinceMs`, oldest first.
+ *
+ * @param rewardPricingId - Primary key of the `reward_pricing` row.
+ * @param sinceMs - Epoch ms lower bound (inclusive) for returned points.
+ */
+export async function getPricingHistory(rewardPricingId: number, sinceMs: number): Promise<RewardPricingHistoryPoint[]> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT recorded_at, cost, demand FROM reward_pricing_history
+     WHERE reward_pricing_id = ? AND recorded_at >= ?
+     ORDER BY recorded_at ASC`,
+    [rewardPricingId, sinceMs],
+  );
+  return rows.map((r) => ({
+    recorded_at: String(r.recorded_at),
+    cost: r.cost,
+    demand: Number(r.demand),
+  }));
+}

--- a/src/twitch/pricing/rewardPricingService.test.ts
+++ b/src/twitch/pricing/rewardPricingService.test.ts
@@ -5,6 +5,7 @@ vi.mock('../../shared/logger', () => ({ createLogger: () => ({ warn: vi.fn(), er
 vi.mock('../../db', () => ({
   getPricingForReward: vi.fn(),
   recordPricingUpdate: vi.fn(),
+  recordPricingHistory: vi.fn(),
   markPricingUnsupported: vi.fn(),
   deletePricingConfig: vi.fn(),
   getGlobalPricingSettings: vi.fn(),
@@ -21,7 +22,7 @@ vi.mock('../twitchApi', () => {
 });
 
 import {
-  getPricingForReward, recordPricingUpdate, markPricingUnsupported, deletePricingConfig,
+  getPricingForReward, recordPricingUpdate, recordPricingHistory, markPricingUnsupported, deletePricingConfig,
   getGlobalPricingSettings, getStreamerById,
 } from '../../db';
 import { getValidToken } from '../eventsub/twitchApiEventSub';
@@ -57,6 +58,7 @@ beforeEach(() => {
   vi.mocked(getGlobalPricingSettings).mockResolvedValue(settings);
   vi.mocked(getStreamerById).mockResolvedValue(streamer);
   vi.mocked(getValidToken).mockResolvedValue('user-token');
+  vi.mocked(recordPricingHistory).mockResolvedValue(undefined);
   vi.mocked(deletePricingConfig).mockResolvedValue(undefined);
   // clearAllMocks() resets call history but not mockResolvedValue/mockRejectedValue
   // implementations, so reset this explicitly — otherwise a test that rejects
@@ -91,12 +93,26 @@ describe('applyRedemptionPricing', () => {
     expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), expect.any(Number));
   });
 
-  it('marks the reward unsupported and disables it on a 403, without recording demand', async () => {
+  it('marks the reward unsupported and disables it on a 403, without recording demand or history', async () => {
     vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
     vi.mocked(updateRewardCost).mockRejectedValueOnce(new TwitchRewardUnsupportedError('403'));
     await applyRedemptionPricing(1, 'rwd1');
     expect(markPricingUnsupported).toHaveBeenCalledWith(1, 'rwd1');
     expect(recordPricingUpdate).not.toHaveBeenCalled();
+    expect(recordPricingHistory).not.toHaveBeenCalled();
+  });
+
+  it('records a price history point using the row id, computed cost, and demand', async () => {
+    vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ id: 42, demand: 0, last_pushed_cost: null }));
+    await applyRedemptionPricing(1, 'rwd1');
+    expect(recordPricingHistory).toHaveBeenCalledWith(42, expect.any(Number), expect.any(Number), expect.any(Number));
+  });
+
+  it('does not fail the sync when recording history throws', async () => {
+    vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
+    vi.mocked(recordPricingHistory).mockRejectedValueOnce(new Error('history db down'));
+    await expect(applyRedemptionPricing(1, 'rwd1')).resolves.toBeUndefined();
+    expect(recordPricingUpdate).toHaveBeenCalled();
   });
 
   it('on a 401, does not mark the reward unsupported but still persists the recalculated demand', async () => {

--- a/src/twitch/pricing/rewardPricingService.ts
+++ b/src/twitch/pricing/rewardPricingService.ts
@@ -1,6 +1,6 @@
 import { createMutationQueue } from '../../shared/mutationQueue';
 import {
-  getPricingForReward, recordPricingUpdate, markPricingUnsupported, deletePricingConfig,
+  getPricingForReward, recordPricingUpdate, recordPricingHistory, markPricingUnsupported, deletePricingConfig,
   getGlobalPricingSettings, getStreamerById,
 } from '../../db';
 import { getValidToken } from '../eventsub/twitchApiEventSub';
@@ -101,7 +101,9 @@ async function pushRewardCostUpdate(
  * persisted, even when the Twitch push fails, so the price is simply retried on the next
  * redemption/decay tick — except when the reward turns out to be permanently unsupported
  * (see {@link pushRewardCostUpdate}), in which case demand is intentionally not persisted
- * since the row won't be read again until re-enabled.
+ * since the row won't be read again until re-enabled. On every successful sync, also logs a
+ * price-history point (best-effort; a failure here is logged and swallowed rather than
+ * affecting the pricing update itself) for the /pricing history graph.
  *
  * @param streamerId - DB row ID of the owning streamer.
  * @param twitchRewardId - Twitch reward UUID.
@@ -133,6 +135,12 @@ async function syncRewardPrice(streamerId: number, twitchRewardId: string, apply
   }
 
   await recordPricingUpdate(streamerId, twitchRewardId, newDemand, now, lastPushedCost);
+
+  try {
+    await recordPricingHistory(row.id, newCost, newDemand, now);
+  } catch (err) {
+    log.warn(`Failed to record price history for reward ${twitchRewardId}:`, err);
+  }
 }
 
 /**

--- a/src/twitch/pricing/rewardPricingService.ts
+++ b/src/twitch/pricing/rewardPricingService.ts
@@ -103,7 +103,7 @@ async function pushRewardCostUpdate(
  * (see {@link pushRewardCostUpdate}), in which case demand is intentionally not persisted
  * since the row won't be read again until re-enabled. On every successful sync, also logs a
  * price-history point (best-effort; a failure here is logged and swallowed rather than
- * affecting the pricing update itself) for the /pricing history graph.
+ * affecting the pricing update itself) for the Channel Points admin history graph.
  *
  * @param streamerId - DB row ID of the owning streamer.
  * @param twitchRewardId - Twitch reward UUID.

--- a/src/web/priceHistoryChart.test.ts
+++ b/src/web/priceHistoryChart.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { renderPriceHistoryChart } from './priceHistoryChart';
+
+describe('renderPriceHistoryChart', () => {
+  it('renders a placeholder when there are no points', () => {
+    const svg = renderPriceHistoryChart([], 1_700_000_000_000, 1_700_010_000_000);
+    expect(svg).toContain('No price history yet');
+    expect(svg).not.toContain('<svg');
+  });
+
+  it('renders an svg with a polyline through the given points', () => {
+    const points = [
+      { t: 1_700_000_000_000, cost: 200 },
+      { t: 1_700_005_000_000, cost: 500 },
+      { t: 1_700_010_000_000, cost: 350 },
+    ];
+    const svg = renderPriceHistoryChart(points, 1_700_000_000_000, 1_700_010_000_000);
+    expect(svg).toContain('<svg');
+    expect(svg).toContain('<polyline');
+    expect(svg).toMatch(/points="[\d.]+,[\d.]+ [\d.]+,[\d.]+ [\d.]+,[\d.]+"/);
+  });
+
+  it('sorts unsorted input points by time before plotting', () => {
+    const points = [
+      { t: 1_700_010_000_000, cost: 350 },
+      { t: 1_700_000_000_000, cost: 200 },
+    ];
+    const svg = renderPriceHistoryChart(points, 1_700_000_000_000, 1_700_010_000_000);
+    const dataPoints = svg.match(/data-points='(.*?)'/)?.[1];
+    expect(dataPoints).toBeDefined();
+    const parsed = JSON.parse(dataPoints!.replace(/&#39;/g, "'"));
+    expect(parsed[0][0]).toBe(1_700_000_000_000);
+    expect(parsed[1][0]).toBe(1_700_010_000_000);
+  });
+
+  it('labels the min and max cost ticks', () => {
+    const points = [
+      { t: 1_700_000_000_000, cost: 200 },
+      { t: 1_700_010_000_000, cost: 800 },
+    ];
+    const svg = renderPriceHistoryChart(points, 1_700_000_000_000, 1_700_010_000_000);
+    expect(svg).toContain('>200<');
+    expect(svg).toContain('>800<');
+  });
+
+  it('labels the end point with its cost', () => {
+    const points = [{ t: 1_700_000_000_000, cost: 480 }];
+    const svg = renderPriceHistoryChart(points, 1_700_000_000_000, 1_700_010_000_000);
+    expect(svg).toContain('480 pts');
+  });
+
+  it('does not collapse the line when all costs are equal (flat range)', () => {
+    const points = [
+      { t: 1_700_000_000_000, cost: 300 },
+      { t: 1_700_010_000_000, cost: 300 },
+    ];
+    // Should not throw or produce NaN coordinates.
+    const svg = renderPriceHistoryChart(points, 1_700_000_000_000, 1_700_010_000_000);
+    expect(svg).not.toContain('NaN');
+  });
+
+  it('embeds the plotted time range as data attributes', () => {
+    const points = [{ t: 1_700_000_000_000, cost: 480 }];
+    const svg = renderPriceHistoryChart(points, 1_700_000_000_000, 1_700_010_000_000);
+    expect(svg).toContain('data-range-start="1700000000000"');
+    expect(svg).toContain('data-range-end="1700010000000"');
+  });
+});

--- a/src/web/priceHistoryChart.test.ts
+++ b/src/web/priceHistoryChart.test.ts
@@ -49,14 +49,15 @@ describe('renderPriceHistoryChart', () => {
     expect(svg).toContain('480 pts');
   });
 
-  it('does not collapse the line when all costs are equal (flat range)', () => {
+  it('centers the line vertically instead of collapsing to the bottom edge when all costs are equal (flat range)', () => {
     const points = [
       { t: 1_700_000_000_000, cost: 300 },
       { t: 1_700_010_000_000, cost: 300 },
     ];
-    // Should not throw or produce NaN coordinates.
     const svg = renderPriceHistoryChart(points, 1_700_000_000_000, 1_700_010_000_000);
     expect(svg).not.toContain('NaN');
+    // HEIGHT=120, PADDING.top=10, PADDING.bottom=20 -> plotTop=10, plotBottom=100, centered=55.0
+    expect(svg).toMatch(/points="[\d.]+,55\.0 [\d.]+,55\.0"/);
   });
 
   it('embeds the plotted time range as data attributes', () => {

--- a/src/web/priceHistoryChart.ts
+++ b/src/web/priceHistoryChart.ts
@@ -1,0 +1,67 @@
+/** One point in a reward's price history, as returned by the DB layer. */
+export interface PriceHistoryPoint {
+  t: number;
+  cost: number;
+}
+
+const WIDTH = 480;
+const HEIGHT = 120;
+const PADDING = { top: 10, right: 12, bottom: 20, left: 44 };
+
+/**
+ * Renders an inline SVG line chart of a reward's price over `[rangeStartMs, rangeEndMs]`.
+ * A single series needs no legend (the card title above it already names what's plotted).
+ * Embeds the plotted points as a `data-points` JSON attribute so `priceHistoryChart.js`
+ * can add a hover crosshair/tooltip without re-deriving the scale server-side.
+ *
+ * @param points - Price history points, any order (sorted internally by time).
+ * @param rangeStartMs - Left edge of the x-axis (epoch ms).
+ * @param rangeEndMs - Right edge of the x-axis (epoch ms).
+ * @returns Self-contained `<svg>` markup, or a "no data yet" placeholder if `points` is empty.
+ */
+export function renderPriceHistoryChart(points: PriceHistoryPoint[], rangeStartMs: number, rangeEndMs: number): string {
+  if (points.length === 0) {
+    return `<div class="hint price-history-empty" style="height:${HEIGHT}px;display:flex;align-items:center;justify-content:center;">No price history yet for this range.</div>`;
+  }
+
+  const sorted = [...points].sort((a, b) => a.t - b.t);
+  const costs = sorted.map((p) => p.cost);
+  const minCost = Math.min(...costs);
+  const maxCost = Math.max(...costs);
+  // Guard against a degenerate (flat) range so the line doesn't collapse to the chart's edge.
+  const costSpan = maxCost === minCost ? 1 : maxCost - minCost;
+
+  const plotLeft = PADDING.left;
+  const plotRight = WIDTH - PADDING.right;
+  const plotTop = PADDING.top;
+  const plotBottom = HEIGHT - PADDING.bottom;
+  const timeSpan = Math.max(1, rangeEndMs - rangeStartMs);
+
+  const toX = (t: number) => plotLeft + ((t - rangeStartMs) / timeSpan) * (plotRight - plotLeft);
+  const toY = (cost: number) => plotBottom - ((cost - minCost) / costSpan) * (plotBottom - plotTop);
+
+  const pixelPoints = sorted.map((p) => ({ x: toX(p.t), y: toY(p.cost), t: p.t, cost: p.cost }));
+  const polyline = pixelPoints.map((p) => `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ');
+  const last = pixelPoints[pixelPoints.length - 1];
+
+  const dataPoints = JSON.stringify(sorted.map((p) => [p.t, p.cost]));
+
+  return `
+<svg class="price-history-chart" viewBox="0 0 ${WIDTH} ${HEIGHT}" width="100%" height="${HEIGHT}"
+     data-points='${dataPoints.replace(/'/g, '&#39;')}'
+     data-plot-left="${plotLeft}" data-plot-right="${plotRight}"
+     data-range-start="${rangeStartMs}" data-range-end="${rangeEndMs}"
+     role="img" aria-label="Price history from ${new Date(rangeStartMs).toLocaleString()} to ${new Date(rangeEndMs).toLocaleString()}, ranging from ${minCost} to ${maxCost} points">
+  <line x1="${plotLeft}" y1="${toY(maxCost).toFixed(1)}" x2="${plotRight}" y2="${toY(maxCost).toFixed(1)}" stroke="var(--border)" stroke-width="1"/>
+  <line x1="${plotLeft}" y1="${toY(minCost).toFixed(1)}" x2="${plotRight}" y2="${toY(minCost).toFixed(1)}" stroke="var(--border)" stroke-width="1"/>
+  <text x="${plotLeft - 6}" y="${toY(maxCost).toFixed(1)}" dy="0.32em" text-anchor="end" class="price-history-tick">${maxCost.toLocaleString()}</text>
+  <text x="${plotLeft - 6}" y="${toY(minCost).toFixed(1)}" dy="0.32em" text-anchor="end" class="price-history-tick">${minCost.toLocaleString()}</text>
+  <polyline points="${polyline}" fill="none" stroke="var(--primary)" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+  <circle cx="${last.x.toFixed(1)}" cy="${last.y.toFixed(1)}" r="4" fill="var(--primary)" stroke="var(--bg-card)" stroke-width="2"/>
+  <text x="${last.x.toFixed(1)}" y="${(last.y - 8).toFixed(1)}" text-anchor="end" class="price-history-end-label">${last.cost.toLocaleString()} pts</text>
+  <g class="price-history-crosshair" style="display:none;">
+    <line class="price-history-crosshair-line" y1="${plotTop}" y2="${plotBottom}" stroke="var(--muted)" stroke-width="1"/>
+    <circle class="price-history-crosshair-dot" r="4" fill="var(--primary)" stroke="var(--bg-card)" stroke-width="2"/>
+  </g>
+</svg>`.trim();
+}

--- a/src/web/priceHistoryChart.ts
+++ b/src/web/priceHistoryChart.ts
@@ -28,8 +28,9 @@ export function renderPriceHistoryChart(points: PriceHistoryPoint[], rangeStartM
   const costs = sorted.map((p) => p.cost);
   const minCost = Math.min(...costs);
   const maxCost = Math.max(...costs);
+  const isFlat = maxCost === minCost;
   // Guard against a degenerate (flat) range so the line doesn't collapse to the chart's edge.
-  const costSpan = maxCost === minCost ? 1 : maxCost - minCost;
+  const costSpan = isFlat ? 1 : maxCost - minCost;
 
   const plotLeft = PADDING.left;
   const plotRight = WIDTH - PADDING.right;
@@ -38,7 +39,9 @@ export function renderPriceHistoryChart(points: PriceHistoryPoint[], rangeStartM
   const timeSpan = Math.max(1, rangeEndMs - rangeStartMs);
 
   const toX = (t: number) => plotLeft + ((t - rangeStartMs) / timeSpan) * (plotRight - plotLeft);
-  const toY = (cost: number) => plotBottom - ((cost - minCost) / costSpan) * (plotBottom - plotTop);
+  const toY = (cost: number) => isFlat
+    ? (plotTop + plotBottom) / 2
+    : plotBottom - ((cost - minCost) / costSpan) * (plotBottom - plotTop);
 
   const pixelPoints = sorted.map((p) => ({ x: toX(p.t), y: toY(p.cost), t: p.t, cost: p.cost }));
   const polyline = pixelPoints.map((p) => `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ');

--- a/src/web/routes/channelPointsAdmin.test.ts
+++ b/src/web/routes/channelPointsAdmin.test.ts
@@ -4,6 +4,7 @@ vi.mock('../../db', () => ({
   getStreamerByDiscordId: vi.fn(),
   getPricingConfigsForStreamer: vi.fn(),
   getGlobalPricingSettings: vi.fn(),
+  getPricingHistory: vi.fn(),
 }));
 
 vi.mock('../csrf', () => ({
@@ -41,7 +42,7 @@ vi.mock('./channelPointsAdminMutations', async () => {
 import express from 'express';
 import supertest from 'supertest';
 import router from './channelPointsAdmin';
-import { getStreamerByDiscordId, getPricingConfigsForStreamer, getGlobalPricingSettings } from '../../db';
+import { getStreamerByDiscordId, getPricingConfigsForStreamer, getGlobalPricingSettings, getPricingHistory } from '../../db';
 import { getCustomRewards } from '../../twitch/twitchApi';
 import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
 import { hasAuthFailedSubs } from '../../twitch/eventsub/twitchEventSubSubscriptions';
@@ -75,6 +76,7 @@ beforeEach(() => {
   vi.mocked(getValidToken).mockResolvedValue('token');
   vi.mocked(hasAuthFailedSubs).mockReturnValue(false);
   vi.mocked(getGlobalPricingSettings).mockResolvedValue({ decay_half_life_periods: 3, redemption_increment: 0.1 });
+  vi.mocked(getPricingHistory).mockResolvedValue([]);
 });
 
 describe('GET /', () => {
@@ -211,6 +213,73 @@ describe('GET /', () => {
       expect(res.body.isConnected).toBe(true);
       expect(res.body.needsReconnect).toBe(false);
       expect(getCustomRewards).toHaveBeenCalled();
+    });
+  });
+
+  it('exposes the selectable history hour options', async () => {
+    const res = await supertest(buildApp()).get('/');
+    expect(res.body.historyHourOptions).toEqual([1, 2, 3, 6, 9, 12, 24]);
+  });
+
+  describe('price history chart', () => {
+    const CONFIG = {
+      id: 1, streamer_id: 123, twitch_reward_id: 'rwd1', enabled: true,
+      base_cost: 200, cooldown_seconds: 300, max_multiplier: 4, curve: 1.5,
+      demand: 0.5, demand_updated_at: '1700000000000', last_pushed_cost: 300, twitch_unsupported: false,
+    };
+
+    beforeEach(() => {
+      vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+      vi.mocked(getCustomRewards).mockResolvedValue([{ id: 'rwd1', title: 'Cool Reward', cost: 200, is_enabled: true } as any]);
+      vi.mocked(getPricingConfigsForStreamer).mockResolvedValue([CONFIG] as any);
+    });
+
+    it('defaults to a 3-hour range when hours is not specified', async () => {
+      const before = Date.now();
+      const res = await supertest(buildApp()).get('/');
+      const after = Date.now();
+
+      expect(res.body.historyHours).toBe(3);
+      expect(getPricingHistory).toHaveBeenCalledWith(1, expect.any(Number));
+      const sinceMs = vi.mocked(getPricingHistory).mock.calls[0][1];
+      expect(sinceMs).toBeGreaterThanOrEqual(before - 3 * 60 * 60 * 1000);
+      expect(sinceMs).toBeLessThanOrEqual(after - 3 * 60 * 60 * 1000);
+    });
+
+    it('respects a valid hours query param', async () => {
+      const res = await supertest(buildApp()).get('/?hours=6');
+      expect(res.body.historyHours).toBe(6);
+      const sinceMs = vi.mocked(getPricingHistory).mock.calls[0][1];
+      expect(Date.now() - sinceMs).toBeCloseTo(6 * 60 * 60 * 1000, -3);
+    });
+
+    it('falls back to the default for an invalid hours value', async () => {
+      const res = await supertest(buildApp()).get('/?hours=999');
+      expect(res.body.historyHours).toBe(3);
+    });
+
+    it('renders a chart string for a reward with a config (with points, and without), and null without a config', async () => {
+      vi.mocked(getPricingHistory).mockResolvedValue([{ recorded_at: '1700000000000', cost: 300, demand: 0.5 }]);
+      const res = await supertest(buildApp()).get('/');
+      expect(typeof res.body.rewards[0].historyChart).toBe('string');
+      expect(res.body.rewards[0].historyChart).toContain('<svg');
+
+      vi.mocked(getPricingConfigsForStreamer).mockResolvedValue([]);
+      const res2 = await supertest(buildApp()).get('/');
+      expect(res2.body.rewards[0].historyChart).toBeNull();
+    });
+
+    it('renders the empty-history placeholder when there are no points yet', async () => {
+      const res = await supertest(buildApp()).get('/');
+      expect(res.body.rewards[0].historyChart).toContain('No price history yet');
+    });
+
+    it('renders a chart for an unlinked (orphaned) reward too', async () => {
+      vi.mocked(getCustomRewards).mockResolvedValue([]);
+      vi.mocked(getPricingHistory).mockResolvedValue([{ recorded_at: '1700000000000', cost: 300, demand: 0.5 }]);
+      const res = await supertest(buildApp()).get('/');
+      expect(res.body.rewards[0].twitchReward).toBeNull();
+      expect(res.body.rewards[0].historyChart).toContain('<svg');
     });
   });
 });

--- a/src/web/routes/channelPointsAdmin.ts
+++ b/src/web/routes/channelPointsAdmin.ts
@@ -115,16 +115,18 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
     // Configs whose reward no longer appears on Twitch (deleted, or the streamer's token
     // lacks the scope to list it) still get processed by the decay scheduler — surface them
     // as "unlinked" rows so they aren't invisible/unmanageable from this page.
-    for (const config of pricingConfigs) {
-      if (matchedRewardIds.has(config.twitch_reward_id)) continue;
-      rewards.push({
-        rewardId: config.twitch_reward_id,
-        twitchReward: null,
-        config,
-        previewPrice: previewPriceFor(config),
-        historyChart: await buildHistoryChart(config),
-      });
-    }
+    const unlinkedRows = await Promise.all(
+      pricingConfigs
+        .filter((config) => !matchedRewardIds.has(config.twitch_reward_id))
+        .map(async (config) => ({
+          rewardId: config.twitch_reward_id,
+          twitchReward: null,
+          config,
+          previewPrice: previewPriceFor(config),
+          historyChart: await buildHistoryChart(config),
+        })),
+    );
+    rewards.push(...unlinkedRows);
 
     const isOwner = req.session.user?.isOwner ?? false;
     const globalSettings = isOwner ? await getGlobalPricingSettings() : null;

--- a/src/web/routes/channelPointsAdmin.ts
+++ b/src/web/routes/channelPointsAdmin.ts
@@ -4,12 +4,13 @@ import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
 import { getStreamerByDiscordId } from '../../db';
 import type { DbStreamerEventSub } from '../../db';
-import { getPricingConfigsForStreamer, getGlobalPricingSettings } from '../../db';
+import { getPricingConfigsForStreamer, getGlobalPricingSettings, getPricingHistory } from '../../db';
 import type { RewardPricingRow } from '../../db';
 import { getCustomRewards, TwitchCustomReward } from '../../twitch/twitchApi';
 import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
 import { hasAuthFailedSubs } from '../../twitch/eventsub/twitchEventSubSubscriptions';
 import { computePrice } from '../../twitch/pricing/rewardPricingMath';
+import { renderPriceHistoryChart } from '../priceHistoryChart';
 import { filterQueryParam, renderError, renderView } from './shared';
 import { router as channelPointsMutationsRouter } from './channelPointsAdminMutations';
 
@@ -24,12 +25,24 @@ const KNOWN_SUCCESSES = new Set([
   'pricing_saved', 'pricing_deleted', 'global_settings_saved', 'reward_created', 'reward_updated', 'reward_deleted',
 ]);
 
+/** Selectable "last N hours" ranges for the price history chart; streams here typically run ~3h. */
+const HISTORY_HOUR_OPTIONS = [1, 2, 3, 6, 9, 12, 24] as const;
+const DEFAULT_HISTORY_HOURS = 3;
+
 /** One row on the Channel Points page: a live Twitch reward, an "unlinked" orphaned pricing config, or both merged. */
 interface ChannelPointRewardRow {
   rewardId: string;
   twitchReward: TwitchCustomReward | null;
   config: RewardPricingRow | null;
   previewPrice: number | null;
+  /** Rendered SVG history chart, or null when there's no config to chart yet. */
+  historyChart: string | null;
+}
+
+/** Parses the `hours` query param against the allowed range options, defaulting when missing/invalid. */
+function parseHistoryHours(value: unknown): number {
+  const n = Number(value);
+  return (HISTORY_HOUR_OPTIONS as readonly number[]).includes(n) ? n : DEFAULT_HISTORY_HOURS;
 }
 
 /** Computes the live preview price for a reward's current demand, from its pricing config. */
@@ -58,11 +71,12 @@ async function fetchTwitchRewards(streamer: DbStreamerEventSub): Promise<TwitchC
 /**
  * GET /channel-points — renders the Channel Points management page: the streamer's live
  * Twitch rewards (creatable/editable/deletable from here) merged with any existing dynamic
- * pricing config (including a live price preview), and — only for the bot owner — the
- * bot-wide pricing decay/increment settings. Shows a reconnect prompt instead of the reward
- * list when the streamer isn't connected, or their connection has started failing with an
- * auth error (mirrors the same check on `/user/settings`).
- * @param req - Express request; reads `req.session.user`, `error`, and `success` query params.
+ * pricing config (including a live price preview and a price history chart over the selected
+ * time range), and — only for the bot owner — the bot-wide pricing decay/increment settings.
+ * Shows a reconnect prompt instead of the reward list when the streamer isn't connected, or
+ * their connection has started failing with an auth error (mirrors the same check on
+ * `/user/settings`).
+ * @param req - Express request; reads `req.session.user`, `error`, `success`, and `hours` query params.
  * @param res - Express response; renders the `channelPointsAdmin` view, or a 500 error page on failure.
  */
 router.get('/', requireAuth, csrfProtection, async (req, res) => {
@@ -75,20 +89,41 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
       ? await Promise.all([getPricingConfigsForStreamer(streamer.id), fetchTwitchRewards(streamer)])
       : [[], []];
 
+    const historyHours = parseHistoryHours(req.query.hours);
+    const rangeEndMs = Date.now();
+    const rangeStartMs = rangeEndMs - historyHours * 60 * 60 * 1000;
+
+    async function buildHistoryChart(config: RewardPricingRow): Promise<string> {
+      const points = await getPricingHistory(config.id, rangeStartMs);
+      return renderPriceHistoryChart(points.map((p) => ({ t: Number(p.recorded_at), cost: p.cost })), rangeStartMs, rangeEndMs);
+    }
+
     const configByRewardId = new Map(pricingConfigs.map((c) => [c.twitch_reward_id, c]));
     const matchedRewardIds = new Set(twitchRewards.map((tr) => tr.id));
 
-    const rewards: ChannelPointRewardRow[] = twitchRewards.map((tr) => {
+    const rewards: ChannelPointRewardRow[] = await Promise.all(twitchRewards.map(async (tr) => {
       const config = configByRewardId.get(tr.id) ?? null;
-      return { rewardId: tr.id, twitchReward: tr, config, previewPrice: config ? previewPriceFor(config) : null };
-    });
+      return {
+        rewardId: tr.id,
+        twitchReward: tr,
+        config,
+        previewPrice: config ? previewPriceFor(config) : null,
+        historyChart: config ? await buildHistoryChart(config) : null,
+      };
+    }));
 
     // Configs whose reward no longer appears on Twitch (deleted, or the streamer's token
     // lacks the scope to list it) still get processed by the decay scheduler — surface them
     // as "unlinked" rows so they aren't invisible/unmanageable from this page.
     for (const config of pricingConfigs) {
       if (matchedRewardIds.has(config.twitch_reward_id)) continue;
-      rewards.push({ rewardId: config.twitch_reward_id, twitchReward: null, config, previewPrice: previewPriceFor(config) });
+      rewards.push({
+        rewardId: config.twitch_reward_id,
+        twitchReward: null,
+        config,
+        previewPrice: previewPriceFor(config),
+        historyChart: await buildHistoryChart(config),
+      });
     }
 
     const isOwner = req.session.user?.isOwner ?? false;
@@ -103,6 +138,8 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
       rewards,
       isOwner,
       globalSettings,
+      historyHours,
+      historyHourOptions: HISTORY_HOUR_OPTIONS,
       error: filterQueryParam(req.query.error, KNOWN_ERRORS),
       success: filterQueryParam(req.query.success, KNOWN_SUCCESSES),
     });

--- a/views/channelPointsAdmin.ejs
+++ b/views/channelPointsAdmin.ejs
@@ -128,6 +128,17 @@
         Turn on dynamic pricing per reward to have its channel point cost automatically rise with usage and decay when idle.
       </p>
 
+      <% if (rewards.some((r) => r.config)) { %>
+      <form method="GET" action="/channel-points" class="form-row-wrap" style="align-items:center;margin-bottom:0.75rem;">
+        <label class="hint hint-compact" for="history-hours" style="padding:0;">Price history range</label>
+        <select id="history-hours" class="input" name="hours" onchange="this.form.submit()" style="width:auto;">
+          <% for (const h of historyHourOptions) { %>
+          <option value="<%= h %>" <%= h === historyHours ? 'selected' : '' %>><%= h %>h</option>
+          <% } %>
+        </select>
+      </form>
+      <% } %>
+
       <% if (rewards.length === 0) { %>
       <div class="card">
         <div class="card-body">
@@ -163,6 +174,12 @@
             </form>
             <% } %>
           </div>
+
+          <% if (r.historyChart) { %>
+          <div style="margin-top:0.5rem;">
+            <%- r.historyChart %>
+          </div>
+          <% } %>
 
           <% if (r.twitchReward) { %>
           <details style="margin-top:0.5rem;">
@@ -234,5 +251,6 @@
   <%- include('partials/pwa-register') %>
   <%- include('partials/footer') %>
   <script src="/utils.js"></script>
+  <script src="/priceHistoryChart.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Follow-up to #345 (dynamic Channel Point pricing), rebased onto `main` now that #349/#350/#348 have all merged (the `/pricing` page this PR originally targeted was renamed and folded into `/channel-points` by #350 — this PR's changes have been ported onto `channelPointsAdmin.*` accordingly, and its `rewardPricingService.ts` changes merged alongside #348's decay/rate-limiter changes to the same file).

- New `reward_pricing_history` table logs a demand/cost snapshot every time a reward's price is recomputed (on redemption and on each decay tick). Retention is bounded to ~25h per reward (pruned on every insert), since 24h is the longest selectable range on the page.
- `/channel-points` now renders an inline SVG line chart per reward (linked or unlinked) showing price over time, with a "last N hours" selector — `1/2/3/6/9/12/24`, defaulting to **3h** (a typical stream length) — that scopes every chart on the page.
- A hover crosshair + tooltip (`public/priceHistoryChart.js`) lets you read the exact price/time at any point along the line, snapping to the nearest recorded sample.
- Chart rendering (`src/web/priceHistoryChart.ts`) is a pure function, fully unit tested, and validated against the site's fixed dark palette per the project's dataviz guidelines (single-series line, no legend needed, recessive gridlines, 2px rounded line, 4px end-marker with a surface ring).

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` — all 116 test files / 2046 tests pass, including coverage for the history DB layer (record + prune, range query), the chart-building pure function (empty state, sorting, flat-range guard, tick/end labels), and the admin route (default/custom/invalid `hours`, chart presence for linked/unlinked/no-config rows)
- [x] Rendered the actual `channelPointsAdmin.ejs` template directly (not just the mocked-`res.render` route tests) with fixture data, confirming the history chart, range selector, and script tag all render correctly
- [ ] Manual walkthrough against a live streamer account: confirm history accumulates across real redemptions/decay ticks and the range selector reloads all charts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151M3CDRw5g2c8UUxk15YD8

---
_Generated by [Claude Code](https://claude.ai/code/session_0151M3CDRw5g2c8UUxk15YD8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “price history” chart to the Channel Points admin page, with selectable time ranges and interactive hover tooltips.
  * Rewards show historical pricing trends over time, including cases with unlinked pricing entries.
* **Bug Fixes**
  * Chart rendering now gracefully handles empty history, flat cost ranges, and invalid range selections.
  * Price-history logging is best-effort and won’t interrupt pricing updates if it fails.
* **Tests**
  * Added automated coverage for chart rendering, history retrieval, and Channel Points admin page behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->