### PR TITLE
Fix POST /voice/leave crash and restore zero-input Streamdeck compatibility

### DIFF
--- a/src/web/routes/companionAuth.ts
+++ b/src/web/routes/companionAuth.ts
@@ -43,7 +43,7 @@ router.get('/companion/login', authLimiter, (req, res) => {
  *   429 comes from `authLimiter` and short-circuits before this handler runs.
  */
 router.post('/api/companion/oauth/token', authLimiter, async (req, res) => {
-  const { code } = req.body as { code?: string };
+  const { code } = (req.body ?? {}) as { code?: string };
   if (!code || typeof code !== 'string') {
     res.status(400).json({ ok: false, error: 'Missing code' });
     return;

--- a/src/web/routes/streamdeckSfx.ts
+++ b/src/web/routes/streamdeckSfx.ts
@@ -37,7 +37,7 @@ router.get('/sfx', requireApiKey, async (req, res) => {
  * body, in whichever guild the key owner is currently connected to voice in.
  */
 router.post('/sfx', requireApiKey, async (req, res) => {
-  const { command } = req.body as { command?: unknown };
+  const { command } = (req.body ?? {}) as { command?: unknown };
   if (typeof command !== 'string' || !command.trim()) {
     res.status(400).json({ ok: false, error: 'Missing or invalid "command" field' });
     return;

--- a/src/web/routes/streamdeckVoice.test.ts
+++ b/src/web/routes/streamdeckVoice.test.ts
@@ -126,6 +126,11 @@ describe('POST /voice/join', () => {
     expect(res.body).toMatchObject({ ok: false });
   });
 
+  it('does not crash when the request has no body at all', async () => {
+    const res = await supertest(buildApp()).post('/voice/join').expect(400);
+    expect(res.body).toMatchObject({ ok: false });
+  });
+
   it('returns 400 when channelId is not a valid Discord snowflake', async () => {
     const res = await supertest(buildApp()).post('/voice/join').send({ channelId: 'not-a-snowflake' }).expect(400);
     expect(res.body).toMatchObject({ ok: false });

--- a/src/web/routes/streamdeckVoice.test.ts
+++ b/src/web/routes/streamdeckVoice.test.ts
@@ -27,6 +27,10 @@ vi.mock('../../discord/discordBot', () => ({
   getDiscordClient: vi.fn(),
 }));
 
+vi.mock('../../discord/voicePresence', () => ({
+  getActiveGuildForUser: vi.fn(),
+}));
+
 vi.mock('../../shared/logger', () => ({
   createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
 }));
@@ -38,6 +42,7 @@ import { isKeyApprovedForGuild, getApprovedGuildIdsForKey } from '../../db';
 import { getAvailableVoiceChannels } from '../../discord/discordUtils';
 import { connect, disconnect } from '../../audio/audioPlayer';
 import { getDiscordClient } from '../../discord/discordBot';
+import { getActiveGuildForUser } from '../../discord/voicePresence';
 
 /** Fake Discord client whose channels.fetch resolves any channel to the given guildId. */
 function makeClient(channelGuildId: string | null = 'guild-123') {
@@ -64,6 +69,7 @@ beforeEach(() => {
   vi.mocked(getAvailableVoiceChannels).mockResolvedValue([]);
   vi.mocked(isKeyApprovedForGuild).mockResolvedValue(true);
   vi.mocked(getApprovedGuildIdsForKey).mockResolvedValue(['guild-123']);
+  vi.mocked(getActiveGuildForUser).mockReturnValue(null);
 });
 
 describe('GET /voice/channels', () => {
@@ -190,9 +196,32 @@ describe('POST /voice/join', () => {
 });
 
 describe('POST /voice/leave', () => {
-  it('returns 400 when both channelId and guildId are missing', async () => {
-    const res = await supertest(buildApp()).post('/voice/leave').send({}).expect(400);
+  it('falls back to the key owner\'s live voice presence when channelId and guildId are both missing', async () => {
+    vi.mocked(getActiveGuildForUser).mockReturnValue('guild-123');
+
+    const res = await supertest(buildApp()).post('/voice/leave').send({}).expect(200);
+
+    expect(res.body).toEqual({ ok: true });
+    expect(vi.mocked(disconnect)).toHaveBeenCalledWith('guild-123');
+    expect(vi.mocked(getActiveGuildForUser)).toHaveBeenCalledWith(expect.anything(), API_KEY_OWNER);
+  });
+
+  it('returns 503 when neither channelId nor guildId is given and the key owner has no live voice presence', async () => {
+    const res = await supertest(buildApp()).post('/voice/leave').send({}).expect(503);
+
     expect(res.body).toMatchObject({ ok: false });
+    expect(vi.mocked(disconnect)).not.toHaveBeenCalled();
+  });
+
+  it('does not crash when the request has no body at all (e.g. a client that sends no Content-Type)', async () => {
+    vi.mocked(getActiveGuildForUser).mockReturnValue('guild-123');
+
+    const res = await supertest(buildApp())
+      .post('/voice/leave')
+      .expect(200);
+
+    expect(res.body).toEqual({ ok: true });
+    expect(vi.mocked(disconnect)).toHaveBeenCalledWith('guild-123');
   });
 
   it('resolves the guild from channelId and disconnects', async () => {

--- a/src/web/routes/streamdeckVoice.ts
+++ b/src/web/routes/streamdeckVoice.ts
@@ -7,8 +7,8 @@ import { connect, disconnect } from '../../audio/audioPlayer';
 import { getDiscordClient } from '../../discord/discordBot';
 import { normalizeDiscordId } from './shared';
 import {
-  resolveGuildIdFromChannelId,
   resolveChannelGuildOrRespond,
+  resolvePresenceGuildOrRespond,
   ensureGuildApproved,
 } from './streamdeckGuildResolution';
 
@@ -41,7 +41,7 @@ router.get('/voice/channels', requireApiKey, async (req, res) => {
 
 /** Disconnects any existing voice connection and joins the voice channel named in the request body. */
 router.post('/voice/join', requireApiKey, async (req, res) => {
-  const { channelId } = req.body as { channelId?: unknown };
+  const { channelId } = (req.body ?? {}) as { channelId?: unknown };
   if (typeof channelId !== 'string') {
     res.status(400).json({ ok: false, error: 'Missing or invalid "channelId" field' });
     return;
@@ -73,19 +73,18 @@ router.post('/voice/join', requireApiKey, async (req, res) => {
 
 /**
  * Disconnects the bot from its voice channel in the target guild. Accepts an
- * explicit `guildId`, or falls back to resolving it from `channelId` — the
- * explicit form matters because the channel may no longer exist (e.g. deleted
- * while the bot was connected to it), in which case resolving via channelId
- * alone would leave the bot stuck connected with no way to force a leave.
+ * explicit `guildId`, or a `channelId` to resolve one from — the explicit form
+ * matters because the channel may no longer exist (e.g. deleted while the bot
+ * was connected to it), in which case resolving via channelId alone would
+ * leave the bot stuck connected with no way to force a leave. If neither is
+ * given (the pre-multi-guild Streamdeck config sends no body at all), falls
+ * back to wherever the key owner currently has a live voice connection, the
+ * same presence-based resolution `/sfx` uses.
  */
 router.post('/voice/leave', requireApiKey, async (req, res) => {
-  const { channelId, guildId: rawGuildId } = req.body as { channelId?: unknown; guildId?: unknown };
+  const { channelId, guildId: rawGuildId } = (req.body ?? {}) as { channelId?: unknown; guildId?: unknown };
   const normalizedChannelId = typeof channelId === 'string' ? normalizeDiscordId(channelId) : null;
   const explicitGuildId = typeof rawGuildId === 'string' ? normalizeDiscordId(rawGuildId) : null;
-  if (!normalizedChannelId && !explicitGuildId) {
-    res.status(400).json({ ok: false, error: 'Missing or invalid "channelId" or "guildId" field' });
-    return;
-  }
 
   let guildId = explicitGuildId;
   if (!guildId) {
@@ -94,14 +93,13 @@ router.post('/voice/leave', requireApiKey, async (req, res) => {
       res.status(503).json({ ok: false, error: 'Discord client not ready' });
       return;
     }
-    guildId = await resolveGuildIdFromChannelId(discordClient, normalizedChannelId!);
-    if (!guildId) {
-      res.status(400).json({ ok: false, error: 'Unknown voice channel' });
-      return;
-    }
+    guildId = normalizedChannelId
+      ? await resolveChannelGuildOrRespond(req, res, discordClient, normalizedChannelId)
+      : await resolvePresenceGuildOrRespond(req, res, discordClient);
+    if (!guildId) return;
+  } else if (!(await ensureGuildApproved(req, res, guildId))) {
+    return;
   }
-
-  if (!(await ensureGuildApproved(req, res, guildId))) return;
 
   disconnect(guildId);
   res.json({ ok: true });


### PR DESCRIPTION
## Summary

Follow-up to #377/#379: hitting "leave" in the deployed Streamdeck plugin crashed the server:

```
TypeError: Cannot destructure property 'channelId' of 'req.body' as it is undefined.
    at /home/ubuntu/bcuk-bot/dist/web/routes/streamdeckVoice.js:75:13
```

The Streamdeck plugin's existing "leave" action sends no request body at all (it predates multi-guild support, when there was only one possible target). `express.json()` leaves `req.body` untouched — not `{}` — when a request has no matching Content-Type/body, so destructuring it directly crashes instead of falling through to a clean error.

- Guarded `req.body` with `?? {}` in `/voice/join`, `/voice/leave`, `/sfx`, and the companion OAuth token exchange (`companionAuth.ts`) — the same crash was latent in all four, just not yet triggered by a real request.
- `/voice/leave` now falls back to the key owner's live voice presence (the same `resolvePresenceGuildOrRespond` helper `/sfx` already uses) when neither `channelId` nor `guildId` is given, instead of returning a 400. This restores the pre-multi-guild "leave the server I'm in" behavior with zero input — matching what the owner's existing Streamdeck plugin config actually sends — instead of requiring a plugin config update.
- Explicit `channelId`/`guildId` still work exactly as before (channelId resolution, explicit-guildId-bypasses-channel-resolution for the deleted-channel case).

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (2293 tests, incl. new tests for the presence fallback and the no-body crash reproduction)
- [ ] Manual: trigger "leave" from the actual Streamdeck plugin (no body) while connected to voice in either guild — confirm it disconnects from the correct guild instead of crashing

Co-Authored-By: Claude Sonnet 5

https://claude.ai/code/session_01Q2YaerArb1BuRRFTERnsJn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2YaerArb1BuRRFTERnsJn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of requests with missing or empty bodies across companion authentication and Stream Deck integrations.
  * Voice disconnect requests can now resolve the active guild from live voice presence when identifiers are unavailable.
  * Added clearer error handling when no active voice presence is available.
  * Prevented crashes for voice requests without a body or content type.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->