### PR TITLE
Escape dynamic values in price history chart SVG

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -553,9 +553,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -573,9 +570,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -593,9 +587,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -613,9 +604,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -633,9 +621,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -653,9 +638,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3143,9 +3125,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3167,9 +3146,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3191,9 +3167,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3215,9 +3188,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/web/priceHistoryChart.test.ts
+++ b/src/web/priceHistoryChart.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { renderPriceHistoryChart } from './priceHistoryChart';
 
 describe('renderPriceHistoryChart', () => {
@@ -105,5 +105,30 @@ describe('renderPriceHistoryChart', () => {
     const points = [{ t: 1_700_000_000_000, cost: 480 }];
     const svg = renderPriceHistoryChart(points, 1_700_000_000_000, 1_700_010_000_000);
     expect(svg).not.toContain('data-elapsed');
+  });
+
+  describe('escaping locale-formatted values embedded in the SVG', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('escapes HTML/XML special characters from Date#toLocaleString before embedding them in aria-label', () => {
+      vi.spyOn(Date.prototype, 'toLocaleString').mockReturnValue('"><script>alert(1)</script>');
+      const points = [{ t: 1_700_000_000_000, cost: 480 }];
+      const svg = renderPriceHistoryChart(points, 1_700_000_000_000, 1_700_010_000_000);
+      expect(svg).not.toContain('<script>');
+      expect(svg).toContain('&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;');
+    });
+
+    it('escapes HTML/XML special characters from Number#toLocaleString before embedding them as tick/end-label text', () => {
+      vi.spyOn(Number.prototype, 'toLocaleString').mockReturnValue('</text><script>alert(1)</script>');
+      const points = [
+        { t: 1_700_000_000_000, cost: 200 },
+        { t: 1_700_010_000_000, cost: 800 },
+      ];
+      const svg = renderPriceHistoryChart(points, 1_700_000_000_000, 1_700_010_000_000);
+      expect(svg).not.toContain('<script>');
+      expect(svg).toContain('&lt;/text&gt;&lt;script&gt;alert(1)&lt;/script&gt;');
+    });
   });
 });

--- a/src/web/priceHistoryChart.ts
+++ b/src/web/priceHistoryChart.ts
@@ -8,6 +8,16 @@ const WIDTH = 480;
 const HEIGHT = 120;
 const PADDING = { top: 10, right: 12, bottom: 20, left: 44 };
 
