### PR TITLE
Add simulated ramp/cooldown chart for dynamic channel-point pricing

### DIFF
--- a/public/priceHistoryChart.js
+++ b/public/priceHistoryChart.js
@@ -27,6 +27,19 @@ function formatTooltipTime(t) {
 }
 
 /**
+ * Formats a duration in ms (elapsed time since a simulation's start) as e.g. "1h 24m" or "12m"
+ * for charts whose x-axis is elapsed time rather than a wall-clock time.
+ * @param {number} ms - Elapsed milliseconds.
+ * @returns {string} Formatted duration.
+ */
+function formatTooltipElapsed(ms) {
+  const totalMinutes = Math.round(ms / 60000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+}
+
+/**
  * Updates a chart's crosshair line/dot and tooltip to the nearest point at a given
  * client X position, or hides them when `clientX` is null.
  * @param {SVGSVGElement} svg - The chart's root SVG element.
@@ -51,6 +64,7 @@ function updateCrosshair(svg, tooltip, clientX) {
   const plotRight = Number(svg.dataset.plotRight);
   const rangeStart = Number(svg.dataset.rangeStart);
   const rangeEnd = Number(svg.dataset.rangeEnd);
+  const isElapsed = svg.dataset.elapsed === 'true';
 
   const svgX = ((clientX - rect.left) / rect.width) * viewBoxWidth;
   const clampedX = Math.min(plotRight, Math.max(plotLeft, svgX));
@@ -71,7 +85,7 @@ function updateCrosshair(svg, tooltip, clientX) {
   const valueEl = document.createElement('strong');
   valueEl.textContent = `${cost.toLocaleString()} pts`;
   const timeEl = document.createElement('span');
-  timeEl.textContent = ` — ${formatTooltipTime(t)}`;
+  timeEl.textContent = ` — ${isElapsed ? formatTooltipElapsed(t) : formatTooltipTime(t)}`;
   tooltip.appendChild(valueEl);
   tooltip.appendChild(timeEl);
   tooltip.style.display = '';

--- a/src/twitch/pricing/rewardPricingSimulation.test.ts
+++ b/src/twitch/pricing/rewardPricingSimulation.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { simulateConstantUsageCycle } from './rewardPricingSimulation';
+import { computePrice } from './rewardPricingMath';
+
+const config = {
+  baseCost: 200,
+  maxMultiplier: 4,
+  curve: 1.5,
+  cooldownSeconds: 60,
+  halfLifeSeconds: 1800,
+  timeToMaxMultiplier: 2,
+};
+
+describe('simulateConstantUsageCycle', () => {
+  it('asymptotes below 100% demand under gentle (default-like) settings', () => {
+    // Steady state = increment/(1-decayPerCooldown) ≈ 0.7297 for these settings — well short of 1.
+    const result = simulateConstantUsageCycle(config);
+    expect(result.peakDemand).toBeGreaterThan(0.7);
+    expect(result.peakDemand).toBeLessThan(0.73);
+  });
+
+  it('clamps at exactly 100% demand when the config drives the steady state past 1', () => {
+    // increment = 600/(0.5*600) = 2, decayPerCooldown = 2^(-1) = 0.5, steady state = 2/0.5 = 4 > 1.
+    const result = simulateConstantUsageCycle({
+      ...config,
+      cooldownSeconds: 600,
+      halfLifeSeconds: 600,
+      timeToMaxMultiplier: 0.5,
+    });
+    expect(result.peakDemand).toBe(1);
+  });
+
+  it('ramp phase is monotonically non-decreasing up to the peak', () => {
+    const result = simulateConstantUsageCycle(config);
+    const ramp = result.points.filter((p) => p.t <= result.peakAtMs);
+    for (let i = 1; i < ramp.length; i++) {
+      expect(ramp[i].cost).toBeGreaterThanOrEqual(ramp[i - 1].cost);
+    }
+  });
+
+  it('cooldown phase is monotonically non-increasing back down toward baseline', () => {
+    const result = simulateConstantUsageCycle(config);
+    const cooldown = result.points.filter((p) => p.t >= result.peakAtMs);
+    for (let i = 1; i < cooldown.length; i++) {
+      expect(cooldown[i].cost).toBeLessThanOrEqual(cooldown[i - 1].cost);
+    }
+    expect(cooldown[cooldown.length - 1].cost).toBeLessThan(cooldown[0].cost);
+  });
+
+  it('starts at baseCost and ends within 1% of baseCost', () => {
+    const result = simulateConstantUsageCycle(config);
+    expect(result.points[0].cost).toBe(config.baseCost);
+    const last = result.points[result.points.length - 1];
+    expect(last.cost).toBeLessThan(config.baseCost * 1.05);
+  });
+
+  it("every point's cost matches computePrice for its implied demand", () => {
+    // Re-derive demand from cost isn't possible in general (curve isn't invertible cleanly for
+    // every case), so instead spot-check the peak point directly.
+    const result = simulateConstantUsageCycle(config);
+    expect(result.points.find((p) => p.t === result.peakAtMs)?.cost).toBe(computePrice(result.peakDemand, config));
+  });
+
+  it('does not loop unreasonably long for an extreme config (near-zero half-life)', () => {
+    const start = Date.now();
+    const result = simulateConstantUsageCycle({ ...config, halfLifeSeconds: 1, cooldownSeconds: 1 });
+    expect(Date.now() - start).toBeLessThan(1000);
+    expect(result.points.length).toBeGreaterThan(0);
+  });
+});

--- a/src/twitch/pricing/rewardPricingSimulation.test.ts
+++ b/src/twitch/pricing/rewardPricingSimulation.test.ts
@@ -51,7 +51,7 @@ describe('simulateConstantUsageCycle', () => {
     const result = simulateConstantUsageCycle(config);
     expect(result.points[0].cost).toBe(config.baseCost);
     const last = result.points[result.points.length - 1];
-    expect(last.cost).toBeLessThan(config.baseCost * 1.05);
+    expect(last.cost).toBeLessThan(config.baseCost * 1.01);
   });
 
   it("every point's cost matches computePrice for its implied demand", () => {
@@ -59,6 +59,11 @@ describe('simulateConstantUsageCycle', () => {
     // every case), so instead spot-check the peak point directly.
     const result = simulateConstantUsageCycle(config);
     expect(result.points.find((p) => p.t === result.peakAtMs)?.cost).toBe(computePrice(result.peakDemand, config));
+  });
+
+  it('reports peakCost as computePrice(peakDemand, config)', () => {
+    const result = simulateConstantUsageCycle(config);
+    expect(result.peakCost).toBe(computePrice(result.peakDemand, config));
   });
 
   it('does not loop unreasonably long for an extreme config (near-zero half-life)', () => {

--- a/src/twitch/pricing/rewardPricingSimulation.ts
+++ b/src/twitch/pricing/rewardPricingSimulation.ts
@@ -14,6 +14,8 @@ export interface SimulationResult {
   points: PriceHistoryPoint[];
   /** The demand reached at the ramp/cooldown transition — may be below 1 (see module docs). */
   peakDemand: number;
+  /** The price at `peakDemand` — `computePrice(peakDemand, config)`. */
+  peakCost: number;
   /** Elapsed ms when the ramp phase ends and the cooldown phase begins. */
   peakAtMs: number;
   /** Elapsed ms of the last point (end of the cooldown phase). */
@@ -71,6 +73,7 @@ export function simulateConstantUsageCycle(config: SimulationConfig): Simulation
 
   const peakAtMs = rampDurationSeconds * 1000;
   const peakDemand = rampDemandAt(rampDurationSeconds);
+  const peakCost = computePrice(peakDemand, config);
 
   if (peakDemand > CONVERGENCE_RATIO) {
     const cooldownDurationSeconds = halfLifeSeconds * Math.log2(1 / CONVERGENCE_RATIO);
@@ -83,6 +86,7 @@ export function simulateConstantUsageCycle(config: SimulationConfig): Simulation
   return {
     points,
     peakDemand,
+    peakCost,
     peakAtMs,
     totalDurationMs: points[points.length - 1].t,
   };

--- a/src/twitch/pricing/rewardPricingSimulation.ts
+++ b/src/twitch/pricing/rewardPricingSimulation.ts
@@ -1,0 +1,89 @@
+import { RewardPricingConfig, computePrice, decayDemand, computeRedemptionIncrement } from './rewardPricingMath';
+import { PriceHistoryPoint } from '../../web/priceHistoryChart';
+
+/** Config needed to simulate a full constant-usage ramp + cooldown cycle for one reward. */
+export interface SimulationConfig extends RewardPricingConfig {
+  cooldownSeconds: number;
+  halfLifeSeconds: number;
+  timeToMaxMultiplier: number;
+}
+
+/** Result of {@link simulateConstantUsageCycle}: the plotted curve plus its key milestones. */
+export interface SimulationResult {
+  /** Price/demand points across the whole cycle, `t` in ms elapsed since the ramp started at 0. */
+  points: PriceHistoryPoint[];
+  /** The demand reached at the ramp/cooldown transition — may be below 1 (see module docs). */
+  peakDemand: number;
+  /** Elapsed ms when the ramp phase ends and the cooldown phase begins. */
+  peakAtMs: number;
+  /** Elapsed ms of the last point (end of the cooldown phase). */
+  totalDurationMs: number;
+}
+
+/**
+ * Fraction of the way to the ramp's asymptote (or, for a config whose steady state clamps at 1,
+ * how precisely the 1.0 crossing is targeted) / fraction of the peak the cooldown phase decays
+ * down to before the simulation stops. Shared so the ramp-up and cooldown-back-down halves of the
+ * chart read as symmetric "close enough to done" thresholds.
+ */
+const CONVERGENCE_RATIO = 0.01;
+/** Points sampled across each phase's continuous curve. */
+const SAMPLE_COUNT = 40;
+
+/**
+ * Simulates a reward's demand/price over one full cycle: constant redemptions at the reward's
+ * own cooldown rate (i.e. redeeming the instant it's available, forever) ramping demand up from
+ * 0, followed by a cooldown phase with no further redemptions decaying demand back down to ~0.
+ *
+ * The ramp phase does not necessarily reach 100% demand. Redeeming every `cooldownSeconds` with
+ * decay in between follows the recurrence `d' = decay(d) + increment`, whose steady state is
+ * `increment / (1 - decayPerCooldown)` — the continuous-time relaxation of that same recurrence is
+ * `demand(t) = steadyState * (1 - 2^(-t/halfLife))`, which is what this function samples. That
+ * only approaches (or, if the steady state is >= 1, actually reaches and clamps at) 100% demand;
+ * for gentler configs it asymptotes below 100%. This function reports whatever the real ramp
+ * peak is via `peakDemand` rather than assuming it always hits 100%.
+ *
+ * @param config - The reward's pricing config plus its cooldown and the streamer's half-life/time-to-max settings.
+ * @returns The simulated points plus the demand/timing at the ramp-to-cooldown transition.
+ */
+export function simulateConstantUsageCycle(config: SimulationConfig): SimulationResult {
+  const { cooldownSeconds, halfLifeSeconds, timeToMaxMultiplier } = config;
+  const redemptionIncrement = computeRedemptionIncrement(cooldownSeconds, halfLifeSeconds, timeToMaxMultiplier);
+  const decayPerCooldown = decayDemand(1, cooldownSeconds, halfLifeSeconds);
+  const steadyStateDemand = redemptionIncrement / (1 - decayPerCooldown);
+
+  // Continuous-time closed form for the ramp recurrence: demand(t) = steadyState * (1 - 2^(-t/halfLife)).
+  const rampDemandAt = (tSeconds: number) => Math.min(1, steadyStateDemand * (1 - decayDemand(1, tSeconds, halfLifeSeconds)));
+
+  // How long to draw the ramp for: the exact time it crosses 100% if the config drives it there,
+  // otherwise the time it gets within CONVERGENCE_RATIO of its (sub-100%) asymptote.
+  const rampDurationSeconds = steadyStateDemand > 1
+    ? halfLifeSeconds * Math.log2(1 / (1 - 1 / steadyStateDemand))
+    : halfLifeSeconds * Math.log2(1 / CONVERGENCE_RATIO);
+
+  const points: PriceHistoryPoint[] = [];
+  const pushPoint = (tMs: number, demand: number) => points.push({ t: tMs, cost: computePrice(demand, config) });
+
+  for (let i = 0; i <= SAMPLE_COUNT; i++) {
+    const tSeconds = (rampDurationSeconds * i) / SAMPLE_COUNT;
+    pushPoint(tSeconds * 1000, rampDemandAt(tSeconds));
+  }
+
+  const peakAtMs = rampDurationSeconds * 1000;
+  const peakDemand = rampDemandAt(rampDurationSeconds);
+
+  if (peakDemand > CONVERGENCE_RATIO) {
+    const cooldownDurationSeconds = halfLifeSeconds * Math.log2(1 / CONVERGENCE_RATIO);
+    for (let i = 1; i <= SAMPLE_COUNT; i++) {
+      const elapsedSeconds = (cooldownDurationSeconds * i) / SAMPLE_COUNT;
+      pushPoint(peakAtMs + elapsedSeconds * 1000, decayDemand(peakDemand, elapsedSeconds, halfLifeSeconds));
+    }
+  }
+
+  return {
+    points,
+    peakDemand,
+    peakAtMs,
+    totalDurationMs: points[points.length - 1].t,
+  };
+}

--- a/src/web/priceHistoryChart.test.ts
+++ b/src/web/priceHistoryChart.test.ts
@@ -75,4 +75,29 @@ describe('renderPriceHistoryChart', () => {
     const svg = renderPriceHistoryChart(points, 1_700_000_000_000, 1_700_010_000_000);
     expect(svg).toContain('preserveAspectRatio="none"');
   });
+
+  it('uses the default date-based aria-label when no override is given', () => {
+    const points = [{ t: 1_700_000_000_000, cost: 480 }];
+    const svg = renderPriceHistoryChart(points, 1_700_000_000_000, 1_700_010_000_000);
+    expect(svg).toContain('aria-label="Price history from');
+  });
+
+  it('uses a custom aria-label when one is provided via options', () => {
+    const points = [{ t: 0, cost: 480 }];
+    const svg = renderPriceHistoryChart(points, 0, 1000, { ariaLabel: 'Simulated demand cycle' });
+    expect(svg).toContain('aria-label="Simulated demand cycle"');
+    expect(svg).not.toContain('Price history from');
+  });
+
+  it('marks the chart as an elapsed-time axis when requested', () => {
+    const points = [{ t: 0, cost: 480 }];
+    const svg = renderPriceHistoryChart(points, 0, 1000, { elapsedTimeAxis: true });
+    expect(svg).toContain('data-elapsed="true"');
+  });
+
+  it('omits the data-elapsed attribute by default', () => {
+    const points = [{ t: 1_700_000_000_000, cost: 480 }];
+    const svg = renderPriceHistoryChart(points, 1_700_000_000_000, 1_700_010_000_000);
+    expect(svg).not.toContain('data-elapsed');
+  });
 });

