### PR TITLE
Fix cross-guild IDOR in Streamdeck key admin routes

### DIFF
--- a/src/db/streamdeckKeys.test.ts
+++ b/src/db/streamdeckKeys.test.ts
@@ -147,40 +147,52 @@ describe('getApiKeyStatus', () => {
 // ─── approveApiKey ────────────────────────────────────────────────────────────
 
 describe('approveApiKey', () => {
-  it('executes UPDATE with approvedBy and discordId', async () => {
+  it('executes UPDATE with approvedBy, discordId, and guildId', async () => {
     const pool = makePool();
     vi.mocked(getPool).mockReturnValue(pool as any);
-    await approveApiKey('user1', 'admin1');
+    await approveApiKey('user1', 'admin1', 'g1');
     const [sql, params] = pool.execute.mock.calls[0] as [string, unknown[]];
     expect(sql).toContain("status = 'approved'");
-    expect(params).toContain('admin1');
-    expect(params).toContain('user1');
+    expect(sql).toContain('guild_id = ?');
+    expect(params).toEqual(['admin1', 'user1', 'g1']);
   });
 });
 
 // ─── denyApiKey ───────────────────────────────────────────────────────────────
 
 describe('denyApiKey', () => {
-  it('executes UPDATE setting status to denied', async () => {
+  it('executes UPDATE setting status to denied, scoped to guildId', async () => {
     const pool = makePool();
     vi.mocked(getPool).mockReturnValue(pool as any);
-    await denyApiKey('user1');
+    await denyApiKey('user1', 'g1');
     const [sql, params] = pool.execute.mock.calls[0] as [string, unknown[]];
     expect(sql).toContain("status = 'denied'");
-    expect(params).toContain('user1');
+    expect(sql).toContain('guild_id = ?');
+    expect(params).toEqual(['user1', 'g1']);
   });
 });
 
 // ─── revokeApiKey ─────────────────────────────────────────────────────────────
 
 describe('revokeApiKey', () => {
-  it('executes UPDATE setting status to revoked', async () => {
+  it('executes UPDATE setting status to revoked, with no guild scoping when guildId is omitted (self-service)', async () => {
     const pool = makePool();
     vi.mocked(getPool).mockReturnValue(pool as any);
     await revokeApiKey('user1');
     const [sql, params] = pool.execute.mock.calls[0] as [string, unknown[]];
     expect(sql).toContain("status = 'revoked'");
-    expect(params).toContain('user1');
+    expect(sql).not.toContain('guild_id');
+    expect(params).toEqual(['user1']);
+  });
+
+  it('scopes the UPDATE to guildId when provided (admin-initiated revoke)', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await revokeApiKey('user1', 'g1');
+    const [sql, params] = pool.execute.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("status = 'revoked'");
+    expect(sql).toContain('guild_id = ?');
+    expect(params).toEqual(['user1', 'g1']);
   });
 });
 
@@ -189,21 +201,22 @@ describe('revokeApiKey', () => {
 describe('getPendingRequests', () => {
   it('returns empty array when no rows', async () => {
     vi.mocked(getPool).mockReturnValue(makePool([]) as any);
-    const result = await getPendingRequests();
+    const result = await getPendingRequests('g1');
     expect(result).toEqual([]);
   });
 
-  it('maps pending rows', async () => {
+  it('maps pending rows and scopes the query to guildId', async () => {
     const row = { discord_id: '1', guild_id: 'g1', status: 'pending', requested_at: new Date(), approved_at: null, approved_by: null, user_name: 'Alice', approver_name: null };
     const pool = makePool([row]);
     vi.mocked(getPool).mockReturnValue(pool as any);
-    const result = await getPendingRequests();
+    const result = await getPendingRequests('g1');
     expect(result).toHaveLength(1);
     expect(result[0].guild_id).toBe('g1');
     expect(result[0].status).toBe('pending');
     expect(result[0].user_name).toBe('Alice');
-    const [sql] = pool.execute.mock.calls[0] as [string, unknown[]];
-    expect(sql).toContain('guild_id');
+    const [sql, params] = pool.execute.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('k.guild_id = ?');
+    expect(params).toEqual(['g1']);
   });
 });
 
@@ -212,25 +225,26 @@ describe('getPendingRequests', () => {
 describe('getAllApiKeys', () => {
   it('returns empty array when no rows', async () => {
     vi.mocked(getPool).mockReturnValue(makePool([]) as any);
-    const result = await getAllApiKeys();
+    const result = await getAllApiKeys('g1');
     expect(result).toEqual([]);
   });
 
-  it('maps multiple rows with different statuses', async () => {
+  it('maps multiple rows and scopes the query to guildId', async () => {
     const rows = [
       { discord_id: '1', guild_id: 'g1', status: 'approved', requested_at: new Date(), approved_at: new Date(), approved_by: '2', user_name: 'Alice', approver_name: 'Admin' },
-      { discord_id: '3', guild_id: 'g2', status: 'revoked', requested_at: new Date(), approved_at: null, approved_by: null, user_name: 'Bob', approver_name: null },
+      { discord_id: '3', guild_id: 'g1', status: 'revoked', requested_at: new Date(), approved_at: null, approved_by: null, user_name: 'Bob', approver_name: null },
     ];
     const pool = makePool(rows);
     vi.mocked(getPool).mockReturnValue(pool as any);
-    const result = await getAllApiKeys();
+    const result = await getAllApiKeys('g1');
     expect(result).toHaveLength(2);
     expect(result[0].guild_id).toBe('g1');
     expect(result[0].status).toBe('approved');
-    expect(result[1].guild_id).toBe('g2');
+    expect(result[1].guild_id).toBe('g1');
     expect(result[1].status).toBe('revoked');
-    const [sql] = pool.execute.mock.calls[0] as [string, unknown[]];
-    expect(sql).toContain('guild_id');
+    const [sql, params] = pool.execute.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('k.guild_id = ?');
+    expect(params).toEqual(['g1']);
   });
 });
 

--- a/src/db/streamdeckKeys.ts
+++ b/src/db/streamdeckKeys.ts
@@ -119,18 +119,19 @@ export async function getApiKeyStatus(discordId: string): Promise<StreamdeckKeyR
 }
 
 /**
- * Approves a pending Streamdeck API key request.
+ * Approves a pending Streamdeck API key request, scoped to the admin's guild.
  *
  * @param discordId Requester's Discord snowflake.
  * @param approvedBy Approver's Discord snowflake.
- * @returns A promise that resolves once the update completes; a no-op if the request isn't pending.
+ * @param guildId Guild the approving admin is acting in; the request must be bound to this guild.
+ * @returns A promise that resolves once the update completes; a no-op if the request isn't pending or isn't bound to `guildId`.
  */
-export async function approveApiKey(discordId: string, approvedBy: string): Promise<void> {
+export async function approveApiKey(discordId: string, approvedBy: string, guildId: string): Promise<void> {
   await getPool().execute(
     `UPDATE streamdeck_api_keys
      SET status = 'approved', approved_at = NOW(), approved_by = ?
-     WHERE discord_id = ? AND status = 'pending'`,
-    [approvedBy, discordId],
+     WHERE discord_id = ? AND status = 'pending' AND guild_id = ?`,
+    [approvedBy, discordId, guildId],
   );
 }
 
@@ -138,12 +139,13 @@ export async function approveApiKey(discordId: string, approvedBy: string): Prom
  * Denies a pending Streamdeck API key request, permanently blocking future requests from this user.
  *
  * @param discordId Requester's Discord snowflake.
- * @returns A promise that resolves once the update completes; a no-op if the request isn't pending.
+ * @param guildId Guild the denying admin is acting in; the request must be bound to this guild.
+ * @returns A promise that resolves once the update completes; a no-op if the request isn't pending or isn't bound to `guildId`.
  */
-export async function denyApiKey(discordId: string): Promise<void> {
+export async function denyApiKey(discordId: string, guildId: string): Promise<void> {
   await getPool().execute(
-    `UPDATE streamdeck_api_keys SET status = 'denied' WHERE discord_id = ? AND status = 'pending'`,
-    [discordId],
+    `UPDATE streamdeck_api_keys SET status = 'denied' WHERE discord_id = ? AND status = 'pending' AND guild_id = ?`,
+    [discordId, guildId],
   );
 }
 
@@ -151,45 +153,58 @@ export async function denyApiKey(discordId: string): Promise<void> {
  * Revokes a Discord user's Streamdeck API key, regardless of its current status.
  *
  * @param discordId User's Discord snowflake.
+ * @param guildId When provided (admin-initiated revoke), the key must be bound to this guild or the update is a no-op. Omitted for self-service revokes, which always act on the caller's own key.
  * @returns A promise that resolves once the update completes.
  */
-export async function revokeApiKey(discordId: string): Promise<void> {
-  await getPool().execute(
-    `UPDATE streamdeck_api_keys SET status = 'revoked' WHERE discord_id = ?`,
-    [discordId],
-  );
+export async function revokeApiKey(discordId: string, guildId?: string): Promise<void> {
+  if (guildId) {
+    await getPool().execute(
+      `UPDATE streamdeck_api_keys SET status = 'revoked' WHERE discord_id = ? AND guild_id = ?`,
+      [discordId, guildId],
+    );
+  } else {
+    await getPool().execute(
+      `UPDATE streamdeck_api_keys SET status = 'revoked' WHERE discord_id = ?`,
+      [discordId],
+    );
+  }
 }
 
 /**
- * Lists pending Streamdeck API key requests.
+ * Lists pending Streamdeck API key requests for one guild.
  *
- * @returns Pending key rows, including requester names and guild bindings, oldest first.
+ * @param guildId Guild to list pending requests for.
+ * @returns Pending key rows for `guildId`, including requester names, oldest first.
  */
-export async function getPendingRequests(): Promise<StreamdeckKeyRow[]> {
+export async function getPendingRequests(guildId: string): Promise<StreamdeckKeyRow[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
     `SELECT k.discord_id, k.guild_id, k.status, k.requested_at, k.approved_at, k.approved_by,
             u.discord_name AS user_name, NULL AS approver_name
      FROM streamdeck_api_keys k
      LEFT JOIN \`user\` u ON u.discord_id = k.discord_id
-     WHERE k.status = 'pending'
+     WHERE k.status = 'pending' AND k.guild_id = ?
      ORDER BY k.requested_at ASC`,
+    [guildId],
   );
   return rows.map(mapRow);
 }
 
 /**
- * Lists all Streamdeck API keys.
+ * Lists all Streamdeck API keys for one guild.
  *
- * @returns Key rows, including requester/approver names and guild bindings, ordered by status then request time.
+ * @param guildId Guild to list keys for.
+ * @returns Key rows for `guildId`, including requester/approver names, ordered by status then request time.
  */
-export async function getAllApiKeys(): Promise<StreamdeckKeyRow[]> {
+export async function getAllApiKeys(guildId: string): Promise<StreamdeckKeyRow[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
     `SELECT k.discord_id, k.guild_id, k.status, k.requested_at, k.approved_at, k.approved_by,
             u.discord_name AS user_name, a.discord_name AS approver_name
      FROM streamdeck_api_keys k
      LEFT JOIN \`user\` u ON u.discord_id = k.discord_id
      LEFT JOIN \`user\` a ON a.discord_id = k.approved_by
+     WHERE k.guild_id = ?
      ORDER BY k.status ASC, k.requested_at ASC`,
+    [guildId],
   );
   return rows.map(mapRow);
 }

--- a/src/web/routes/streamdeckKeys.test.ts
+++ b/src/web/routes/streamdeckKeys.test.ts
@@ -168,7 +168,7 @@ describe('POST /admin/streamdeck-keys/approve', () => {
   it('approves key and redirects to /admin/streamdeck-keys', async () => {
     const res = await supertest(buildApp()).post('/admin/streamdeck-keys/approve').send(`discord_id=${VALID_DISCORD_ID}`);
     expect(res.headers.location).toBe('/admin/streamdeck-keys');
-    expect(approveApiKey).toHaveBeenCalledWith(VALID_DISCORD_ID, SESSION_USER.discordId);
+    expect(approveApiKey).toHaveBeenCalledWith(VALID_DISCORD_ID, SESSION_USER.discordId, GUILD_ID);
   });
 
   it('redirects to ?error=invalid_discord_id for invalid ID', async () => {
@@ -189,7 +189,7 @@ describe('POST /admin/streamdeck-keys/deny', () => {
   it('denies key and redirects', async () => {
     const res = await supertest(buildApp()).post('/admin/streamdeck-keys/deny').send(`discord_id=${VALID_DISCORD_ID}`);
     expect(res.headers.location).toBe('/admin/streamdeck-keys');
-    expect(denyApiKey).toHaveBeenCalledWith(VALID_DISCORD_ID);
+    expect(denyApiKey).toHaveBeenCalledWith(VALID_DISCORD_ID, GUILD_ID);
   });
 
   it('redirects to ?error=invalid_discord_id for invalid ID', async () => {
@@ -210,7 +210,7 @@ describe('POST /admin/streamdeck-keys/revoke', () => {
   it('revokes key and redirects', async () => {
     const res = await supertest(buildApp()).post('/admin/streamdeck-keys/revoke').send(`discord_id=${VALID_DISCORD_ID}`);
     expect(res.headers.location).toBe('/admin/streamdeck-keys');
-    expect(revokeApiKey).toHaveBeenCalledWith(VALID_DISCORD_ID);
+    expect(revokeApiKey).toHaveBeenCalledWith(VALID_DISCORD_ID, GUILD_ID);
   });
 
   it('redirects to ?error=invalid_discord_id for invalid ID', async () => {

--- a/src/web/routes/streamdeckKeys.ts
+++ b/src/web/routes/streamdeckKeys.ts
@@ -75,10 +75,11 @@ router.post('/streamdeck-key/revoke', csrfProtection, async (req, res) => {
 
 const ADMIN_KNOWN_ERRORS = new Set(['approve_failed', 'deny_failed', 'revoke_failed', 'invalid_discord_id']);
 
-/** Renders the admin Streamdeck key management page, listing pending and all key requests. */
+/** Renders the admin Streamdeck key management page, listing pending and all key requests for the admin's current guild. */
 router.get('/admin/streamdeck-keys', requireAdmin, csrfProtection, async (req, res) => {
   try {
-    const [pending, all] = await Promise.all([getPendingRequests(), getAllApiKeys()]);
+    const guildId = req.session.user!.currentGuildId!;
+    const [pending, all] = await Promise.all([getPendingRequests(guildId), getAllApiKeys(guildId)]);
     renderView(res, 'streamdeck-keys-admin', {
       user: req.session.user,
       csrfToken: req.csrfToken(),
@@ -92,36 +93,36 @@ router.get('/admin/streamdeck-keys', requireAdmin, csrfProtection, async (req, r
   }
 });
 
-/** Approves a pending Streamdeck API key request for the Discord ID in the request body. */
+/** Approves a pending Streamdeck API key request for the Discord ID in the request body, scoped to the admin's current guild. */
 router.post('/admin/streamdeck-keys/approve', requireAdmin, csrfProtection, async (req, res) => {
   const validId = normalizeDiscordId((req.body as { discord_id?: string }).discord_id);
   if (!validId) return res.redirect('/admin/streamdeck-keys?error=invalid_discord_id');
   try {
-    await approveApiKey(validId, req.session.user!.discordId);
+    await approveApiKey(validId, req.session.user!.discordId, req.session.user!.currentGuildId!);
     res.redirect('/admin/streamdeck-keys');
   } catch (err) {
     logAndRedirectError({ res, log, logLabel: 'Streamdeck key approve error:', err, basePath: '/admin/streamdeck-keys', errorCode: 'approve_failed' });
   }
 });
 
-/** Denies a pending Streamdeck API key request for the Discord ID in the request body. */
+/** Denies a pending Streamdeck API key request for the Discord ID in the request body, scoped to the admin's current guild. */
 router.post('/admin/streamdeck-keys/deny', requireAdmin, csrfProtection, async (req, res) => {
   const validId = normalizeDiscordId((req.body as { discord_id?: string }).discord_id);
   if (!validId) return res.redirect('/admin/streamdeck-keys?error=invalid_discord_id');
   try {
-    await denyApiKey(validId);
+    await denyApiKey(validId, req.session.user!.currentGuildId!);
     res.redirect('/admin/streamdeck-keys');
   } catch (err) {
     logAndRedirectError({ res, log, logLabel: 'Streamdeck key deny error:', err, basePath: '/admin/streamdeck-keys', errorCode: 'deny_failed' });
   }
 });
 
-/** Revokes the Streamdeck API key for the Discord ID in the request body. */
+/** Revokes the Streamdeck API key for the Discord ID in the request body, scoped to the admin's current guild. */
 router.post('/admin/streamdeck-keys/revoke', requireAdmin, csrfProtection, async (req, res) => {
   const validId = normalizeDiscordId((req.body as { discord_id?: string }).discord_id);
   if (!validId) return res.redirect('/admin/streamdeck-keys?error=invalid_discord_id');
   try {
-    await revokeApiKey(validId);
+    await revokeApiKey(validId, req.session.user!.currentGuildId!);
     res.redirect('/admin/streamdeck-keys');
   } catch (err) {
     logAndRedirectError({ res, log, logLabel: 'Streamdeck key admin revoke error:', err, basePath: '/admin/streamdeck-keys', errorCode: 'revoke_failed' });


### PR DESCRIPTION
## Summary

This branch was used to run a full security review of the project (auth/sessions/CSRF/authorization, SQL injection, XSS/templating, file upload/SSRF/secrets/rate-limiting). Most areas checked out clean; this PR fixes the one confirmed **High**-severity finding.

**Cross-guild IDOR in Streamdeck key admin routes** (`src/web/routes/streamdeckKeys.ts`, `src/db/streamdeckKeys.ts`): `/admin/streamdeck-keys*` is gated by `requireAdmin`, which only checks the admin's access level in their *currently selected* guild. But the backing DB functions (`getPendingRequests`, `getAllApiKeys`, `approveApiKey`, `denyApiKey`, `revokeApiKey`) had no `guild_id` filtering, so an Admin of any single guild could view every other guild's pending/approved Streamdeck key requests (info disclosure) and approve, deny, or revoke keys belonging to members of guilds they have no authority over.

- Added a required `guildId` parameter to `approveApiKey`, `denyApiKey`, `getPendingRequests`, and `getAllApiKeys`, scoping all queries with `AND guild_id = ?`.
- Added an optional `guildId` parameter to `revokeApiKey`: self-service revoke (a user revoking their own key) still omits it and acts on the caller's own key regardless of guild; the admin-initiated revoke route now passes the admin's current guild so it can't touch another guild's key.
- Updated the five admin route handlers in `src/web/routes/streamdeckKeys.ts` to pass `req.session.user.currentGuildId` through.
- Updated JSDoc and unit tests (`src/db/streamdeckKeys.test.ts`, `src/web/routes/streamdeckKeys.test.ts`) to cover the new guild scoping.

### Other findings from the review (not fixed here, informational/lower severity)
- Custom commands/counters/SFX/stream groups are a single global catalog rather than per-guild — likely an intentional design, flagged for awareness only.
- CSRF token accepted via `?_csrf=` query string in addition to body/header — no exploitable path found, hardening suggestion only.
- OAuth `state` compared with `===` instead of `timingSafeEqual` — low practical risk given single-use 128-bit tokens.
- CSP allows `'unsafe-inline'` for styles only (script-src is locked to `'self'`).
- `EVENTSUB_TOKEN_SECRET` silently defaults to `''` instead of failing at boot like `SESSION_SECRET` does.

SQL injection, XSS, secrets handling, file upload/path traversal, and SSRF were all reviewed in depth and found to have no exploitable issues.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — all 2192 tests pass, including updated `streamdeckKeys` unit tests


---
_Generated by [Claude Code](https://claude.ai/code/session_01FuQmyhSjc3i3y53HpeZRZ4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Admin Streamdeck key management is now restricted to the currently selected guild.
  - Approvals, denials, revocations, and key listings no longer affect or display keys from other guilds.
  - Self-service revocations continue to work without requiring a guild selection.
- **Tests**
  - Added coverage verifying guild-specific filtering and action behavior across key management workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->