### PR TITLE
Issue #378 follow-ups: multi-guild status, cache dedup, state cleanup

### DIFF
--- a/public/streamdeck-keys.js
+++ b/public/streamdeck-keys.js
@@ -3,9 +3,19 @@ function getRevokeKeyConfirmationMessage() {
   return 'Revoke your API key? It will stop working immediately.';
 }
 
+/** Returns the confirmation message for rotating (generating a new) Streamdeck API key. */
+function getRotateKeyConfirmationMessage() {
+  return 'Generate a new API key? Your current key will stop working immediately, everywhere it was set up.';
+}
+
 /** Confirms revocation before allowing the Streamdeck key revoke form to submit. */
 document.addEventListener('submit', function (event) {
   confirmSubmit(event, 'js-confirm-revoke-key', getRevokeKeyConfirmationMessage);
+});
+
+/** Confirms rotation before allowing the Streamdeck key rotate form to submit. */
+document.addEventListener('submit', function (event) {
+  confirmSubmit(event, 'js-confirm-rotate-key', getRotateKeyConfirmationMessage);
 });
 
 registerCopyToClipboardHandler('copy-key-btn', 'new-key', 'Copy');

--- a/src/audio/audioPlayer.test.ts
+++ b/src/audio/audioPlayer.test.ts
@@ -99,7 +99,7 @@ describe('connect', () => {
     );
     expect(mod.isConnected('guild-A')).toBe(true);
     expect(mod.getCurrentChannelId('guild-A')).toBe('chan-1');
-    expect(vi.mocked(status.setVoiceConnected)).toHaveBeenCalledWith('vc-chan-1');
+    expect(vi.mocked(status.setVoiceConnected)).toHaveBeenCalledWith('guild-A', 'vc-chan-1');
   });
 
   it('rejects when no channelId is given', async () => {
@@ -153,7 +153,7 @@ describe('per-guild isolation', () => {
     expect(mod.getCurrentChannelId('guild-B')).toBe('chan-B');
   });
 
-  it('disconnecting one guild leaves the other connected and does not clear global voice status', async () => {
+  it('disconnecting one guild leaves the other connected and only clears that guild\'s voice status', async () => {
     const a = makeClient();
     const b = makeClient();
     const status = await import('../shared/statusStore.js');
@@ -165,8 +165,9 @@ describe('per-guild isolation', () => {
 
     expect(mod.isConnected('guild-A')).toBe(false);
     expect(mod.isConnected('guild-B')).toBe(true);
-    // Another guild is still connected, so the shared/global voice status must not be cleared.
-    expect(vi.mocked(status.setVoiceDisconnected)).not.toHaveBeenCalled();
+    // Voice status is scoped per guild, so only guild-A's status is cleared.
+    expect(vi.mocked(status.setVoiceDisconnected)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(status.setVoiceDisconnected)).toHaveBeenCalledWith('guild-A');
   });
 
   it('a scheduled reconnect in one guild does not affect the other guild', async () => {
@@ -214,7 +215,8 @@ describe('per-guild isolation', () => {
     expect(mod.isConnected('guild-A')).toBe(false);
     expect(mod.isConnected('guild-B')).toBe(false);
     expect(mod.isConnected()).toBe(false);
-    expect(vi.mocked(status.setVoiceDisconnected)).toHaveBeenCalled();
+    expect(vi.mocked(status.setVoiceDisconnected)).toHaveBeenCalledWith('guild-A');
+    expect(vi.mocked(status.setVoiceDisconnected)).toHaveBeenCalledWith('guild-B');
   });
 });
 
@@ -333,7 +335,7 @@ describe('reconnect', () => {
 
       expect(mod.isConnected('guild-A')).toBe(false);
       expect(conn.destroy).toHaveBeenCalled();
-      expect(vi.mocked(status.setVoiceDisconnected)).toHaveBeenCalled();
+      expect(vi.mocked(status.setVoiceDisconnected)).toHaveBeenCalledWith('guild-A');
     } finally {
       vi.useRealTimers();
     }
@@ -356,7 +358,7 @@ describe('per-guild audio player', () => {
     idleHandler();
 
     expect(mod.isPlaying('guild-A')).toBe(false);
-    expect(vi.mocked(status.setVoiceIdle)).toHaveBeenCalled();
+    expect(vi.mocked(status.setVoiceIdle)).toHaveBeenCalledWith('guild-A');
   });
 
   it('error handler resets the playing flag', async () => {
@@ -375,7 +377,7 @@ describe('per-guild audio player', () => {
     expect(mod.isPlaying('guild-A')).toBe(false);
   });
 
-  it('does not clear the shared/global voice status when another guild is still playing (Idle)', async () => {
+  it('going idle in one guild only clears that guild\'s voice status (Idle)', async () => {
     const a = makeClient();
     const b = makeClient();
     const voice = await import('@discordjs/voice');
@@ -395,10 +397,11 @@ describe('per-guild audio player', () => {
 
     expect(mod.isPlaying('guild-A')).toBe(false);
     expect(mod.isPlaying('guild-B')).toBe(true);
-    expect(vi.mocked(status.setVoiceIdle)).not.toHaveBeenCalled();
+    expect(vi.mocked(status.setVoiceIdle)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(status.setVoiceIdle)).toHaveBeenCalledWith('guild-A');
   });
 
-  it('clears the shared/global voice status once the last playing guild goes idle', async () => {
+  it('clears the guild\'s voice status once it goes idle', async () => {
     const { client } = makeClient();
     const voice = await import('@discordjs/voice');
     const status = await import('../shared/statusStore.js');
@@ -412,10 +415,10 @@ describe('per-guild audio player', () => {
     const idleHandler = fakePlayer.on.mock.calls.find(([e]) => e === 'idle')?.[1] as () => void;
     idleHandler();
 
-    expect(vi.mocked(status.setVoiceIdle)).toHaveBeenCalled();
+    expect(vi.mocked(status.setVoiceIdle)).toHaveBeenCalledWith('guild-A');
   });
 
-  it('does not clear the shared/global voice status on error when another guild is still playing', async () => {
+  it('an error in one guild only clears that guild\'s voice status', async () => {
     const a = makeClient();
     const b = makeClient();
     const voice = await import('@discordjs/voice');
@@ -435,7 +438,8 @@ describe('per-guild audio player', () => {
 
     expect(mod.isPlaying('guild-A')).toBe(false);
     expect(mod.isPlaying('guild-B')).toBe(true);
-    expect(vi.mocked(status.setVoiceIdle)).not.toHaveBeenCalled();
+    expect(vi.mocked(status.setVoiceIdle)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(status.setVoiceIdle)).toHaveBeenCalledWith('guild-A');
   });
 
   it('playing one guild does not affect another guild\'s playing flag or player instance', async () => {

--- a/src/audio/audioPlayer.test.ts
+++ b/src/audio/audioPlayer.test.ts
@@ -234,6 +234,45 @@ describe('isConnected / getCurrentChannelId for unknown guilds', () => {
   });
 });
 
+describe('forgetGuild', () => {
+  it('is a no-op for a guild with no state', () => {
+    expect(() => mod.forgetGuild('never-seen')).not.toThrow();
+  });
+
+  it('disconnects a still-connected guild and clears its voice status before forgetting it', async () => {
+    const { client } = makeClient();
+    const status = await import('../shared/statusStore.js');
+    await mod.connect(client as never, 'guild-A', 'chan-1');
+    vi.mocked(status.setVoiceDisconnected).mockClear();
+
+    mod.forgetGuild('guild-A');
+
+    expect(mod.isConnected('guild-A')).toBe(false);
+    expect(vi.mocked(status.setVoiceDisconnected)).toHaveBeenCalledWith('guild-A');
+  });
+
+  it('drops the guild\'s current-channel state entirely', async () => {
+    const { client } = makeClient();
+    await mod.connect(client as never, 'guild-A', 'chan-1');
+
+    mod.forgetGuild('guild-A');
+
+    expect(mod.getCurrentChannelId('guild-A')).toBeNull();
+  });
+
+  it('does not affect another guild\'s state', async () => {
+    const a = makeClient();
+    const b = makeClient();
+    await mod.connect(a.client as never, 'guild-A', 'chan-A');
+    await mod.connect(b.client as never, 'guild-B', 'chan-B');
+
+    mod.forgetGuild('guild-A');
+
+    expect(mod.isConnected('guild-B')).toBe(true);
+    expect(mod.getCurrentChannelId('guild-B')).toBe('chan-B');
+  });
+});
+
 describe('reconnect', () => {
   it('schedules a reconnect after a failed connect and retries when the timer fires', async () => {
     vi.useFakeTimers();

--- a/src/audio/audioPlayer.ts
+++ b/src/audio/audioPlayer.ts
@@ -83,14 +83,6 @@ function anyConnected(): boolean {
   return false;
 }
 
-/** True if any guild's audio player is currently playing. */
-function anyPlaying(): boolean {
-  for (const state of states.values()) {
-    if (state.playing) return true;
-  }
-  return false;
-}
-
 // ─── Reconnect ────────────────────────────────────────────────────────────────
 
 const RECONNECT_BASE_DELAY_MS = 5_000;
@@ -132,19 +124,12 @@ function getPlayer(state: GuildVoiceState): DjsAudioPlayer {
     });
     guildPlayer.on(AudioPlayerStatus.Idle, () => {
       state.playing = false;
-      // Another guild may still be playing — only clear the shared/global
-      // status once no guild remains playing, mirroring the disconnected-status
-      // guard in tearDownGuild/disconnectGuild below.
-      if (!anyPlaying()) {
-        setVoiceIdle();
-      }
+      setVoiceIdle(state.guildId);
     });
     guildPlayer.on('error', (err) => {
       log.error(`Error: ${err.message}`, err);
       state.playing = false;
-      if (!anyPlaying()) {
-        setVoiceIdle();
-      }
+      setVoiceIdle(state.guildId);
     });
     state.player = guildPlayer;
   }
@@ -163,17 +148,14 @@ function stopGuildPlayer(state: GuildVoiceState): void {
 
 /**
  * Releases a guild's playback footprint after its connection is gone. Always
- * stops this guild's own player so playback in one guild never bleeds into
- * another; the shared/global voice-status dashboard is only cleared once no
- * guild remains connected, so tearing down one guild's connection doesn't
- * report the whole bot as disconnected while another guild is still live.
+ * stops this guild's own player and clears this guild's own voice status —
+ * status is scoped per guild, so tearing down one guild's connection never
+ * affects another guild's reported state.
  */
 function tearDownGuild(state: GuildVoiceState): void {
   state.currentChannelId = null;
   stopGuildPlayer(state);
-  if (!anyConnected()) {
-    setVoiceDisconnected();
-  }
+  setVoiceDisconnected(state.guildId);
 }
 
 /** Builds the ConnectionHandlerDeps callbacks bound to a specific guild's mutable voice state. */
@@ -260,7 +242,7 @@ export async function connect(client: Client, guildId: string, channelId: string
     state.reconnectAttempts = 0;
 
     joinedConnection.subscribe(getPlayer(state));
-    setVoiceConnected(channel.name);
+    setVoiceConnected(guildId, channel.name);
     log.info(`Joined voice channel: ${channel.name}`);
   } catch (err) {
     if (attemptId === state.currentAttemptId) {
@@ -292,9 +274,7 @@ function disconnectGuild(state: GuildVoiceState): void {
     existingConnection.destroy();
     state.connection = null;
     stopGuildPlayer(state);
-    if (!anyConnected()) {
-      setVoiceDisconnected();
-    }
+    setVoiceDisconnected(state.guildId);
     log.info(`Disconnected from voice channel for guild ${state.guildId}.`);
   }
 }

--- a/src/audio/audioPlayer.ts
+++ b/src/audio/audioPlayer.ts
@@ -323,6 +323,23 @@ export function getCurrentChannelId(guildId: string): string | null {
 }
 
 /**
+ * Fully forgets a guild's voice state — disconnecting first if still
+ * connected — so it stops occupying memory once the bot is no longer in
+ * that guild. Safe to call for a guild with no state (no-op). Called from
+ * the `guildDelete` handler; a guild the bot rejoins later starts fresh via
+ * {@link getState}'s lazy creation.
+ *
+ * @param guildId - Guild to forget.
+ */
+export function forgetGuild(guildId: string): void {
+  const state = states.get(guildId);
+  if (state) {
+    disconnectGuild(state);
+  }
+  states.delete(guildId);
+}
+
+/**
  * Marks playback as active for the given guild and sends the resource to that
  * guild's own audio player.
  *

--- a/src/commands/commandRouter.test.ts
+++ b/src/commands/commandRouter.test.ts
@@ -33,7 +33,7 @@ vi.mock('../shared/statusStore', () => ({
   setVoicePlaying: vi.fn(),
 }));
 
-import { handleCommand } from './commandRouter';
+import { handleCommand, forgetGuildCommandState } from './commandRouter';
 import { findTrigger, findSoundFiles } from '../db';
 import { isPlaying } from '../audio/audioPlayer';
 import { playFile, VoiceNotConnectedError } from '../audio/sfxPlayer';
@@ -116,6 +116,26 @@ describe('handleCommand', () => {
     await handleCommand('!ding', 'twitch', GUILD_B);
 
     expect(vi.mocked(playFile)).toHaveBeenCalledTimes(2);
+  });
+
+  it('forgetGuildCommandState resets a guild\'s cooldown so a subsequent command fires immediately', async () => {
+    vi.mocked(isPlaying).mockReturnValue(false);
+    vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
+    vi.mocked(findSoundFiles).mockResolvedValue(FILES);
+    vi.mocked(pickWeightedRandom).mockReturnValue('ding.mp3');
+
+    await handleCommand('!ding', 'twitch', GUILD_A);
+    expect(vi.mocked(playFile)).toHaveBeenCalledTimes(1);
+
+    forgetGuildCommandState(GUILD_A);
+
+    // Same timestamp — without forgetting, this would be blocked by the cooldown.
+    await handleCommand('!ding', 'twitch', GUILD_A);
+    expect(vi.mocked(playFile)).toHaveBeenCalledTimes(2);
+  });
+
+  it('forgetGuildCommandState is a no-op for a guild with no state', () => {
+    expect(() => forgetGuildCommandState('never-seen')).not.toThrow();
   });
 
   it('plays the correct file and updates status for a known command', async () => {

--- a/src/commands/commandRouter.test.ts
+++ b/src/commands/commandRouter.test.ts
@@ -128,7 +128,7 @@ describe('handleCommand', () => {
 
     expect(vi.mocked(findTrigger)).toHaveBeenCalledWith('!ding');
     expect(vi.mocked(playFile)).toHaveBeenCalledWith(path.posix.join(SFX_ROOT, 'ding.mp3'), GUILD_A);
-    expect(vi.mocked(setVoicePlaying)).toHaveBeenCalledWith('ding.mp3', '!ding', 'discord');
+    expect(vi.mocked(setVoicePlaying)).toHaveBeenCalledWith(GUILD_A, 'ding.mp3', '!ding', 'discord');
   });
 
   it('blocks a second concurrent call via the inFlight flag', async () => {
@@ -245,7 +245,7 @@ describe('handleCommand', () => {
       await handleCommand('!safe', 'twitch', GUILD_A);
 
       expect(vi.mocked(playFile)).toHaveBeenCalledWith(path.posix.join(SFX_ROOT, 'valid-sound.mp3'), GUILD_A);
-      expect(vi.mocked(setVoicePlaying)).toHaveBeenCalledWith('valid-sound.mp3', '!safe', 'twitch');
+      expect(vi.mocked(setVoicePlaying)).toHaveBeenCalledWith(GUILD_A, 'valid-sound.mp3', '!safe', 'twitch');
     });
 
     it('allows valid filenames in subdirectories within the SFX folder', async () => {
@@ -258,7 +258,7 @@ describe('handleCommand', () => {
       await handleCommand('!safe', 'twitch', GUILD_A);
 
       expect(vi.mocked(playFile)).toHaveBeenCalledWith(path.posix.join(SFX_ROOT, 'category', 'sound.mp3'), GUILD_A);
-      expect(vi.mocked(setVoicePlaying)).toHaveBeenCalledWith('category/sound.mp3', '!safe', 'twitch');
+      expect(vi.mocked(setVoicePlaying)).toHaveBeenCalledWith(GUILD_A, 'category/sound.mp3', '!safe', 'twitch');
     });
   });
 });

--- a/src/commands/commandRouter.ts
+++ b/src/commands/commandRouter.ts
@@ -29,6 +29,18 @@ function getGuildCommandState(guildId: string): GuildCommandState {
 }
 
 /**
+ * Forgets a guild's cooldown/in-flight state so it stops occupying memory
+ * once the bot is no longer in that guild. Safe to call for a guild with no
+ * state (no-op). Called from the `guildDelete` handler; a guild the bot
+ * rejoins later starts fresh via {@link getGuildCommandState}'s lazy creation.
+ *
+ * @param guildId - Guild to forget.
+ */
+export function forgetGuildCommandState(guildId: string): void {
+  guildStates.delete(guildId);
+}
+
+/**
  * Looks up a trigger command's sound files, picks one, and plays it into the
  * given guild, recording the play time on that guild's cooldown state and a
  * command-monitor entry on success.

--- a/src/commands/commandRouter.ts
+++ b/src/commands/commandRouter.ts
@@ -65,7 +65,7 @@ async function lookupAndPlay(
   try {
     playFile(fullPath, guildId);
     state.lastPlayedAt = Date.now();
-    setVoicePlaying(filename, command, source);
+    setVoicePlaying(guildId, filename, command, source);
     recordCommandTestEntry({ source, command, response: filename, channel: null, user: null });
   } catch (err) {
     if (err instanceof VoiceNotConnectedError) {

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -122,6 +122,8 @@ vi.mock('./db/streamdeckKeys', () => ({
 
 vi.mock('./db/lookupCache', () => ({
   createManagedLookupCache: vi.fn(),
+  DEFAULT_REFRESH_FAILURE_BACKOFF_MS: 5_000,
+  DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS: 60_000,
 }));
 
 import { upsertUserRecord, setTwitchBotEnabledRecord, removeUserRecord } from './db/users';

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -14,6 +14,7 @@ vi.mock('./db/users', () => ({
   getAllUsers: vi.fn(),
   updateDiscordName: vi.fn(),
   getTwitchEnabledChannels: vi.fn(),
+  getAllTwitchLinkedUsers: vi.fn(),
   updateAccessLevel: vi.fn(),
 }));
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,4 +1,5 @@
 export type { RefreshingLookupCache, ManagedLookupCacheOptions, ManagedLookupCache } from './db/lookupCache';
+export { createManagedLookupCache } from './db/lookupCache';
 export { getPool, closePool } from './db/pool';
 
 // ─── Guilds ──────────────────────────────────────────────────────────────────
@@ -24,9 +25,9 @@ export type { DbGuildCommandOverride } from './db/guildCommandOverrides';
 export {
   AccessLevel, ACCESS_LEVEL_LABELS,
   findUser, findUserByTwitchName, findOwnerUser, getAllUsers, getGuildMemberUsers,
-  updateDiscordName, getTwitchEnabledChannels, updateAccessLevel,
+  updateDiscordName, getTwitchEnabledChannels, getAllTwitchLinkedUsers, updateAccessLevel,
 } from './db/users';
-export type { AccessLevelValue, DbUser } from './db/users';
+export type { AccessLevelValue, DbUser, TwitchLinkedUser } from './db/users';
 
 import { upsertUserRecord, setTwitchBotEnabledRecord, removeUserRecord } from './db/users';
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,5 +1,9 @@
 export type { RefreshingLookupCache, ManagedLookupCacheOptions, ManagedLookupCache } from './db/lookupCache';
-export { createManagedLookupCache } from './db/lookupCache';
+export {
+  createManagedLookupCache,
+  DEFAULT_REFRESH_FAILURE_BACKOFF_MS,
+  DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS,
+} from './db/lookupCache';
 export { getPool, closePool } from './db/pool';
 
 // ─── Guilds ──────────────────────────────────────────────────────────────────

--- a/src/db/lookupCache.test.ts
+++ b/src/db/lookupCache.test.ts
@@ -1,6 +1,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { createManagedLookupCache } from './lookupCache';
+import {
+  createManagedLookupCache,
+  DEFAULT_REFRESH_FAILURE_BACKOFF_MS,
+  DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS,
+} from './lookupCache';
 import type { RefreshingLookupCache } from './lookupCache';
+
+describe('default backoff constants', () => {
+  it('exposes a shared backoff pair so callers do not each hardcode their own', () => {
+    expect(DEFAULT_REFRESH_FAILURE_BACKOFF_MS).toBe(5_000);
+    expect(DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS).toBe(60_000);
+    expect(DEFAULT_REFRESH_FAILURE_BACKOFF_MS).toBeLessThan(DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS);
+  });
+});
 
 interface TC extends RefreshingLookupCache {
   data: string;

--- a/src/db/lookupCache.ts
+++ b/src/db/lookupCache.ts
@@ -2,6 +2,12 @@ import { createLogger } from '../shared/logger';
 
 const log = createLogger('DB');
 
+/** Default backoff (ms) before retrying after a failed background refresh. */
+export const DEFAULT_REFRESH_FAILURE_BACKOFF_MS = 5_000;
+
+/** Default ceiling (ms) exponential backoff climbs to after repeated refresh failures. */
+export const DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS = 60_000;
+
 export interface RefreshingLookupCache {
   loadedAt: number;
 }

--- a/src/db/users.test.ts
+++ b/src/db/users.test.ts
@@ -17,6 +17,7 @@ import {
   upsertUserRecord,
   updateDiscordName,
   getTwitchEnabledChannels,
+  getAllTwitchLinkedUsers,
   setTwitchBotEnabledRecord,
   updateAccessLevel,
   removeUserRecord,
@@ -329,6 +330,41 @@ describe('getTwitchEnabledChannels', () => {
     vi.mocked(getPool).mockReturnValue(makePool([rows]) as any);
     const result = await getTwitchEnabledChannels();
     expect(result).toEqual(['alice']);
+  });
+});
+
+// ─── getAllTwitchLinkedUsers ───────────────────────────────────────────────────
+
+describe('getAllTwitchLinkedUsers', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([[]]) as any);
+    const result = await getAllTwitchLinkedUsers();
+    expect(result).toEqual([]);
+  });
+
+  it('maps discord_id and twitch_name through normalizeTwitchChannelName', async () => {
+    vi.mocked(normalizeTwitchChannelName).mockImplementation((s) => `normalized_${s}`);
+    const rows = [
+      { discord_id: '1', twitch_name: 'Alice' },
+      { discord_id: '2', twitch_name: 'Bob' },
+    ];
+    vi.mocked(getPool).mockReturnValue(makePool([rows]) as any);
+    const result = await getAllTwitchLinkedUsers();
+    expect(result).toEqual([
+      { twitchName: 'normalized_Alice', discordId: '1' },
+      { twitchName: 'normalized_Bob', discordId: '2' },
+    ]);
+  });
+
+  it('filters out entries where normalizeTwitchChannelName returns null', async () => {
+    vi.mocked(normalizeTwitchChannelName).mockReturnValueOnce('alice').mockReturnValueOnce(null);
+    const rows = [
+      { discord_id: '1', twitch_name: 'alice' },
+      { discord_id: '2', twitch_name: 'bad!' },
+    ];
+    vi.mocked(getPool).mockReturnValue(makePool([rows]) as any);
+    const result = await getAllTwitchLinkedUsers();
+    expect(result).toEqual([{ twitchName: 'alice', discordId: '1' }]);
   });
 });
 

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -215,6 +215,35 @@ export async function getTwitchEnabledChannels(): Promise<string[]> {
     .filter((v): v is string => v !== null);
 }
 
+/** A user's normalized Twitch channel name paired with their Discord ID. */
+export interface TwitchLinkedUser {
+  twitchName: string;
+  discordId: string;
+}
+
+/**
+ * Returns every user with a linked Twitch channel name, for bulk-loading a
+ * Twitch-channel → Discord-ID lookup cache. Unlike `getTwitchEnabledChannels`,
+ * this is not filtered by `is_twitch_bot_enabled` — it matches the same
+ * `twitch_name`-only lookup that `findUserByTwitchName` performs.
+ * @returns Normalized channel names paired with their owner's Discord ID;
+ *   invalid/unparseable names are silently dropped.
+ */
+export async function getAllTwitchLinkedUsers(): Promise<TwitchLinkedUser[]> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT discord_id, twitch_name
+     FROM \`user\`
+     WHERE twitch_name IS NOT NULL
+       AND twitch_name <> ''`,
+  );
+  return rows
+    .map((r) => {
+      const twitchName = normalizeTwitchChannelName(String(r.twitch_name));
+      return twitchName ? { twitchName, discordId: String(r.discord_id) } : null;
+    })
+    .filter((v): v is TwitchLinkedUser => v !== null);
+}
+
 /**
  * Sets whether a user's Twitch bot integration is enabled.
  * @param discordId - Discord snowflake as a string.

--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -15,6 +15,7 @@ vi.mock('../commands/customCommandHandler', () => ({ executeCustomCommandForDisc
 vi.mock('../commands/counterHandler', () => ({ executeCounterCommandForDiscord: vi.fn().mockResolvedValue(undefined) }));
 vi.mock('../shared/statusStore', () => ({ setDiscordReady: vi.fn(), clearVoiceStatus: vi.fn() }));
 vi.mock('../audio/audioPlayer', () => ({ forgetGuild: vi.fn() }));
+vi.mock('../web/routes/adminRefresh', () => ({ forgetGuildRefreshState: vi.fn() }));
 vi.mock('./guildRegistry', () => ({
   // Only the legacy configured guild is registered in these tests.
   isRegisteredGuild: vi.fn((id: string) => id === 'guild-id'),
@@ -280,9 +281,10 @@ describe('startDiscordBot — guildDelete handler', () => {
     return mockInstance.on.mock.calls.find(([event]: string[]) => event === 'guildDelete')?.[1] as Function;
   }
 
-  it('forgets the departed guild\'s in-memory voice, command, and status state', async () => {
+  it('forgets the departed guild\'s in-memory voice, command, status, and refresh state', async () => {
     const audioPlayer = await import('../audio/audioPlayer.js');
     const status = await import('../shared/statusStore.js');
+    const adminRefresh = await import('../web/routes/adminRefresh.js');
     const cb = getGuildDeleteCb();
 
     cb({ id: 'departed-guild', name: 'Departed Server' });
@@ -290,6 +292,7 @@ describe('startDiscordBot — guildDelete handler', () => {
     expect(vi.mocked(audioPlayer.forgetGuild)).toHaveBeenCalledWith('departed-guild');
     expect(vi.mocked(commands.forgetGuildCommandState)).toHaveBeenCalledWith('departed-guild');
     expect(vi.mocked(status.clearVoiceStatus)).toHaveBeenCalledWith('departed-guild');
+    expect(vi.mocked(adminRefresh.forgetGuildRefreshState)).toHaveBeenCalledWith('departed-guild');
   });
 
   it('does not touch the guild DB row', async () => {

--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -7,10 +7,14 @@ vi.mock('../shared/config', () => ({
   GLOBAL_COOLDOWN_MS: 0,
   EVENTSUB_TOKEN_SECRET: undefined,
 }));
-vi.mock('../commands/commandRouter', () => ({ handleCommand: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../commands/commandRouter', () => ({
+  handleCommand: vi.fn().mockResolvedValue(undefined),
+  forgetGuildCommandState: vi.fn(),
+}));
 vi.mock('../commands/customCommandHandler', () => ({ executeCustomCommandForDiscord: vi.fn().mockResolvedValue(undefined) }));
 vi.mock('../commands/counterHandler', () => ({ executeCounterCommandForDiscord: vi.fn().mockResolvedValue(undefined) }));
-vi.mock('../shared/statusStore', () => ({ setDiscordReady: vi.fn() }));
+vi.mock('../shared/statusStore', () => ({ setDiscordReady: vi.fn(), clearVoiceStatus: vi.fn() }));
+vi.mock('../audio/audioPlayer', () => ({ forgetGuild: vi.fn() }));
 vi.mock('./guildRegistry', () => ({
   // Only the legacy configured guild is registered in these tests.
   isRegisteredGuild: vi.fn((id: string) => id === 'guild-id'),
@@ -265,6 +269,36 @@ describe('startDiscordBot — guildCreate handler', () => {
 
     expect(vi.mocked(guilds.setMemberAccessLevel)).not.toHaveBeenCalled();
     expect(vi.mocked(registry.reloadGuildRegistry)).not.toHaveBeenCalled();
+  });
+});
+
+// ─── startDiscordBot — guildDelete handler ────────────────────────────────────
+
+describe('startDiscordBot — guildDelete handler', () => {
+  function getGuildDeleteCb() {
+    mod.startDiscordBot();
+    return mockInstance.on.mock.calls.find(([event]: string[]) => event === 'guildDelete')?.[1] as Function;
+  }
+
+  it('forgets the departed guild\'s in-memory voice, command, and status state', async () => {
+    const audioPlayer = await import('../audio/audioPlayer.js');
+    const status = await import('../shared/statusStore.js');
+    const cb = getGuildDeleteCb();
+
+    cb({ id: 'departed-guild', name: 'Departed Server' });
+
+    expect(vi.mocked(audioPlayer.forgetGuild)).toHaveBeenCalledWith('departed-guild');
+    expect(vi.mocked(commands.forgetGuildCommandState)).toHaveBeenCalledWith('departed-guild');
+    expect(vi.mocked(status.clearVoiceStatus)).toHaveBeenCalledWith('departed-guild');
+  });
+
+  it('does not touch the guild DB row', async () => {
+    const guilds = await import('../db.js');
+    const cb = getGuildDeleteCb();
+
+    cb({ id: 'departed-guild', name: 'Departed Server' });
+
+    expect(vi.mocked(guilds.upsertGuild)).not.toHaveBeenCalled();
   });
 });
 

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -5,6 +5,7 @@ import { executeCustomCommandForDiscord } from '../commands/customCommandHandler
 import { executeCounterCommandForDiscord } from '../commands/counterHandler';
 import { setDiscordReady, clearVoiceStatus } from '../shared/statusStore';
 import { forgetGuild as forgetGuildVoiceState } from '../audio/audioPlayer';
+import { forgetGuildRefreshState } from '../web/routes/adminRefresh';
 import { isRegisteredGuild, reloadGuildRegistry } from './guildRegistry';
 import { upsertGuild, getAllGuilds, getGuildById, findUser, upsertUser, setMemberAccessLevel, AccessLevel } from '../db';
 import { createLogger } from '../shared/logger';
@@ -159,15 +160,16 @@ export function startDiscordBot(): void {
   });
 
   // The bot's per-guild in-memory state (voice connections, command cooldowns,
-  // dashboard voice status) is populated lazily and never expires on its own.
-  // Without this, a guild the bot is kicked from — or that deletes itself —
-  // leaves its entry behind forever in a long-running process. None of this
-  // touches the `guild` DB row, which (like guildCreate) is intentionally
-  // never deleted on leave.
+  // dashboard voice status, admin name-refresh progress) is populated lazily
+  // and never expires on its own. Without this, a guild the bot is kicked
+  // from — or that deletes itself — leaves its entry behind forever in a
+  // long-running process. None of this touches the `guild` DB row, which
+  // (like guildCreate) is intentionally never deleted on leave.
   localClient.on('guildDelete', (guild) => {
     forgetGuildVoiceState(guild.id);
     forgetGuildCommandState(guild.id);
     clearVoiceStatus(guild.id);
+    forgetGuildRefreshState(guild.id);
     log.info(`Forgot in-memory state for guild '${guild.name}' (${guild.id}) — bot removed.`);
   });
 

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -1,9 +1,10 @@
 import { Client, GatewayIntentBits, Guild } from 'discord.js';
 import { DISCORD_TOKEN } from '../shared/config';
-import { handleCommand } from '../commands/commandRouter';
+import { handleCommand, forgetGuildCommandState } from '../commands/commandRouter';
 import { executeCustomCommandForDiscord } from '../commands/customCommandHandler';
 import { executeCounterCommandForDiscord } from '../commands/counterHandler';
-import { setDiscordReady } from '../shared/statusStore';
+import { setDiscordReady, clearVoiceStatus } from '../shared/statusStore';
+import { forgetGuild as forgetGuildVoiceState } from '../audio/audioPlayer';
 import { isRegisteredGuild, reloadGuildRegistry } from './guildRegistry';
 import { upsertGuild, getAllGuilds, getGuildById, findUser, upsertUser, setMemberAccessLevel, AccessLevel } from '../db';
 import { createLogger } from '../shared/logger';
@@ -155,6 +156,19 @@ export function startDiscordBot(): void {
       await reloadGuildRegistry();
       log.info(`Registered guild '${guild.name}' (${guild.id}).`);
     })().catch((err) => log.error(`Failed to register guild ${guild.id}:`, err));
+  });
+
+  // The bot's per-guild in-memory state (voice connections, command cooldowns,
+  // dashboard voice status) is populated lazily and never expires on its own.
+  // Without this, a guild the bot is kicked from — or that deletes itself —
+  // leaves its entry behind forever in a long-running process. None of this
+  // touches the `guild` DB row, which (like guildCreate) is intentionally
+  // never deleted on leave.
+  localClient.on('guildDelete', (guild) => {
+    forgetGuildVoiceState(guild.id);
+    forgetGuildCommandState(guild.id);
+    clearVoiceStatus(guild.id);
+    log.info(`Forgot in-memory state for guild '${guild.name}' (${guild.id}) — bot removed.`);
   });
 
   localClient.once('clientReady', async (c) => {

--- a/src/shared/statusStore.test.ts
+++ b/src/shared/statusStore.test.ts
@@ -9,12 +9,12 @@ beforeEach(async () => {
 
 describe('Discord status', () => {
   it('starts as not ready', () => {
-    expect(mod.getStatus().discord.ready).toBe(false);
+    expect(mod.getStatus(null).discord.ready).toBe(false);
   });
 
   it('setDiscordReady marks ready with tag and guildName', () => {
     mod.setDiscordReady('Bot#1234', 'MyGuild');
-    const { discord } = mod.getStatus();
+    const { discord } = mod.getStatus(null);
     expect(discord.ready).toBe(true);
     expect(discord.tag).toBe('Bot#1234');
     expect(discord.guildName).toBe('MyGuild');
@@ -23,24 +23,31 @@ describe('Discord status', () => {
 
 describe('Voice status', () => {
   it('starts disconnected and idle', () => {
-    const { voice } = mod.getStatus();
+    const { voice } = mod.getStatus('guild-A');
+    expect(voice.connected).toBe(false);
+    expect(voice.playing).toBe(false);
+    expect(voice.currentFile).toBeNull();
+  });
+
+  it('reports a default disconnected/idle status for a null guildId', () => {
+    const { voice } = mod.getStatus(null);
     expect(voice.connected).toBe(false);
     expect(voice.playing).toBe(false);
     expect(voice.currentFile).toBeNull();
   });
 
   it('setVoiceConnected marks connected with channelName', () => {
-    mod.setVoiceConnected('General');
-    const { voice } = mod.getStatus();
+    mod.setVoiceConnected('guild-A', 'General');
+    const { voice } = mod.getStatus('guild-A');
     expect(voice.connected).toBe(true);
     expect(voice.channelName).toBe('General');
   });
 
   it('setVoiceDisconnected clears connected, playing, file, and channelName', () => {
-    mod.setVoiceConnected('General');
-    mod.setVoicePlaying('clap.mp3', '!clap', 'discord');
-    mod.setVoiceDisconnected();
-    const { voice } = mod.getStatus();
+    mod.setVoiceConnected('guild-A', 'General');
+    mod.setVoicePlaying('guild-A', 'clap.mp3', '!clap', 'discord');
+    mod.setVoiceDisconnected('guild-A');
+    const { voice } = mod.getStatus('guild-A');
     expect(voice.connected).toBe(false);
     expect(voice.channelName).toBeNull();
     expect(voice.playing).toBe(false);
@@ -48,8 +55,8 @@ describe('Voice status', () => {
   });
 
   it('setVoicePlaying sets playing, file, command, source, and lastPlayedAt', () => {
-    mod.setVoicePlaying('clap.mp3', '!clap', 'discord');
-    const { voice } = mod.getStatus();
+    mod.setVoicePlaying('guild-A', 'clap.mp3', '!clap', 'discord');
+    const { voice } = mod.getStatus('guild-A');
     expect(voice.playing).toBe(true);
     expect(voice.currentFile).toBe('clap.mp3');
     expect(voice.lastCommand).toBe('!clap');
@@ -58,23 +65,46 @@ describe('Voice status', () => {
   });
 
   it('setVoiceIdle clears playing and currentFile but preserves lastPlayedAt', () => {
-    mod.setVoicePlaying('clap.mp3', '!clap', 'discord');
-    mod.setVoiceIdle();
-    const { voice } = mod.getStatus();
+    mod.setVoicePlaying('guild-A', 'clap.mp3', '!clap', 'discord');
+    mod.setVoiceIdle('guild-A');
+    const { voice } = mod.getStatus('guild-A');
     expect(voice.playing).toBe(false);
     expect(voice.currentFile).toBeNull();
     expect(voice.lastPlayedAt).toBeInstanceOf(Date);
+  });
+
+  it('scopes voice status per guild — one guild playing does not affect another', () => {
+    mod.setVoiceConnected('guild-A', 'General');
+    mod.setVoicePlaying('guild-A', 'clap.mp3', '!clap', 'discord');
+    const { voice: voiceB } = mod.getStatus('guild-B');
+    expect(voiceB.connected).toBe(false);
+    expect(voiceB.playing).toBe(false);
+    expect(voiceB.currentFile).toBeNull();
+    const { voice: voiceA } = mod.getStatus('guild-A');
+    expect(voiceA.connected).toBe(true);
+    expect(voiceA.playing).toBe(true);
+    expect(voiceA.currentFile).toBe('clap.mp3');
+  });
+
+  it('clearVoiceStatus removes a guild entirely, resetting it to default on next read', () => {
+    mod.setVoiceConnected('guild-A', 'General');
+    mod.setVoicePlaying('guild-A', 'clap.mp3', '!clap', 'discord');
+    mod.clearVoiceStatus('guild-A');
+    const { voice } = mod.getStatus('guild-A');
+    expect(voice.connected).toBe(false);
+    expect(voice.playing).toBe(false);
+    expect(voice.currentFile).toBeNull();
   });
 });
 
 describe('Twitch channel status', () => {
   it('starts with no channels', () => {
-    expect(mod.getStatus().twitch).toEqual({});
+    expect(mod.getStatus(null).twitch).toEqual({});
   });
 
   it('setTwitchChannel connected records lastConnectedAt', () => {
     mod.setTwitchChannel('mychan', true);
-    const entry = mod.getStatus().twitch['mychan'];
+    const entry = mod.getStatus(null).twitch['mychan'];
     expect(entry.connected).toBe(true);
     expect(entry.lastConnectedAt).toBeInstanceOf(Date);
     expect(entry.lastDisconnectedAt).toBeNull();
@@ -83,66 +113,66 @@ describe('Twitch channel status', () => {
   it('setTwitchChannel disconnected records lastDisconnectedAt', () => {
     mod.setTwitchChannel('mychan', true);
     mod.setTwitchChannel('mychan', false);
-    const entry = mod.getStatus().twitch['mychan'];
+    const entry = mod.getStatus(null).twitch['mychan'];
     expect(entry.connected).toBe(false);
     expect(entry.lastDisconnectedAt).toBeInstanceOf(Date);
   });
 
   it('strips leading # from channel name', () => {
     mod.setTwitchChannel('#mychan', true);
-    expect(mod.getStatus().twitch['mychan']).toBeDefined();
+    expect(mod.getStatus(null).twitch['mychan']).toBeDefined();
   });
 
   it('normalises to lowercase', () => {
     mod.setTwitchChannel('MyChan', true);
-    expect(mod.getStatus().twitch['mychan']).toBeDefined();
+    expect(mod.getStatus(null).twitch['mychan']).toBeDefined();
   });
 
   it('reconnecting does not overwrite lastConnectedAt again', () => {
     mod.setTwitchChannel('mychan', true);
-    const first = mod.getStatus().twitch['mychan'].lastConnectedAt;
+    const first = mod.getStatus(null).twitch['mychan'].lastConnectedAt;
     mod.setTwitchChannel('mychan', true); // already connected — no change
-    expect(mod.getStatus().twitch['mychan'].lastConnectedAt).toEqual(first);
+    expect(mod.getStatus(null).twitch['mychan'].lastConnectedAt).toEqual(first);
   });
 
   it('setTwitchChannelLive updates isLive for an existing channel', () => {
     mod.setTwitchChannel('mychan', true);
     mod.setTwitchChannelLive('mychan', true);
-    expect(mod.getStatus().twitch['mychan'].isLive).toBe(true);
+    expect(mod.getStatus(null).twitch['mychan'].isLive).toBe(true);
     mod.setTwitchChannelLive('mychan', false);
-    expect(mod.getStatus().twitch['mychan'].isLive).toBe(false);
+    expect(mod.getStatus(null).twitch['mychan'].isLive).toBe(false);
   });
 
   it('setTwitchChannelLive is a no-op for unknown channels', () => {
     mod.setTwitchChannelLive('unknown', true);
-    expect(mod.getStatus().twitch['unknown']).toBeUndefined();
+    expect(mod.getStatus(null).twitch['unknown']).toBeUndefined();
   });
 });
 
 describe('TikTok channel status', () => {
   it('starts with no channels', () => {
-    expect(mod.getStatus().tiktok).toEqual({});
+    expect(mod.getStatus(null).tiktok).toEqual({});
   });
 
   it('setTikTokChannel connected records state', () => {
     mod.setTikTokChannel('creator1', true);
-    expect(mod.getStatus().tiktok['creator1'].connected).toBe(true);
-    expect(mod.getStatus().tiktok['creator1'].lastConnectedAt).toBeInstanceOf(Date);
+    expect(mod.getStatus(null).tiktok['creator1'].connected).toBe(true);
+    expect(mod.getStatus(null).tiktok['creator1'].lastConnectedAt).toBeInstanceOf(Date);
   });
 });
 
 describe('getStatus returns shallow copies', () => {
   it('mutating returned discord object does not affect internal state', () => {
     mod.setDiscordReady('Bot#1234', 'MyGuild');
-    const snapshot = mod.getStatus();
+    const snapshot = mod.getStatus(null);
     (snapshot.discord as Record<string, unknown>).tag = 'mutated';
-    expect(mod.getStatus().discord.tag).toBe('Bot#1234');
+    expect(mod.getStatus(null).discord.tag).toBe('Bot#1234');
   });
 
   it('mutating returned voice object does not affect internal state', () => {
-    mod.setVoiceConnected('General');
-    const snapshot = mod.getStatus();
+    mod.setVoiceConnected('guild-A', 'General');
+    const snapshot = mod.getStatus('guild-A');
     (snapshot.voice as Record<string, unknown>).channelName = 'mutated';
-    expect(mod.getStatus().voice.channelName).toBe('General');
+    expect(mod.getStatus('guild-A').voice.channelName).toBe('General');
   });
 });

--- a/src/shared/statusStore.ts
+++ b/src/shared/statusStore.ts
@@ -30,6 +30,16 @@ function defaultVoiceStatus(): VoiceStatus {
   };
 }
 
+/** Returns the value for `key` in `map`, creating and inserting `makeDefault()` if absent. */
+function getOrCreate<K, V>(map: Map<K, V>, key: K, makeDefault: () => V): V {
+  let value = map.get(key);
+  if (!value) {
+    value = makeDefault();
+    map.set(key, value);
+  }
+  return value;
+}
+
 const state = {
   discord: {
     ready: false,
@@ -43,12 +53,7 @@ const state = {
 
 /** Returns a guild's voice status, creating a default (disconnected/idle) record on first use. */
 function getVoiceState(guildId: string): VoiceStatus {
-  let voice = state.voice.get(guildId);
-  if (!voice) {
-    voice = defaultVoiceStatus();
-    state.voice.set(guildId, voice);
-  }
-  return voice;
+  return getOrCreate(state.voice, guildId, defaultVoiceStatus);
 }
 
 /**
@@ -115,17 +120,16 @@ export function setVoiceIdle(guildId: string): void {
   voice.currentFile = null;
 }
 
+/** Returns a fresh, disconnected channel status record with no connection history yet. */
+function defaultChannelStatus(): ChannelStatus {
+  return { connected: false, lastConnectedAt: null, lastDisconnectedAt: null, isLive: false };
+}
+
 function updateChannel(map: Map<string, ChannelStatus>, key: string, connected: boolean): void {
-  const existing: ChannelStatus = map.get(key) ?? {
-    connected: false,
-    lastConnectedAt: null,
-    lastDisconnectedAt: null,
-    isLive: false,
-  };
+  const existing = getOrCreate(map, key, defaultChannelStatus);
   if (connected && !existing.connected) existing.lastConnectedAt = new Date();
   if (!connected && existing.connected) existing.lastDisconnectedAt = new Date();
   existing.connected = connected;
-  map.set(key, existing);
 }
 
 /** Updates the connected state for a Twitch channel. */

--- a/src/shared/statusStore.ts
+++ b/src/shared/statusStore.ts
@@ -6,24 +6,58 @@ export interface ChannelStatus {
   isLive: boolean;
 }
 
+/** Live voice-connection and playback status for a single guild. */
+export interface VoiceStatus {
+  connected: boolean;
+  channelName: string | null;
+  playing: boolean;
+  currentFile: string | null;
+  lastCommand: string | null;
+  lastSource: string | null;
+  lastPlayedAt: Date | null;
+}
+
+/** Returns a fresh, disconnected/idle voice status record. */
+function defaultVoiceStatus(): VoiceStatus {
+  return {
+    connected: false,
+    channelName: null,
+    playing: false,
+    currentFile: null,
+    lastCommand: null,
+    lastSource: null,
+    lastPlayedAt: null,
+  };
+}
+
 const state = {
   discord: {
     ready: false,
     tag: null as string | null,
     guildName: null as string | null,
   },
-  voice: {
-    connected: false,
-    channelName: null as string | null,
-    playing: false,
-    currentFile: null as string | null,
-    lastCommand: null as string | null,
-    lastSource: null as string | null,
-    lastPlayedAt: null as Date | null,
-  },
+  voice: new Map<string, VoiceStatus>(),
   twitch: new Map<string, ChannelStatus>(),
   tiktok: new Map<string, ChannelStatus>(),
 };
+
+/** Returns a guild's voice status, creating a default (disconnected/idle) record on first use. */
+function getVoiceState(guildId: string): VoiceStatus {
+  let voice = state.voice.get(guildId);
+  if (!voice) {
+    voice = defaultVoiceStatus();
+    state.voice.set(guildId, voice);
+  }
+  return voice;
+}
+
+/**
+ * Removes a guild's voice status entirely, e.g. when the bot leaves the guild.
+ * @param guildId - Guild whose voice status should be forgotten.
+ */
+export function clearVoiceStatus(guildId: string): void {
+  state.voice.delete(guildId);
+}
 
 /** Marks the Discord bot as ready with its tag and guild name. */
 export function setDiscordReady(tag: string, guildName: string): void {
@@ -32,33 +66,53 @@ export function setDiscordReady(tag: string, guildName: string): void {
   state.discord.guildName = guildName;
 }
 
-/** Records that the bot has joined a voice channel. */
-export function setVoiceConnected(channelName: string): void {
-  state.voice.connected = true;
-  state.voice.channelName = channelName;
+/**
+ * Records that the bot has joined a voice channel in the given guild.
+ * @param guildId - Guild the bot connected in.
+ * @param channelName - Name of the voice channel joined.
+ */
+export function setVoiceConnected(guildId: string, channelName: string): void {
+  const voice = getVoiceState(guildId);
+  voice.connected = true;
+  voice.channelName = channelName;
 }
 
-/** Records that the bot has left the voice channel and clears playback state. */
-export function setVoiceDisconnected(): void {
-  state.voice.connected = false;
-  state.voice.channelName = null;
-  state.voice.playing = false;
-  state.voice.currentFile = null;
+/**
+ * Records that the bot has left the given guild's voice channel and clears its playback state.
+ * @param guildId - Guild the bot disconnected from.
+ */
+export function setVoiceDisconnected(guildId: string): void {
+  const voice = getVoiceState(guildId);
+  voice.connected = false;
+  voice.channelName = null;
+  voice.playing = false;
+  voice.currentFile = null;
 }
 
-/** Updates voice state to reflect that a file is now playing. */
-export function setVoicePlaying(file: string, command: string, source: string): void {
-  state.voice.playing = true;
-  state.voice.currentFile = file;
-  state.voice.lastCommand = command;
-  state.voice.lastSource = source;
-  state.voice.lastPlayedAt = new Date();
+/**
+ * Updates a guild's voice state to reflect that a file is now playing there.
+ * @param guildId - Guild the sound is playing in.
+ * @param file - File name being played.
+ * @param command - Trigger command that caused playback.
+ * @param source - Where the command came from (e.g. 'discord', 'twitch', 'streamdeck').
+ */
+export function setVoicePlaying(guildId: string, file: string, command: string, source: string): void {
+  const voice = getVoiceState(guildId);
+  voice.playing = true;
+  voice.currentFile = file;
+  voice.lastCommand = command;
+  voice.lastSource = source;
+  voice.lastPlayedAt = new Date();
 }
 
-/** Clears the playing flag and current file when playback finishes. */
-export function setVoiceIdle(): void {
-  state.voice.playing = false;
-  state.voice.currentFile = null;
+/**
+ * Clears the playing flag and current file for a guild when its playback finishes.
+ * @param guildId - Guild whose playback went idle.
+ */
+export function setVoiceIdle(guildId: string): void {
+  const voice = getVoiceState(guildId);
+  voice.playing = false;
+  voice.currentFile = null;
 }
 
 function updateChannel(map: Map<string, ChannelStatus>, key: string, connected: boolean): void {
@@ -91,11 +145,19 @@ export function setTwitchChannelLive(login: string, isLive: boolean): void {
   if (existing) existing.isLive = isLive;
 }
 
-/** Returns a snapshot of the current bot status (Discord, voice, Twitch channels, TikTok channels). */
-export function getStatus() {
+/**
+ * Returns a snapshot of the current bot status (Discord, voice for the given
+ * guild, Twitch channels, TikTok channels). Voice status is scoped to a
+ * single guild so a viewer of one guild's dashboard never sees another
+ * guild's now-playing info; a null guildId (no guild selected yet) reports a
+ * default disconnected/idle voice status.
+ *
+ * @param guildId - Guild to read voice status for, or null if none is selected.
+ */
+export function getStatus(guildId: string | null) {
   return {
     discord: { ...state.discord },
-    voice: { ...state.voice },
+    voice: { ...((guildId ? state.voice.get(guildId) : undefined) ?? defaultVoiceStatus()) },
     twitch: Object.fromEntries(state.twitch) as Record<string, ChannelStatus>,
     tiktok: Object.fromEntries(state.tiktok) as Record<string, ChannelStatus>,
   };

--- a/src/tiktok/tiktokBot.test.ts
+++ b/src/tiktok/tiktokBot.test.ts
@@ -65,10 +65,13 @@ vi.mock('../shared/statusStore', () => ({
 // Uses the real createManagedLookupCache (not a fake) so tests below can
 // exercise its actual TTL / stale-while-revalidate behaviour.
 vi.mock('../db', async () => {
-  const { createManagedLookupCache } = await vi.importActual<typeof import('../db/lookupCache')>('../db/lookupCache');
+  const { createManagedLookupCache, DEFAULT_REFRESH_FAILURE_BACKOFF_MS, DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS } =
+    await vi.importActual<typeof import('../db/lookupCache')>('../db/lookupCache');
   return {
     findOwnerUser: vi.fn(),
     createManagedLookupCache,
+    DEFAULT_REFRESH_FAILURE_BACKOFF_MS,
+    DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS,
   };
 });
 

--- a/src/tiktok/tiktokBot.test.ts
+++ b/src/tiktok/tiktokBot.test.ts
@@ -62,9 +62,15 @@ vi.mock('../shared/statusStore', () => ({
   setTikTokChannel: vi.fn(),
 }));
 
-vi.mock('../db', () => ({
-  findOwnerUser: vi.fn(),
-}));
+// Uses the real createManagedLookupCache (not a fake) so tests below can
+// exercise its actual TTL / stale-while-revalidate behaviour.
+vi.mock('../db', async () => {
+  const { createManagedLookupCache } = await vi.importActual<typeof import('../db/lookupCache')>('../db/lookupCache');
+  return {
+    findOwnerUser: vi.fn(),
+    createManagedLookupCache,
+  };
+});
 
 vi.mock('../discord/discordBot', () => ({
   getDiscordClient: vi.fn(),
@@ -278,10 +284,16 @@ describe('chat handling', () => {
     vi.mocked(findOwnerUser).mockResolvedValue({ discord_id: 'new-owner-discord-id' } as any);
     await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1);
 
+    // The cache is now stale — this lookup kicks a background refresh but
+    // (per the shared lookupCache's stale-while-revalidate strategy) still
+    // serves the last-good owner for this call.
     getConnection('alice').emit('chat', { content: '!again' });
     await vi.waitFor(() => expect(handleCommand).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(findOwnerUser).toHaveBeenCalledTimes(2));
 
-    expect(findOwnerUser).toHaveBeenCalledTimes(2);
+    // A subsequent lookup picks up the refreshed owner.
+    getConnection('alice').emit('chat', { content: '!third' });
+    await vi.waitFor(() => expect(handleCommand).toHaveBeenCalledTimes(3));
     expect(getActiveGuildForUser).toHaveBeenLastCalledWith(expect.anything(), 'new-owner-discord-id');
   });
 });

--- a/src/tiktok/tiktokBot.ts
+++ b/src/tiktok/tiktokBot.ts
@@ -9,7 +9,7 @@ import type {
 import { TIKTOK_CHANNELS, TIKTOK_SIGN_API_KEY } from '../shared/config';
 import { handleCommand } from '../commands/commandRouter';
 import { setTikTokChannel } from '../shared/statusStore';
-import { findOwnerUser } from '../db';
+import { createManagedLookupCache, findOwnerUser, type RefreshingLookupCache } from '../db';
 import { getDiscordClient } from '../discord/discordBot';
 import { getActiveGuildForUser } from '../discord/voicePresence';
 
@@ -21,14 +21,37 @@ const log = createLogger('TikTok');
 // on every chat message. Bounded by a TTL so a reassigned is_owner is picked
 // up within a few minutes rather than staying stale until the process restarts.
 const OWNER_DISCORD_ID_CACHE_TTL_MS = 5 * 60 * 1000;
-let cachedOwner: { discordId: string; cachedAt: number } | null = null;
+const OWNER_DISCORD_ID_CACHE_REFRESH_FAILURE_BACKOFF_MS = 5_000;
+const OWNER_DISCORD_ID_CACHE_REFRESH_FAILURE_MAX_BACKOFF_MS = 60_000;
+
+interface OwnerDiscordIdCache extends RefreshingLookupCache {
+  discordId: string | null;
+}
+
+/** Returns a fresh, immediately-stale "no owner resolved yet" cache entry. */
+function createEmptyOwnerDiscordIdCache(): OwnerDiscordIdCache {
+  return { loadedAt: 0, discordId: null };
+}
+
+const ownerDiscordIdLookupCache = createManagedLookupCache<OwnerDiscordIdCache>({
+  cacheName: 'tiktok owner discord id cache',
+  ttlMs: OWNER_DISCORD_ID_CACHE_TTL_MS,
+  refreshFailureBackoffMs: OWNER_DISCORD_ID_CACHE_REFRESH_FAILURE_BACKOFF_MS,
+  refreshFailureMaxBackoffMs: OWNER_DISCORD_ID_CACHE_REFRESH_FAILURE_MAX_BACKOFF_MS,
+  createEmptyCache: createEmptyOwnerDiscordIdCache,
+  loadCache: async () => {
+    const owner = await findOwnerUser();
+    // Only a successful resolution is cached for the full TTL; a miss stays
+    // immediately stale (loadedAt: 0) so the next lookup retries instead of
+    // being stuck unresolved until the TTL expires.
+    return owner ? { loadedAt: Date.now(), discordId: owner.discord_id } : createEmptyOwnerDiscordIdCache();
+  },
+});
 
 /** Resolves the bot owner's Discord ID, caching a successful lookup. */
 async function resolveOwnerDiscordId(): Promise<string | null> {
-  if (cachedOwner && Date.now() - cachedOwner.cachedAt < OWNER_DISCORD_ID_CACHE_TTL_MS) return cachedOwner.discordId;
-  const owner = await findOwnerUser();
-  if (owner) cachedOwner = { discordId: owner.discord_id, cachedAt: Date.now() };
-  return owner?.discord_id ?? null;
+  const cache = await ownerDiscordIdLookupCache.getCache();
+  return cache.discordId;
 }
 
 /**
@@ -47,7 +70,7 @@ async function resolveGuildIdForTikTokCommand(): Promise<string | null> {
 
 /** Test-only: clears the cached owner discord_id so each test starts from a clean slate. */
 export function __resetOwnerDiscordIdCacheForTests(): void {
-  cachedOwner = null;
+  ownerDiscordIdLookupCache.invalidate();
 }
 
 // TypedEventEmitter<ClientEventMap> is the base of TikTokLiveConnection but TypeScript

--- a/src/tiktok/tiktokBot.ts
+++ b/src/tiktok/tiktokBot.ts
@@ -9,7 +9,13 @@ import type {
 import { TIKTOK_CHANNELS, TIKTOK_SIGN_API_KEY } from '../shared/config';
 import { handleCommand } from '../commands/commandRouter';
 import { setTikTokChannel } from '../shared/statusStore';
-import { createManagedLookupCache, findOwnerUser, type RefreshingLookupCache } from '../db';
+import {
+  createManagedLookupCache,
+  DEFAULT_REFRESH_FAILURE_BACKOFF_MS,
+  DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS,
+  findOwnerUser,
+  type RefreshingLookupCache,
+} from '../db';
 import { getDiscordClient } from '../discord/discordBot';
 import { getActiveGuildForUser } from '../discord/voicePresence';
 
@@ -21,8 +27,6 @@ const log = createLogger('TikTok');
 // on every chat message. Bounded by a TTL so a reassigned is_owner is picked
 // up within a few minutes rather than staying stale until the process restarts.
 const OWNER_DISCORD_ID_CACHE_TTL_MS = 5 * 60 * 1000;
-const OWNER_DISCORD_ID_CACHE_REFRESH_FAILURE_BACKOFF_MS = 5_000;
-const OWNER_DISCORD_ID_CACHE_REFRESH_FAILURE_MAX_BACKOFF_MS = 60_000;
 
 interface OwnerDiscordIdCache extends RefreshingLookupCache {
   discordId: string | null;
@@ -36,8 +40,8 @@ function createEmptyOwnerDiscordIdCache(): OwnerDiscordIdCache {
 const ownerDiscordIdLookupCache = createManagedLookupCache<OwnerDiscordIdCache>({
   cacheName: 'tiktok owner discord id cache',
   ttlMs: OWNER_DISCORD_ID_CACHE_TTL_MS,
-  refreshFailureBackoffMs: OWNER_DISCORD_ID_CACHE_REFRESH_FAILURE_BACKOFF_MS,
-  refreshFailureMaxBackoffMs: OWNER_DISCORD_ID_CACHE_REFRESH_FAILURE_MAX_BACKOFF_MS,
+  refreshFailureBackoffMs: DEFAULT_REFRESH_FAILURE_BACKOFF_MS,
+  refreshFailureMaxBackoffMs: DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS,
   createEmptyCache: createEmptyOwnerDiscordIdCache,
   loadCache: async () => {
     const owner = await findOwnerUser();

--- a/src/twitch/twitchBot.test.ts
+++ b/src/twitch/twitchBot.test.ts
@@ -35,10 +35,16 @@ vi.mock('../shared/config', () => ({
   TWITCH_OAUTH_TOKEN: 'oauth:test',
 }));
 
-vi.mock('../db', () => ({
-  getTwitchEnabledChannels: vi.fn(),
-  findUserByTwitchName: vi.fn(),
-}));
+// Uses the real createManagedLookupCache (not a fake) so tests below can
+// exercise its actual TTL / stale-while-revalidate behaviour.
+vi.mock('../db', async () => {
+  const { createManagedLookupCache } = await vi.importActual<typeof import('../db/lookupCache')>('../db/lookupCache');
+  return {
+    getTwitchEnabledChannels: vi.fn(),
+    getAllTwitchLinkedUsers: vi.fn(),
+    createManagedLookupCache,
+  };
+});
 
 vi.mock('../discord/discordBot', () => ({
   getDiscordClient: vi.fn(),
@@ -95,7 +101,7 @@ import {
   getActiveChannelUserIds,
   setChannelJoinedHook,
 } from './twitchChannelMembership';
-import { getTwitchEnabledChannels, findUserByTwitchName } from '../db';
+import { getTwitchEnabledChannels, getAllTwitchLinkedUsers } from '../db';
 import { getDiscordClient } from '../discord/discordBot';
 import { getActiveGuildForUser } from '../discord/voicePresence';
 import { getUsers } from './twitchApi';
@@ -163,7 +169,7 @@ describe('handleTwitchMessage', () => {
     // Reset call history so only message-dispatch calls are visible to assertions.
     vi.clearAllMocks();
     resetMockClient();
-    vi.mocked(findUserByTwitchName).mockResolvedValue({ discord_id: 'streamer-discord-id' } as any);
+    vi.mocked(getAllTwitchLinkedUsers).mockResolvedValue([{ twitchName: 'streamer', discordId: 'streamer-discord-id' }]);
     vi.mocked(getDiscordClient).mockReturnValue({} as any);
     vi.mocked(getActiveGuildForUser).mockReturnValue('guild-A');
     __resetTwitchChannelDiscordIdCacheForTests();
@@ -231,12 +237,12 @@ describe('handleTwitchMessage', () => {
     sendMessage('#streamer', makeTags(), '!cmd');
 
     await vi.waitFor(() => expect(handleCommand).toHaveBeenCalledOnce());
-    expect(findUserByTwitchName).toHaveBeenCalledWith('streamer');
+    expect(getAllTwitchLinkedUsers).toHaveBeenCalled();
     expect(getActiveGuildForUser).toHaveBeenCalledWith(expect.anything(), 'streamer-discord-id');
   });
 
   it('passes a null guildId to handleCommand when the channel has no linked Discord user', async () => {
-    vi.mocked(findUserByTwitchName).mockResolvedValue(null);
+    vi.mocked(getAllTwitchLinkedUsers).mockResolvedValue([]);
     vi.mocked(handleCommand).mockResolvedValue(undefined);
 
     sendMessage('#streamer', makeTags(), '!cmd');
@@ -251,15 +257,21 @@ describe('handleTwitchMessage', () => {
 
     sendMessage('#streamer', makeTags(), '!cmd');
     await vi.waitFor(() => expect(handleCommand).toHaveBeenCalledTimes(1));
-    expect(findUserByTwitchName).toHaveBeenCalledOnce();
+    expect(getAllTwitchLinkedUsers).toHaveBeenCalledOnce();
 
-    vi.mocked(findUserByTwitchName).mockResolvedValue({ discord_id: 'new-streamer-discord-id' } as any);
+    vi.mocked(getAllTwitchLinkedUsers).mockResolvedValue([{ twitchName: 'streamer', discordId: 'new-streamer-discord-id' }]);
     await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1);
 
+    // The cache is now stale — this lookup kicks a background refresh but
+    // (per the shared lookupCache's stale-while-revalidate strategy) still
+    // serves the last-good mapping for this call.
     sendMessage('#streamer', makeTags(), '!again');
     await vi.waitFor(() => expect(handleCommand).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(getAllTwitchLinkedUsers).toHaveBeenCalledTimes(2));
 
-    expect(findUserByTwitchName).toHaveBeenCalledTimes(2);
+    // A subsequent lookup picks up the refreshed mapping.
+    sendMessage('#streamer', makeTags(), '!third');
+    await vi.waitFor(() => expect(handleCommand).toHaveBeenCalledTimes(3));
     expect(getActiveGuildForUser).toHaveBeenLastCalledWith(expect.anything(), 'new-streamer-discord-id');
   });
 

--- a/src/twitch/twitchBot.test.ts
+++ b/src/twitch/twitchBot.test.ts
@@ -38,11 +38,15 @@ vi.mock('../shared/config', () => ({
 // Uses the real createManagedLookupCache (not a fake) so tests below can
 // exercise its actual TTL / stale-while-revalidate behaviour.
 vi.mock('../db', async () => {
-  const { createManagedLookupCache } = await vi.importActual<typeof import('../db/lookupCache')>('../db/lookupCache');
+  const { createManagedLookupCache, DEFAULT_REFRESH_FAILURE_BACKOFF_MS, DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS } =
+    await vi.importActual<typeof import('../db/lookupCache')>('../db/lookupCache');
   return {
     getTwitchEnabledChannels: vi.fn(),
     getAllTwitchLinkedUsers: vi.fn(),
+    findUserByTwitchName: vi.fn(),
     createManagedLookupCache,
+    DEFAULT_REFRESH_FAILURE_BACKOFF_MS,
+    DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS,
   };
 });
 
@@ -101,7 +105,7 @@ import {
   getActiveChannelUserIds,
   setChannelJoinedHook,
 } from './twitchChannelMembership';
-import { getTwitchEnabledChannels, getAllTwitchLinkedUsers } from '../db';
+import { getTwitchEnabledChannels, getAllTwitchLinkedUsers, findUserByTwitchName } from '../db';
 import { getDiscordClient } from '../discord/discordBot';
 import { getActiveGuildForUser } from '../discord/voicePresence';
 import { getUsers } from './twitchApi';
@@ -170,6 +174,7 @@ describe('handleTwitchMessage', () => {
     vi.clearAllMocks();
     resetMockClient();
     vi.mocked(getAllTwitchLinkedUsers).mockResolvedValue([{ twitchName: 'streamer', discordId: 'streamer-discord-id' }]);
+    vi.mocked(findUserByTwitchName).mockResolvedValue(null);
     vi.mocked(getDiscordClient).mockReturnValue({} as any);
     vi.mocked(getActiveGuildForUser).mockReturnValue('guild-A');
     __resetTwitchChannelDiscordIdCacheForTests();
@@ -243,6 +248,7 @@ describe('handleTwitchMessage', () => {
 
   it('passes a null guildId to handleCommand when the channel has no linked Discord user', async () => {
     vi.mocked(getAllTwitchLinkedUsers).mockResolvedValue([]);
+    vi.mocked(findUserByTwitchName).mockResolvedValue(null);
     vi.mocked(handleCommand).mockResolvedValue(undefined);
 
     sendMessage('#streamer', makeTags(), '!cmd');
@@ -250,6 +256,29 @@ describe('handleTwitchMessage', () => {
     await vi.waitFor(() => expect(handleCommand).toHaveBeenCalledOnce());
     expect(handleCommand).toHaveBeenCalledWith('!cmd', 'twitch', null);
     expect(getActiveGuildForUser).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a live lookup when a channel is missing from the bulk cache, so a just-linked streamer works on the very next message', async () => {
+    // Simulate a channel that was linked after the bulk cache's last load —
+    // it's absent from the cached map even though the cache itself is fresh.
+    vi.mocked(getAllTwitchLinkedUsers).mockResolvedValue([]);
+    vi.mocked(findUserByTwitchName).mockResolvedValue({ discord_id: 'freshly-linked-discord-id' } as any);
+    vi.mocked(handleCommand).mockResolvedValue(undefined);
+
+    sendMessage('#streamer', makeTags(), '!cmd');
+
+    await vi.waitFor(() => expect(handleCommand).toHaveBeenCalledOnce());
+    expect(findUserByTwitchName).toHaveBeenCalledWith('streamer');
+    expect(getActiveGuildForUser).toHaveBeenCalledWith(expect.anything(), 'freshly-linked-discord-id');
+  });
+
+  it('does not fall back to a live lookup when the channel is already present in the bulk cache', async () => {
+    vi.mocked(handleCommand).mockResolvedValue(undefined);
+
+    sendMessage('#streamer', makeTags(), '!cmd');
+
+    await vi.waitFor(() => expect(handleCommand).toHaveBeenCalledOnce());
+    expect(findUserByTwitchName).not.toHaveBeenCalled();
   });
 
   it('re-resolves the linked discord_id after the cache TTL expires, picking up a relink', async () => {

--- a/src/twitch/twitchBot.ts
+++ b/src/twitch/twitchBot.ts
@@ -11,7 +11,10 @@ import { normalizeTwitchChannelName } from './twitchChannelName';
 import { createLogger } from '../shared/logger';
 import {
   createManagedLookupCache,
+  DEFAULT_REFRESH_FAILURE_BACKOFF_MS,
+  DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS,
   getAllTwitchLinkedUsers,
+  findUserByTwitchName,
   type RefreshingLookupCache,
 } from '../db';
 import { getDiscordClient } from '../discord/discordBot';
@@ -37,8 +40,6 @@ const TWITCH_CHAT_MESSAGE_PATTERN = /^\[#[^\]]+\] <[^>]+>: /;
 // so a relinked twitch_name is picked up within a few minutes rather than
 // staying stale until the process restarts.
 const CHANNEL_DISCORD_ID_CACHE_TTL_MS = 5 * 60 * 1000;
-const CHANNEL_DISCORD_ID_CACHE_REFRESH_FAILURE_BACKOFF_MS = 5_000;
-const CHANNEL_DISCORD_ID_CACHE_REFRESH_FAILURE_MAX_BACKOFF_MS = 60_000;
 
 interface TwitchChannelDiscordIdCache extends RefreshingLookupCache {
   discordIdByChannel: Map<string, string>;
@@ -52,8 +53,8 @@ function createEmptyTwitchChannelDiscordIdCache(): TwitchChannelDiscordIdCache {
 const twitchChannelDiscordIdLookupCache = createManagedLookupCache<TwitchChannelDiscordIdCache>({
   cacheName: 'twitch channel discord id cache',
   ttlMs: CHANNEL_DISCORD_ID_CACHE_TTL_MS,
-  refreshFailureBackoffMs: CHANNEL_DISCORD_ID_CACHE_REFRESH_FAILURE_BACKOFF_MS,
-  refreshFailureMaxBackoffMs: CHANNEL_DISCORD_ID_CACHE_REFRESH_FAILURE_MAX_BACKOFF_MS,
+  refreshFailureBackoffMs: DEFAULT_REFRESH_FAILURE_BACKOFF_MS,
+  refreshFailureMaxBackoffMs: DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS,
   createEmptyCache: createEmptyTwitchChannelDiscordIdCache,
   loadCache: async () => {
     const linkedUsers = await getAllTwitchLinkedUsers();
@@ -62,10 +63,18 @@ const twitchChannelDiscordIdLookupCache = createManagedLookupCache<TwitchChannel
   },
 });
 
-/** Resolves the Discord ID linked to a Twitch channel's `twitch_name`, or null if unlinked. */
+/**
+ * Resolves the Discord ID linked to a Twitch channel's `twitch_name`, or null if unlinked.
+ * A channel absent from the bulk cache falls back to a live lookup — the cache has no
+ * per-key invalidation, so a channel linked since the last bulk refresh would otherwise
+ * stay unresolved for up to the cache's TTL instead of working on the very next message.
+ */
 async function resolveDiscordIdForTwitchChannel(normalizedChannel: string): Promise<string | null> {
   const cache = await twitchChannelDiscordIdLookupCache.getCache();
-  return cache.discordIdByChannel.get(normalizedChannel) ?? null;
+  const cachedDiscordId = cache.discordIdByChannel.get(normalizedChannel);
+  if (cachedDiscordId) return cachedDiscordId;
+  const user = await findUserByTwitchName(normalizedChannel);
+  return user?.discord_id ?? null;
 }
 
 /** Test-only: clears the Twitch-channel → discord_id cache so each test starts from a clean slate. */

--- a/src/twitch/twitchBot.ts
+++ b/src/twitch/twitchBot.ts
@@ -9,7 +9,11 @@ import { executeCountdownForTwitch } from '../commands/countdownHandler';
 import { setTwitchChannel } from '../shared/statusStore';
 import { normalizeTwitchChannelName } from './twitchChannelName';
 import { createLogger } from '../shared/logger';
-import { findUserByTwitchName } from '../db';
+import {
+  createManagedLookupCache,
+  getAllTwitchLinkedUsers,
+  type RefreshingLookupCache,
+} from '../db';
 import { getDiscordClient } from '../discord/discordBot';
 import { getActiveGuildForUser } from '../discord/voicePresence';
 import {
@@ -27,26 +31,46 @@ let client: tmi.Client | null = null;
 let connected = false;
 const TWITCH_CHAT_MESSAGE_PATTERN = /^\[#[^\]]+\] <[^>]+>: /;
 
-// Caches only successful Twitch-channel → discord_id resolutions (never a
-// miss) so a not-yet-linked channel keeps retrying instead of being stuck
-// unresolved until a restart, while a linked channel avoids a DB round trip
-// on every chat message. Bounded by a TTL so a relinked twitch_name is picked
-// up within a few minutes rather than staying stale until the process restarts.
+// Bulk-loads every twitch_name → discord_id mapping in one query (like
+// getTwitchEnabledChannels()) instead of a lazy per-channel lookup, so a
+// chat message never blocks on an individual DB round trip. Bounded by a TTL
+// so a relinked twitch_name is picked up within a few minutes rather than
+// staying stale until the process restarts.
 const CHANNEL_DISCORD_ID_CACHE_TTL_MS = 5 * 60 * 1000;
-const twitchChannelDiscordIdCache = new Map<string, { discordId: string; cachedAt: number }>();
+const CHANNEL_DISCORD_ID_CACHE_REFRESH_FAILURE_BACKOFF_MS = 5_000;
+const CHANNEL_DISCORD_ID_CACHE_REFRESH_FAILURE_MAX_BACKOFF_MS = 60_000;
+
+interface TwitchChannelDiscordIdCache extends RefreshingLookupCache {
+  discordIdByChannel: Map<string, string>;
+}
+
+/** Returns a fresh, empty Twitch-channel → discord_id cache. */
+function createEmptyTwitchChannelDiscordIdCache(): TwitchChannelDiscordIdCache {
+  return { loadedAt: 0, discordIdByChannel: new Map() };
+}
+
+const twitchChannelDiscordIdLookupCache = createManagedLookupCache<TwitchChannelDiscordIdCache>({
+  cacheName: 'twitch channel discord id cache',
+  ttlMs: CHANNEL_DISCORD_ID_CACHE_TTL_MS,
+  refreshFailureBackoffMs: CHANNEL_DISCORD_ID_CACHE_REFRESH_FAILURE_BACKOFF_MS,
+  refreshFailureMaxBackoffMs: CHANNEL_DISCORD_ID_CACHE_REFRESH_FAILURE_MAX_BACKOFF_MS,
+  createEmptyCache: createEmptyTwitchChannelDiscordIdCache,
+  loadCache: async () => {
+    const linkedUsers = await getAllTwitchLinkedUsers();
+    const discordIdByChannel = new Map(linkedUsers.map((u) => [u.twitchName, u.discordId]));
+    return { loadedAt: Date.now(), discordIdByChannel };
+  },
+});
 
 /** Resolves the Discord ID linked to a Twitch channel's `twitch_name`, or null if unlinked. */
 async function resolveDiscordIdForTwitchChannel(normalizedChannel: string): Promise<string | null> {
-  const cached = twitchChannelDiscordIdCache.get(normalizedChannel);
-  if (cached && Date.now() - cached.cachedAt < CHANNEL_DISCORD_ID_CACHE_TTL_MS) return cached.discordId;
-  const user = await findUserByTwitchName(normalizedChannel);
-  if (user) twitchChannelDiscordIdCache.set(normalizedChannel, { discordId: user.discord_id, cachedAt: Date.now() });
-  return user?.discord_id ?? null;
+  const cache = await twitchChannelDiscordIdLookupCache.getCache();
+  return cache.discordIdByChannel.get(normalizedChannel) ?? null;
 }
 
 /** Test-only: clears the Twitch-channel → discord_id cache so each test starts from a clean slate. */
 export function __resetTwitchChannelDiscordIdCacheForTests(): void {
-  twitchChannelDiscordIdCache.clear();
+  twitchChannelDiscordIdLookupCache.invalidate();
 }
 
 /** Resolves which guild a Twitch chat command should target: the linked streamer's active voice guild. */

--- a/src/web/routes/adminRefresh.test.ts
+++ b/src/web/routes/adminRefresh.test.ts
@@ -24,7 +24,7 @@ import express from 'express';
 import supertest from 'supertest';
 
 // Import module last so mocks are in place before module-level code runs
-import router, { refreshStates, getRefreshState } from './adminRefresh';
+import router, { refreshStates, getRefreshState, forgetGuildRefreshState } from './adminRefresh';
 
 const GUILD_ID = '900000000000000001';
 const OTHER_GUILD_ID = '900000000000000002';
@@ -66,6 +66,28 @@ describe('getRefreshState', () => {
       startedAt: null,
       finishedAt: null,
     });
+  });
+});
+
+// ─── forgetGuildRefreshState ────────────────────────────────────────────────
+
+describe('forgetGuildRefreshState', () => {
+  it('removes a guild\'s recorded refresh state, resetting it to idle on next read', () => {
+    refreshStates.set(GUILD_ID, { outcome: 'success', updatedCount: 3, failureCount: 0, startedAt: 1, finishedAt: 2 });
+
+    forgetGuildRefreshState(GUILD_ID);
+
+    expect(getRefreshState(GUILD_ID)).toEqual({
+      outcome: 'idle',
+      updatedCount: 0,
+      failureCount: 0,
+      startedAt: null,
+      finishedAt: null,
+    });
+  });
+
+  it('is a no-op for a guild with no recorded state', () => {
+    expect(() => forgetGuildRefreshState('never-seen')).not.toThrow();
   });
 });
 

--- a/src/web/routes/adminRefresh.ts
+++ b/src/web/routes/adminRefresh.ts
@@ -32,6 +32,18 @@ export function getRefreshState(guildId: string): RefreshState {
   return refreshStates.get(guildId) ?? idleRefreshState();
 }
 
+/**
+ * Forgets a guild's Discord-name-refresh progress state so it stops occupying
+ * memory once the bot is no longer in that guild. Safe to call for a guild
+ * with no state (no-op). Called from the `guildDelete` handler; a guild the
+ * bot rejoins later starts fresh via {@link getRefreshState}'s idle default.
+ *
+ * @param guildId - Guild to forget.
+ */
+export function forgetGuildRefreshState(guildId: string): void {
+  refreshStates.delete(guildId);
+}
+
 const log = createLogger('Web');
 
 async function runDiscordNameRefresh(guildId: string): Promise<void> {

--- a/src/web/routes/api.test.ts
+++ b/src/web/routes/api.test.ts
@@ -73,9 +73,16 @@ beforeEach(() => {
 });
 
 describe('GET /status', () => {
-  it('returns the status snapshot', async () => {
+  it('returns the status snapshot for the session guild', async () => {
     const res = await supertest(buildApp()).get('/status').expect(200);
     expect(res.body).toEqual({ discord: {}, voice: {}, twitch: {}, tiktok: {} });
+    expect(vi.mocked(getStatus)).toHaveBeenCalledWith(GUILD_ID);
+  });
+
+  it('returns 400 when no guild is selected', async () => {
+    const res = await supertest(buildApp(null)).get('/status').expect(400);
+    expect(res.body).toEqual({ ok: false, error: 'No guild selected' });
+    expect(vi.mocked(getStatus)).not.toHaveBeenCalled();
   });
 });
 

--- a/src/web/routes/api.ts
+++ b/src/web/routes/api.ts
@@ -14,9 +14,9 @@ const router = Router();
 
 /**
  * Resolves the guild the request acts in from the session, replying 400 when no
- * guild is selected. Voice routes are guild-scoped — the bot can hold a separate
- * connection per guild — and the guild is taken from the session (never the
- * request body) so a Mod cannot drive another guild's voice connection.
+ * guild is selected. Voice and status routes are guild-scoped — the bot can hold
+ * a separate connection per guild — and the guild is taken from the session
+ * (never the request body) so a Mod cannot drive or view another guild's state.
  *
  * @returns The current guild ID, or null when the response has already been sent.
  */
@@ -31,12 +31,16 @@ function getSessionGuildId(req: Request, res: Response): string | null {
 
 /**
  * GET /status — live bot status JSON, polled by the dashboard frontend every
- * few seconds.
- * @param _req - Express request (unused).
- * @param res - Express response; returns `getStatus()`.
+ * few seconds. Voice status is scoped to the viewer's current guild so a
+ * Manager on guild B's dashboard never sees guild A's now-playing info.
+ * @param req - Express request; guild is taken from the session.
+ * @param res - Express response; returns `getStatus(guildId)`, or 400 if no
+ *   guild is selected.
  */
-router.get('/status', requireAuth, (_req, res) => {
-  res.json(getStatus());
+router.get('/status', requireAuth, (req, res) => {
+  const guildId = getSessionGuildId(req, res);
+  if (!guildId) return;
+  res.json(getStatus(guildId));
 });
 
 /**

--- a/src/web/routes/dashboard.test.ts
+++ b/src/web/routes/dashboard.test.ts
@@ -61,6 +61,12 @@ describe('GET /', () => {
     expect(res.body.status).toEqual(STATUS);
     expect(res.body.needsReconnect).toBe(false);
     expect(getStreamerByDiscordId).not.toHaveBeenCalled();
+    expect(getStatus).toHaveBeenCalledWith(null);
+  });
+
+  it('scopes status to the session\'s current guild', async () => {
+    await supertest(buildApp({ discordId: '100', currentGuildId: 'guild-A' })).get('/');
+    expect(getStatus).toHaveBeenCalledWith('guild-A');
   });
 
   it('sets needsReconnect true when the streamer has auth-failed subs', async () => {

--- a/src/web/routes/dashboard.ts
+++ b/src/web/routes/dashboard.ts
@@ -19,7 +19,7 @@ const router = Router();
  */
 router.get('/', csrfProtection, async (req, res) => {
   try {
-    const status = getStatus();
+    const status = getStatus(req.session.user?.currentGuildId ?? null);
     let needsReconnect = false;
     if (req.session.user) {
       const streamer = await getStreamerByDiscordId(req.session.user.discordId);

--- a/src/web/routes/eventsubAdmin.ts
+++ b/src/web/routes/eventsubAdmin.ts
@@ -5,6 +5,7 @@ import { csrfProtection } from '../csrf';
 import { requireAdmin } from '../middleware';
 import { reloadEventSubSubscriptions } from '../../twitch/eventsub/twitchEventSub';
 import { parsePositiveIntId } from './shared';
+import { redirectStreamsInvalid, redirectStreamsFailure } from './streamsErrors';
 
 const log = createLogger('Web');
 const router = Router();
@@ -23,14 +24,13 @@ const router = Router();
  */
 router.post('/streams/twitch-disconnect/:streamerId', requireAdmin, csrfProtection, async (req, res) => {
   const streamerId = parsePositiveIntId(req.params.streamerId);
-  if (streamerId === null) return res.redirect('/admin/streams?error=invalid_id');
+  if (streamerId === null) return redirectStreamsInvalid(res, 'invalid_id');
 
   try {
     await clearStreamerToken(streamerId);
     reloadEventSubSubscriptions();
   } catch (err) {
-    log.error('EventSub admin disconnect error:', err);
-    return res.redirect('/admin/streams?error=eventsub_disconnect_failed');
+    return redirectStreamsFailure(res, log, 'EventSub admin disconnect error:', err, 'eventsub_disconnect_failed');
   }
   res.redirect('/admin/streams');
 });

--- a/src/web/routes/streamGroups.ts
+++ b/src/web/routes/streamGroups.ts
@@ -3,7 +3,8 @@ import { Router } from 'express';
 import { addStreamGroup, updateStreamGroup, removeStreamGroupAndStreamers } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireManager } from '../middleware';
-import { logAndRedirectError, parsePositiveIntId } from './shared';
+import { parsePositiveIntId } from './shared';
+import { redirectStreamsInvalid, redirectStreamsFailure } from './streamsErrors';
 import { triggerRestart } from './streamRestart';
 
 const log = createLogger('Web');
@@ -30,7 +31,7 @@ router.post('/streams/groups/add', requireManager, csrfProtection, async (req, r
   const delete_old_posts = req.body.delete_old_posts === 'on';
 
   if (hasMissingValues(name, discord_channel, live_message, new_game_message)) {
-    return res.redirect('/admin/streams?error=missing_fields');
+    return redirectStreamsInvalid(res, 'missing_fields');
   }
 
   try {
@@ -45,7 +46,7 @@ router.post('/streams/groups/add', requireManager, csrfProtection, async (req, r
     });
     triggerRestart();
   } catch (err) {
-    return logAndRedirectError({ res, log, logLabel: 'Add stream group error:', err, basePath: '/admin/streams', errorCode: 'add_group_failed' });
+    return redirectStreamsFailure(res, log, 'Add stream group error:', err, 'add_group_failed');
   }
   res.redirect('/admin/streams');
 });
@@ -66,11 +67,11 @@ router.post('/streams/groups/update', requireManager, csrfProtection, async (req
   const delete_old_posts = req.body.delete_old_posts === 'on';
 
   if (hasMissingValues(group_id, name, discord_channel, live_message, new_game_message)) {
-    return res.redirect('/admin/streams?error=missing_fields');
+    return redirectStreamsInvalid(res, 'missing_fields');
   }
 
   const parsedGroupId = parsePositiveIntId(group_id);
-  if (parsedGroupId === null) return res.redirect('/admin/streams?error=invalid_id');
+  if (parsedGroupId === null) return redirectStreamsInvalid(res, 'invalid_id');
 
   try {
     const updated = await updateStreamGroup({
@@ -83,10 +84,10 @@ router.post('/streams/groups/update', requireManager, csrfProtection, async (req
       multiTwitch: multi_twitch,
       deleteOldPosts: delete_old_posts,
     });
-    if (!updated) return res.redirect('/admin/streams?error=update_group_failed');
+    if (!updated) return redirectStreamsInvalid(res, 'update_group_failed');
     triggerRestart();
   } catch (err) {
-    return logAndRedirectError({ res, log, logLabel: 'Update stream group error:', err, basePath: '/admin/streams', errorCode: 'update_group_failed' });
+    return redirectStreamsFailure(res, log, 'Update stream group error:', err, 'update_group_failed');
   }
   res.redirect('/admin/streams');
 });
@@ -101,17 +102,17 @@ router.post('/streams/groups/update', requireManager, csrfProtection, async (req
  */
 router.post('/streams/groups/remove', requireManager, csrfProtection, async (req, res) => {
   const { group_id } = req.body as { group_id?: string };
-  if (!group_id) return res.redirect('/admin/streams?error=missing_fields');
+  if (!group_id) return redirectStreamsInvalid(res, 'missing_fields');
   const parsedGroupId = parsePositiveIntId(group_id);
-  if (parsedGroupId === null) return res.redirect('/admin/streams?error=invalid_id');
+  if (parsedGroupId === null) return redirectStreamsInvalid(res, 'invalid_id');
 
   try {
     const guildId = req.session.user!.currentGuildId!;
     const removed = await removeStreamGroupAndStreamers(parsedGroupId, guildId);
-    if (!removed) return res.redirect('/admin/streams?error=remove_group_failed');
+    if (!removed) return redirectStreamsInvalid(res, 'remove_group_failed');
     triggerRestart();
   } catch (err) {
-    return logAndRedirectError({ res, log, logLabel: 'Remove stream group error:', err, basePath: '/admin/streams', errorCode: 'remove_group_failed' });
+    return redirectStreamsFailure(res, log, 'Remove stream group error:', err, 'remove_group_failed');
   }
   res.redirect('/admin/streams');
 });

--- a/src/web/routes/streamStreamers.ts
+++ b/src/web/routes/streamStreamers.ts
@@ -3,7 +3,8 @@ import { Router } from 'express';
 import { addStreamer, removeStreamer, findUser } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireManager } from '../middleware';
-import { logAndRedirectError, parsePositiveIntId, normalizeDiscordId } from './shared';
+import { parsePositiveIntId, normalizeDiscordId } from './shared';
+import { redirectStreamsInvalid, redirectStreamsFailure } from './streamsErrors';
 import { triggerRestart } from './streamRestart';
 
 const log = createLogger('Web');
@@ -24,17 +25,17 @@ router.post('/streams/streamers/add', requireManager, csrfProtection, async (req
   const discordId = normalizeDiscordId(typeof discord_id === 'string' ? discord_id : undefined);
   const rawGroupId = Array.isArray(group_id) ? group_id[0] : group_id;
   const groupId = typeof rawGroupId === 'string' ? rawGroupId.trim() : null;
-  if (!discordId || !groupId) return res.redirect('/admin/streams?error=missing_fields');
+  if (!discordId || !groupId) return redirectStreamsInvalid(res, 'missing_fields');
   const parsedGroupId = parsePositiveIntId(groupId);
-  if (parsedGroupId === null) return res.redirect('/admin/streams?error=invalid_id');
+  if (parsedGroupId === null) return redirectStreamsInvalid(res, 'invalid_id');
 
   try {
     const user = await findUser(discordId);
-    if (!user?.twitch_name) return res.redirect('/admin/streams?error=missing_fields');
+    if (!user?.twitch_name) return redirectStreamsInvalid(res, 'missing_fields');
     await addStreamer(discordId, parsedGroupId, req.session.user!.currentGuildId!);
     triggerRestart();
   } catch (err) {
-    return logAndRedirectError({ res, log, logLabel: 'Add streamer error:', err, basePath: '/admin/streams', errorCode: 'add_streamer_failed' });
+    return redirectStreamsFailure(res, log, 'Add streamer error:', err, 'add_streamer_failed');
   }
   res.redirect('/admin/streams');
 });
@@ -49,16 +50,16 @@ router.post('/streams/streamers/add', requireManager, csrfProtection, async (req
  */
 router.post('/streams/streamers/remove', requireManager, csrfProtection, async (req, res) => {
   const { streamer_id } = req.body as { streamer_id?: string };
-  if (!streamer_id) return res.redirect('/admin/streams?error=missing_fields');
+  if (!streamer_id) return redirectStreamsInvalid(res, 'missing_fields');
   const parsedStreamerId = parsePositiveIntId(streamer_id);
-  if (parsedStreamerId === null) return res.redirect('/admin/streams?error=invalid_id');
+  if (parsedStreamerId === null) return redirectStreamsInvalid(res, 'invalid_id');
 
   try {
     const removed = await removeStreamer(parsedStreamerId, req.session.user!.currentGuildId!);
-    if (!removed) return res.redirect('/admin/streams?error=remove_streamer_failed');
+    if (!removed) return redirectStreamsInvalid(res, 'remove_streamer_failed');
     triggerRestart();
   } catch (err) {
-    return logAndRedirectError({ res, log, logLabel: 'Remove streamer error:', err, basePath: '/admin/streams', errorCode: 'remove_streamer_failed' });
+    return redirectStreamsFailure(res, log, 'Remove streamer error:', err, 'remove_streamer_failed');
   }
   res.redirect('/admin/streams');
 });

--- a/src/web/routes/streamdeckKeys.test.ts
+++ b/src/web/routes/streamdeckKeys.test.ts
@@ -134,14 +134,28 @@ describe('POST /streamdeck-key/request', () => {
     expect(createApiKeyAndRequestGuildAccess).not.toHaveBeenCalled();
   });
 
-  it('rotates the key when a guild status already exists for this guild (lost-key flow)', async () => {
+  it('is idempotent — a duplicate request while approved neither creates nor rotates a key', async () => {
     vi.mocked(getGuildStatusForKey).mockResolvedValue({ discord_id: '1', guild_id: GUILD_ID, status: 'approved' } as any);
 
     const res = await supertest(buildApp()).post('/streamdeck-key/request');
 
     expect(res.status).toBe(200);
-    expect((res.body as any).locals.newKey).toBeTruthy();
-    expect(rotateApiKey).toHaveBeenCalledWith(SESSION_USER.discordId);
+    expect((res.body as any).locals.newKey).toBeNull();
+    expect((res.body as any).locals.keyRow).toMatchObject({ status: 'approved' });
+    expect(rotateApiKey).not.toHaveBeenCalled();
+    expect(createApiKeyAndRequestGuildAccess).not.toHaveBeenCalled();
+    expect(requestGuildAccessForExistingKey).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent — a duplicate request while pending neither creates nor rotates a key', async () => {
+    vi.mocked(getGuildStatusForKey).mockResolvedValue({ discord_id: '1', guild_id: GUILD_ID, status: 'pending' } as any);
+
+    const res = await supertest(buildApp()).post('/streamdeck-key/request');
+
+    expect(res.status).toBe(200);
+    expect((res.body as any).locals.newKey).toBeNull();
+    expect((res.body as any).locals.keyRow).toMatchObject({ status: 'pending' });
+    expect(rotateApiKey).not.toHaveBeenCalled();
     expect(createApiKeyAndRequestGuildAccess).not.toHaveBeenCalled();
     expect(requestGuildAccessForExistingKey).not.toHaveBeenCalled();
   });
@@ -200,11 +214,6 @@ describe('POST /streamdeck-key/request', () => {
       persistedGuildStatus = { status: 'pending' };
       return { plain: 'a'.repeat(64), status: 'pending' };
     });
-    vi.mocked(rotateApiKey).mockImplementation(async () => {
-      callOrder.push('rotate');
-      return { plain: 'b'.repeat(64) };
-    });
-
     const app = buildApp();
     // supertest/superagent requests are thenable but lazy — chaining .then()
     // immediately (rather than just holding the unawaited value) is what
@@ -224,10 +233,46 @@ describe('POST /streamdeck-key/request', () => {
     await secondReq;
 
     // The second request only starts once the first has fully committed its
-    // guild-status row, so it sees existingGuildStatus set and takes the
-    // rotate path instead of racing into a second identity insert.
-    expect(callOrder).toEqual(['hasApiKey-start', 'hasApiKey-end', 'create', 'rotate']);
+    // guild-status row, so it sees existingGuildStatus already set (pending)
+    // and takes the idempotent no-op branch — it never even reaches the
+    // hasApiKey check, let alone races into a second identity insert.
+    expect(callOrder).toEqual(['hasApiKey-start', 'hasApiKey-end', 'create']);
     expect(createApiKeyAndRequestGuildAccess).toHaveBeenCalledTimes(1);
+    expect(rotateApiKey).not.toHaveBeenCalled();
+  });
+});
+
+// ─── POST /streamdeck-key/rotate ─────────────────────────────────────────────
+
+describe('POST /streamdeck-key/rotate', () => {
+  it('rotates the key when the user already has one, regardless of this guild\'s status', async () => {
+    vi.mocked(hasApiKey).mockResolvedValue(true);
+    vi.mocked(getGuildStatusForKey).mockResolvedValue({ discord_id: '1', guild_id: GUILD_ID, status: 'approved' } as any);
+
+    const res = await supertest(buildApp()).post('/streamdeck-key/rotate');
+
+    expect(res.status).toBe(200);
+    expect((res.body as any).locals.newKey).toBeTruthy();
+    expect((res.body as any).locals.keyRow).toMatchObject({ status: 'approved' });
+    expect(rotateApiKey).toHaveBeenCalledWith(SESSION_USER.discordId);
+  });
+
+  it('redirects to ?error=rotate_failed when the user has no existing key', async () => {
+    vi.mocked(hasApiKey).mockResolvedValue(false);
+
+    const res = await supertest(buildApp()).post('/streamdeck-key/rotate');
+
+    expect(res.headers.location).toBe('/streamdeck-key?error=rotate_failed');
+    expect(rotateApiKey).not.toHaveBeenCalled();
+  });
+
+  it('redirects to ?error=rotate_failed on a DB error', async () => {
+    vi.mocked(hasApiKey).mockResolvedValue(true);
+    vi.mocked(rotateApiKey).mockRejectedValueOnce(new Error('DB error'));
+
+    const res = await supertest(buildApp()).post('/streamdeck-key/rotate');
+
+    expect(res.headers.location).toBe('/streamdeck-key?error=rotate_failed');
   });
 });
 

--- a/src/web/routes/streamdeckKeys.test.ts
+++ b/src/web/routes/streamdeckKeys.test.ts
@@ -326,6 +326,31 @@ describe('POST /streamdeck-key/rotate', () => {
     expect(rotateApiKey).toHaveBeenCalledOnce();
   });
 
+  it('does not reuse another guild\'s cached approval status for the same user within the dedupe window', async () => {
+    const OTHER_GUILD_ID = '900000000000000002';
+    const sessionInGuildA = SESSION_USER;
+    const sessionInGuildB = { ...SESSION_USER, currentGuildId: OTHER_GUILD_ID };
+
+    vi.mocked(hasApiKey).mockResolvedValue(true);
+    vi.mocked(rotateApiKey).mockResolvedValue({ plain: 'shared-plain-key' } as any);
+    vi.mocked(getGuildStatusForKey).mockImplementation(async (_discordId, guildId) => ({
+      discord_id: SESSION_USER.discordId,
+      guild_id: guildId,
+      status: guildId === GUILD_ID ? 'approved' : 'pending',
+    } as any));
+
+    const appA = buildApp(sessionInGuildA);
+    const firstInA = await supertest(appA).post('/streamdeck-key/rotate');
+    expect((firstInA.body as any).locals.keyRow).toMatchObject({ guild_id: GUILD_ID, status: 'approved' });
+
+    // Same discordId, different guild, within the dedupe window — must not
+    // be served guild A's cached keyRow.
+    const appB = buildApp(sessionInGuildB);
+    const firstInB = await supertest(appB).post('/streamdeck-key/rotate');
+    expect((firstInB.body as any).locals.keyRow).toMatchObject({ guild_id: OTHER_GUILD_ID, status: 'pending' });
+    expect(rotateApiKey).toHaveBeenCalledTimes(2);
+  });
+
   it('rotates again once the dedupe window has passed', async () => {
     // Uses a Date.now() spy (not fake timers) so supertest's real HTTP round
     // trip isn't disrupted — the dedupe check reads Date.now() lazily, so

--- a/src/web/routes/streamdeckKeys.test.ts
+++ b/src/web/routes/streamdeckKeys.test.ts
@@ -26,7 +26,7 @@ vi.mock('../../shared/logger', () => ({ createLogger: () => ({ info: vi.fn(), er
 
 import express from 'express';
 import supertest from 'supertest';
-import router from './streamdeckKeys';
+import router, { __resetRecentRotationsForTests } from './streamdeckKeys';
 import {
   hasApiKey, createApiKeyAndRequestGuildAccess, requestGuildAccessForExistingKey, rotateApiKey,
   getGuildStatusForKey, revokeApiKey,
@@ -69,6 +69,7 @@ beforeEach(() => {
   vi.mocked(getGuildStatusForKey).mockResolvedValue(null);
   vi.mocked(getAllApiKeys).mockResolvedValue([]);
   vi.mocked(getPendingRequests).mockResolvedValue([]);
+  __resetRecentRotationsForTests();
 });
 
 // ─── GET /streamdeck-key ──────────────────────────────────────────────────────
@@ -134,7 +135,7 @@ describe('POST /streamdeck-key/request', () => {
     expect(createApiKeyAndRequestGuildAccess).not.toHaveBeenCalled();
   });
 
-  it('is idempotent — a duplicate request while approved neither creates nor rotates a key', async () => {
+  it('is idempotent — a duplicate request while approved neither creates nor rotates a key, and does not re-query the guild status', async () => {
     vi.mocked(getGuildStatusForKey).mockResolvedValue({ discord_id: '1', guild_id: GUILD_ID, status: 'approved' } as any);
 
     const res = await supertest(buildApp()).post('/streamdeck-key/request');
@@ -145,6 +146,8 @@ describe('POST /streamdeck-key/request', () => {
     expect(rotateApiKey).not.toHaveBeenCalled();
     expect(createApiKeyAndRequestGuildAccess).not.toHaveBeenCalled();
     expect(requestGuildAccessForExistingKey).not.toHaveBeenCalled();
+    // The no-op branch reuses the status already fetched instead of a redundant re-query.
+    expect(getGuildStatusForKey).toHaveBeenCalledOnce();
   });
 
   it('is idempotent — a duplicate request while pending neither creates nor rotates a key', async () => {
@@ -273,6 +276,80 @@ describe('POST /streamdeck-key/rotate', () => {
     const res = await supertest(buildApp()).post('/streamdeck-key/rotate');
 
     expect(res.headers.location).toBe('/streamdeck-key?error=rotate_failed');
+  });
+
+  it('fetches the rotated key hash and the guild status concurrently, not sequentially', async () => {
+    vi.mocked(hasApiKey).mockResolvedValue(true);
+    const callOrder: string[] = [];
+    let resolveRotate!: () => void;
+    const rotateGate = new Promise<void>((resolve) => { resolveRotate = resolve; });
+    let resolveStatus!: () => void;
+    const statusGate = new Promise<void>((resolve) => { resolveStatus = resolve; });
+
+    vi.mocked(rotateApiKey).mockImplementation(async () => {
+      callOrder.push('rotate-start');
+      await rotateGate;
+      callOrder.push('rotate-end');
+      return { plain: 'b'.repeat(64) };
+    });
+    vi.mocked(getGuildStatusForKey).mockImplementation(async () => {
+      callOrder.push('status-start');
+      await statusGate;
+      callOrder.push('status-end');
+      return { discord_id: '1', guild_id: GUILD_ID, status: 'approved' } as any;
+    });
+
+    const reqPromise = supertest(buildApp()).post('/streamdeck-key/rotate').then((r) => r);
+    // Both calls should have started before either resolves — proving they
+    // run concurrently rather than one awaiting the other's completion.
+    await vi.waitFor(() => expect(callOrder).toEqual(['rotate-start', 'status-start']));
+
+    resolveRotate();
+    resolveStatus();
+    await reqPromise;
+  });
+
+  it('a rapid duplicate rotate within the dedupe window reuses the first rotation instead of rotating again', async () => {
+    vi.mocked(hasApiKey).mockResolvedValue(true);
+    vi.mocked(rotateApiKey).mockResolvedValue({ plain: 'first-plain-key' } as any);
+
+    const app = buildApp();
+    const first = await supertest(app).post('/streamdeck-key/rotate');
+    expect((first.body as any).locals.newKey).toBe('first-plain-key');
+
+    // If the dedupe guard failed to kick in, this second call would return
+    // whatever rotateApiKey resolves to now — which is unchanged, so a
+    // regression here wouldn't be masked by a queued "once" value.
+    const second = await supertest(app).post('/streamdeck-key/rotate');
+
+    expect((second.body as any).locals.newKey).toBe('first-plain-key');
+    expect(rotateApiKey).toHaveBeenCalledOnce();
+  });
+
+  it('rotates again once the dedupe window has passed', async () => {
+    // Uses a Date.now() spy (not fake timers) so supertest's real HTTP round
+    // trip isn't disrupted — the dedupe check reads Date.now() lazily, so
+    // there's no setTimeout/interval involved to fake.
+    const dateNowSpy = vi.spyOn(Date, 'now');
+    try {
+      vi.mocked(hasApiKey).mockResolvedValue(true);
+      vi.mocked(rotateApiKey).mockResolvedValueOnce({ plain: 'first-plain-key' } as any);
+      dateNowSpy.mockReturnValue(1_000_000);
+
+      const app = buildApp();
+      const first = await supertest(app).post('/streamdeck-key/rotate');
+      expect((first.body as any).locals.newKey).toBe('first-plain-key');
+
+      vi.mocked(rotateApiKey).mockResolvedValueOnce({ plain: 'second-plain-key' } as any);
+      dateNowSpy.mockReturnValue(1_000_000 + 10_000 + 1);
+
+      const second = await supertest(app).post('/streamdeck-key/rotate');
+
+      expect((second.body as any).locals.newKey).toBe('second-plain-key');
+      expect(rotateApiKey).toHaveBeenCalledTimes(2);
+    } finally {
+      dateNowSpy.mockRestore();
+    }
   });
 });
 

--- a/src/web/routes/streamdeckKeys.test.ts
+++ b/src/web/routes/streamdeckKeys.test.ts
@@ -278,35 +278,32 @@ describe('POST /streamdeck-key/rotate', () => {
     expect(res.headers.location).toBe('/streamdeck-key?error=rotate_failed');
   });
 
-  it('fetches the rotated key hash and the guild status concurrently, not sequentially', async () => {
+  it('reads the guild status before rotating the key, not concurrently', async () => {
     vi.mocked(hasApiKey).mockResolvedValue(true);
     const callOrder: string[] = [];
-    let resolveRotate!: () => void;
-    const rotateGate = new Promise<void>((resolve) => { resolveRotate = resolve; });
-    let resolveStatus!: () => void;
-    const statusGate = new Promise<void>((resolve) => { resolveStatus = resolve; });
 
-    vi.mocked(rotateApiKey).mockImplementation(async () => {
-      callOrder.push('rotate-start');
-      await rotateGate;
-      callOrder.push('rotate-end');
-      return { plain: 'b'.repeat(64) };
-    });
     vi.mocked(getGuildStatusForKey).mockImplementation(async () => {
-      callOrder.push('status-start');
-      await statusGate;
-      callOrder.push('status-end');
+      callOrder.push('status');
       return { discord_id: '1', guild_id: GUILD_ID, status: 'approved' } as any;
     });
+    vi.mocked(rotateApiKey).mockImplementation(async () => {
+      callOrder.push('rotate');
+      return { plain: 'b'.repeat(64) };
+    });
 
-    const reqPromise = supertest(buildApp()).post('/streamdeck-key/rotate').then((r) => r);
-    // Both calls should have started before either resolves — proving they
-    // run concurrently rather than one awaiting the other's completion.
-    await vi.waitFor(() => expect(callOrder).toEqual(['rotate-start', 'status-start']));
+    await supertest(buildApp()).post('/streamdeck-key/rotate');
 
-    resolveRotate();
-    resolveStatus();
-    await reqPromise;
+    expect(callOrder).toEqual(['status', 'rotate']);
+  });
+
+  it('never rotates the key if reading the guild status fails first, so no plaintext is generated and lost', async () => {
+    vi.mocked(hasApiKey).mockResolvedValue(true);
+    vi.mocked(getGuildStatusForKey).mockRejectedValueOnce(new Error('DB down'));
+
+    const res = await supertest(buildApp()).post('/streamdeck-key/rotate');
+
+    expect(res.headers.location).toBe('/streamdeck-key?error=rotate_failed');
+    expect(rotateApiKey).not.toHaveBeenCalled();
   });
 
   it('a rapid duplicate rotate within the dedupe window reuses the first rotation instead of rotating again', async () => {
@@ -326,7 +323,7 @@ describe('POST /streamdeck-key/rotate', () => {
     expect(rotateApiKey).toHaveBeenCalledOnce();
   });
 
-  it('does not reuse another guild\'s cached approval status for the same user within the dedupe window', async () => {
+  it('reuses the same rotated key across a guild switch within the dedupe window, but always reports the current guild\'s fresh status', async () => {
     const OTHER_GUILD_ID = '900000000000000002';
     const sessionInGuildA = SESSION_USER;
     const sessionInGuildB = { ...SESSION_USER, currentGuildId: OTHER_GUILD_ID };
@@ -341,14 +338,19 @@ describe('POST /streamdeck-key/rotate', () => {
 
     const appA = buildApp(sessionInGuildA);
     const firstInA = await supertest(appA).post('/streamdeck-key/rotate');
+    expect((firstInA.body as any).locals.newKey).toBe('shared-plain-key');
     expect((firstInA.body as any).locals.keyRow).toMatchObject({ guild_id: GUILD_ID, status: 'approved' });
 
-    // Same discordId, different guild, within the dedupe window — must not
-    // be served guild A's cached keyRow.
+    // Same discordId, different guild, within the dedupe window — the
+    // global key secret is reused (not rotated again, which would silently
+    // invalidate the one just shown for guild A), but the guild's approval
+    // status is still read fresh and correctly reflects guild B, not a
+    // stale cached value from guild A.
     const appB = buildApp(sessionInGuildB);
     const firstInB = await supertest(appB).post('/streamdeck-key/rotate');
+    expect((firstInB.body as any).locals.newKey).toBe('shared-plain-key');
     expect((firstInB.body as any).locals.keyRow).toMatchObject({ guild_id: OTHER_GUILD_ID, status: 'pending' });
-    expect(rotateApiKey).toHaveBeenCalledTimes(2);
+    expect(rotateApiKey).toHaveBeenCalledOnce();
   });
 
   it('rotates again once the dedupe window has passed', async () => {
@@ -374,6 +376,34 @@ describe('POST /streamdeck-key/rotate', () => {
       expect(rotateApiKey).toHaveBeenCalledTimes(2);
     } finally {
       dateNowSpy.mockRestore();
+    }
+  });
+
+  it('actively evicts the cached plaintext once the dedupe window elapses, not just on next access', async () => {
+    // Captures the scheduled eviction callback instead of letting a real
+    // timer fire, then invokes it directly — proving eviction happens via
+    // that callback (not merely via the lazy age check on next read) by
+    // triggering a second rotation while Date.now() is still unchanged
+    // (i.e. still "within window" by age alone).
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    try {
+      vi.mocked(hasApiKey).mockResolvedValue(true);
+      vi.mocked(rotateApiKey).mockResolvedValueOnce({ plain: 'first-plain-key' } as any);
+
+      const app = buildApp();
+      await supertest(app).post('/streamdeck-key/rotate');
+
+      const [callback, delay] = setTimeoutSpy.mock.calls.at(-1)!;
+      expect(delay).toBe(10_000);
+      (callback as () => void)();
+
+      vi.mocked(rotateApiKey).mockResolvedValueOnce({ plain: 'second-plain-key' } as any);
+      const second = await supertest(app).post('/streamdeck-key/rotate');
+
+      expect((second.body as any).locals.newKey).toBe('second-plain-key');
+      expect(rotateApiKey).toHaveBeenCalledTimes(2);
+    } finally {
+      setTimeoutSpy.mockRestore();
     }
   });
 });

--- a/src/web/routes/streamdeckKeys.ts
+++ b/src/web/routes/streamdeckKeys.ts
@@ -23,7 +23,7 @@ const router = Router();
 
 // ─── User routes (any authenticated user) ────────────────────────────────────
 
-const USER_KNOWN_ERRORS = new Set(['request_failed', 'revoke_failed']);
+const USER_KNOWN_ERRORS = new Set(['request_failed', 'rotate_failed', 'revoke_failed']);
 
 /**
  * Renders the current user's Streamdeck API key status page for their current guild.
@@ -53,12 +53,14 @@ router.get('/streamdeck-key', csrfProtection, async (req, res) => {
  * A brand-new user gets a freshly minted key (plaintext shown once). A user
  * who already has a key from another guild reuses it — no plaintext to show,
  * since only the key's hash is ever stored. A previously revoked request for
- * this guild is re-requested (routed back through the normal approval flow)
- * rather than just rotating the secret, since rotating alone would leave the
- * guild's status stuck on `revoked` while showing the user a "new" key that
- * still isn't authorized here. Re-requesting when this guild already has a
- * pending/approved request on file rotates the key's secret instead (the
- * "lost my key" flow), which also stops the old key working everywhere.
+ * this guild is re-requested (routed back through the normal approval flow).
+ *
+ * Idempotent when this guild already has a pending/approved request on file —
+ * it just re-renders the current status without touching the key, so an
+ * accidental duplicate submission (double-click, browser retry, two requests
+ * racing through `userMutationQueue`) never silently invalidates a plaintext
+ * key the user was just shown. Genuine key rotation (the "lost my key" flow)
+ * is a separate explicit action — see `POST /streamdeck-key/rotate` below.
  *
  * The check-then-act sequence below is serialized per `discordId` through
  * `userMutationQueue` — without it, two concurrent requests from a brand-new
@@ -83,9 +85,9 @@ router.post('/streamdeck-key/request', csrfProtection, async (req, res) => {
         }
         if (existingGuildStatus.status === 'revoked') {
           await requestGuildAccessForExistingKey(discordId, accessLevel, guildId);
-        } else {
-          ({ plain: resolvedPlain } = await rotateApiKey(discordId));
         }
+        // pending/approved: idempotent no-op — the caller just gets the current
+        // status back, with no key mutation.
       } else if (await hasApiKey(discordId)) {
         await requestGuildAccessForExistingKey(discordId, accessLevel, guildId);
       } else {
@@ -103,6 +105,48 @@ router.post('/streamdeck-key/request', csrfProtection, async (req, res) => {
     });
   } catch (err) {
     logAndRedirectError({ res, log, logLabel: 'Streamdeck key request error:', err, basePath: '/streamdeck-key', errorCode: 'request_failed' });
+  }
+});
+
+/**
+ * Rotates the current user's existing Streamdeck API key secret — the
+ * explicit "lost my key" action. Every guild's approval state is left
+ * untouched; only the key's identity (hash) changes, so the old key
+ * immediately stops working everywhere. Distinct from
+ * `POST /streamdeck-key/request`, which never rotates a key that's already
+ * pending or approved.
+ *
+ * Serialized per `discordId` through `userMutationQueue` for the same reason
+ * as `/streamdeck-key/request` — to keep the has-a-key check and the
+ * rotation itself atomic with respect to concurrent requests.
+ *
+ * @param req - Express request; reads `req.session.user` (discordId, currentGuildId).
+ * @param res - Express response; renders the `streamdeck-keys` view with the freshly
+ *   rotated plaintext key on success, or redirects to
+ *   `/streamdeck-key?error=rotate_failed` if the user has no key yet or rotation fails.
+ * @returns A promise that resolves once the view has been rendered or the error redirect issued.
+ */
+router.post('/streamdeck-key/rotate', csrfProtection, async (req, res) => {
+  const discordId = req.session.user!.discordId;
+  const guildId = req.session.user!.currentGuildId!;
+  try {
+    const { plain, keyRow } = await userMutationQueue.run(discordId, async () => {
+      if (!(await hasApiKey(discordId))) {
+        throw new Error('Cannot rotate: no existing Streamdeck API key');
+      }
+      const { plain: rotatedPlain } = await rotateApiKey(discordId);
+      return { plain: rotatedPlain, keyRow: await getGuildStatusForKey(discordId, guildId) };
+    });
+    renderView(res, 'streamdeck-keys', {
+      user: req.session.user,
+      csrfToken: req.csrfToken(),
+      keyRow,
+      newKey: plain,
+      error: null,
+      webPort: WEB_PORT,
+    });
+  } catch (err) {
+    logAndRedirectError({ res, log, logLabel: 'Streamdeck key rotate error:', err, basePath: '/streamdeck-key', errorCode: 'rotate_failed' });
   }
 });
 

--- a/src/web/routes/streamdeckKeys.ts
+++ b/src/web/routes/streamdeckKeys.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '../../shared/logger';
-import { Router } from 'express';
+import { Router, type Request, type Response } from 'express';
 import {
   hasApiKey,
   createApiKeyAndRequestGuildAccess,
@@ -11,6 +11,7 @@ import {
   denyApiKey,
   getAllApiKeys,
   getPendingRequests,
+  type StreamdeckKeyGuildStatusRow,
 } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireAdmin } from '../middleware';
@@ -20,6 +21,31 @@ import { userMutationQueue } from './adminUserMutationQueue';
 
 const log = createLogger('Web');
 const router = Router();
+
+/**
+ * Renders the current user's Streamdeck key status page, shared by
+ * GET /streamdeck-key and the success paths of the request/rotate POST
+ * handlers below (they only differ in what `keyRow`/`newKey` they pass in).
+ * @param req - Express request; reads `req.session.user` and `req.csrfToken()`.
+ * @param res - Express response.
+ * @param keyRow - The current (possibly just-created/rotated) guild-status row, or null.
+ * @param newKey - Freshly generated plaintext key to display once, or null if none.
+ */
+function renderKeyStatus(
+  req: Request,
+  res: Response,
+  keyRow: StreamdeckKeyGuildStatusRow | null,
+  newKey: string | null,
+): void {
+  renderView(res, 'streamdeck-keys', {
+    user: req.session.user,
+    csrfToken: req.csrfToken(),
+    keyRow,
+    newKey,
+    error: null,
+    webPort: WEB_PORT,
+  });
+}
 
 // ─── User routes (any authenticated user) ────────────────────────────────────
 
@@ -85,9 +111,11 @@ router.post('/streamdeck-key/request', csrfProtection, async (req, res) => {
         }
         if (existingGuildStatus.status === 'revoked') {
           await requestGuildAccessForExistingKey(discordId, accessLevel, guildId);
+        } else {
+          // pending/approved: idempotent no-op — nothing changed, so the
+          // status already fetched above is still current; skip re-querying it.
+          return { plain: resolvedPlain, keyRow: existingGuildStatus };
         }
-        // pending/approved: idempotent no-op — the caller just gets the current
-        // status back, with no key mutation.
       } else if (await hasApiKey(discordId)) {
         await requestGuildAccessForExistingKey(discordId, accessLevel, guildId);
       } else {
@@ -95,18 +123,34 @@ router.post('/streamdeck-key/request', csrfProtection, async (req, res) => {
       }
       return { plain: resolvedPlain, keyRow: await getGuildStatusForKey(discordId, guildId) };
     });
-    renderView(res, 'streamdeck-keys', {
-      user: req.session.user,
-      csrfToken: req.csrfToken(),
-      keyRow,
-      newKey: plain,
-      error: null,
-      webPort: WEB_PORT,
-    });
+    renderKeyStatus(req, res, keyRow, plain);
   } catch (err) {
     logAndRedirectError({ res, log, logLabel: 'Streamdeck key request error:', err, basePath: '/streamdeck-key', errorCode: 'request_failed' });
   }
 });
+
+interface RecentRotation {
+  plain: string;
+  keyRow: StreamdeckKeyGuildStatusRow | null;
+  rotatedAt: number;
+}
+
+// Tracks a just-completed rotation per discordId for a short window so a
+// rapid duplicate POST /streamdeck-key/rotate (a network-level retry of a
+// timed-out request, or the same "Lost your key?" confirm landing twice from
+// two tabs) reuses the response already rendered instead of rotating again
+// and silently invalidating the key the user was just shown — the same class
+// of accidental-duplicate bug this file's /request handler guards against.
+// Entries are checked lazily by age (like the rest of this codebase's TTL
+// caches) rather than actively evicted; bounded by the small, admin-managed
+// user table this app already assumes elsewhere (see CLAUDE.md's user model).
+const ROTATE_DEDUPE_WINDOW_MS = 10_000;
+const recentRotations = new Map<string, RecentRotation>();
+
+/** Test-only: clears the rotate dedupe cache so each test starts from a clean slate. */
+export function __resetRecentRotationsForTests(): void {
+  recentRotations.clear();
+}
 
 /**
  * Rotates the current user's existing Streamdeck API key secret — the
@@ -118,7 +162,9 @@ router.post('/streamdeck-key/request', csrfProtection, async (req, res) => {
  *
  * Serialized per `discordId` through `userMutationQueue` for the same reason
  * as `/streamdeck-key/request` — to keep the has-a-key check and the
- * rotation itself atomic with respect to concurrent requests.
+ * rotation itself atomic with respect to concurrent requests. A rotation
+ * within `ROTATE_DEDUPE_WINDOW_MS` of the last one for this user reuses that
+ * result instead of rotating again (see {@link recentRotations}).
  *
  * @param req - Express request; reads `req.session.user` (discordId, currentGuildId).
  * @param res - Express response; renders the `streamdeck-keys` view with the freshly
@@ -131,20 +177,23 @@ router.post('/streamdeck-key/rotate', csrfProtection, async (req, res) => {
   const guildId = req.session.user!.currentGuildId!;
   try {
     const { plain, keyRow } = await userMutationQueue.run(discordId, async () => {
+      const recent = recentRotations.get(discordId);
+      if (recent && Date.now() - recent.rotatedAt < ROTATE_DEDUPE_WINDOW_MS) return recent;
+
       if (!(await hasApiKey(discordId))) {
         throw new Error('Cannot rotate: no existing Streamdeck API key');
       }
-      const { plain: rotatedPlain } = await rotateApiKey(discordId);
-      return { plain: rotatedPlain, keyRow: await getGuildStatusForKey(discordId, guildId) };
+      // Independent reads/writes on unrelated tables (key hash vs. guild
+      // approval status) — safe to run concurrently.
+      const [{ plain: rotatedPlain }, rotatedKeyRow] = await Promise.all([
+        rotateApiKey(discordId),
+        getGuildStatusForKey(discordId, guildId),
+      ]);
+      const result: RecentRotation = { plain: rotatedPlain, keyRow: rotatedKeyRow, rotatedAt: Date.now() };
+      recentRotations.set(discordId, result);
+      return result;
     });
-    renderView(res, 'streamdeck-keys', {
-      user: req.session.user,
-      csrfToken: req.csrfToken(),
-      keyRow,
-      newKey: plain,
-      error: null,
-      webPort: WEB_PORT,
-    });
+    renderKeyStatus(req, res, keyRow, plain);
   } catch (err) {
     logAndRedirectError({ res, log, logLabel: 'Streamdeck key rotate error:', err, basePath: '/streamdeck-key', errorCode: 'rotate_failed' });
   }

--- a/src/web/routes/streamdeckKeys.ts
+++ b/src/web/routes/streamdeckKeys.ts
@@ -131,30 +131,26 @@ router.post('/streamdeck-key/request', csrfProtection, async (req, res) => {
 
 interface RecentRotation {
   plain: string;
-  keyRow: StreamdeckKeyGuildStatusRow | null;
   rotatedAt: number;
 }
 
-// Tracks a just-completed rotation per (discordId, guildId) for a short
-// window so a rapid duplicate POST /streamdeck-key/rotate (a network-level
-// retry of a timed-out request, or the same "Lost your key?" confirm landing
-// twice from two tabs) reuses the response already rendered instead of
-// rotating again and silently invalidating the key the user was just shown —
-// the same class of accidental-duplicate bug this file's /request handler
-// guards against. Guild-scoped (not just discordId) because the cached
-// keyRow is guild-specific (from getGuildStatusForKey) — a user rotating
-// while switching between two guilds they belong to must not have the wrong
-// guild's approval status served back to them. Entries are checked lazily by
-// age (like the rest of this codebase's TTL caches) rather than actively
-// evicted; bounded by the small, admin-managed user table this app already
-// assumes elsewhere (see CLAUDE.md's user model).
+// Tracks a just-completed rotation per discordId (not per guild — the key
+// secret itself is global to the user, only its per-guild approval status
+// differs) for a short window, so a rapid duplicate POST
+// /streamdeck-key/rotate reuses the plaintext already rendered instead of
+// rotating again and silently invalidating the key the user was just
+// shown — the same class of accidental-duplicate bug this file's /request
+// handler guards against. Keying this by discordId alone (rather than also
+// guildId) matters: a user switching between two guilds they belong to and
+// clicking "Lost your key?" in each within the window must get back the
+// *same* key, not a second, silently-invalidating rotation — the guild's
+// approval status is always read fresh per request instead (see the route
+// handler below), so it's never served stale across guilds. Entries both
+// expire lazily by age (like the rest of this codebase's TTL caches) and are
+// actively evicted via a guarded timer once expired, so a plaintext key
+// never lingers in process memory longer than the dedupe window.
 const ROTATE_DEDUPE_WINDOW_MS = 10_000;
 const recentRotations = new Map<string, RecentRotation>();
-
-/** Builds the `recentRotations` cache key for a (discordId, guildId) pair. */
-function recentRotationKey(discordId: string, guildId: string): string {
-  return `${discordId}:${guildId}`;
-}
 
 /** Test-only: clears the rotate dedupe cache so each test starts from a clean slate. */
 export function __resetRecentRotationsForTests(): void {
@@ -169,40 +165,42 @@ export function __resetRecentRotationsForTests(): void {
  * `POST /streamdeck-key/request`, which never rotates a key that's already
  * pending or approved.
  *
- * Serialized per `discordId` through `userMutationQueue` for the same reason
- * as `/streamdeck-key/request` — to keep the has-a-key check and the
- * rotation itself atomic with respect to concurrent requests. A rotation
- * within `ROTATE_DEDUPE_WINDOW_MS` of the last one for this (discordId,
- * guildId) pair reuses that result instead of rotating again (see
- * {@link recentRotations}).
+ * The guild's approval status is read *before* the key is rotated, so a
+ * transient failure of that read never strands an already-rotated (and now
+ * unrecoverable — only the hash is ever stored) plaintext key behind a
+ * "failed" response. Rotation itself is serialized per `discordId` through
+ * `userMutationQueue` for the same reason as `/streamdeck-key/request` — to
+ * keep the has-a-key check and the rotation atomic with respect to
+ * concurrent requests. A rotation within `ROTATE_DEDUPE_WINDOW_MS` of the
+ * last one for this user reuses that plaintext instead of rotating again
+ * (see {@link recentRotations}).
  *
  * @param req - Express request; reads `req.session.user` (discordId, currentGuildId).
  * @param res - Express response; renders the `streamdeck-keys` view with the freshly
  *   rotated plaintext key on success, or redirects to
- *   `/streamdeck-key?error=rotate_failed` if the user has no key yet or rotation fails.
+ *   `/streamdeck-key?error=rotate_failed` if the user has no key yet, the status
+ *   read fails, or rotation fails.
  * @returns A promise that resolves once the view has been rendered or the error redirect issued.
  */
 router.post('/streamdeck-key/rotate', csrfProtection, async (req, res) => {
   const discordId = req.session.user!.discordId;
   const guildId = req.session.user!.currentGuildId!;
   try {
-    const { plain, keyRow } = await userMutationQueue.run(discordId, async () => {
-      const dedupeKey = recentRotationKey(discordId, guildId);
-      const recent = recentRotations.get(dedupeKey);
-      if (recent && Date.now() - recent.rotatedAt < ROTATE_DEDUPE_WINDOW_MS) return recent;
+    const keyRow = await getGuildStatusForKey(discordId, guildId);
+    const plain = await userMutationQueue.run(discordId, async () => {
+      const recent = recentRotations.get(discordId);
+      if (recent && Date.now() - recent.rotatedAt < ROTATE_DEDUPE_WINDOW_MS) return recent.plain;
 
       if (!(await hasApiKey(discordId))) {
         throw new Error('Cannot rotate: no existing Streamdeck API key');
       }
-      // Independent reads/writes on unrelated tables (key hash vs. guild
-      // approval status) — safe to run concurrently.
-      const [{ plain: rotatedPlain }, rotatedKeyRow] = await Promise.all([
-        rotateApiKey(discordId),
-        getGuildStatusForKey(discordId, guildId),
-      ]);
-      const result: RecentRotation = { plain: rotatedPlain, keyRow: rotatedKeyRow, rotatedAt: Date.now() };
-      recentRotations.set(dedupeKey, result);
-      return result;
+      const { plain: rotatedPlain } = await rotateApiKey(discordId);
+      const result: RecentRotation = { plain: rotatedPlain, rotatedAt: Date.now() };
+      recentRotations.set(discordId, result);
+      setTimeout(() => {
+        if (recentRotations.get(discordId) === result) recentRotations.delete(discordId);
+      }, ROTATE_DEDUPE_WINDOW_MS).unref();
+      return rotatedPlain;
     });
     renderKeyStatus(req, res, keyRow, plain);
   } catch (err) {

--- a/src/web/routes/streamdeckKeys.ts
+++ b/src/web/routes/streamdeckKeys.ts
@@ -135,17 +135,26 @@ interface RecentRotation {
   rotatedAt: number;
 }
 
-// Tracks a just-completed rotation per discordId for a short window so a
-// rapid duplicate POST /streamdeck-key/rotate (a network-level retry of a
-// timed-out request, or the same "Lost your key?" confirm landing twice from
-// two tabs) reuses the response already rendered instead of rotating again
-// and silently invalidating the key the user was just shown — the same class
-// of accidental-duplicate bug this file's /request handler guards against.
-// Entries are checked lazily by age (like the rest of this codebase's TTL
-// caches) rather than actively evicted; bounded by the small, admin-managed
-// user table this app already assumes elsewhere (see CLAUDE.md's user model).
+// Tracks a just-completed rotation per (discordId, guildId) for a short
+// window so a rapid duplicate POST /streamdeck-key/rotate (a network-level
+// retry of a timed-out request, or the same "Lost your key?" confirm landing
+// twice from two tabs) reuses the response already rendered instead of
+// rotating again and silently invalidating the key the user was just shown —
+// the same class of accidental-duplicate bug this file's /request handler
+// guards against. Guild-scoped (not just discordId) because the cached
+// keyRow is guild-specific (from getGuildStatusForKey) — a user rotating
+// while switching between two guilds they belong to must not have the wrong
+// guild's approval status served back to them. Entries are checked lazily by
+// age (like the rest of this codebase's TTL caches) rather than actively
+// evicted; bounded by the small, admin-managed user table this app already
+// assumes elsewhere (see CLAUDE.md's user model).
 const ROTATE_DEDUPE_WINDOW_MS = 10_000;
 const recentRotations = new Map<string, RecentRotation>();
+
+/** Builds the `recentRotations` cache key for a (discordId, guildId) pair. */
+function recentRotationKey(discordId: string, guildId: string): string {
+  return `${discordId}:${guildId}`;
+}
 
 /** Test-only: clears the rotate dedupe cache so each test starts from a clean slate. */
 export function __resetRecentRotationsForTests(): void {
@@ -163,8 +172,9 @@ export function __resetRecentRotationsForTests(): void {
  * Serialized per `discordId` through `userMutationQueue` for the same reason
  * as `/streamdeck-key/request` — to keep the has-a-key check and the
  * rotation itself atomic with respect to concurrent requests. A rotation
- * within `ROTATE_DEDUPE_WINDOW_MS` of the last one for this user reuses that
- * result instead of rotating again (see {@link recentRotations}).
+ * within `ROTATE_DEDUPE_WINDOW_MS` of the last one for this (discordId,
+ * guildId) pair reuses that result instead of rotating again (see
+ * {@link recentRotations}).
  *
  * @param req - Express request; reads `req.session.user` (discordId, currentGuildId).
  * @param res - Express response; renders the `streamdeck-keys` view with the freshly
@@ -177,7 +187,8 @@ router.post('/streamdeck-key/rotate', csrfProtection, async (req, res) => {
   const guildId = req.session.user!.currentGuildId!;
   try {
     const { plain, keyRow } = await userMutationQueue.run(discordId, async () => {
-      const recent = recentRotations.get(discordId);
+      const dedupeKey = recentRotationKey(discordId, guildId);
+      const recent = recentRotations.get(dedupeKey);
       if (recent && Date.now() - recent.rotatedAt < ROTATE_DEDUPE_WINDOW_MS) return recent;
 
       if (!(await hasApiKey(discordId))) {
@@ -190,7 +201,7 @@ router.post('/streamdeck-key/rotate', csrfProtection, async (req, res) => {
         getGuildStatusForKey(discordId, guildId),
       ]);
       const result: RecentRotation = { plain: rotatedPlain, keyRow: rotatedKeyRow, rotatedAt: Date.now() };
-      recentRotations.set(discordId, result);
+      recentRotations.set(dedupeKey, result);
       return result;
     });
     renderKeyStatus(req, res, keyRow, plain);

--- a/src/web/routes/streamdeckSfx.test.ts
+++ b/src/web/routes/streamdeckSfx.test.ts
@@ -117,7 +117,7 @@ describe('POST /sfx', () => {
       .expect(200);
 
     expect(res.body).toEqual({ ok: true, file: 'ding.mp3' });
-    expect(vi.mocked(setVoicePlaying)).toHaveBeenCalledWith('ding.mp3', '!ding', 'streamdeck');
+    expect(vi.mocked(setVoicePlaying)).toHaveBeenCalledWith('guild-123', 'ding.mp3', '!ding', 'streamdeck');
   });
 
   it('normalises the command to lowercase before lookup', async () => {

--- a/src/web/routes/streamdeckSfx.ts
+++ b/src/web/routes/streamdeckSfx.ts
@@ -83,7 +83,7 @@ router.post('/sfx', requireApiKey, async (req, res) => {
 
   try {
     playFile(filename, guildId);
-    setVoicePlaying(filename, normalizedCommand, 'streamdeck');
+    setVoicePlaying(guildId, filename, normalizedCommand, 'streamdeck');
     log.info(`Playing '${filename.replace(/[\r\n]/g, '')}' for trigger '${normalizedCommand.replace(/[\r\n]/g, '')}' in guild ${guildId}`);
     res.json({ ok: true, file: filename });
   } catch (err: unknown) {

--- a/src/web/routes/streams.ts
+++ b/src/web/routes/streams.ts
@@ -6,33 +6,20 @@ import { requireManager } from '../middleware';
 import { getLiveStates } from '../../twitch/monitor/twitchMonitor';
 import { AccessLevel } from '../../db';
 import { filterQueryParam, renderView, renderError } from './shared';
+import { STREAMS_ERROR_CODES, STREAMS_ERROR_MESSAGES, type StreamsErrorCode } from './streamsErrors';
 import groupsRouter from './streamGroups';
 import streamersRouter from './streamStreamers';
 
 const log = createLogger('Web');
 const router = Router();
 
-const KNOWN_ERRORS = new Set([
-  'missing_fields', 'invalid_id',
-  'add_group_failed', 'update_group_failed', 'remove_group_failed',
-  'add_streamer_failed', 'remove_streamer_failed',
-  'eventsub_disconnect_failed',
-]);
+const KNOWN_ERRORS: ReadonlySet<StreamsErrorCode> = new Set(STREAMS_ERROR_CODES);
 const KNOWN_SUCCESSES = new Set<string>([]);
 
-export const ERROR_MESSAGES: Record<string, string> = {
-  missing_fields:             'All required fields must be filled in.',
-  invalid_id:                 'Invalid ID — please try again.',
-  add_group_failed:           'Failed to add stream group. Please try again.',
-  update_group_failed:        'Failed to update stream group. Please try again.',
-  remove_group_failed:        'Failed to remove stream group. Please try again.',
-  add_streamer_failed:        'Failed to add streamer. Please try again.',
-  remove_streamer_failed:     'Failed to remove streamer. Please try again.',
-  eventsub_disconnect_failed: 'Failed to disconnect Twitch account. Please try again.',
-};
+export const ERROR_MESSAGES = STREAMS_ERROR_MESSAGES;
 
 function getFriendlyError(key: string): string {
-  return ERROR_MESSAGES[key] ?? `An error occurred (${key}).`;
+  return (ERROR_MESSAGES as Record<string, string>)[key] ?? `An error occurred (${key}).`;
 }
 
 // ─── View ─────────────────────────────────────────────────────────────────────

--- a/src/web/routes/streamsErrors.test.ts
+++ b/src/web/routes/streamsErrors.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Response } from 'express';
+import {
+  STREAMS_ERROR_CODES,
+  STREAMS_ERROR_MESSAGES,
+  redirectStreamsInvalid,
+  redirectStreamsFailure,
+} from './streamsErrors';
+
+function mockRes() {
+  const redirect = vi.fn();
+  return { res: { redirect } as unknown as Response, redirect };
+}
+
+function mockLog() {
+  const error = vi.fn();
+  return { log: { error } as unknown as import('winston').Logger, error };
+}
+
+describe('STREAMS_ERROR_MESSAGES', () => {
+  it('has exactly one message per code in STREAMS_ERROR_CODES', () => {
+    expect(Object.keys(STREAMS_ERROR_MESSAGES).sort()).toEqual([...STREAMS_ERROR_CODES].sort());
+  });
+});
+
+describe('redirectStreamsInvalid', () => {
+  it('redirects to the streams page with the given error code', () => {
+    const { res, redirect } = mockRes();
+    redirectStreamsInvalid(res, 'missing_fields');
+    expect(redirect).toHaveBeenCalledWith('/admin/streams?error=missing_fields');
+  });
+});
+
+describe('redirectStreamsFailure', () => {
+  it('logs the error with the given label and redirects with the error code', () => {
+    const { res, redirect } = mockRes();
+    const { log, error } = mockLog();
+    const err = new Error('boom');
+
+    redirectStreamsFailure(res, log, 'Add stream group error:', err, 'add_group_failed');
+
+    expect(error).toHaveBeenCalledWith('Add stream group error:', err);
+    expect(redirect).toHaveBeenCalledWith('/admin/streams?error=add_group_failed');
+  });
+});

--- a/src/web/routes/streamsErrors.ts
+++ b/src/web/routes/streamsErrors.ts
@@ -1,0 +1,66 @@
+import type { Response } from 'express';
+import type { Logger } from 'winston';
+import { logAndRedirectError } from './shared';
+
+/** Path every streams-page error redirect targets. */
+const STREAMS_BASE_PATH = '/admin/streams';
+
+/**
+ * Every `error` query-param code the streams page — and the routes that
+ * redirect back to it (stream groups, streamers, and the admin EventSub
+ * disconnect) — can produce. Kept as a single source of truth so a typo'd
+ * code fails to compile instead of silently rendering no error message.
+ */
+export const STREAMS_ERROR_CODES = [
+  'missing_fields',
+  'invalid_id',
+  'add_group_failed',
+  'update_group_failed',
+  'remove_group_failed',
+  'add_streamer_failed',
+  'remove_streamer_failed',
+  'eventsub_disconnect_failed',
+] as const;
+
+export type StreamsErrorCode = (typeof STREAMS_ERROR_CODES)[number];
+
+/** Human-readable message for each {@link StreamsErrorCode}. */
+export const STREAMS_ERROR_MESSAGES: Record<StreamsErrorCode, string> = {
+  missing_fields:             'All required fields must be filled in.',
+  invalid_id:                 'Invalid ID — please try again.',
+  add_group_failed:           'Failed to add stream group. Please try again.',
+  update_group_failed:        'Failed to update stream group. Please try again.',
+  remove_group_failed:        'Failed to remove stream group. Please try again.',
+  add_streamer_failed:        'Failed to add streamer. Please try again.',
+  remove_streamer_failed:     'Failed to remove streamer. Please try again.',
+  eventsub_disconnect_failed: 'Failed to disconnect Twitch account. Please try again.',
+};
+
+/**
+ * Redirects to the streams page with a type-checked `error` query param, for
+ * a validation failure that has no caught error to log.
+ * @param res - Express response object.
+ * @param errorCode - One of {@link StreamsErrorCode}.
+ */
+export function redirectStreamsInvalid(res: Response, errorCode: StreamsErrorCode): void {
+  res.redirect(`${STREAMS_BASE_PATH}?error=${errorCode}`);
+}
+
+/**
+ * Logs a caught error and redirects to the streams page with a type-checked
+ * `error` query param.
+ * @param res - Express response object.
+ * @param log - Logger to record the error on.
+ * @param logLabel - Message prefix passed to `log.error`.
+ * @param err - The caught error value, forwarded to `log.error` unchanged.
+ * @param errorCode - One of {@link StreamsErrorCode}.
+ */
+export function redirectStreamsFailure(
+  res: Response,
+  log: Logger,
+  logLabel: string,
+  err: unknown,
+  errorCode: StreamsErrorCode,
+): void {
+  logAndRedirectError({ res, log, logLabel, err, basePath: STREAMS_BASE_PATH, errorCode });
+}

--- a/views/streamdeck-keys.ejs
+++ b/views/streamdeck-keys.ejs
@@ -17,6 +17,7 @@
       <% if (error) { %>
       <% const errorMessages = {
         request_failed: 'Failed to generate API key. Please try again.',
+        rotate_failed:  'Failed to generate a new key. Please try again.',
         revoke_failed:  'Failed to revoke API key. Please try again.',
       }; %>
       <div class="card card-alert-danger" role="alert" aria-live="assertive" aria-atomic="true">
@@ -61,10 +62,10 @@
           <span class="muted" style="font-size:.85rem;">Requested <%= keyRow.requested_at.toLocaleDateString() %></span>
         </div>
         <p>Your key is awaiting Admin approval. No further action is needed — the key you already copied will become active automatically once an Admin approves your request. Refresh this page to check the current status.</p>
-        <p class="muted" style="margin-top:.5rem;">Want to cancel and start over? Requesting a new key will replace the pending one<%= user.guilds && user.guilds.length > 1 ? ' — and immediately stop your existing key from working in every server it was approved for, not just this one' : '' %>.</p>
-        <form method="POST" action="/streamdeck-key/request" style="margin-top:1rem;">
+        <p class="muted" style="margin-top:.5rem;">Lost the key you copied? Generating a new one won't affect your approval status, but the old key will immediately stop working<%= user.guilds && user.guilds.length > 1 ? ' — in every server it was approved for, not just this one' : '' %>.</p>
+        <form method="POST" action="/streamdeck-key/rotate" class="js-confirm-rotate-key" style="margin-top:1rem;">
           <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-          <button type="submit" class="btn btn-sm">Generate New Key (replaces pending)</button>
+          <button type="submit" class="btn btn-sm btn-ghost">Lost your key?</button>
         </form>
 
         <% } else if (keyRow.status === 'approved') { %>
@@ -75,9 +76,9 @@
         <p>Your API key is active. See the <strong>How to Use</strong> section below for setup instructions.</p>
         <p class="muted">If you have lost your key, you can generate a new one. The old key will immediately stop working<%= user.guilds && user.guilds.length > 1 ? ' — in every server it was approved for, not just this one' : '' %>.</p>
         <div style="display:flex;gap:.5rem;flex-wrap:wrap;margin-top:1rem;">
-          <form method="POST" action="/streamdeck-key/request">
+          <form method="POST" action="/streamdeck-key/rotate" class="js-confirm-rotate-key">
             <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-            <button type="submit" class="btn btn-sm">Generate New Key</button>
+            <button type="submit" class="btn btn-sm btn-ghost">Lost your key?</button>
           </form>
           <form method="POST" action="/streamdeck-key/revoke" class="js-confirm-revoke-key">
             <input type="hidden" name="_csrf" value="<%= csrfToken %>">
@@ -85,7 +86,7 @@
           </form>
         </div>
         <% if (user.guilds && user.guilds.length > 1) { %>
-        <p class="muted" style="margin-top:.5rem;">Revoking only removes access for this server — the key stays active in any other server it's approved for. Use <strong>Generate New Key</strong> to invalidate it everywhere.</p>
+        <p class="muted" style="margin-top:.5rem;">Revoking only removes access for this server — the key stays active in any other server it's approved for. Use <strong>Lost your key?</strong> to invalidate it everywhere.</p>
         <% } %>
 
         <% } else if (keyRow.status === 'revoked') { %>


### PR DESCRIPTION
## Summary

Works through the follow-up items tracked in #378, one commit per item.

- [x] **Item 1** — Global `statusStore` leaked cross-guild playback status (`src/shared/statusStore.ts`, `src/audio/audioPlayer.ts`). Voice status (`currentFile`/`lastCommand`/`channelName`/etc.) is now keyed per guild, like the existing Twitch/TikTok channel maps. `GET /api/status` and the dashboard page now scope the response to the viewer's session `currentGuildId`, so a Manager on guild B's dashboard can no longer see guild A's now-playing info.
- [x] **Item 2** — Hand-rolled TTL caches in `twitchBot.ts`/`tiktokBot.ts` duplicated `src/db/lookupCache.ts`'s `createManagedLookupCache`. TikTok's single-value owner lookup is now a direct swap; Twitch's per-channel lookup is now a bulk "all twitch-linked users" load (new `getAllTwitchLinkedUsers` in `src/db/users.ts`) built into one managed cache, replacing the lazily-populated per-channel `Map`.
- [x] **Item 3** — Per-guild/per-channel state (`audioPlayer.ts`'s `states` Map, `commandRouter.ts`'s `guildStates` Map, plus the new per-guild voice status from item 1) was never evicted. Added a `guildDelete` listener in `discordBot.ts` that forgets a departed guild's in-memory state. Only in-memory state is touched — the `guild` DB row is intentionally never deleted on leave. `twitchChannelDiscordIdCache` (the third Map named in the original issue) no longer needs this treatment since item 2 already replaced it with a single bulk-loaded, TTL-bounded cache.
- [x] ~~Item 4~~ — **Skipped.** TikTok's chat integration isn't fully functional or in active use yet, so the `tiktok_name` DB migration + admin UI + per-channel routing rework this item needs isn't worth doing right now. Left as-is in #378 for whenever TikTok is actually used.
- [x] **Item 5** — `streams.ts`'s `KNOWN_ERRORS`/`ERROR_MESSAGES` registry lived apart from the routes producing those codes (`streamGroups.ts`, `streamStreamers.ts`, `eventsubAdmin.ts`). New `src/web/routes/streamsErrors.ts` defines a `StreamsErrorCode` string-literal union, an exhaustive message map keyed by it, and two type-checked redirect helpers all three route files now use — a typo'd code now fails to compile instead of silently rendering no message.
- [x] **Item 6** — `POST /streamdeck-key/request` treated any repeat submission while a guild's status was already pending/approved as a "lost my key" action, silently rotating the secret — including on an accidental duplicate submission. `/request` is now idempotent for that case; genuine rotation moved to a new explicit `POST /streamdeck-key/rotate`, exposed as a de-emphasized "Lost your key?" button (confirmed with the repo owner) with a client-side confirmation dialog.

### Self-review fixes

Ran a structured multi-angle code review against the diff before requesting external review and fixed what it found:
- **Correctness regression** — the item-2 bulk Twitch cache dropped the old per-channel cache's "always retry on miss" guarantee, so a newly-linked streamer's commands could silently go nowhere for up to 5 minutes. `resolveDiscordIdForTwitchChannel` now falls back to a live lookup on a cache miss.
- **Item-3 gap** — `adminRefresh.ts`'s `refreshStates` Map was a fourth per-guild in-memory Map the `guildDelete` cleanup missed. Added `forgetGuildRefreshState`, wired into the same handler.
- **Item-6 hardening** — the new `/rotate` endpoint had no idempotency guard of its own (the same duplicate-submission risk `/request` was just fixed for, in narrower form); `/request` re-queried the guild status redundantly in its no-op branch; `/rotate`'s two independent DB calls ran sequentially instead of via `Promise.all`; and `/request`/`/rotate` had a duplicated `renderView` success block now extracted into a shared helper.
- **Cleanup** — extracted a shared `getOrCreate` Map helper (`statusStore.ts`) and a shared backoff-constant pair (`db/lookupCache.ts`) that item 1/2 had each re-implemented locally.

Two review findings were noted but intentionally left alone: `sfxPublic.ts` has the same hand-rolled-cache pattern item 2 fixed elsewhere, but wasn't named in #378's scope; `getAllTwitchLinkedUsers`'s row-mapping overlap with `getTwitchEnabledChannels` was judged acceptable, minor duplication.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (2325 tests)
- [x] Verified the `StreamsErrorCode` union rejects a typo'd error code at compile time (introduced one temporarily, confirmed `tsc` failed, reverted)
- [x] Verified the `discordBot.ts` ⇄ `adminRefresh.ts` import cycle resolves correctly at runtime (loaded both modules with real env vars outside the test mocks, confirmed all functions are defined)
- [ ] Manual verification of the dashboard scoping, guildDelete cleanup, and Streamdeck key request/rotate flow (no runnable dev environment in this session — flagged for review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016oBX7fHmNmQeR9Vbem3TnF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-guild voice/status isolation, including complete in-memory cleanup when a server is removed.
  * Managed caching for Twitch identity lookups with stale-while-revalidate refresh and configurable backoff.
  * Added a “rotate key” confirmation flow and short-term rotation deduping, plus support for the `rotate_failed` outcome.

* **Bug Fixes**
  * Prevent duplicate Streamdeck key requests from re-rotating or unnecessarily invalidating keys.
  * Ensure dashboard and status views are correctly scoped to the currently selected server.
  * Stream admin routes now use consistent validation/failure redirects; Streamdeck SFX and playback status now record the correct server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->