--- a/src/web/priceHistoryChart.test.ts
+++ b/src/web/priceHistoryChart.test.ts
@@ -89,6 +89,12 @@ describe('renderPriceHistoryChart', () => {
     expect(svg).not.toContain('Price history from');
   });
 
+  it('escapes double quotes and ampersands in a custom aria-label', () => {
+    const points = [{ t: 0, cost: 480 }];
+    const svg = renderPriceHistoryChart(points, 0, 1000, { ariaLabel: 'Peak "demand" & price' });
+    expect(svg).toContain('aria-label="Peak &quot;demand&quot; &amp; price"');
+  });
+
   it('marks the chart as an elapsed-time axis when requested', () => {
     const points = [{ t: 0, cost: 480 }];
     const svg = renderPriceHistoryChart(points, 0, 1000, { elapsedTimeAxis: true });

--- a/src/web/priceHistoryChart.ts
+++ b/src/web/priceHistoryChart.ts
@@ -66,6 +66,7 @@ export function renderPriceHistoryChart(
   const dataPoints = JSON.stringify(sorted.map((p) => [p.t, p.cost]));
   const ariaLabel = options?.ariaLabel
     ?? `Price history from ${new Date(rangeStartMs).toLocaleString()} to ${new Date(rangeEndMs).toLocaleString()}, ranging from ${minCost} to ${maxCost} points`;
+  const escapedAriaLabel = ariaLabel.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
 
   return `
 <svg class="price-history-chart" viewBox="0 0 ${WIDTH} ${HEIGHT}" width="100%" height="${HEIGHT}" preserveAspectRatio="none"
@@ -73,7 +74,7 @@ export function renderPriceHistoryChart(
      data-plot-left="${plotLeft}" data-plot-right="${plotRight}"
      data-range-start="${rangeStartMs}" data-range-end="${rangeEndMs}"
      ${options?.elapsedTimeAxis ? 'data-elapsed="true"' : ''}
-     role="img" aria-label="${ariaLabel}">
+     role="img" aria-label="${escapedAriaLabel}">
   <line x1="${plotLeft}" y1="${toY(maxCost).toFixed(1)}" x2="${plotRight}" y2="${toY(maxCost).toFixed(1)}" stroke="var(--border)" stroke-width="1"/>
   <line x1="${plotLeft}" y1="${toY(minCost).toFixed(1)}" x2="${plotRight}" y2="${toY(minCost).toFixed(1)}" stroke="var(--border)" stroke-width="1"/>
   <text x="${plotLeft - 6}" y="${toY(maxCost).toFixed(1)}" dy="0.32em" text-anchor="end" class="price-history-tick">${maxCost.toLocaleString()}</text>

--- a/src/web/priceHistoryChart.ts
+++ b/src/web/priceHistoryChart.ts
@@ -22,9 +22,20 @@ const PADDING = { top: 10, right: 12, bottom: 20, left: 44 };
  * @param points - Price history points, any order (sorted internally by time).
  * @param rangeStartMs - Left edge of the x-axis (epoch ms).
  * @param rangeEndMs - Right edge of the x-axis (epoch ms).
+ * @param options.ariaLabel - Overrides the default "Price history from ... to ..." aria-label —
+ *   needed when `rangeStartMs`/`rangeEndMs` aren't real epoch times (e.g. a simulated timeline
+ *   starting at 0), where the default wording would render a nonsensical 1970 date.
+ * @param options.elapsedTimeAxis - Marks the chart's x-axis as elapsed time rather than wall-clock
+ *   time (via a `data-elapsed` attribute), so `priceHistoryChart.js`'s hover tooltip formats it as
+ *   a duration instead of a clock time.
  * @returns Self-contained `<svg>` markup, or a "no data yet" placeholder if `points` is empty.
  */
-export function renderPriceHistoryChart(points: PriceHistoryPoint[], rangeStartMs: number, rangeEndMs: number): string {
+export function renderPriceHistoryChart(
+  points: PriceHistoryPoint[],
+  rangeStartMs: number,
+  rangeEndMs: number,
+  options?: { ariaLabel?: string; elapsedTimeAxis?: boolean },
+): string {
   if (points.length === 0) {
     return `<div class="hint price-history-empty" style="height:${HEIGHT}px;display:flex;align-items:center;justify-content:center;">No price history yet for this range.</div>`;
   }
@@ -53,13 +64,16 @@ export function renderPriceHistoryChart(points: PriceHistoryPoint[], rangeStartM
   const last = pixelPoints[pixelPoints.length - 1];
 
   const dataPoints = JSON.stringify(sorted.map((p) => [p.t, p.cost]));
+  const ariaLabel = options?.ariaLabel
+    ?? `Price history from ${new Date(rangeStartMs).toLocaleString()} to ${new Date(rangeEndMs).toLocaleString()}, ranging from ${minCost} to ${maxCost} points`;
 
   return `
 <svg class="price-history-chart" viewBox="0 0 ${WIDTH} ${HEIGHT}" width="100%" height="${HEIGHT}" preserveAspectRatio="none"
      data-points='${dataPoints.replace(/'/g, '&#39;')}'
      data-plot-left="${plotLeft}" data-plot-right="${plotRight}"
      data-range-start="${rangeStartMs}" data-range-end="${rangeEndMs}"
-     role="img" aria-label="Price history from ${new Date(rangeStartMs).toLocaleString()} to ${new Date(rangeEndMs).toLocaleString()}, ranging from ${minCost} to ${maxCost} points">
+     ${options?.elapsedTimeAxis ? 'data-elapsed="true"' : ''}
+     role="img" aria-label="${ariaLabel}">
   <line x1="${plotLeft}" y1="${toY(maxCost).toFixed(1)}" x2="${plotRight}" y2="${toY(maxCost).toFixed(1)}" stroke="var(--border)" stroke-width="1"/>
   <line x1="${plotLeft}" y1="${toY(minCost).toFixed(1)}" x2="${plotRight}" y2="${toY(minCost).toFixed(1)}" stroke="var(--border)" stroke-width="1"/>
   <text x="${plotLeft - 6}" y="${toY(maxCost).toFixed(1)}" dy="0.32em" text-anchor="end" class="price-history-tick">${maxCost.toLocaleString()}</text>

--- a/src/web/routes/channelPointsAdmin.test.ts
+++ b/src/web/routes/channelPointsAdmin.test.ts
@@ -284,4 +284,46 @@ describe('GET /', () => {
       expect(res.body.rewards[0].historyChart).toContain('<svg');
     });
   });
