### PR TITLE
Add Twitch API layer for creating/updating/deleting Channel Point rewards

### DIFF
--- a/src/twitch/twitchApi.test.ts
+++ b/src/twitch/twitchApi.test.ts
@@ -8,7 +8,8 @@ vi.mock('../shared/config', () => ({
 
 import {
   getUsers, getStreams, getChannelInfo, getSharedChatSession, getAppToken,
-  updateRewardCost, TwitchRewardUnsupportedError, TwitchRewardAuthError,
+  updateRewardCost, createCustomReward, updateCustomReward, deleteCustomReward,
+  TwitchRewardUnsupportedError, TwitchRewardAuthError,
 } from './twitchApi';
 
 const TOKEN_RESPONSE = { access_token: 'test-token', expires_in: 3600 };
@@ -157,7 +158,7 @@ describe('getSharedChatSession', () => {
 
 describe('updateRewardCost', () => {
   it('sends a PATCH with broadcaster_id and id query params and the new cost in the body', async () => {
-    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(200, {}));
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(200, { data: [{ id: 'rwd1', cost: 500 }] }));
     await updateRewardCost('bc1', 'rwd1', 500, 'user-token');
 
     const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0];
@@ -170,7 +171,7 @@ describe('updateRewardCost', () => {
 
   it('throws with the response status on a non-OK response', async () => {
     vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(400, {}));
-    await expect(updateRewardCost('bc1', 'rwd1', 500, 'user-token')).rejects.toThrow('updateRewardCost failed: 400');
+    await expect(updateRewardCost('bc1', 'rwd1', 500, 'user-token')).rejects.toThrow('updateCustomReward failed: 400');
   });
 
   it('does not retry on failure (single fetch call)', async () => {
@@ -197,5 +198,96 @@ describe('updateRewardCost', () => {
   it('does not throw TwitchRewardAuthError for other non-OK statuses', async () => {
     vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(400, {}));
     await expect(updateRewardCost('bc1', 'rwd1', 500, 'user-token')).rejects.not.toBeInstanceOf(TwitchRewardAuthError);
+  });
+});
+
+describe('createCustomReward', () => {
+  const input = { title: 'Cool Reward', cost: 500 };
+
+  it('sends a POST with broadcaster_id and the input as the body, returning the created reward', async () => {
+    const created = { id: 'rwd1', title: 'Cool Reward', cost: 500 };
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(200, { data: [created] }));
+
+    const result = await createCustomReward('bc1', 'user-token', input);
+
+    const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+    expect(String(url)).toContain('broadcaster_id=bc1');
+    expect(init?.method).toBe('POST');
+    expect(init?.body).toBe(JSON.stringify(input));
+    expect((init?.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+    expect(result).toEqual(created);
+  });
+
+  it('throws TwitchRewardUnsupportedError on a 403 response', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(403, {}));
+    await expect(createCustomReward('bc1', 'user-token', input)).rejects.toBeInstanceOf(TwitchRewardUnsupportedError);
+  });
+
+  it('throws TwitchRewardAuthError on a 401 response', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(401, {}));
+    await expect(createCustomReward('bc1', 'user-token', input)).rejects.toBeInstanceOf(TwitchRewardAuthError);
+  });
+
+  it('throws a generic error for other non-OK statuses', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(500, {}));
+    await expect(createCustomReward('bc1', 'user-token', input)).rejects.toThrow('createCustomReward failed: 500');
+  });
+});
+
+describe('updateCustomReward', () => {
+  it('sends a PATCH with broadcaster_id and id query params and the partial input as the body, returning the updated reward', async () => {
+    const updated = { id: 'rwd1', title: 'New Title' };
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(200, { data: [updated] }));
+
+    const result = await updateCustomReward('bc1', 'rwd1', 'user-token', { title: 'New Title' });
+
+    const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+    expect(String(url)).toContain('broadcaster_id=bc1');
+    expect(String(url)).toContain('id=rwd1');
+    expect(init?.method).toBe('PATCH');
+    expect(init?.body).toBe(JSON.stringify({ title: 'New Title' }));
+    expect(result).toEqual(updated);
+  });
+
+  it('throws TwitchRewardUnsupportedError on a 403 response', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(403, {}));
+    await expect(updateCustomReward('bc1', 'rwd1', 'user-token', { title: 'x' })).rejects.toBeInstanceOf(TwitchRewardUnsupportedError);
+  });
+
+  it('throws TwitchRewardAuthError on a 401 response', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(401, {}));
+    await expect(updateCustomReward('bc1', 'rwd1', 'user-token', { title: 'x' })).rejects.toBeInstanceOf(TwitchRewardAuthError);
+  });
+
+  it('throws a generic error for other non-OK statuses', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(500, {}));
+    await expect(updateCustomReward('bc1', 'rwd1', 'user-token', { title: 'x' })).rejects.toThrow('updateCustomReward failed: 500');
+  });
+});
+
+describe('deleteCustomReward', () => {
+  it('sends a DELETE with broadcaster_id and id query params', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(204, {}));
+    await deleteCustomReward('bc1', 'rwd1', 'user-token');
+
+    const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+    expect(String(url)).toContain('broadcaster_id=bc1');
+    expect(String(url)).toContain('id=rwd1');
+    expect(init?.method).toBe('DELETE');
+  });
+
+  it('throws TwitchRewardUnsupportedError on a 403 response', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(403, {}));
+    await expect(deleteCustomReward('bc1', 'rwd1', 'user-token')).rejects.toBeInstanceOf(TwitchRewardUnsupportedError);
+  });
+
+  it('throws TwitchRewardAuthError on a 401 response', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(401, {}));
+    await expect(deleteCustomReward('bc1', 'rwd1', 'user-token')).rejects.toBeInstanceOf(TwitchRewardAuthError);
+  });
+
+  it('throws a generic error for other non-OK statuses', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(500, {}));
+    await expect(deleteCustomReward('bc1', 'rwd1', 'user-token')).rejects.toThrow('deleteCustomReward failed: 500');
   });
 });

