### PR TITLE
Validate renderView data against EJS option-injection/prototype pollution

### DIFF
--- a/src/web/routes/shared.test.ts
+++ b/src/web/routes/shared.test.ts
@@ -216,6 +216,11 @@ describe('renderView', () => {
     expect(() => renderView(res, 'error', { outputFunctionName: 'x' })).toThrow(/reserved key/);
   });
 
+  it('throws when data contains the EJS "escape" option key', () => {
+    const { res } = mockRes();
+    expect(() => renderView(res, 'error', { escape: (x: unknown) => String(x) })).toThrow(/reserved key/);
+  });
+
   it('throws when data contains a prototype-pollution key', () => {
     const { res } = mockRes();
     const data = JSON.parse('{"__proto__": {"polluted": true}}') as Record<string, unknown>;

--- a/src/web/routes/shared.test.ts
+++ b/src/web/routes/shared.test.ts
@@ -210,6 +210,35 @@ describe('renderView', () => {
     expect(() => renderView(res, '../../etc/passwd')).toThrow();
     expect(render).not.toHaveBeenCalled();
   });
+
+  it('throws when data contains an EJS-reserved option key', () => {
+    const { res } = mockRes();
+    expect(() => renderView(res, 'error', { outputFunctionName: 'x' })).toThrow(/reserved key/);
+  });
+
+  it('throws when data contains a prototype-pollution key', () => {
+    const { res } = mockRes();
+    const data = JSON.parse('{"__proto__": {"polluted": true}}') as Record<string, unknown>;
+    expect(() => renderView(res, 'error', data)).toThrow(/reserved key/);
+  });
+
+  it('throws when data contains a "constructor" key', () => {
+    const { res } = mockRes();
+    expect(() => renderView(res, 'error', { constructor: {} })).toThrow(/reserved key/);
+  });
+
+  it('does not call res.render when data has a reserved key', () => {
+    const { res, render } = mockRes();
+    expect(() => renderView(res, 'error', { cache: true })).toThrow();
+    expect(render).not.toHaveBeenCalled();
+  });
+
+  it('throws when data is not a plain object', () => {
+    const { res } = mockRes();
+    expect(() => renderView(res, 'error', [1, 2, 3] as unknown as Record<string, unknown>)).toThrow(
+      /plain object/,
+    );
+  });
 });
 
 describe('renderError', () => {

--- a/src/web/routes/shared.test.ts
+++ b/src/web/routes/shared.test.ts
@@ -221,6 +221,18 @@ describe('renderView', () => {
     expect(() => renderView(res, 'error', { escape: (x: unknown) => String(x) })).toThrow(/reserved key/);
   });
 
+  it('throws when data contains the deprecated EJS "scope" alias for "context"', () => {
+    const { res } = mockRes();
+    expect(() => renderView(res, 'error', { scope: {} })).toThrow(/reserved key/);
+  });
+
+  it('throws when data contains a "settings" key (EJS renderFile\'s Express compat bypass)', () => {
+    const { res } = mockRes();
+    expect(() => renderView(res, 'error', { settings: { 'view options': { outputFunctionName: 'x' } } })).toThrow(
+      /reserved key/,
+    );
+  });
+
   it('throws when data contains a prototype-pollution key', () => {
     const { res } = mockRes();
     const data = JSON.parse('{"__proto__": {"polluted": true}}') as Record<string, unknown>;

--- a/src/web/routes/shared.ts
+++ b/src/web/routes/shared.ts
@@ -113,7 +113,7 @@ const RESERVED_RENDER_DATA_KEYS = new Set([
   'views',
   'root',
   'client',
-  'escapeFunction',
+  'escape',
   'compileDebug',
   'debug',
   'delimiter',
@@ -125,6 +125,10 @@ const RESERVED_RENDER_DATA_KEYS = new Set([
   'rmWhitespace',
   'outputFunctionName',
   'async',
+  'destructuredLocals',
+  'context',
+  'beautify',
+  'includer',
 ]);
 
 /**

--- a/src/web/routes/shared.ts
+++ b/src/web/routes/shared.ts
@@ -127,8 +127,15 @@ const RESERVED_RENDER_DATA_KEYS = new Set([
   'async',
   'destructuredLocals',
   'context',
+  'scope',
   'beautify',
   'includer',
+  // EJS's `renderFile` special-cases a `settings` key on the data object (for Express 2/3
+  // compat): `settings.views`/`settings['view cache']` set compile options directly, and
+  // `settings['view options']` is shallow-copied into the real options *without* being
+  // filtered by any key list at all. Blocking `settings` outright closes that whole nested
+  // bypass rather than trying to enumerate every option it could smuggle through.
+  'settings',
 ]);
 
 /**

--- a/src/web/routes/shared.ts
+++ b/src/web/routes/shared.ts
@@ -98,16 +98,59 @@ export function normalizeDiscordId(value: string | undefined): string | null {
 }
 
 /**
+ * Keys that must never appear in `renderView`'s `data` argument. Express's EJS integration
+ * uses the same object as both template locals and `ejs.compile` options, so an
+ * attacker-controlled key here (e.g. `outputFunctionName`) could alter template compilation —
+ * a known EJS option-injection class of SSTI. `__proto__`/`constructor`/`prototype` are
+ * blocked for the same reason (prototype pollution of the render options object).
+ */
+const RESERVED_RENDER_DATA_KEYS = new Set([
+  '__proto__',
+  'constructor',
+  'prototype',
+  'cache',
+  'filename',
+  'views',
+  'root',
+  'client',
+  'escapeFunction',
+  'compileDebug',
+  'debug',
+  'delimiter',
+  'openDelimiter',
+  'closeDelimiter',
+  'strict',
+  '_with',
+  'localsName',
+  'rmWhitespace',
+  'outputFunctionName',
+  'async',
+]);
+
+/**
  * Renders an EJS view after checking `view` against the actual `.ejs` files present
  * under `views/`. Throws if `view` isn't a real template, so a template name can never
- * be attacker-controlled or silently mistyped.
+ * be attacker-controlled or silently mistyped. Also validates `data`: it must be a plain
+ * object and must not contain any key in {@link RESERVED_RENDER_DATA_KEYS}, preventing a
+ * caller from ever smuggling EJS compile-option or prototype-pollution keys into the
+ * render call.
  * @param res - Express response object.
  * @param view - Name of the view to render (without the `.ejs` extension).
- * @param data - Template data, forwarded to `res.render` unchanged.
+ * @param data - Template data, forwarded to `res.render` unchanged once validated.
  */
 export function renderView(res: Response, view: string, data?: Record<string, unknown>): void {
   if (!getKnownViews().has(view)) {
     throw new Error(`renderView: unknown view "${view}"`);
+  }
+  if (data !== undefined) {
+    if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+      throw new Error('renderView: data must be a plain object');
+    }
+    for (const key of Object.keys(data)) {
+      if (RESERVED_RENDER_DATA_KEYS.has(key)) {
+        throw new Error(`renderView: data contains reserved key "${key}"`);
+      }
+    }
   }
   res.render(view, data);
 }


### PR DESCRIPTION
## Summary
- Aikido flagged `res.render(view, data)` in `src/web/routes/shared.ts` as a possible SSTI sink: `view` was already validated against the real `.ejs` templates, but `data` was forwarded unchanged.
- Express's EJS integration reuses the same object as both template locals and `ejs.compile` options, so a future caller merging user-controlled keys into `data` could smuggle in options like `outputFunctionName`/`client`, or trigger prototype pollution via `__proto__`/`constructor`/`prototype`.
- `renderView` now throws if `data` isn't a plain object, or if it contains any key in a new `RESERVED_RENDER_DATA_KEYS` denylist (EJS internal option keys + prototype-pollution keys), before calling `res.render`.
- Verified all 23 existing `renderView` call sites use static object literals with safe key names, so none are affected by the new guard.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (2142 tests passed)
- [x] Added tests in `shared.test.ts` covering: reserved EJS option key, `__proto__` (via `JSON.parse`), `constructor` key, non-plain-object `data`, and confirming `res.render` is not called when rejected.


---
_Generated by [Claude Code](https://claude.ai/code/session_013iwVW2K2EtdFqf2iVmrfCn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened view rendering security by validating render data before passing it to the template engine.
  * Rejects non-plain-object inputs and blocks reserved template option keys, prototype-pollution-related keys, and other disallowed fields to prevent unsafe injection.
  * Ensures rendering does not occur when invalid data is provided.
* **Tests**
  * Added test cases covering rejection of invalid/unsafe render data, including reserved keys and array inputs, with assertions that rendering is not triggered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->