### PR TITLE
Make the pre-escaped SVG chart contract explicit (historyChart/simulationChart → *SafeHtml)

### DIFF
--- a/src/web/routes/channelPointsAdmin.test.ts
+++ b/src/web/routes/channelPointsAdmin.test.ts
@@ -277,17 +277,17 @@ describe('GET /', () => {
     it('renders a chart string for a reward with a config (with points, and without), and null without a config', async () => {
       vi.mocked(getPricingHistory).mockResolvedValue([{ recorded_at: '1700000000000', cost: 300, demand: 0.5 }]);
       const res = await supertest(buildApp()).get('/');
-      expect(typeof res.body.rewards[0].historyChart).toBe('string');
-      expect(res.body.rewards[0].historyChart).toContain('<svg');
+      expect(typeof res.body.rewards[0].historyChartSafeHtml).toBe('string');
+      expect(res.body.rewards[0].historyChartSafeHtml).toContain('<svg');
 
       vi.mocked(getPricingConfigsForStreamer).mockResolvedValue([]);
       const res2 = await supertest(buildApp()).get('/');
-      expect(res2.body.rewards[0].historyChart).toBeNull();
+      expect(res2.body.rewards[0].historyChartSafeHtml).toBeNull();
     });
 
     it('renders the empty-history placeholder when there are no points yet', async () => {
       const res = await supertest(buildApp()).get('/');
-      expect(res.body.rewards[0].historyChart).toContain('No price history yet');
+      expect(res.body.rewards[0].historyChartSafeHtml).toContain('No price history yet');
     });
 
     it('renders a chart for an unlinked (orphaned) reward too', async () => {
@@ -295,7 +295,7 @@ describe('GET /', () => {
       vi.mocked(getPricingHistory).mockResolvedValue([{ recorded_at: '1700000000000', cost: 300, demand: 0.5 }]);
       const res = await supertest(buildApp()).get('/');
       expect(res.body.rewards[0].twitchReward).toBeNull();
-      expect(res.body.rewards[0].historyChart).toContain('<svg');
+      expect(res.body.rewards[0].historyChartSafeHtml).toContain('<svg');
     });
   });
 
@@ -314,15 +314,15 @@ describe('GET /', () => {
 
     it('renders a simulation chart and summary for a reward with a config', async () => {
       const res = await supertest(buildApp()).get('/');
-      expect(res.body.rewards[0].simulationChart).toContain('<svg');
+      expect(res.body.rewards[0].simulationChartSafeHtml).toContain('<svg');
       expect(typeof res.body.rewards[0].simulationSummary).toBe('string');
       expect(res.body.rewards[0].simulationSummary).toMatch(/% demand/);
     });
 
-    it('leaves simulationChart/simulationSummary null for a reward with no pricing config', async () => {
+    it('leaves simulationChartSafeHtml/simulationSummary null for a reward with no pricing config', async () => {
       vi.mocked(getPricingConfigsForStreamer).mockResolvedValue([]);
       const res = await supertest(buildApp()).get('/');
-      expect(res.body.rewards[0].simulationChart).toBeNull();
+      expect(res.body.rewards[0].simulationChartSafeHtml).toBeNull();
       expect(res.body.rewards[0].simulationSummary).toBeNull();
     });
 
@@ -330,7 +330,7 @@ describe('GET /', () => {
       vi.mocked(getCustomRewards).mockResolvedValue([]);
       const res = await supertest(buildApp()).get('/');
       expect(res.body.rewards[0].twitchReward).toBeNull();
-      expect(res.body.rewards[0].simulationChart).toContain('<svg');
+      expect(res.body.rewards[0].simulationChartSafeHtml).toContain('<svg');
     });
   });
 });

--- a/src/web/routes/channelPointsAdmin.ts
+++ b/src/web/routes/channelPointsAdmin.ts
@@ -37,11 +37,18 @@ interface ChannelPointRewardRow {
   twitchReward: TwitchCustomReward | null;
   config: RewardPricingRow | null;
   previewPrice: number | null;
-  /** Rendered SVG history chart, or null when there's no config to chart yet. */
-  historyChart: string | null;
-  /** Rendered SVG chart simulating a constant-use ramp-to-peak-demand-then-cooldown cycle, or null when there's no config to simulate yet. */
-  simulationChart: string | null;
-  /** One-line human-readable summary of the simulation's peak demand/price and phase durations, or null alongside a null `simulationChart`. */
+  /**
+   * Rendered SVG history chart, already HTML-escaped by `renderPriceHistoryChart` and safe to
+   * output raw (`<%- %>`) in the view — or null when there's no config to chart yet.
+   */
+  historyChartSafeHtml: string | null;
+  /**
+   * Rendered SVG chart simulating a constant-use ramp-to-peak-demand-then-cooldown cycle, already
+   * HTML-escaped by `renderPriceHistoryChart` and safe to output raw (`<%- %>`) in the view — or
+   * null when there's no config to simulate yet.
+   */
+  simulationChartSafeHtml: string | null;
+  /** One-line human-readable summary of the simulation's peak demand/price and phase durations, or null alongside a null `simulationChartSafeHtml`. */
   simulationSummary: string | null;
 }
 
@@ -144,9 +151,9 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
 
     // Only ever called for a config drawn from `pricingConfigs`, which is populated in the same
     // branch as `pricingSettings` above — so `pricingSettings` is guaranteed non-null here.
-    function buildSimulation(config: RewardPricingRow): { simulationChart: string; simulationSummary: string } {
+    function buildSimulation(config: RewardPricingRow): { simulationChartSafeHtml: string; simulationSummary: string } {
       const { chart, summary } = buildSimulationChart(config, pricingSettings!);
-      return { simulationChart: chart, simulationSummary: summary };
+      return { simulationChartSafeHtml: chart, simulationSummary: summary };
     }
 
     const configByRewardId = new Map(pricingConfigs.map((c) => [c.twitch_reward_id, c]));
@@ -159,8 +166,8 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
         twitchReward: tr,
         config,
         previewPrice: config ? previewPriceFor(config) : null,
-        historyChart: config ? await buildHistoryChart(config) : null,
-        ...(config ? buildSimulation(config) : { simulationChart: null, simulationSummary: null }),
+        historyChartSafeHtml: config ? await buildHistoryChart(config) : null,
+        ...(config ? buildSimulation(config) : { simulationChartSafeHtml: null, simulationSummary: null }),
       };
     }));
 
