### PR TITLE
Push channel points price history live via SSE

### DIFF
--- a/public/priceHistoryChart.js
+++ b/public/priceHistoryChart.js
@@ -198,17 +198,42 @@ function applyLivePricingUpdate(event) {
   if (priceEl) priceEl.textContent = event.cost.toLocaleString();
 }
 
-/** Opens the `/channel-points/events` SSE connection and applies each pushed update, when the page has at least one live chart. */
+const SSE_RECONNECT_BASE_MS = 3000;
+const SSE_RECONNECT_MAX_MS = 60000;
+
+/**
+ * Opens the `/channel-points/events` SSE connection and applies each pushed update, when the
+ * page has at least one live chart. Reconnects on error with an exponential backoff (capped at
+ * `SSE_RECONNECT_MAX_MS`) instead of relying on the browser's fixed ~3s retry — otherwise a
+ * persistent failure (e.g. the per-streamer connection cap being hit) would hammer the endpoint
+ * indefinitely for as long as the tab stays open.
+ * @returns {void}
+ */
 function initLivePricingUpdates() {
   if (document.querySelectorAll('.price-history-container').length === 0) return;
-  const source = new EventSource('/channel-points/events');
-  source.onmessage = (event) => {
-    try {
-      applyLivePricingUpdate(JSON.parse(event.data));
-    } catch {
-      // Malformed/comment-only SSE frames (e.g. keepalive pings) are expected — ignore.
-    }
-  };
+
+  let backoffMs = SSE_RECONNECT_BASE_MS;
+  let reconnectTimer = null;
+
+  function connect() {
+    const source = new EventSource('/channel-points/events');
+    source.onopen = () => { backoffMs = SSE_RECONNECT_BASE_MS; };
+    source.onmessage = (event) => {
+      try {
+        applyLivePricingUpdate(JSON.parse(event.data));
+      } catch {
+        // Malformed/comment-only SSE frames (e.g. keepalive pings) are expected — ignore.
+      }
+    };
+    source.onerror = () => {
+      source.close();
+      clearTimeout(reconnectTimer);
+      reconnectTimer = setTimeout(connect, backoffMs);
+      backoffMs = Math.min(backoffMs * 2, SSE_RECONNECT_MAX_MS);
+    };
+  }
+
+  connect();
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/public/priceHistoryChart.js
+++ b/public/priceHistoryChart.js
@@ -79,20 +79,139 @@ function updateCrosshair(svg, tooltip, clientX) {
   tooltip.style.top = `${rect.top + window.scrollY - 8}px`;
 }
 
-/** Wires up hover/focus crosshair+tooltip behavior for every `.price-history-chart` on the page. */
-function initPriceHistoryCharts() {
-  const charts = document.querySelectorAll('.price-history-chart');
-  if (charts.length === 0) return;
+/** Lazily created shared tooltip element, reused across all charts on the page. */
+let sharedTooltip = null;
 
-  const tooltip = document.createElement('div');
-  tooltip.className = 'price-history-tooltip';
-  tooltip.style.display = 'none';
-  document.body.appendChild(tooltip);
-
-  charts.forEach((svg) => {
-    svg.addEventListener('pointermove', (event) => updateCrosshair(svg, tooltip, event.clientX));
-    svg.addEventListener('pointerleave', () => updateCrosshair(svg, tooltip, null));
-  });
+/**
+ * Wires up hover/focus crosshair+tooltip behavior for a single chart SVG.
+ * @param {SVGSVGElement} svg - The chart's root SVG element.
+ * @returns {void}
+ */
+function wireChartInteractivity(svg) {
+  if (!sharedTooltip) {
+    sharedTooltip = document.createElement('div');
+    sharedTooltip.className = 'price-history-tooltip';
+    sharedTooltip.style.display = 'none';
+    document.body.appendChild(sharedTooltip);
+  }
+  svg.addEventListener('pointermove', (event) => updateCrosshair(svg, sharedTooltip, event.clientX));
+  svg.addEventListener('pointerleave', () => updateCrosshair(svg, sharedTooltip, null));
 }
 
-document.addEventListener('DOMContentLoaded', initPriceHistoryCharts);
+/** Wires up hover/focus crosshair+tooltip behavior for every `.price-history-chart` on the page. */
+function initPriceHistoryCharts() {
+  document.querySelectorAll('.price-history-chart').forEach(wireChartInteractivity);
+}
+
+// ─── Live updates (Server-Sent Events) ─────────────────────────────────────
+
+const CHART_WIDTH = 480;
+const CHART_HEIGHT = 120;
+const CHART_PADDING = { top: 10, right: 12, bottom: 20, left: 44 };
+
+/**
+ * Builds the inner markup for a reward's price history chart from a set of points, mirroring
+ * `renderPriceHistoryChart` in `src/web/priceHistoryChart.ts` (duplicated here since the SSE
+ * live-update path redraws entirely client-side, with no shared server/browser code path).
+ * @param {Array<[number, number]>} points - `[time, cost]` pairs, any order.
+ * @param {number} rangeStartMs - Left edge of the x-axis (epoch ms).
+ * @param {number} rangeEndMs - Right edge of the x-axis (epoch ms).
+ * @returns {string} Self-contained `<svg>` markup, or a "no data yet" placeholder if empty.
+ */
+function buildPriceHistoryChartMarkup(points, rangeStartMs, rangeEndMs) {
+  if (points.length === 0) {
+    return `<div class="hint price-history-empty" style="height:${CHART_HEIGHT}px;display:flex;align-items:center;justify-content:center;">No price history yet for this range.</div>`;
+  }
+
+  const sorted = [...points].sort((a, b) => a[0] - b[0]);
+  const costs = sorted.map((p) => p[1]);
+  const minCost = Math.min(...costs);
+  const maxCost = Math.max(...costs);
+  const isFlat = maxCost === minCost;
+  const costSpan = isFlat ? 1 : maxCost - minCost;
+
+  const plotLeft = CHART_PADDING.left;
+  const plotRight = CHART_WIDTH - CHART_PADDING.right;
+  const plotTop = CHART_PADDING.top;
+  const plotBottom = CHART_HEIGHT - CHART_PADDING.bottom;
+  const timeSpan = Math.max(1, rangeEndMs - rangeStartMs);
+
+  const toX = (t) => plotLeft + ((t - rangeStartMs) / timeSpan) * (plotRight - plotLeft);
+  const toY = (cost) => (isFlat
+    ? (plotTop + plotBottom) / 2
+    : plotBottom - ((cost - minCost) / costSpan) * (plotBottom - plotTop));
+
+  const pixelPoints = sorted.map((p) => ({ x: toX(p[0]), y: toY(p[1]) }));
+  const polyline = pixelPoints.map((p) => `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(' ');
+  const last = pixelPoints[pixelPoints.length - 1];
+  const lastCost = sorted[sorted.length - 1][1];
+
+  const dataPoints = JSON.stringify(sorted).replace(/'/g, '&#39;');
+
+  return `
+<svg class="price-history-chart" viewBox="0 0 ${CHART_WIDTH} ${CHART_HEIGHT}" width="100%" height="${CHART_HEIGHT}"
+     data-points='${dataPoints}'
+     data-plot-left="${plotLeft}" data-plot-right="${plotRight}"
+     data-range-start="${rangeStartMs}" data-range-end="${rangeEndMs}"
+     role="img" aria-label="Price history from ${new Date(rangeStartMs).toLocaleString()} to ${new Date(rangeEndMs).toLocaleString()}, ranging from ${minCost} to ${maxCost} points">
+  <line x1="${plotLeft}" y1="${toY(maxCost).toFixed(1)}" x2="${plotRight}" y2="${toY(maxCost).toFixed(1)}" stroke="var(--border)" stroke-width="1"/>
+  <line x1="${plotLeft}" y1="${toY(minCost).toFixed(1)}" x2="${plotRight}" y2="${toY(minCost).toFixed(1)}" stroke="var(--border)" stroke-width="1"/>
+  <text x="${plotLeft - 6}" y="${toY(maxCost).toFixed(1)}" dy="0.32em" text-anchor="end" class="price-history-tick">${maxCost.toLocaleString()}</text>
+  <text x="${plotLeft - 6}" y="${toY(minCost).toFixed(1)}" dy="0.32em" text-anchor="end" class="price-history-tick">${minCost.toLocaleString()}</text>
+  <polyline points="${polyline}" fill="none" stroke="var(--primary)" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+  <circle cx="${last.x.toFixed(1)}" cy="${last.y.toFixed(1)}" r="4" fill="var(--primary)" stroke="var(--bg-card)" stroke-width="2"/>
+  <text x="${last.x.toFixed(1)}" y="${(last.y - 8).toFixed(1)}" text-anchor="end" class="price-history-end-label">${lastCost.toLocaleString()} pts</text>
+  <g class="price-history-crosshair" style="display:none;">
+    <line class="price-history-crosshair-line" y1="${plotTop}" y2="${plotBottom}" stroke="var(--muted)" stroke-width="1"/>
+    <circle class="price-history-crosshair-dot" r="4" fill="var(--primary)" stroke="var(--bg-card)" stroke-width="2"/>
+  </g>
+</svg>`.trim();
+}
+
+/**
+ * Applies a live price/demand point pushed over SSE to one reward's chart card: appends the
+ * point (sliding the visible window forward to "now"), redraws the chart, and updates the
+ * demand/price text next to it.
+ * @param {{rewardId: string, cost: number, demand: number, recordedAt: number}} event - The pushed update.
+ * @returns {void}
+ */
+function applyLivePricingUpdate(event) {
+  const container = document.querySelector(`.price-history-container[data-reward-id="${CSS.escape(event.rewardId)}"]`);
+  if (!container) return;
+
+  const existingSvg = container.querySelector('.price-history-chart');
+  const existingPoints = existingSvg ? JSON.parse(existingSvg.dataset.points || '[]') : [];
+  existingPoints.push([event.recordedAt, event.cost]);
+
+  const rangeMs = Number(container.dataset.rangeMs);
+  const rangeEndMs = Date.now();
+  const rangeStartMs = rangeEndMs - rangeMs;
+  const visiblePoints = existingPoints.filter(([t]) => t >= rangeStartMs);
+
+  container.innerHTML = buildPriceHistoryChartMarkup(visiblePoints, rangeStartMs, rangeEndMs);
+  const newSvg = container.querySelector('.price-history-chart');
+  if (newSvg) wireChartInteractivity(newSvg);
+
+  const demandEl = document.getElementById(`demand-${event.rewardId}`);
+  if (demandEl) demandEl.textContent = `${(event.demand * 100).toFixed(1)}%`;
+  const priceEl = document.getElementById(`price-${event.rewardId}`);
+  if (priceEl) priceEl.textContent = event.cost.toLocaleString();
+}
+
+/** Opens the `/channel-points/events` SSE connection and applies each pushed update, when the page has at least one live chart. */
+function initLivePricingUpdates() {
+  if (document.querySelectorAll('.price-history-container').length === 0) return;
+  const source = new EventSource('/channel-points/events');
+  source.onmessage = (event) => {
+    try {
+      applyLivePricingUpdate(JSON.parse(event.data));
+    } catch {
+      // Malformed/comment-only SSE frames (e.g. keepalive pings) are expected — ignore.
+    }
+  };
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initPriceHistoryCharts();
+  initLivePricingUpdates();
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -57,6 +57,7 @@ vi.mock('./twitch/eventsub/twitchEventSubHandler', () => ({
 }));
 vi.mock('./web/routes/overlaySource', () => ({ pushOverlayEvent: vi.fn() }));
 vi.mock('./web/routes/companionEvents', () => ({ pushCompanionEvent: vi.fn() }));
+vi.mock('./web/routes/channelPointsEvents', () => ({ pushPricingUpdate: vi.fn() }));
 vi.mock('./commands/counterScheduler', () => ({
   startCounterScheduler: vi.fn(),
   stopCounterScheduler: vi.fn(),
@@ -64,6 +65,9 @@ vi.mock('./commands/counterScheduler', () => ({
 vi.mock('./twitch/pricing/rewardPricingScheduler', () => ({
   startRewardPricingScheduler: vi.fn(),
   stopRewardPricingScheduler: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('./twitch/pricing/rewardPricingService', () => ({
+  registerRewardPricingRuntime: vi.fn(),
 }));
 vi.mock('./shared/logger', () => ({
   createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
@@ -128,6 +132,15 @@ describe('startup — guild registry preload', () => {
     await runMain();
 
     expect(vi.mocked(registerEventSubCompanionRuntime)).toHaveBeenCalledWith({ pushCompanionEvent });
+  });
+
+  it('registers the reward pricing runtime with pushPricingUpdate on a clean startup', async () => {
+    const { registerRewardPricingRuntime } = await import('./twitch/pricing/rewardPricingService.js');
+    const { pushPricingUpdate } = await import('./web/routes/channelPointsEvents.js');
+
+    await runMain();
+
+    expect(vi.mocked(registerRewardPricingRuntime)).toHaveBeenCalledWith({ pushPricingUpdate });
   });
 
   it('calls process.exit(1) and does not start the bot when reloadGuildRegistry rejects', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,8 +17,10 @@ import { registerCountdownTwitchRuntime } from './commands/countdownHandler';
 import { registerEventSubOverlayRuntime, registerEventSubTwitchRuntime, registerEventSubCompanionRuntime } from './twitch/eventsub/twitchEventSubHandler';
 import { pushOverlayEvent } from './web/routes/overlaySource';
 import { pushCompanionEvent } from './web/routes/companionEvents';
+import { pushPricingUpdate } from './web/routes/channelPointsEvents';
 import { startCounterScheduler, stopCounterScheduler } from './commands/counterScheduler';
 import { startRewardPricingScheduler, stopRewardPricingScheduler } from './twitch/pricing/rewardPricingScheduler';
+import { registerRewardPricingRuntime } from './twitch/pricing/rewardPricingService';
 import { createLogger } from './shared/logger';
 
 const log = createLogger('Bot');
@@ -73,6 +75,7 @@ async function main(): Promise<void> {
   registerEventSubOverlayRuntime({ pushOverlayEvent });
   registerEventSubCompanionRuntime({ pushCompanionEvent });
   registerEventSubTwitchRuntime({ send: sayInChannel });
+  registerRewardPricingRuntime({ pushPricingUpdate });
 
   // Load the guild registry before the Discord client connects so the
   // messageCreate gate recognises registered guilds from the first message.

--- a/src/shared/config.test.ts
+++ b/src/shared/config.test.ts
@@ -177,6 +177,11 @@ describe('config — parsePositiveIntEnv-backed values', () => {
     const config = await loadConfig({ OVERLAY_MAX_SSE_PER_CHANNEL: undefined });
     expect(config.OVERLAY_MAX_SSE_PER_CHANNEL).toBe(10);
   });
+
+  it('defaults CHANNEL_POINTS_MAX_SSE_PER_STREAMER to 5 when unset', async () => {
+    const config = await loadConfig({ CHANNEL_POINTS_MAX_SSE_PER_STREAMER: undefined });
+    expect(config.CHANNEL_POINTS_MAX_SSE_PER_STREAMER).toBe(5);
+  });
 });
 
 describe('config — GLOBAL_COOLDOWN_MS', () => {

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -47,6 +47,7 @@ export const OVERLAY_FOLDER = process.env.OVERLAY_FOLDER ?? './overlay-videos';
 export const OVERLAY_MAX_FILE_MB = parsePositiveIntEnv(process.env.OVERLAY_MAX_FILE_MB, 100);
 export const COMPANION_MAX_SSE_PER_TOKEN = parsePositiveIntEnv(process.env.COMPANION_MAX_SSE_PER_TOKEN, 3);
 export const OVERLAY_MAX_SSE_PER_CHANNEL = parsePositiveIntEnv(process.env.OVERLAY_MAX_SSE_PER_CHANNEL, 10);
+export const CHANNEL_POINTS_MAX_SSE_PER_STREAMER = parsePositiveIntEnv(process.env.CHANNEL_POINTS_MAX_SSE_PER_STREAMER, 5);
 const _COOLDOWN = parseInt(process.env.GLOBAL_COOLDOWN_MS ?? '3000', 10);
 if (Number.isNaN(_COOLDOWN)) throw new Error('Invalid GLOBAL_COOLDOWN_MS: must be a number');
 export const GLOBAL_COOLDOWN_MS = _COOLDOWN;

--- a/src/twitch/pricing/rewardPricingService.test.ts
+++ b/src/twitch/pricing/rewardPricingService.test.ts
@@ -29,7 +29,7 @@ import { getValidToken } from '../eventsub/twitchApiEventSub';
 import { updateRewardCost, deleteCustomReward, TwitchRewardUnsupportedError, TwitchRewardAuthError } from '../twitchApi';
 import {
   applyRedemptionPricing, applyDecayTick, resetAndDeletePricing, deleteRewardAndPricing,
-  __resetPushRateLimiterForTests,
+  registerRewardPricingRuntime, __resetPushRateLimiterForTests,
 } from './rewardPricingService';
 
 const settings = { half_life_seconds: 1800, time_to_max_multiplier: 2 };
@@ -363,5 +363,40 @@ describe('redemption push rate limiting', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe('live pricing update push', () => {
+  it('pushes the computed cost and demand to the registered runtime after a successful sync', async () => {
+    const pushPricingUpdate = vi.fn();
+    registerRewardPricingRuntime({ pushPricingUpdate });
+    vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
+
+    await applyRedemptionPricing(1, 'rwd1');
+
+    expect(pushPricingUpdate).toHaveBeenCalledWith(1, {
+      rewardId: 'rwd1', cost: expect.any(Number), demand: expect.any(Number), recordedAt: expect.any(Number),
+    });
+  });
+
+  it('still pushes the live update when recording price history fails', async () => {
+    const pushPricingUpdate = vi.fn();
+    registerRewardPricingRuntime({ pushPricingUpdate });
+    vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
+    vi.mocked(recordPricingHistory).mockRejectedValueOnce(new Error('history db down'));
+
+    await applyRedemptionPricing(1, 'rwd1');
+
+    expect(pushPricingUpdate).toHaveBeenCalled();
+  });
+
+  it('does not push when the reward has no pricing config', async () => {
+    const pushPricingUpdate = vi.fn();
+    registerRewardPricingRuntime({ pushPricingUpdate });
+    vi.mocked(getPricingForReward).mockResolvedValue(null);
+
+    await applyRedemptionPricing(1, 'rwd1');
+
+    expect(pushPricingUpdate).not.toHaveBeenCalled();
   });
 });

--- a/src/twitch/pricing/rewardPricingService.test.ts
+++ b/src/twitch/pricing/rewardPricingService.test.ts
@@ -399,4 +399,14 @@ describe('live pricing update push', () => {
 
     expect(pushPricingUpdate).not.toHaveBeenCalled();
   });
+
+  it('does not fail the sync when the runtime push throws', async () => {
+    registerRewardPricingRuntime({
+      pushPricingUpdate: () => { throw new Error('push failed'); },
+    });
+    vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
+
+    await expect(applyRedemptionPricing(1, 'rwd1')).resolves.toBeUndefined();
+    expect(recordPricingUpdate).toHaveBeenCalled();
+  });
 });

--- a/src/twitch/pricing/rewardPricingService.ts
+++ b/src/twitch/pricing/rewardPricingService.ts
@@ -10,6 +10,17 @@ import { createLogger } from '../../shared/logger';
 
 const log = createLogger('RewardPricing');
 
+/** Runtime hooks injected from index.ts, mirroring the `registerEventSub*Runtime` pattern — avoids a circular import back into `web/routes/channelPointsEvents`. */
+interface RewardPricingRuntime {
+  pushPricingUpdate: (streamerId: number, event: import('../../web/routes/channelPointsEvents').PricingUpdateEvent) => void;
+}
+let _runtime: RewardPricingRuntime | null = null;
+
+/** Registers the live-pricing-update push hook. Call once from index.ts after startup. */
+export function registerRewardPricingRuntime(runtime: RewardPricingRuntime): void {
+  _runtime = runtime;
+}
+
 // Serializes read-modify-write cycles per reward, so a redemption and a concurrent
 // decay-scheduler tick on the same reward never race each other. Different rewards
 // (different keys) run fully concurrently.
@@ -103,7 +114,8 @@ async function pushRewardCostUpdate(
  * (see {@link pushRewardCostUpdate}), in which case demand is intentionally not persisted
  * since the row won't be read again until re-enabled. On every successful sync, also logs a
  * price-history point (best-effort; a failure here is logged and swallowed rather than
- * affecting the pricing update itself) for the Channel Points admin history graph.
+ * affecting the pricing update itself) and pushes a live update to any open Channel Points
+ * admin pages for this streamer, so the price history graph updates without a page refresh.
  *
  * @param streamerId - DB row ID of the owning streamer.
  * @param twitchRewardId - Twitch reward UUID.
@@ -143,6 +155,8 @@ async function syncRewardPrice(streamerId: number, twitchRewardId: string, apply
   } catch (err) {
     log.warn(`Failed to record price history for reward ${twitchRewardId}:`, err);
   }
+
+  _runtime?.pushPricingUpdate(streamerId, { rewardId: twitchRewardId, cost: newCost, demand: newDemand, recordedAt: now });
 }
 
 /**

--- a/src/twitch/pricing/rewardPricingService.ts
+++ b/src/twitch/pricing/rewardPricingService.ts
@@ -156,7 +156,11 @@ async function syncRewardPrice(streamerId: number, twitchRewardId: string, apply
     log.warn(`Failed to record price history for reward ${twitchRewardId}:`, err);
   }
 
-  _runtime?.pushPricingUpdate(streamerId, { rewardId: twitchRewardId, cost: newCost, demand: newDemand, recordedAt: now });
+  try {
+    _runtime?.pushPricingUpdate(streamerId, { rewardId: twitchRewardId, cost: newCost, demand: newDemand, recordedAt: now });
+  } catch (err) {
+    log.warn(`Failed to push live price update for reward ${twitchRewardId}:`, err);
+  }
 }
 
 /**

--- a/src/web/routes/channelPointsAdmin.test.ts
+++ b/src/web/routes/channelPointsAdmin.test.ts
@@ -39,6 +39,11 @@ vi.mock('./channelPointsAdminMutations', async () => {
   return { router: Router() };
 });
 
+vi.mock('./channelPointsEvents', async () => {
+  const { Router } = await import('express');
+  return { default: Router() };
+});
+
 import express from 'express';
 import supertest from 'supertest';
 import router from './channelPointsAdmin';

--- a/src/web/routes/channelPointsAdmin.ts
+++ b/src/web/routes/channelPointsAdmin.ts
@@ -13,6 +13,7 @@ import { computePrice } from '../../twitch/pricing/rewardPricingMath';
 import { renderPriceHistoryChart } from '../priceHistoryChart';
 import { filterQueryParam, renderError, renderView } from './shared';
 import { router as channelPointsMutationsRouter } from './channelPointsAdminMutations';
+import channelPointsEventsRouter from './channelPointsEvents';
 
 const log = createLogger('ChannelPointsAdmin');
 const router = Router();
@@ -148,6 +149,7 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
   }
 });
 
+router.use(channelPointsEventsRouter);
 router.use(channelPointsMutationsRouter);
 
 export default router;

--- a/src/web/routes/channelPointsEvents.test.ts
+++ b/src/web/routes/channelPointsEvents.test.ts
@@ -8,6 +8,10 @@ vi.mock('../../shared/config', () => ({
   CHANNEL_POINTS_MAX_SSE_PER_STREAMER: 5,
 }));
 
+vi.mock('../../shared/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
+}));
+
 import express from 'express';
 import supertest from 'supertest';
 import router, { MAX_SSE_CONNECTIONS_PER_STREAMER, connections, pushPricingUpdate } from './channelPointsEvents';
@@ -70,6 +74,25 @@ describe('GET /events — auth', () => {
     const res = await supertest(buildApp()).get('/events');
     expect(res.status).toBe(403);
   });
+
+  it('returns 500 (and logs) instead of crashing when req.session.user is missing', async () => {
+    const app = express();
+    app.use((req: any, _res, next) => {
+      req.session = {}; // no `user` — requireAuth normally guarantees this, but the handler shouldn't crash if it didn't run
+      next();
+    });
+    app.use(router);
+
+    const res = await supertest(app).get('/events');
+    expect(res.status).toBe(500);
+    expect(getStreamerByDiscordId).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 (and logs) when getStreamerByDiscordId rejects', async () => {
+    vi.mocked(getStreamerByDiscordId).mockRejectedValue(new Error('db down'));
+    const res = await supertest(buildApp()).get('/events');
+    expect(res.status).toBe(500);
+  });
 });
 
 describe('GET /events — SSE connection limit', () => {
@@ -84,24 +107,26 @@ describe('GET /events — SSE connection limit', () => {
   });
 
   it('accepts a connection when the streamer is below the limit', async () => {
+    // Invokes the handler directly (as the lifecycle tests below do) rather than a real
+    // supertest round-trip: an open SSE response has no natural end, and destroying the
+    // underlying socket to clean up after a real connection raises an unhandled
+    // 'aborted'/ECONNRESET error from Node's http internals that a client-side listener
+    // can't fully suppress.
     const dummies = new Set(
       Array.from({ length: MAX_SSE_CONNECTIONS_PER_STREAMER - 1 }, () => ({}) as any),
     );
     connections.set(123, dummies);
 
-    const req = supertest(buildApp()).get('/events');
-    const p = new Promise<number>((resolve) => {
-      req
-        .buffer(false)
-        .parse((_res, _cb) => {
-          resolve(_res.statusCode ?? 0);
-          (_res as any).resume();
-        })
-        .end();
-    });
-    const status = await p;
-    expect(status).not.toBe(429);
-    expect(status).toBe(200);
+    const handler = getRouteHandler('/events');
+    const res = makeSseRes();
+    const { req, triggerClose } = makeSseReq('discord1');
+
+    await handler(req, res, vi.fn());
+
+    expect(res.status).not.toHaveBeenCalledWith(429);
+    expect(connections.get(123)?.has(res as any)).toBe(true);
+
+    triggerClose(); // clears the 25s keepalive interval so it doesn't leak into other tests
   });
 });
 

--- a/src/web/routes/channelPointsEvents.test.ts
+++ b/src/web/routes/channelPointsEvents.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../db', () => ({
+  getStreamerByDiscordId: vi.fn(),
+}));
+
+vi.mock('../../shared/config', () => ({
+  CHANNEL_POINTS_MAX_SSE_PER_STREAMER: 5,
+}));
+
+import express from 'express';
+import supertest from 'supertest';
+import router, { MAX_SSE_CONNECTIONS_PER_STREAMER, connections, pushPricingUpdate } from './channelPointsEvents';
+import { getStreamerByDiscordId } from '../../db';
+
+/** Finds a route's handler function directly from the router's internal stack, bypassing HTTP entirely — needed to control fake timers and the request's 'close' event deterministically. */
+function getRouteHandler(routePath: string): (req: any, res: any, next: any) => void {
+  const layer = (router as any).stack.find((l: any) => l.route?.path === routePath);
+  return layer.route.stack[0].handle;
+}
+
+function makeSseRes() {
+  return {
+    setHeader: vi.fn(),
+    flushHeaders: vi.fn(),
+    write: vi.fn(),
+    status: vi.fn().mockReturnThis(),
+    end: vi.fn(),
+  };
+}
+
+function makeSseReq(discordId: string) {
+  let closeCb: (() => void) | undefined;
+  return {
+    req: {
+      session: { user: { discordId } },
+      on: (event: string, cb: () => void) => {
+        if (event === 'close') closeCb = cb;
+      },
+    },
+    triggerClose: () => closeCb?.(),
+  };
+}
+
+function buildApp() {
+  const app = express();
+  app.use((req: any, _res, next) => {
+    req.session = { user: { discordId: 'discord1' } };
+    next();
+  });
+  app.use(router);
+  return app;
+}
+
+beforeEach(() => {
+  connections.clear();
+  vi.clearAllMocks();
+  vi.mocked(getStreamerByDiscordId).mockResolvedValue({ id: 123 } as any);
+});
+
+describe('MAX_SSE_CONNECTIONS_PER_STREAMER', () => {
+  it('re-exports the value from config', () => {
+    expect(MAX_SSE_CONNECTIONS_PER_STREAMER).toBe(5);
+  });
+});
+
+describe('GET /events — auth', () => {
+  it('returns 403 when the session user has no streamer row', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
+    const res = await supertest(buildApp()).get('/events');
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('GET /events — SSE connection limit', () => {
+  it('returns 429 when the streamer slot is full', async () => {
+    const dummies = new Set(
+      Array.from({ length: MAX_SSE_CONNECTIONS_PER_STREAMER }, () => ({}) as any),
+    );
+    connections.set(123, dummies);
+
+    const res = await supertest(buildApp()).get('/events');
+    expect(res.status).toBe(429);
+  });
+
+  it('accepts a connection when the streamer is below the limit', async () => {
+    const dummies = new Set(
+      Array.from({ length: MAX_SSE_CONNECTIONS_PER_STREAMER - 1 }, () => ({}) as any),
+    );
+    connections.set(123, dummies);
+
+    const req = supertest(buildApp()).get('/events');
+    const p = new Promise<number>((resolve) => {
+      req
+        .buffer(false)
+        .parse((_res, _cb) => {
+          resolve(_res.statusCode ?? 0);
+          (_res as any).resume();
+        })
+        .end();
+    });
+    const status = await p;
+    expect(status).not.toBe(429);
+    expect(status).toBe(200);
+  });
+});
+
+describe('GET /events — connection lifecycle (direct handler invocation)', () => {
+  it('registers a new Set for a streamer with no prior connections', async () => {
+    const handler = getRouteHandler('/events');
+    const res = makeSseRes();
+    const { req, triggerClose } = makeSseReq('discord1');
+
+    await handler(req, res, vi.fn());
+
+    expect(connections.get(123)?.has(res as any)).toBe(true);
+    expect(res.write).toHaveBeenCalledWith(': connected\n\n');
+
+    triggerClose(); // clears the 25s keepalive interval so it doesn't leak into other tests
+  });
+
+  it('sends a ping every 25 seconds', async () => {
+    vi.useFakeTimers();
+    try {
+      const handler = getRouteHandler('/events');
+      const res = makeSseRes();
+      const { req, triggerClose } = makeSseReq('discord1');
+
+      await handler(req, res, vi.fn());
+      res.write.mockClear();
+
+      vi.advanceTimersByTime(25_000);
+      expect(res.write).toHaveBeenCalledWith(': ping\n\n');
+      triggerClose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears the interval and evicts the client when a ping write fails', async () => {
+    vi.useFakeTimers();
+    try {
+      const handler = getRouteHandler('/events');
+      const res = makeSseRes();
+      const { req } = makeSseReq('discord1');
+
+      await handler(req, res, vi.fn());
+      res.write.mockImplementation(() => {
+        throw new Error('broken pipe');
+      });
+
+      vi.advanceTimersByTime(25_000);
+
+      expect(connections.get(123)).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('removes the client (and empty Set) when the request closes', async () => {
+    const handler = getRouteHandler('/events');
+    const res = makeSseRes();
+    const { req, triggerClose } = makeSseReq('discord1');
+
+    await handler(req, res, vi.fn());
+    expect(connections.get(123)?.has(res as any)).toBe(true);
+
+    triggerClose();
+    expect(connections.get(123)).toBeUndefined();
+  });
+
+  it('removes only the closing client, keeping the streamer entry when others remain', async () => {
+    const handler = getRouteHandler('/events');
+    const res1 = makeSseRes();
+    const res2 = makeSseRes();
+    const { req: req1, triggerClose: closeReq1 } = makeSseReq('discord1');
+    const { req: req2 } = makeSseReq('discord1');
+
+    await handler(req1, res1, vi.fn());
+    await handler(req2, res2, vi.fn());
+
+    closeReq1();
+    expect(connections.get(123)?.has(res1 as any)).toBe(false);
+    expect(connections.get(123)?.has(res2 as any)).toBe(true);
+  });
+});
+
+describe('pushPricingUpdate', () => {
+  const sample = { rewardId: 'rwd1', cost: 500, demand: 0.5, recordedAt: 1_700_000_000_000 };
+
+  it('does nothing when there are no connections for the streamer', () => {
+    expect(() => pushPricingUpdate(999, sample)).not.toThrow();
+  });
+
+  it('writes the update payload to every connected client', () => {
+    const res1 = { write: vi.fn() };
+    const res2 = { write: vi.fn() };
+    connections.set(123, new Set([res1, res2] as any));
+
+    pushPricingUpdate(123, sample);
+
+    const expectedPayload = `data: ${JSON.stringify(sample)}\n\n`;
+    expect(res1.write).toHaveBeenCalledWith(expectedPayload);
+    expect(res2.write).toHaveBeenCalledWith(expectedPayload);
+  });
+
+  it('drops a client whose write throws but keeps the others', () => {
+    const good = { write: vi.fn() };
+    const dead = { write: vi.fn(() => { throw new Error('broken pipe'); }) };
+    connections.set(123, new Set([good, dead] as any));
+
+    pushPricingUpdate(123, sample);
+
+    const clients = connections.get(123);
+    expect(clients?.has(good as any)).toBe(true);
+    expect(clients?.has(dead as any)).toBe(false);
+  });
+
+  it('deletes the map entry once every client has been dropped', () => {
+    const dead = { write: vi.fn(() => { throw new Error('broken pipe'); }) };
+    connections.set(123, new Set([dead] as any));
+
+    pushPricingUpdate(123, sample);
+
+    expect(connections.has(123)).toBe(false);
+  });
+});

--- a/src/web/routes/channelPointsEvents.ts
+++ b/src/web/routes/channelPointsEvents.ts
@@ -1,7 +1,9 @@
+import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import { getStreamerByDiscordId } from '../../db';
 import { CHANNEL_POINTS_MAX_SSE_PER_STREAMER } from '../../shared/config';
 
+const log = createLogger('ChannelPointsEvents');
 const router = Router();
 
 /** A live price/demand update for one reward, pushed to the Channel Points admin page. */
@@ -43,10 +45,18 @@ export function pushPricingUpdate(streamerId: number, event: PricingUpdateEvent)
  * @param req - Express request; reads `req.session.user`.
  * @param res - Express response; upgrades to a `text/event-stream` connection kept alive with
  *   periodic pings and torn down on client disconnect; replies 403 if the session user isn't a
- *   monitored streamer, or 429 if the streamer's connection limit is exceeded.
+ *   monitored streamer, 429 if the streamer's connection limit is exceeded, or 500 on an
+ *   unexpected lookup failure (also logged, unlike a plain unhandled rejection).
  */
 router.get('/events', async (req, res) => {
-  const streamer = await getStreamerByDiscordId(req.session.user!.discordId);
+  let streamer;
+  try {
+    streamer = await getStreamerByDiscordId(req.session.user!.discordId);
+  } catch (err) {
+    log.error('Failed to resolve streamer for SSE events:', err);
+    res.status(500).end();
+    return;
+  }
   if (!streamer) {
     res.status(403).end();
     return;

--- a/src/web/routes/channelPointsEvents.ts
+++ b/src/web/routes/channelPointsEvents.ts
@@ -1,0 +1,95 @@
+import { Router } from 'express';
+import { getStreamerByDiscordId } from '../../db';
+import { CHANNEL_POINTS_MAX_SSE_PER_STREAMER } from '../../shared/config';
+
+const router = Router();
+
+/** A live price/demand update for one reward, pushed to the Channel Points admin page. */
+export interface PricingUpdateEvent {
+  rewardId: string;
+  cost: number;
+  demand: number;
+  recordedAt: number;
+}
+
+// In-memory map of active SSE connections keyed by streamer DB ID.
+export const connections = new Map<number, Set<import('express').Response>>();
+
+export const MAX_SSE_CONNECTIONS_PER_STREAMER = CHANNEL_POINTS_MAX_SSE_PER_STREAMER;
+
+/** Push a reward price/demand update to every open Channel Points admin page for this streamer. */
+export function pushPricingUpdate(streamerId: number, event: PricingUpdateEvent): void {
+  const clients = connections.get(streamerId);
+  if (!clients || clients.size === 0) return;
+  const payload = JSON.stringify(event);
+  const dead: import('express').Response[] = [];
+  for (const res of clients) {
+    try {
+      res.write(`data: ${payload}\n\n`);
+    } catch {
+      dead.push(res);
+    }
+  }
+  for (const res of dead) clients.delete(res);
+  if (clients.size === 0) connections.delete(streamerId);
+}
+
+/**
+ * GET /channel-points/events — SSE endpoint streaming live `pushPricingUpdate` price/demand
+ * points for the logged-in streamer's own rewards, so the Channel Points admin page's price
+ * history charts can update without a manual refresh. Mounted behind the parent router's
+ * `requireAuth`, so a session user is always present; still resolves the streamer row here
+ * (rather than trusting a cached id) so a revoked streamer record takes effect immediately.
+ * @param req - Express request; reads `req.session.user`.
+ * @param res - Express response; upgrades to a `text/event-stream` connection kept alive with
+ *   periodic pings and torn down on client disconnect; replies 403 if the session user isn't a
+ *   monitored streamer, or 429 if the streamer's connection limit is exceeded.
+ */
+router.get('/events', async (req, res) => {
+  const streamer = await getStreamerByDiscordId(req.session.user!.discordId);
+  if (!streamer) {
+    res.status(403).end();
+    return;
+  }
+
+  const key = streamer.id;
+  if (!connections.has(key)) connections.set(key, new Set());
+  const clients = connections.get(key)!;
+  clients.add(res);
+  if (clients.size > MAX_SSE_CONNECTIONS_PER_STREAMER) {
+    clients.delete(res);
+    res.status(429).end();
+    return;
+  }
+
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no'); // disable Nginx buffering if behind proxy
+  res.flushHeaders();
+
+  res.write(': connected\n\n');
+
+  const keepalive = setInterval(() => {
+    try {
+      res.write(': ping\n\n');
+    } catch {
+      clearInterval(keepalive);
+      const clients = connections.get(key);
+      if (clients) {
+        clients.delete(res);
+        if (clients.size === 0) connections.delete(key);
+      }
+    }
+  }, 25_000);
+
+  req.on('close', () => {
+    clearInterval(keepalive);
+    const clients = connections.get(key);
+    if (!clients) return;
+    clients.delete(res);
+    if (clients.size === 0) connections.delete(key);
+  });
+});
+
+export default router;

--- a/views/channelPointsAdmin.ejs
+++ b/views/channelPointsAdmin.ejs
@@ -161,7 +161,7 @@
               <% if (r.config && r.config.twitch_unsupported) { %>
               <p class="hint hint-compact" style="color:var(--danger, #c0392b);">This reward can't be managed by the bot — it was created via the Twitch dashboard (or another app), and Twitch only allows the app that created a reward to change its cost. Dynamic pricing has been disabled.</p>
               <% } else if (r.config) { %>
-              <p class="hint hint-compact">Demand: <%= (r.config.demand * 100).toFixed(1) %>% — computed price (redemptions sync within seconds; idle decay syncs at least every 30s): <%= r.previewPrice.toLocaleString() %> pts</p>
+              <p class="hint hint-compact">Demand: <span id="demand-<%= r.rewardId %>"><%= (r.config.demand * 100).toFixed(1) %>%</span> — computed price (updates live as demand changes): <span id="price-<%= r.rewardId %>"><%= r.previewPrice.toLocaleString() %></span> pts</p>
               <% } %>
             </div>
             <% if (r.twitchReward) { %>
@@ -172,8 +172,8 @@
             <% } %>
           </div>
 
-          <% if (r.historyChart) { %>
-          <div style="margin-top:0.5rem;">
+          <% if (r.config) { %>
+          <div class="price-history-container" data-reward-id="<%= r.rewardId %>" data-range-ms="<%= historyHours * 60 * 60 * 1000 %>" style="margin-top:0.5rem;">
             <%- r.historyChart %>
           </div>
           <% } %>


### PR DESCRIPTION
## Summary

- The `/channel-points` admin page's price history charts previously only updated on a manual page refresh, even though pricing recalculates continuously (every redemption, plus a 30s decay tick).
- Added a new `/channel-points/events` SSE endpoint (`src/web/routes/channelPointsEvents.ts`), following the existing `overlaySource`/`companionEvents` SSE pattern, scoped per-streamer and gated behind the page's existing session auth.
- `rewardPricingService.syncRewardPrice` now pushes a live `{ rewardId, cost, demand, recordedAt }` update after every successful pricing sync, wired in via the same `registerXRuntime` pattern used for overlay/companion events (avoids a circular import between `twitch/pricing` and `web/routes`).
- Client-side (`public/priceHistoryChart.js`) listens on the SSE stream and redraws each reward's chart + demand/price text in place as updates arrive, sliding the visible time window forward to "now" rather than requiring a reload.
- Added `CHANNEL_POINTS_MAX_SSE_PER_STREAMER` (default 5) to cap concurrent connections per streamer, matching the existing overlay/companion SSE caps.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (2133 tests passing)
- [ ] Manual: open `/channel-points` with dynamic pricing enabled on a reward, redeem it (or wait for a decay tick), confirm the chart and demand/price text update live without a refresh


---
_Generated by [Claude Code](https://claude.ai/code/session_01J2PrxZLhJK84FfAGGdQTKj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Channel Points pricing pages now update live as demand changes, without requiring a refresh.
  * Price history charts now share smoother hover tooltips and continue working after live updates.

* **Bug Fixes**
  * Improved handling of live update connections, including connection limits and cleanup for disconnected clients.
  * Updated pricing displays to stay in sync with the latest values more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->