+/** Escapes HTML/XML special characters so a value is safe to embed as SVG text or an attribute value. */
+function escapeHtml(value: string | number): string {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 /**
  * Renders an inline SVG line chart of a reward's price over `[rangeStartMs, rangeEndMs]`.
  * A single series needs no legend (the card title above it already names what's plotted).
@@ -64,24 +74,25 @@ export function renderPriceHistoryChart(
   const last = pixelPoints[pixelPoints.length - 1];
 
   const dataPoints = JSON.stringify(sorted.map((p) => [p.t, p.cost]));
-  const ariaLabel = options?.ariaLabel
-    ?? `Price history from ${new Date(rangeStartMs).toLocaleString()} to ${new Date(rangeEndMs).toLocaleString()}, ranging from ${minCost} to ${maxCost} points`;
-  const escapedAriaLabel = ariaLabel.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+  const ariaLabel = escapeHtml(
+    options?.ariaLabel
+      ?? `Price history from ${new Date(rangeStartMs).toLocaleString()} to ${new Date(rangeEndMs).toLocaleString()}, ranging from ${minCost} to ${maxCost} points`
+  );
 
   return `
 <svg class="price-history-chart" viewBox="0 0 ${WIDTH} ${HEIGHT}" width="100%" height="${HEIGHT}" preserveAspectRatio="none"
-     data-points='${dataPoints.replace(/'/g, '&#39;')}'
+     data-points='${escapeHtml(dataPoints)}'
      data-plot-left="${plotLeft}" data-plot-right="${plotRight}"
      data-range-start="${rangeStartMs}" data-range-end="${rangeEndMs}"
      ${options?.elapsedTimeAxis ? 'data-elapsed="true"' : ''}
-     role="img" aria-label="${escapedAriaLabel}">
+     role="img" aria-label="${ariaLabel}">
   <line x1="${plotLeft}" y1="${toY(maxCost).toFixed(1)}" x2="${plotRight}" y2="${toY(maxCost).toFixed(1)}" stroke="var(--border)" stroke-width="1"/>
   <line x1="${plotLeft}" y1="${toY(minCost).toFixed(1)}" x2="${plotRight}" y2="${toY(minCost).toFixed(1)}" stroke="var(--border)" stroke-width="1"/>
-  <text x="${plotLeft - 6}" y="${toY(maxCost).toFixed(1)}" dy="0.32em" text-anchor="end" class="price-history-tick">${maxCost.toLocaleString()}</text>
-  <text x="${plotLeft - 6}" y="${toY(minCost).toFixed(1)}" dy="0.32em" text-anchor="end" class="price-history-tick">${minCost.toLocaleString()}</text>
+  <text x="${plotLeft - 6}" y="${toY(maxCost).toFixed(1)}" dy="0.32em" text-anchor="end" class="price-history-tick">${escapeHtml(maxCost.toLocaleString())}</text>
+  <text x="${plotLeft - 6}" y="${toY(minCost).toFixed(1)}" dy="0.32em" text-anchor="end" class="price-history-tick">${escapeHtml(minCost.toLocaleString())}</text>
   <polyline points="${polyline}" fill="none" stroke="var(--primary)" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
   <circle cx="${last.x.toFixed(1)}" cy="${last.y.toFixed(1)}" r="4" fill="var(--primary)" stroke="var(--bg-card)" stroke-width="2"/>
-  <text x="${last.x.toFixed(1)}" y="${(last.y - 8).toFixed(1)}" text-anchor="end" class="price-history-end-label">${last.cost.toLocaleString()} pts</text>
+  <text x="${last.x.toFixed(1)}" y="${(last.y - 8).toFixed(1)}" text-anchor="end" class="price-history-end-label">${escapeHtml(last.cost.toLocaleString())} pts</text>
   <g class="price-history-crosshair" style="display:none;">
     <line class="price-history-crosshair-line" y1="${plotTop}" y2="${plotBottom}" stroke="var(--muted)" stroke-width="1"/>
     <circle class="price-history-crosshair-dot" r="4" fill="var(--primary)" stroke="var(--bg-card)" stroke-width="2"/>


### PR DESCRIPTION
## Summary

- `views/channelPointsAdmin.ejs:177` renders `r.historyChart` with `<%- %>` (unescaped), and that SVG string is built by `renderPriceHistoryChart()` in `src/web/priceHistoryChart.ts`, which interpolated `Date#toLocaleString()` and `Number#toLocaleString()` output directly into the `aria-label` attribute and `<text>` node content.
- Locale-formatted output isn't guaranteed to be free of HTML/XML-special characters, so added an `escapeHtml()` helper and applied it to every dynamic value embedded in the SVG (`aria-label`, the min/max tick labels, and the end-point cost label), plus the `data-points` JSON attribute for defense in depth.

## Investigation of related findings

A security scan also flagged two other `<%- %>` usages as potentially unescaped output:
- `views/command-monitor.ejs:25` — `data-command-monitor-entries='<%- htmlAttrJson(recentEntries) %>'`
- `views/dashboard.ejs:16` — `data-initial-status="<%- htmlAttrJson(status) %>"`

Both already pass their payload through a local `htmlAttrJson()` helper that escapes `& " ' < >` before the raw output — this is intentional and correct, since using `<%=` there would double-encode the JSON (EJS's own escaper would turn `&amp;` into `&amp;amp;`) and corrupt the payload. No change needed for these two.

Every other `<%- %>` in `views/` is `include('partials/...')`, rendering a static partial template rather than injecting untrusted/dynamic data — not a vulnerability.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (2139 tests passing)
- [x] Added tests that stub `Date#toLocaleString` / `Number#toLocaleString` to return HTML-special-character strings and assert the SVG output escapes them


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9nzYPBKBJkdr3AZ8E7Qjv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart output escaping so special characters are handled safely in labels, attributes, and text.
  * Prevented unescaped content from appearing in chart text and accessibility labels, including cases with embedded markup.
  * Added test coverage to confirm escaped output is rendered correctly and existing mocks are restored between tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->