### PR TITLE
Fix price history range dropdown not submitting under CSP

### DIFF
--- a/public/priceHistoryChart.js
+++ b/public/priceHistoryChart.js
@@ -103,6 +103,19 @@ function initPriceHistoryCharts() {
   document.querySelectorAll('.price-history-chart').forEach(wireChartInteractivity);
 }
 
+/**
+ * Wires the "Price history range" `<select>` to auto-submit its enclosing form on change.
+ * This has to be done from an external script rather than an inline `onchange` attribute —
+ * the page's CSP sets `script-src-attr 'none'`, which silently blocks inline event-handler
+ * attributes (the select just sits there doing nothing on change, with no visible error).
+ */
+function initHistoryRangeSelect() {
+  const select = document.getElementById('history-hours');
+  if (select instanceof HTMLSelectElement && select.form) {
+    select.addEventListener('change', () => select.form.submit());
+  }
+}
+
 // ─── Live updates (Server-Sent Events) ─────────────────────────────────────
 
 const CHART_WIDTH = 480;
@@ -238,5 +251,6 @@ function initLivePricingUpdates() {
 
 document.addEventListener('DOMContentLoaded', () => {
   initPriceHistoryCharts();
+  initHistoryRangeSelect();
   initLivePricingUpdates();
 });

--- a/views/channelPointsAdmin.ejs
+++ b/views/channelPointsAdmin.ejs
@@ -128,7 +128,7 @@
       <% if (rewards.some((r) => r.config)) { %>
       <form method="GET" action="/channel-points" class="form-row-wrap" style="align-items:center;margin-bottom:0.75rem;">
         <label class="hint hint-compact" for="history-hours" style="padding:0;">Price history range</label>
-        <select id="history-hours" class="input" name="hours" onchange="this.form.submit()" style="width:auto;">
+        <select id="history-hours" class="input" name="hours" style="width:auto;">
           <% for (const h of historyHourOptions) { %>
           <option value="<%= h %>" <%= h === historyHours ? 'selected' : '' %>><%= h %>h</option>
           <% } %>


### PR DESCRIPTION
## Summary

Follow-up to #355. After the tooltip-alignment fix landed, the "Price history range" dropdown on `/channel-points` still had no effect when changed — confirmed the page wasn't reloading at all when a new option was picked.

Root cause: the `<select>` used an inline `onchange="this.form.submit()"` attribute to auto-submit on change. The app's CSP (`src/web/server.ts`) sets `script-src-attr: ["'none'"]`, which blocks inline event-handler attributes. The browser silently drops the handler and logs a CSP violation to the console — no visible error, so the dropdown just did nothing.

Verified with a headless-browser repro against a page carrying the same CSP: the inline attribute triggers a `script-src-attr 'none'` violation and never fires, while wiring the same behavior via an external script's `addEventListener` (which the CSP permits, since `script-src` allows `'self'`) submits the form correctly.

Fix: moved the handler into `public/priceHistoryChart.js` (already loaded on this page) as a plain `addEventListener('change', ...)`.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 2137 tests passing)
- [x] Manual repro in headless Chromium: confirmed the CSP violation with the old inline attribute, and confirmed the new script-based handler successfully submits the form on `change`


---
_Generated by [Claude Code](https://claude.ai/code/session_012A348gGZS9qLijcj6kaGY2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Selecting a price history range now reliably submits the form to update the chart.
  * The price history range control continues to behave the same for users, with smoother page interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->