### PR TITLE
Fix: invalidate custom-command cache on guild override writes

### DIFF
--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -24,6 +24,13 @@ vi.mock('./db/customCommandCache', () => ({
   getCustomCommandForDiscord: vi.fn(),
 }));
 
+vi.mock('./db/guildCommandOverrides', () => ({
+  getOverridesForGuild: vi.fn(),
+  getAllOverrides: vi.fn(),
+  upsertOverride: vi.fn(),
+  removeOverride: vi.fn(),
+}));
+
 vi.mock('./db/customCommands', () => ({
   getAllCustomCommandsWithAssignments: vi.fn(),
   addCustomCommand: vi.fn(),
@@ -128,13 +135,16 @@ vi.mock('./db/lookupCache', () => ({
 
 import { upsertUserRecord, setTwitchBotEnabledRecord, removeUserRecord } from './db/users';
 import { invalidateCustomCommandLookupCache } from './db/customCommandCache';
-import { upsertUser, updateTwitchBotEnabled, removeUser } from './db';
+import { upsertOverride as upsertOverrideRecord, removeOverride as removeOverrideRecord } from './db/guildCommandOverrides';
+import { upsertUser, updateTwitchBotEnabled, removeUser, upsertOverride, removeOverride } from './db';
 
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(upsertUserRecord).mockResolvedValue(false);
   vi.mocked(setTwitchBotEnabledRecord).mockResolvedValue(undefined);
   vi.mocked(removeUserRecord).mockResolvedValue(undefined);
+  vi.mocked(upsertOverrideRecord).mockResolvedValue(undefined);
+  vi.mocked(removeOverrideRecord).mockResolvedValue(undefined);
 });
 
 // ─── upsertUser ───────────────────────────────────────────────────────────────
@@ -196,6 +206,38 @@ describe('removeUser', () => {
   it('propagates errors from removeUserRecord', async () => {
     vi.mocked(removeUserRecord).mockRejectedValue(new Error('DB error'));
     await expect(removeUser('1')).rejects.toThrow('DB error');
+    expect(invalidateCustomCommandLookupCache).not.toHaveBeenCalled();
+  });
+});
+
+// ─── upsertOverride ─────────────────────────────────────────────────────────
+
+describe('upsertOverride', () => {
+  it('always calls invalidateCustomCommandLookupCache on success', async () => {
+    await upsertOverride('1', 5, { isDisabled: false, output: null });
+    expect(upsertOverrideRecord).toHaveBeenCalledWith('1', 5, { isDisabled: false, output: null });
+    expect(invalidateCustomCommandLookupCache).toHaveBeenCalledOnce();
+  });
+
+  it('propagates errors from upsertOverrideRecord without calling invalidate', async () => {
+    vi.mocked(upsertOverrideRecord).mockRejectedValue(new Error('DB error'));
+    await expect(upsertOverride('1', 5, { isDisabled: true, output: 'hi' })).rejects.toThrow('DB error');
+    expect(invalidateCustomCommandLookupCache).not.toHaveBeenCalled();
+  });
+});
+
+// ─── removeOverride ─────────────────────────────────────────────────────────
+
+describe('removeOverride', () => {
+  it('always calls invalidateCustomCommandLookupCache on success', async () => {
+    await removeOverride('1', 5);
+    expect(removeOverrideRecord).toHaveBeenCalledWith('1', 5);
+    expect(invalidateCustomCommandLookupCache).toHaveBeenCalledOnce();
+  });
+
+  it('propagates errors from removeOverrideRecord without calling invalidate', async () => {
+    vi.mocked(removeOverrideRecord).mockRejectedValue(new Error('DB error'));
+    await expect(removeOverride('1', 5)).rejects.toThrow('DB error');
     expect(invalidateCustomCommandLookupCache).not.toHaveBeenCalled();
   });
 });

--- a/src/db.ts
+++ b/src/db.ts
@@ -19,10 +19,43 @@ export {
 } from './db/guildMembers';
 export type { DbGuildMember } from './db/guildMembers';
 
-export {
-  getOverridesForGuild, getAllOverrides, upsertOverride, removeOverride,
-} from './db/guildCommandOverrides';
+export { getOverridesForGuild, getAllOverrides } from './db/guildCommandOverrides';
 export type { DbGuildCommandOverride } from './db/guildCommandOverrides';
+
+import {
+  upsertOverride as upsertOverrideRecord,
+  removeOverride as removeOverrideRecord,
+} from './db/guildCommandOverrides';
+
+/**
+ * Inserts or updates a guild's override for a catalog command and invalidates
+ * the custom-command lookup cache, since overrides affect Discord command resolution.
+ * @param guildId - BIGINT snowflake as a string.
+ * @param commandId - The catalog command's command_id.
+ * @param override.isDisabled - When true, the command does not fire in this guild.
+ * @param override.output - Replacement Discord output, or null to use the catalog output.
+ * @returns Resolves once the upsert (and cache invalidation) completes.
+ */
+export async function upsertOverride(
+  guildId: string,
+  commandId: number,
+  override: { isDisabled: boolean; output: string | null },
+): Promise<void> {
+  await upsertOverrideRecord(guildId, commandId, override);
+  invalidateCustomCommandLookupCache();
+}
+
+/**
+ * Removes a guild's override for a command and invalidates the custom-command
+ * lookup cache. No-op if the override is absent.
+ * @param guildId - BIGINT snowflake as a string.
+ * @param commandId - The catalog command's command_id.
+ * @returns Resolves once the deletion (and cache invalidation) completes.
+ */
+export async function removeOverride(guildId: string, commandId: number): Promise<void> {
+  await removeOverrideRecord(guildId, commandId);
+  invalidateCustomCommandLookupCache();
+}
 
 // ─── User / access-level ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `db.ts` re-exported `upsertOverride`/`removeOverride` straight from `db/guildCommandOverrides.ts` with no cache-invalidation wrapper, unlike every other write path that feeds the custom-command lookup cache (`upsertUser`, `removeUser`, `updateTwitchBotEnabled`, and all of `db/customCommands.ts`).
- Effect: editing or removing a per-guild command override wouldn't take effect until the lookup cache's 5-minute TTL expired.
- Fix: `db.ts` now wraps `upsertOverride`/`removeOverride` the same way it wraps the user mutation functions, calling `invalidateCustomCommandLookupCache()` after each write.

## Test plan
- [x] Added `upsertOverride`/`removeOverride` describe blocks to `src/db.test.ts` mirroring the existing `upsertUser`/`removeUser` coverage (invalidates on success, does not invalidate on error).
- [x] `npx tsc --noEmit`
- [x] `npm test` (2332 tests passing)

Part of a series of PRs from a project-wide de-duplication review; this one isolates the one correctness bug found so it can land independently of the pure refactors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RBKcCSsAKKoryf1Zrv31dR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated command override changes so custom command lookups refresh immediately after an override is added, updated, or removed.
  * Ensured database errors are properly reported without triggering unnecessary cache invalidation.
* **Tests**
  * Added coverage for successful and failed command override operations, including validation of database calls and cache behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->