+
+  describe('simulated ramp/cooldown chart', () => {
+    const CONFIG = {
+      id: 1, streamer_id: 123, twitch_reward_id: 'rwd1', enabled: true,
+      base_cost: 200, cooldown_seconds: 300, max_multiplier: 4, curve: 1.5,
+      demand: 0.5, demand_updated_at: '1700000000000', last_pushed_cost: 300, twitch_unsupported: false,
+    };
+
+    beforeEach(() => {
+      vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+      vi.mocked(getCustomRewards).mockResolvedValue([{ id: 'rwd1', title: 'Cool Reward', cost: 200, is_enabled: true } as any]);
+      vi.mocked(getPricingConfigsForStreamer).mockResolvedValue([CONFIG] as any);
+    });
+
+    it('renders a simulation chart and summary for a reward with a config', async () => {
+      const res = await supertest(buildApp()).get('/');
+      expect(res.body.rewards[0].simulationChart).toContain('<svg');
+      expect(typeof res.body.rewards[0].simulationSummary).toBe('string');
+      expect(res.body.rewards[0].simulationSummary).toMatch(/% demand/);
+    });
+
+    it('leaves simulationChart/simulationSummary null for a reward with no pricing config', async () => {
+      vi.mocked(getPricingConfigsForStreamer).mockResolvedValue([]);
+      const res = await supertest(buildApp()).get('/');
+      expect(res.body.rewards[0].simulationChart).toBeNull();
+      expect(res.body.rewards[0].simulationSummary).toBeNull();
+    });
+
+    it('leaves simulationChart/simulationSummary null when pricing settings are unavailable (not a streamer)', async () => {
+      vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
+      vi.mocked(getPricingConfigsForStreamer).mockResolvedValue([]);
+      const res = await supertest(buildApp()).get('/');
+      expect(res.body.rewards).toEqual([]);
+    });
+
+    it('renders a simulation chart for an unlinked (orphaned) reward too', async () => {
+      vi.mocked(getCustomRewards).mockResolvedValue([]);
+      const res = await supertest(buildApp()).get('/');
+      expect(res.body.rewards[0].twitchReward).toBeNull();
+      expect(res.body.rewards[0].simulationChart).toContain('<svg');
+    });
+  });
 });

