### PR TITLE
Rework channel points dynamic pricing: unify cooldowns, time-based half-life, derived increment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,3 +75,7 @@ CodeRabbit auto-reviews pushes but is rate-limited per developer; a rate-limited
 
 - **`@coderabbitai review`** — reviews only what changed since the last review. Default choice.
 - **`@coderabbitai full review`** — re-reviews the entire PR from scratch. Use this instead when the last review surfaced a lot of issues, or the intervening changes are large.
+
+**Avoid re-triggering thrash:**
+- **Never push a new commit while a review is in progress** — the in-flight review fails outright ("head commit changed during the review") and wastes the attempt. Wait for the review to finish (or fail/rate-limit) before pushing again.
+- **Never re-trigger `@coderabbitai review` while already rate-limited or still in progress.** Each attempt costs a try and can reset/extend the cooldown countdown shown in the "Review limit reached" comment — retrying early makes the wait longer, not shorter. Wait out the full countdown from the *most recent* rate-limit comment, trigger exactly once, then leave it alone until it either posts real findings or rate-limits again.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,4 +78,4 @@ CodeRabbit auto-reviews pushes but is rate-limited per developer; a rate-limited
 
 **Avoid re-triggering thrash:**
 - **Never push a new commit while a review is in progress** — the in-flight review fails outright ("head commit changed during the review") and wastes the attempt. Wait for the review to finish (or fail/rate-limit) before pushing again.
