### PR TITLE
Dedup: consolidate db/ layer boilerplate

### DIFF
--- a/src/db/commandConflicts.test.ts
+++ b/src/db/commandConflicts.test.ts
@@ -21,6 +21,10 @@ vi.mock('./commandStringUtils', () => ({
       this.commands = cmds;
     }
   },
+  normalizeCommand: vi.fn((command: string) => {
+    const normalized = command.trim().toLowerCase();
+    return normalized.length > 0 ? normalized : null;
+  }),
 }));
 
 import {

--- a/src/db/commandConflicts.ts
+++ b/src/db/commandConflicts.ts
@@ -15,6 +15,13 @@ import { fromBit } from './utils';
 
 // ─── Conflict assertions ──────────────────────────────────────────────────────
 
+/**
+ * Throws if a Discord-enabled custom command already uses `triggerString`.
+ * @param triggerString Trigger string to check for conflicts.
+ * @param executor Pool or transaction connection to query with.
+ * @param excludeCommandId Command id to exclude from the conflict check (e.g. the command being edited).
+ * @throws {CommandConflictError} If a conflicting Discord-enabled command exists.
+ */
 export async function assertDiscordTriggerAvailable(
   triggerString: string,
   executor: SqlExecutor,
@@ -40,6 +47,14 @@ export async function assertDiscordTriggerAvailable(
   }
 }
 
+/**
+ * Checks whether `triggerString` is already used by a multi-Twitch command, or by a command
+ * assigned to a user whose Twitch bot is enabled.
+ * @param executor Pool or transaction connection to query with.
+ * @param triggerString Trigger string to check for conflicts.
+ * @param excludeCommandId Command id to exclude from the conflict check.
+ * @returns True if a conflicting command exists.
+ */
 async function hasMultiTwitchTriggerConflict(
   executor: SqlExecutor,
   triggerString: string,
@@ -72,6 +87,14 @@ async function hasMultiTwitchTriggerConflict(
   return conflictRows.length > 0;
 }
 
+/**
+ * Throws if `triggerString` is already used by a multi-Twitch command, or by a command
+ * assigned to a user whose Twitch bot is enabled.
+ * @param executor Pool or transaction connection to query with.
+ * @param triggerString Trigger string to check for conflicts.
+ * @param excludeCommandId Command id to exclude from the conflict check.
+ * @throws {CommandConflictError} If a conflicting command exists.
+ */
 export async function assertMultiTwitchTriggerAvailable(
   executor: SqlExecutor,
   triggerString: string,
@@ -82,6 +105,14 @@ export async function assertMultiTwitchTriggerAvailable(
   }
 }
 
+/**
+ * Checks whether assigning `triggerString` to the command's existing single-Twitch users would
+ * overlap with another command already covering the same Twitch channel (or a multi-Twitch command).
+ * @param executor Pool or transaction connection to query with.
+ * @param commandId Command id whose Twitch-enabled assignees are checked for overlap.
+ * @param triggerString Trigger string being assigned.
+ * @returns True if an overlapping assignment exists.
+ */
 async function hasSingleTwitchAssignmentOverlap(
   executor: SqlExecutor,
   commandId: number,
@@ -114,6 +145,14 @@ async function hasSingleTwitchAssignmentOverlap(
   return overlapRows.length > 0;
 }
 
+/**
+ * Throws if assigning `triggerString` to the command's existing single-Twitch users would
+ * overlap with another command already covering the same Twitch channel (or a multi-Twitch command).
+ * @param executor Pool or transaction connection to query with.
+ * @param commandId Command id whose Twitch-enabled assignees are checked for overlap.
+ * @param triggerString Trigger string being assigned.
+ * @throws {CommandConflictError} If an overlapping assignment exists.
+ */
 export async function assertNoSingleTwitchAssignmentOverlap(
   executor: SqlExecutor,
   commandId: number,
@@ -172,6 +211,15 @@ export async function getUserTwitchEligibility(executor: SqlExecutor, discordId:
   };
 }
 
+/**
+ * Checks whether `triggerString` is already used by another command that is either
+ * multi-Twitch or assigned to a user with the same normalized Twitch channel name.
+ * @param executor Pool or transaction connection to query with.
+ * @param commandId Command id to exclude from the conflict check.
+ * @param triggerString Trigger string to check for conflicts.
+ * @param normalizedTwitchName Normalized (lowercased) Twitch channel name to match against.
+ * @returns True if a conflicting command exists.
+ */
 async function hasTwitchChannelTriggerConflict(
   executor: SqlExecutor,
   commandId: number,
@@ -200,6 +248,15 @@ async function hasTwitchChannelTriggerConflict(
   return conflictRows.length > 0;
 }
 
+/**
+ * Throws if `triggerString` is already used by another command that is either
+ * multi-Twitch or assigned to a user with the same normalized Twitch channel name.
+ * @param executor Pool or transaction connection to query with.
+ * @param commandId Command id to exclude from the conflict check.
+ * @param triggerString Trigger string to check for conflicts.
+ * @param normalizedTwitchName Normalized (lowercased) Twitch channel name to match against.
+ * @throws {CommandConflictError} If a conflicting command exists.
+ */
 export async function assertNoTwitchChannelTriggerConflict(
   executor: SqlExecutor,
   commandId: number,
@@ -211,6 +268,13 @@ export async function assertNoTwitchChannelTriggerConflict(
   }
 }
 
+/**
+ * Inserts (or no-ops if already present) an assignment linking a Discord user to a custom command
+ * for single-Twitch triggering.
+ * @param executor Pool or transaction connection to query with.
+ * @param commandId Command id being assigned.
+ * @param discordId Discord snowflake of the user being assigned.
+ */
 export async function insertUserCommandAssignment(
   executor: SqlExecutor,
   commandId: number,
@@ -225,6 +289,17 @@ export async function insertUserCommandAssignment(
   );
 }
 
+/**
+ * Assigns a Discord user to a custom command for single-Twitch triggering, running the conflict
+ * check and insert inside a transaction guarded by a named lock on the command's trigger string.
+ * Retries on deadlock up to `MAX_DEADLOCK_RETRIES` times, re-acquiring the transaction each attempt
+ * while holding the same session-scoped lock across attempts.
+ * @param connection Transaction-capable pool connection to run the work on.
+ * @param commandId Command id being assigned.
+ * @param discordId Discord snowflake of the user being assigned.
+ * @throws {CommandConflictError} If the assignment would create a Twitch-channel trigger conflict.
+ * @throws If the deadlock retry limit is reached.
+ */
 export async function assignUserToCommandWithinTransaction(
   connection: mysql.PoolConnection,
   commandId: number,

--- a/src/db/commandConflicts.ts
+++ b/src/db/commandConflicts.ts
@@ -3,7 +3,7 @@ import mysql from 'mysql2/promise';
 
 const log = createLogger('DB');
 import { normalizeTwitchChannelName } from '../twitch/twitchChannelName';
-import { type SqlExecutor, CommandConflictError } from './commandStringUtils';
+import { type SqlExecutor, CommandConflictError, normalizeCommand } from './commandStringUtils';
 import {
   acquireNamedLock,
   releaseNamedLock,
@@ -11,6 +11,7 @@ import {
   isDeadlockError,
   MAX_DEADLOCK_RETRIES,
 } from './commandLocks';
+import { fromBit } from './utils';
 
 // ─── Conflict assertions ──────────────────────────────────────────────────────
 
@@ -123,6 +124,13 @@ export async function assertNoSingleTwitchAssignmentOverlap(
   }
 }
 
+/**
+ * Looks up a custom command's trigger string by its id, normalized (trimmed, lowercased).
+ * @param executor Pool or transaction connection to query with.
+ * @param commandId Primary key of the `custom_command` row.
+ * @returns The normalized trigger string.
+ * @throws If no command exists with the given id.
+ */
 export async function getCommandTriggerStringById(executor: SqlExecutor, commandId: number): Promise<string> {
   const [commandRows] = await executor.execute<mysql.RowDataPacket[]>(
     'SELECT trigger_string FROM custom_command WHERE command_id = ? LIMIT 1',
@@ -132,7 +140,7 @@ export async function getCommandTriggerStringById(executor: SqlExecutor, command
     throw new Error(`Custom command not found: ${commandId}`);
   }
 
-  return String(commandRows[0].trigger_string).trim().toLowerCase();
+  return normalizeCommand(String(commandRows[0].trigger_string)) ?? '';
 }
 
 interface UserTwitchEligibility {
@@ -140,6 +148,14 @@ interface UserTwitchEligibility {
   isTwitchBotEnabled: boolean;
 }
 
+/**
+ * Looks up a user's normalized Twitch channel name and Twitch-bot-enabled flag, used to
+ * decide whether a Twitch-channel trigger conflict check applies to them.
+ * @param executor Pool or transaction connection to query with.
+ * @param discordId Discord snowflake of the user to look up.
+ * @returns The user's normalized Twitch channel name (or null if unset/invalid) and Twitch-bot-enabled flag.
+ * @throws If no user exists with the given `discordId`.
+ */
 export async function getUserTwitchEligibility(executor: SqlExecutor, discordId: string): Promise<UserTwitchEligibility> {
   const [userRows] = await executor.execute<mysql.RowDataPacket[]>(
     'SELECT twitch_name, is_twitch_bot_enabled FROM `user` WHERE discord_id = ? LIMIT 1',
@@ -152,11 +168,7 @@ export async function getUserTwitchEligibility(executor: SqlExecutor, discordId:
   const twitchName = userRows[0].twitch_name ? String(userRows[0].twitch_name) : null;
   return {
     normalizedTwitchName: twitchName ? normalizeTwitchChannelName(twitchName) : null,
-    // MySQL BIT(1) columns arrive as a single-byte Buffer on some driver configurations
-    // and as a numeric 0/1 on others; check byte 0 in the Buffer path, loose-equality for numeric.
-    isTwitchBotEnabled: Buffer.isBuffer(userRows[0].is_twitch_bot_enabled)
-      ? userRows[0].is_twitch_bot_enabled[0] === 1
-      : userRows[0].is_twitch_bot_enabled == 1,
+    isTwitchBotEnabled: fromBit(userRows[0].is_twitch_bot_enabled),
   };
 }
 

--- a/src/db/commandStringUtils.test.ts
+++ b/src/db/commandStringUtils.test.ts
@@ -1,12 +1,31 @@
 import { describe, it, expect } from 'vitest';
 import {
   requireTrimmedString,
+  normalizeCommand,
   normalizeCommandList,
   normalizeCommandInputs,
   isMysqlDuplicateEntryError,
   CommandNotFoundError,
   CommandConflictError,
 } from './commandStringUtils';
+
+describe('normalizeCommand', () => {
+  it('trims and lowercases a command string', () => {
+    expect(normalizeCommand('  !Foo  ')).toBe('!foo');
+  });
+
+  it('returns null for an empty string', () => {
+    expect(normalizeCommand('')).toBeNull();
+  });
+
+  it('returns null for a whitespace-only string', () => {
+    expect(normalizeCommand('   ')).toBeNull();
+  });
+
+  it('leaves an already-normalized command unchanged', () => {
+    expect(normalizeCommand('!clap')).toBe('!clap');
+  });
+});
 
 describe('requireTrimmedString', () => {
   it('returns the trimmed string when valid', () => {

--- a/src/db/commandStringUtils.ts
+++ b/src/db/commandStringUtils.ts
@@ -15,7 +15,8 @@ export function requireTrimmedString(value: string, fieldName: string, maxLength
   return normalizedValue;
 }
 
-function normalizeCommand(command: string): string | null {
+/** Trims and lowercases a single command string; returns null when the result is blank. */
+export function normalizeCommand(command: string): string | null {
   const normalized = command.trim().toLowerCase();
   return normalized.length > 0 ? normalized : null;
 }

--- a/src/db/commandStringUtils.ts
+++ b/src/db/commandStringUtils.ts
@@ -4,6 +4,14 @@ export type SqlExecutor = mysql.Pool | mysql.PoolConnection;
 
 // ─── String normalisation ────────────────────────────────────────────────────
 
+/**
+ * Trims `value` and throws if the result is blank or exceeds `maxLength`.
+ * @param value String to validate.
+ * @param fieldName Name used in the thrown error message.
+ * @param maxLength Optional maximum allowed length after trimming.
+ * @returns The trimmed, non-blank string.
+ * @throws If the trimmed value is blank or exceeds `maxLength`.
+ */
 export function requireTrimmedString(value: string, fieldName: string, maxLength?: number): string {
   const normalizedValue = value.trim();
   if (!normalizedValue) {
@@ -21,6 +29,12 @@ export function normalizeCommand(command: string): string | null {
   return normalized.length > 0 ? normalized : null;
 }
 
+/**
+ * Normalizes (trims, lowercases) a single command string or list of command strings, dropping
+ * any that become blank.
+ * @param commandOrCommands A single command string or array of command strings.
+ * @returns The normalized, non-blank command strings.
+ */
 export function normalizeCommandList(commandOrCommands: string | string[]): string[] {
   const commands = Array.isArray(commandOrCommands) ? commandOrCommands : [commandOrCommands];
   return commands
@@ -28,10 +42,20 @@ export function normalizeCommandList(commandOrCommands: string | string[]): stri
     .filter((command): command is string => command !== null);
 }
 
+/**
+ * Normalizes a single command string or list of command strings and deduplicates the result.
+ * @param commandOrCommands A single command string or array of command strings.
+ * @returns The normalized, deduplicated, non-blank command strings.
+ */
 export function normalizeCommandInputs(commandOrCommands: string | string[]): string[] {
   return Array.from(new Set(normalizeCommandList(commandOrCommands)));
 }
 
+/**
+ * Builds a comma-separated `?` placeholder list for use in a SQL `IN (...)` clause.
+ * @param count Number of placeholders to generate.
+ * @returns A string of `count` placeholders joined by `, `.
+ */
 export function buildInClausePlaceholders(count: number): string {
   return Array.from({ length: count }, () => '?').join(', ');
 }
@@ -55,6 +79,11 @@ export class CommandConflictError extends Error {
   }
 }
 
+/**
+ * Checks whether `error` is a MySQL duplicate-entry error (unique index violation).
+ * @param error Value to check, typically a caught error.
+ * @returns True if `error` is a MySQL `ER_DUP_ENTRY` / errno 1062 error.
+ */
 export function isMysqlDuplicateEntryError(error: unknown): boolean {
   if (!error || typeof error !== 'object') {
     return false;

--- a/src/db/companionOAuthCodes.test.ts
+++ b/src/db/companionOAuthCodes.test.ts
@@ -1,6 +1,29 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('./pool', () => ({ getPool: vi.fn() }));
+// `withTransaction` is reimplemented here (rather than via `importOriginal`) so this
+// test doesn't pull in pool.ts's real `../shared/config` import chain, which throws
+// in a test environment with no DISCORD_TOKEN etc. set. The logic mirrors pool.ts's
+// real implementation exactly, driven by the same mocked `getPool()`.
+vi.mock('./pool', () => {
+  const getPool = vi.fn();
+  return {
+    getPool,
+    withTransaction: async (work: (conn: unknown) => Promise<unknown>) => {
+      const conn = await getPool().getConnection();
+      try {
+        await conn.beginTransaction();
+        const result = await work(conn);
+        await conn.commit();
+        return result;
+      } catch (err) {
+        await conn.rollback().catch(() => {});
+        throw err;
+      } finally {
+        conn.release();
+      }
+    },
+  };
+});
 vi.mock('mysql2/promise', () => ({ default: {} }));
 
 import { getPool } from './pool';

--- a/src/db/companionOAuthCodes.ts
+++ b/src/db/companionOAuthCodes.ts
@@ -1,6 +1,6 @@
 import { randomBytes, createHash } from 'crypto';
 import mysql from 'mysql2/promise';
-import { getPool } from './pool';
+import { getPool, withTransaction } from './pool';
 import { issueTokenOnConnection } from './companionTokens';
 
 const CODE_TTL_SECONDS = 60;
@@ -64,36 +64,31 @@ export async function consumeCode(code: string): Promise<string | null> {
  */
 export async function exchangeCodeForToken(code: string): Promise<string | null> {
   const hash = createHash('sha256').update(code).digest('hex');
-  const conn = await getPool().getConnection();
+  class CodeNotFound extends Error {}
   try {
-    await conn.beginTransaction();
-    const [result] = await conn.execute<mysql.ResultSetHeader>(
-      `UPDATE companion_oauth_codes
-       SET used_at = NOW()
-       WHERE code_hash = ? AND used_at IS NULL AND expires_at > NOW()`,
-      [hash],
-    );
-    if (result.affectedRows === 0) {
-      await conn.rollback();
-      return null;
-    }
+    return await withTransaction(async (conn) => {
+      const [result] = await conn.execute<mysql.ResultSetHeader>(
+        `UPDATE companion_oauth_codes
+         SET used_at = NOW()
+         WHERE code_hash = ? AND used_at IS NULL AND expires_at > NOW()`,
+        [hash],
+      );
+      if (result.affectedRows === 0) {
+        throw new CodeNotFound();
+      }
 
-    const [rows] = await conn.execute<mysql.RowDataPacket[]>(
-      `SELECT discord_id FROM companion_oauth_codes WHERE code_hash = ?`,
-      [hash],
-    );
-    if (rows.length === 0) {
-      await conn.rollback();
-      return null;
-    }
+      const [rows] = await conn.execute<mysql.RowDataPacket[]>(
+        `SELECT discord_id FROM companion_oauth_codes WHERE code_hash = ?`,
+        [hash],
+      );
+      if (rows.length === 0) {
+        throw new CodeNotFound();
+      }
 
-    const token = await issueTokenOnConnection(conn, String(rows[0].discord_id));
-    await conn.commit();
-    return token;
+      return issueTokenOnConnection(conn, String(rows[0].discord_id));
+    });
   } catch (err) {
-    await conn.rollback().catch(() => {});
+    if (err instanceof CodeNotFound) return null;
     throw err;
-  } finally {
-    conn.release();
   }
 }

--- a/src/db/counterCache.test.ts
+++ b/src/db/counterCache.test.ts
@@ -17,6 +17,10 @@ vi.mock('./commandLocks', () => ({
 }));
 vi.mock('./commandStringUtils', () => ({
   normalizeCommandList: vi.fn((arr: string[]) => arr.map((s: string) => s.trim().toLowerCase())),
+  normalizeCommand: vi.fn((command: string) => {
+    const normalized = command.trim().toLowerCase();
+    return normalized.length > 0 ? normalized : null;
+  }),
 }));
 
 import { findCounterByCommand, isCounterCommandTaken } from './counterCache';

--- a/src/db/counterCache.ts
+++ b/src/db/counterCache.ts
@@ -17,6 +17,11 @@ interface CounterLookupCache extends RefreshingLookupCache {
 
 // ─── Cache builder ────────────────────────────────────────────────────────────
 
+/**
+ * Creates an empty, already-stale counter lookup cache used as the initial/fallback state
+ * before the first successful refresh.
+ * @returns An empty `CounterLookupCache` with `loadedAt` set to 0.
+ */
 function createEmptyCounterLookupCache(): CounterLookupCache {
   return {
     // Keep the fallback cache immediately stale so a new refresh can start as soon
@@ -26,6 +31,12 @@ function createEmptyCounterLookupCache(): CounterLookupCache {
   };
 }
 
+/**
+ * Builds a counter lookup cache keyed by normalized trigger/check command, sorted by counter id
+ * so the lowest id wins on collision. Logs a warning and skips the duplicate on any collision.
+ * @param counters Counters to index.
+ * @returns The populated `CounterLookupCache`.
+ */
 function buildCounterLookupCache(counters: DbCounter[]): CounterLookupCache {
   const byCommand = new Map<string, DbMatchedCounter>();
   const sortedCounters = [...counters].sort((left, right) => left.id - right.id);

--- a/src/db/counterCache.ts
+++ b/src/db/counterCache.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '../shared/logger';
 import { createManagedLookupCache, type RefreshingLookupCache } from './lookupCache';
-import { normalizeCommandList } from './commandStringUtils';
+import { normalizeCommandList, normalizeCommand } from './commandStringUtils';
 import { isAnyCommandTakenAcrossTables } from './commandLocks';
 // counters imports invalidateCounterLookupCache from this module;
 // this module imports getAllCounters from counters.
@@ -48,8 +48,8 @@ function buildCounterLookupCache(counters: DbCounter[]): CounterLookupCache {
   };
 
   for (const counter of sortedCounters) {
-    registerCounterCommand(counter.trigger_command.trim().toLowerCase(), counter, 'trigger', 'trigger_command');
-    registerCounterCommand(counter.check_command.trim().toLowerCase(), counter, 'check', 'check_command');
+    registerCounterCommand(normalizeCommand(counter.trigger_command) ?? '', counter, 'trigger', 'trigger_command');
+    registerCounterCommand(normalizeCommand(counter.check_command) ?? '', counter, 'check', 'check_command');
   }
 
   return { loadedAt: Date.now(), byCommand };
@@ -75,7 +75,7 @@ export function invalidateCounterLookupCache(): void {
 
 /** Looks up a counter by its trigger or check command string; returns null if not found. */
 export async function findCounterByCommand(command: string): Promise<DbMatchedCounter | null> {
-  const normalizedCommand = command.trim().toLowerCase();
+  const normalizedCommand = normalizeCommand(command);
   if (!normalizedCommand) return null;
 
   const cache = await counterLookupCacheState.getCache();

--- a/src/db/counters.test.ts
+++ b/src/db/counters.test.ts
@@ -1,6 +1,29 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('./pool', () => ({ getPool: vi.fn() }));
+// `withTransaction` is reimplemented here (rather than via `importOriginal`) so this
+// test doesn't pull in pool.ts's real `../shared/config` import chain, which throws
+// in a test environment with no DISCORD_TOKEN etc. set. The logic mirrors pool.ts's
+// real implementation exactly, driven by the same mocked `getPool()`.
+vi.mock('./pool', () => {
+  const getPool = vi.fn();
+  return {
+    getPool,
+    withTransaction: async (work: (conn: unknown) => Promise<unknown>) => {
+      const conn = await getPool().getConnection();
+      try {
+        await conn.beginTransaction();
+        const result = await work(conn);
+        await conn.commit();
+        return result;
+      } catch (err) {
+        await conn.rollback().catch(() => {});
+        throw err;
+      } finally {
+        conn.release();
+      }
+    },
+  };
+});
 vi.mock('mysql2/promise', () => ({ default: {} }));
 vi.mock('./commandLocks', () => ({
   runSerializedCommandWrite: vi.fn(async (_cmds: unknown, _opts: unknown, fn: (conn: unknown) => Promise<unknown>) => fn(mockConnection)),
@@ -10,6 +33,10 @@ vi.mock('./commandStringUtils', () => ({
     const t = v.trim();
     if (!t) throw new Error(`${_name} is required`);
     return t;
+  }),
+  normalizeCommand: vi.fn((command: string) => {
+    const normalized = command.trim().toLowerCase();
+    return normalized.length > 0 ? normalized : null;
   }),
   CommandConflictError: class CommandConflictError extends Error {
     constructor(cmds: string[]) { super(String(cmds)); }

--- a/src/db/counters.ts
+++ b/src/db/counters.ts
@@ -58,6 +58,7 @@ export interface CounterHistoryEntry {
 
 // ─── Row mapper ───────────────────────────────────────────────────────────────
 
+/** Maps a raw `counter` table row to a {@link DbCounter}. */
 function mapCounter(row: mysql.RowDataPacket): DbCounter {
   return {
     id: row.id,
@@ -79,6 +80,16 @@ interface NormalizedCounterFields {
   incrementMessage: string;
 }
 
+/**
+ * Trims and validates a counter's editable fields (lowercasing the trigger/check commands),
+ * enforcing per-field length limits.
+ * @param triggerCommand Command that increments the counter.
+ * @param checkCommand Command that reports the counter's current value.
+ * @param message Message shown when the counter is checked.
+ * @param incrementMessage Message shown when the counter is incremented.
+ * @returns The normalized fields.
+ * @throws If any field is blank or exceeds its maximum length.
+ */
 function normalizeCounterFields(
   triggerCommand: string,
   checkCommand: string,
@@ -95,6 +106,10 @@ function normalizeCounterFields(
 
 // ─── Queries ─────────────────────────────────────────────────────────────────
 
+/**
+ * Fetches all counters, ordered by trigger command.
+ * @returns All counters.
+ */
 export async function getAllCounters(): Promise<DbCounter[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
     `SELECT id, trigger_command, check_command, message, increment_message, reset_yearly, current_value
@@ -211,6 +226,17 @@ export async function getCounterHistory(
 
 // ─── CRUD ─────────────────────────────────────────────────────────────────────
 
+/**
+ * Creates a new counter, starting at 0, after validating fields and checking the trigger/check
+ * commands don't conflict with other reserved or in-use commands.
+ * @param triggerCommand Command that increments the counter.
+ * @param checkCommand Command that reports the counter's current value.
+ * @param message Message shown when the counter is checked.
+ * @param incrementMessage Message shown when the counter is incremented.
+ * @param resetYearly Whether the counter's value is archived and reset each new year.
+ * @throws If `triggerCommand` and `checkCommand` are the same, either is reserved, or either is
+ *   already taken by another command.
+ */
 export async function addCounter(
   triggerCommand: string,
   checkCommand: string,
@@ -241,6 +267,12 @@ export async function addCounter(
   invalidateCounterLookupCache();
 }
 
+/**
+ * Checks whether a counter with the given id exists.
+ * @param id The counter's numeric id.
+ * @param executor Pool or transaction connection to query with.
+ * @returns True if the counter exists.
+ */
 async function counterExists(id: number, executor: SqlExecutor = getPool()): Promise<boolean> {
   const [rows] = await executor.execute<mysql.RowDataPacket[]>(
     'SELECT 1 FROM counter WHERE id = ? LIMIT 1',
@@ -249,6 +281,12 @@ async function counterExists(id: number, executor: SqlExecutor = getPool()): Pro
   return rows.length > 0;
 }
 
+/**
+ * Looks up a counter's current trigger/check command strings by id.
+ * @param id The counter's numeric id.
+ * @param executor Pool or transaction connection to query with.
+ * @returns The counter's trigger and check commands, or `null` if no counter exists with the given id.
+ */
 async function getCounterCommandsById(
   id: number,
   executor: SqlExecutor = getPool(),
@@ -261,6 +299,14 @@ async function getCounterCommandsById(
   return { trigger_command: rows[0].trigger_command, check_command: rows[0].check_command };
 }
 
+/**
+ * Updates an existing counter's fields, locking both its old and new trigger/check commands
+ * so concurrent writes can't create a conflict during the transition.
+ * @param input The counter's id and updated fields.
+ * @throws {CounterNotFoundError} If no counter exists with the given id.
+ * @throws If `triggerCommand` and `checkCommand` are the same, either is reserved, or either is
+ *   already taken by another command.
+ */
 export async function updateCounter(input: UpdateCounterInput): Promise<void> {
   const { id, triggerCommand, checkCommand, message, incrementMessage, resetYearly } = input;
 
@@ -308,6 +354,11 @@ export async function updateCounter(input: UpdateCounterInput): Promise<void> {
   invalidateCounterLookupCache();
 }
 
+/**
+ * Deletes a counter by id, locking its trigger/check commands during the delete.
+ * @param id The counter's numeric id.
+ * @throws {CounterNotFoundError} If no counter exists with the given id.
+ */
 export async function removeCounter(id: number): Promise<void> {
   const current = await getCounterCommandsById(id);
   if (!current) throw new CounterNotFoundError(id);
@@ -327,6 +378,11 @@ export async function removeCounter(id: number): Promise<void> {
   invalidateCounterLookupCache();
 }
 
+/**
+ * Resets a counter's `current_value` to 0.
+ * @param id The counter's numeric id.
+ * @throws {CounterNotFoundError} If no counter exists with the given id.
+ */
 export async function resetCounterCurrentValue(id: number): Promise<void> {
   const [result] = await getPool().execute<mysql.ResultSetHeader>(
     'UPDATE counter SET current_value = 0 WHERE id = ?',
@@ -365,6 +421,13 @@ export async function incrementCounter(id: number): Promise<number> {
   return newValue;
 }
 
+/**
+ * Archives the current value of every yearly-reset counter into that year's `value<year>`
+ * column (only for counters where the column is still `NULL`), then resets `current_value` to 0.
+ * @param year Calendar year to archive into; must be a key of `ARCHIVE_YEAR_COLUMNS`.
+ * @returns The number of counters archived and reset.
+ * @throws If `year` is not a valid archive year.
+ */
 export async function archiveAndResetYearlyCounters(year: number): Promise<number> {
   const columnName = ARCHIVE_YEAR_COLUMNS.get(year);
   if (!columnName) {

--- a/src/db/counters.ts
+++ b/src/db/counters.ts
@@ -1,6 +1,6 @@
 import mysql from 'mysql2/promise';
-import { getPool } from './pool';
-import { requireTrimmedString, type SqlExecutor } from './commandStringUtils';
+import { getPool, withTransaction } from './pool';
+import { requireTrimmedString, normalizeCommand, type SqlExecutor } from './commandStringUtils';
 import { runSerializedCommandWrite } from './commandLocks';
 import { assertNotReservedCommand } from './reservedCommands';
 import { fromBit } from './utils';
@@ -278,8 +278,8 @@ export async function updateCounter(input: UpdateCounterInput): Promise<void> {
   // Lock old commands too so concurrent adds/updates can't sneak in during the
   // transition window while the old trigger/check names are being released.
   const commandsToLock = [
-    current.trigger_command.trim().toLowerCase(),
-    current.check_command.trim().toLowerCase(),
+    normalizeCommand(current.trigger_command) ?? '',
+    normalizeCommand(current.check_command) ?? '',
     fields.triggerCommand,
     fields.checkCommand,
   ];
@@ -342,10 +342,14 @@ export async function resetCounterCurrentValue(id: number): Promise<void> {
   invalidateCounterLookupCache();
 }
 
+/**
+ * Atomically increments a counter's `current_value` and returns the new value.
+ * @param id The counter's numeric id.
+ * @returns The counter's `current_value` after the increment.
+ * @throws {CounterNotFoundError} If no counter exists with the given id.
+ */
 export async function incrementCounter(id: number): Promise<number> {
-  const conn = await getPool().getConnection();
-  try {
-    await conn.beginTransaction();
+  const newValue = await withTransaction(async (conn) => {
     const [result] = await conn.execute<mysql.ResultSetHeader>(
       'UPDATE counter SET current_value = current_value + 1 WHERE id = ?',
       [id],
@@ -355,16 +359,10 @@ export async function incrementCounter(id: number): Promise<number> {
       'SELECT current_value FROM counter WHERE id = ?',
       [id],
     );
-    const newValue = (rows[0] as mysql.RowDataPacket).current_value as number;
-    await conn.commit();
-    invalidateCounterLookupCache();
-    return newValue;
-  } catch (err) {
-    await conn.rollback().catch(() => {});
-    throw err;
-  } finally {
-    conn.release();
-  }
+    return (rows[0] as mysql.RowDataPacket).current_value as number;
+  });
+  invalidateCounterLookupCache();
+  return newValue;
 }
 
 export async function archiveAndResetYearlyCounters(year: number): Promise<number> {

--- a/src/db/customCommandCache.ts
+++ b/src/db/customCommandCache.ts
@@ -39,6 +39,11 @@ interface TwitchCandidateContext {
 
 // ─── Cache builder helpers ────────────────────────────────────────────────────
 
+/**
+ * Creates an empty, already-stale custom command lookup cache used as the initial/fallback
+ * state before the first successful refresh.
+ * @returns An empty `CustomCommandLookupCache` with `loadedAt` set to 0.
+ */
 function createEmptyCustomCommandLookupCache(): CustomCommandLookupCache {
   return {
     // Keep the fallback cache immediately stale so a new refresh can start as soon
@@ -66,6 +71,13 @@ function buildOverridesByGuild(
   return byGuild;
 }
 
+/**
+ * Builds the cache key used to look up a Twitch custom command, combining the normalized
+ * channel name and trigger string.
+ * @param channelName Twitch channel name to normalize.
+ * @param triggerString Trigger string to normalize.
+ * @returns The composite cache key, or null if either input normalizes to nothing.
+ */
 function getTwitchCommandCacheKey(channelName: string, triggerString: string): string | null {
   const normalizedChannelName = normalizeTwitchChannelName(channelName);
   const normalizedTriggerString = normalizeCommand(triggerString);
@@ -77,12 +89,25 @@ function getTwitchCommandCacheKey(channelName: string, triggerString: string): s
   return `${normalizedChannelName}::${normalizedTriggerString}`;
 }
 
+/**
+ * Normalizes a list of Twitch channel names, dropping any that fail to normalize.
+ * @param activeTwitchChannels Raw Twitch channel names.
+ * @returns The normalized channel names.
+ */
 function normalizeActiveTwitchChannels(activeTwitchChannels: string[]): string[] {
   return activeTwitchChannels
     .map((channel) => normalizeTwitchChannelName(channel))
     .filter((channel): channel is string => channel !== null);
 }
 
+/**
+ * Picks which of two competing Twitch command candidates for the same channel+trigger should
+ * win: same command wins trivially, otherwise higher `priority` wins, and ties break toward the
+ * lower `command_id`.
+ * @param existingCandidate The candidate currently registered for the cache key.
+ * @param nextCandidate The new candidate being considered.
+ * @returns The candidate that should occupy the cache key.
+ */
 function pickPreferredTwitchCandidate(
   existingCandidate: TwitchCommandCandidate,
   nextCandidate: TwitchCommandCandidate,
@@ -100,6 +125,13 @@ function pickPreferredTwitchCandidate(
     : existingCandidate;
 }
 
+/**
+ * Registers a Discord-enabled command under its trigger string, logging and skipping on collision
+ * with an already-registered command. No-ops if the command isn't Discord-enabled.
+ * @param discordByTrigger Map being built from trigger string to command.
+ * @param triggerString Normalized trigger string to register under.
+ * @param command Command to register.
+ */
 function registerDiscordCommand(
   discordByTrigger: Map<string, DbCustomCommand>,
   triggerString: string,
@@ -121,6 +153,16 @@ function registerDiscordCommand(
   discordByTrigger.set(triggerString, command);
 }
 
+/**
+ * Registers a Twitch command candidate under a channel+trigger cache key, resolving collisions
+ * via {@link pickPreferredTwitchCandidate} and logging the outcome (info on a priority-driven
+ * remap, warn on a same-priority remap or an ignored duplicate).
+ * @param context Mutable candidate map being built.
+ * @param cacheKey Composite channel+trigger cache key.
+ * @param triggerString Trigger string, used only for log messages.
+ * @param channelName Twitch channel name, used only for log messages.
+ * @param candidate Candidate being registered.
+ */
 function registerTwitchCandidate(
   context: TwitchCandidateContext,
   cacheKey: string,
@@ -157,6 +199,15 @@ function registerTwitchCandidate(
   context.candidateByCacheKey.set(cacheKey, preferredCandidate);
 }
 
+/**
+ * Registers a multi-Twitch command as a candidate on every active Twitch channel. No-ops if the
+ * command isn't multi-Twitch.
+ * @param context Mutable candidate map being built.
+ * @param activeChannels Normalized names of currently active Twitch channels.
+ * @param triggerString Normalized trigger string.
+ * @param command Command to register.
+ * @param isMultiTwitch Whether the command is flagged as multi-Twitch.
+ */
 function registerMultiTwitchCandidates(
   context: TwitchCandidateContext,
   activeChannels: string[],
@@ -183,6 +234,14 @@ function registerMultiTwitchCandidates(
   }
 }
 
+/**
+ * Registers a command as a candidate on each assigned user's Twitch channel, skipping users
+ * without a Twitch name or with Twitch bot disabled.
+ * @param context Mutable candidate map being built.
+ * @param assignedUsers Users the command is individually assigned to.
+ * @param triggerString Normalized trigger string.
+ * @param command Command to register.
+ */
 function registerAssignedTwitchCandidates(
   context: TwitchCandidateContext,
   assignedUsers: DbCustomCommandAssignedUser[],
@@ -208,6 +267,16 @@ function registerAssignedTwitchCandidates(
   }
 }
 
+/**
+ * Builds the full custom command lookup cache: indexes Discord-enabled commands by trigger,
+ * resolves the winning Twitch command per channel+trigger among multi-Twitch and per-user
+ * assigned candidates, and indexes per-guild overrides. Commands are processed in ascending
+ * `command_id` order so collisions resolve deterministically.
+ * @param commands All custom commands with their assigned users.
+ * @param activeTwitchChannels Names of currently active Twitch channels.
+ * @param overrides All per-guild command overrides.
+ * @returns The populated `CustomCommandLookupCache`.
+ */
 function buildCustomCommandLookupCache(
   commands: DbCustomCommandWithAssignments[],
   activeTwitchChannels: string[],
@@ -288,10 +357,17 @@ const customCommandLookupCacheState = createManagedLookupCache<CustomCommandLook
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 
+/** Marks the custom command lookup cache as stale so the next read triggers a refresh. */
 export function invalidateCustomCommandLookupCache(): void {
   customCommandLookupCacheState.invalidate();
 }
 
+/**
+ * Looks up the custom command that fires for a trigger string on a given Twitch channel.
+ * @param channelName Twitch channel the message came from.
+ * @param triggerString Trigger string to match, matched case-insensitively.
+ * @returns The matching command, or null if none matches or either input is invalid.
+ */
 export async function getCustomCommandForTwitchChannel(channelName: string, triggerString: string): Promise<DbCustomCommand | null> {
   const cacheKey = getTwitchCommandCacheKey(channelName, triggerString);
   if (!cacheKey) {

--- a/src/db/customCommandCache.ts
+++ b/src/db/customCommandCache.ts
@@ -1,6 +1,7 @@
 import { createLogger } from '../shared/logger';
 import { normalizeTwitchChannelName } from '../twitch/twitchChannelName';
 import { createManagedLookupCache, type RefreshingLookupCache } from './lookupCache';
+import { normalizeCommand } from './commandStringUtils';
 import { getTwitchEnabledChannels } from './users';
 // customCommands imports invalidateCustomCommandLookupCache from this module;
 // this module imports getAllCustomCommandsWithAssignments from customCommands.
@@ -67,7 +68,7 @@ function buildOverridesByGuild(
 
 function getTwitchCommandCacheKey(channelName: string, triggerString: string): string | null {
   const normalizedChannelName = normalizeTwitchChannelName(channelName);
-  const normalizedTriggerString = triggerString.trim().toLowerCase();
+  const normalizedTriggerString = normalizeCommand(triggerString);
 
   if (!normalizedChannelName || !normalizedTriggerString) {
     return null;
@@ -221,7 +222,7 @@ function buildCustomCommandLookupCache(
   };
 
   for (const command of sortedCommands) {
-    const normalizedTriggerString = command.trigger_string.trim().toLowerCase();
+    const normalizedTriggerString = normalizeCommand(command.trigger_string);
     if (!normalizedTriggerString) {
       continue;
     }
@@ -318,7 +319,7 @@ export async function getCustomCommandForDiscord(
   triggerString: string,
   guildId: string,
 ): Promise<DbCustomCommand | null> {
-  const normalizedTriggerString = triggerString.trim().toLowerCase();
+  const normalizedTriggerString = normalizeCommand(triggerString);
   if (!normalizedTriggerString) {
     return null;
   }

--- a/src/db/eventSub.ts
+++ b/src/db/eventSub.ts
@@ -161,6 +161,15 @@ export async function clearStreamerToken(streamerId: number): Promise<void> {
   );
 }
 
+/** Extracts the 9 event-config column values (everything but `streamer_id`) from a config, in SQL parameter order, coercing booleans to 0/1 for BIT(1) columns. */
+function eventConfigParams(config: EventSubConfig): Array<string | number> {
+  return [
+    config.follow_enabled ? 1 : 0, config.follow_message,
+    config.sub_enabled ? 1 : 0, config.sub_message, config.resub_message, config.giftsub_message,
+    config.raid_enabled ? 1 : 0, config.raid_message, config.raid_shoutout_enabled ? 1 : 0,
+  ];
+}
+
 const DEFAULT_EVENT_CONFIG: EventSubConfig = {
   follow_enabled: false,
   follow_message: 'Thanks {display_name} for the follow!',
@@ -180,19 +189,13 @@ const DEFAULT_EVENT_CONFIG: EventSubConfig = {
  * @param streamerId - DB row ID of the streamer to initialise config for.
  */
 export async function initEventConfig(streamerId: number): Promise<void> {
-  const c = DEFAULT_EVENT_CONFIG;
   await getPool().execute(
     `INSERT IGNORE INTO streamer_event_config
        (streamer_id, follow_enabled, follow_message,
         sub_enabled, sub_message, resub_message, giftsub_message,
         raid_enabled, raid_message, raid_shoutout_enabled)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    [
-      streamerId,
-      c.follow_enabled ? 1 : 0, c.follow_message,
-      c.sub_enabled ? 1 : 0, c.sub_message, c.resub_message, c.giftsub_message,
-      c.raid_enabled ? 1 : 0, c.raid_message, c.raid_shoutout_enabled ? 1 : 0,
-    ],
+    [streamerId, ...eventConfigParams(DEFAULT_EVENT_CONFIG)],
   );
 }
 
@@ -216,11 +219,6 @@ export async function saveEventConfig(streamerId: number, config: EventSubConfig
        resub_message=new_row.resub_message, giftsub_message=new_row.giftsub_message,
        raid_enabled=new_row.raid_enabled, raid_message=new_row.raid_message,
        raid_shoutout_enabled=new_row.raid_shoutout_enabled`,
-    [
-      streamerId,
-      config.follow_enabled ? 1 : 0, config.follow_message,
-      config.sub_enabled ? 1 : 0, config.sub_message, config.resub_message, config.giftsub_message,
-      config.raid_enabled ? 1 : 0, config.raid_message, config.raid_shoutout_enabled ? 1 : 0,
-    ],
+    [streamerId, ...eventConfigParams(config)],
   );
 }

--- a/src/db/eventSub.ts
+++ b/src/db/eventSub.ts
@@ -27,6 +27,7 @@ export interface DbStreamerEventSub {
   config: EventSubConfig | null;
 }
 
+/** Maps a raw `streamer_event_config` row to an {@link EventSubConfig}. */
 function mapConfig(r: mysql.RowDataPacket): EventSubConfig {
   return {
     follow_enabled: fromBit(r.follow_enabled),
@@ -41,6 +42,12 @@ function mapConfig(r: mysql.RowDataPacket): EventSubConfig {
   };
 }
 
+/**
+ * Decrypts a stored token value, treating a missing secret or a decryption failure (corrupted
+ * data or wrong key) as an absent token rather than throwing.
+ * @param value Encrypted token value, or null.
+ * @returns The decrypted token, or null if `value` is null, the secret is unset, or decryption fails.
+ */
 function maybeDecrypt(value: string | null): string | null {
   if (!value) return null;
   if (!EVENTSUB_TOKEN_SECRET) return null; // secret absent — treat stored value as unusable
@@ -51,6 +58,7 @@ function maybeDecrypt(value: string | null): string | null {
   }
 }
 
+/** Maps a joined streamer/user/event-config row to a {@link DbStreamerEventSub}, decrypting tokens. */
 function mapStreamerEventSub(r: mysql.RowDataPacket): DbStreamerEventSub {
   return {
     id: r.id,

--- a/src/db/overlayVideos.test.ts
+++ b/src/db/overlayVideos.test.ts
@@ -1,6 +1,29 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('./pool', () => ({ getPool: vi.fn() }));
+// `withTransaction` is reimplemented here (rather than via `importOriginal`) so this
+// test doesn't pull in pool.ts's real `../shared/config` import chain, which throws
+// in a test environment with no DISCORD_TOKEN etc. set. The logic mirrors pool.ts's
+// real implementation exactly, driven by the same mocked `getPool()`.
+vi.mock('./pool', () => {
+  const getPool = vi.fn();
+  return {
+    getPool,
+    withTransaction: async (work: (conn: unknown) => Promise<unknown>) => {
+      const conn = await getPool().getConnection();
+      try {
+        await conn.beginTransaction();
+        const result = await work(conn);
+        await conn.commit();
+        return result;
+      } catch (err) {
+        await conn.rollback().catch(() => {});
+        throw err;
+      } finally {
+        conn.release();
+      }
+    },
+  };
+});
 vi.mock('mysql2/promise', () => ({ default: {} }));
 
 import { getPool } from './pool';

--- a/src/db/overlayVideos.ts
+++ b/src/db/overlayVideos.ts
@@ -24,6 +24,7 @@ export interface OverlayWeightedVideo {
   weight: number;
 }
 
+/** Maps a raw `overlay_video` row to an {@link OverlayVideo}. */
 function mapVideo(r: mysql.RowDataPacket): OverlayVideo {
   return {
     id: r.id,
@@ -34,6 +35,11 @@ function mapVideo(r: mysql.RowDataPacket): OverlayVideo {
   };
 }
 
+/**
+ * Fetches all overlay videos belonging to a streamer, newest first.
+ * @param streamerId DB row ID of the owning streamer.
+ * @returns The streamer's overlay videos.
+ */
 export async function getVideosForStreamer(streamerId: number): Promise<OverlayVideo[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
     `SELECT id, streamer_id, name, filename, created_at
@@ -45,6 +51,13 @@ export async function getVideosForStreamer(streamerId: number): Promise<OverlayV
   return rows.map(mapVideo);
 }
 
+/**
+ * Inserts a new overlay video row.
+ * @param streamerId DB row ID of the owning streamer.
+ * @param name Display name for the video.
+ * @param filename Stored filename of the video.
+ * @returns The new row's primary key.
+ */
 export async function addVideo(streamerId: number, name: string, filename: string): Promise<number> {
   const [result] = await getPool().execute<mysql.ResultSetHeader>(
     `INSERT INTO overlay_video (streamer_id, name, filename) VALUES (?, ?, ?)`,
@@ -53,6 +66,12 @@ export async function addVideo(streamerId: number, name: string, filename: strin
   return result.insertId;
 }
 
+/**
+ * Looks up an overlay video by id, scoped to the owning streamer.
+ * @param videoId Primary key of the `overlay_video` row.
+ * @param streamerId DB row ID of the owning streamer.
+ * @returns The video, or null if no matching row exists.
+ */
 export async function getVideoById(videoId: number, streamerId: number): Promise<OverlayVideo | null> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
     `SELECT id, streamer_id, name, filename, created_at
@@ -95,6 +114,11 @@ export async function deleteVideo(videoId: number, streamerId: number): Promise<
   }
 }
 
+/**
+ * Fetches all overlay rewards belonging to a streamer, each with its assigned weighted videos.
+ * @param streamerId DB row ID of the owning streamer.
+ * @returns The streamer's overlay rewards with their assigned videos.
+ */
 export async function getRewardsForStreamer(streamerId: number): Promise<OverlayRewardWithVideos[]> {
   const [rewardRows] = await getPool().execute<mysql.RowDataPacket[]>(
     `SELECT r.id, r.streamer_id, r.twitch_reward_id,
@@ -129,6 +153,13 @@ export async function getRewardsForStreamer(streamerId: number): Promise<Overlay
   return Array.from(rewardMap.values());
 }
 
+/**
+ * Inserts an overlay reward for a streamer's Twitch channel-point reward, or returns the existing
+ * row's id if one already exists for this streamer+reward.
+ * @param streamerId DB row ID of the owning streamer.
+ * @param twitchRewardId Twitch channel-point reward id.
+ * @returns The reward row's primary key.
+ */
 export async function upsertReward(streamerId: number, twitchRewardId: string): Promise<number> {
   const [result] = await getPool().execute<mysql.ResultSetHeader>(
     `INSERT INTO overlay_reward (streamer_id, twitch_reward_id) VALUES (?, ?)
@@ -182,6 +213,11 @@ export async function setRewardVideos(
   }
 }
 
+/**
+ * Deletes an overlay reward row, scoped to the owning streamer.
+ * @param rewardId Primary key of the `overlay_reward` row.
+ * @param streamerId DB row ID of the owning streamer.
+ */
 export async function deleteReward(rewardId: number, streamerId: number): Promise<void> {
   await getPool().execute(
     `DELETE FROM overlay_reward WHERE id = ? AND streamer_id = ?`,
@@ -189,6 +225,13 @@ export async function deleteReward(rewardId: number, streamerId: number): Promis
   );
 }
 
+/**
+ * Fetches the weighted videos assigned to a streamer's Twitch channel-point reward, for use when
+ * randomly selecting a video to play.
+ * @param twitchRewardId Twitch channel-point reward id.
+ * @param streamerId DB row ID of the owning streamer.
+ * @returns The reward's assigned videos with their filenames and weights.
+ */
 export async function getVideosForReward(
   twitchRewardId: string,
   streamerId: number,

--- a/src/db/overlayVideos.ts
+++ b/src/db/overlayVideos.ts
@@ -1,5 +1,5 @@
 import mysql from 'mysql2/promise';
-import { getPool } from './pool';
+import { getPool, withTransaction } from './pool';
 
 export interface OverlayVideo {
   id: number;
@@ -63,33 +63,35 @@ export async function getVideoById(videoId: number, streamerId: number): Promise
   return rows.length === 0 ? null : mapVideo(rows[0]);
 }
 
+/**
+ * Delete an overlay video row, scoped to the owning streamer.
+ * @param videoId Primary key of the `overlay_video` row.
+ * @param streamerId DB row ID of the owning streamer.
+ * @returns The deleted row's filename (for filesystem cleanup), or null if no matching row existed.
+ */
 export async function deleteVideo(videoId: number, streamerId: number): Promise<string | null> {
-  const conn = await getPool().getConnection();
+  class VideoNotFound extends Error {}
   try {
-    await conn.beginTransaction();
-    const [rows] = await conn.execute<mysql.RowDataPacket[]>(
-      `SELECT filename FROM overlay_video WHERE id = ? AND streamer_id = ?`,
-      [videoId, streamerId],
-    );
-    if (rows.length === 0) {
-      await conn.rollback();
-      return null;
-    }
-    const filename: string = rows[0].filename;
-    const [del] = await conn.execute<mysql.ResultSetHeader>(
-      `DELETE FROM overlay_video WHERE id = ? AND streamer_id = ?`, [videoId, streamerId],
-    );
-    if (del.affectedRows === 0) {
-      await conn.rollback();
-      return null;
-    }
-    await conn.commit();
-    return filename;
+    return await withTransaction(async (conn) => {
+      const [rows] = await conn.execute<mysql.RowDataPacket[]>(
+        `SELECT filename FROM overlay_video WHERE id = ? AND streamer_id = ?`,
+        [videoId, streamerId],
+      );
+      if (rows.length === 0) {
+        throw new VideoNotFound();
+      }
+      const filename: string = rows[0].filename;
+      const [del] = await conn.execute<mysql.ResultSetHeader>(
+        `DELETE FROM overlay_video WHERE id = ? AND streamer_id = ?`, [videoId, streamerId],
+      );
+      if (del.affectedRows === 0) {
+        throw new VideoNotFound();
+      }
+      return filename;
+    });
   } catch (err) {
-    await conn.rollback().catch(() => {});
+    if (err instanceof VideoNotFound) return null;
     throw err;
-  } finally {
-    conn.release();
   }
 }
 
@@ -136,42 +138,47 @@ export async function upsertReward(streamerId: number, twitchRewardId: string): 
   return result.insertId;
 }
 
+/**
+ * Replaces the set of videos assigned to a reward with `videos`, scoped to the owning streamer.
+ * A no-op if `rewardId` doesn't belong to `streamerId`. Throws if any video in `videos` doesn't
+ * belong to `streamerId`, rolling back the whole replacement.
+ * @param rewardId Primary key of the `overlay_reward` row.
+ * @param streamerId DB row ID of the owning streamer.
+ * @param videos The videos (and their weights) to assign to the reward.
+ */
 export async function setRewardVideos(
   rewardId: number,
   streamerId: number,
   videos: Array<{ videoId: number; weight: number }>,
 ): Promise<void> {
-  const conn = await getPool().getConnection();
+  class RewardNotFound extends Error {}
   try {
-    await conn.beginTransaction();
-    // Verify reward belongs to this streamer
-    const [check] = await conn.execute<mysql.RowDataPacket[]>(
-      `SELECT id FROM overlay_reward WHERE id = ? AND streamer_id = ?`,
-      [rewardId, streamerId],
-    );
-    if (check.length === 0) {
-      await conn.rollback();
-      return;
-    }
-    await conn.execute(`DELETE FROM overlay_reward_video WHERE reward_id = ?`, [rewardId]);
-    for (const v of videos) {
-      const [insert] = await conn.execute<mysql.ResultSetHeader>(
-        `INSERT INTO overlay_reward_video (reward_id, video_id, weight)
-         SELECT ?, ov.id, ?
-         FROM overlay_video ov
-         WHERE ov.id = ? AND ov.streamer_id = ?`,
-        [rewardId, Math.max(1, v.weight), v.videoId, streamerId],
+    await withTransaction(async (conn) => {
+      // Verify reward belongs to this streamer
+      const [check] = await conn.execute<mysql.RowDataPacket[]>(
+        `SELECT id FROM overlay_reward WHERE id = ? AND streamer_id = ?`,
+        [rewardId, streamerId],
       );
-      if (insert.affectedRows !== 1) {
-        throw new Error(`Video ${v.videoId} does not belong to streamer ${streamerId}`);
+      if (check.length === 0) {
+        throw new RewardNotFound();
       }
-    }
-    await conn.commit();
+      await conn.execute(`DELETE FROM overlay_reward_video WHERE reward_id = ?`, [rewardId]);
+      for (const v of videos) {
+        const [insert] = await conn.execute<mysql.ResultSetHeader>(
+          `INSERT INTO overlay_reward_video (reward_id, video_id, weight)
+           SELECT ?, ov.id, ?
+           FROM overlay_video ov
+           WHERE ov.id = ? AND ov.streamer_id = ?`,
+          [rewardId, Math.max(1, v.weight), v.videoId, streamerId],
+        );
+        if (insert.affectedRows !== 1) {
+          throw new Error(`Video ${v.videoId} does not belong to streamer ${streamerId}`);
+        }
+      }
+    });
   } catch (err) {
-    await conn.rollback().catch(() => {});
+    if (err instanceof RewardNotFound) return;
     throw err;
-  } finally {
-    conn.release();
   }
 }
 

--- a/src/db/pool.test.ts
+++ b/src/db/pool.test.ts
@@ -10,7 +10,7 @@ vi.mock('../shared/config', () => ({
   DB_NAME: 'test-db',
 }));
 
-import { getPool, closePool } from './pool';
+import { getPool, closePool, withTransaction } from './pool';
 
 beforeEach(async () => {
   vi.clearAllMocks();
@@ -66,5 +66,66 @@ describe('closePool', () => {
     await closePool();
     getPool();
     expect(createPool).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('withTransaction', () => {
+  /** Builds a fake pool connection whose lifecycle methods resolve successfully. */
+  function makeConn() {
+    return {
+      beginTransaction: vi.fn().mockResolvedValue(undefined),
+      commit: vi.fn().mockResolvedValue(undefined),
+      rollback: vi.fn().mockResolvedValue(undefined),
+      release: vi.fn(),
+    };
+  }
+
+  it('begins, runs work, commits, releases, and returns the work result', async () => {
+    const conn = makeConn();
+    createPool.mockReturnValue({ end: vi.fn(), getConnection: vi.fn().mockResolvedValue(conn) });
+    const work = vi.fn().mockResolvedValue('the-result');
+
+    const result = await withTransaction(work);
+
+    expect(result).toBe('the-result');
+    expect(conn.beginTransaction).toHaveBeenCalledOnce();
+    expect(work).toHaveBeenCalledWith(conn);
+    expect(conn.commit).toHaveBeenCalledOnce();
+    expect(conn.rollback).not.toHaveBeenCalled();
+    expect(conn.release).toHaveBeenCalledOnce();
+  });
+
+  it('rolls back, releases, and rethrows when work throws', async () => {
+    const conn = makeConn();
+    createPool.mockReturnValue({ end: vi.fn(), getConnection: vi.fn().mockResolvedValue(conn) });
+    const boom = new Error('boom');
+
+    await expect(withTransaction(async () => { throw boom; })).rejects.toBe(boom);
+
+    expect(conn.rollback).toHaveBeenCalledOnce();
+    expect(conn.commit).not.toHaveBeenCalled();
+    expect(conn.release).toHaveBeenCalledOnce();
+  });
+
+  it('swallows a rollback failure and still rethrows the original error', async () => {
+    const conn = makeConn();
+    conn.rollback.mockRejectedValue(new Error('rollback failed'));
+    createPool.mockReturnValue({ end: vi.fn(), getConnection: vi.fn().mockResolvedValue(conn) });
+    const original = new Error('original failure');
+
+    await expect(withTransaction(async () => { throw original; })).rejects.toBe(original);
+
+    expect(conn.release).toHaveBeenCalledOnce();
+  });
+
+  it('releases the connection even when commit throws', async () => {
+    const conn = makeConn();
+    conn.commit.mockRejectedValue(new Error('commit failed'));
+    createPool.mockReturnValue({ end: vi.fn(), getConnection: vi.fn().mockResolvedValue(conn) });
+
+    await expect(withTransaction(async () => 'value')).rejects.toThrow('commit failed');
+
+    expect(conn.rollback).toHaveBeenCalledOnce();
+    expect(conn.release).toHaveBeenCalledOnce();
   });
 });

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -1,8 +1,9 @@
-import mysql from 'mysql2/promise';
+import mysql, { type PoolConnection } from 'mysql2/promise';
 import { DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME } from '../shared/config';
 
 let pool: mysql.Pool | undefined;
 
+/** Returns the shared connection pool, creating it on first use. */
 export function getPool(): mysql.Pool {
   if (!pool) {
     pool = mysql.createPool({
@@ -22,9 +23,36 @@ export function getPool(): mysql.Pool {
   return pool;
 }
 
+/** Closes the shared connection pool, if one has been created, and clears the singleton. */
 export async function closePool(): Promise<void> {
   if (pool) {
     await pool.end();
     pool = undefined;
+  }
+}
+
+/**
+ * Runs `work` inside a database transaction: acquires a connection, begins the
+ * transaction, invokes `work(conn)`, and commits once it resolves. If `work`
+ * throws (including a caller-defined sentinel error used to signal an early
+ * "not found" exit), the transaction is rolled back — rollback failures are
+ * swallowed (mirroring every hand-written transaction this replaces) so the
+ * original error still propagates — and the error is rethrown. The connection
+ * is always released in a `finally`, regardless of outcome.
+ * @param work Callback that receives the transaction's connection and performs the work.
+ * @returns The value returned by `work`, once the transaction has committed.
+ */
+export async function withTransaction<T>(work: (conn: PoolConnection) => Promise<T>): Promise<T> {
+  const conn = await getPool().getConnection();
+  try {
+    await conn.beginTransaction();
+    const result = await work(conn);
+    await conn.commit();
+    return result;
+  } catch (err) {
+    await conn.rollback().catch(() => {});
+    throw err;
+  } finally {
+    conn.release();
   }
 }

--- a/src/db/reservedCommands.ts
+++ b/src/db/reservedCommands.ts
@@ -1,3 +1,5 @@
+import { normalizeCommand } from './commandStringUtils';
+
 export interface BuiltInCommandMeta {
   description: string;
 }
@@ -22,8 +24,9 @@ export class ReservedCommandError extends Error {
   }
 }
 
+/** Throws {@link ReservedCommandError} if `trigger` (trimmed, lowercased) matches a built-in command. */
 export function assertNotReservedCommand(trigger: string): void {
-  const normalized = trigger.trim().toLowerCase();
+  const normalized = normalizeCommand(trigger) ?? '';
   if (RESERVED_BUILT_IN_COMMANDS.has(normalized)) {
     throw new ReservedCommandError(normalized);
   }

--- a/src/db/sfx.test.ts
+++ b/src/db/sfx.test.ts
@@ -1,6 +1,29 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('./pool', () => ({ getPool: vi.fn() }));
+// `withTransaction` is reimplemented here (rather than via `importOriginal`) so this
+// test doesn't pull in pool.ts's real `../shared/config` import chain, which throws
+// in a test environment with no DISCORD_TOKEN etc. set. The logic mirrors pool.ts's
+// real implementation exactly, driven by the same mocked `getPool()`.
+vi.mock('./pool', () => {
+  const getPool = vi.fn();
+  return {
+    getPool,
+    withTransaction: async (work: (conn: unknown) => Promise<unknown>) => {
+      const conn = await getPool().getConnection();
+      try {
+        await conn.beginTransaction();
+        const result = await work(conn);
+        await conn.commit();
+        return result;
+      } catch (err) {
+        await conn.rollback().catch(() => {});
+        throw err;
+      } finally {
+        conn.release();
+      }
+    },
+  };
+});
 vi.mock('mysql2/promise', () => ({ default: {} }));
 
 import { getPool } from './pool';

--- a/src/db/sfx.ts
+++ b/src/db/sfx.ts
@@ -1,6 +1,6 @@
 import mysql from 'mysql2/promise';
-import { getPool } from './pool';
-import { fromBit } from './utils';
+import { getPool, withTransaction } from './pool';
+import { fromBit, affectedOrExists } from './utils';
 
 export interface SfxTrigger {
   id: bigint;
@@ -133,12 +133,13 @@ export async function renameCategory(id: number, name: string): Promise<boolean>
     `UPDATE sfxcategory SET name = ? WHERE id = ?`,
     [name, id],
   );
-  if (result.affectedRows > 0) return true;
-  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    `SELECT id FROM sfxcategory WHERE id = ?`,
-    [id],
-  );
-  return rows.length > 0;
+  return affectedOrExists(result.affectedRows, async () => {
+    const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+      `SELECT id FROM sfxcategory WHERE id = ?`,
+      [id],
+    );
+    return rows.length > 0;
+  });
 }
 
 /**
@@ -203,12 +204,13 @@ export async function updateSfxTrigger(
      WHERE id = ?`,
     [command, categoryId, description, hidden ? 1 : 0, id.toString()],
   );
-  if (result.affectedRows > 0) return true;
-  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    `SELECT id FROM sfxtrigger WHERE id = ?`,
-    [id.toString()],
-  );
-  return rows.length > 0;
+  return affectedOrExists(result.affectedRows, async () => {
+    const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+      `SELECT id FROM sfxtrigger WHERE id = ?`,
+      [id.toString()],
+    );
+    return rows.length > 0;
+  });
 }
 
 /**
@@ -226,31 +228,28 @@ export async function updateSfxTrigger(
  * @param id Trigger id.
  */
 export async function deleteSfxTrigger(id: bigint): Promise<{ files: string[] } | null> {
-  const conn = await getPool().getConnection();
+  class TriggerNotFound extends Error {}
   try {
-    await conn.beginTransaction();
-    const [triggerRows] = await conn.execute<mysql.RowDataPacket[]>(
-      `SELECT id FROM sfxtrigger WHERE id = ? FOR UPDATE`,
-      [id.toString()],
-    );
-    if (triggerRows.length === 0) {
-      await conn.rollback();
-      return null;
-    }
-    const [rows] = await conn.execute<mysql.RowDataPacket[]>(
-      `SELECT file FROM sfx WHERE trigger_id = ? FOR UPDATE`,
-      [id.toString()],
-    );
-    const files = rows.map((r) => r.file as string);
-    await conn.execute(`DELETE FROM sfx WHERE trigger_id = ?`, [id.toString()]);
-    await conn.execute(`DELETE FROM sfxtrigger WHERE id = ?`, [id.toString()]);
-    await conn.commit();
-    return { files };
+    return await withTransaction(async (conn) => {
+      const [triggerRows] = await conn.execute<mysql.RowDataPacket[]>(
+        `SELECT id FROM sfxtrigger WHERE id = ? FOR UPDATE`,
+        [id.toString()],
+      );
+      if (triggerRows.length === 0) {
+        throw new TriggerNotFound();
+      }
+      const [rows] = await conn.execute<mysql.RowDataPacket[]>(
+        `SELECT file FROM sfx WHERE trigger_id = ? FOR UPDATE`,
+        [id.toString()],
+      );
+      const files = rows.map((r) => r.file as string);
+      await conn.execute(`DELETE FROM sfx WHERE trigger_id = ?`, [id.toString()]);
+      await conn.execute(`DELETE FROM sfxtrigger WHERE id = ?`, [id.toString()]);
+      return { files };
+    });
   } catch (err) {
-    await conn.rollback().catch(() => {});
+    if (err instanceof TriggerNotFound) return null;
     throw err;
-  } finally {
-    conn.release();
   }
 }
 
@@ -290,9 +289,10 @@ export async function updateSfxFile(id: number, weight: number, hidden: boolean)
     `UPDATE sfx SET weight = ?, hidden = ? WHERE id = ?`,
     [weight, hidden ? 1 : 0, id],
   );
-  if (result.affectedRows > 0) return true;
-  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(`SELECT id FROM sfx WHERE id = ?`, [id]);
-  return rows.length > 0;
+  return affectedOrExists(result.affectedRows, async () => {
+    const [rows] = await getPool().execute<mysql.RowDataPacket[]>(`SELECT id FROM sfx WHERE id = ?`, [id]);
+    return rows.length > 0;
+  });
 }
 
 /**
@@ -306,30 +306,26 @@ export async function updateSfxFile(id: number, weight: number, hidden: boolean)
  * @param id sfx row id.
  */
 export async function deleteSfxFile(id: number): Promise<string | null> {
-  const conn = await getPool().getConnection();
+  class FileNotFound extends Error {}
   try {
-    await conn.beginTransaction();
-    const [rows] = await conn.execute<mysql.RowDataPacket[]>(
-      `SELECT file FROM sfx WHERE id = ? FOR UPDATE`,
-      [id],
-    );
-    if (rows.length === 0) {
-      await conn.rollback();
-      return null;
-    }
-    const file: string = rows[0].file;
-    const [result] = await conn.execute<mysql.ResultSetHeader>(`DELETE FROM sfx WHERE id = ?`, [id]);
-    if (result.affectedRows === 0) {
-      await conn.rollback();
-      return null;
-    }
-    await conn.commit();
-    return file;
+    return await withTransaction(async (conn) => {
+      const [rows] = await conn.execute<mysql.RowDataPacket[]>(
+        `SELECT file FROM sfx WHERE id = ? FOR UPDATE`,
+        [id],
+      );
+      if (rows.length === 0) {
+        throw new FileNotFound();
+      }
+      const file: string = rows[0].file;
+      const [result] = await conn.execute<mysql.ResultSetHeader>(`DELETE FROM sfx WHERE id = ?`, [id]);
+      if (result.affectedRows === 0) {
+        throw new FileNotFound();
+      }
+      return file;
+    });
   } catch (err) {
-    await conn.rollback().catch(() => {});
+    if (err instanceof FileNotFound) return null;
     throw err;
-  } finally {
-    conn.release();
   }
 }
 

--- a/src/db/streamMonitor.test.ts
+++ b/src/db/streamMonitor.test.ts
@@ -1,6 +1,29 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('./pool', () => ({ getPool: vi.fn() }));
+// `withTransaction` is reimplemented here (rather than via `importOriginal`) so this
+// test doesn't pull in pool.ts's real `../shared/config` import chain, which throws
+// in a test environment with no DISCORD_TOKEN etc. set. The logic mirrors pool.ts's
+// real implementation exactly, driven by the same mocked `getPool()`.
+vi.mock('./pool', () => {
+  const getPool = vi.fn();
+  return {
+    getPool,
+    withTransaction: async (work: (conn: unknown) => Promise<unknown>) => {
+      const conn = await getPool().getConnection();
+      try {
+        await conn.beginTransaction();
+        const result = await work(conn);
+        await conn.commit();
+        return result;
+      } catch (err) {
+        await conn.rollback().catch(() => {});
+        throw err;
+      } finally {
+        conn.release();
+      }
+    },
+  };
+});
 vi.mock('mysql2/promise', () => ({ default: {} }));
 
 import { getPool } from './pool';

--- a/src/db/streamMonitor.ts
+++ b/src/db/streamMonitor.ts
@@ -1,5 +1,5 @@
 import mysql from 'mysql2/promise';
-import { getPool } from './pool';
+import { getPool, withTransaction } from './pool';
 import { fromBit } from './utils';
 
 export interface DbStreamGroup {
@@ -48,18 +48,44 @@ export interface DbStreamerFull {
   group: DbStreamGroup;
 }
 
+/** Raw group-related field values, keyed the way `mapStreamGroup`/`buildStreamGroup` expect them, regardless of the source row's own column aliases. */
+interface RawStreamGroupFields {
+  id: number;
+  guild_id: unknown;
+  name: string;
+  discord_channel: unknown;
+  live_message: string;
+  new_game_message: string;
+  multi_twitch: unknown;
+  delete_old_posts: unknown;
+}
+
+/** Converts raw group field values to a `DbStreamGroup`, converting BIGINT/bit columns to string/boolean. */
+function buildStreamGroup(fields: RawStreamGroupFields): DbStreamGroup {
+  return {
+    id: fields.id,
+    guild_id: String(fields.guild_id),
+    name: fields.name,
+    discord_channel: String(fields.discord_channel),
+    live_message: fields.live_message,
+    new_game_message: fields.new_game_message,
+    multi_twitch: fromBit(fields.multi_twitch),
+    delete_old_posts: fromBit(fields.delete_old_posts),
+  };
+}
+
 /** Maps a `stream_group` row to a `DbStreamGroup`, converting BIGINT/bit columns to string/boolean. */
 function mapStreamGroup(r: mysql.RowDataPacket): DbStreamGroup {
-  return {
+  return buildStreamGroup({
     id: r.id,
-    guild_id: String(r.guild_id),
+    guild_id: r.guild_id,
     name: r.name,
-    discord_channel: String(r.discord_channel),
+    discord_channel: r.discord_channel,
     live_message: r.live_message,
     new_game_message: r.new_game_message,
-    multi_twitch: fromBit(r.multi_twitch),
-    delete_old_posts: fromBit(r.delete_old_posts),
-  };
+    multi_twitch: r.multi_twitch,
+    delete_old_posts: r.delete_old_posts,
+  });
 }
 
 /** Extracts the shared column values (everything but `guildId`/`id`) from an add/update input, in SQL parameter order. */
@@ -174,16 +200,16 @@ export async function getAllStreamersWithGroups(): Promise<DbStreamerFull[]> {
     discord_message_id: r.discord_message_id ?? null,
     discord_channel_id: r.discord_channel_id !== null && r.discord_channel_id !== undefined ? String(r.discord_channel_id) : null,
     live_game: r.live_game ?? null,
-    group: {
+    group: buildStreamGroup({
       id: r.group_id,
-      guild_id: String(r.guild_id),
+      guild_id: r.guild_id,
       name: r.group_name,
-      discord_channel: String(r.discord_channel),
+      discord_channel: r.discord_channel,
       live_message: r.live_message,
       new_game_message: r.new_game_message,
-      multi_twitch: fromBit(r.multi_twitch),
-      delete_old_posts: fromBit(r.delete_old_posts),
-    },
+      multi_twitch: r.multi_twitch,
+      delete_old_posts: r.delete_old_posts,
+    }),
   }));
 }
 
@@ -237,9 +263,7 @@ export async function removeStreamer(id: number, guildId: string): Promise<boole
  * @returns True if the group was actually deleted; false if it didn't belong to `guildId`.
  */
 export async function removeStreamGroupAndStreamers(groupId: number, guildId: string): Promise<boolean> {
-  const conn = await getPool().getConnection();
-  try {
-    await conn.beginTransaction();
+  return withTransaction(async (conn) => {
     await conn.execute(
       `DELETE s FROM streamer s JOIN stream_group g ON s.group_id = g.id WHERE s.group_id = ? AND g.guild_id = ?`,
       [groupId, guildId],
@@ -247,15 +271,8 @@ export async function removeStreamGroupAndStreamers(groupId: number, guildId: st
     const [result] = await conn.execute<mysql.ResultSetHeader>(
       'DELETE FROM stream_group WHERE id = ? AND guild_id = ?', [groupId, guildId],
     );
-    await conn.commit();
     return result.affectedRows > 0;
-  } catch (err) {
-    // Swallow rollback failures (e.g. connection already dropped) so the original error propagates.
-    await conn.rollback().catch(() => {});
-    throw err;
-  } finally {
-    conn.release();
-  }
+  });
 }
 
 /**

--- a/src/db/streamdeckKeys.test.ts
+++ b/src/db/streamdeckKeys.test.ts
@@ -1,6 +1,29 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('./pool', () => ({ getPool: vi.fn() }));
+// `withTransaction` is reimplemented here (rather than via `importOriginal`) so this
+// test doesn't pull in pool.ts's real `../shared/config` import chain, which throws
+// in a test environment with no DISCORD_TOKEN etc. set. The logic mirrors pool.ts's
+// real implementation exactly, driven by the same mocked `getPool()`.
+vi.mock('./pool', () => {
+  const getPool = vi.fn();
+  return {
+    getPool,
+    withTransaction: async (work: (conn: unknown) => Promise<unknown>) => {
+      const conn = await getPool().getConnection();
+      try {
+        await conn.beginTransaction();
+        const result = await work(conn);
+        await conn.commit();
+        return result;
+      } catch (err) {
+        await conn.rollback().catch(() => {});
+        throw err;
+      } finally {
+        conn.release();
+      }
+    },
+  };
+});
 vi.mock('mysql2/promise', () => ({ default: {} }));
 vi.mock('./users', () => ({
   AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },

--- a/src/db/streamdeckKeys.ts
+++ b/src/db/streamdeckKeys.ts
@@ -1,6 +1,6 @@
 import { randomBytes, createHash, timingSafeEqual } from 'crypto';
 import mysql from 'mysql2/promise';
-import { getPool } from './pool';
+import { getPool, withTransaction } from './pool';
 import { AccessLevel } from './users';
 
 /** Per-guild approval state for a Streamdeck API key. */
@@ -77,9 +77,7 @@ export async function createApiKeyAndRequestGuildAccess(
   // Both inserts must commit together — a partial failure would strand a key
   // identity with no guild-status row, and the plaintext (only ever returned
   // here) would be unrecoverable.
-  const conn = await getPool().getConnection();
-  try {
-    await conn.beginTransaction();
+  await withTransaction(async (conn) => {
     await conn.execute(
       'INSERT INTO streamdeck_api_keys (discord_id, key_hash, created_at) VALUES (?, ?, ?)',
       [discordId, hash, now],
@@ -90,13 +88,7 @@ export async function createApiKeyAndRequestGuildAccess(
        VALUES (?, ?, ?, ?, ?, ?)`,
       [discordId, guildId, status, now, status === 'approved' ? now : null, status === 'approved' ? discordId : null],
     );
-    await conn.commit();
-  } catch (err) {
-    await conn.rollback().catch(() => {});
-    throw err;
-  } finally {
-    conn.release();
-  }
+  });
 
   return { plain, status };
 }

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -34,6 +34,7 @@ export interface DbUser {
 
 const USER_SELECT = 'discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level, is_owner';
 
+/** Maps a raw `user` table row to a {@link DbUser}. */
 function mapUser(r: mysql.RowDataPacket): DbUser {
   return {
     discord_id: String(r.discord_id),
@@ -128,7 +129,13 @@ export async function getGuildMemberUsers(guildId: string): Promise<DbUser[]> {
   return rows.map(mapUser);
 }
 
-// Short timeout so callers fail fast instead of hanging 50s under lock contention.
+/**
+ * Runs `fn` on a dedicated connection with a short (5s) `innodb_lock_wait_timeout`, so callers
+ * fail fast instead of hanging up to the default 50s under lock contention. The timeout is reset
+ * to the session default and the connection released before returning.
+ * @param fn Callback that receives the connection and performs the work.
+ * @returns The value returned by `fn`.
+ */
 async function withShortLockTimeout<T>(fn: (conn: mysql.PoolConnection) => Promise<T>): Promise<T> {
   const connection = await getPool().getConnection();
   try {

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -32,6 +32,8 @@ export interface DbUser {
   is_owner: boolean;
 }
 
+const USER_SELECT = 'discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level, is_owner';
+
 function mapUser(r: mysql.RowDataPacket): DbUser {
   return {
     discord_id: String(r.discord_id),
@@ -50,7 +52,7 @@ function mapUser(r: mysql.RowDataPacket): DbUser {
  */
 export async function findUser(discordId: string): Promise<DbUser | null> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    'SELECT discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level, is_owner FROM `user` WHERE discord_id = ?',
+    `SELECT ${USER_SELECT} FROM \`user\` WHERE discord_id = ?`,
     [discordId],
   );
   return rows.length === 0 ? null : mapUser(rows[0]);
@@ -70,12 +72,12 @@ export async function findUserByTwitchName(twitchName: string, excludeDiscordId?
   }
 
   const sql = excludeDiscordId
-    ? `SELECT discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level, is_owner
+    ? `SELECT ${USER_SELECT}
        FROM \`user\`
        WHERE twitch_name = ?
          AND discord_id <> ?
        LIMIT 1`
-    : `SELECT discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level, is_owner
+    : `SELECT ${USER_SELECT}
        FROM \`user\`
        WHERE twitch_name = ?
        LIMIT 1`;
@@ -92,7 +94,7 @@ export async function findUserByTwitchName(twitchName: string, excludeDiscordId?
  */
 export async function findOwnerUser(): Promise<DbUser | null> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    'SELECT discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level, is_owner FROM `user` WHERE is_owner = 1 LIMIT 1',
+    `SELECT ${USER_SELECT} FROM \`user\` WHERE is_owner = 1 LIMIT 1`,
   );
   return rows.length === 0 ? null : mapUser(rows[0]);
 }
@@ -100,7 +102,7 @@ export async function findOwnerUser(): Promise<DbUser | null> {
 /** Returns every user row, ordered by access level (highest first) then name. */
 export async function getAllUsers(): Promise<DbUser[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    'SELECT discord_id, discord_name, is_twitch_bot_enabled, twitch_name, access_level, is_owner FROM `user` ORDER BY access_level DESC, discord_name ASC',
+    `SELECT ${USER_SELECT} FROM \`user\` ORDER BY access_level DESC, discord_name ASC`,
   );
   return rows.map(mapUser);
 }

--- a/src/db/utils.test.ts
+++ b/src/db/utils.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { fromBit } from './utils';
+import { describe, it, expect, vi } from 'vitest';
+import { fromBit, affectedOrExists } from './utils';
 
 describe('fromBit', () => {
   it('returns true for Buffer with first byte 1', () => {
@@ -28,5 +28,27 @@ describe('fromBit', () => {
 
   it('returns false for undefined', () => {
     expect(fromBit(undefined)).toBe(false);
+  });
+});
+
+describe('affectedOrExists', () => {
+  it('returns true without calling existsCheck when affectedRows > 0', async () => {
+    const existsCheck = vi.fn().mockResolvedValue(false);
+    const result = await affectedOrExists(1, existsCheck);
+    expect(result).toBe(true);
+    expect(existsCheck).not.toHaveBeenCalled();
+  });
+
+  it('calls existsCheck and returns its result when affectedRows is 0', async () => {
+    const existsCheck = vi.fn().mockResolvedValue(true);
+    const result = await affectedOrExists(0, existsCheck);
+    expect(result).toBe(true);
+    expect(existsCheck).toHaveBeenCalledOnce();
+  });
+
+  it('returns false when affectedRows is 0 and existsCheck resolves false', async () => {
+    const existsCheck = vi.fn().mockResolvedValue(false);
+    const result = await affectedOrExists(0, existsCheck);
+    expect(result).toBe(false);
   });
 });

--- a/src/db/utils.ts
+++ b/src/db/utils.ts
@@ -3,3 +3,15 @@ export function fromBit(value: unknown): boolean {
   if (Buffer.isBuffer(value)) return value[0] === 1;
   return value == 1;
 }
+
+/**
+ * Distinguishes a no-op `UPDATE` (0 affected rows because every value was
+ * already equal) from one that matched nothing because the row doesn't exist.
+ * @param affectedRows `affectedRows` from the `UPDATE`'s `ResultSetHeader`.
+ * @param existsCheck Callback that checks whether the target row still exists; only called when `affectedRows` is 0.
+ * @returns True if the update affected a row or the target row still exists; false only if it doesn't exist.
+ */
+export async function affectedOrExists(affectedRows: number, existsCheck: () => Promise<boolean>): Promise<boolean> {
+  if (affectedRows > 0) return true;
+  return existsCheck();
+}


### PR DESCRIPTION
## Summary

Project-wide de-duplication review — this PR covers `src/db/*.ts` only.

- **`withTransaction` helper** (`src/db/pool.ts`): wraps get-connection / beginTransaction / commit / rollback-and-swallow / release. Replaces hand-rolled transaction boilerplate in:
  - `src/db/sfx.ts` — `deleteSfxTrigger`, `deleteSfxFile`
  - `src/db/streamMonitor.ts` — `removeStreamGroupAndStreamers`
  - `src/db/overlayVideos.ts` — `deleteVideo`, `setRewardVideos`
  - `src/db/streamdeckKeys.ts` — `createApiKeyAndRequestGuildAccess`
  - `src/db/companionOAuthCodes.ts` — `exchangeCodeForToken`
  - `src/db/counters.ts` — `incrementCounter`

  For the functions that do a "not found" check inside the transaction (and previously rolled back + returned early without going through the normal commit path), the callback now throws a small function-local sentinel error class, which `withTransaction` rolls back on, and the outer function catches to translate back to `null`/`void`. This preserves the exact original external behavior (return values, rollback-not-commit on the not-found path) while sharing the try/catch/finally scaffolding.

- **Exported `normalizeCommand`** (`src/db/commandStringUtils.ts`, was private) and replaced hand-rolled `.trim().toLowerCase()` equivalents in `counterCache.ts`, `counters.ts`, `customCommandCache.ts`, `commandConflicts.ts`, `reservedCommands.ts`, wherever the code was normalizing a single command string identically.

- **`affectedOrExists` helper** (`src/db/utils.ts`): factors out the "UPDATE, then fall back to a SELECT EXISTS check when 0 rows affected" pattern, used in `sfx.ts`'s `renameCategory`, `updateSfxTrigger`, `updateSfxFile`.

- **Fixed `commandConflicts.ts`'s `getUserTwitchEligibility`** to use the existing `fromBit()` helper instead of manually re-deriving BIT(1)-to-boolean decoding.

- **`USER_SELECT` constant** (`src/db/users.ts`): extracted the repeated 6-column list used in `findUser`, `findUserByTwitchName`, `findOwnerUser`, `getAllUsers`, matching the `REWARD_PRICING_SELECT`/`EVENT_SUB_SELECT` convention already used elsewhere.

- **`streamMonitor.ts` field-mapping reuse**: extracted a shared `buildStreamGroup` helper so `mapStreamGroup` and `getAllStreamersWithGroups` share one copy of the BIGINT/bit conversions instead of two.

- **`eventSub.ts` param builder**: added `eventConfigParams(config)`, mirroring `streamGroupParams()` in `streamMonitor.ts`, shared between `initEventConfig` and `saveEventConfig`'s INSERT param lists.

No behavior changes — return types, thrown error types, and commit/rollback semantics are preserved exactly for every refactored function.

### Not changed (and why)
- `getGuildMemberUsers` in `users.ts` was left with its own inline SELECT list — it's a different join query (per-guild `access_level`), not the same shape as `USER_SELECT`.
- `counters.ts`'s `normalizeCounterFields` still uses `requireTrimmedString(...).toLowerCase()` rather than `normalizeCommand` — it does length validation and throws on blank, which is materially different from `normalizeCommand`'s trim+lowercase-or-null behavior, so it wasn't force-fit.
- Call sites where `normalizeCommand`'s `string | null` return needed to feed into a non-nullable `string` context (e.g. `commandConflicts.ts`'s `getCommandTriggerStringById`, `reservedCommands.ts`'s `assertNotReservedCommand`, a couple of spots in `counters.ts`/`counterCache.ts`) use `normalizeCommand(x) ?? ''` — behaviorally identical to the old `.trim().toLowerCase()` since an empty string is falsy either way.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — all 2339 tests pass (added tests for `withTransaction`, the newly-exported `normalizeCommand`, and `affectedOrExists`; updated mocks in `sfx.test.ts`, `streamMonitor.test.ts`, `overlayVideos.test.ts`, `streamdeckKeys.test.ts`, `companionOAuthCodes.test.ts`, `counters.test.ts` to provide a working `withTransaction` alongside the existing mocked `getPool`, and `counterCache.test.ts`/`commandConflicts.test.ts` to mock the newly-imported `normalizeCommand`)
- [x] Existing transaction-behavior assertions (rollback-not-commit on not-found, rollback-and-rethrow on error, release-always-called) still pass unchanged against the refactored functions


---
_Generated by [Claude Code](https://claude.ai/code/session_01RBKcCSsAKKoryf1Zrv31dR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command normalization across custom commands, counters, caches, and reserved-command checks.
  * Improved handling of no-op updates and missing records.
  * Strengthened transaction handling for database operations, including reliable rollback and cleanup.
  * Improved conversion of stored boolean values and event configuration data.

* **Tests**
  * Expanded coverage for command normalization, transaction behavior, and update-result handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->