### PR TITLE
test: add ts-node dev-toolchain smoke test

### DIFF
--- a/src/shared/tsNodeDevToolchain.test.ts
+++ b/src/shared/tsNodeDevToolchain.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
+import path from 'path';
+
+// tsc (used by `npm run build`) and Vitest (its own esbuild transform) never
+// exercise ts-node, so a TypeScript bump can break `npm run dev` while CI
+// stays green — as happened with TypeScript 7, which doesn't yet expose the
+// `ts.sys`-shaped API ts-node's registration step reads. This spawns a fresh
+// Node process that registers ts-node exactly as the `dev` script does and
+// requires a real project module, so that breakage shows up as a failing test.
+describe('ts-node dev toolchain', () => {
+  it('registers and transpiles a real project module without throwing', () => {
+    const projectRoot = path.resolve(__dirname, '..', '..');
+    const fixture = path.join(__dirname, 'pathUtils.ts');
+    const script = `
+      require('ts-node').register();
+      const { safeResolve } = require(${JSON.stringify(fixture)});
+      const result = safeResolve('/srv/files', 'audio.mp3');
+      if (result !== '/srv/files/audio.mp3') {
+        console.error('unexpected result: ' + result);
+        process.exit(1);
+      }
+    `;
+
+    try {
+      execFileSync(process.execPath, ['-e', script], { cwd: projectRoot, stdio: 'pipe' });
+    } catch (err) {
+      const e = err as { stderr?: Buffer; message: string };
+      throw new Error(
+        `ts-node failed to register/transpile a project module — this breaks \`npm run dev\`:\n${e.stderr?.toString() ?? e.message}`
+      );
+    }
+  }, 15000);
+});

--- a/src/shared/tsNodeDevToolchain.test.ts
+++ b/src/shared/tsNodeDevToolchain.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it } from 'vitest';
 import { execFileSync } from 'child_process';
 import path from 'path';
 


### PR DESCRIPTION
## Summary

- While reviewing the dependabot TypeScript 7 upgrade (#366), CI stayed green even though `npm run dev` is completely broken on TS7 — `tsc` (build) and Vitest (own esbuild transform) never touch `ts-node`, which the `dev` script relies on.
- Confirmed locally: `ts-node`'s registration step reads `ts.sys`, which TypeScript 7's not-yet-stable programmatic API doesn't populate, so it throws before ever reaching project code.
- Adds `src/shared/tsNodeDevToolchain.test.ts`, which spawns a fresh Node process that registers `ts-node` exactly as the `dev` script does and requires a real project module (`pathUtils.ts`). This rides along the existing `npm test` step in CI (`ci.yml` already runs it on every push/PR across both OS matrices), so no workflow changes were needed — a future toolchain-breaking bump will now show up as a failing test instead of a silent gap.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 2164 tests)
- [x] Verified the new test passes against current `typescript@6.0.3` on `main`
- [x] Verified the new test fails with the actual `ts.sys` crash when run against the `dependabot/npm_and_yarn/typescript-7.0.2` branch (checked out in a separate worktree, not part of this PR's diff)


---
_Generated by [Claude Code](https://claude.ai/code/session_011WP53FF7Vtg6YY1FnhJQ6e)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for the TypeScript development toolchain.
  * Verifies a real module can be loaded in a spawned Node process and resolves file paths correctly.
  * Improves error reporting so local development failures are easier to diagnose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->