--- a/src/twitch/twitchApi.ts
+++ b/src/twitch/twitchApi.ts
@@ -169,10 +169,22 @@ export async function getChannelInfo(broadcasterIds: string[]): Promise<TwitchCh
   return results;
 }
 
-/** An optionally-enabled numeric limit on a custom reward (max redemptions, cooldown, etc). */
-export interface TwitchCustomRewardLimit {
+/** A custom reward's per-stream redemption limit, as returned by Twitch (`max_per_stream_setting`). */
+export interface TwitchMaxPerStreamSetting {
   is_enabled: boolean;
-  value: number;
+  max_per_stream: number;
+}
+
+/** A custom reward's per-user-per-stream redemption limit, as returned by Twitch (`max_per_user_per_stream_setting`). */
+export interface TwitchMaxPerUserPerStreamSetting {
+  is_enabled: boolean;
+  max_per_user_per_stream: number;
+}
+
+/** A custom reward's global cooldown, as returned by Twitch (`global_cooldown_setting`). */
+export interface TwitchGlobalCooldownSetting {
+  is_enabled: boolean;
+  global_cooldown_seconds: number;
 }
 
 export interface TwitchCustomReward {
@@ -186,9 +198,9 @@ export interface TwitchCustomReward {
   is_paused: boolean;
   is_in_stock: boolean;
   should_redemptions_skip_request_queue: boolean;
-  max_per_stream_setting: TwitchCustomRewardLimit;
-  max_per_user_per_stream_setting: TwitchCustomRewardLimit;
-  global_cooldown_setting: TwitchCustomRewardLimit;
+  max_per_stream_setting: TwitchMaxPerStreamSetting;
+  max_per_user_per_stream_setting: TwitchMaxPerUserPerStreamSetting;
+  global_cooldown_setting: TwitchGlobalCooldownSetting;
 }
 
 export async function getCustomRewards(broadcasterId: string, userToken: string): Promise<TwitchCustomReward[]> {

--- a/src/twitch/twitchApi.ts
+++ b/src/twitch/twitchApi.ts
@@ -169,11 +169,26 @@ export async function getChannelInfo(broadcasterIds: string[]): Promise<TwitchCh
   return results;
 }
 
+/** An optionally-enabled numeric limit on a custom reward (max redemptions, cooldown, etc). */
+export interface TwitchCustomRewardLimit {
+  is_enabled: boolean;
+  value: number;
+}
+
 export interface TwitchCustomReward {
   id: string;
   title: string;
   cost: number;
   is_enabled: boolean;
+  prompt: string;
+  is_user_input_required: boolean;
+  background_color: string;
+  is_paused: boolean;
+  is_in_stock: boolean;
+  should_redemptions_skip_request_queue: boolean;
+  max_per_stream_setting: TwitchCustomRewardLimit;
+  max_per_user_per_stream_setting: TwitchCustomRewardLimit;
+  global_cooldown_setting: TwitchCustomRewardLimit;
 }
 
 export async function getCustomRewards(broadcasterId: string, userToken: string): Promise<TwitchCustomReward[]> {
@@ -188,9 +203,10 @@ export async function getCustomRewards(broadcasterId: string, userToken: string)
 }
 
 /**
- * Thrown when Twitch returns 403 for a reward cost update — Twitch only allows the app that
- * created a reward to manage it, so this is permanent for a given reward, not a transient
- * failure worth retrying.
+ * Thrown when Twitch returns 403 for a reward create/update/delete/cost-update call — Twitch
+ * only allows the app that created a reward to manage it (or, on create, the broadcaster may
+ * not have channel points available), so this is permanent, not a transient failure worth
+ * retrying.
  */
 export class TwitchRewardUnsupportedError extends Error {
   constructor(message: string) {
@@ -200,10 +216,11 @@ export class TwitchRewardUnsupportedError extends Error {
 }
 
 /**
- * Thrown when Twitch returns 401 for a reward cost update — the broadcaster token is
- * invalid, or (most commonly) lacks the `channel:manage:redemptions` scope. Unlike
- * `TwitchRewardUnsupportedError`, this is not permanent for the reward: reconnecting the
- * streamer's Twitch account (to grant the scope, or replace a revoked token) resolves it.
+ * Thrown when Twitch returns 401 for a reward create/update/delete/cost-update call — the
+ * broadcaster token is invalid, or (most commonly) lacks the `channel:manage:redemptions`
+ * scope. Unlike `TwitchRewardUnsupportedError`, this is not permanent for the reward:
+ * reconnecting the streamer's Twitch account (to grant the scope, or replace a revoked
+ * token) resolves it.
  */
 export class TwitchRewardAuthError extends Error {
   constructor(message: string) {
@@ -212,12 +229,116 @@ export class TwitchRewardAuthError extends Error {
   }
 }
 
+/** Fields accepted by Twitch's create/update custom reward endpoints. */
+export interface CustomRewardInput {
+  title: string;
+  cost: number;
+  prompt?: string;
+  is_enabled?: boolean;
+  background_color?: string;
+  is_user_input_required?: boolean;
+  is_max_per_stream_enabled?: boolean;
+  max_per_stream?: number;
+  is_max_per_user_per_stream_enabled?: boolean;
+  max_per_user_per_stream?: number;
+  is_global_cooldown_enabled?: boolean;
+  global_cooldown_seconds?: number;
+  should_redemptions_skip_request_queue?: boolean;
+}
+
+/** Throws the standard reward-management errors for a non-OK Helix response; otherwise no-ops. */
+function throwForRewardManagementFailure(res: Response, label: string, rewardId?: string): void {
+  const suffix = rewardId ? ` reward ${rewardId}` : '';
+  if (res.status === 403) throw new TwitchRewardUnsupportedError(`[TwitchAPI] ${label}:${suffix} cannot be managed by this app (403)`);
+  if (res.status === 401) throw new TwitchRewardAuthError(`[TwitchAPI] ${label}: broadcaster token invalid or missing scope${suffix} (401)`);
+  if (!res.ok) throw new Error(`[TwitchAPI] ${label} failed: ${res.status}`);
+}
+
 /**
- * Updates a custom reward's cost on Twitch via Helix. Requires a broadcaster user token
- * with the channel:manage:redemptions scope (app tokens cannot manage custom rewards).
- * Not wrapped in fetchHelixWithRetry — the caller (dynamic pricing sync) already tolerates
- * a failed push by retrying on the next redemption/decay tick, so retrying here would just
- * duplicate that behaviour.
+ * Creates a new custom reward on Twitch via Helix. Requires a broadcaster user token with the
+ * channel:manage:redemptions scope (app tokens cannot manage custom rewards). Not wrapped in
+ * fetchHelixWithRetry — this is a synchronous admin action; on failure the caller shows an
+ * error and lets the streamer retry, rather than silently retrying in the background.
+ *
+ * @param broadcasterId - Twitch user ID to create the reward for.
+ * @param userToken - Broadcaster OAuth user token with the channel:manage:redemptions scope.
+ * @param input - The reward's fields (title/cost required, the rest optional).
+ * @throws {TwitchRewardUnsupportedError} When Twitch returns 403 (channel points aren't
+ *   available for the broadcaster, e.g. not affiliate/partner).
+ * @throws {TwitchRewardAuthError} When Twitch returns 401 (invalid token, or missing the
+ *   channel:manage:redemptions scope).
+ */
+export async function createCustomReward(broadcasterId: string, userToken: string, input: CustomRewardInput): Promise<TwitchCustomReward> {
+  const res = await twitchFetch(
+    `https://api.twitch.tv/helix/channel_points/custom_rewards?broadcaster_id=${encodeURIComponent(broadcasterId)}`,
+    {
+      method: 'POST',
+      headers: { ...authHeaders(userToken), 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    },
+  );
+  throwForRewardManagementFailure(res, 'createCustomReward');
+  const data = await res.json() as { data: TwitchCustomReward[] };
+  return data.data[0];
+}
+
+/**
+ * Updates any subset of a custom reward's fields on Twitch via Helix. Requires a broadcaster
+ * user token with the channel:manage:redemptions scope. Only rewards created by this app's
+ * client_id can be updated — Twitch returns 403 otherwise. Not wrapped in fetchHelixWithRetry,
+ * for the same reason as `createCustomReward`.
+ *
+ * @param broadcasterId - Twitch user ID of the reward's broadcaster.
+ * @param rewardId - Twitch reward UUID to update.
+ * @param userToken - Broadcaster OAuth user token with the channel:manage:redemptions scope.
+ * @param input - The fields to update; omitted fields are left unchanged on Twitch.
+ * @throws {TwitchRewardUnsupportedError} When Twitch returns 403 (reward created by a
+ *   different client_id, or channel points aren't available for the broadcaster).
+ * @throws {TwitchRewardAuthError} When Twitch returns 401 (invalid token, or missing the
+ *   channel:manage:redemptions scope).
+ */
+export async function updateCustomReward(
+  broadcasterId: string, rewardId: string, userToken: string, input: Partial<CustomRewardInput>,
+): Promise<TwitchCustomReward> {
+  const res = await twitchFetch(
+    `https://api.twitch.tv/helix/channel_points/custom_rewards?broadcaster_id=${encodeURIComponent(broadcasterId)}&id=${encodeURIComponent(rewardId)}`,
+    {
+      method: 'PATCH',
+      headers: { ...authHeaders(userToken), 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    },
+  );
+  throwForRewardManagementFailure(res, 'updateCustomReward', rewardId);
+  const data = await res.json() as { data: TwitchCustomReward[] };
+  return data.data[0];
+}
+
+/**
+ * Deletes a custom reward from Twitch via Helix. Requires a broadcaster user token with the
+ * channel:manage:redemptions scope. Only rewards created by this app's client_id can be
+ * deleted — Twitch returns 403 otherwise.
+ *
+ * @param broadcasterId - Twitch user ID of the reward's broadcaster.
+ * @param rewardId - Twitch reward UUID to delete.
+ * @param userToken - Broadcaster OAuth user token with the channel:manage:redemptions scope.
+ * @throws {TwitchRewardUnsupportedError} When Twitch returns 403 (reward created by a
+ *   different client_id).
+ * @throws {TwitchRewardAuthError} When Twitch returns 401 (invalid token, or missing the
+ *   channel:manage:redemptions scope).
+ */
+export async function deleteCustomReward(broadcasterId: string, rewardId: string, userToken: string): Promise<void> {
+  const res = await twitchFetch(
+    `https://api.twitch.tv/helix/channel_points/custom_rewards?broadcaster_id=${encodeURIComponent(broadcasterId)}&id=${encodeURIComponent(rewardId)}`,
+    { method: 'DELETE', headers: authHeaders(userToken) },
+  );
+  throwForRewardManagementFailure(res, 'deleteCustomReward', rewardId);
+}
+
+/**
+ * Updates a custom reward's cost on Twitch via Helix. Thin wrapper over `updateCustomReward`
+ * kept for its narrower, unchanged signature — the dynamic pricing sync (`rewardPricingService.ts`)
+ * only ever needs to push a cost, and tolerates a failed push by retrying on the next
+ * redemption/decay tick.
  *
  * @param broadcasterId - Twitch user ID of the reward's broadcaster.
  * @param rewardId - Twitch reward UUID to update.
@@ -229,17 +350,7 @@ export class TwitchRewardAuthError extends Error {
  *   channel:manage:redemptions scope).
  */
 export async function updateRewardCost(broadcasterId: string, rewardId: string, cost: number, userToken: string): Promise<void> {
-  const res = await twitchFetch(
-    `https://api.twitch.tv/helix/channel_points/custom_rewards?broadcaster_id=${encodeURIComponent(broadcasterId)}&id=${encodeURIComponent(rewardId)}`,
-    {
-      method: 'PATCH',
-      headers: { ...authHeaders(userToken), 'Content-Type': 'application/json' },
-      body: JSON.stringify({ cost }),
-    },
-  );
-  if (res.status === 403) throw new TwitchRewardUnsupportedError(`[TwitchAPI] updateRewardCost: reward ${rewardId} cannot be managed by this app (403)`);
-  if (res.status === 401) throw new TwitchRewardAuthError(`[TwitchAPI] updateRewardCost: broadcaster token invalid or missing scope for reward ${rewardId} (401)`);
-  if (!res.ok) throw new Error(`[TwitchAPI] updateRewardCost failed: ${res.status}`);
+  await updateCustomReward(broadcasterId, rewardId, userToken, { cost });
 }
 
 export interface SharedChatParticipant {

--- a/src/web/routes/pricingAdmin.test.ts
+++ b/src/web/routes/pricingAdmin.test.ts
@@ -83,7 +83,7 @@ describe('GET /', () => {
 
   it('merges live Twitch rewards with existing pricing config and computes a preview price', async () => {
     vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    vi.mocked(getCustomRewards).mockResolvedValue([{ id: 'rwd1', title: 'Cool Reward', cost: 200, is_enabled: true }]);
+    vi.mocked(getCustomRewards).mockResolvedValue([{ id: 'rwd1', title: 'Cool Reward', cost: 200, is_enabled: true } as any]);
     vi.mocked(getPricingConfigsForStreamer).mockResolvedValue([{
       id: 1, streamer_id: 123, twitch_reward_id: 'rwd1', enabled: true,
       base_cost: 200, cooldown_seconds: 300, max_multiplier: 4, curve: 1.5,
@@ -136,7 +136,7 @@ describe('GET /', () => {
 
   it('passes through twitch_unsupported so the view can show the disabled-by-Twitch message', async () => {
     vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    vi.mocked(getCustomRewards).mockResolvedValue([{ id: 'rwd1', title: 'Cool Reward', cost: 200, is_enabled: true }]);
+    vi.mocked(getCustomRewards).mockResolvedValue([{ id: 'rwd1', title: 'Cool Reward', cost: 200, is_enabled: true } as any]);
     vi.mocked(getPricingConfigsForStreamer).mockResolvedValue([{
       id: 1, streamer_id: 123, twitch_reward_id: 'rwd1', enabled: false,
       base_cost: 200, cooldown_seconds: 300, max_multiplier: 4, curve: 1.5,
@@ -150,7 +150,7 @@ describe('GET /', () => {
 
   it('leaves config/previewPrice null for a reward with no pricing config yet', async () => {
     vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    vi.mocked(getCustomRewards).mockResolvedValue([{ id: 'rwd1', title: 'Cool Reward', cost: 200, is_enabled: true }]);
+    vi.mocked(getCustomRewards).mockResolvedValue([{ id: 'rwd1', title: 'Cool Reward', cost: 200, is_enabled: true } as any]);
 
     const res = await supertest(buildApp()).get('/');
     expect(res.body.rewards[0].config).toBeNull();


### PR DESCRIPTION
## Summary

First of two PRs building a Channel Points management page — this one is the backend API layer only, no routes/UI changes.

Dynamic pricing can only adjust an existing reward's cost — the bot has no way to create a reward, so streamers still have to start on Twitch's own dashboard before dynamic pricing can be attached. This adds the full Helix create/update/delete calls the follow-up UI PR will need:

- `createCustomReward` / `updateCustomReward` / `deleteCustomReward` in `src/twitch/twitchApi.ts`, all reusing the existing `TwitchRewardUnsupportedError` (403) / `TwitchRewardAuthError` (401) error classes already established for `updateRewardCost` — no new error types.
- Extended `TwitchCustomReward` with the full Helix reward shape (`prompt`, `is_user_input_required`, `background_color`, `is_paused`, `is_in_stock`, `should_redemptions_skip_request_queue`, and the per-stream/per-user/cooldown limit settings) instead of just `id`/`title`/`cost`/`is_enabled`.
- Refactored `updateRewardCost` into a thin wrapper over the new `updateCustomReward`, so dynamic pricing's existing narrow cost-push behavior is unchanged — same signature, same error semantics, `rewardPricingService.ts` and its tests needed zero changes. Only the internal error-message text changed (`"updateCustomReward failed"` instead of `"updateRewardCost failed"`, since it's the same underlying Helix call).

No routes or UI use these new functions yet — that's the next PR.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` — all 114 test files / 1971 tests pass, including new coverage for `createCustomReward`/`updateCustomReward`/`deleteCustomReward` (happy path request shape, 403 → `TwitchRewardUnsupportedError`, 401 → `TwitchRewardAuthError`, other non-OK → generic error) and a regression check that `updateRewardCost`'s request shape is unchanged after the refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151M3CDRw5g2c8UUxk15YD8

---
_Generated by [Claude Code](https://claude.ai/code/session_0151M3CDRw5g2c8UUxk15YD8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating, updating, and deleting Twitch custom rewards.
  * Expanded Twitch reward data returned by the app with additional prompt/UX, queue, pause/stock, and limit/cooldown settings.

* **Bug Fixes**
  * Improved error handling for reward operations, including clearer authorization and unsupported-case behavior.
  * Refined reward cost updates to use the same reward update flow for consistent results.

* **Tests**
  * Expanded and adjusted Twitch reward API tests to cover custom reward CRUD success and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->