--- a/src/web/routes/channelPointsAdmin.test.ts
+++ b/src/web/routes/channelPointsAdmin.test.ts
@@ -312,13 +312,6 @@ describe('GET /', () => {
       expect(res.body.rewards[0].simulationSummary).toBeNull();
     });
 
-    it('leaves simulationChart/simulationSummary null when pricing settings are unavailable (not a streamer)', async () => {
-      vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
-      vi.mocked(getPricingConfigsForStreamer).mockResolvedValue([]);
-      const res = await supertest(buildApp()).get('/');
-      expect(res.body.rewards).toEqual([]);
-    });
-
     it('renders a simulation chart for an unlinked (orphaned) reward too', async () => {
       vi.mocked(getCustomRewards).mockResolvedValue([]);
       const res = await supertest(buildApp()).get('/');

--- a/src/web/routes/channelPointsAdmin.ts
+++ b/src/web/routes/channelPointsAdmin.ts
@@ -5,11 +5,12 @@ import { requireAuth } from '../middleware';
 import { getStreamerByDiscordId } from '../../db';
 import type { DbStreamerEventSub } from '../../db';
 import { getPricingConfigsForStreamer, getPricingSettingsForStreamer, getPricingHistory } from '../../db';
-import type { RewardPricingRow } from '../../db';
+import type { RewardPricingRow, StreamerPricingSettings } from '../../db';
 import { getCustomRewards, TwitchCustomReward } from '../../twitch/twitchApi';
 import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
 import { hasAuthFailedSubs } from '../../twitch/eventsub/twitchEventSubSubscriptions';
 import { computePrice } from '../../twitch/pricing/rewardPricingMath';
+import { simulateConstantUsageCycle } from '../../twitch/pricing/rewardPricingSimulation';
 import { renderPriceHistoryChart } from '../priceHistoryChart';
 import { filterQueryParam, renderError, renderView } from './shared';
 import { router as channelPointsMutationsRouter } from './channelPointsAdminMutations';
@@ -38,6 +39,53 @@ interface ChannelPointRewardRow {
   previewPrice: number | null;
   /** Rendered SVG history chart, or null when there's no config to chart yet. */
   historyChart: string | null;
+  /** Rendered SVG chart simulating a constant-use ramp-to-peak-demand-then-cooldown cycle, or null when there's no config to simulate yet. */
+  simulationChart: string | null;
+  /** One-line human-readable summary of the simulation's peak demand/price and phase durations, or null alongside a null `simulationChart`. */
+  simulationSummary: string | null;
+}
+
+/** Formats a duration in ms as e.g. "1h 24m" or "12m", for the simulation summary sentence. */
+function formatDurationShort(ms: number): string {
+  const totalMinutes = Math.round(ms / 60_000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours === 0) return `${minutes}m`;
+  return minutes === 0 ? `${hours}h` : `${hours}h ${minutes}m`;
+}
+
+/**
+ * Simulates a reward's demand/price over one constant-use ramp + cooldown cycle and renders it
+ * as an SVG chart alongside a one-line summary of the peak reached and how long each phase takes —
+ * this is illustrative (not real usage data), so admins can see how their base cost/multiplier/
+ * curve/cooldown and the streamer's half-life/time-to-max settings shape the pricing curve.
+ */
+function buildSimulationChart(config: RewardPricingRow, settings: StreamerPricingSettings): { chart: string; summary: string } {
+  const result = simulateConstantUsageCycle({
+    baseCost: config.base_cost,
+    maxMultiplier: config.max_multiplier,
+    curve: config.curve,
+    cooldownSeconds: config.cooldown_seconds,
+    halfLifeSeconds: settings.half_life_seconds,
+    timeToMaxMultiplier: settings.time_to_max_multiplier,
+  });
+
+  const peakCost = computePrice(result.peakDemand, {
+    baseCost: config.base_cost,
+    maxMultiplier: config.max_multiplier,
+    curve: config.curve,
+  });
+
+  const chart = renderPriceHistoryChart(result.points, 0, result.totalDurationMs, {
+    elapsedTimeAxis: true,
+    ariaLabel: `Simulated constant-use cycle peaking at ${(result.peakDemand * 100).toFixed(0)}% demand, ${peakCost} points, then cooling down`,
+  });
+
+  const summary = `Simulated: constant redemptions peak at ${(result.peakDemand * 100).toFixed(1)}% demand `
+    + `(${peakCost.toLocaleString()} pts) after ~${formatDurationShort(result.peakAtMs)} of continuous use, `
+    + `then cool back down over ~${formatDurationShort(result.totalDurationMs - result.peakAtMs)}.`;
+
+  return { chart, summary };
 }
 
 /** Parses the `hours` query param against the allowed range options, defaulting when missing/invalid. */
@@ -85,9 +133,9 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
     const isConnected = !!streamer?.eventsub_access_token;
     const needsReconnect = isConnected && !!streamer?.twitch_name && hasAuthFailedSubs(streamer.twitch_name);
 
-    const [pricingConfigs, twitchRewards] = streamer && isConnected && !needsReconnect
-      ? await Promise.all([getPricingConfigsForStreamer(streamer.id), fetchTwitchRewards(streamer)])
-      : [[], []];
+    const [pricingConfigs, twitchRewards, pricingSettings] = streamer && isConnected && !needsReconnect
+      ? await Promise.all([getPricingConfigsForStreamer(streamer.id), fetchTwitchRewards(streamer), getPricingSettingsForStreamer(streamer.id)])
+      : [[], [], null];
 
     const historyHours = parseHistoryHours(req.query.hours);
     const rangeEndMs = Date.now();
@@ -96,6 +144,12 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
     async function buildHistoryChart(config: RewardPricingRow): Promise<string> {
       const points = await getPricingHistory(config.id, rangeStartMs);
       return renderPriceHistoryChart(points.map((p) => ({ t: Number(p.recorded_at), cost: p.cost })), rangeStartMs, rangeEndMs);
+    }
+
+    function buildSimulation(config: RewardPricingRow): { simulationChart: string | null; simulationSummary: string | null } {
+      if (!pricingSettings) return { simulationChart: null, simulationSummary: null };
+      const { chart, summary } = buildSimulationChart(config, pricingSettings);
+      return { simulationChart: chart, simulationSummary: summary };
     }
 
     const configByRewardId = new Map(pricingConfigs.map((c) => [c.twitch_reward_id, c]));
@@ -109,6 +163,7 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
         config,
         previewPrice: config ? previewPriceFor(config) : null,
         historyChart: config ? await buildHistoryChart(config) : null,
+        ...(config ? buildSimulation(config) : { simulationChart: null, simulationSummary: null }),
       };
     }));
 
