### PR TITLE
Fix missing HSTS header by setting NODE_ENV=production in npm start

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "ts-node src/index.ts",
     "build": "tsc -p tsconfig.build.json",
-    "start": "node dist/index.js",
+    "start": "NODE_ENV=production node dist/index.js",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Router } from 'express';
 import request from 'supertest';
 import { EventEmitter } from 'events';
@@ -178,6 +178,30 @@ describe('CSP header', () => {
     const csp = res.headers['content-security-policy'];
     expect(csp).toContain("font-src 'self'");
     expect(csp).not.toMatch(/font-src[^;]*https:/);
+  });
+});
+
+describe('HSTS header', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it('sends Strict-Transport-Security when NODE_ENV=production', async () => {
+    vi.resetModules();
+    process.env.NODE_ENV = 'production';
+    const { app: prodApp } = await import('./server.js');
+    const res = await request(prodApp).get('/__marker_dashboard');
+    expect(res.headers['strict-transport-security']).toBe('max-age=31536000; includeSubDomains');
+  });
+
+  it('omits Strict-Transport-Security outside production', async () => {
+    vi.resetModules();
+    process.env.NODE_ENV = 'test';
+    const { app: devApp } = await import('./server.js');
+    const res = await request(devApp).get('/__marker_dashboard');
+    expect(res.headers['strict-transport-security']).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- Aikido flagged `https://bcuk.expiredminotaur.com` as missing the `Strict-Transport-Security` header (risk score 89).
- `src/web/server.ts` already configures helmet to send HSTS (and to mark cookies `secure`, and set `upgradeInsecureRequests`) whenever `isProduction` (`process.env.NODE_ENV === 'production'`) is true — but `deploy.sh` runs the app via `npm start`, and the `start` script never set `NODE_ENV`. In the real deployment this left HSTS, secure cookies, and upgrade-insecure-requests all silently disabled.
- Fix: `package.json`'s `start` script now sets `NODE_ENV=production node dist/index.js`, so the existing production hardening in `server.ts` actually takes effect on the live site.

## Test plan
- [x] Added a `describe('HSTS header', ...)` block to `src/web/server.test.ts` that dynamically re-imports the app with `NODE_ENV=production` and asserts the `Strict-Transport-Security` header is sent, and a second test asserting it's omitted outside production.
- [x] `npx tsc --noEmit`
- [x] `npm test` (all 2191 tests pass)

https://claude.ai/code/session_01TcgtC2GoTuHgYHu4sMziZC


---
_Generated by [Claude Code](https://claude.ai/code/session_01TcgtC2GoTuHgYHu4sMziZC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Production runs now start with the correct environment settings.
  * Added verification for security response headers so they appear in production and stay off in non-production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->