@@ -175,7 +182,7 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
           twitchReward: null,
           config,
           previewPrice: previewPriceFor(config),
-          historyChart: await buildHistoryChart(config),
+          historyChartSafeHtml: await buildHistoryChart(config),
           ...buildSimulation(config),
         })),
     );

--- a/views/channelPointsAdmin.ejs
+++ b/views/channelPointsAdmin.ejs
@@ -174,14 +174,16 @@
 
           <% if (r.config) { %>
           <div class="price-history-container" data-reward-id="<%= r.rewardId %>" data-range-ms="<%= historyHours * 60 * 60 * 1000 %>" style="margin-top:0.5rem;">
-            <%- r.historyChart %>
+            <%# historyChartSafeHtml is pre-escaped SVG from renderPriceHistoryChart(); the "SafeHtml" suffix is the contract that <%- %> here is safe. %>
+            <%- r.historyChartSafeHtml %>
           </div>
           <% } %>
 
-          <% if (r.config && r.simulationChart) { %>
+          <% if (r.config && r.simulationChartSafeHtml) { %>
           <div style="margin-top:0.75rem;">
             <p class="hint hint-compact">Simulated: constant use &rarr; cooldown</p>
-            <%- r.simulationChart %>
+            <%# simulationChartSafeHtml is pre-escaped SVG from renderPriceHistoryChart(); the "SafeHtml" suffix is the contract that <%- %> here is safe. %>
+            <%- r.simulationChartSafeHtml %>
             <p class="hint hint-compact"><%= r.simulationSummary %></p>
           </div>
           <% } %>


### PR DESCRIPTION
## Summary

A security scan flagged `views/channelPointsAdmin.ejs:177`, where `<%- r.historyChart %>` outputs raw HTML via EJS's unescaped tag (`<%- %>` vs. the escaping `<%= %>`).

Investigation confirmed the code is **not currently exploitable**: `renderPriceHistoryChart()` (`src/web/priceHistoryChart.ts`) already runs every interpolated value — the aria-label, the `data-points` JSON attribute, and all rendered text — through `escapeHtml()` before the SVG string is built. The finding is a legitimate maintenance-risk flag, though: nothing in the code signalled that skipping EJS's escaping at that call site was intentional and safe, so a future refactor of `renderPriceHistoryChart()` or the route handler could silently reintroduce an XSS without anyone noticing the safety contract had been broken.

## Changes

- Renamed the `ChannelPointRewardRow` fields `historyChart` → `historyChartSafeHtml` and `simulationChart` → `simulationChartSafeHtml` in `src/web/routes/channelPointsAdmin.ts`, so the type itself documents that the value is pre-escaped HTML safe for raw output.
- Updated the JSDoc on both fields to spell out the contract (pre-escaped by `renderPriceHistoryChart`, safe for `<%- %>`).
- Added a short EJS comment at each raw-output site in `views/channelPointsAdmin.ejs` reiterating the same contract, so it's visible right where the risky pattern is used.
- Updated `src/web/routes/channelPointsAdmin.test.ts` to match the renamed fields.

No behavioral change — `npx tsc --noEmit` and `npm test` (120 files / 2191 tests) both pass.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test`
- [ ] Manual smoke test of the Channel Points admin page (chart still renders) if desired


---
_Generated by [Claude Code](https://claude.ai/code/session_01WZmh6CtKHHYP8PtvbdZtAL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering of channel point reward history and simulation charts.
  * Charts now display correctly for configured and unlinked rewards.
  * Added clearer empty-history handling when no historical data is available.
  * Simulation results now include the associated demand percentage summary.
  * Charts and summaries correctly remain unavailable when no pricing configuration exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->