### PR TITLE
Fix 401 errors on dynamic pricing reward cost pushes

### DIFF
--- a/src/twitch/pricing/rewardPricingService.test.ts
+++ b/src/twitch/pricing/rewardPricingService.test.ts
@@ -14,7 +14,8 @@ vi.mock('../../db', () => ({
 vi.mock('../eventsub/twitchApiEventSub', () => ({ getValidToken: vi.fn() }));
 vi.mock('../twitchApi', () => {
   class TwitchRewardUnsupportedError extends Error {}
-  return { updateRewardCost: vi.fn(), TwitchRewardUnsupportedError };
+  class TwitchRewardAuthError extends Error {}
+  return { updateRewardCost: vi.fn(), TwitchRewardUnsupportedError, TwitchRewardAuthError };
 });
 
 import {
@@ -22,7 +23,7 @@ import {
   getGlobalPricingSettings, getStreamerById,
 } from '../../db';
 import { getValidToken } from '../eventsub/twitchApiEventSub';
-import { updateRewardCost, TwitchRewardUnsupportedError } from '../twitchApi';
+import { updateRewardCost, TwitchRewardUnsupportedError, TwitchRewardAuthError } from '../twitchApi';
 import { applyRedemptionPricing, applyDecayTick, resetAndDeletePricing } from './rewardPricingService';
 
 const settings = { decay_half_life_periods: 3, redemption_increment: 0.1 };
@@ -52,6 +53,10 @@ beforeEach(() => {
   vi.mocked(getStreamerById).mockResolvedValue(streamer);
   vi.mocked(getValidToken).mockResolvedValue('user-token');
   vi.mocked(deletePricingConfig).mockResolvedValue(undefined);
+  // clearAllMocks() resets call history but not mockResolvedValue/mockRejectedValue
+  // implementations, so reset this explicitly — otherwise a test that rejects
+  // updateRewardCost without ...Once leaks that rejection into later tests.
+  vi.mocked(updateRewardCost).mockResolvedValue(undefined);
 });
 
 describe('applyRedemptionPricing', () => {
@@ -78,10 +83,18 @@ describe('applyRedemptionPricing', () => {
 
   it('marks the reward unsupported and disables it on a 403, without recording demand', async () => {
     vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
-    vi.mocked(updateRewardCost).mockRejectedValue(new TwitchRewardUnsupportedError('403'));
+    vi.mocked(updateRewardCost).mockRejectedValueOnce(new TwitchRewardUnsupportedError('403'));
     await applyRedemptionPricing(1, 'rwd1');
     expect(markPricingUnsupported).toHaveBeenCalledWith(1, 'rwd1');
     expect(recordPricingUpdate).not.toHaveBeenCalled();
+  });
+
+  it('on a 401, does not mark the reward unsupported but still persists the recalculated demand', async () => {
+    vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
+    vi.mocked(updateRewardCost).mockRejectedValueOnce(new TwitchRewardAuthError('401'));
+    await applyRedemptionPricing(1, 'rwd1');
+    expect(markPricingUnsupported).not.toHaveBeenCalled();
+    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), null);
   });
 
   it('skips the Twitch call when the recomputed price equals last_pushed_cost', async () => {
@@ -96,7 +109,7 @@ describe('applyRedemptionPricing', () => {
 
   it('swallows a Twitch push failure but still persists the recalculated demand', async () => {
     vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
-    vi.mocked(updateRewardCost).mockRejectedValue(new Error('Twitch down'));
+    vi.mocked(updateRewardCost).mockRejectedValueOnce(new Error('Twitch down'));
     await expect(applyRedemptionPricing(1, 'rwd1')).resolves.toBeUndefined();
     expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), null);
   });

--- a/src/twitch/pricing/rewardPricingService.ts
+++ b/src/twitch/pricing/rewardPricingService.ts
@@ -19,20 +19,66 @@ function queueKey(streamerId: number, twitchRewardId: string): string {
   return `${streamerId}:${twitchRewardId}`;
 }
 
+/** Outcome of {@link pushRewardCostUpdate}. */
+interface PushCostResult {
+  /** The cost to persist as `last_pushed_cost` — the new cost on success, otherwise unchanged. */
+  lastPushedCost: number | null;
+  /** True when the reward was found to be permanently unsupported (403) — `markPricingUnsupported` has already run. */
+  unsupported: boolean;
+}
+
+/**
+ * Resolves the streamer's broadcaster token and pushes a recomputed cost to Twitch for one
+ * reward. A 403 (the reward was created outside this app and can never be managed by it) is
+ * treated as permanent: the row is disabled via `markPricingUnsupported`. A 401 (invalid
+ * token, or missing the channel:manage:redemptions scope) is logged with an actionable message
+ * but otherwise treated like any other transient failure — the token is shared with other bot
+ * features, so it's never cleared from here; reconnecting Twitch in User Settings (to grant
+ * the scope, or replace a revoked token) is what actually resolves it. Any other failure is
+ * also logged and swallowed. In every failure case, `previousLastPushedCost` is returned
+ * unchanged so the price is simply retried on the next redemption/decay tick.
+ *
+ * @param streamerId - DB row ID of the owning streamer.
+ * @param twitchRewardId - Twitch reward UUID.
+ * @param newCost - The recomputed cost to push.
+ * @param previousLastPushedCost - The reward's current `last_pushed_cost`, returned unchanged on failure.
+ */
+async function pushRewardCostUpdate(
+  streamerId: number, twitchRewardId: string, newCost: number, previousLastPushedCost: number | null,
+): Promise<PushCostResult> {
+  try {
+    const streamer = await getStreamerById(streamerId);
+    const token = streamer ? await getValidToken(streamer) : null;
+    if (!streamer?.twitch_user_id || !token) {
+      log.warn(`No valid broadcaster token for streamer ${streamerId} — skipping Twitch price push for reward ${twitchRewardId}`);
+      return { lastPushedCost: previousLastPushedCost, unsupported: false };
+    }
+    await updateRewardCost(streamer.twitch_user_id, twitchRewardId, newCost, token);
+    return { lastPushedCost: newCost, unsupported: false };
+  } catch (err) {
+    if (err instanceof TwitchRewardUnsupportedError) {
+      log.warn(`Reward ${twitchRewardId} (streamer ${streamerId}) can't be managed by this app — disabling dynamic pricing:`, err);
+      await markPricingUnsupported(streamerId, twitchRewardId);
+      return { lastPushedCost: previousLastPushedCost, unsupported: true };
+    }
+    if (err instanceof TwitchRewardAuthError) {
+      log.warn(`Broadcaster token for streamer ${streamerId} is invalid or missing the channel:manage:redemptions scope — reconnect Twitch in User Settings to fix reward ${twitchRewardId}:`, err);
+    } else {
+      log.error(`Failed to push new price for reward ${twitchRewardId}:`, err);
+    }
+    return { lastPushedCost: previousLastPushedCost, unsupported: false };
+  }
+}
+
 /**
  * Recomputes demand and price for one reward and persists the result, pushing the new
  * cost to Twitch only when it differs from the last pushed cost. No-ops entirely (no DB
  * write, no Twitch call) when the reward has no pricing config or dynamic pricing is
- * disabled for it — this is where "optional per reward" is enforced. A transient failure
- * resolving the streamer's token or pushing to Twitch is caught and logged; the recalculated
- * demand is still persisted so the price is simply retried on the next redemption/decay tick.
- * A 403 from Twitch (the reward was created outside this app and can never be managed by it)
- * is treated as permanent instead: the row is disabled via `markPricingUnsupported` and demand
- * is intentionally not persisted, since the row won't be read again until re-enabled. A 401
- * (invalid token, or missing the channel:manage:redemptions scope) is logged with an actionable
- * message but otherwise treated like any other transient push failure — the token is shared
- * with other bot features, so it's never cleared from here; reconnecting Twitch in User
- * Settings (to grant the scope, or replace a revoked token) is what actually resolves it.
+ * disabled for it — this is where "optional per reward" is enforced. Demand is always
+ * persisted, even when the Twitch push fails, so the price is simply retried on the next
+ * redemption/decay tick — except when the reward turns out to be permanently unsupported
+ * (see {@link pushRewardCostUpdate}), in which case demand is intentionally not persisted
+ * since the row won't be read again until re-enabled.
  *
  * @param streamerId - DB row ID of the owning streamer.
  * @param twitchRewardId - Twitch reward UUID.
@@ -58,27 +104,9 @@ async function syncRewardPrice(streamerId: number, twitchRewardId: string, apply
 
   let lastPushedCost = row.last_pushed_cost;
   if (newCost !== row.last_pushed_cost) {
-    try {
-      const streamer = await getStreamerById(streamerId);
-      const token = streamer ? await getValidToken(streamer) : null;
-      if (streamer?.twitch_user_id && token) {
-        await updateRewardCost(streamer.twitch_user_id, twitchRewardId, newCost, token);
-        lastPushedCost = newCost;
-      } else {
-        log.warn(`No valid broadcaster token for streamer ${streamerId} — skipping Twitch price push for reward ${twitchRewardId}`);
-      }
-    } catch (err) {
-      if (err instanceof TwitchRewardUnsupportedError) {
-        log.warn(`Reward ${twitchRewardId} (streamer ${streamerId}) can't be managed by this app — disabling dynamic pricing:`, err);
-        await markPricingUnsupported(streamerId, twitchRewardId);
-        return; // markPricingUnsupported already disabled the row; no need to also record demand.
-      }
-      if (err instanceof TwitchRewardAuthError) {
-        log.warn(`Broadcaster token for streamer ${streamerId} is invalid or missing the channel:manage:redemptions scope — reconnect Twitch in User Settings to fix reward ${twitchRewardId}:`, err);
-      } else {
-        log.error(`Failed to push new price for reward ${twitchRewardId}:`, err);
-      }
-    }
+    const result = await pushRewardCostUpdate(streamerId, twitchRewardId, newCost, row.last_pushed_cost);
+    if (result.unsupported) return; // markPricingUnsupported already disabled the row; no need to also record demand.
+    lastPushedCost = result.lastPushedCost;
   }
 
   await recordPricingUpdate(streamerId, twitchRewardId, newDemand, now, lastPushedCost);

--- a/src/twitch/pricing/rewardPricingService.ts
+++ b/src/twitch/pricing/rewardPricingService.ts
@@ -4,7 +4,7 @@ import {
   getGlobalPricingSettings, getStreamerById,
 } from '../../db';
 import { getValidToken } from '../eventsub/twitchApiEventSub';
-import { updateRewardCost, TwitchRewardUnsupportedError } from '../twitchApi';
+import { updateRewardCost, TwitchRewardUnsupportedError, TwitchRewardAuthError } from '../twitchApi';
 import { computePrice, decayDemand, applyRedemption } from './rewardPricingMath';
 import { createLogger } from '../../shared/logger';
 
@@ -28,7 +28,11 @@ function queueKey(streamerId: number, twitchRewardId: string): string {
  * demand is still persisted so the price is simply retried on the next redemption/decay tick.
  * A 403 from Twitch (the reward was created outside this app and can never be managed by it)
  * is treated as permanent instead: the row is disabled via `markPricingUnsupported` and demand
- * is intentionally not persisted, since the row won't be read again until re-enabled.
+ * is intentionally not persisted, since the row won't be read again until re-enabled. A 401
+ * (invalid token, or missing the channel:manage:redemptions scope) is logged with an actionable
+ * message but otherwise treated like any other transient push failure — the token is shared
+ * with other bot features, so it's never cleared from here; reconnecting Twitch in User
+ * Settings (to grant the scope, or replace a revoked token) is what actually resolves it.
  *
  * @param streamerId - DB row ID of the owning streamer.
  * @param twitchRewardId - Twitch reward UUID.
@@ -69,7 +73,11 @@ async function syncRewardPrice(streamerId: number, twitchRewardId: string, apply
         await markPricingUnsupported(streamerId, twitchRewardId);
         return; // markPricingUnsupported already disabled the row; no need to also record demand.
       }
-      log.error(`Failed to push new price for reward ${twitchRewardId}:`, err);
+      if (err instanceof TwitchRewardAuthError) {
+        log.warn(`Broadcaster token for streamer ${streamerId} is invalid or missing the channel:manage:redemptions scope — reconnect Twitch in User Settings to fix reward ${twitchRewardId}:`, err);
+      } else {
+        log.error(`Failed to push new price for reward ${twitchRewardId}:`, err);
+      }
     }
   }
 

--- a/src/twitch/twitchApi.test.ts
+++ b/src/twitch/twitchApi.test.ts
@@ -8,7 +8,7 @@ vi.mock('../shared/config', () => ({
 
 import {
   getUsers, getStreams, getChannelInfo, getSharedChatSession, getAppToken,
-  updateRewardCost, TwitchRewardUnsupportedError,
+  updateRewardCost, TwitchRewardUnsupportedError, TwitchRewardAuthError,
 } from './twitchApi';
 
 const TOKEN_RESPONSE = { access_token: 'test-token', expires_in: 3600 };
@@ -187,5 +187,15 @@ describe('updateRewardCost', () => {
   it('does not throw TwitchRewardUnsupportedError for other non-OK statuses', async () => {
     vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(400, {}));
     await expect(updateRewardCost('bc1', 'rwd1', 500, 'user-token')).rejects.not.toBeInstanceOf(TwitchRewardUnsupportedError);
+  });
+
+  it('throws TwitchRewardAuthError specifically on a 401 response', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(401, {}));
+    await expect(updateRewardCost('bc1', 'rwd1', 500, 'user-token')).rejects.toBeInstanceOf(TwitchRewardAuthError);
+  });
+
+  it('does not throw TwitchRewardAuthError for other non-OK statuses', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(400, {}));
+    await expect(updateRewardCost('bc1', 'rwd1', 500, 'user-token')).rejects.not.toBeInstanceOf(TwitchRewardAuthError);
   });
 });

--- a/src/twitch/twitchApi.ts
+++ b/src/twitch/twitchApi.ts
@@ -50,6 +50,14 @@ export function authHeaders(token: string): Record<string, string> {
   };
 }
 
+/**
+ * Clears the cached app token on a 401 response, so the next call re-fetches rather than
+ * reusing an invalidated token until `appTokenExpiry`. No-ops for any other status.
+ */
+function invalidateAppTokenIfUnauthorized(res: Response): void {
+  if (res.status === 401) { cachedAppToken = null; appTokenExpiry = 0; }
+}
+
 function chunks<T>(arr: T[], size: number): T[][] {
   if (size <= 0) throw new Error(`chunks: size must be > 0, got ${size}`);
   const result: T[][] = [];
@@ -101,9 +109,7 @@ export async function getUsers(logins: string[]): Promise<TwitchUser[]> {
     const params = batch.map((l) => `login=${encodeURIComponent(l)}`).join('&');
     const res = await fetchHelixWithRetry(`https://api.twitch.tv/helix/users?${params}`, authHeaders(token));
     if (!res.ok) {
-      // Clear the cached token on 401 so the next call re-fetches rather than
-      // reusing an invalidated token until appTokenExpiry.
-      if (res.status === 401) { cachedAppToken = null; appTokenExpiry = 0; }
+      invalidateAppTokenIfUnauthorized(res);
       throw new Error(`[TwitchAPI] getUsers failed: ${res.status}`);
     }
     const data = await res.json() as { data: Array<{ login: string; id: string }> };
@@ -130,7 +136,7 @@ export async function getStreams(userIds: string[]): Promise<TwitchStream[]> {
     const params = batch.map((id) => `user_id=${encodeURIComponent(id)}`).join('&');
     const res = await fetchHelixWithRetry(`https://api.twitch.tv/helix/streams?${params}&first=100`, authHeaders(token));
     if (!res.ok) {
-      if (res.status === 401) { cachedAppToken = null; appTokenExpiry = 0; }
+      invalidateAppTokenIfUnauthorized(res);
       throw new Error(`[TwitchAPI] getStreams failed: ${res.status}`);
     }
     const data = await res.json() as { data: TwitchStream[] };
@@ -154,7 +160,7 @@ export async function getChannelInfo(broadcasterIds: string[]): Promise<TwitchCh
     const params = batch.map((id) => `broadcaster_id=${encodeURIComponent(id)}`).join('&');
     const res = await fetchHelixWithRetry(`https://api.twitch.tv/helix/channels?${params}`, authHeaders(token));
     if (!res.ok) {
-      if (res.status === 401) { cachedAppToken = null; appTokenExpiry = 0; }
+      invalidateAppTokenIfUnauthorized(res);
       throw new Error(`[TwitchAPI] getChannelInfo failed: ${res.status}`);
     }
     const data = await res.json() as { data: TwitchChannelInfo[] };
@@ -265,7 +271,7 @@ export async function getSharedChatSession(broadcasterId: string): Promise<Share
   );
   if (res.status === 404 || res.status === 403) return null;
   if (!res.ok) {
-    if (res.status === 401) { cachedAppToken = null; appTokenExpiry = 0; }
+    invalidateAppTokenIfUnauthorized(res);
     throw new Error(`[TwitchAPI] getSharedChatSession failed: ${res.status}`);
   }
   const data = await res.json() as { data: SharedChatSession[] };

--- a/src/twitch/twitchApi.ts
+++ b/src/twitch/twitchApi.ts
@@ -194,10 +194,24 @@ export class TwitchRewardUnsupportedError extends Error {
 }
 
 /**
+ * Thrown when Twitch returns 401 for a reward cost update — the broadcaster token is
+ * invalid, or (most commonly) lacks the `channel:manage:redemptions` scope. Unlike
+ * `TwitchRewardUnsupportedError`, this is not permanent for the reward: reconnecting the
+ * streamer's Twitch account (to grant the scope, or replace a revoked token) resolves it.
+ */
+export class TwitchRewardAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TwitchRewardAuthError';
+  }
+}
+
+/**
  * Updates a custom reward's cost on Twitch via Helix. Requires a broadcaster user token
- * (app tokens cannot manage custom rewards). Not wrapped in fetchHelixWithRetry — the
- * caller (dynamic pricing sync) already tolerates a failed push by retrying on the next
- * redemption/decay tick, so retrying here would just duplicate that behaviour.
+ * with the channel:manage:redemptions scope (app tokens cannot manage custom rewards).
+ * Not wrapped in fetchHelixWithRetry — the caller (dynamic pricing sync) already tolerates
+ * a failed push by retrying on the next redemption/decay tick, so retrying here would just
+ * duplicate that behaviour.
  *
  * @param broadcasterId - Twitch user ID of the reward's broadcaster.
  * @param rewardId - Twitch reward UUID to update.
@@ -205,6 +219,8 @@ export class TwitchRewardUnsupportedError extends Error {
  * @param userToken - Broadcaster OAuth user token with the channel:manage:redemptions scope.
  * @throws {TwitchRewardUnsupportedError} When Twitch returns 403 (reward created by a
  *   different client_id, or channel points aren't available for the broadcaster).
+ * @throws {TwitchRewardAuthError} When Twitch returns 401 (invalid token, or missing the
+ *   channel:manage:redemptions scope).
  */
 export async function updateRewardCost(broadcasterId: string, rewardId: string, cost: number, userToken: string): Promise<void> {
   const res = await twitchFetch(
@@ -216,6 +232,7 @@ export async function updateRewardCost(broadcasterId: string, rewardId: string, 
     },
   );
   if (res.status === 403) throw new TwitchRewardUnsupportedError(`[TwitchAPI] updateRewardCost: reward ${rewardId} cannot be managed by this app (403)`);
+  if (res.status === 401) throw new TwitchRewardAuthError(`[TwitchAPI] updateRewardCost: broadcaster token invalid or missing scope for reward ${rewardId} (401)`);
   if (!res.ok) throw new Error(`[TwitchAPI] updateRewardCost failed: ${res.status}`);
 }
 

--- a/src/web/routes/userSettings.ts
+++ b/src/web/routes/userSettings.ts
@@ -12,7 +12,7 @@ import { TWITCH_CLIENT_ID, TWITCH_EVENTSUB_REDIRECT_URI, EVENTSUB_TOKEN_SECRET }
 const log = createLogger('Web');
 const router = Router();
 
-const TWITCH_OAUTH_SCOPE = 'moderator:read:followers channel:read:subscriptions channel:read:redemptions';
+const TWITCH_OAUTH_SCOPE = 'moderator:read:followers channel:read:subscriptions channel:read:redemptions channel:manage:redemptions';
 
 const KNOWN_ERRORS = new Set([
   'no_streamer_record',


### PR DESCRIPTION
## Summary

Fixes `[ERROR] [RewardPricing] Failed to push new price for reward ...: [TwitchAPI] updateRewardCost failed: 401`, seen on every redemption/decay tick since #345 merged.

**Root cause:** dynamic pricing's `updateRewardCost` call needs the `channel:manage:redemptions` Twitch scope, but the Twitch OAuth connect flow in User Settings (`TWITCH_OAUTH_SCOPE`) never requested it. So this isn't a revoked/expired token — every existing streamer's token is simply missing a scope that was never asked for.

- Added `channel:manage:redemptions` to `TWITCH_OAUTH_SCOPE` (`src/web/routes/userSettings.ts`) so new/re-connections request it. **Already-connected streamers still need to disconnect/reconnect once in User Settings** to actually grant the scope on their existing token — Twitch doesn't retroactively add scopes to a live token.
- Added `TwitchRewardAuthError`, thrown specifically on a `401` from `updateRewardCost` (`src/twitch/twitchApi.ts`), distinct from the existing `403` → `TwitchRewardUnsupportedError` (which is permanent for that one reward, since it means a different app created it).
- In `rewardPricingService.ts`, a `401` is now logged with an actionable "reconnect Twitch in User Settings" message instead of a generic error. It does **not** disable the reward and does **not** clear the stored token — the token is shared with other bot features (EventSub, follower/subscriber reads), so clearing it here would break those too. A reconnect is what actually resolves it.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` — all 114 test files / 1959 tests pass, including new coverage: `updateRewardCost` throwing `TwitchRewardAuthError` specifically on 401 (and not on other statuses), and `rewardPricingService` not marking a reward unsupported on 401 while still persisting recalculated demand
- [ ] Manual walkthrough: reconnect a streamer's Twitch account in User Settings, confirm the OAuth consent screen now requests the redemptions-management scope, and that dynamic pricing pushes succeed afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151M3CDRw5g2c8UUxk15YD8

---
_Generated by [Claude Code](https://claude.ai/code/session_0151M3CDRw5g2c8UUxk15YD8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Twitch connection permissions to support managing channel redemptions.

* **Bug Fixes**
  * Improved handling of Twitch reward price updates so authorization failures are treated differently from unsupported rewards.
  * Prevented failed reward cost updates from blocking future retry attempts when the update can’t be applied.
  * Made Twitch token handling more reliable after unauthorized responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->