### PR TITLE
Fix deploy.sh killing the screen session instead of just the bot

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -93,7 +93,7 @@ if pgrep -f "node dist/index.js" > /dev/null 2>&1; then
     fi
 fi
 
-screen -S "$SCREEN_SESSION" -X stuff "cd ${REPO_DIR} && npm start\n"
+screen -S "$SCREEN_SESSION" -X stuff "cd '${REPO_DIR}' && npm start\n"
 echo "==> Bot restarted."
 
 echo "==> Deploy complete."

--- a/deploy.sh
+++ b/deploy.sh
@@ -69,7 +69,17 @@ trap - ERR  # Rollback no longer needed — code is good.
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 echo "==> Restarting bot in screen session '$SCREEN_SESSION'..."
-if screen -list | grep -Eq "[0-9]+\.${SCREEN_SESSION}[[:space:]]"; then
+
+# The screen window always runs a plain, persistent `bash` — never `bash -c "... && npm start"`
+# directly. If npm start were the window's own command, Ctrl-C-ing it to stop the bot would
+# make that command (and so the shell, and so the single-window session) exit immediately,
+# leaving nothing for the restart command below to `stuff` into.
+if ! screen -list | grep -Eq "[0-9]+\.${SCREEN_SESSION}[[:space:]]"; then
+    echo "==> Screen session '$SCREEN_SESSION' not found. Creating it..."
+    screen -dmS "$SCREEN_SESSION" bash
+fi
+
+if pgrep -f "node dist/index.js" > /dev/null 2>&1; then
     screen -S "$SCREEN_SESSION" -X stuff $'\003'
 
     # Wait up to 15s for the node process to fully exit before restarting.
@@ -81,13 +91,9 @@ if screen -list | grep -Eq "[0-9]+\.${SCREEN_SESSION}[[:space:]]"; then
     if pgrep -f "node dist/index.js" > /dev/null 2>&1; then
         echo "WARNING: Node process did not stop within 15s. Attempting restart anyway..."
     fi
-
-    screen -S "$SCREEN_SESSION" -X stuff "cd ${REPO_DIR} && npm start\n"
-    echo "==> Bot restarted."
-else
-    echo "WARNING: Screen session '$SCREEN_SESSION' not found. Starting a new one..."
-    screen -dmS "$SCREEN_SESSION" bash -c "cd '${REPO_DIR}' && npm start"
-    echo "==> Bot started in new screen session '$SCREEN_SESSION'."
 fi
+
+screen -S "$SCREEN_SESSION" -X stuff "cd ${REPO_DIR} && npm start\n"
+echo "==> Bot restarted."
 
 echo "==> Deploy complete."


### PR DESCRIPTION
## Summary

- Running `deploy.sh` while the bot was already running would kill the bot and then fail with "No screen session found", leaving it offline until the script was run a second time.
- Root cause: the screen window ran `bash -c "cd '...' && npm start"` directly. Sending Ctrl-C to stop `npm start` for a redeploy also terminated that `bash -c` command — and since it was the window's only process, the entire single-window screen session died with it. The very next line then tried to `stuff` the restart command into that now-dead session, which fails and (under `set -e`) aborts the script before the bot is restarted.
- Fix: the screen window now always runs a persistent, bare `bash` shell. `npm start` is only ever sent into it via `stuff`, both on first creation and on restart, so stopping the bot (Ctrl-C) just returns to a live shell prompt instead of tearing down the session.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (2220 tests passing)
- [x] `bash -n deploy.sh` (syntax check)
- [ ] Manual verification on the actual deploy host: run `deploy.sh` with the bot already running in the `BCUK` screen session and confirm it restarts cleanly without recreating the session.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fx3QCtcMTbFmPpDjRL1uWZ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment restart handling by ensuring the bot runs in an available screen session.
  * Added more reliable process stopping and restarting behavior.
  * Added confirmation output after the restart command is issued.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->