### PR TITLE
Make Channel Points disclosure toggles read as clickable

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -358,3 +358,18 @@ textarea.input, .stream-textarea { width: 100%; resize: vertical; font-family: v
 }
 .price-history-tooltip strong { color: var(--primary); }
 .price-history-tooltip span { color: var(--muted); }
+
+/* ── Disclosure toggles (<details><summary>) ─────────────
+   Native <summary> markers read as decorative, not "click me" — style these
+   as an explicit link-colored control with a chevron that rotates on open. */
+.disclosure-toggle {
+  display: inline-flex; align-items: center; gap: .35rem; cursor: pointer;
+  color: var(--primary); list-style: none;
+}
+.disclosure-toggle::-webkit-details-marker { display: none; }
+.disclosure-toggle:hover { text-decoration: underline; }
+.disclosure-toggle::before {
+  content: '▸'; display: inline-block; font-size: .75em;
+  transition: transform .15s ease;
+}
+details[open] > .disclosure-toggle::before { transform: rotate(90deg); }

--- a/public/style.css
+++ b/public/style.css
@@ -368,6 +368,7 @@ textarea.input, .stream-textarea { width: 100%; resize: vertical; font-family: v
 }
 .disclosure-toggle::-webkit-details-marker { display: none; }
 .disclosure-toggle:hover { text-decoration: underline; }
+.disclosure-toggle:focus-visible { outline: 2px solid var(--primary); outline-offset: 2px; }
 .disclosure-toggle::before {
   content: '▸'; display: inline-block; font-size: .75em;
   transition: transform .15s ease;

--- a/views/channelPointsAdmin.ejs
+++ b/views/channelPointsAdmin.ejs
@@ -100,7 +100,7 @@
     <!-- ── Create Reward ───────────────────────────────────────────── -->
     <section class="section">
       <details>
-        <summary class="section-title" style="cursor:pointer;display:inline-block;">+ Create new reward</summary>
+        <summary class="section-title disclosure-toggle">Create new reward</summary>
         <div class="card card-spaced">
           <div class="card-body">
             <form method="POST" action="/channel-points/rewards">
@@ -183,7 +183,7 @@
 
           <% if (r.twitchReward) { %>
           <details style="margin-top:0.5rem;">
-            <summary class="hint hint-compact" style="cursor:pointer;">Edit reward</summary>
+            <summary class="hint hint-compact disclosure-toggle">Edit reward</summary>
             <form method="POST" action="/channel-points/rewards/<%= r.rewardId %>" style="margin-top:0.5rem;">
               <input type="hidden" name="_csrf" value="<%= csrfToken %>">
               <%- include('partials/rewardFields', { idPrefix: r.rewardId, values: r.twitchReward }) %>


### PR DESCRIPTION
## Summary

Follow-up to user feedback after deploying #350: the "+ Create new reward" and "Edit reward" `<details>/<summary>` disclosures on `/channel-points` didn't read as clickable — they relied on a bare `cursor: pointer` and the browser's own (small, easy-to-miss) native `<summary>` marker.

- New `.disclosure-toggle` CSS class: link-colored text (`var(--primary)`, matching the site's existing `a { color: var(--primary) }` convention) plus a chevron (`▸`) that rotates 90° when the `<details>` is open, with an underline on hover. Hides the native browser marker (`::-webkit-details-marker` + `list-style: none`) so there's no duplicate/mismatched arrow.
- Applied to both disclosures in `channelPointsAdmin.ejs`; dropped the old literal `"+ "` prefix on "Create new reward" since the chevron now conveys the expand/collapse affordance.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` — all 114 test files / 2026 tests pass (no test asserts on this markup directly, since route tests mock `res.render`)
- [x] Rendered the actual `channelPointsAdmin.ejs` template directly and confirmed both summaries carry the new `disclosure-toggle` class

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151M3CDRw5g2c8UUxk15YD8

---
_Generated by [Claude Code](https://claude.ai/code/session_0151M3CDRw5g2c8UUxk15YD8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a shared “disclosure toggle” visual style for `<details>/<summary>` sections, including chevron indicator behavior and keyboard focus support.
* **Style**
  * Applied the new disclosure toggle styling to the channel points reward “Create new reward” and “Edit reward” summaries for a more consistent, link-like appearance with improved hover effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->