### PR TITLE
Fix streamdeck_multi_guild.sql FK type mismatch against deployed schema

### DIFF
--- a/migrations/streamdeck_multi_guild.sql
+++ b/migrations/streamdeck_multi_guild.sql
@@ -10,6 +10,13 @@
 -- in the pre-split shape (guild_id/status/requested_at/approved_at/approved_by
 -- columns present). Guarded behind an existence check since the table may be
 -- absent on some deployments.
+--
+-- streamdeck_key_guild_status.discord_id is declared VARCHAR(64) (matching
+-- utf8mb4_0900_ai_ci) rather than the BIGINT schema.sql documents for `user`
+-- and `guild` — some deployments' streamdeck_api_keys.discord_id predates the
+-- BIGINT convention and is still VARCHAR(64); MySQL's FK type/collation check
+-- (error 3780) requires an exact match to whatever streamdeck_api_keys
+-- actually has. Run `SHOW CREATE TABLE streamdeck_api_keys` first if unsure.
 
 SET @sd_exists = (
   SELECT COUNT(*) FROM information_schema.tables
@@ -25,7 +32,7 @@ SET @already_split = (
 SET @sql = IF(@sd_exists = 0,
   'SELECT ''streamdeck_api_keys absent — skipping streamdeck multi-guild migration''',
   'CREATE TABLE IF NOT EXISTS streamdeck_key_guild_status (
-     discord_id   BIGINT                                       NOT NULL,
+     discord_id   VARCHAR(64) COLLATE utf8mb4_0900_ai_ci       NOT NULL,
      guild_id     BIGINT                                       NOT NULL,
      status       ENUM(''pending'',''approved'',''revoked'',''denied'') NOT NULL DEFAULT ''pending'',
      requested_at DATETIME                                     NOT NULL,
@@ -79,11 +86,12 @@ SET @sql = IF(@sd_exists = 0 OR @already_split = 0,
   'UPDATE streamdeck_api_keys SET created_at = requested_at');
 PREPARE _s FROM @sql; EXECUTE _s; DEALLOCATE PREPARE _s;
 
--- The old approved_by FK (`FOREIGN KEY (approved_by) REFERENCES user(discord_id)
--- ON DELETE SET NULL`) was never given an explicit name in schema.sql, so MySQL
--- auto-generated one (e.g. streamdeck_api_keys_ibfk_2). DROP COLUMN approved_by
--- fails with error 1553 unless that constraint is dropped first — look its name
--- up rather than guessing it.
+-- Some deployments' streamdeck_api_keys has an approved_by FK (`FOREIGN KEY
+-- (approved_by) REFERENCES user(discord_id) ON DELETE SET NULL`); others have
+-- none at all. Where it exists it was never given an explicit name in
+-- schema.sql, so MySQL auto-generated one (e.g. streamdeck_api_keys_ibfk_2).
+-- DROP COLUMN approved_by fails with error 1553 unless that constraint is
+-- dropped first — look its name up rather than guessing (or assuming) it.
 SET @approved_by_fk = (
   SELECT CONSTRAINT_NAME FROM information_schema.KEY_COLUMN_USAGE
   WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'streamdeck_api_keys'

--- a/migrations/streamdeck_multi_guild.sql
+++ b/migrations/streamdeck_multi_guild.sql
@@ -81,10 +81,17 @@ SET @sql = IF(@sd_exists = 0 OR @already_split = 0 OR @created_at_exists = 1,
      ADD COLUMN created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP');
 PREPARE _s FROM @sql; EXECUTE _s; DEALLOCATE PREPARE _s;
 
+-- This UPDATE intentionally has no WHERE clause — every row needs its
+-- created_at backfilled — which trips SQL_SAFE_UPDATES if a client (e.g.
+-- MySQL Workbench) has it enabled by default. Disable it for this statement
+-- only and restore it immediately after.
+SET @prior_safe_updates = @@SESSION.sql_safe_updates;
+SET SQL_SAFE_UPDATES = 0;
 SET @sql = IF(@sd_exists = 0 OR @already_split = 0,
   'SELECT ''nothing to backfill for created_at''',
   'UPDATE streamdeck_api_keys SET created_at = requested_at');
 PREPARE _s FROM @sql; EXECUTE _s; DEALLOCATE PREPARE _s;
+SET SQL_SAFE_UPDATES = @prior_safe_updates;
 
 -- Some deployments' streamdeck_api_keys has an approved_by FK (`FOREIGN KEY
 -- (approved_by) REFERENCES user(discord_id) ON DELETE SET NULL`); others have


### PR DESCRIPTION
## Summary

Follow-up to #377: running `migrations/streamdeck_multi_guild.sql` against production failed with:

```
Error Code: 3780. Referencing column 'discord_id' and referenced column 'discord_id' in
foreign key constraint 'streamdeck_key_guild_status_ibfk_1' are incompatible.
```

Production's `streamdeck_api_keys.discord_id` is `VARCHAR(64)` (collation `utf8mb4_0900_ai_ci`), not the `BIGINT` that `schema.sql` documents — a pre-existing drift that was invisible to the application because `mysql2`'s `bigNumberStrings: true` already makes BIGINT columns behave as JS strings, so a VARCHAR holding the same digits was functionally identical from the app's perspective.

- `streamdeck_key_guild_status.discord_id` now declared `VARCHAR(64) COLLATE utf8mb4_0900_ai_ci` to match the deployed `streamdeck_api_keys.discord_id` exactly — MySQL's FK type/collation check (error 3780) requires an exact match.
- `approved_by` stays `BIGINT` — confirmed via `SHOW CREATE TABLE user` that `user.discord_id` is genuinely `BIGINT` on the same deployment.
- Updated the migration's header comment and the `approved_by` FK comment to reflect that these deployment-shape assumptions can vary, and to point at `SHOW CREATE TABLE streamdeck_api_keys` as the way to verify before running.

No application code changes — `discord_id` is always handled as a string in TypeScript regardless of the underlying SQL type.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (2291 tests) — SQL-only change, no test changes needed
- [ ] Re-run `migrations/streamdeck_multi_guild.sql` against production and confirm it completes

Co-Authored-By: Claude Sonnet 5

https://claude.ai/code/session_01Q2YaerArb1BuRRFTERnsJn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2YaerArb1BuRRFTERnsJn)_