### PR TITLE
Fix EJS parse error from literal tag syntax inside comments

### DIFF
--- a/src/web/ejsTemplates.test.ts
+++ b/src/web/ejsTemplates.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import ejs from 'ejs';
+
+const viewsDir = path.join(__dirname, '../../views');
+
+/** Recursively lists all `.ejs` files under a directory, returning paths relative to it. */
+function listEjsFiles(dir: string, baseDir = dir): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) return listEjsFiles(fullPath, baseDir);
+    if (entry.name.endsWith('.ejs')) return [path.relative(baseDir, fullPath)];
+    return [];
+  });
+}
+
+describe('EJS templates', () => {
+  const templates = listEjsFiles(viewsDir);
+
+  it('finds at least one template to check', () => {
+    expect(templates.length).toBeGreaterThan(0);
+  });
+
+  it.each(templates)('%s compiles without a syntax error', (relativePath) => {
+    const fullPath = path.join(viewsDir, relativePath);
+    const source = fs.readFileSync(fullPath, 'utf8');
+    expect(() => ejs.compile(source, { filename: fullPath })).not.toThrow();
+  });
+});

--- a/views/channelPointsAdmin.ejs
+++ b/views/channelPointsAdmin.ejs
@@ -174,7 +174,7 @@
 
           <% if (r.config) { %>
           <div class="price-history-container" data-reward-id="<%= r.rewardId %>" data-range-ms="<%= historyHours * 60 * 60 * 1000 %>" style="margin-top:0.5rem;">
-            <%# historyChartSafeHtml is pre-escaped SVG from renderPriceHistoryChart(); the "SafeHtml" suffix is the contract that <%- %> here is safe. %>
+            <%# historyChartSafeHtml is pre-escaped SVG from renderPriceHistoryChart(); the "SafeHtml" suffix is the contract that the raw-output tag below is safe. %>
             <%- r.historyChartSafeHtml %>
           </div>
           <% } %>
@@ -182,7 +182,7 @@
           <% if (r.config && r.simulationChartSafeHtml) { %>
           <div style="margin-top:0.75rem;">
             <p class="hint hint-compact">Simulated: constant use &rarr; cooldown</p>
-            <%# simulationChartSafeHtml is pre-escaped SVG from renderPriceHistoryChart(); the "SafeHtml" suffix is the contract that <%- %> here is safe. %>
+            <%# simulationChartSafeHtml is pre-escaped SVG from renderPriceHistoryChart(); the "SafeHtml" suffix is the contract that the raw-output tag below is safe. %>
             <%- r.simulationChartSafeHtml %>
             <p class="hint hint-compact"><%= r.simulationSummary %></p>
           </div>


### PR DESCRIPTION
## Summary

- `views/channelPointsAdmin.ejs` failed to render with `Could not find matching close tag for "<%#"`.
- Root cause: the two `<%# ... %>` comments describing `historyChartSafeHtml`/`simulationChartSafeHtml` contained a literal `<%- %>` inside the comment text. EJS's tokenizer reads that literal sequence as the start of a new tag, which breaks the close-tag scan for the enclosing comment.
- Fixed by rewording the comments to describe the raw-output tag without embedding actual EJS tag syntax.
- Added `src/web/ejsTemplates.test.ts`, a test that compile-checks every `.ejs` file under `views/` so this class of bug (a template syntax error that only surfaces at request time) is caught by `npm test` instead of reaching production.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (121 files / 2220 tests passed)
- [x] Verified the new test fails against the pre-fix template (reproduces the original error) and passes against the fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated validation to ensure all EJS templates compile successfully.

* **Style**
  * Cleaned up comments and whitespace in the channel points administration template without changing displayed content or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->