@@ -124,11 +179,10 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
           config,
           previewPrice: previewPriceFor(config),
           historyChart: await buildHistoryChart(config),
+          ...buildSimulation(config),
         })),
     );
     rewards.push(...unlinkedRows);
-
-    const pricingSettings = streamer && isConnected && !needsReconnect ? await getPricingSettingsForStreamer(streamer.id) : null;
 
     renderView(res, 'channelPointsAdmin', {
       user: req.session.user,

--- a/src/web/routes/channelPointsAdmin.ts
+++ b/src/web/routes/channelPointsAdmin.ts
@@ -70,19 +70,13 @@ function buildSimulationChart(config: RewardPricingRow, settings: StreamerPricin
     timeToMaxMultiplier: settings.time_to_max_multiplier,
   });
 
-  const peakCost = computePrice(result.peakDemand, {
-    baseCost: config.base_cost,
-    maxMultiplier: config.max_multiplier,
-    curve: config.curve,
-  });
-
   const chart = renderPriceHistoryChart(result.points, 0, result.totalDurationMs, {
     elapsedTimeAxis: true,
-    ariaLabel: `Simulated constant-use cycle peaking at ${(result.peakDemand * 100).toFixed(0)}% demand, ${peakCost} points, then cooling down`,
+    ariaLabel: `Simulated constant-use cycle peaking at ${(result.peakDemand * 100).toFixed(0)}% demand, ${result.peakCost} points, then cooling down`,
   });
 
   const summary = `Simulated: constant redemptions peak at ${(result.peakDemand * 100).toFixed(1)}% demand `
-    + `(${peakCost.toLocaleString()} pts) after ~${formatDurationShort(result.peakAtMs)} of continuous use, `
+    + `(${result.peakCost.toLocaleString()} pts) after ~${formatDurationShort(result.peakAtMs)} of continuous use, `
     + `then cool back down over ~${formatDurationShort(result.totalDurationMs - result.peakAtMs)}.`;
 
   return { chart, summary };
@@ -146,9 +140,10 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
       return renderPriceHistoryChart(points.map((p) => ({ t: Number(p.recorded_at), cost: p.cost })), rangeStartMs, rangeEndMs);
     }
 
