### PR TITLE
Add optional round-to-nearest-5/10 setting for dynamic channel point pricing

### DIFF
--- a/DATABASE-SCHEMA.md
+++ b/DATABASE-SCHEMA.md
@@ -204,12 +204,13 @@ Dynamic Channel Point Pricing: per-reward config and demand state. Independent o
 | `cooldown_seconds` | `INT` | Mirrors the reward's own Twitch global cooldown (or a fallback default when it has none) — kept in sync automatically, not directly editable |
 | `max_multiplier` | `DECIMAL(6,3)` | Max price = `base_cost * (1 + max_multiplier)` |
 | `curve` | `DECIMAL(5,3)` | Exponent controlling how aggressively price rises with demand |
+| `round_to_nearest` | `INT` | Rounds the computed price to the nearest multiple of this many points (`0`, `5`, or `10`); `0` disables rounding |
 | `demand` | `DECIMAL(9,6)` | Current demand, in `[0,1]` |
 | `demand_updated_at` | `BIGINT` | Epoch ms the `demand` value was last computed as of |
 | `last_pushed_cost` | `INT` NULL | Last cost actually pushed to Twitch; used to skip redundant Helix calls |
 | `twitch_unsupported` | `TINYINT(1)` | Set (and `enabled` forced to 0) when Twitch returns 403 — the reward was created outside this app and can never be managed by it |
 
-Created by `migrations/reward_pricing.sql`.
+Created by `migrations/reward_pricing.sql`. `round_to_nearest` added by `migrations/reward_pricing_round_to_nearest.sql`.
 
 ## `reward_pricing_settings`
 

--- a/migrations/reward_pricing_round_to_nearest.sql
+++ b/migrations/reward_pricing_round_to_nearest.sql
@@ -1,0 +1,5 @@
+-- Adds an optional "round to nearest N points" step to dynamic pricing's computed price,
+-- per reward. 0 (the default) disables rounding, preserving existing behaviour.
+ALTER TABLE reward_pricing
+  ADD COLUMN round_to_nearest INT NOT NULL DEFAULT 0 AFTER curve,
+  ADD CONSTRAINT chk_reward_pricing_round_to_nearest CHECK (round_to_nearest IN (0, 5, 10));

