### PR TITLE
Simulate the channel-points ramp as a real cooldown sawtooth

### DIFF
--- a/src/twitch/pricing/rewardPricingSimulation.test.ts
+++ b/src/twitch/pricing/rewardPricingSimulation.test.ts
@@ -30,12 +30,30 @@ describe('simulateConstantUsageCycle', () => {
     expect(result.peakDemand).toBe(1);
   });
 
-  it('ramp phase is monotonically non-decreasing up to the peak', () => {
+  it('ramp phase saw-tooths: demand dips between redemptions instead of rising smoothly', () => {
+    // The old continuous approximation was monotonically non-decreasing throughout the ramp;
+    // a real cooldown-gated ramp should dip (decay) at least once before the next redemption.
     const result = simulateConstantUsageCycle(config);
     const ramp = result.points.filter((p) => p.t <= result.peakAtMs);
-    for (let i = 1; i < ramp.length; i++) {
-      expect(ramp[i].cost).toBeGreaterThanOrEqual(ramp[i - 1].cost);
+    const hasDip = ramp.some((p, i) => i > 0 && p.cost < ramp[i - 1].cost);
+    expect(hasDip).toBe(true);
+  });
+
+  it("ramp phase's redemption jumps (tooth peaks) rise monotonically toward the overall peak", () => {
+    const result = simulateConstantUsageCycle(config);
+    const ramp = result.points.filter((p) => p.t <= result.peakAtMs);
+    const jumps = ramp.filter((p, i) => i === 0 || p.cost >= ramp[i - 1].cost);
+    for (let i = 1; i < jumps.length; i++) {
+      expect(jumps[i].cost).toBeGreaterThanOrEqual(jumps[i - 1].cost);
     }
+  });
+
+  it('holds a point exactly at each rendered redemption time with the closed-form demand applied', () => {
+    // First tooth (k=0): demand = increment (no decay yet), reached instantly at t=0.
+    const result = simulateConstantUsageCycle(config);
+    const increment = config.cooldownSeconds / (config.timeToMaxMultiplier * config.halfLifeSeconds);
+    const firstTooth = result.points.find((p) => p.t === 0 && p.cost > config.baseCost);
+    expect(firstTooth?.cost).toBe(computePrice(increment, config));
   });
 
   it('cooldown phase is monotonically non-increasing back down toward baseline', () => {
@@ -71,5 +89,13 @@ describe('simulateConstantUsageCycle', () => {
     const result = simulateConstantUsageCycle({ ...config, halfLifeSeconds: 1, cooldownSeconds: 1 });
     expect(Date.now() - start).toBeLessThan(1000);
     expect(result.points.length).toBeGreaterThan(0);
+  });
+
+  it('stays fast and bounds the point count for a cooldown far shorter than the half-life', () => {
+    // Would need ~1.9M redemptions to converge without the MAX_REDEMPTIONS cap.
+    const start = Date.now();
+    const result = simulateConstantUsageCycle({ ...config, cooldownSeconds: 1, halfLifeSeconds: 86_400 });
+    expect(Date.now() - start).toBeLessThan(1000);
+    expect(result.points.length).toBeLessThan(500);
   });
 });

--- a/src/twitch/pricing/rewardPricingSimulation.test.ts
+++ b/src/twitch/pricing/rewardPricingSimulation.test.ts
@@ -42,7 +42,17 @@ describe('simulateConstantUsageCycle', () => {
   it("ramp phase's redemption jumps (tooth peaks) rise monotonically toward the overall peak", () => {
     const result = simulateConstantUsageCycle(config);
     const ramp = result.points.filter((p) => p.t <= result.peakAtMs);
-    const jumps = ramp.filter((p, i) => i === 0 || p.cost >= ramp[i - 1].cost);
+    // Identify tooth peaks structurally (the final peak, or a point immediately followed by its
+    // own decay-to-next-redemption point) rather than by comparing costs — a cost-comparison
+    // filter would silently exclude a regressed (decreasing) jump instead of catching it.
+    const cooldownMs = config.cooldownSeconds * 1000;
+    const jumps = ramp.filter((p, i) => {
+      const next = ramp[i + 1];
+      const isFinalPeak = p.t === result.peakAtMs;
+      const isJumpFollowedByDecay = next !== undefined && next.t === p.t + cooldownMs && next.cost <= p.cost;
+      return p.cost > config.baseCost && (isFinalPeak || isJumpFollowedByDecay);
+    });
+    expect(jumps.length).toBeGreaterThan(1);
     for (let i = 1; i < jumps.length; i++) {
       expect(jumps[i].cost).toBeGreaterThanOrEqual(jumps[i - 1].cost);
     }

--- a/src/twitch/pricing/rewardPricingSimulation.ts
+++ b/src/twitch/pricing/rewardPricingSimulation.ts
@@ -29,21 +29,37 @@ export interface SimulationResult {
  * chart read as symmetric "close enough to done" thresholds.
  */
 const CONVERGENCE_RATIO = 0.01;
-/** Points sampled across each phase's continuous curve. */
+/** Points sampled across the cooldown phase's continuous decay curve. */
 const SAMPLE_COUNT = 40;
+/**
+ * Hard ceiling on how many real cooldown-spaced redemptions the ramp is allowed to need before
+ * it's considered "converged". Guards against a pathological config (a cooldown far shorter than
+ * the half-life) blowing the ramp's time axis out to unreasonable real-world durations.
+ */
+const MAX_REDEMPTIONS = 5000;
+/**
+ * Max number of real redemptions ("teeth") actually drawn in the ramp phase. When there are more
+ * real redemptions than this before convergence, they're subsampled evenly across the ramp so the
+ * rendered sawtooth stays legible and the point count stays bounded — the last rendered tooth is
+ * always the true peak.
+ */
+const MAX_RENDERED_TEETH = 50;
 
 /**
  * Simulates a reward's demand/price over one full cycle: constant redemptions at the reward's
  * own cooldown rate (i.e. redeeming the instant it's available, forever) ramping demand up from
  * 0, followed by a cooldown phase with no further redemptions decaying demand back down to ~0.
  *
- * The ramp phase does not necessarily reach 100% demand. Redeeming every `cooldownSeconds` with
- * decay in between follows the recurrence `d' = decay(d) + increment`, whose steady state is
- * `increment / (1 - decayPerCooldown)` — the continuous-time relaxation of that same recurrence is
- * `demand(t) = steadyState * (1 - 2^(-t/halfLife))`, which is what this function samples. That
- * only approaches (or, if the steady state is >= 1, actually reaches and clamps at) 100% demand;
- * for gentler configs it asymptotes below 100%. This function reports whatever the real ramp
- * peak is via `peakDemand` rather than assuming it always hits 100%.
+ * The ramp phase does not necessarily reach 100% demand, and it isn't smooth: real redemptions
+ * only ever land on cooldown-spaced instants, so demand jumps up at each one and decays
+ * continuously until the next — the recurrence `d_k = decay(d_{k-1}) + increment`, `d_{-1} = 0`.
+ * That recurrence has the closed form `demandAfterRedemption(k) = steadyState * (1 -
+ * decayPerCooldown^(k+1))`, where `steadyState = increment / (1 - decayPerCooldown)` is its fixed
+ * point — this function samples that exact discrete trajectory (jump, then decay, repeat) rather
+ * than smoothing over the cooldown-shaped teeth. The ramp only approaches (or, if the steady
+ * state is >= 1, actually reaches and clamps at) 100% demand; for gentler configs it asymptotes
+ * below 100%. This function reports whatever the real ramp peak is via `peakDemand` rather than
+ * assuming it always hits 100%.
  *
  * @param config - The reward's pricing config plus its cooldown and the streamer's half-life/time-to-max settings.
  * @returns The simulated points plus the demand/timing at the ramp-to-cooldown transition.
@@ -54,26 +70,44 @@ export function simulateConstantUsageCycle(config: SimulationConfig): Simulation
   const decayPerCooldown = decayDemand(1, cooldownSeconds, halfLifeSeconds);
   const steadyStateDemand = redemptionIncrement / (1 - decayPerCooldown);
 
-  // Continuous-time closed form for the ramp recurrence: demand(t) = steadyState * (1 - 2^(-t/halfLife)).
-  const rampDemandAt = (tSeconds: number) => Math.min(1, steadyStateDemand * (1 - decayDemand(1, tSeconds, halfLifeSeconds)));
+  // Closed form for the ramp recurrence (see module docs): demand right after the (k+1)-th
+  // redemption (0-indexed) is steadyState * (1 - decayPerCooldown^(k+1)).
+  const demandAfterRedemption = (k: number) => Math.min(1, steadyStateDemand * (1 - Math.pow(decayPerCooldown, k + 1)));
 
-  // How long to draw the ramp for: the exact time it crosses 100% if the config drives it there,
-  // otherwise the time it gets within CONVERGENCE_RATIO of its (sub-100%) asymptote.
-  const rampDurationSeconds = steadyStateDemand > 1
-    ? halfLifeSeconds * Math.log2(1 / (1 - 1 / steadyStateDemand))
-    : halfLifeSeconds * Math.log2(1 / CONVERGENCE_RATIO);
+  // How many redemptions the ramp needs: the exact count that clamps demand at 100% if the
+  // config drives it there, otherwise the count that gets within CONVERGENCE_RATIO of the
+  // (sub-100%) steady state.
+  const rawRedemptionsNeeded = steadyStateDemand > 1
+    ? Math.log(1 - 1 / steadyStateDemand) / Math.log(decayPerCooldown)
+    : Math.log(CONVERGENCE_RATIO) / Math.log(decayPerCooldown);
+  const redemptionCount = Math.min(MAX_REDEMPTIONS, Math.max(1, Math.ceil(rawRedemptionsNeeded)));
+
+  const peakAtMs = (redemptionCount - 1) * cooldownSeconds * 1000;
+  const peakDemand = demandAfterRedemption(redemptionCount - 1);
+  const peakCost = computePrice(peakDemand, config);
 
   const points: PriceHistoryPoint[] = [];
   const pushPoint = (tMs: number, demand: number) => points.push({ t: tMs, cost: computePrice(demand, config) });
 
-  for (let i = 0; i <= SAMPLE_COUNT; i++) {
-    const tSeconds = (rampDurationSeconds * i) / SAMPLE_COUNT;
-    pushPoint(tSeconds * 1000, rampDemandAt(tSeconds));
-  }
+  // Baseline before the very first redemption fires — skipped when the peak is already reached
+  // at t=0 (first redemption immediately clamps demand), so it doesn't collide with the peak point.
+  if (peakAtMs > 0) pushPoint(0, 0);
 
-  const peakAtMs = rampDurationSeconds * 1000;
-  const peakDemand = rampDemandAt(rampDurationSeconds);
-  const peakCost = computePrice(peakDemand, config);
+  const teethToRender = Math.min(redemptionCount, MAX_RENDERED_TEETH);
+  for (let i = 0; i < teethToRender; i++) {
+    const k = teethToRender === 1 ? redemptionCount - 1 : Math.round((i * (redemptionCount - 1)) / (teethToRender - 1));
+    const redemptionAtMs = k * cooldownSeconds * 1000;
+    const jumpDemand = demandAfterRedemption(k);
+    pushPoint(redemptionAtMs, jumpDemand);
+
+    if (k < redemptionCount - 1) {
+      // Decay from this redemption until just before the next one. Nudged 1ms earlier when that
+      // would otherwise land exactly on peakAtMs (the tooth immediately before the final one),
+      // so it doesn't get swept into the cooldown phase's "monotonically decreasing" points.
+      const decayAtMs = redemptionAtMs + cooldownSeconds * 1000;
+      pushPoint(decayAtMs === peakAtMs ? decayAtMs - 1 : decayAtMs, decayDemand(jumpDemand, cooldownSeconds, halfLifeSeconds));
+    }
+  }
 
   if (peakDemand > CONVERGENCE_RATIO) {
     const cooldownDurationSeconds = halfLifeSeconds * Math.log2(1 / CONVERGENCE_RATIO);


### PR DESCRIPTION
## Summary

- The channel-points pricing simulation chart's ramp phase previously drew a smoothed continuous-time approximation of the redemption recurrence (`steadyState * (1 - 2^(-t/halfLife))`), which visually hid that redemptions only happen at real cooldown-spaced instants, with demand decaying continuously in between.
- `simulateConstantUsageCycle` now samples the recurrence's exact closed form per redemption (`demandAfterRedemption(k) = steadyState * (1 - decayPerCooldown^(k+1))`), so the ramp is drawn as a real sawtooth: a jump at each cooldown-spaced redemption, then a decay down to just before the next one — exactly the "wait for cooldown, decay in between" behavior the live pricing engine (`applyRedemption`) already implements.
- When a config would need more redemptions than fit legibly on the chart, teeth are subsampled evenly across the ramp (capped at 50 rendered teeth, capped at 5000 redemptions considered for convergence) so the chart stays legible and fast regardless of how short the cooldown is relative to the half-life.
- The cooldown-phase (post-peak decay, no more redemptions) curve is unchanged — it was already an accurate continuous decay since no cooldown gating applies there.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 2166 tests)
- [x] Manually verified simulated points for the default-ish config now show real decay dips between rendered redemptions (e.g. cost dropping from 218 → 217 between two cooldown-spaced points) instead of monotonically rising
- [x] Added/updated Vitest coverage: sawtooth dip is present in the ramp, tooth peaks still rise monotonically toward the overall peak, first tooth's demand matches the closed-form value, and a stress case (cooldown far shorter than half-life) stays fast and bounded in point count


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xb9SwnA1nAnsjdvL9DaFSF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pricing simulation so ramp behavior now reflects discrete cooldown-driven “tooth” steps instead of a smooth monotonic rise.
  * Fixed peak and intermediate pricing checks so simulated values better match expected redemption timing.
  * Reduced excessive point generation in fast-cooldown scenarios, keeping simulations responsive and capped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->