-    function buildSimulation(config: RewardPricingRow): { simulationChart: string | null; simulationSummary: string | null } {
-      if (!pricingSettings) return { simulationChart: null, simulationSummary: null };
-      const { chart, summary } = buildSimulationChart(config, pricingSettings);
+    // Only ever called for a config drawn from `pricingConfigs`, which is populated in the same
+    // branch as `pricingSettings` above — so `pricingSettings` is guaranteed non-null here.
+    function buildSimulation(config: RewardPricingRow): { simulationChart: string; simulationSummary: string } {
+      const { chart, summary } = buildSimulationChart(config, pricingSettings!);
       return { simulationChart: chart, simulationSummary: summary };
     }
 

--- a/views/channelPointsAdmin.ejs
+++ b/views/channelPointsAdmin.ejs
@@ -178,6 +178,14 @@
           </div>
           <% } %>
 
+          <% if (r.config && r.simulationChart) { %>
+          <div style="margin-top:0.75rem;">
+            <p class="hint hint-compact">Simulated: constant use &rarr; cooldown</p>
+            <%- r.simulationChart %>
+            <p class="hint hint-compact"><%= r.simulationSummary %></p>
+          </div>
+          <% } %>
+
           <% if (r.twitchReward) { %>
           <details style="margin-top:0.5rem;">
             <summary class="hint hint-compact disclosure-toggle">Edit reward</summary>


### PR DESCRIPTION
## Summary

- Adds a second SVG chart under each configured reward's real price-history chart on `/channel-points`, simulating what constant redemptions at the reward's cooldown rate would do: demand ramps up, then (once redemptions stop) cools back down to baseline.
- The simulation is driven by pure math (`src/twitch/pricing/rewardPricingSimulation.ts`), reusing the existing `computePrice`/`decayDemand`/`computeRedemptionIncrement` functions — no formula duplication.
- Uses each reward's actual `base_cost`/`max_multiplier`/`curve`/`cooldown_seconds` and the streamer's `half_life_seconds`/`time_to_max_multiplier` settings, so tuning those values changes the shape immediately (no need to wait for real usage data to see the effect).
- Surfaces a non-obvious property of the pricing math: constant max-rate redemption doesn't always reach 100% demand — it converges to a steady state (`increment / (1 - decayPerCooldown)`) that can land well below 100% depending on the config (e.g. only ~72% under this bot's default settings). The simulation reports and charts the real peak rather than assuming it's always 100%.
- Extends `renderPriceHistoryChart` with an optional `options` param (`ariaLabel`, `elapsedTimeAxis`) so the simulated chart's accessibility label and hover-tooltip formatting make sense for a relative timeline instead of showing a bogus 1970 date — existing calls are unaffected by default.
- Small addition to `public/priceHistoryChart.js` so the hover tooltip shows an elapsed duration (e.g. "3h 49m") instead of a wall-clock time when a chart is marked `data-elapsed`.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (2152 tests, including new `rewardPricingSimulation.test.ts` and extended `priceHistoryChart.test.ts`/`channelPointsAdmin.test.ts`)
- [x] Rendered the `channelPointsAdmin.ejs` view directly with mock data and screenshotted it in a headless browser (no live DB/Twitch/Discord credentials available in this environment): confirmed the simulated chart renders below the real history chart with the expected ramp-then-cooldown shape, and hovering it shows a correct elapsed-time tooltip (not a 1970 date)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ag8H5SXhv2ha6qiWzPtdCS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a simulation preview on the Channel Points admin page to show how reward pricing changes over a full usage cycle.
  * Charts now support elapsed-time tooltips, making time labels clearer for non-clock-based timelines.
  * Improved chart accessibility and customization with better labels and optional elapsed-time display.
* **Bug Fixes**
  * Simulation charts and summaries now appear consistently only when pricing data is available, including for unlinked rewards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->