--- a/schema.sql
+++ b/schema.sql
@@ -278,6 +278,9 @@ CREATE TABLE IF NOT EXISTS reward_pricing (
   cooldown_seconds  INT          NOT NULL DEFAULT 60,
   max_multiplier    DECIMAL(6,3) NOT NULL DEFAULT 1.000,
   curve             DECIMAL(5,3) NOT NULL DEFAULT 1.000,
+  -- Rounds the computed price to the nearest multiple of this many points (e.g. 5 or 10).
+  -- 0 (the default) disables rounding.
+  round_to_nearest  INT          NOT NULL DEFAULT 0,
   demand            DECIMAL(9,6) NOT NULL DEFAULT 0.000000,
   demand_updated_at BIGINT       NOT NULL,
   last_pushed_cost  INT          NULL,
@@ -291,7 +294,8 @@ CREATE TABLE IF NOT EXISTS reward_pricing (
   CONSTRAINT chk_reward_pricing_base_cost        CHECK (base_cost > 0),
   CONSTRAINT chk_reward_pricing_cooldown_seconds CHECK (cooldown_seconds > 0),
   CONSTRAINT chk_reward_pricing_max_multiplier   CHECK (max_multiplier >= 0),
-  CONSTRAINT chk_reward_pricing_curve            CHECK (curve > 0)
+  CONSTRAINT chk_reward_pricing_curve            CHECK (curve > 0),
+  CONSTRAINT chk_reward_pricing_round_to_nearest CHECK (round_to_nearest IN (0, 5, 10))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ---------------------------------------------------------------------------

--- a/src/db/rewardPricing.test.ts
+++ b/src/db/rewardPricing.test.ts
@@ -37,6 +37,7 @@ const sampleRow = {
   cooldown_seconds: 300,
   max_multiplier: '4.000',
   curve: '1.500',
+  round_to_nearest: 0,
   demand: '0.500000',
   demand_updated_at: '1700000000000',
   last_pushed_cost: 400,
@@ -61,6 +62,7 @@ describe('getPricingForReward', () => {
       cooldown_seconds: 300,
       max_multiplier: 4,
       curve: 1.5,
+      round_to_nearest: 0,
       demand: 0.5,
       demand_updated_at: '1700000000000',
       last_pushed_cost: 400,
@@ -125,7 +127,7 @@ describe('upsertPricingConfig', () => {
   it('uses the row-alias ON DUPLICATE KEY UPDATE form', async () => {
     const pool = makePool();
     vi.mocked(getPool).mockReturnValue(pool as any);
-    await upsertPricingConfig(7, 'rwd-abc', { enabled: true, base_cost: 200, cooldown_seconds: 300, max_multiplier: 4, curve: 1.5 });
+    await upsertPricingConfig(7, 'rwd-abc', { enabled: true, base_cost: 200, cooldown_seconds: 300, max_multiplier: 4, curve: 1.5, round_to_nearest: 0 });
     const sql: string = pool.execute.mock.calls[0][0];
     expect(sql).toContain('AS new_row');
     expect(sql).toContain('ON DUPLICATE KEY UPDATE');
@@ -134,7 +136,7 @@ describe('upsertPricingConfig', () => {
   it('does not touch demand, demand_updated_at, or last_pushed_cost in the SET list', async () => {
     const pool = makePool();
     vi.mocked(getPool).mockReturnValue(pool as any);
-    await upsertPricingConfig(7, 'rwd-abc', { enabled: true, base_cost: 200, cooldown_seconds: 300, max_multiplier: 4, curve: 1.5 });
+    await upsertPricingConfig(7, 'rwd-abc', { enabled: true, base_cost: 200, cooldown_seconds: 300, max_multiplier: 4, curve: 1.5, round_to_nearest: 0 });
     const sql: string = pool.execute.mock.calls[0][0];
     const setClause = sql.split('ON DUPLICATE KEY UPDATE')[1];
     expect(setClause).not.toContain('demand=');
@@ -145,16 +147,26 @@ describe('upsertPricingConfig', () => {
   it('clears twitch_unsupported in the SET list, so an explicit save gives the reward another attempt', async () => {
     const pool = makePool();
     vi.mocked(getPool).mockReturnValue(pool as any);
-    await upsertPricingConfig(7, 'rwd-abc', { enabled: true, base_cost: 200, cooldown_seconds: 300, max_multiplier: 4, curve: 1.5 });
+    await upsertPricingConfig(7, 'rwd-abc', { enabled: true, base_cost: 200, cooldown_seconds: 300, max_multiplier: 4, curve: 1.5, round_to_nearest: 0 });
     const sql: string = pool.execute.mock.calls[0][0];
     const setClause = sql.split('ON DUPLICATE KEY UPDATE')[1];
     expect(setClause).toContain('twitch_unsupported=0');
   });
 
+  it('includes round_to_nearest in both the column list and the SET list', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await upsertPricingConfig(7, 'rwd-abc', { enabled: true, base_cost: 200, cooldown_seconds: 300, max_multiplier: 4, curve: 1.5, round_to_nearest: 5 });
+    const sql: string = pool.execute.mock.calls[0][0];
+    expect(sql).toContain('round_to_nearest');
+    const setClause = sql.split('ON DUPLICATE KEY UPDATE')[1];
+    expect(setClause).toContain('round_to_nearest=new_row.round_to_nearest');
+  });
+
   it('passes converted enabled boolean and config fields', async () => {
     const pool = makePool();
     vi.mocked(getPool).mockReturnValue(pool as any);
-    await upsertPricingConfig(7, 'rwd-abc', { enabled: false, base_cost: 100, cooldown_seconds: 60, max_multiplier: 2, curve: 1 });
+    await upsertPricingConfig(7, 'rwd-abc', { enabled: false, base_cost: 100, cooldown_seconds: 60, max_multiplier: 2, curve: 1, round_to_nearest: 10 });
     const params: unknown[] = pool.execute.mock.calls[0][1];
     expect(params[0]).toBe(7);
     expect(params[1]).toBe('rwd-abc');
@@ -163,6 +175,7 @@ describe('upsertPricingConfig', () => {
     expect(params[4]).toBe(60);
     expect(params[5]).toBe(2);
     expect(params[6]).toBe(1);
+    expect(params[7]).toBe(10);
   });
 });
 

--- a/src/db/rewardPricing.ts
+++ b/src/db/rewardPricing.ts
@@ -12,6 +12,8 @@ export interface RewardPricingRow {
   cooldown_seconds: number;
   max_multiplier: number;
   curve: number;
+  /** Rounds the computed price to the nearest multiple of this many points (e.g. 5 or 10). 0 disables rounding. */
+  round_to_nearest: number;
   demand: number;
   /** Epoch ms as a string — BIGINT column; never coerce with Number() at this layer. */
   demand_updated_at: string;
@@ -27,6 +29,8 @@ export interface RewardPricingInput {
   cooldown_seconds: number;
   max_multiplier: number;
   curve: number;
+  /** Rounds the computed price to the nearest multiple of this many points (e.g. 5 or 10). 0 disables rounding. */
+  round_to_nearest: number;
 }
 
 /** Per-streamer settings shared by every one of their rewards' demand calculations. */
@@ -55,6 +59,7 @@ function mapRow(r: mysql.RowDataPacket): RewardPricingRow {
     cooldown_seconds: r.cooldown_seconds,
     max_multiplier: Number(r.max_multiplier),
     curve: Number(r.curve),
+    round_to_nearest: r.round_to_nearest,
     demand: Number(r.demand),
     demand_updated_at: String(r.demand_updated_at),
     last_pushed_cost: r.last_pushed_cost == null ? null : Number(r.last_pushed_cost),
@@ -64,7 +69,7 @@ function mapRow(r: mysql.RowDataPacket): RewardPricingRow {
 
 const REWARD_PRICING_SELECT = `
   id, streamer_id, twitch_reward_id, enabled, base_cost, cooldown_seconds,
-  max_multiplier, curve, demand, demand_updated_at, last_pushed_cost, twitch_unsupported`;
+  max_multiplier, curve, round_to_nearest, demand, demand_updated_at, last_pushed_cost, twitch_unsupported`;
 
 /**
  * Look up a single reward's pricing config/demand row, or null if not configured.
@@ -121,9 +126,9 @@ export async function getAllEnabledPricingRows(): Promise<RewardPricingRow[]> {
 
 /**
  * Create or update a reward's pricing config. Only touches the config columns
- * (enabled/base_cost/cooldown_seconds/max_multiplier/curve) — demand, demand_updated_at,
- * and last_pushed_cost are left untouched on an update so editing config never resets
- * in-flight demand state. New rows start at demand=0 with demand_updated_at=now.
+ * (enabled/base_cost/cooldown_seconds/max_multiplier/curve/round_to_nearest) — demand,
+ * demand_updated_at, and last_pushed_cost are left untouched on an update so editing config
+ * never resets in-flight demand state. New rows start at demand=0 with demand_updated_at=now.
  * Always clears `twitch_unsupported`, since an explicit save is the streamer opting back
  * in and deserves another attempt (e.g. after recreating the reward via the bot).
  *
@@ -138,15 +143,16 @@ export async function upsertPricingConfig(
 ): Promise<void> {
   await getPool().execute(
     `INSERT INTO reward_pricing
-       (streamer_id, twitch_reward_id, enabled, base_cost, cooldown_seconds, max_multiplier, curve, demand_updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?) AS new_row
+       (streamer_id, twitch_reward_id, enabled, base_cost, cooldown_seconds, max_multiplier, curve, round_to_nearest, demand_updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) AS new_row
      ON DUPLICATE KEY UPDATE
        enabled=new_row.enabled, base_cost=new_row.base_cost, cooldown_seconds=new_row.cooldown_seconds,
-       max_multiplier=new_row.max_multiplier, curve=new_row.curve, twitch_unsupported=0`,
+       max_multiplier=new_row.max_multiplier, curve=new_row.curve, round_to_nearest=new_row.round_to_nearest,
+       twitch_unsupported=0`,
     [
       streamerId, twitchRewardId,
       input.enabled ? 1 : 0, input.base_cost, input.cooldown_seconds, input.max_multiplier, input.curve,
-      Date.now(),
+      input.round_to_nearest, Date.now(),
     ],
   );
 }

--- a/src/twitch/pricing/rewardPricingMath.test.ts
+++ b/src/twitch/pricing/rewardPricingMath.test.ts
@@ -47,6 +47,16 @@ describe('computePrice', () => {
     expect(computePrice(0.5, { ...config, roundToNearest: -5 })).toBe(computePrice(0.5, config));
   });
 
+  it('clamps a rounded price back up to baseCost when rounding would push it below the minimum', () => {
+    // baseCost=1, raw=1 -> round(1/5)*5 = round(0.2)*5 = 0, which is below baseCost and clamped back up.
+    expect(computePrice(0, { baseCost: 1, maxMultiplier: 1, curve: 1, roundToNearest: 5 })).toBe(1);
+  });
+
+  it('clamps a rounded price back down to the max when rounding would push it above the max', () => {
+    // baseCost=100, maxMultiplier=0.53 -> max=153, raw=153 -> round(153/5)*5 = round(30.6)*5 = 155, clamped to 153.
+    expect(computePrice(1, { baseCost: 100, maxMultiplier: 0.53, curve: 1, roundToNearest: 5 })).toBe(153);
+  });
+
   it('is unaffected by a missing roundToNearest', () => {
     expect(computePrice(0.5, config)).toBe(483);
   });

--- a/src/twitch/pricing/rewardPricingMath.test.ts
+++ b/src/twitch/pricing/rewardPricingMath.test.ts
@@ -31,6 +31,25 @@ describe('computePrice', () => {
   it('clamps demand below 0 before computing', () => {
     expect(computePrice(-5, config)).toBe(computePrice(0, config));
   });
+
+  it('rounds to the nearest multiple of roundToNearest when set', () => {
+    // usage=0.5, curve=1.5 -> raw = 200 * 2.414214 = 482.8427 -> nearest 10 = 480
+    expect(computePrice(0.5, { ...config, roundToNearest: 10 })).toBe(480);
+    // nearest 5 = 485
+    expect(computePrice(0.5, { ...config, roundToNearest: 5 })).toBe(485);
+  });
+
+  it('is unaffected by roundToNearest when it is 0', () => {
+    expect(computePrice(0.5, { ...config, roundToNearest: 0 })).toBe(computePrice(0.5, config));
+  });
+
+  it('is unaffected by roundToNearest when it is negative', () => {
+    expect(computePrice(0.5, { ...config, roundToNearest: -5 })).toBe(computePrice(0.5, config));
+  });
+
+  it('is unaffected by a missing roundToNearest', () => {
+    expect(computePrice(0.5, config)).toBe(483);
+  });
 });
 
 describe('decayDemand', () => {

--- a/src/twitch/pricing/rewardPricingMath.ts
+++ b/src/twitch/pricing/rewardPricingMath.ts
@@ -10,19 +10,22 @@ export interface RewardPricingConfig {
 /**
  * Computes the current redemption price from demand and a reward's pricing config.
  * price = round(baseCost * (1 + clamp(demand,0,1)^curve * maxMultiplier)), then, if
- * `config.roundToNearest` is set, rounded again to the nearest multiple of it.
+ * `config.roundToNearest` is set, rounded again to the nearest multiple of it and clamped
+ * back into range — rounding to a coarse step can otherwise push the price below `baseCost`
+ * (even to a Twitch-invalid 0) or above the max.
  *
  * @param demand - Current demand value; clamped to [0,1] before use.
  * @param config - The reward's pricing configuration.
- * @returns The rounded price, bounded to [baseCost, baseCost*(1+maxMultiplier)] before any
- *   `roundToNearest` step is applied.
+ * @returns The price, always bounded to [baseCost, baseCost*(1+maxMultiplier)].
  */
 export function computePrice(demand: number, config: RewardPricingConfig): number {
   const usage = Math.min(1, Math.max(0, demand));
   const curved = Math.pow(usage, config.curve);
   const raw = config.baseCost * (1 + curved * config.maxMultiplier);
   if (config.roundToNearest && config.roundToNearest > 0) {
-    return Math.round(raw / config.roundToNearest) * config.roundToNearest;
+    const max = config.baseCost * (1 + config.maxMultiplier);
+    const rounded = Math.round(raw / config.roundToNearest) * config.roundToNearest;
+    return Math.max(config.baseCost, Math.min(max, rounded));
   }
   return Math.round(raw);
 }

--- a/src/twitch/pricing/rewardPricingMath.ts
+++ b/src/twitch/pricing/rewardPricingMath.ts
@@ -3,20 +3,28 @@ export interface RewardPricingConfig {
   baseCost: number;
   maxMultiplier: number;
   curve: number;
+  /** Rounds the computed price to the nearest multiple of this many points (e.g. 5 or 10). Omit, 0, or a non-positive value disables rounding. */
+  roundToNearest?: number;
 }
 
 /**
  * Computes the current redemption price from demand and a reward's pricing config.
- * price = round(baseCost * (1 + clamp(demand,0,1)^curve * maxMultiplier)).
+ * price = round(baseCost * (1 + clamp(demand,0,1)^curve * maxMultiplier)), then, if
+ * `config.roundToNearest` is set, rounded again to the nearest multiple of it.
  *
  * @param demand - Current demand value; clamped to [0,1] before use.
  * @param config - The reward's pricing configuration.
- * @returns The rounded price, bounded to [baseCost, baseCost*(1+maxMultiplier)].
+ * @returns The rounded price, bounded to [baseCost, baseCost*(1+maxMultiplier)] before any
+ *   `roundToNearest` step is applied.
  */
 export function computePrice(demand: number, config: RewardPricingConfig): number {
   const usage = Math.min(1, Math.max(0, demand));
   const curved = Math.pow(usage, config.curve);
-  return Math.round(config.baseCost * (1 + curved * config.maxMultiplier));
+  const raw = config.baseCost * (1 + curved * config.maxMultiplier);
+  if (config.roundToNearest && config.roundToNearest > 0) {
+    return Math.round(raw / config.roundToNearest) * config.roundToNearest;
+  }
+  return Math.round(raw);
 }
 
 /**

--- a/src/twitch/pricing/rewardPricingService.test.ts
+++ b/src/twitch/pricing/rewardPricingService.test.ts
@@ -45,6 +45,7 @@ function makeRow(overrides: Partial<Record<string, unknown>> = {}) {
     cooldown_seconds: 300,
     max_multiplier: 4,
     curve: 1.5,
+    round_to_nearest: 0,
     demand: 0,
     demand_updated_at: String(Date.now()),
     last_pushed_cost: null,
@@ -198,6 +199,31 @@ describe('applyDecayTick', () => {
     const [, , demandArg] = vi.mocked(recordPricingUpdate).mock.calls[0];
     // decay(0.5, ~300s elapsed, half_life=1800s) = 0.5 * 2^(-300/1800)
     expect(demandArg).toBeCloseTo(0.5 * Math.pow(2, -300 / 1800), 2);
+  });
+});
+
+describe('round_to_nearest', () => {
+  it('pushes the price rounded to the configured step, not the raw computed price', async () => {
+    // decay-only tick (no redemption increment) with elapsed~0 keeps demand pinned at exactly 0.5.
+    vi.mocked(getPricingForReward).mockResolvedValue(makeRow({
+      demand: 0.5, demand_updated_at: String(Date.now()), last_pushed_cost: null, round_to_nearest: 10,
+    }));
+    await applyDecayTick(1, 'rwd1');
+    // raw price at demand=0.5 (base_cost=200, max_multiplier=4, curve=1.5) is 482.84,
+    // which rounds to 480 at round_to_nearest=10 (see rewardPricingMath.test.ts).
+    expect(updateRewardCost).toHaveBeenCalledWith('bc1', 'rwd1', 480, 'user-token');
+    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), 480);
+  });
+
+  it('skips the Twitch push (but still persists demand) when the rounded price matches last_pushed_cost, even though the underlying demand has changed', async () => {
+    // demand=0.5 (raw 482.84) and demand=0.55 (raw 526.32) both round to 500 at
+    // round_to_nearest=100 — the update should only fire once the *rounded* price moves.
+    vi.mocked(getPricingForReward).mockResolvedValue(makeRow({
+      demand: 0.55, demand_updated_at: String(Date.now()), last_pushed_cost: 500, round_to_nearest: 100,
+    }));
+    await applyDecayTick(1, 'rwd1');
+    expect(updateRewardCost).not.toHaveBeenCalled();
+    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), 500);
   });
 });
 

--- a/src/twitch/pricing/rewardPricingService.ts
+++ b/src/twitch/pricing/rewardPricingService.ts
@@ -106,7 +106,10 @@ async function pushRewardCostUpdate(
 
 /**
  * Recomputes demand and price for one reward and persists the result, pushing the new
- * cost to Twitch only when it differs from the last pushed cost. No-ops entirely (no DB
+ * cost to Twitch only when it differs from the last pushed cost — since `newCost` is
+ * already rounded to `row.round_to_nearest` (see `computePrice`), this comparison (and
+ * therefore the Twitch push) naturally only fires when the *rounded* price changes, not
+ * on every sub-step fluctuation in demand. No-ops entirely (no DB
  * write, no Twitch call) when the reward has no pricing config or dynamic pricing is
  * disabled for it — this is where "optional per reward" is enforced. Demand is always
  * persisted, even when the Twitch push fails, so the price is simply retried on the next
@@ -139,6 +142,7 @@ async function syncRewardPrice(streamerId: number, twitchRewardId: string, apply
     baseCost: row.base_cost,
     maxMultiplier: row.max_multiplier,
     curve: row.curve,
+    roundToNearest: row.round_to_nearest,
   });
 
   let lastPushedCost = row.last_pushed_cost;

--- a/src/twitch/pricing/rewardPricingSimulation.test.ts
+++ b/src/twitch/pricing/rewardPricingSimulation.test.ts
@@ -94,6 +94,16 @@ describe('simulateConstantUsageCycle', () => {
     expect(result.peakCost).toBe(computePrice(result.peakDemand, config));
   });
 
+  it('rounds every plotted point and peakCost to roundToNearest when configured', () => {
+    const roundedConfig = { ...config, roundToNearest: 10 };
+    const result = simulateConstantUsageCycle(roundedConfig);
+    for (const point of result.points) {
+      expect(point.cost % 10).toBe(0);
+    }
+    expect(result.peakCost % 10).toBe(0);
+    expect(result.peakCost).toBe(computePrice(result.peakDemand, roundedConfig));
+  });
+
   it('does not loop unreasonably long for an extreme config (near-zero half-life)', () => {
     const start = Date.now();
     const result = simulateConstantUsageCycle({ ...config, halfLifeSeconds: 1, cooldownSeconds: 1 });

--- a/src/web/routes/channelPointsAdmin.test.ts
+++ b/src/web/routes/channelPointsAdmin.test.ts
@@ -112,6 +112,20 @@ describe('GET /', () => {
     expect(res.body.rewards[0].previewPrice).toBe(1000);
   });
 
+  it('rounds the preview price to round_to_nearest when configured on the pricing config', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(getCustomRewards).mockResolvedValue([{ id: 'rwd1', title: 'Cool Reward', cost: 200, is_enabled: true } as any]);
+    vi.mocked(getPricingConfigsForStreamer).mockResolvedValue([{
+      id: 1, streamer_id: 123, twitch_reward_id: 'rwd1', enabled: true,
+      base_cost: 200, cooldown_seconds: 300, max_multiplier: 4, curve: 1.5, round_to_nearest: 10,
+      demand: 0.5, demand_updated_at: '1700000000000', last_pushed_cost: 480, twitch_unsupported: false,
+    }] as any);
+
+    const res = await supertest(buildApp()).get('/');
+    // raw price at demand=0.5 with these params is 482.84, rounded to nearest 10 -> 480.
+    expect(res.body.rewards[0].previewPrice).toBe(480);
+  });
+
   it('renders with an empty reward list when getCustomRewards throws', async () => {
     vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
     vi.mocked(getCustomRewards).mockRejectedValue(new Error('Twitch down'));

--- a/src/web/routes/channelPointsAdmin.ts
+++ b/src/web/routes/channelPointsAdmin.ts
@@ -65,6 +65,7 @@ function buildSimulationChart(config: RewardPricingRow, settings: StreamerPricin
     baseCost: config.base_cost,
     maxMultiplier: config.max_multiplier,
     curve: config.curve,
+    roundToNearest: config.round_to_nearest,
     cooldownSeconds: config.cooldown_seconds,
     halfLifeSeconds: settings.half_life_seconds,
     timeToMaxMultiplier: settings.time_to_max_multiplier,
@@ -94,6 +95,7 @@ function previewPriceFor(config: RewardPricingRow): number {
     baseCost: config.base_cost,
     maxMultiplier: config.max_multiplier,
     curve: config.curve,
+    roundToNearest: config.round_to_nearest,
   });
 }
 

--- a/src/web/routes/channelPointsAdminPricingMutations.test.ts
+++ b/src/web/routes/channelPointsAdminPricingMutations.test.ts
@@ -114,9 +114,37 @@ describe('POST /rewards/:twitchRewardId/pricing', () => {
       .send({ enabled: 'on', base_cost: '200', max_multiplier: '4', curve: '1.5' });
     expect(res.headers.location).toBe('/channel-points?success=pricing_saved');
     expect(upsertPricingConfig).toHaveBeenCalledWith(MOCK_STREAMER.id, VALID_REWARD_ID, {
-      enabled: true, base_cost: 200, cooldown_seconds: 300, max_multiplier: 4, curve: 1.5,
+      enabled: true, base_cost: 200, cooldown_seconds: 300, max_multiplier: 4, curve: 1.5, round_to_nearest: 0,
     });
     expect(applyDecayTick).toHaveBeenCalledWith(MOCK_STREAMER.id, VALID_REWARD_ID);
+  });
+
+  it('defaults round_to_nearest to 0 (off) when not sent', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    await supertest(buildApp())
+      .post(`/rewards/${VALID_REWARD_ID}/pricing`)
+      .type('form')
+      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5' });
+    expect(upsertPricingConfig).toHaveBeenCalledWith(MOCK_STREAMER.id, VALID_REWARD_ID, expect.objectContaining({ round_to_nearest: 0 }));
+  });
+
+  it('saves a configured round_to_nearest value', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    await supertest(buildApp())
+      .post(`/rewards/${VALID_REWARD_ID}/pricing`)
+      .type('form')
+      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5', round_to_nearest: '10' });
+    expect(upsertPricingConfig).toHaveBeenCalledWith(MOCK_STREAMER.id, VALID_REWARD_ID, expect.objectContaining({ round_to_nearest: 10 }));
+  });
+
+  it('redirects with invalid_config when round_to_nearest is outside {0, 5, 10}', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp())
+      .post(`/rewards/${VALID_REWARD_ID}/pricing`)
+      .type('form')
+      .send({ base_cost: '200', max_multiplier: '4', curve: '1.5', round_to_nearest: '7' });
+    expect(res.headers.location).toBe('/channel-points?error=invalid_config');
+    expect(upsertPricingConfig).not.toHaveBeenCalled();
   });
 
   it('falls back to the existing pricing config cooldown when the reward is no longer found on Twitch', async () => {

--- a/src/web/routes/channelPointsAdminPricingMutations.ts
+++ b/src/web/routes/channelPointsAdminPricingMutations.ts
@@ -11,7 +11,7 @@ import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
 import { logAndRedirectError } from './shared';
 import {
   requireStreamer, parsePositiveIntField, parseNonNegativeNumberField, parsePositiveNumberField,
-  parseCheckboxField, parseRewardIdParam, effectiveCooldownSeconds, handleRewardDeleteAction,
+  parseCheckboxField, parseRoundToNearestField, parseRewardIdParam, effectiveCooldownSeconds, handleRewardDeleteAction,
 } from './channelPointsAdminShared';
 import { applyDecayTick, resetAndDeletePricing } from '../../twitch/pricing/rewardPricingService';
 
@@ -47,7 +47,7 @@ async function resolveCooldownSecondsForPricing(streamer: DbStreamerEventSub, tw
  * reward's live Twitch global cooldown (see {@link resolveCooldownSecondsForPricing}), so it
  * can never drift from the reward's actual Twitch-enforced cooldown.
  * @param req - Express request; reads the `twitchRewardId` route param and `enabled`,
- *   `base_cost`, `max_multiplier`, `curve` from `req.body`.
+ *   `base_cost`, `max_multiplier`, `curve`, `round_to_nearest` from `req.body`.
  * @param res - Express response; redirects to `/channel-points?success=pricing_saved` on success,
  *   or to `/channel-points?error=<code>` if the requester isn't a streamer (`not_a_streamer`),
  *   the reward ID isn't a valid UUID (`invalid_reward_id`), any config field is invalid
@@ -65,7 +65,8 @@ router.post('/rewards/:twitchRewardId/pricing', requireAuth, csrfProtection, asy
     const baseCost = parsePositiveIntField(body.base_cost);
     const maxMultiplier = parseNonNegativeNumberField(body.max_multiplier);
     const curve = parsePositiveNumberField(body.curve);
-    if (baseCost === null || maxMultiplier === null || curve === null) {
+    const roundToNearest = parseRoundToNearestField(body.round_to_nearest);
+    if (baseCost === null || maxMultiplier === null || curve === null || roundToNearest === null) {
       return res.redirect('/channel-points?error=invalid_config');
     }
 
@@ -74,6 +75,7 @@ router.post('/rewards/:twitchRewardId/pricing', requireAuth, csrfProtection, asy
 
     await upsertPricingConfig(streamer.id, twitchRewardId, {
       enabled, base_cost: baseCost, cooldown_seconds: cooldownSeconds, max_multiplier: maxMultiplier, curve,
+      round_to_nearest: roundToNearest,
     });
 
     // Best-effort immediate resync so the reward's Twitch-side cost reflects the new

--- a/src/web/routes/channelPointsAdminShared.test.ts
+++ b/src/web/routes/channelPointsAdminShared.test.ts
@@ -5,8 +5,8 @@ vi.mock('../../db', () => ({ getStreamerByDiscordId: vi.fn(), DEFAULT_PRICING_CO
 import { getStreamerByDiscordId } from '../../db';
 import {
   requireStreamer, parsePositiveIntField, parseNonNegativeNumberField, parsePositiveNumberField,
-  parseCheckboxField, parseHexColorField, parseRewardIdParam, parseRewardFields, effectiveCooldownSeconds,
-  handleRewardDeleteAction,
+  parseCheckboxField, parseHexColorField, parseRoundToNearestField, parseRewardIdParam, parseRewardFields,
+  effectiveCooldownSeconds, handleRewardDeleteAction,
 } from './channelPointsAdminShared';
 
 const VALID_REWARD_ID = '12345678-1234-1234-8234-123456789abc';
@@ -222,6 +222,40 @@ describe('parseHexColorField', () => {
 
   it('returns null for a hex string missing the leading #', () => {
     expect(parseHexColorField('00E5CB')).toBeNull();
+  });
+});
+
+describe('parseRoundToNearestField', () => {
+  it('accepts 0 (off)', () => {
+    expect(parseRoundToNearestField('0')).toBe(0);
+  });
+
+  it('accepts 5', () => {
+    expect(parseRoundToNearestField('5')).toBe(5);
+  });
+
+  it('accepts 10', () => {
+    expect(parseRoundToNearestField('10')).toBe(10);
+  });
+
+  it('defaults to 0 (off) when undefined, since the setting is optional', () => {
+    expect(parseRoundToNearestField(undefined)).toBe(0);
+  });
+
+  it('defaults to 0 (off) for a blank string', () => {
+    expect(parseRoundToNearestField('')).toBe(0);
+  });
+
+  it('rejects a value outside {0, 5, 10}', () => {
+    expect(parseRoundToNearestField('7')).toBeNull();
+  });
+
+  it('rejects non-numeric input', () => {
+    expect(parseRoundToNearestField('abc')).toBeNull();
+  });
+
+  it('rejects an array (repeated field)', () => {
+    expect(parseRoundToNearestField(['5', '10'])).toBeNull();
   });
 });
 

--- a/src/web/routes/channelPointsAdminShared.ts
+++ b/src/web/routes/channelPointsAdminShared.ts
@@ -102,6 +102,20 @@ export function parsePositiveNumberField(value: string | string[] | undefined): 
   return Number.isFinite(n) && n > 0 ? n : null;
 }
 
+const VALID_ROUND_TO_NEAREST = new Set([0, 5, 10]);
+
+/**
+ * Parses the optional "round to nearest" pricing field (0/5/10 points). Missing or blank
+ * input defaults to `0` (rounding off) rather than being rejected, since the setting is
+ * optional. An array (repeated field) or any value outside `{0, 5, 10}` is a validation error.
+ */
+export function parseRoundToNearestField(value: string | string[] | undefined): number | null {
+  if (Array.isArray(value)) return null;
+  if (typeof value !== 'string' || value.trim() === '') return 0;
+  const n = Number(value);
+  return VALID_ROUND_TO_NEAREST.has(n) ? n : null;
+}
+
 /**
  * The cooldown (seconds) dynamic pricing should use for a reward: its own Twitch global
  * cooldown when enabled, otherwise a fallback default — keeps pricing's `cooldown_seconds`

--- a/views/channelPointsAdmin.ejs
+++ b/views/channelPointsAdmin.ejs
@@ -20,7 +20,7 @@
         invalid_reward_fields: 'Please check the reward fields — title and cost are required, a prompt is required when viewer input is required, and any enabled limit needs a value.',
         create_failed:         'Failed to create the reward — please try again, or reconnect Twitch if this keeps happening.',
         update_failed:         'Failed to update the reward — Twitch only allows the app that created a reward to edit it.',
-        invalid_config:        'Base cost and curve must be positive numbers, and max multiplier must be zero or greater.',
+        invalid_config:        'Base cost and curve must be positive numbers, max multiplier must be zero or greater, and round to nearest must be Off, 5, or 10.',
         save_failed:           'Failed to save — please try again.',
         delete_failed:         'Delete failed — please try again.',
         invalid_settings:      'Half-life and time-to-max-demand multiplier must both be positive numbers.',
@@ -238,6 +238,15 @@
                   <label class="hint hint-compact" for="curve-<%= r.rewardId %>">Curve</label>
                   <input id="curve-<%= r.rewardId %>" class="input" type="number" step="0.1" min="0.1" name="curve" style="width:7rem;"
                     value="<%= r.config ? r.config.curve : 1 %>" required>
+                </div>
+                <div>
+                  <label class="hint hint-compact" for="round-to-nearest-<%= r.rewardId %>">Round to nearest</label>
+                  <% const roundToNearest = r.config ? r.config.round_to_nearest : 0; %>
+                  <select id="round-to-nearest-<%= r.rewardId %>" class="input" name="round_to_nearest" style="width:7rem;">
+                    <option value="0" <%= roundToNearest === 0 ? 'selected' : '' %>>Off</option>
+                    <option value="5" <%= roundToNearest === 5 ? 'selected' : '' %>>5</option>
+                    <option value="10" <%= roundToNearest === 10 ? 'selected' : '' %>>10</option>
+                  </select>
                 </div>
                 <div>
                   <button type="submit" class="btn">Save</button>


### PR DESCRIPTION
## Summary

- Adds a new per-reward `round_to_nearest` setting (0 = off, 5, or 10) to dynamic channel point pricing. `computePrice` now rounds its result to the nearest multiple of this step when set.
- The simulation preview chart on `/channel-points` shares `computePrice`, so it automatically reflects rounding — no separate simulation logic needed.
- The existing "only push to Twitch when the computed price differs from `last_pushed_cost`" comparison now operates on the *rounded* price, so points only update when the rounded value actually changes, not on every sub-step demand fluctuation — this respects the existing 30-second decay-tick scheduler cadence without any new interval logic.
- Added a "Round to nearest" dropdown (Off/5/10) to the per-reward pricing form on the Channel Points admin page.

## Changes

- `src/twitch/pricing/rewardPricingMath.ts` — `computePrice` accepts an optional `roundToNearest` config field.
- `src/db/rewardPricing.ts` + `migrations/reward_pricing_round_to_nearest.sql` + `schema.sql` + `DATABASE-SCHEMA.md` — new `round_to_nearest INT NOT NULL DEFAULT 0` column on `reward_pricing`, constrained to `{0, 5, 10}`.
- `src/twitch/pricing/rewardPricingService.ts` — passes `row.round_to_nearest` into `computePrice`.
- `src/web/routes/channelPointsAdmin.ts` — preview price and simulation chart both pass through `round_to_nearest`.
- `src/web/routes/channelPointsAdminShared.ts` — new `parseRoundToNearestField` validator (defaults to `0`/off when omitted, since the setting is optional).
- `src/web/routes/channelPointsAdminPricingMutations.ts` — parses and persists `round_to_nearest` on save.
- `views/channelPointsAdmin.ejs` — new "Round to nearest" select field.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (2187 tests passing)
- [ ] Manually verify the "Round to nearest" dropdown on `/channel-points` saves and the price preview/simulation chart reflect rounded values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkcpFVPRGs8pbobmdc3bQw

---
_Generated by [Claude Code](https://claude.ai/code/session_01JkcpFVPRGs8pbobmdc3bQw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “round to nearest” option for dynamic reward pricing (Off, 5, or 10).
  * Price previews, simulations, and Twitch redemption cost calculations now use the rounded result.
* **Bug Fixes**
  * Twitch pushes now occur only when the rounded computed cost changes, avoiding unnecessary updates.
  * Validation prevents saving unsupported rounding values.
* **Documentation**
  * Updated reward pricing schema/migration docs to describe the new rounding setting and its constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->