### PR TITLE
Speed up idle decay to 30s, rate-limit redemption pushes to 1/5s per reward

### DIFF
--- a/src/twitch/pricing/rewardPricingScheduler.test.ts
+++ b/src/twitch/pricing/rewardPricingScheduler.test.ts
@@ -83,10 +83,10 @@ describe('startRewardPricingScheduler / stopRewardPricingScheduler', () => {
     startRewardPricingScheduler();
 
     expect(getAllEnabledPricingRows).not.toHaveBeenCalled();
-    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    await vi.advanceTimersByTimeAsync(30_000);
     expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(1);
 
-    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    await vi.advanceTimersByTimeAsync(30_000);
     expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(2);
   });
 
@@ -95,23 +95,23 @@ describe('startRewardPricingScheduler / stopRewardPricingScheduler', () => {
     startRewardPricingScheduler();
     startRewardPricingScheduler(); // second call should no-op, not replace the tracked handle
 
-    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    await vi.advanceTimersByTimeAsync(30_000);
     // If the second call had leaked a duplicate interval, this would be 2.
     expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(1);
 
     await stopRewardPricingScheduler();
-    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    await vi.advanceTimersByTimeAsync(30_000);
     expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(1); // fully stopped, no orphaned timer still firing
   });
 
   it('stop prevents further ticks', async () => {
     vi.mocked(getAllEnabledPricingRows).mockResolvedValue([]);
     startRewardPricingScheduler();
-    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    await vi.advanceTimersByTimeAsync(30_000);
     expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(1);
 
     await stopRewardPricingScheduler();
-    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    await vi.advanceTimersByTimeAsync(30_000);
     expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(1);
   });
 

--- a/src/twitch/pricing/rewardPricingScheduler.ts
+++ b/src/twitch/pricing/rewardPricingScheduler.ts
@@ -4,7 +4,7 @@ import { applyDecayTick } from './rewardPricingService';
 
 const log = createLogger('RewardPricingScheduler');
 
-const DECAY_POLL_INTERVAL_MS = 5 * 60_000;
+const DECAY_POLL_INTERVAL_MS = 30_000;
 
 let tickTimer: ReturnType<typeof setInterval> | null = null;
 let tickRunning = false;

--- a/src/twitch/pricing/rewardPricingService.test.ts
+++ b/src/twitch/pricing/rewardPricingService.test.ts
@@ -28,6 +28,7 @@ import { getValidToken } from '../eventsub/twitchApiEventSub';
 import { updateRewardCost, deleteCustomReward, TwitchRewardUnsupportedError, TwitchRewardAuthError } from '../twitchApi';
 import {
   applyRedemptionPricing, applyDecayTick, resetAndDeletePricing, deleteRewardAndPricing,
+  __resetPushRateLimiterForTests,
 } from './rewardPricingService';
 
 const settings = { decay_half_life_periods: 3, redemption_increment: 0.1 };