-- **Never re-trigger `@coderabbitai review` while already rate-limited or still in progress.** Each attempt costs a try and can reset/extend the cooldown countdown shown in the "Review limit reached" comment — retrying early makes the wait longer, not shorter. Wait out the full countdown from the *most recent* rate-limit comment, trigger exactly once, then leave it alone until it either posts real findings or rate-limits again.
+- **Never re-trigger `@coderabbitai review` while already rate-limited or still in progress.** Each rate-limit reply just reports the currently remaining cooldown (it doesn't reset or extend it) — retrying early is simply wasted, not counterproductive. Wait out the countdown, trigger exactly once, then leave it alone until it either posts real findings or rate-limits again.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ Export `registerXRuntime(runtime)` from the handler file to store the platform c
 
 ## PR Reviews (CodeRabbit)
 
-CodeRabbit auto-reviews pushes but is rate-limited per developer; a rate-limited push gets a "Review limit reached" comment with a wait time and no actual diff review. Once the cooldown has passed, trigger a fresh review with a PR comment:
+CodeRabbit auto-reviews pushes but is rate-limited per developer; a rate-limited push gets a "Review limit reached" comment with a wait time and no actual diff review. **It never auto-retries** once the cooldown passes — a manual trigger is required every time, even if you just wait it out. After the wait time shown in the rate-limit comment has elapsed, post a PR comment:
 
 - **`@coderabbitai review`** — reviews only what changed since the last review. Default choice.
 - **`@coderabbitai full review`** — re-reviews the entire PR from scratch. Use this instead when the last review surfaced a lot of issues, or the intervening changes are large.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,3 +66,12 @@ npm test      # Vitest
 ## New Command Handler Pattern
 
 Export `registerXRuntime(runtime)` from the handler file to store the platform client — avoids circular imports with `src/index.ts`. Call it from `index.ts` after the client is ready. Record matches via `commandMonitorStore`.
+
+---
+
+## PR Reviews (CodeRabbit)
+
+CodeRabbit auto-reviews pushes but is rate-limited per developer; a rate-limited push gets a "Review limit reached" comment with a wait time and no actual diff review. Once the cooldown has passed, trigger a fresh review with a PR comment:
+
+- **`@coderabbitai review`** — reviews only what changed since the last review. Default choice.
+- **`@coderabbitai full review`** — re-reviews the entire PR from scratch. Use this instead when the last review surfaced a lot of issues, or the intervening changes are large.

--- a/DATABASE-SCHEMA.md
+++ b/DATABASE-SCHEMA.md
@@ -201,7 +201,7 @@ Dynamic Channel Point Pricing: per-reward config and demand state. Independent o
 | `twitch_reward_id` | `VARCHAR(255)` | Twitch reward UUID; unique per `(streamer_id, twitch_reward_id)` |
 | `enabled` | `TINYINT(1)` | Whether dynamic pricing is active for this reward |
 | `base_cost` | `INT` | Minimum price |
-| `cooldown_seconds` | `INT` | Used to normalize demand decay/increment across rewards |
+| `cooldown_seconds` | `INT` | Mirrors the reward's own Twitch global cooldown (or a fallback default when it has none) — kept in sync automatically, not directly editable |
 | `max_multiplier` | `DECIMAL(6,3)` | Max price = `base_cost * (1 + max_multiplier)` |
 | `curve` | `DECIMAL(5,3)` | Exponent controlling how aggressively price rises with demand |
 | `demand` | `DECIMAL(9,6)` | Current demand, in `[0,1]` |
@@ -211,17 +211,17 @@ Dynamic Channel Point Pricing: per-reward config and demand state. Independent o
 
 Created by `migrations/reward_pricing.sql`.
 
-## `pricing_global_settings`
+## `reward_pricing_settings`
 
-Single global row (`id` pinned to 1) — bot-wide decay/increment settings shared by every `reward_pricing` row.
+One row per streamer — their own decay half-life and time-to-max-demand multiplier, shared by every one of their `reward_pricing` rows. The redemption increment isn't stored here; it's derived per-reward from the reward's own `cooldown_seconds` plus these two settings.
 
 | Column | Type | Notes |
 | --- | --- | --- |
-| `id` | `TINYINT` PK | Always `1` (enforced by a CHECK constraint) |
-| `decay_half_life_periods` | `DECIMAL(8,3)` | Cooldown-periods of inactivity for demand to halve |
-| `redemption_increment` | `DECIMAL(6,4)` | Flat demand increase applied per redemption |
+| `streamer_id` | `INT` PK | FK to `streamer.id` ON DELETE CASCADE |
+| `half_life_seconds` | `INT` | Fixed seconds of inactivity for demand to halve — independent of any reward's cooldown |
+| `time_to_max_multiplier` | `DECIMAL(6,3)` | Redemptions at a reward's own cooldown frequency reach 100% demand after this many half-lives |
 
-Created by `migrations/reward_pricing.sql`.
+Created by `migrations/reward_pricing_settings.sql` (replaces the earlier `pricing_global_settings` singleton table from `migrations/reward_pricing.sql`).
 
 ## `reward_pricing_history`
 

--- a/migrations/reward_pricing_settings.sql
+++ b/migrations/reward_pricing_settings.sql
@@ -1,0 +1,15 @@
+-- Replaces the single bot-wide pricing_global_settings row with per-streamer settings:
+-- half-life is now a fixed duration (seconds), not normalized by any reward's cooldown, and
+-- the redemption increment is no longer stored — it's derived per-reward from the reward's own
+-- cooldown, the streamer's half-life, and time_to_max_multiplier (see rewardPricingMath.ts).
+DROP TABLE IF EXISTS pricing_global_settings;
+
+CREATE TABLE reward_pricing_settings (
+  streamer_id          INT          NOT NULL,
+  half_life_seconds     INT          NOT NULL DEFAULT 1800,
+  time_to_max_multiplier DECIMAL(6,3) NOT NULL DEFAULT 2.000,
+  PRIMARY KEY (streamer_id),
+  FOREIGN KEY (streamer_id) REFERENCES streamer(id) ON DELETE CASCADE,
+  CONSTRAINT chk_reward_pricing_settings_half_life CHECK (half_life_seconds > 0),
+  CONSTRAINT chk_reward_pricing_settings_multiplier CHECK (time_to_max_multiplier > 0)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/schema.sql
+++ b/schema.sql
@@ -295,16 +295,20 @@ CREATE TABLE IF NOT EXISTS reward_pricing (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ---------------------------------------------------------------------------
--- pricing_global_settings
--- Single global row (id pinned to 1) — bot-wide decay/increment settings
--- shared by every reward_pricing row.
+-- reward_pricing_settings
+-- One row per streamer — their own decay half-life and time-to-max-demand
+-- multiplier, shared by every one of their reward_pricing rows. The
+-- redemption increment is not stored here; it's derived per-reward from the
+-- reward's own cooldown plus these two settings (see rewardPricingMath.ts).
 -- ---------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS pricing_global_settings (
-  id                       TINYINT      NOT NULL DEFAULT 1,
-  decay_half_life_periods DECIMAL(8,3) NOT NULL DEFAULT 3.000,
-  redemption_increment     DECIMAL(6,4) NOT NULL DEFAULT 0.1000,
-  PRIMARY KEY (id),
-  CONSTRAINT chk_pricing_global_settings_singleton CHECK (id = 1)
+CREATE TABLE IF NOT EXISTS reward_pricing_settings (
+  streamer_id            INT          NOT NULL,
+  half_life_seconds      INT          NOT NULL DEFAULT 1800,
+  time_to_max_multiplier DECIMAL(6,3) NOT NULL DEFAULT 2.000,
+  PRIMARY KEY (streamer_id),
+  FOREIGN KEY (streamer_id) REFERENCES streamer(id) ON DELETE CASCADE,
+  CONSTRAINT chk_reward_pricing_settings_half_life  CHECK (half_life_seconds > 0),
+  CONSTRAINT chk_reward_pricing_settings_multiplier CHECK (time_to_max_multiplier > 0)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ---------------------------------------------------------------------------

--- a/src/db.ts
+++ b/src/db.ts
@@ -150,11 +150,12 @@ export {
 
 // ─── Channel point pricing ───────────────────────────────────────────────────
 
-export type { RewardPricingRow, RewardPricingInput, GlobalPricingSettings } from './db/rewardPricing';
+export type { RewardPricingRow, RewardPricingInput, StreamerPricingSettings } from './db/rewardPricing';
 export {
   getPricingForReward, getPricingConfigById, getPricingConfigsForStreamer, getAllEnabledPricingRows,
   upsertPricingConfig, recordPricingUpdate, deletePricingConfig, markPricingUnsupported,
-  initGlobalPricingSettings, getGlobalPricingSettings, saveGlobalPricingSettings,
+  updatePricingCooldownForReward, getPricingSettingsForStreamer, savePricingSettingsForStreamer,
+  DEFAULT_PRICING_COOLDOWN_SECONDS,
 } from './db/rewardPricing';
 
 export type { RewardPricingHistoryPoint } from './db/rewardPricingHistory';

--- a/src/db/rewardPricing.test.ts
+++ b/src/db/rewardPricing.test.ts
@@ -13,9 +13,9 @@ import {
   recordPricingUpdate,
   deletePricingConfig,
   markPricingUnsupported,
-  initGlobalPricingSettings,
-  getGlobalPricingSettings,
-  saveGlobalPricingSettings,
+  updatePricingCooldownForReward,
+  getPricingSettingsForStreamer,
+  savePricingSettingsForStreamer,
 } from './rewardPricing';
 
 function makePool(rows: unknown[] = [], meta: unknown = {}) {
@@ -204,39 +204,46 @@ describe('deletePricingConfig', () => {
   });
 });
 
-describe('initGlobalPricingSettings', () => {
-  it('uses INSERT IGNORE with the default settings', async () => {
+describe('updatePricingCooldownForReward', () => {
+  it('updates cooldown_seconds, scoped by streamerId and twitchRewardId', async () => {
     const pool = makePool();
     vi.mocked(getPool).mockReturnValue(pool as any);
-    await initGlobalPricingSettings();
+    await updatePricingCooldownForReward(7, 'rwd-abc', 120);
     const sql: string = pool.execute.mock.calls[0][0];
-    expect(sql).toContain('INSERT IGNORE');
-    expect(pool.execute.mock.calls[0][1]).toEqual([3, 0.1]);
+    expect(sql).toContain('SET cooldown_seconds = ?');
+    expect(pool.execute.mock.calls[0][1]).toEqual([120, 7, 'rwd-abc']);
   });
 });
 
-describe('getGlobalPricingSettings', () => {
+describe('getPricingSettingsForStreamer', () => {
   it('returns defaults without throwing when the row is missing', async () => {
     vi.mocked(getPool).mockReturnValue(makePool([]) as any);
-    const settings = await getGlobalPricingSettings();
-    expect(settings).toEqual({ decay_half_life_periods: 3, redemption_increment: 0.1 });
+    const settings = await getPricingSettingsForStreamer(7);
+    expect(settings).toEqual({ half_life_seconds: 1800, time_to_max_multiplier: 2 });
   });
 
   it('returns the stored row converted to numbers', async () => {
-    vi.mocked(getPool).mockReturnValue(makePool([{ decay_half_life_periods: '5.000', redemption_increment: '0.2000' }]) as any);
-    const settings = await getGlobalPricingSettings();
-    expect(settings).toEqual({ decay_half_life_periods: 5, redemption_increment: 0.2 });
+    vi.mocked(getPool).mockReturnValue(makePool([{ half_life_seconds: '900', time_to_max_multiplier: '3.000' }]) as any);
+    const settings = await getPricingSettingsForStreamer(7);
+    expect(settings).toEqual({ half_life_seconds: 900, time_to_max_multiplier: 3 });
+  });
+
+  it('queries scoped by streamerId', async () => {
+    const pool = makePool([]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await getPricingSettingsForStreamer(7);
+    expect(pool.execute.mock.calls[0][1]).toEqual([7]);
   });
 });
 
-describe('saveGlobalPricingSettings', () => {
-  it('uses the row-alias upsert form and passes the new settings', async () => {
+describe('savePricingSettingsForStreamer', () => {
+  it('uses the row-alias upsert form and passes the streamerId and new settings', async () => {
     const pool = makePool();
     vi.mocked(getPool).mockReturnValue(pool as any);
-    await saveGlobalPricingSettings({ decay_half_life_periods: 4, redemption_increment: 0.15 });
+    await savePricingSettingsForStreamer(7, { half_life_seconds: 600, time_to_max_multiplier: 1.5 });
     const sql: string = pool.execute.mock.calls[0][0];
     expect(sql).toContain('AS new_row');
     expect(sql).toContain('ON DUPLICATE KEY UPDATE');
-    expect(pool.execute.mock.calls[0][1]).toEqual([4, 0.15]);
+    expect(pool.execute.mock.calls[0][1]).toEqual([7, 600, 1.5]);
   });
 });

--- a/src/db/rewardPricing.ts
+++ b/src/db/rewardPricing.ts
@@ -29,16 +29,21 @@ export interface RewardPricingInput {
   curve: number;
 }
 
-/** Bot-wide settings shared by every reward's demand calculations. */
-export interface GlobalPricingSettings {
-  decay_half_life_periods: number;
-  redemption_increment: number;
+/** Per-streamer settings shared by every one of their rewards' demand calculations. */
+export interface StreamerPricingSettings {
+  /** Fixed duration (seconds) of inactivity for demand to halve — the same for every reward, regardless of its own cooldown. */
+  half_life_seconds: number;
+  /** Redemptions at a reward's own cooldown frequency reach 100% demand after this many half-lives. */
+  time_to_max_multiplier: number;
 }
 
-const DEFAULT_GLOBAL_SETTINGS: GlobalPricingSettings = {
-  decay_half_life_periods: 3,
-  redemption_increment: 0.1,
+const DEFAULT_STREAMER_PRICING_SETTINGS: StreamerPricingSettings = {
+  half_life_seconds: 1800, // 30 minutes
+  time_to_max_multiplier: 2,
 };
+
+/** Fallback cooldown (seconds) used for a reward's pricing math when it has no Twitch-enforced cooldown. */
+export const DEFAULT_PRICING_COOLDOWN_SECONDS = 60;
 
 function mapRow(r: mysql.RowDataPacket): RewardPricingRow {
   return {
@@ -200,44 +205,53 @@ export async function deletePricingConfig(id: number, streamerId: number): Promi
 }
 
 /**
- * Insert the default global pricing settings row (id=1) if one does not already exist.
- * Safe to call multiple times; called once at bot startup.
+ * Updates an existing pricing config's `cooldown_seconds` to mirror the reward's current
+ * effective Twitch cooldown (its `global_cooldown_seconds` when enabled, otherwise the
+ * fallback default) — keeps the two in sync when the reward is edited after pricing was
+ * first configured. No-ops (0 rows affected) if no pricing config exists for this reward.
+ *
+ * @param streamerId - DB row ID of the owning streamer.
+ * @param twitchRewardId - Twitch reward UUID.
+ * @param cooldownSeconds - The reward's current effective cooldown, in seconds.
  */
-export async function initGlobalPricingSettings(): Promise<void> {
-  const s = DEFAULT_GLOBAL_SETTINGS;
+export async function updatePricingCooldownForReward(streamerId: number, twitchRewardId: string, cooldownSeconds: number): Promise<void> {
   await getPool().execute(
-    `INSERT IGNORE INTO pricing_global_settings (id, decay_half_life_periods, redemption_increment)
-     VALUES (1, ?, ?)`,
-    [s.decay_half_life_periods, s.redemption_increment],
+    `UPDATE reward_pricing SET cooldown_seconds = ? WHERE streamer_id = ? AND twitch_reward_id = ?`,
+    [cooldownSeconds, streamerId, twitchRewardId],
   );
 }
 
 /**
- * Read the global pricing settings. Falls back to hardcoded defaults (without throwing)
- * if the singleton row is missing, e.g. before initGlobalPricingSettings has run.
+ * Read a streamer's dynamic-pricing settings (decay half-life and time-to-max-demand
+ * multiplier). Falls back to hardcoded defaults (without throwing) if the streamer has no
+ * settings row yet, e.g. before they've ever saved this form.
+ *
+ * @param streamerId - DB row ID of the streamer.
  */
-export async function getGlobalPricingSettings(): Promise<GlobalPricingSettings> {
+export async function getPricingSettingsForStreamer(streamerId: number): Promise<StreamerPricingSettings> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    `SELECT decay_half_life_periods, redemption_increment FROM pricing_global_settings WHERE id = 1`,
+    `SELECT half_life_seconds, time_to_max_multiplier FROM reward_pricing_settings WHERE streamer_id = ?`,
+    [streamerId],
   );
-  if (rows.length === 0) return { ...DEFAULT_GLOBAL_SETTINGS };
+  if (rows.length === 0) return { ...DEFAULT_STREAMER_PRICING_SETTINGS };
   return {
-    decay_half_life_periods: Number(rows[0].decay_half_life_periods),
-    redemption_increment: Number(rows[0].redemption_increment),
+    half_life_seconds: Number(rows[0].half_life_seconds),
+    time_to_max_multiplier: Number(rows[0].time_to_max_multiplier),
   };
 }
 
 /**
- * Upsert the global pricing settings row (id=1).
+ * Upsert a streamer's dynamic-pricing settings (decay half-life and time-to-max-demand multiplier).
  *
- * @param settings - The new global decay/increment settings.
+ * @param streamerId - DB row ID of the streamer.
+ * @param settings - The new half-life/time-to-max settings.
  */
-export async function saveGlobalPricingSettings(settings: GlobalPricingSettings): Promise<void> {
+export async function savePricingSettingsForStreamer(streamerId: number, settings: StreamerPricingSettings): Promise<void> {
   await getPool().execute(
-    `INSERT INTO pricing_global_settings (id, decay_half_life_periods, redemption_increment)
-     VALUES (1, ?, ?) AS new_row
+    `INSERT INTO reward_pricing_settings (streamer_id, half_life_seconds, time_to_max_multiplier)
+     VALUES (?, ?, ?) AS new_row
      ON DUPLICATE KEY UPDATE
-       decay_half_life_periods=new_row.decay_half_life_periods, redemption_increment=new_row.redemption_increment`,
-    [settings.decay_half_life_periods, settings.redemption_increment],
+       half_life_seconds=new_row.half_life_seconds, time_to_max_multiplier=new_row.time_to_max_multiplier`,
+    [streamerId, settings.half_life_seconds, settings.time_to_max_multiplier],
   );
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -12,7 +12,6 @@ vi.mock('./db', () => ({
     }),
   })),
   closePool: vi.fn().mockResolvedValue(undefined),
-  initGlobalPricingSettings: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock('./discord/discordBot', () => ({
   startDiscordBot: vi.fn(),
@@ -159,33 +158,12 @@ describe('startup — guild registry preload', () => {
 // ─── Reward pricing scheduler startup/shutdown ────────────────────────────────
 
 describe('startup — reward pricing scheduler', () => {
-  it('starts the scheduler after initializing global pricing settings', async () => {
-    const db = await import('./db.js');
+  it('starts the scheduler', async () => {
     const { startRewardPricingScheduler } = await import('./twitch/pricing/rewardPricingScheduler.js');
 
     await runMain();
 
-    expect(vi.mocked(db.initGlobalPricingSettings)).toHaveBeenCalledOnce();
     expect(vi.mocked(startRewardPricingScheduler)).toHaveBeenCalledOnce();
-
-    const [initCallOrder] = vi.mocked(db.initGlobalPricingSettings).mock.invocationCallOrder;
-    const [schedulerCallOrder] = vi.mocked(startRewardPricingScheduler).mock.invocationCallOrder;
-    expect(initCallOrder).toBeLessThan(schedulerCallOrder);
-  });
-
-  it('still starts the scheduler and continues startup when initGlobalPricingSettings rejects', async () => {
-    const db = await import('./db.js');
-    const { startRewardPricingScheduler } = await import('./twitch/pricing/rewardPricingScheduler.js');
-    const { startEventSub } = await import('./twitch/eventsub/twitchEventSub.js');
-    vi.mocked(db.initGlobalPricingSettings).mockRejectedValueOnce(new Error('db down'));
-
-    await runMain();
-
-    // A transient settings-bootstrap failure shouldn't disable decay for the process lifetime —
-    // the pricing read path falls back to defaults, so the scheduler starts regardless.
-    expect(vi.mocked(startRewardPricingScheduler)).toHaveBeenCalledOnce();
-    expect(vi.mocked(startEventSub)).toHaveBeenCalledOnce();
-    expect(exitSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -158,12 +158,15 @@ describe('startup — guild registry preload', () => {
 // ─── Reward pricing scheduler startup/shutdown ────────────────────────────────
 
 describe('startup — reward pricing scheduler', () => {
-  it('starts the scheduler', async () => {
+  it('starts the scheduler and continues startup through to startEventSub on a clean run', async () => {
     const { startRewardPricingScheduler } = await import('./twitch/pricing/rewardPricingScheduler.js');
+    const { startEventSub } = await import('./twitch/eventsub/twitchEventSub.js');
 
     await runMain();
 
     expect(vi.mocked(startRewardPricingScheduler)).toHaveBeenCalledOnce();
+    expect(vi.mocked(startEventSub)).toHaveBeenCalledOnce();
+    expect(exitSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import 'mediaplex'; // Must be imported first to register as Opus provider
-import { getPool, closePool, initGlobalPricingSettings } from './db';
+import { getPool, closePool } from './db';
 import { startTwitchBot, stopTwitchBot, sayInChannel } from './twitch/twitchBot';
 import { getActiveChannels, getActiveChannelUserIds, setChannelJoinedHook } from './twitch/twitchChannelMembership';
 import { startDiscordBot, stopDiscordBot } from './discord/discordBot';
@@ -89,12 +89,6 @@ async function main(): Promise<void> {
   await startTikTokBot();
   startWebPanel();
   startCounterScheduler();
-
-  try {
-    await initGlobalPricingSettings();
-  } catch (err) {
-    log.error('initGlobalPricingSettings startup error:', err);
-  }
   startRewardPricingScheduler();
 
   startTwitchMonitor().catch((err) => log.error('TwitchMonitor startup error:', err));

--- a/src/twitch/pricing/rewardPricingMath.test.ts
+++ b/src/twitch/pricing/rewardPricingMath.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { computePrice, decayDemand, applyRedemption } from './rewardPricingMath';
+import { computePrice, decayDemand, applyRedemption, computeRedemptionIncrement } from './rewardPricingMath';
 
-const config = { baseCost: 200, cooldownSeconds: 300, maxMultiplier: 4, curve: 1.5 };
+const config = { baseCost: 200, maxMultiplier: 4, curve: 1.5 };
 
 describe('computePrice', () => {
   it('returns baseCost at demand=0', () => {
@@ -19,7 +19,7 @@ describe('computePrice', () => {
   });
 
   it('rounds to the nearest integer', () => {
-    const c = { baseCost: 100, cooldownSeconds: 60, maxMultiplier: 1, curve: 1 };
+    const c = { baseCost: 100, maxMultiplier: 1, curve: 1 };
     // usage=0.006 -> price = round(100 * 1.006) = round(100.6) = 101
     expect(computePrice(0.006, c)).toBe(101);
   });
@@ -35,85 +35,72 @@ describe('computePrice', () => {
 
 describe('decayDemand', () => {
   it('returns demand unchanged when elapsedSeconds is 0', () => {
-    expect(decayDemand(0.8, 0, 300, 3)).toBe(0.8);
+    expect(decayDemand(0.8, 0, 1800)).toBe(0.8);
   });
 
-  it('halves demand exactly after one half-life worth of periods', () => {
-    // elapsedSeconds = cooldownSeconds * decayHalfLifePeriods -> periodsElapsed = decayHalfLifePeriods
-    const result = decayDemand(0.8, 300 * 3, 300, 3);
-    expect(result).toBeCloseTo(0.4, 10);
+  it('halves demand exactly after one half-life', () => {
+    expect(decayDemand(0.8, 1800, 1800)).toBeCloseTo(0.4, 10);
   });
 
-  it('quarters demand after two half-lives worth of periods', () => {
-    const result = decayDemand(0.8, 300 * 6, 300, 3);
-    expect(result).toBeCloseTo(0.2, 10);
+  it('quarters demand after two half-lives', () => {
+    expect(decayDemand(0.8, 3600, 1800)).toBeCloseTo(0.2, 10);
   });
 
   it('clamps to 0 for very large elapsed time', () => {
-    expect(decayDemand(1, 1e9, 300, 3)).toBe(0);
+    expect(decayDemand(1, 1e9, 1800)).toBe(0);
   });
 
   it('never goes negative', () => {
-    expect(decayDemand(0, 1000, 300, 3)).toBeGreaterThanOrEqual(0);
+    expect(decayDemand(0, 1000, 1800)).toBeGreaterThanOrEqual(0);
   });
 
   it('is a no-op when elapsedSeconds is negative (clock skew)', () => {
-    expect(decayDemand(0.5, -10, 300, 3)).toBe(0.5);
+    expect(decayDemand(0.5, -10, 1800)).toBe(0.5);
   });
 
-  it('is a no-op when cooldownSeconds is non-positive', () => {
-    expect(decayDemand(0.5, 100, 0, 3)).toBe(0.5);
-  });
-
-  it('is a no-op when decayHalfLifePeriods is non-positive', () => {
-    expect(decayDemand(0.5, 100, 300, 0)).toBe(0.5);
+  it('is a no-op when halfLifeSeconds is non-positive', () => {
+    expect(decayDemand(0.5, 100, 0)).toBe(0.5);
   });
 
   it('still clamps an out-of-range demand even in the no-op path', () => {
-    expect(decayDemand(1.5, 0, 300, 3)).toBe(1);
-    expect(decayDemand(-1.5, 0, 300, 3)).toBe(0);
+    expect(decayDemand(1.5, 0, 1800)).toBe(1);
+    expect(decayDemand(-1.5, 0, 1800)).toBe(0);
+  });
+});
+
+describe('computeRedemptionIncrement', () => {
+  it('matches the documented example: 10-min cooldown, 30-min half-life, x2 multiplier -> 1/6 demand per redemption', () => {
+    expect(computeRedemptionIncrement(600, 1800, 2)).toBeCloseTo(1 / 6, 10);
+  });
+
+  it('scales linearly with cooldown', () => {
+    expect(computeRedemptionIncrement(1200, 1800, 2)).toBeCloseTo(1 / 3, 10);
+  });
+
+  it('scales inversely with the time-to-max multiplier', () => {
+    expect(computeRedemptionIncrement(600, 1800, 4)).toBeCloseTo(1 / 12, 10);
+  });
+
+  it('scales inversely with half-life', () => {
+    expect(computeRedemptionIncrement(600, 3600, 2)).toBeCloseTo(1 / 12, 10);
   });
 });
 
 describe('applyRedemption', () => {
   it('decays then adds the redemption increment', () => {
-    // decay(0.8, 300, 300, 3) ≈ 0.8 * 2^(-1/3) ≈ 0.635200
-    const result = applyRedemption(0.8, 300, 300, 3, 0.1);
+    // decay(0.8, 600, 1800) = 0.8 * 2^(-600/1800) = 0.8 * 2^(-1/3) ≈ 0.635200
+    const result = applyRedemption(0.8, 600, 1800, 0.1);
     expect(result).toBeCloseTo(0.6352 + 0.1, 3);
   });
 
   it('clamps to 1 when the result would overflow', () => {
-    expect(applyRedemption(0.95, 0, 300, 3, 0.5)).toBe(1);
+    expect(applyRedemption(0.95, 0, 1800, 0.5)).toBe(1);
   });
 
   it('applies decay before the increment (order matters)', () => {
     // If increment were applied before decay, elapsed=huge would still decay demand+increment to ~0.
     // Applying decay first means the increment survives even after demand fully decays.
-    const result = applyRedemption(1, 1e9, 300, 3, 0.2);
+    const result = applyRedemption(1, 1e9, 1800, 0.2);
     expect(result).toBeCloseTo(0.2, 10);
-  });
-});
-
-describe('cooldown normalization — comparable rates across different cooldowns', () => {
-  it('two rewards with different cooldowns redeemed at their own max frequency converge to the same steady-state demand', () => {
-    const decayHalfLifePeriods = 3;
-    const redemptionIncrement = 0.1;
-
-    function simulate(cooldownSeconds: number, iterations: number): number {
-      let demand = 0;
-      for (let i = 0; i < iterations; i++) {
-        demand = applyRedemption(demand, cooldownSeconds, cooldownSeconds, decayHalfLifePeriods, redemptionIncrement);
-      }
-      return demand;
-    }
-
-    const shortCooldown = simulate(30, 200);
-    const longCooldown = simulate(300, 200);
-
-    expect(Math.abs(shortCooldown - longCooldown)).toBeLessThan(1e-6);
-
-    const r = Math.pow(2, -1 / decayHalfLifePeriods);
-    const expectedSteadyState = redemptionIncrement / (1 - r);
-    expect(shortCooldown).toBeCloseTo(Math.min(1, expectedSteadyState), 6);
   });
 });

--- a/src/twitch/pricing/rewardPricingMath.ts
+++ b/src/twitch/pricing/rewardPricingMath.ts
@@ -1,7 +1,6 @@
-/** Per-reward pricing parameters used by the price/demand calculations below. */
+/** Per-reward pricing parameters used by {@link computePrice}. */
 export interface RewardPricingConfig {
   baseCost: number;
-  cooldownSeconds: number;
   maxMultiplier: number;
   curve: number;
 }
@@ -21,49 +20,64 @@ export function computePrice(demand: number, config: RewardPricingConfig): numbe
 }
 
 /**
- * Decays demand continuously over elapsed time, normalized by the reward's own cooldown
- * so rewards with different cooldowns decay at comparable relative rates. Guards against
- * non-positive cooldown/half-life or negative elapsed time by treating them as a no-op
+ * Decays demand continuously over elapsed time against a fixed half-life — demand halves every
+ * `halfLifeSeconds` of inactivity, the same for every reward regardless of its own cooldown.
+ * Guards against a non-positive half-life or negative elapsed time by treating them as a no-op
  * rather than throwing or producing NaN/Infinity.
  *
  * @param demand - Demand value before decay.
  * @param elapsedSeconds - Real seconds elapsed since the demand value was last updated.
- * @param cooldownSeconds - The reward's configured cooldown, used to normalize elapsed time.
- * @param decayHalfLifePeriods - Global setting: number of cooldown-periods for demand to halve.
+ * @param halfLifeSeconds - Streamer's configured half-life, in seconds.
  * @returns The decayed demand, clamped to [0,1].
  */
 export function decayDemand(
   demand: number,
   elapsedSeconds: number,
-  cooldownSeconds: number,
-  decayHalfLifePeriods: number,
+  halfLifeSeconds: number,
 ): number {
-  if (elapsedSeconds <= 0 || cooldownSeconds <= 0 || decayHalfLifePeriods <= 0) {
+  if (elapsedSeconds <= 0 || halfLifeSeconds <= 0) {
     return Math.min(1, Math.max(0, demand));
   }
-  const periodsElapsed = elapsedSeconds / cooldownSeconds;
-  const decayed = demand * Math.pow(2, -periodsElapsed / decayHalfLifePeriods);
+  const decayed = demand * Math.pow(2, -elapsedSeconds / halfLifeSeconds);
   return Math.min(1, Math.max(0, decayed));
 }
 
 /**
- * Applies a single redemption to demand: first decays for elapsed time, then adds the
- * global redemption increment, then clamps to [0,1].
+ * Computes the flat demand increase applied for a single redemption of a reward with the given
+ * cooldown: redeeming at that reward's own maximum frequency (i.e. every `cooldownSeconds`,
+ * ignoring decay) reaches 100% demand after `timeToMaxMultiplier` half-lives worth of time.
+ * E.g. a 10-minute cooldown with a 30-minute half-life and `timeToMaxMultiplier=2` (60 minutes
+ * to reach max) adds 10/60 = 1/6 demand per redemption.
+ *
+ * @param cooldownSeconds - The reward's own cooldown, in seconds.
+ * @param halfLifeSeconds - Streamer's configured half-life, in seconds.
+ * @param timeToMaxMultiplier - Streamer's configured "time to 100% demand", expressed as a
+ *   multiple of the half-life.
+ */
+export function computeRedemptionIncrement(
+  cooldownSeconds: number,
+  halfLifeSeconds: number,
+  timeToMaxMultiplier: number,
+): number {
+  return cooldownSeconds / (timeToMaxMultiplier * halfLifeSeconds);
+}
+
+/**
+ * Applies a single redemption to demand: first decays for elapsed time, then adds
+ * `redemptionIncrement`, then clamps to [0,1].
  *
  * @param demand - Demand value before this redemption.
  * @param elapsedSeconds - Real seconds elapsed since the demand value was last updated.
- * @param cooldownSeconds - The reward's configured cooldown, used to normalize decay.
- * @param decayHalfLifePeriods - Global setting: number of cooldown-periods for demand to halve.
- * @param redemptionIncrement - Global setting: flat demand increase applied per redemption.
+ * @param halfLifeSeconds - Streamer's configured half-life, in seconds.
+ * @param redemptionIncrement - Flat demand increase for this redemption (see {@link computeRedemptionIncrement}).
  * @returns The updated demand, clamped to [0,1].
  */
 export function applyRedemption(
   demand: number,
   elapsedSeconds: number,
-  cooldownSeconds: number,
-  decayHalfLifePeriods: number,
+  halfLifeSeconds: number,
   redemptionIncrement: number,
 ): number {
-  const decayed = decayDemand(demand, elapsedSeconds, cooldownSeconds, decayHalfLifePeriods);
+  const decayed = decayDemand(demand, elapsedSeconds, halfLifeSeconds);
   return Math.min(1, Math.max(0, decayed + redemptionIncrement));
 }

--- a/src/twitch/pricing/rewardPricingService.test.ts
+++ b/src/twitch/pricing/rewardPricingService.test.ts
@@ -8,7 +8,7 @@ vi.mock('../../db', () => ({
   recordPricingHistory: vi.fn(),
   markPricingUnsupported: vi.fn(),
   deletePricingConfig: vi.fn(),
-  getGlobalPricingSettings: vi.fn(),
+  getPricingSettingsForStreamer: vi.fn(),
   getStreamerById: vi.fn(),
 }));
 
@@ -23,7 +23,7 @@ vi.mock('../twitchApi', () => {
 
 import {
   getPricingForReward, recordPricingUpdate, recordPricingHistory, markPricingUnsupported, deletePricingConfig,
-  getGlobalPricingSettings, getStreamerById,
+  getPricingSettingsForStreamer, getStreamerById,
 } from '../../db';
 import { getValidToken } from '../eventsub/twitchApiEventSub';
 import { updateRewardCost, deleteCustomReward, TwitchRewardUnsupportedError, TwitchRewardAuthError } from '../twitchApi';
@@ -32,7 +32,7 @@ import {
   __resetPushRateLimiterForTests,
 } from './rewardPricingService';
 
-const settings = { decay_half_life_periods: 3, redemption_increment: 0.1 };
+const settings = { half_life_seconds: 1800, time_to_max_multiplier: 2 };
 const streamer = { id: 1, twitch_user_id: 'bc1', eventsub_access_token: 'tok' } as any;
 
 function makeRow(overrides: Partial<Record<string, unknown>> = {}) {
@@ -55,7 +55,7 @@ function makeRow(overrides: Partial<Record<string, unknown>> = {}) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(getGlobalPricingSettings).mockResolvedValue(settings);
+  vi.mocked(getPricingSettingsForStreamer).mockResolvedValue(settings);
   vi.mocked(getStreamerById).mockResolvedValue(streamer);
   vi.mocked(getValidToken).mockResolvedValue('user-token');
   vi.mocked(recordPricingHistory).mockResolvedValue(undefined);
@@ -191,13 +191,13 @@ describe('applyDecayTick', () => {
   it('applies decay without the redemption increment', async () => {
     vi.mocked(getPricingForReward).mockResolvedValue(makeRow({
       demand: 0.5,
-      demand_updated_at: String(Date.now() - 300_000), // 300s elapsed, cooldown=300s -> 1 period of decay
+      demand_updated_at: String(Date.now() - 300_000), // 300s elapsed
       last_pushed_cost: null,
     }));
     await applyDecayTick(1, 'rwd1');
     const [, , demandArg] = vi.mocked(recordPricingUpdate).mock.calls[0];
-    // decay(0.5, 300, 300, 3) = 0.5 * 2^(-1/3) ≈ 0.39700
-    expect(demandArg).toBeCloseTo(0.397, 2);
+    // decay(0.5, ~300s elapsed, half_life=1800s) = 0.5 * 2^(-300/1800)
+    expect(demandArg).toBeCloseTo(0.5 * Math.pow(2, -300 / 1800), 2);
   });
 });
 

--- a/src/twitch/pricing/rewardPricingService.ts
+++ b/src/twitch/pricing/rewardPricingService.ts
@@ -1,11 +1,11 @@
 import { createMutationQueue } from '../../shared/mutationQueue';
 import {
   getPricingForReward, recordPricingUpdate, recordPricingHistory, markPricingUnsupported, deletePricingConfig,
-  getGlobalPricingSettings, getStreamerById,
+  getPricingSettingsForStreamer, getStreamerById,
 } from '../../db';
 import { getValidToken } from '../eventsub/twitchApiEventSub';
 import { updateRewardCost, deleteCustomReward, TwitchRewardUnsupportedError, TwitchRewardAuthError } from '../twitchApi';
-import { computePrice, decayDemand, applyRedemption } from './rewardPricingMath';
+import { computePrice, decayDemand, applyRedemption, computeRedemptionIncrement } from './rewardPricingMath';
 import { createLogger } from '../../shared/logger';
 
 const log = createLogger('RewardPricing');
@@ -113,16 +113,18 @@ async function syncRewardPrice(streamerId: number, twitchRewardId: string, apply
   const row = await getPricingForReward(streamerId, twitchRewardId);
   if (!row || !row.enabled) return;
 
-  const settings = await getGlobalPricingSettings();
+  const settings = await getPricingSettingsForStreamer(streamerId);
   const now = Date.now();
   const elapsedSeconds = Math.max(0, (now - Number(row.demand_updated_at)) / 1000);
   const newDemand = applyIncrement
-    ? applyRedemption(row.demand, elapsedSeconds, row.cooldown_seconds, settings.decay_half_life_periods, settings.redemption_increment)
-    : decayDemand(row.demand, elapsedSeconds, row.cooldown_seconds, settings.decay_half_life_periods);
+    ? applyRedemption(
+        row.demand, elapsedSeconds, settings.half_life_seconds,
+        computeRedemptionIncrement(row.cooldown_seconds, settings.half_life_seconds, settings.time_to_max_multiplier),
+      )
+    : decayDemand(row.demand, elapsedSeconds, settings.half_life_seconds);
 
   const newCost = computePrice(newDemand, {
     baseCost: row.base_cost,
-    cooldownSeconds: row.cooldown_seconds,
     maxMultiplier: row.max_multiplier,
     curve: row.curve,
   });

--- a/src/web/routes/channelPointsAdmin.test.ts
+++ b/src/web/routes/channelPointsAdmin.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('../../db', () => ({
   getStreamerByDiscordId: vi.fn(),
   getPricingConfigsForStreamer: vi.fn(),
-  getGlobalPricingSettings: vi.fn(),
+  getPricingSettingsForStreamer: vi.fn(),
   getPricingHistory: vi.fn(),
 }));
 
@@ -42,14 +42,13 @@ vi.mock('./channelPointsAdminMutations', async () => {
 import express from 'express';
 import supertest from 'supertest';
 import router from './channelPointsAdmin';
-import { getStreamerByDiscordId, getPricingConfigsForStreamer, getGlobalPricingSettings, getPricingHistory } from '../../db';
+import { getStreamerByDiscordId, getPricingConfigsForStreamer, getPricingSettingsForStreamer, getPricingHistory } from '../../db';
 import { getCustomRewards } from '../../twitch/twitchApi';
 import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
 import { hasAuthFailedSubs } from '../../twitch/eventsub/twitchEventSubSubscriptions';
 
 type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3; isOwner: boolean };
 const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: 0, isOwner: false };
-const OWNER: SessionUser = { ...USER, discordId: '200000000000000002', isOwner: true };
 
 const MOCK_STREAMER = {
   id: 123, twitch_user_id: 'twitch123', twitch_name: 'teststreamer', discord_id: USER.discordId,
@@ -75,7 +74,7 @@ beforeEach(() => {
   vi.mocked(getCustomRewards).mockResolvedValue([]);
   vi.mocked(getValidToken).mockResolvedValue('token');
   vi.mocked(hasAuthFailedSubs).mockReturnValue(false);
-  vi.mocked(getGlobalPricingSettings).mockResolvedValue({ decay_half_life_periods: 3, redemption_increment: 0.1 });
+  vi.mocked(getPricingSettingsForStreamer).mockResolvedValue({ half_life_seconds: 1800, time_to_max_multiplier: 2 });
   vi.mocked(getPricingHistory).mockResolvedValue([]);
 });
 
@@ -168,19 +167,17 @@ describe('GET /', () => {
     expect(res.body.rewards[0].previewPrice).toBeNull();
   });
 
-  it('does not include global settings for a non-owner', async () => {
+  it('includes the streamer\'s own pricing settings when connected', async () => {
     vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
     const res = await supertest(buildApp(USER)).get('/');
-    expect(res.body.isOwner).toBe(false);
-    expect(res.body.globalSettings).toBeNull();
-    expect(getGlobalPricingSettings).not.toHaveBeenCalled();
+    expect(res.body.pricingSettings).toEqual({ half_life_seconds: 1800, time_to_max_multiplier: 2 });
+    expect(getPricingSettingsForStreamer).toHaveBeenCalledWith(MOCK_STREAMER.id);
   });
 
-  it('includes global settings for the bot owner', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    const res = await supertest(buildApp(OWNER)).get('/');
-    expect(res.body.isOwner).toBe(true);
-    expect(res.body.globalSettings).toEqual({ decay_half_life_periods: 3, redemption_increment: 0.1 });
+  it('does not fetch pricing settings when not a streamer', async () => {
+    const res = await supertest(buildApp(USER)).get('/');
+    expect(res.body.pricingSettings).toBeNull();
+    expect(getPricingSettingsForStreamer).not.toHaveBeenCalled();
   });
 
   describe('reconnect detection', () => {

--- a/src/web/routes/channelPointsAdmin.ts
+++ b/src/web/routes/channelPointsAdmin.ts
@@ -4,7 +4,7 @@ import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
 import { getStreamerByDiscordId } from '../../db';
 import type { DbStreamerEventSub } from '../../db';
-import { getPricingConfigsForStreamer, getGlobalPricingSettings, getPricingHistory } from '../../db';
+import { getPricingConfigsForStreamer, getPricingSettingsForStreamer, getPricingHistory } from '../../db';
 import type { RewardPricingRow } from '../../db';
 import { getCustomRewards, TwitchCustomReward } from '../../twitch/twitchApi';
 import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
@@ -19,10 +19,10 @@ const router = Router();
 
 const KNOWN_ERRORS = new Set([
   'not_a_streamer', 'invalid_reward_id', 'invalid_config', 'save_failed',
-  'delete_failed', 'not_owner', 'invalid_settings', 'invalid_reward_fields', 'create_failed', 'update_failed',
+  'delete_failed', 'invalid_settings', 'invalid_reward_fields', 'create_failed', 'update_failed',
 ]);
 const KNOWN_SUCCESSES = new Set([
-  'pricing_saved', 'pricing_deleted', 'global_settings_saved', 'reward_created', 'reward_updated', 'reward_deleted',
+  'pricing_saved', 'pricing_deleted', 'pricing_settings_saved', 'reward_created', 'reward_updated', 'reward_deleted',
 ]);
 
 /** Selectable "last N hours" ranges for the price history chart; streams here typically run ~3h. */
@@ -49,7 +49,6 @@ function parseHistoryHours(value: unknown): number {
 function previewPriceFor(config: RewardPricingRow): number {
   return computePrice(config.demand, {
     baseCost: config.base_cost,
-    cooldownSeconds: config.cooldown_seconds,
     maxMultiplier: config.max_multiplier,
     curve: config.curve,
   });
@@ -72,7 +71,7 @@ async function fetchTwitchRewards(streamer: DbStreamerEventSub): Promise<TwitchC
  * GET /channel-points — renders the Channel Points management page: the streamer's live
  * Twitch rewards (creatable/editable/deletable from here) merged with any existing dynamic
  * pricing config (including a live price preview and a price history chart over the selected
- * time range), and — only for the bot owner — the bot-wide pricing decay/increment settings.
+ * time range), and the streamer's own pricing decay-half-life/time-to-max settings.
  * Shows a reconnect prompt instead of the reward list when the streamer isn't connected, or
  * their connection has started failing with an auth error (mirrors the same check on
  * `/user/settings`).
@@ -128,8 +127,7 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
     );
     rewards.push(...unlinkedRows);
 
-    const isOwner = req.session.user?.isOwner ?? false;
-    const globalSettings = isOwner ? await getGlobalPricingSettings() : null;
+    const pricingSettings = streamer && isConnected && !needsReconnect ? await getPricingSettingsForStreamer(streamer.id) : null;
 
     renderView(res, 'channelPointsAdmin', {
       user: req.session.user,
@@ -138,8 +136,7 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
       isConnected,
       needsReconnect,
       rewards,
-      isOwner,
-      globalSettings,
+      pricingSettings,
       historyHours,
       historyHourOptions: HISTORY_HOUR_OPTIONS,
       error: filterQueryParam(req.query.error, KNOWN_ERRORS),

--- a/src/web/routes/channelPointsAdminMutations.test.ts
+++ b/src/web/routes/channelPointsAdminMutations.test.ts
@@ -6,11 +6,7 @@ vi.mock('../../shared/logger', () => ({
 
 vi.mock('../../db', () => ({
   getStreamerByDiscordId: vi.fn(),
-  upsertPricingConfig: vi.fn(),
-  getPricingForReward: vi.fn(),
   updatePricingCooldownForReward: vi.fn(),
-  savePricingSettingsForStreamer: vi.fn(),
-  DEFAULT_PRICING_COOLDOWN_SECONDS: 60,
 }));
 
 vi.mock('../csrf', () => ({
@@ -27,7 +23,6 @@ vi.mock('../middleware', () => ({
 vi.mock('../../twitch/twitchApi', () => ({
   createCustomReward: vi.fn(),
   updateCustomReward: vi.fn(),
-  getCustomRewards: vi.fn(),
 }));
 
 vi.mock('../../twitch/eventsub/twitchApiEventSub', () => ({
@@ -35,21 +30,23 @@ vi.mock('../../twitch/eventsub/twitchApiEventSub', () => ({
 }));
 
 vi.mock('../../twitch/pricing/rewardPricingService', () => ({
-  applyDecayTick: vi.fn().mockResolvedValue(undefined),
-  resetAndDeletePricing: vi.fn().mockResolvedValue(undefined),
   deleteRewardAndPricing: vi.fn().mockResolvedValue(undefined),
 }));
+
+// This module composes channelPointsAdminPricingMutations's router too; stub it out so this
+// file only exercises the reward-CRUD routes defined directly in channelPointsAdminMutations.
+vi.mock('./channelPointsAdminPricingMutations', async () => {
+  const { Router } = await import('express');
+  return { router: Router() };
+});
 
 import express from 'express';
 import supertest from 'supertest';
 import { router } from './channelPointsAdminMutations';
-import {
-  getStreamerByDiscordId, upsertPricingConfig, getPricingForReward, updatePricingCooldownForReward,
-  savePricingSettingsForStreamer,
-} from '../../db';
-import { createCustomReward, updateCustomReward, getCustomRewards } from '../../twitch/twitchApi';
+import { getStreamerByDiscordId, updatePricingCooldownForReward } from '../../db';
+import { createCustomReward, updateCustomReward } from '../../twitch/twitchApi';
 import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
-import { applyDecayTick, resetAndDeletePricing, deleteRewardAndPricing } from '../../twitch/pricing/rewardPricingService';
+import { deleteRewardAndPricing } from '../../twitch/pricing/rewardPricingService';
 
 type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3; isOwner: boolean };
 const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: 0, isOwner: false };
@@ -81,13 +78,7 @@ beforeEach(() => {
   vi.mocked(getValidToken).mockResolvedValue('user-token');
   vi.mocked(createCustomReward).mockResolvedValue(VALID_REWARD_TWITCH_DATA as any);
   vi.mocked(updateCustomReward).mockResolvedValue(VALID_REWARD_TWITCH_DATA as any);
-  vi.mocked(getCustomRewards).mockResolvedValue([VALID_REWARD_TWITCH_DATA as any]);
-  vi.mocked(getPricingForReward).mockResolvedValue(null);
   vi.mocked(updatePricingCooldownForReward).mockResolvedValue(undefined);
-  vi.mocked(upsertPricingConfig).mockResolvedValue(undefined);
-  vi.mocked(savePricingSettingsForStreamer).mockResolvedValue(undefined);
-  vi.mocked(applyDecayTick).mockResolvedValue(undefined);
-  vi.mocked(resetAndDeletePricing).mockResolvedValue(undefined);
   vi.mocked(deleteRewardAndPricing).mockResolvedValue(undefined);
 });
 
@@ -209,177 +200,5 @@ describe('POST /rewards/:twitchRewardId/delete', () => {
     vi.mocked(deleteRewardAndPricing).mockRejectedValueOnce(new Error('403'));
     const res = await supertest(buildApp()).post(`/rewards/${VALID_REWARD_ID}/delete`);
     expect(res.headers.location).toBe('/channel-points?error=delete_failed');
-  });
-});
-
-describe('POST /rewards/:twitchRewardId/pricing', () => {
-  it('redirects with error when user is not a streamer', async () => {
-    const res = await supertest(buildApp())
-      .post(`/rewards/${VALID_REWARD_ID}/pricing`)
-      .type('form')
-      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5' });
-    expect(res.headers.location).toBe('/channel-points?error=not_a_streamer');
-  });
-
-  it('redirects with error for an invalid reward id', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    const res = await supertest(buildApp())
-      .post('/rewards/not-a-uuid/pricing')
-      .type('form')
-      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5' });
-    expect(res.headers.location).toBe('/channel-points?error=invalid_reward_id');
-  });
-
-  it.each([
-    ['base_cost', { base_cost: '0' }],
-    ['max_multiplier', { max_multiplier: '-1' }],
-    ['curve', { curve: '0' }],
-  ])('redirects with invalid_config when %s is invalid', async (_name, override) => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    const res = await supertest(buildApp())
-      .post(`/rewards/${VALID_REWARD_ID}/pricing`)
-      .type('form')
-      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5', ...override });
-    expect(res.headers.location).toBe('/channel-points?error=invalid_config');
-  });
-
-  it('saves the config using the reward\'s live Twitch cooldown, best-effort resyncs, and redirects to success', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    const res = await supertest(buildApp())
-      .post(`/rewards/${VALID_REWARD_ID}/pricing`)
-      .type('form')
-      .send({ enabled: 'on', base_cost: '200', max_multiplier: '4', curve: '1.5' });
-    expect(res.headers.location).toBe('/channel-points?success=pricing_saved');
-    expect(upsertPricingConfig).toHaveBeenCalledWith(MOCK_STREAMER.id, VALID_REWARD_ID, {
-      enabled: true, base_cost: 200, cooldown_seconds: 300, max_multiplier: 4, curve: 1.5,
-    });
-    expect(applyDecayTick).toHaveBeenCalledWith(MOCK_STREAMER.id, VALID_REWARD_ID);
-  });
-
-  it('falls back to the existing pricing config cooldown when the reward is no longer found on Twitch', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    vi.mocked(getCustomRewards).mockResolvedValue([]);
-    vi.mocked(getPricingForReward).mockResolvedValue({ cooldown_seconds: 120 } as any);
-    await supertest(buildApp())
-      .post(`/rewards/${VALID_REWARD_ID}/pricing`)
-      .type('form')
-      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5' });
-    expect(upsertPricingConfig).toHaveBeenCalledWith(MOCK_STREAMER.id, VALID_REWARD_ID, expect.objectContaining({ cooldown_seconds: 120 }));
-  });
-
-  it('falls back to the default cooldown when the reward is unknown and no pricing config exists yet', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    vi.mocked(getCustomRewards).mockResolvedValue([]);
-    vi.mocked(getPricingForReward).mockResolvedValue(null);
-    await supertest(buildApp())
-      .post(`/rewards/${VALID_REWARD_ID}/pricing`)
-      .type('form')
-      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5' });
-    expect(upsertPricingConfig).toHaveBeenCalledWith(MOCK_STREAMER.id, VALID_REWARD_ID, expect.objectContaining({ cooldown_seconds: 60 }));
-  });
-
-  it('treats a missing enabled checkbox as false', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    await supertest(buildApp())
-      .post(`/rewards/${VALID_REWARD_ID}/pricing`)
-      .type('form')
-      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5' });
-    expect(upsertPricingConfig).toHaveBeenCalledWith(MOCK_STREAMER.id, VALID_REWARD_ID, expect.objectContaining({ enabled: false }));
-  });
-
-  it('still redirects to success when the best-effort resync throws', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    vi.mocked(applyDecayTick).mockRejectedValueOnce(new Error('twitch down'));
-    const res = await supertest(buildApp())
-      .post(`/rewards/${VALID_REWARD_ID}/pricing`)
-      .type('form')
-      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5' });
-    expect(res.headers.location).toBe('/channel-points?success=pricing_saved');
-  });
-
-  it('redirects with save_failed when upsertPricingConfig throws', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    vi.mocked(upsertPricingConfig).mockRejectedValueOnce(new Error('DB down'));
-    const res = await supertest(buildApp())
-      .post(`/rewards/${VALID_REWARD_ID}/pricing`)
-      .type('form')
-      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5' });
-    expect(res.headers.location).toBe('/channel-points?error=save_failed');
-  });
-});
-
-describe('POST /rewards/:twitchRewardId/pricing/delete', () => {
-  it('redirects with error when user is not a streamer', async () => {
-    const res = await supertest(buildApp()).post(`/rewards/${VALID_REWARD_ID}/pricing/delete`);
-    expect(res.headers.location).toBe('/channel-points?error=not_a_streamer');
-  });
-
-  it('redirects with error for an invalid reward id', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    const res = await supertest(buildApp()).post('/rewards/not-a-uuid/pricing/delete');
-    expect(res.headers.location).toBe('/channel-points?error=invalid_reward_id');
-  });
-
-  it('disables pricing and redirects to success', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    const res = await supertest(buildApp()).post(`/rewards/${VALID_REWARD_ID}/pricing/delete`);
-    expect(res.headers.location).toBe('/channel-points?success=pricing_deleted');
-    expect(resetAndDeletePricing).toHaveBeenCalledWith(MOCK_STREAMER.id, VALID_REWARD_ID);
-  });
-
-  it('redirects with delete_failed when resetAndDeletePricing throws', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    vi.mocked(resetAndDeletePricing).mockRejectedValueOnce(new Error('DB down'));
-    const res = await supertest(buildApp()).post(`/rewards/${VALID_REWARD_ID}/pricing/delete`);
-    expect(res.headers.location).toBe('/channel-points?error=delete_failed');
-  });
-});
-
-describe('POST /settings/pricing', () => {
-  it('redirects with error when user is not a streamer', async () => {
-    const res = await supertest(buildApp(USER))
-      .post('/settings/pricing')
-      .type('form')
-      .send({ half_life_minutes: '30', time_to_max_multiplier: '2' });
-    expect(res.headers.location).toBe('/channel-points?error=not_a_streamer');
-    expect(savePricingSettingsForStreamer).not.toHaveBeenCalled();
-  });
-
-  it('rejects an invalid half_life_minutes', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    const res = await supertest(buildApp())
-      .post('/settings/pricing')
-      .type('form')
-      .send({ half_life_minutes: '0', time_to_max_multiplier: '2' });
-    expect(res.headers.location).toBe('/channel-points?error=invalid_settings');
-  });
-
-  it('rejects an invalid time_to_max_multiplier', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    const res = await supertest(buildApp())
-      .post('/settings/pricing')
-      .type('form')
-      .send({ half_life_minutes: '30', time_to_max_multiplier: '0' });
-    expect(res.headers.location).toBe('/channel-points?error=invalid_settings');
-  });
-
-  it('saves the settings converted to seconds and redirects to success', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    const res = await supertest(buildApp())
-      .post('/settings/pricing')
-      .type('form')
-      .send({ half_life_minutes: '30', time_to_max_multiplier: '2' });
-    expect(res.headers.location).toBe('/channel-points?success=pricing_settings_saved');
-    expect(savePricingSettingsForStreamer).toHaveBeenCalledWith(MOCK_STREAMER.id, { half_life_seconds: 1800, time_to_max_multiplier: 2 });
-  });
-
-  it('redirects with save_failed when savePricingSettingsForStreamer throws', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    vi.mocked(savePricingSettingsForStreamer).mockRejectedValueOnce(new Error('DB down'));
-    const res = await supertest(buildApp())
-      .post('/settings/pricing')
-      .type('form')
-      .send({ half_life_minutes: '30', time_to_max_multiplier: '2' });
-    expect(res.headers.location).toBe('/channel-points?error=save_failed');
   });
 });

--- a/src/web/routes/channelPointsAdminMutations.test.ts
+++ b/src/web/routes/channelPointsAdminMutations.test.ts
@@ -7,7 +7,10 @@ vi.mock('../../shared/logger', () => ({
 vi.mock('../../db', () => ({
   getStreamerByDiscordId: vi.fn(),
   upsertPricingConfig: vi.fn(),
-  saveGlobalPricingSettings: vi.fn(),
+  getPricingForReward: vi.fn(),
+  updatePricingCooldownForReward: vi.fn(),
+  savePricingSettingsForStreamer: vi.fn(),
+  DEFAULT_PRICING_COOLDOWN_SECONDS: 60,
 }));
 
 vi.mock('../csrf', () => ({
@@ -24,6 +27,7 @@ vi.mock('../middleware', () => ({
 vi.mock('../../twitch/twitchApi', () => ({
   createCustomReward: vi.fn(),
   updateCustomReward: vi.fn(),
+  getCustomRewards: vi.fn(),
 }));
 
 vi.mock('../../twitch/eventsub/twitchApiEventSub', () => ({
@@ -39,14 +43,16 @@ vi.mock('../../twitch/pricing/rewardPricingService', () => ({
 import express from 'express';
 import supertest from 'supertest';
 import { router } from './channelPointsAdminMutations';
-import { getStreamerByDiscordId, upsertPricingConfig, saveGlobalPricingSettings } from '../../db';
-import { createCustomReward, updateCustomReward } from '../../twitch/twitchApi';
+import {
+  getStreamerByDiscordId, upsertPricingConfig, getPricingForReward, updatePricingCooldownForReward,
+  savePricingSettingsForStreamer,
+} from '../../db';
+import { createCustomReward, updateCustomReward, getCustomRewards } from '../../twitch/twitchApi';
 import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
 import { applyDecayTick, resetAndDeletePricing, deleteRewardAndPricing } from '../../twitch/pricing/rewardPricingService';
 
 type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3; isOwner: boolean };
 const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: 0, isOwner: false };
-const OWNER: SessionUser = { ...USER, discordId: '200000000000000002', isOwner: true };
 
 const MOCK_STREAMER = { id: 123, twitch_user_id: 'twitch123', twitch_name: 'teststreamer', discord_id: USER.discordId };
 
@@ -67,14 +73,19 @@ function buildApp(sessionUser: SessionUser = USER) {
   return app;
 }
 
+const VALID_REWARD_TWITCH_DATA = { id: VALID_REWARD_ID, global_cooldown_setting: { is_enabled: true, global_cooldown_seconds: 300 } };
+
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
   vi.mocked(getValidToken).mockResolvedValue('user-token');
-  vi.mocked(createCustomReward).mockResolvedValue({ id: VALID_REWARD_ID } as any);
-  vi.mocked(updateCustomReward).mockResolvedValue({ id: VALID_REWARD_ID } as any);
+  vi.mocked(createCustomReward).mockResolvedValue(VALID_REWARD_TWITCH_DATA as any);
+  vi.mocked(updateCustomReward).mockResolvedValue(VALID_REWARD_TWITCH_DATA as any);
+  vi.mocked(getCustomRewards).mockResolvedValue([VALID_REWARD_TWITCH_DATA as any]);
+  vi.mocked(getPricingForReward).mockResolvedValue(null);
+  vi.mocked(updatePricingCooldownForReward).mockResolvedValue(undefined);
   vi.mocked(upsertPricingConfig).mockResolvedValue(undefined);
-  vi.mocked(saveGlobalPricingSettings).mockResolvedValue(undefined);
+  vi.mocked(savePricingSettingsForStreamer).mockResolvedValue(undefined);
   vi.mocked(applyDecayTick).mockResolvedValue(undefined);
   vi.mocked(resetAndDeletePricing).mockResolvedValue(undefined);
   vi.mocked(deleteRewardAndPricing).mockResolvedValue(undefined);
@@ -142,13 +153,21 @@ describe('POST /rewards/:twitchRewardId', () => {
     expect(res.headers.location).toBe('/channel-points?error=invalid_reward_fields');
   });
 
-  it('updates the reward and redirects to success', async () => {
+  it('updates the reward, syncs the pricing cooldown to match, and redirects to success', async () => {
     vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
     const res = await supertest(buildApp()).post(`/rewards/${VALID_REWARD_ID}`).type('form').send(VALID_REWARD_FORM);
     expect(res.headers.location).toBe('/channel-points?success=reward_updated');
     expect(updateCustomReward).toHaveBeenCalledWith('twitch123', VALID_REWARD_ID, 'user-token', expect.objectContaining({
       title: 'Cool Reward', cost: 200,
     }));
+    expect(updatePricingCooldownForReward).toHaveBeenCalledWith(MOCK_STREAMER.id, VALID_REWARD_ID, 300);
+  });
+
+  it('still redirects to success when the best-effort cooldown sync throws', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(updatePricingCooldownForReward).mockRejectedValueOnce(new Error('DB down'));
+    const res = await supertest(buildApp()).post(`/rewards/${VALID_REWARD_ID}`).type('form').send(VALID_REWARD_FORM);
+    expect(res.headers.location).toBe('/channel-points?success=reward_updated');
   });
 
   it('redirects with update_failed when no valid token is available', async () => {
@@ -198,7 +217,7 @@ describe('POST /rewards/:twitchRewardId/pricing', () => {
     const res = await supertest(buildApp())
       .post(`/rewards/${VALID_REWARD_ID}/pricing`)
       .type('form')
-      .send({ base_cost: '200', cooldown_seconds: '300', max_multiplier: '4', curve: '1.5' });
+      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5' });
     expect(res.headers.location).toBe('/channel-points?error=not_a_streamer');
   });
 
@@ -207,13 +226,12 @@ describe('POST /rewards/:twitchRewardId/pricing', () => {
     const res = await supertest(buildApp())
       .post('/rewards/not-a-uuid/pricing')
       .type('form')
-      .send({ base_cost: '200', cooldown_seconds: '300', max_multiplier: '4', curve: '1.5' });
+      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5' });
     expect(res.headers.location).toBe('/channel-points?error=invalid_reward_id');
   });
 
   it.each([
     ['base_cost', { base_cost: '0' }],
-    ['cooldown_seconds', { cooldown_seconds: '0' }],
     ['max_multiplier', { max_multiplier: '-1' }],
     ['curve', { curve: '0' }],
   ])('redirects with invalid_config when %s is invalid', async (_name, override) => {
@@ -221,16 +239,16 @@ describe('POST /rewards/:twitchRewardId/pricing', () => {
     const res = await supertest(buildApp())
       .post(`/rewards/${VALID_REWARD_ID}/pricing`)
       .type('form')
-      .send({ base_cost: '200', cooldown_seconds: '300', max_multiplier: '4', curve: '1.5', ...override });
+      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5', ...override });
     expect(res.headers.location).toBe('/channel-points?error=invalid_config');
   });
 
-  it('saves the config, best-effort resyncs, and redirects to success', async () => {
+  it('saves the config using the reward\'s live Twitch cooldown, best-effort resyncs, and redirects to success', async () => {
     vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
     const res = await supertest(buildApp())
       .post(`/rewards/${VALID_REWARD_ID}/pricing`)
       .type('form')
-      .send({ enabled: 'on', base_cost: '200', cooldown_seconds: '300', max_multiplier: '4', curve: '1.5' });
+      .send({ enabled: 'on', base_cost: '200', max_multiplier: '4', curve: '1.5' });
     expect(res.headers.location).toBe('/channel-points?success=pricing_saved');
     expect(upsertPricingConfig).toHaveBeenCalledWith(MOCK_STREAMER.id, VALID_REWARD_ID, {
       enabled: true, base_cost: 200, cooldown_seconds: 300, max_multiplier: 4, curve: 1.5,
@@ -238,12 +256,34 @@ describe('POST /rewards/:twitchRewardId/pricing', () => {
     expect(applyDecayTick).toHaveBeenCalledWith(MOCK_STREAMER.id, VALID_REWARD_ID);
   });
 
+  it('falls back to the existing pricing config cooldown when the reward is no longer found on Twitch', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(getCustomRewards).mockResolvedValue([]);
+    vi.mocked(getPricingForReward).mockResolvedValue({ cooldown_seconds: 120 } as any);
+    await supertest(buildApp())
+      .post(`/rewards/${VALID_REWARD_ID}/pricing`)
+      .type('form')
+      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5' });
+    expect(upsertPricingConfig).toHaveBeenCalledWith(MOCK_STREAMER.id, VALID_REWARD_ID, expect.objectContaining({ cooldown_seconds: 120 }));
+  });
+
+  it('falls back to the default cooldown when the reward is unknown and no pricing config exists yet', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(getCustomRewards).mockResolvedValue([]);
+    vi.mocked(getPricingForReward).mockResolvedValue(null);
+    await supertest(buildApp())
+      .post(`/rewards/${VALID_REWARD_ID}/pricing`)
+      .type('form')
+      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5' });
+    expect(upsertPricingConfig).toHaveBeenCalledWith(MOCK_STREAMER.id, VALID_REWARD_ID, expect.objectContaining({ cooldown_seconds: 60 }));
+  });
+
   it('treats a missing enabled checkbox as false', async () => {
     vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
     await supertest(buildApp())
       .post(`/rewards/${VALID_REWARD_ID}/pricing`)
       .type('form')
-      .send({ base_cost: '200', cooldown_seconds: '300', max_multiplier: '4', curve: '1.5' });
+      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5' });
     expect(upsertPricingConfig).toHaveBeenCalledWith(MOCK_STREAMER.id, VALID_REWARD_ID, expect.objectContaining({ enabled: false }));
   });
 
@@ -253,7 +293,7 @@ describe('POST /rewards/:twitchRewardId/pricing', () => {
     const res = await supertest(buildApp())
       .post(`/rewards/${VALID_REWARD_ID}/pricing`)
       .type('form')
-      .send({ base_cost: '200', cooldown_seconds: '300', max_multiplier: '4', curve: '1.5' });
+      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5' });
     expect(res.headers.location).toBe('/channel-points?success=pricing_saved');
   });
 
@@ -263,7 +303,7 @@ describe('POST /rewards/:twitchRewardId/pricing', () => {
     const res = await supertest(buildApp())
       .post(`/rewards/${VALID_REWARD_ID}/pricing`)
       .type('form')
-      .send({ base_cost: '200', cooldown_seconds: '300', max_multiplier: '4', curve: '1.5' });
+      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5' });
     expect(res.headers.location).toBe('/channel-points?error=save_failed');
   });
 });
@@ -295,47 +335,51 @@ describe('POST /rewards/:twitchRewardId/pricing/delete', () => {
   });
 });
 
-describe('POST /settings/global', () => {
-  it('rejects a non-owner even without checking guild access level', async () => {
+describe('POST /settings/pricing', () => {
+  it('redirects with error when user is not a streamer', async () => {
     const res = await supertest(buildApp(USER))
-      .post('/settings/global')
+      .post('/settings/pricing')
       .type('form')
-      .send({ decay_half_life_periods: '3', redemption_increment: '0.1' });
-    expect(res.headers.location).toBe('/channel-points?error=not_owner');
-    expect(saveGlobalPricingSettings).not.toHaveBeenCalled();
+      .send({ half_life_minutes: '30', time_to_max_multiplier: '2' });
+    expect(res.headers.location).toBe('/channel-points?error=not_a_streamer');
+    expect(savePricingSettingsForStreamer).not.toHaveBeenCalled();
   });
 
-  it('rejects an invalid decay_half_life_periods for an owner', async () => {
-    const res = await supertest(buildApp(OWNER))
-      .post('/settings/global')
+  it('rejects an invalid half_life_minutes', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp())
+      .post('/settings/pricing')
       .type('form')
-      .send({ decay_half_life_periods: '0', redemption_increment: '0.1' });
+      .send({ half_life_minutes: '0', time_to_max_multiplier: '2' });
     expect(res.headers.location).toBe('/channel-points?error=invalid_settings');
   });
 
-  it('rejects a redemption_increment above 1', async () => {
-    const res = await supertest(buildApp(OWNER))
-      .post('/settings/global')
+  it('rejects an invalid time_to_max_multiplier', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp())
+      .post('/settings/pricing')
       .type('form')
-      .send({ decay_half_life_periods: '3', redemption_increment: '1.5' });
+      .send({ half_life_minutes: '30', time_to_max_multiplier: '0' });
     expect(res.headers.location).toBe('/channel-points?error=invalid_settings');
   });
 
-  it('saves and redirects to success for an owner', async () => {
-    const res = await supertest(buildApp(OWNER))
-      .post('/settings/global')
+  it('saves the settings converted to seconds and redirects to success', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp())
+      .post('/settings/pricing')
       .type('form')
-      .send({ decay_half_life_periods: '4', redemption_increment: '0.2' });
-    expect(res.headers.location).toBe('/channel-points?success=global_settings_saved');
-    expect(saveGlobalPricingSettings).toHaveBeenCalledWith({ decay_half_life_periods: 4, redemption_increment: 0.2 });
+      .send({ half_life_minutes: '30', time_to_max_multiplier: '2' });
+    expect(res.headers.location).toBe('/channel-points?success=pricing_settings_saved');
+    expect(savePricingSettingsForStreamer).toHaveBeenCalledWith(MOCK_STREAMER.id, { half_life_seconds: 1800, time_to_max_multiplier: 2 });
   });
 
-  it('redirects with save_failed when saveGlobalPricingSettings throws', async () => {
-    vi.mocked(saveGlobalPricingSettings).mockRejectedValueOnce(new Error('DB down'));
-    const res = await supertest(buildApp(OWNER))
-      .post('/settings/global')
+  it('redirects with save_failed when savePricingSettingsForStreamer throws', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(savePricingSettingsForStreamer).mockRejectedValueOnce(new Error('DB down'));
+    const res = await supertest(buildApp())
+      .post('/settings/pricing')
       .type('form')
-      .send({ decay_half_life_periods: '4', redemption_increment: '0.2' });
+      .send({ half_life_minutes: '30', time_to_max_multiplier: '2' });
     expect(res.headers.location).toBe('/channel-points?error=save_failed');
   });
 });

--- a/src/web/routes/channelPointsAdminMutations.ts
+++ b/src/web/routes/channelPointsAdminMutations.ts
@@ -2,13 +2,16 @@ import { createLogger } from '../../shared/logger';
 import { Router, Request, Response } from 'express';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
-import { upsertPricingConfig, saveGlobalPricingSettings, DbStreamerEventSub } from '../../db';
-import { createCustomReward, updateCustomReward } from '../../twitch/twitchApi';
+import {
+  upsertPricingConfig, savePricingSettingsForStreamer, getPricingForReward, updatePricingCooldownForReward,
+  DEFAULT_PRICING_COOLDOWN_SECONDS, DbStreamerEventSub,
+} from '../../db';
+import { createCustomReward, updateCustomReward, getCustomRewards } from '../../twitch/twitchApi';
 import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
 import { logAndRedirectError } from './shared';
 import {
   requireStreamer, parsePositiveIntField, parseNonNegativeNumberField, parsePositiveNumberField,
-  parseCheckboxField, parseRewardIdParam, parseRewardFields,
+  parseCheckboxField, parseRewardIdParam, parseRewardFields, effectiveCooldownSeconds,
 } from './channelPointsAdminShared';
 import { applyDecayTick, resetAndDeletePricing, deleteRewardAndPricing } from '../../twitch/pricing/rewardPricingService';
 
@@ -94,7 +97,15 @@ router.post('/rewards/:twitchRewardId', requireAuth, csrfProtection, async (req,
     const token = streamer.twitch_user_id ? await getValidToken(streamer) : null;
     if (!streamer.twitch_user_id || !token) return res.redirect('/channel-points?error=update_failed');
 
-    await updateCustomReward(streamer.twitch_user_id, twitchRewardId, token, input);
+    const updated = await updateCustomReward(streamer.twitch_user_id, twitchRewardId, token, input);
+
+    // Best-effort: if the reward's Twitch cooldown changed, keep any existing pricing config's
+    // cooldown_seconds mirroring it (no-ops if no pricing config exists for this reward).
+    try {
+      await updatePricingCooldownForReward(streamer.id, twitchRewardId, effectiveCooldownSeconds(updated));
+    } catch (err) {
+      log.warn('Failed to sync pricing cooldown after reward edit:', err);
+    }
 
     res.redirect('/channel-points?success=reward_updated');
   } catch (err) {
@@ -121,10 +132,35 @@ router.post('/rewards/:twitchRewardId/delete', requireAuth, csrfProtection, (req
   ));
 
 /**
+ * Determines the `cooldown_seconds` a saved pricing config should use: the reward's live Twitch
+ * global cooldown when it can be looked up, otherwise the reward's existing pricing config
+ * cooldown (if any), otherwise the fallback default. Never throws — a lookup failure just
+ * falls through to the next source, so saving a pricing config never fails on a Twitch hiccup.
+ * Keeps pricing's cooldown mirroring the reward's real Twitch cooldown instead of a
+ * separately-edited value.
+ */
+async function resolveCooldownSecondsForPricing(streamer: DbStreamerEventSub, twitchRewardId: string): Promise<number> {
+  try {
+    const token = streamer.twitch_user_id ? await getValidToken(streamer) : null;
+    if (streamer.twitch_user_id && token) {
+      const rewards = await getCustomRewards(streamer.twitch_user_id, token);
+      const reward = rewards.find((r) => r.id === twitchRewardId);
+      if (reward) return effectiveCooldownSeconds(reward);
+    }
+  } catch (err) {
+    log.warn('Failed to look up live Twitch cooldown while saving pricing config:', err);
+  }
+  const existing = await getPricingForReward(streamer.id, twitchRewardId);
+  return existing?.cooldown_seconds ?? DEFAULT_PRICING_COOLDOWN_SECONDS;
+}
+
+/**
  * POST /channel-points/rewards/:twitchRewardId/pricing — creates or updates a reward's dynamic
- * pricing config.
+ * pricing config. `cooldown_seconds` is not a form field — it's always derived from the
+ * reward's live Twitch global cooldown (see {@link resolveCooldownSecondsForPricing}), so it
+ * can never drift from the reward's actual Twitch-enforced cooldown.
  * @param req - Express request; reads the `twitchRewardId` route param and `enabled`,
- *   `base_cost`, `cooldown_seconds`, `max_multiplier`, `curve` from `req.body`.
+ *   `base_cost`, `max_multiplier`, `curve` from `req.body`.
  * @param res - Express response; redirects to `/channel-points?success=pricing_saved` on success,
  *   or to `/channel-points?error=<code>` if the requester isn't a streamer (`not_a_streamer`),
  *   the reward ID isn't a valid UUID (`invalid_reward_id`), any config field is invalid
@@ -140,14 +176,14 @@ router.post('/rewards/:twitchRewardId/pricing', requireAuth, csrfProtection, asy
 
     const body = req.body as Record<string, string | string[] | undefined>;
     const baseCost = parsePositiveIntField(body.base_cost);
-    const cooldownSeconds = parsePositiveIntField(body.cooldown_seconds);
     const maxMultiplier = parseNonNegativeNumberField(body.max_multiplier);
     const curve = parsePositiveNumberField(body.curve);
-    if (baseCost === null || cooldownSeconds === null || maxMultiplier === null || curve === null) {
+    if (baseCost === null || maxMultiplier === null || curve === null) {
       return res.redirect('/channel-points?error=invalid_config');
     }
 
     const enabled = parseCheckboxField(body.enabled);
+    const cooldownSeconds = await resolveCooldownSecondsForPricing(streamer, twitchRewardId);
 
     await upsertPricingConfig(streamer.id, twitchRewardId, {
       enabled, base_cost: baseCost, cooldown_seconds: cooldownSeconds, max_multiplier: maxMultiplier, curve,
@@ -184,33 +220,33 @@ router.post('/rewards/:twitchRewardId/pricing/delete', requireAuth, csrfProtecti
   ));
 
 /**
- * POST /channel-points/settings/global — updates the bot-wide decay/increment settings shared by
- * every reward's demand calculations. Restricted to the bot owner (`req.session.user.isOwner`)
- * since this setting is not scoped to any single guild or streamer.
- * @param req - Express request; reads `decay_half_life_periods` and `redemption_increment`
- *   from `req.body`.
- * @param res - Express response; redirects to `/channel-points?success=global_settings_saved` on
- *   success, or to `/channel-points?error=<code>` if the requester isn't the bot owner (`not_owner`),
- *   a field is invalid (`invalid_settings`), or saving fails (`save_failed`).
+ * POST /channel-points/settings/pricing — updates the streamer's own dynamic-pricing settings
+ * (decay half-life and time-to-max-demand multiplier), shared by every one of their rewards'
+ * demand calculations.
+ * @param req - Express request; reads `half_life_minutes` and `time_to_max_multiplier` from `req.body`.
+ * @param res - Express response; redirects to `/channel-points?success=pricing_settings_saved` on
+ *   success, or to `/channel-points?error=<code>` if the requester isn't a streamer
+ *   (`not_a_streamer`), a field is invalid (`invalid_settings`), or saving fails (`save_failed`).
  */
-router.post('/settings/global', requireAuth, csrfProtection, async (req, res) => {
+router.post('/settings/pricing', requireAuth, csrfProtection, async (req, res) => {
   try {
-    if (!req.session.user?.isOwner) return res.redirect('/channel-points?error=not_owner');
+    const streamer = await requireStreamer(req, res);
+    if (!streamer) return;
 
     const body = req.body as Record<string, string | string[] | undefined>;
-    const decayHalfLifePeriods = parsePositiveNumberField(body.decay_half_life_periods);
-    const redemptionIncrement = parseNonNegativeNumberField(body.redemption_increment);
-    if (decayHalfLifePeriods === null || redemptionIncrement === null || redemptionIncrement > 1) {
+    const halfLifeMinutes = parsePositiveNumberField(body.half_life_minutes);
+    const timeToMaxMultiplier = parsePositiveNumberField(body.time_to_max_multiplier);
+    if (halfLifeMinutes === null || timeToMaxMultiplier === null) {
       return res.redirect('/channel-points?error=invalid_settings');
     }
 
-    await saveGlobalPricingSettings({
-      decay_half_life_periods: decayHalfLifePeriods,
-      redemption_increment: redemptionIncrement,
+    await savePricingSettingsForStreamer(streamer.id, {
+      half_life_seconds: Math.round(halfLifeMinutes * 60),
+      time_to_max_multiplier: timeToMaxMultiplier,
     });
 
-    res.redirect('/channel-points?success=global_settings_saved');
+    res.redirect('/channel-points?success=pricing_settings_saved');
   } catch (err) {
-    logAndRedirectError({ res, log, logLabel: 'Global pricing settings save error:', err, basePath: '/channel-points', errorCode: 'save_failed' });
+    logAndRedirectError({ res, log, logLabel: 'Pricing settings save error:', err, basePath: '/channel-points', errorCode: 'save_failed' });
   }
 });

--- a/src/web/routes/channelPointsAdminMutations.ts
+++ b/src/web/routes/channelPointsAdminMutations.ts
@@ -1,49 +1,19 @@
 import { createLogger } from '../../shared/logger';
-import { Router, Request, Response } from 'express';
+import { Router } from 'express';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
-import {
-  upsertPricingConfig, savePricingSettingsForStreamer, getPricingForReward, updatePricingCooldownForReward,
-  DEFAULT_PRICING_COOLDOWN_SECONDS, DbStreamerEventSub,
-} from '../../db';
-import { createCustomReward, updateCustomReward, getCustomRewards } from '../../twitch/twitchApi';
+import { updatePricingCooldownForReward } from '../../db';
+import { createCustomReward, updateCustomReward } from '../../twitch/twitchApi';
 import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
 import { logAndRedirectError } from './shared';
 import {
-  requireStreamer, parsePositiveIntField, parseNonNegativeNumberField, parsePositiveNumberField,
-  parseCheckboxField, parseRewardIdParam, parseRewardFields, effectiveCooldownSeconds,
+  requireStreamer, parseRewardIdParam, parseRewardFields, effectiveCooldownSeconds, handleRewardDeleteAction,
 } from './channelPointsAdminShared';
-import { applyDecayTick, resetAndDeletePricing, deleteRewardAndPricing } from '../../twitch/pricing/rewardPricingService';
+import { deleteRewardAndPricing } from '../../twitch/pricing/rewardPricingService';
+import { router as pricingMutationsRouter } from './channelPointsAdminPricingMutations';
 
 const log = createLogger('ChannelPointsAdminMutations');
 export const router = Router();
-
-/**
- * Shared body for the two reward-scoped "delete" routes: resolves the requester's streamer
- * record and the `:twitchRewardId` route param, runs `action`, then redirects to
- * `/channel-points` with `success=<successCode>` or (on a thrown error) `error=<errorCode>`
- * via `logAndRedirectError`.
- */
-async function handleRewardDeleteAction(
-  req: Request,
-  res: Response,
-  action: (streamer: DbStreamerEventSub, twitchRewardId: string) => Promise<void>,
-  opts: { successCode: string; errorLogLabel: string; errorCode: string },
-): Promise<void> {
-  try {
-    const streamer = await requireStreamer(req, res);
-    if (!streamer) return;
-
-    const twitchRewardId = parseRewardIdParam(req.params.twitchRewardId);
-    if (twitchRewardId === null) return res.redirect('/channel-points?error=invalid_reward_id');
-
-    await action(streamer, twitchRewardId);
-
-    res.redirect(`/channel-points?success=${opts.successCode}`);
-  } catch (err) {
-    logAndRedirectError({ res, log, logLabel: opts.errorLogLabel, err, basePath: '/channel-points', errorCode: opts.errorCode });
-  }
-}
 
 /**
  * POST /channel-points/rewards — creates a new custom reward on Twitch.
@@ -128,125 +98,9 @@ router.post('/rewards/:twitchRewardId/delete', requireAuth, csrfProtection, (req
   handleRewardDeleteAction(
     req, res,
     (streamer, twitchRewardId) => deleteRewardAndPricing(streamer.id, twitchRewardId),
-    { successCode: 'reward_deleted', errorLogLabel: 'Reward delete error:', errorCode: 'delete_failed' },
+    { log, successCode: 'reward_deleted', errorLogLabel: 'Reward delete error:', errorCode: 'delete_failed' },
   ));
 
-/**
- * Determines the `cooldown_seconds` a saved pricing config should use: the reward's live Twitch
- * global cooldown when it can be looked up, otherwise the reward's existing pricing config
- * cooldown (if any), otherwise the fallback default. Never throws — a lookup failure just
- * falls through to the next source, so saving a pricing config never fails on a Twitch hiccup.
- * Keeps pricing's cooldown mirroring the reward's real Twitch cooldown instead of a
- * separately-edited value.
- */
-async function resolveCooldownSecondsForPricing(streamer: DbStreamerEventSub, twitchRewardId: string): Promise<number> {
-  try {
-    const token = streamer.twitch_user_id ? await getValidToken(streamer) : null;
-    if (streamer.twitch_user_id && token) {
-      const rewards = await getCustomRewards(streamer.twitch_user_id, token);
-      const reward = rewards.find((r) => r.id === twitchRewardId);
-      if (reward) return effectiveCooldownSeconds(reward);
-    }
-  } catch (err) {
-    log.warn('Failed to look up live Twitch cooldown while saving pricing config:', err);
-  }
-  const existing = await getPricingForReward(streamer.id, twitchRewardId);
-  return existing?.cooldown_seconds ?? DEFAULT_PRICING_COOLDOWN_SECONDS;
-}
-
-/**
- * POST /channel-points/rewards/:twitchRewardId/pricing — creates or updates a reward's dynamic
- * pricing config. `cooldown_seconds` is not a form field — it's always derived from the
- * reward's live Twitch global cooldown (see {@link resolveCooldownSecondsForPricing}), so it
- * can never drift from the reward's actual Twitch-enforced cooldown.
- * @param req - Express request; reads the `twitchRewardId` route param and `enabled`,
- *   `base_cost`, `max_multiplier`, `curve` from `req.body`.
- * @param res - Express response; redirects to `/channel-points?success=pricing_saved` on success,
- *   or to `/channel-points?error=<code>` if the requester isn't a streamer (`not_a_streamer`),
- *   the reward ID isn't a valid UUID (`invalid_reward_id`), any config field is invalid
- *   (`invalid_config`), or saving fails (`save_failed`).
- */
-router.post('/rewards/:twitchRewardId/pricing', requireAuth, csrfProtection, async (req, res) => {
-  try {
-    const streamer = await requireStreamer(req, res);
-    if (!streamer) return;
-
-    const twitchRewardId = parseRewardIdParam(req.params.twitchRewardId);
-    if (twitchRewardId === null) return res.redirect('/channel-points?error=invalid_reward_id');
-
-    const body = req.body as Record<string, string | string[] | undefined>;
-    const baseCost = parsePositiveIntField(body.base_cost);
-    const maxMultiplier = parseNonNegativeNumberField(body.max_multiplier);
-    const curve = parsePositiveNumberField(body.curve);
-    if (baseCost === null || maxMultiplier === null || curve === null) {
-      return res.redirect('/channel-points?error=invalid_config');
-    }
-
-    const enabled = parseCheckboxField(body.enabled);
-    const cooldownSeconds = await resolveCooldownSecondsForPricing(streamer, twitchRewardId);
-
-    await upsertPricingConfig(streamer.id, twitchRewardId, {
-      enabled, base_cost: baseCost, cooldown_seconds: cooldownSeconds, max_multiplier: maxMultiplier, curve,
-    });
-
-    // Best-effort immediate resync so the reward's Twitch-side cost reflects the new
-    // config right away instead of waiting for the next redemption/decay tick.
-    try {
-      await applyDecayTick(streamer.id, twitchRewardId);
-    } catch (err) {
-      log.warn('Immediate pricing resync after save failed:', err);
-    }
-
-    res.redirect('/channel-points?success=pricing_saved');
-  } catch (err) {
-    logAndRedirectError({ res, log, logLabel: 'Pricing config save error:', err, basePath: '/channel-points', errorCode: 'save_failed' });
-  }
-});
-
-/**
- * POST /channel-points/rewards/:twitchRewardId/pricing/delete — turns off dynamic pricing for
- * a reward while keeping the reward itself on Twitch (see `resetAndDeletePricing`, which
- * best-effort resets the Twitch-side cost back to `base_cost` first).
- * @param req - Express request; reads the `twitchRewardId` route param.
- * @param res - Express response; redirects to `/channel-points?success=pricing_deleted` on success,
- *   or to `/channel-points?error=<code>` if the requester isn't a streamer (`not_a_streamer`),
- *   the reward ID isn't a valid UUID (`invalid_reward_id`), or the delete fails (`delete_failed`).
- */
-router.post('/rewards/:twitchRewardId/pricing/delete', requireAuth, csrfProtection, (req, res) =>
-  handleRewardDeleteAction(
-    req, res,
-    (streamer, twitchRewardId) => resetAndDeletePricing(streamer.id, twitchRewardId),
-    { successCode: 'pricing_deleted', errorLogLabel: 'Pricing config delete error:', errorCode: 'delete_failed' },
-  ));
-
-/**
- * POST /channel-points/settings/pricing — updates the streamer's own dynamic-pricing settings
- * (decay half-life and time-to-max-demand multiplier), shared by every one of their rewards'
- * demand calculations.
- * @param req - Express request; reads `half_life_minutes` and `time_to_max_multiplier` from `req.body`.
- * @param res - Express response; redirects to `/channel-points?success=pricing_settings_saved` on
- *   success, or to `/channel-points?error=<code>` if the requester isn't a streamer
- *   (`not_a_streamer`), a field is invalid (`invalid_settings`), or saving fails (`save_failed`).
- */
-router.post('/settings/pricing', requireAuth, csrfProtection, async (req, res) => {
-  try {
-    const streamer = await requireStreamer(req, res);
-    if (!streamer) return;
-
-    const body = req.body as Record<string, string | string[] | undefined>;
-    const halfLifeMinutes = parsePositiveNumberField(body.half_life_minutes);
-    const timeToMaxMultiplier = parsePositiveNumberField(body.time_to_max_multiplier);
-    if (halfLifeMinutes === null || timeToMaxMultiplier === null) {
-      return res.redirect('/channel-points?error=invalid_settings');
-    }
-
-    await savePricingSettingsForStreamer(streamer.id, {
-      half_life_seconds: Math.round(halfLifeMinutes * 60),
-      time_to_max_multiplier: timeToMaxMultiplier,
-    });
-
-    res.redirect('/channel-points?success=pricing_settings_saved');
-  } catch (err) {
-    logAndRedirectError({ res, log, logLabel: 'Pricing settings save error:', err, basePath: '/channel-points', errorCode: 'save_failed' });
-  }
-});
+// Pricing config and pricing-settings routes live in their own module to keep this file scoped
+// to reward CRUD — see channelPointsAdminPricingMutations.ts.
+router.use(pricingMutationsRouter);

--- a/src/web/routes/channelPointsAdminPricingMutations.test.ts
+++ b/src/web/routes/channelPointsAdminPricingMutations.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../shared/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+}));
+
+vi.mock('../../db', () => ({
+  getStreamerByDiscordId: vi.fn(),
+  upsertPricingConfig: vi.fn(),
+  getPricingForReward: vi.fn(),
+  savePricingSettingsForStreamer: vi.fn(),
+  DEFAULT_PRICING_COOLDOWN_SECONDS: 60,
+}));
+
+vi.mock('../csrf', () => ({
+  csrfProtection: (req: any, _res: any, next: any) => {
+    req.csrfToken = () => 'test-csrf-token';
+    next();
+  },
+}));
+
+vi.mock('../middleware', () => ({
+  requireAuth: (_req: any, _res: any, next: any) => next(),
+}));
+
+vi.mock('../../twitch/twitchApi', () => ({
+  getCustomRewards: vi.fn(),
+}));
+
+vi.mock('../../twitch/eventsub/twitchApiEventSub', () => ({
+  getValidToken: vi.fn(),
+}));
+
+vi.mock('../../twitch/pricing/rewardPricingService', () => ({
+  applyDecayTick: vi.fn().mockResolvedValue(undefined),
+  resetAndDeletePricing: vi.fn().mockResolvedValue(undefined),
+}));
+
+import express from 'express';
+import supertest from 'supertest';
+import { router } from './channelPointsAdminPricingMutations';
+import { getStreamerByDiscordId, upsertPricingConfig, getPricingForReward, savePricingSettingsForStreamer } from '../../db';
+import { getCustomRewards } from '../../twitch/twitchApi';
+import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
+import { applyDecayTick, resetAndDeletePricing } from '../../twitch/pricing/rewardPricingService';
+
+type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3; isOwner: boolean };
+const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: 0, isOwner: false };
+
+const MOCK_STREAMER = { id: 123, twitch_user_id: 'twitch123', twitch_name: 'teststreamer', discord_id: USER.discordId };
+
+const VALID_REWARD_ID = '12345678-1234-1234-8234-123456789abc';
+const VALID_REWARD_TWITCH_DATA = { id: VALID_REWARD_ID, global_cooldown_setting: { is_enabled: true, global_cooldown_seconds: 300 } };
+
+function buildApp(sessionUser: SessionUser = USER) {
+  const app = express();
+  app.use(express.urlencoded({ extended: false }));
+  app.use((req: any, _res: any, next: any) => {
+    req.session = { user: sessionUser };
+    next();
+  });
+  app.use(router);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
+  vi.mocked(getValidToken).mockResolvedValue('user-token');
+  vi.mocked(getCustomRewards).mockResolvedValue([VALID_REWARD_TWITCH_DATA as any]);
+  vi.mocked(getPricingForReward).mockResolvedValue(null);
+  vi.mocked(upsertPricingConfig).mockResolvedValue(undefined);
+  vi.mocked(savePricingSettingsForStreamer).mockResolvedValue(undefined);
+  vi.mocked(applyDecayTick).mockResolvedValue(undefined);
+  vi.mocked(resetAndDeletePricing).mockResolvedValue(undefined);
+});
+
+describe('POST /rewards/:twitchRewardId/pricing', () => {
+  it('redirects with error when user is not a streamer', async () => {
+    const res = await supertest(buildApp())
+      .post(`/rewards/${VALID_REWARD_ID}/pricing`)
+      .type('form')
+      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5' });
+    expect(res.headers.location).toBe('/channel-points?error=not_a_streamer');
+  });
+
+  it('redirects with error for an invalid reward id', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp())
+      .post('/rewards/not-a-uuid/pricing')
+      .type('form')
+      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5' });
+    expect(res.headers.location).toBe('/channel-points?error=invalid_reward_id');
+  });
+
+  it.each([
+    ['base_cost', { base_cost: '0' }],
+    ['max_multiplier', { max_multiplier: '-1' }],
+    ['curve', { curve: '0' }],
+  ])('redirects with invalid_config when %s is invalid', async (_name, override) => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp())
+      .post(`/rewards/${VALID_REWARD_ID}/pricing`)
+      .type('form')
+      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5', ...override });
+    expect(res.headers.location).toBe('/channel-points?error=invalid_config');
+  });
+
+  it('saves the config using the reward\'s live Twitch cooldown, best-effort resyncs, and redirects to success', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp())
+      .post(`/rewards/${VALID_REWARD_ID}/pricing`)
+      .type('form')
+      .send({ enabled: 'on', base_cost: '200', max_multiplier: '4', curve: '1.5' });
+    expect(res.headers.location).toBe('/channel-points?success=pricing_saved');
+    expect(upsertPricingConfig).toHaveBeenCalledWith(MOCK_STREAMER.id, VALID_REWARD_ID, {
+      enabled: true, base_cost: 200, cooldown_seconds: 300, max_multiplier: 4, curve: 1.5,
+    });
+    expect(applyDecayTick).toHaveBeenCalledWith(MOCK_STREAMER.id, VALID_REWARD_ID);
+  });
+
+  it('falls back to the existing pricing config cooldown when the reward is no longer found on Twitch', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(getCustomRewards).mockResolvedValue([]);
+    vi.mocked(getPricingForReward).mockResolvedValue({ cooldown_seconds: 120 } as any);
+    await supertest(buildApp())
+      .post(`/rewards/${VALID_REWARD_ID}/pricing`)
+      .type('form')
+      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5' });
+    expect(upsertPricingConfig).toHaveBeenCalledWith(MOCK_STREAMER.id, VALID_REWARD_ID, expect.objectContaining({ cooldown_seconds: 120 }));
+  });
+
+  it('falls back to the default cooldown when the reward is unknown and no pricing config exists yet', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(getCustomRewards).mockResolvedValue([]);
+    vi.mocked(getPricingForReward).mockResolvedValue(null);
+    await supertest(buildApp())
+      .post(`/rewards/${VALID_REWARD_ID}/pricing`)
+      .type('form')
+      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5' });
+    expect(upsertPricingConfig).toHaveBeenCalledWith(MOCK_STREAMER.id, VALID_REWARD_ID, expect.objectContaining({ cooldown_seconds: 60 }));
+  });
+
+  it('treats a missing enabled checkbox as false', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    await supertest(buildApp())
+      .post(`/rewards/${VALID_REWARD_ID}/pricing`)
+      .type('form')
+      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5' });
+    expect(upsertPricingConfig).toHaveBeenCalledWith(MOCK_STREAMER.id, VALID_REWARD_ID, expect.objectContaining({ enabled: false }));
+  });
+
+  it('still redirects to success when the best-effort resync throws', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(applyDecayTick).mockRejectedValueOnce(new Error('twitch down'));
+    const res = await supertest(buildApp())
+      .post(`/rewards/${VALID_REWARD_ID}/pricing`)
+      .type('form')
+      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5' });
+    expect(res.headers.location).toBe('/channel-points?success=pricing_saved');
+  });
+
+  it('redirects with save_failed when upsertPricingConfig throws', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(upsertPricingConfig).mockRejectedValueOnce(new Error('DB down'));
+    const res = await supertest(buildApp())
+      .post(`/rewards/${VALID_REWARD_ID}/pricing`)
+      .type('form')
+      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5' });
+    expect(res.headers.location).toBe('/channel-points?error=save_failed');
+  });
+});
+
+describe('POST /rewards/:twitchRewardId/pricing/delete', () => {
+  it('redirects with error when user is not a streamer', async () => {
+    const res = await supertest(buildApp()).post(`/rewards/${VALID_REWARD_ID}/pricing/delete`);
+    expect(res.headers.location).toBe('/channel-points?error=not_a_streamer');
+  });
+
+  it('redirects with error for an invalid reward id', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp()).post('/rewards/not-a-uuid/pricing/delete');
+    expect(res.headers.location).toBe('/channel-points?error=invalid_reward_id');
+  });
+
+  it('disables pricing and redirects to success', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp()).post(`/rewards/${VALID_REWARD_ID}/pricing/delete`);
+    expect(res.headers.location).toBe('/channel-points?success=pricing_deleted');
+    expect(resetAndDeletePricing).toHaveBeenCalledWith(MOCK_STREAMER.id, VALID_REWARD_ID);
+  });
+
+  it('redirects with delete_failed when resetAndDeletePricing throws', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(resetAndDeletePricing).mockRejectedValueOnce(new Error('DB down'));
+    const res = await supertest(buildApp()).post(`/rewards/${VALID_REWARD_ID}/pricing/delete`);
+    expect(res.headers.location).toBe('/channel-points?error=delete_failed');
+  });
+});
+
+describe('POST /settings/pricing', () => {
+  it('redirects with error when user is not a streamer', async () => {
+    const res = await supertest(buildApp(USER))
+      .post('/settings/pricing')
+      .type('form')
+      .send({ half_life_minutes: '30', time_to_max_multiplier: '2' });
+    expect(res.headers.location).toBe('/channel-points?error=not_a_streamer');
+    expect(savePricingSettingsForStreamer).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid half_life_minutes', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp())
+      .post('/settings/pricing')
+      .type('form')
+      .send({ half_life_minutes: '0', time_to_max_multiplier: '2' });
+    expect(res.headers.location).toBe('/channel-points?error=invalid_settings');
+  });
+
+  it('rejects an invalid time_to_max_multiplier', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp())
+      .post('/settings/pricing')
+      .type('form')
+      .send({ half_life_minutes: '30', time_to_max_multiplier: '0' });
+    expect(res.headers.location).toBe('/channel-points?error=invalid_settings');
+  });
+
+  it('saves the settings converted to seconds and redirects to success', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp())
+      .post('/settings/pricing')
+      .type('form')
+      .send({ half_life_minutes: '30', time_to_max_multiplier: '2' });
+    expect(res.headers.location).toBe('/channel-points?success=pricing_settings_saved');
+    expect(savePricingSettingsForStreamer).toHaveBeenCalledWith(MOCK_STREAMER.id, { half_life_seconds: 1800, time_to_max_multiplier: 2 });
+  });
+
+  it('redirects with save_failed when savePricingSettingsForStreamer throws', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(savePricingSettingsForStreamer).mockRejectedValueOnce(new Error('DB down'));
+    const res = await supertest(buildApp())
+      .post('/settings/pricing')
+      .type('form')
+      .send({ half_life_minutes: '30', time_to_max_multiplier: '2' });
+    expect(res.headers.location).toBe('/channel-points?error=save_failed');
+  });
+});

--- a/src/web/routes/channelPointsAdminPricingMutations.test.ts
+++ b/src/web/routes/channelPointsAdminPricingMutations.test.ts
@@ -141,6 +141,17 @@ describe('POST /rewards/:twitchRewardId/pricing', () => {
     expect(upsertPricingConfig).toHaveBeenCalledWith(MOCK_STREAMER.id, VALID_REWARD_ID, expect.objectContaining({ cooldown_seconds: 60 }));
   });
 
+  it('falls back to the existing pricing config cooldown when the live Twitch lookup throws', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(getCustomRewards).mockRejectedValueOnce(new Error('Twitch down'));
+    vi.mocked(getPricingForReward).mockResolvedValue({ cooldown_seconds: 90 } as any);
+    await supertest(buildApp())
+      .post(`/rewards/${VALID_REWARD_ID}/pricing`)
+      .type('form')
+      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5' });
+    expect(upsertPricingConfig).toHaveBeenCalledWith(MOCK_STREAMER.id, VALID_REWARD_ID, expect.objectContaining({ cooldown_seconds: 90 }));
+  });
+
   it('treats a missing enabled checkbox as false', async () => {
     vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
     await supertest(buildApp())

--- a/src/web/routes/channelPointsAdminPricingMutations.test.ts
+++ b/src/web/routes/channelPointsAdminPricingMutations.test.ts
@@ -217,6 +217,16 @@ describe('POST /settings/pricing', () => {
     expect(res.headers.location).toBe('/channel-points?error=invalid_settings');
   });
 
+  it('rejects a half_life_minutes so small it would round down to 0 seconds', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp())
+      .post('/settings/pricing')
+      .type('form')
+      .send({ half_life_minutes: '0.001', time_to_max_multiplier: '2' });
+    expect(res.headers.location).toBe('/channel-points?error=invalid_settings');
+    expect(savePricingSettingsForStreamer).not.toHaveBeenCalled();
+  });
+
   it('rejects an invalid time_to_max_multiplier', async () => {
     vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
     const res = await supertest(buildApp())

--- a/src/web/routes/channelPointsAdminPricingMutations.ts
+++ b/src/web/routes/channelPointsAdminPricingMutations.ts
@@ -1,0 +1,139 @@
+import { createLogger } from '../../shared/logger';
+import { Router } from 'express';
+import { csrfProtection } from '../csrf';
+import { requireAuth } from '../middleware';
+import {
+  upsertPricingConfig, savePricingSettingsForStreamer, getPricingForReward,
+  DEFAULT_PRICING_COOLDOWN_SECONDS, DbStreamerEventSub,
+} from '../../db';
+import { getCustomRewards } from '../../twitch/twitchApi';
+import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
+import { logAndRedirectError } from './shared';
+import {
+  requireStreamer, parsePositiveIntField, parseNonNegativeNumberField, parsePositiveNumberField,
+  parseCheckboxField, parseRewardIdParam, effectiveCooldownSeconds, handleRewardDeleteAction,
+} from './channelPointsAdminShared';
+import { applyDecayTick, resetAndDeletePricing } from '../../twitch/pricing/rewardPricingService';
+
+const log = createLogger('ChannelPointsAdminPricingMutations');
+export const router = Router();
+
+/**
+ * Determines the `cooldown_seconds` a saved pricing config should use: the reward's live Twitch
+ * global cooldown when it can be looked up, otherwise the reward's existing pricing config
+ * cooldown (if any), otherwise the fallback default. Never throws — a lookup failure just
+ * falls through to the next source, so saving a pricing config never fails on a Twitch hiccup.
+ * Keeps pricing's cooldown mirroring the reward's real Twitch cooldown instead of a
+ * separately-edited value.
+ */
+async function resolveCooldownSecondsForPricing(streamer: DbStreamerEventSub, twitchRewardId: string): Promise<number> {
+  try {
+    const token = streamer.twitch_user_id ? await getValidToken(streamer) : null;
+    if (streamer.twitch_user_id && token) {
+      const rewards = await getCustomRewards(streamer.twitch_user_id, token);
+      const reward = rewards.find((r) => r.id === twitchRewardId);
+      if (reward) return effectiveCooldownSeconds(reward);
+    }
+  } catch (err) {
+    log.warn('Failed to look up live Twitch cooldown while saving pricing config:', err);
+  }
+  const existing = await getPricingForReward(streamer.id, twitchRewardId);
+  return existing?.cooldown_seconds ?? DEFAULT_PRICING_COOLDOWN_SECONDS;
+}
+
+/**
+ * POST /channel-points/rewards/:twitchRewardId/pricing — creates or updates a reward's dynamic
+ * pricing config. `cooldown_seconds` is not a form field — it's always derived from the
+ * reward's live Twitch global cooldown (see {@link resolveCooldownSecondsForPricing}), so it
+ * can never drift from the reward's actual Twitch-enforced cooldown.
+ * @param req - Express request; reads the `twitchRewardId` route param and `enabled`,
+ *   `base_cost`, `max_multiplier`, `curve` from `req.body`.
+ * @param res - Express response; redirects to `/channel-points?success=pricing_saved` on success,
+ *   or to `/channel-points?error=<code>` if the requester isn't a streamer (`not_a_streamer`),
+ *   the reward ID isn't a valid UUID (`invalid_reward_id`), any config field is invalid
+ *   (`invalid_config`), or saving fails (`save_failed`).
+ */
+router.post('/rewards/:twitchRewardId/pricing', requireAuth, csrfProtection, async (req, res) => {
+  try {
+    const streamer = await requireStreamer(req, res);
+    if (!streamer) return;
+
+    const twitchRewardId = parseRewardIdParam(req.params.twitchRewardId);
+    if (twitchRewardId === null) return res.redirect('/channel-points?error=invalid_reward_id');
+
+    const body = req.body as Record<string, string | string[] | undefined>;
+    const baseCost = parsePositiveIntField(body.base_cost);
+    const maxMultiplier = parseNonNegativeNumberField(body.max_multiplier);
+    const curve = parsePositiveNumberField(body.curve);
+    if (baseCost === null || maxMultiplier === null || curve === null) {
+      return res.redirect('/channel-points?error=invalid_config');
+    }
+
+    const enabled = parseCheckboxField(body.enabled);
+    const cooldownSeconds = await resolveCooldownSecondsForPricing(streamer, twitchRewardId);
+
+    await upsertPricingConfig(streamer.id, twitchRewardId, {
+      enabled, base_cost: baseCost, cooldown_seconds: cooldownSeconds, max_multiplier: maxMultiplier, curve,
+    });
+
+    // Best-effort immediate resync so the reward's Twitch-side cost reflects the new
+    // config right away instead of waiting for the next redemption/decay tick.
+    try {
+      await applyDecayTick(streamer.id, twitchRewardId);
+    } catch (err) {
+      log.warn('Immediate pricing resync after save failed:', err);
+    }
+
+    res.redirect('/channel-points?success=pricing_saved');
+  } catch (err) {
+    logAndRedirectError({ res, log, logLabel: 'Pricing config save error:', err, basePath: '/channel-points', errorCode: 'save_failed' });
+  }
+});
+
+/**
+ * POST /channel-points/rewards/:twitchRewardId/pricing/delete — turns off dynamic pricing for
+ * a reward while keeping the reward itself on Twitch (see `resetAndDeletePricing`, which
+ * best-effort resets the Twitch-side cost back to `base_cost` first).
+ * @param req - Express request; reads the `twitchRewardId` route param.
+ * @param res - Express response; redirects to `/channel-points?success=pricing_deleted` on success,
+ *   or to `/channel-points?error=<code>` if the requester isn't a streamer (`not_a_streamer`),
+ *   the reward ID isn't a valid UUID (`invalid_reward_id`), or the delete fails (`delete_failed`).
+ */
+router.post('/rewards/:twitchRewardId/pricing/delete', requireAuth, csrfProtection, (req, res) =>
+  handleRewardDeleteAction(
+    req, res,
+    (streamer, twitchRewardId) => resetAndDeletePricing(streamer.id, twitchRewardId),
+    { log, successCode: 'pricing_deleted', errorLogLabel: 'Pricing config delete error:', errorCode: 'delete_failed' },
+  ));
+
+/**
+ * POST /channel-points/settings/pricing — updates the streamer's own dynamic-pricing settings
+ * (decay half-life and time-to-max-demand multiplier), shared by every one of their rewards'
+ * demand calculations.
+ * @param req - Express request; reads `half_life_minutes` and `time_to_max_multiplier` from `req.body`.
+ * @param res - Express response; redirects to `/channel-points?success=pricing_settings_saved` on
+ *   success, or to `/channel-points?error=<code>` if the requester isn't a streamer
+ *   (`not_a_streamer`), a field is invalid (`invalid_settings`), or saving fails (`save_failed`).
+ */
+router.post('/settings/pricing', requireAuth, csrfProtection, async (req, res) => {
+  try {
+    const streamer = await requireStreamer(req, res);
+    if (!streamer) return;
+
+    const body = req.body as Record<string, string | string[] | undefined>;
+    const halfLifeMinutes = parsePositiveNumberField(body.half_life_minutes);
+    const timeToMaxMultiplier = parsePositiveNumberField(body.time_to_max_multiplier);
+    if (halfLifeMinutes === null || timeToMaxMultiplier === null) {
+      return res.redirect('/channel-points?error=invalid_settings');
+    }
+
+    await savePricingSettingsForStreamer(streamer.id, {
+      half_life_seconds: Math.round(halfLifeMinutes * 60),
+      time_to_max_multiplier: timeToMaxMultiplier,
+    });
+
+    res.redirect('/channel-points?success=pricing_settings_saved');
+  } catch (err) {
+    logAndRedirectError({ res, log, logLabel: 'Pricing settings save error:', err, basePath: '/channel-points', errorCode: 'save_failed' });
+  }
+});

--- a/src/web/routes/channelPointsAdminPricingMutations.ts
+++ b/src/web/routes/channelPointsAdminPricingMutations.ts
@@ -127,8 +127,15 @@ router.post('/settings/pricing', requireAuth, csrfProtection, async (req, res) =
       return res.redirect('/channel-points?error=invalid_settings');
     }
 
+    // A sub-30-second value rounds to 0, which the DB rejects (half_life_seconds > 0) — catch
+    // that here so it reports as invalid_settings instead of an opaque save_failed.
+    const halfLifeSeconds = Math.round(halfLifeMinutes * 60);
+    if (halfLifeSeconds < 1) {
+      return res.redirect('/channel-points?error=invalid_settings');
+    }
+
     await savePricingSettingsForStreamer(streamer.id, {
-      half_life_seconds: Math.round(halfLifeMinutes * 60),
+      half_life_seconds: halfLifeSeconds,
       time_to_max_multiplier: timeToMaxMultiplier,
     });
 

--- a/src/web/routes/channelPointsAdminShared.test.ts
+++ b/src/web/routes/channelPointsAdminShared.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('../../db', () => ({ getStreamerByDiscordId: vi.fn() }));
+vi.mock('../../db', () => ({ getStreamerByDiscordId: vi.fn(), DEFAULT_PRICING_COOLDOWN_SECONDS: 60 }));
 
 import { getStreamerByDiscordId } from '../../db';
 import {
   requireStreamer, parsePositiveIntField, parseNonNegativeNumberField, parsePositiveNumberField,
-  parseCheckboxField, parseHexColorField, parseRewardIdParam, parseRewardFields,
+  parseCheckboxField, parseHexColorField, parseRewardIdParam, parseRewardFields, effectiveCooldownSeconds,
 } from './channelPointsAdminShared';
 
 const VALID_REWARD_ID = '12345678-1234-1234-8234-123456789abc';
@@ -175,6 +175,16 @@ describe('parseHexColorField', () => {
 
   it('returns null for a hex string missing the leading #', () => {
     expect(parseHexColorField('00E5CB')).toBeNull();
+  });
+});
+
+describe('effectiveCooldownSeconds', () => {
+  it('returns the reward global cooldown when enabled', () => {
+    expect(effectiveCooldownSeconds({ global_cooldown_setting: { is_enabled: true, global_cooldown_seconds: 120 } })).toBe(120);
+  });
+
+  it('falls back to the default when the reward has no global cooldown enabled', () => {
+    expect(effectiveCooldownSeconds({ global_cooldown_setting: { is_enabled: false, global_cooldown_seconds: 999 } })).toBe(60);
   });
 });
 

--- a/src/web/routes/channelPointsAdminShared.test.ts
+++ b/src/web/routes/channelPointsAdminShared.test.ts
@@ -6,6 +6,7 @@ import { getStreamerByDiscordId } from '../../db';
 import {
   requireStreamer, parsePositiveIntField, parseNonNegativeNumberField, parsePositiveNumberField,
   parseCheckboxField, parseHexColorField, parseRewardIdParam, parseRewardFields, effectiveCooldownSeconds,
+  handleRewardDeleteAction,
 } from './channelPointsAdminShared';
 
 const VALID_REWARD_ID = '12345678-1234-1234-8234-123456789abc';
@@ -37,6 +38,52 @@ describe('requireStreamer', () => {
     const result = await requireStreamer(req, res);
     expect(result).toBeNull();
     expect(res.redirect).toHaveBeenCalledWith('/channel-points?error=not_a_streamer');
+  });
+});
+
+describe('handleRewardDeleteAction', () => {
+  const streamer = { id: 1 };
+  function makeReqRes(twitchRewardId = VALID_REWARD_ID, discordId = '123') {
+    const req = { session: { user: { discordId } }, params: { twitchRewardId } } as any;
+    const res = { redirect: vi.fn() } as any;
+    return { req, res };
+  }
+  const opts = { log: { error: vi.fn() } as any, successCode: 'thing_deleted', errorLogLabel: 'delete error:', errorCode: 'delete_failed' };
+
+  it('redirects to not_a_streamer without running the action when the requester is not a streamer', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
+    const action = vi.fn();
+    const { req, res } = makeReqRes();
+    await handleRewardDeleteAction(req, res, action, opts);
+    expect(action).not.toHaveBeenCalled();
+    expect(res.redirect).toHaveBeenCalledWith('/channel-points?error=not_a_streamer');
+  });
+
+  it('redirects to invalid_reward_id without running the action for a malformed reward id', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(streamer as any);
+    const action = vi.fn();
+    const { req, res } = makeReqRes('not-a-uuid');
+    await handleRewardDeleteAction(req, res, action, opts);
+    expect(action).not.toHaveBeenCalled();
+    expect(res.redirect).toHaveBeenCalledWith('/channel-points?error=invalid_reward_id');
+  });
+
+  it('runs the action and redirects to the success code', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(streamer as any);
+    const action = vi.fn().mockResolvedValue(undefined);
+    const { req, res } = makeReqRes();
+    await handleRewardDeleteAction(req, res, action, opts);
+    expect(action).toHaveBeenCalledWith(streamer, VALID_REWARD_ID);
+    expect(res.redirect).toHaveBeenCalledWith('/channel-points?success=thing_deleted');
+  });
+
+  it('logs and redirects to the error code when the action throws', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(streamer as any);
+    const action = vi.fn().mockRejectedValue(new Error('boom'));
+    const { req, res } = makeReqRes();
+    await handleRewardDeleteAction(req, res, action, opts);
+    expect(opts.log.error).toHaveBeenCalledWith(opts.errorLogLabel, expect.any(Error));
+    expect(res.redirect).toHaveBeenCalledWith('/channel-points?error=delete_failed');
   });
 });
 

--- a/src/web/routes/channelPointsAdminShared.ts
+++ b/src/web/routes/channelPointsAdminShared.ts
@@ -1,7 +1,7 @@
 import type { Request, Response } from 'express';
-import { getStreamerByDiscordId } from '../../db';
+import { getStreamerByDiscordId, DEFAULT_PRICING_COOLDOWN_SECONDS } from '../../db';
 import type { DbStreamerEventSub } from '../../db';
-import type { CustomRewardInput } from '../../twitch/twitchApi';
+import type { CustomRewardInput, TwitchCustomReward } from '../../twitch/twitchApi';
 import { trimField } from './shared';
 
 /**
@@ -52,7 +52,7 @@ export function parsePositiveIntField(value: string | string[] | undefined): num
 }
 
 /**
- * Parses a required non-negative decimal form field (e.g. max_multiplier, redemption_increment).
+ * Parses a required non-negative decimal form field (e.g. max_multiplier).
  * Rejects arrays (repeated fields), empty/whitespace input, non-numeric input, and negative values.
  */
 export function parseNonNegativeNumberField(value: string | string[] | undefined): number | null {
@@ -63,7 +63,7 @@ export function parseNonNegativeNumberField(value: string | string[] | undefined
 }
 
 /**
- * Parses a required strictly-positive decimal form field (e.g. curve, decay_half_life_periods).
+ * Parses a required strictly-positive decimal form field (e.g. curve, half_life_minutes).
  * Rejects arrays (repeated fields), empty/whitespace input, non-numeric input, and non-positive values.
  */
 export function parsePositiveNumberField(value: string | string[] | undefined): number | null {
@@ -71,6 +71,17 @@ export function parsePositiveNumberField(value: string | string[] | undefined): 
   if (typeof value !== 'string' || value.trim() === '') return null;
   const n = Number(value);
   return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+/**
+ * The cooldown (seconds) dynamic pricing should use for a reward: its own Twitch global
+ * cooldown when enabled, otherwise a fallback default — keeps pricing's `cooldown_seconds`
+ * mirroring the reward's real Twitch cooldown instead of a separately-edited value.
+ */
+export function effectiveCooldownSeconds(reward: Pick<TwitchCustomReward, 'global_cooldown_setting'>): number {
+  return reward.global_cooldown_setting.is_enabled
+    ? reward.global_cooldown_setting.global_cooldown_seconds
+    : DEFAULT_PRICING_COOLDOWN_SECONDS;
 }
 
 const REWARD_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;

--- a/src/web/routes/channelPointsAdminShared.ts
+++ b/src/web/routes/channelPointsAdminShared.ts
@@ -1,8 +1,9 @@
 import type { Request, Response } from 'express';
+import type { Logger } from 'winston';
 import { getStreamerByDiscordId, DEFAULT_PRICING_COOLDOWN_SECONDS } from '../../db';
 import type { DbStreamerEventSub } from '../../db';
 import type { CustomRewardInput, TwitchCustomReward } from '../../twitch/twitchApi';
-import { trimField } from './shared';
+import { trimField, logAndRedirectError } from './shared';
 
 /**
  * Loads the requesting user's streamer record, redirecting to
@@ -17,6 +18,34 @@ export async function requireStreamer(req: Request, res: Response): Promise<DbSt
     return null;
   }
   return streamer;
+}
+
+/**
+ * Shared body for reward-scoped "delete" routes (deleting a reward entirely, or just turning
+ * off its dynamic pricing): resolves the requester's streamer record and the `:twitchRewardId`
+ * route param, runs `action`, then redirects to `/channel-points` with `success=<successCode>`
+ * or (on a thrown error) `error=<errorCode>` via `logAndRedirectError`. Shared between
+ * `channelPointsAdminMutations.ts` and `channelPointsAdminPricingMutations.ts`.
+ */
+export async function handleRewardDeleteAction(
+  req: Request,
+  res: Response,
+  action: (streamer: DbStreamerEventSub, twitchRewardId: string) => Promise<void>,
+  opts: { log: Logger; successCode: string; errorLogLabel: string; errorCode: string },
+): Promise<void> {
+  try {
+    const streamer = await requireStreamer(req, res);
+    if (!streamer) return;
+
+    const twitchRewardId = parseRewardIdParam(req.params.twitchRewardId);
+    if (twitchRewardId === null) return res.redirect('/channel-points?error=invalid_reward_id');
+
+    await action(streamer, twitchRewardId);
+
+    res.redirect(`/channel-points?success=${opts.successCode}`);
+  } catch (err) {
+    logAndRedirectError({ res, log: opts.log, logLabel: opts.errorLogLabel, err, basePath: '/channel-points', errorCode: opts.errorCode });
+  }
 }
 
 /**

--- a/views/channelPointsAdmin.ejs
+++ b/views/channelPointsAdmin.ejs
@@ -20,11 +20,10 @@
         invalid_reward_fields: 'Please check the reward fields — title and cost are required, a prompt is required when viewer input is required, and any enabled limit needs a value.',
         create_failed:         'Failed to create the reward — please try again, or reconnect Twitch if this keeps happening.',
         update_failed:         'Failed to update the reward — Twitch only allows the app that created a reward to edit it.',
-        invalid_config:        'Base cost, cooldown, and curve must be positive numbers, and max multiplier must be zero or greater.',
+        invalid_config:        'Base cost and curve must be positive numbers, and max multiplier must be zero or greater.',
         save_failed:           'Failed to save — please try again.',
         delete_failed:         'Delete failed — please try again.',
-        not_owner:             'Only the bot owner can change the global pricing settings.',
-        invalid_settings:      'Decay half-life must be positive, and the redemption increment must be between 0 and 1.',
+        invalid_settings:      'Half-life and time-to-max-demand multiplier must both be positive numbers.',
       }; %>
       <%= errorMessages[error] ?? `An error occurred (${error}).` %>
     </div>
@@ -38,7 +37,7 @@
         reward_deleted:         'Reward deleted.',
         pricing_saved:          'Pricing config saved.',
         pricing_deleted:        'Dynamic pricing disabled.',
-        global_settings_saved:  'Global pricing settings saved.',
+        pricing_settings_saved: 'Pricing settings saved.',
       }; %>
       <%= successMessages[success] ?? 'Done.' %>
     </div>
@@ -65,27 +64,26 @@
     </section>
     <% } else { %>
 
-    <% if (isOwner) { %>
-    <!-- ── Global Settings (bot owner only) ───────────────────────── -->
+    <!-- ── Pricing Settings ────────────────────────────────────────── -->
     <section class="section">
-      <h2 class="section-title">Global Pricing Settings</h2>
+      <h2 class="section-title">Pricing Settings</h2>
       <p class="hint" style="margin-bottom:0.75rem;">
-        Shared by every reward's demand calculation, across all streamers.
+        Shared by every one of your rewards' demand calculations.
       </p>
       <div class="card">
         <div class="card-body">
-          <form method="POST" action="/channel-points/settings/global">
+          <form method="POST" action="/channel-points/settings/pricing">
             <input type="hidden" name="_csrf" value="<%= csrfToken %>">
             <div class="form-row-wrap" style="align-items:flex-end;">
               <div>
-                <label class="hint hint-compact" for="decay-half-life">Decay half-life (cooldown periods)</label>
-                <input id="decay-half-life" class="input" type="number" step="0.1" min="0.1" name="decay_half_life_periods"
-                  value="<%= globalSettings.decay_half_life_periods %>" required>
+                <label class="hint hint-compact" for="half-life-minutes">Demand half-life (minutes)</label>
+                <input id="half-life-minutes" class="input" type="number" step="0.5" min="0.5" name="half_life_minutes"
+                  value="<%= pricingSettings.half_life_seconds / 60 %>" required>
               </div>
               <div>
-                <label class="hint hint-compact" for="redemption-increment">Redemption increment (0–1)</label>
-                <input id="redemption-increment" class="input" type="number" step="0.01" min="0" max="1" name="redemption_increment"
-                  value="<%= globalSettings.redemption_increment %>" required>
+                <label class="hint hint-compact" for="time-to-max-multiplier">Time to max demand (× half-life)</label>
+                <input id="time-to-max-multiplier" class="input" type="number" step="0.1" min="0.1" name="time_to_max_multiplier"
+                  value="<%= pricingSettings.time_to_max_multiplier %>" required>
               </div>
               <div>
                 <button type="submit" class="btn">Save</button>
@@ -95,7 +93,6 @@
         </div>
       </div>
     </section>
-    <% } %>
 
     <!-- ── Create Reward ───────────────────────────────────────────── -->
     <section class="section">
@@ -218,9 +215,11 @@
                     value="<%= r.config ? r.config.base_cost : (r.twitchReward ? r.twitchReward.cost : '') %>" required>
                 </div>
                 <div>
-                  <label class="hint hint-compact" for="cooldown-<%= r.rewardId %>">Cooldown (s)</label>
-                  <input id="cooldown-<%= r.rewardId %>" class="input" type="number" min="1" step="1" name="cooldown_seconds" style="width:7rem;"
-                    value="<%= r.config ? r.config.cooldown_seconds : 60 %>" required>
+                  <span class="hint hint-compact">Cooldown (s)</span>
+                  <p class="hint hint-compact" style="margin:0;">
+                    <%= r.config ? r.config.cooldown_seconds : (r.twitchReward && r.twitchReward.global_cooldown_setting.is_enabled ? r.twitchReward.global_cooldown_setting.global_cooldown_seconds : 60) %>
+                    (synced from the reward's Twitch global cooldown)
+                  </p>
                 </div>
                 <div>
                   <label class="hint hint-compact" for="max-mult-<%= r.rewardId %>">Max multiplier</label>


### PR DESCRIPTION
## Summary

Three changes to dynamic channel points pricing, as requested:

- **Unify the two cooldown settings.** A reward's dynamic-pricing "Cooldown (s)" field and its actual Twitch "Global cooldown (s)" could previously drift apart. Pricing's `cooldown_seconds` is no longer a separately-edited form field — it's always derived from the reward's live Twitch global cooldown (or a 60s fallback when the reward has none), synced both when pricing is saved and when the reward itself is edited.
- **Half-life is now a fixed duration, per streamer.** Previously `decay_half_life_periods` was a bot-wide setting expressed in "cooldown periods" (so effective decay time varied per reward). It's now `half_life_seconds`, a plain time duration configured per streamer (default 30 minutes), replacing the old singleton `pricing_global_settings` table with a per-streamer `reward_pricing_settings` table.
- **Redemption increment is now derived, not configured.** Instead of a flat global `redemption_increment`, each redemption's demand bump is computed as `cooldown_seconds / (time_to_max_multiplier * half_life_seconds)` — i.e. redeeming at a reward's own max frequency reaches 100% demand after `time_to_max_multiplier` half-lives (defaulting to 2x, so a 10-minute-cooldown reward with the 30-minute default half-life adds 1/6 demand per redemption).

## Details

- `src/twitch/pricing/rewardPricingMath.ts`: `decayDemand` now takes a fixed `halfLifeSeconds` instead of `cooldownSeconds` + `decayHalfLifePeriods`; added `computeRedemptionIncrement`; removed the unused `cooldownSeconds` field from `RewardPricingConfig` (it was never read by `computePrice`).
- `src/db/rewardPricing.ts`: replaced `getGlobalPricingSettings`/`saveGlobalPricingSettings`/`initGlobalPricingSettings` with per-streamer `getPricingSettingsForStreamer`/`savePricingSettingsForStreamer`; added `updatePricingCooldownForReward` to keep a pricing config's cooldown in sync with the reward's Twitch cooldown.
- `src/web/routes/channelPointsAdminMutations.ts`: the pricing-save route derives `cooldown_seconds` from a fresh Twitch lookup (falling back to the existing config, then the default); the reward-edit route re-syncs an existing pricing config's cooldown after every edit; the settings route (`POST /settings/pricing`, renamed from `/settings/global`) is now per-streamer instead of bot-owner-only.
- `views/channelPointsAdmin.ejs`: removed the editable "Cooldown (s)" input from the per-reward pricing form (now a read-only synced value); replaced the owner-only "Global Pricing Settings" section with a per-streamer "Pricing Settings" section (half-life in minutes, time-to-max multiplier).
- `migrations/reward_pricing_settings.sql` / `schema.sql` / `DATABASE-SCHEMA.md`: drop `pricing_global_settings`, add `reward_pricing_settings` (per-streamer).

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (2052 tests)
- [ ] Manually verify in the Channel Points admin UI: create a reward with a Twitch global cooldown, enable dynamic pricing, confirm the pricing "Cooldown (s)" display matches; edit the reward's Twitch cooldown and confirm the pricing config updates to match; adjust the per-streamer half-life/time-to-max settings and confirm demand decay/increment behavior over a few redemptions matches expectations.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V2KQajhJAQAdoe4XGFBT6e)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added streamer-specific Channel Points dynamic pricing settings (demand half-life and time-to-max-demand multiplier).
  * Added a reward pricing sync that automatically aligns pricing cooldown with the reward’s Twitch cooldown.

* **Bug Fixes**
  * Improved reward pricing update/delete flows to better tolerate Twitch cooldown lookup or sync failures while still completing the main action.

* **UI**
  * Updated the Channel Points admin page to replace global pricing settings with streamer-specific pricing settings.
  * Changed the per-reward “Cooldown (s)” field to read-only synced cooldown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->