### PR TITLE
Fix distorted price history chart on wide cards

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -350,7 +350,13 @@ textarea.input, .stream-textarea { width: 100%; resize: vertical; font-family: v
 
 /* ── Price history chart (pricing admin) ──────────────── */
 .price-history-tick, .price-history-end-label { font-size: 9px; fill: var(--muted); }
-.price-history-chart { display: block; cursor: crosshair; touch-action: none; }
+/* height:auto + aspect-ratio (matching the 480x120 viewBox in priceHistoryChart.ts/.js) keeps the
+   chart's box proportional to the viewBox at any width — needed because the SVGs use
+   preserveAspectRatio="none" so hover math can assume a 1:1 coordinate stretch; without a matching
+   aspect ratio that stretch is non-uniform and visibly distorts the line. max-width caps how tall
+   that makes the chart on wide cards (uncapped, a ~1200px-wide card would need a ~300px-tall chart
+   to stay undistorted). */
+.price-history-chart { display: block; width: 100%; max-width: 640px; height: auto; aspect-ratio: 480 / 120; cursor: crosshair; touch-action: none; }
 .price-history-tooltip {
   position: absolute; z-index: 20; pointer-events: none;
   background: var(--bg-card); border: 1px solid var(--border); border-radius: 6px;


### PR DESCRIPTION
## Summary

Follow-up to #355. That PR fixed the hover crosshair/tooltip by adding `preserveAspectRatio="none"` to the chart SVGs, so the viewBox stretches 1:1 to fill the box's actual rendered width (the hover math needs that 1:1 assumption to hold). But the box itself was still `width: 100%` with a fixed `height: 120px` — on a card much wider than the chart's 480x120 viewBox, that meant the horizontal stretch factor was far greater than the vertical one, visibly distorting the plotted line into sharp, unnaturally thin spikes (reported as the graph "looking stretched" on desktop).

Fix: lock the chart's rendered box to the same 480:120 aspect ratio as its viewBox (`height: auto` + `aspect-ratio: 480 / 120` in `public/style.css`), so the `none` stretch stays uniform on both axes at any width — no more distortion. Capped with `max-width: 640px` so the chart doesn't grow unreasonably tall on very wide cards (uncapped, a ~1200px-wide card would need a ~300px-tall chart to stay undistorted).

This is a pure CSS change — the hover/crosshair math in `priceHistoryChart.js` reads the SVG's actual rendered box size at runtime, so it's unaffected and still accurate.

Verified with a headless-browser repro: the rendered box is now exactly 640×160 (4:1, matching the viewBox) instead of stretching to the full ~1118px card width, and the hover crosshair still tracks the cursor within a couple of pixels across the whole chart.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 2137 tests passing — no test changes needed, this is CSS-only)
- [x] Manual repro in headless Chromium: confirmed the chart box is now a fixed 4:1 aspect ratio (no distortion) and hover accuracy is unaffected


---
_Generated by [Claude Code](https://claude.ai/code/session_012A348gGZS9qLijcj6kaGY2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the chart’s layout so price history graphics keep the correct proportions across different screen sizes.
  - Limited the chart’s maximum width to prevent it from stretching too wide and added responsive sizing for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->