### PR TITLE
Fix channel points price chart hover misalignment

### DIFF
--- a/public/priceHistoryChart.js
+++ b/public/priceHistoryChart.js
@@ -149,7 +149,7 @@ function buildPriceHistoryChartMarkup(points, rangeStartMs, rangeEndMs) {
   const dataPoints = JSON.stringify(sorted).replace(/'/g, '&#39;');
 
   return `
-<svg class="price-history-chart" viewBox="0 0 ${CHART_WIDTH} ${CHART_HEIGHT}" width="100%" height="${CHART_HEIGHT}"
+<svg class="price-history-chart" viewBox="0 0 ${CHART_WIDTH} ${CHART_HEIGHT}" width="100%" height="${CHART_HEIGHT}" preserveAspectRatio="none"
      data-points='${dataPoints}'
      data-plot-left="${plotLeft}" data-plot-right="${plotRight}"
      data-range-start="${rangeStartMs}" data-range-end="${rangeEndMs}"

--- a/src/web/priceHistoryChart.test.ts
+++ b/src/web/priceHistoryChart.test.ts
@@ -66,4 +66,13 @@ describe('renderPriceHistoryChart', () => {
     expect(svg).toContain('data-range-start="1700000000000"');
     expect(svg).toContain('data-range-end="1700010000000"');
   });
+
+  it('disables aspect-ratio preservation so the viewBox stretches to fill its actual rendered size', () => {
+    // Without this, the browser letterboxes the chart whenever its rendered box doesn't
+    // match the 480:120 viewBox ratio (the common case — the card is much wider), which
+    // throws off priceHistoryChart.js's pointer-to-chart-coordinate hover math.
+    const points = [{ t: 1_700_000_000_000, cost: 480 }];
+    const svg = renderPriceHistoryChart(points, 1_700_000_000_000, 1_700_010_000_000);
+    expect(svg).toContain('preserveAspectRatio="none"');
+  });
 });

--- a/src/web/priceHistoryChart.ts
+++ b/src/web/priceHistoryChart.ts
@@ -13,6 +13,11 @@ const PADDING = { top: 10, right: 12, bottom: 20, left: 44 };
  * A single series needs no legend (the card title above it already names what's plotted).
  * Embeds the plotted points as a `data-points` JSON attribute so `priceHistoryChart.js`
  * can add a hover crosshair/tooltip without re-deriving the scale server-side.
+ * Uses `preserveAspectRatio="none"` so the rendered box always stretches the 480x120
+ * viewBox to fill its actual on-screen size — without it, the browser's default
+ * "meet" scaling letterboxes the chart (renders it at native size, centered) whenever
+ * the box's aspect ratio doesn't match 480:120, which silently breaks the hover math in
+ * `priceHistoryChart.js` (it maps pointer position to the chart assuming a 1:1 stretch).
  *
  * @param points - Price history points, any order (sorted internally by time).
  * @param rangeStartMs - Left edge of the x-axis (epoch ms).
@@ -50,7 +55,7 @@ export function renderPriceHistoryChart(points: PriceHistoryPoint[], rangeStartM
   const dataPoints = JSON.stringify(sorted.map((p) => [p.t, p.cost]));
 
   return `
-<svg class="price-history-chart" viewBox="0 0 ${WIDTH} ${HEIGHT}" width="100%" height="${HEIGHT}"
+<svg class="price-history-chart" viewBox="0 0 ${WIDTH} ${HEIGHT}" width="100%" height="${HEIGHT}" preserveAspectRatio="none"
      data-points='${dataPoints.replace(/'/g, '&#39;')}'
      data-plot-left="${plotLeft}" data-plot-right="${plotRight}"
      data-range-start="${rangeStartMs}" data-range-end="${rangeEndMs}"


### PR DESCRIPTION
## Summary

The price history chart's hover crosshair/tooltip didn't line up with the mouse — it seemed to react across the whole page rather than just the graph, and switching the history-range dropdown didn't seem to visibly change anything.

Root cause: both SVG generators (`src/web/priceHistoryChart.ts` for the initial page render, `public/priceHistoryChart.js` for the live SSE-updated redraw) set `viewBox="0 0 480 120"` with `width="100%" height="120"`, but never set `preserveAspectRatio`. Since the card is much wider than 480px, the browser's default `xMidYMid meet` scaling **letterboxes** the chart: it renders the content at its native 480×120 size, centered in the wider box, rather than stretching to fill it. The hover math in `priceHistoryChart.js` assumes the viewBox stretches 1:1 across the SVG's full rendered width, so mouse position got mapped onto a region far larger than what was actually drawn — near the chart's edges the crosshair could be off by hundreds of pixels. This same letterboxing also kept the chart pinned to a small, fixed-size sliver regardless of the container width or selected range, making range changes easy to miss.

Fix: add `preserveAspectRatio="none"` to both SVGs so the viewBox stretches non-uniformly to fill the actual rendered box, matching what the hover-mapping code already assumes.

Verified with a standalone Playwright repro comparing crosshair screen position vs. mouse position before/after the fix — before, hovering near the chart edges put the crosshair ~250px off; after, it tracks the cursor within a few pixels across the full width.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 2137 tests passing)
- [x] Added a regression test asserting the rendered SVG includes `preserveAspectRatio="none"`
- [x] Manual repro in headless Chromium confirming crosshair now tracks the mouse across the chart width (previously off by up to ~250px near the edges)


---
_Generated by [Claude Code](https://claude.ai/code/session_012A348gGZS9qLijcj6kaGY2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the price history chart’s scaling so it fills its available space more consistently.
  * Fixed hover and pointer behavior on the chart by keeping the rendered chart size aligned with expected dimensions.
  
* **Tests**
  * Added coverage to verify the chart SVG includes the updated scaling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->