@@ -62,6 +63,10 @@ beforeEach(() => {
   // updateRewardCost without ...Once leaks that rejection into later tests.
   vi.mocked(updateRewardCost).mockResolvedValue(undefined);
   vi.mocked(deleteCustomReward).mockResolvedValue(undefined);
+  // The push rate limiter's last-pushed-at cache is module-level state that would
+  // otherwise leak between tests (e.g. a push in one test silently rate-limiting
+  // the next test's push, since both use the same default reward key).
+  __resetPushRateLimiterForTests();
 });
 
 describe('applyRedemptionPricing', () => {
@@ -304,5 +309,43 @@ describe('deleteRewardAndPricing', () => {
     resolveFirst();
     await Promise.all([redemption, del]);
     expect(order).toEqual(['read', 'write', 'read', 'delete']);
+  });
+});
+
+describe('redemption push rate limiting', () => {
+  it('does not push to Twitch again for the same reward within the rate-limit window, but still persists demand both times', async () => {
+    vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
+
+    await applyRedemptionPricing(1, 'rwd1');
+    await applyRedemptionPricing(1, 'rwd1'); // same reward, moments later — within the 5s window
+
+    expect(updateRewardCost).toHaveBeenCalledTimes(1);
+    expect(recordPricingUpdate).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not rate-limit a different reward for the same streamer', async () => {
+    vi.mocked(getPricingForReward).mockImplementation(async (_streamerId, twitchRewardId) =>
+      makeRow({ twitch_reward_id: twitchRewardId, demand: 0, last_pushed_cost: null }));
+
+    await applyRedemptionPricing(1, 'rwd1');
+    await applyRedemptionPricing(1, 'rwd2');
+
+    expect(updateRewardCost).toHaveBeenCalledTimes(2);
+  });
+
+  it('pushes again once the rate-limit window has elapsed', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
+
+      await applyRedemptionPricing(1, 'rwd1');
+      expect(updateRewardCost).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      await applyRedemptionPricing(1, 'rwd1');
+      expect(updateRewardCost).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/twitch/pricing/rewardPricingService.ts
+++ b/src/twitch/pricing/rewardPricingService.ts
@@ -19,6 +19,20 @@ function queueKey(streamerId: number, twitchRewardId: string): string {
   return `${streamerId}:${twitchRewardId}`;
 }
 
+// Caps how often a single reward's cost is actually pushed to Twitch, even if demand keeps
+// changing faster than that (e.g. a redemption burst during a raid/hype train) — every
+// redemption still updates demand immediately, but the resulting price is coalesced onto
+// Twitch at most this often. Skipped pushes aren't lost: since last_pushed_cost is left
+// unchanged, the next redemption (once the window has passed) or the next decay tick
+// (every 30s, well above this interval) will push the fully caught-up price.
+const MIN_PUSH_INTERVAL_MS = 5_000;
+const lastPushedAt = new Map<string, number>();
+
+/** Test-only: clears the in-memory last-pushed-at cache so each test starts from a clean slate. */
+export function __resetPushRateLimiterForTests(): void {
+  lastPushedAt.clear();
+}
+
 /** Outcome of {@link pushRewardCostUpdate}. */
 interface PushCostResult {
   /** The cost to persist as `last_pushed_cost` — the new cost on success, otherwise unchanged. */
@@ -29,13 +43,16 @@ interface PushCostResult {
 
 /**
  * Resolves the streamer's broadcaster token and pushes a recomputed cost to Twitch for one
- * reward. A 403 (the reward was created outside this app and can never be managed by it) is
- * treated as permanent: the row is disabled via `markPricingUnsupported`. A 401 (invalid
- * token, or missing the channel:manage:redemptions scope) is logged with an actionable message
- * but otherwise treated like any other transient failure — the token is shared with other bot
- * features, so it's never cleared from here; reconnecting Twitch in User Settings (to grant
- * the scope, or replace a revoked token) is what actually resolves it. Any other failure is
- * also logged and swallowed. In every failure case, `previousLastPushedCost` is returned
+ * reward, unless `MIN_PUSH_INTERVAL_MS` hasn't yet elapsed since the last successful push for
+ * this reward (see `lastPushedAt`), in which case the push is skipped entirely (no DB/token
+ * lookups) and `previousLastPushedCost` is returned unchanged. A 403 (the reward was created
+ * outside this app and can never be managed by it) is treated as permanent: the row is
+ * disabled via `markPricingUnsupported`. A 401 (invalid token, or missing the
+ * channel:manage:redemptions scope) is logged with an actionable message but otherwise
+ * treated like any other transient failure — the token is shared with other bot features, so
+ * it's never cleared from here; reconnecting Twitch in User Settings (to grant the scope, or
+ * replace a revoked token) is what actually resolves it. Any other failure is also logged and
+ * swallowed. In every failure/rate-limited case, `previousLastPushedCost` is returned
  * unchanged so the price is simply retried on the next redemption/decay tick.
  *
  * @param streamerId - DB row ID of the owning streamer.
@@ -46,6 +63,11 @@ interface PushCostResult {
 async function pushRewardCostUpdate(
   streamerId: number, twitchRewardId: string, newCost: number, previousLastPushedCost: number | null,
 ): Promise<PushCostResult> {
+  const key = queueKey(streamerId, twitchRewardId);
+  const lastPush = lastPushedAt.get(key) ?? 0;
+  if (Date.now() - lastPush < MIN_PUSH_INTERVAL_MS) {
+    return { lastPushedCost: previousLastPushedCost, unsupported: false };
+  }
   try {
     const streamer = await getStreamerById(streamerId);
     const token = streamer ? await getValidToken(streamer) : null;
@@ -54,6 +76,7 @@ async function pushRewardCostUpdate(
       return { lastPushedCost: previousLastPushedCost, unsupported: false };
     }
     await updateRewardCost(streamer.twitch_user_id, twitchRewardId, newCost, token);
+    lastPushedAt.set(key, Date.now());
     return { lastPushedCost: newCost, unsupported: false };
   } catch (err) {
     if (err instanceof TwitchRewardUnsupportedError) {


### PR DESCRIPTION
## Summary

Follows up on a question about the decay scheduler's 5-minute poll interval possibly making prices feel laggy.

- **Decay scheduler interval: 5 min → 30s** (`DECAY_POLL_INTERVAL_MS` in `rewardPricingScheduler.ts`). Twitch's Helix rate limit is per-streamer (each broadcaster's own OAuth token has its own ~800 req/min bucket), so even at 30s a streamer would need >1600 enabled rewards changing price on every single tick to get close — Twitch caps custom rewards at 50 per channel, so there's no realistic risk here.
- **New: 5-second minimum spacing between actual Twitch pushes, per reward** (`rewardPricingService.ts`). This addresses the bigger latent risk: redemptions already push to Twitch immediately with *no* throttling at all — a redemption burst (raid, hype train) on one reward could previously fire many back-to-back Helix PATCH calls. Demand is still updated in the DB on every redemption; the resulting cost is now coalesced onto Twitch at most once per 5s window per reward. Skipped pushes aren't lost — `last_pushed_cost` is left unchanged, so the next redemption (once the window passes) or the next decay tick (now every 30s) pushes the fully caught-up price.
- Updated the stale "may take up to 5 min to sync to Twitch" hint text on `/pricing` to reflect the new behavior.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` — all 114 test files / 1962 tests pass, including 3 new tests for the push rate limiter (same-reward push suppressed within the window but demand still recorded both times, a different reward isn't affected, and a push succeeds again once the window elapses via fake timers)
- [ ] Manual walkthrough: rapidly redeem the same reward several times within a few seconds and confirm the Twitch-visible cost still updates promptly without excessive API calls, and that idle price decay is now visibly faster than the old 5-minute cadence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151M3CDRw5g2c8UUxk15YD8

---
_Generated by [Claude Code](https://claude.ai/code/session_0151M3CDRw5g2c8UUxk15YD8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reward cost updates are now rate-limited, reducing repeated pushes for the same reward while still keeping pricing changes saved.
  * Scheduler ticks now run more frequently, so reward pricing recalculations happen sooner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->