### PR TITLE
Dedup: consolidate web/routes boilerplate

### DIFF
--- a/src/web/routes/adminUserValidation.test.ts
+++ b/src/web/routes/adminUserValidation.test.ts
@@ -13,6 +13,7 @@ vi.mock('../../twitch/twitchChannelName', () => ({
 }));
 vi.mock('./shared', () => ({
   trimField: (v: unknown) => (typeof v === 'string' ? v.trim() : ''),
+  normalizeDiscordId: (v: unknown) => (typeof v === 'string' && /^\d{17,20}$/.test(v.trim()) ? v.trim() : null),
 }));
 vi.mock('./adminUserMutations', () => ({
   isLockWaitTimeoutDbError: vi.fn().mockReturnValue(false),

--- a/src/web/routes/adminUserValidation.ts
+++ b/src/web/routes/adminUserValidation.ts
@@ -1,12 +1,11 @@
 import { Request, Response } from 'express';
 import { createLogger } from '../../shared/logger';
 import { findUser, getMemberAccessLevel, AccessLevel } from '../../db';
-import { trimField } from './shared';
+import { trimField, normalizeDiscordId } from './shared';
 import { normalizeTwitchChannelName } from '../../twitch/twitchChannelName';
 import { isLockWaitTimeoutDbError } from './adminUserMutations';
 
 const log = createLogger('Web');
-const DISCORD_ID_RE = /^\d{17,20}$/;
 
 /**
  * Resolves the acting user's current guild from the session.
@@ -45,9 +44,12 @@ export function resolveValidDiscordId(res: Response, rawId: string | undefined):
   return trimmed;
 }
 
-/** Returns `'invalid_discord_id'` when `id` doesn't look like a Discord snowflake, else null. */
+/**
+ * Returns `'invalid_discord_id'` when `id` doesn't look like a Discord snowflake, else null.
+ * Derives its answer from `normalizeDiscordId` rather than maintaining a second snowflake regex.
+ */
 export function discordIdError(id: string): string | null {
-  return DISCORD_ID_RE.test(id) ? null : 'invalid_discord_id';
+  return normalizeDiscordId(id) ? null : 'invalid_discord_id';
 }
 
 /** Returns `'invalid_access_level'` when `levelStr` isn't a known `AccessLevel` value, else null. */

--- a/src/web/routes/api.ts
+++ b/src/web/routes/api.ts
@@ -3,11 +3,11 @@ import { Router, type Request, type Response } from 'express';
 import { getStatus } from '../../shared/statusStore';
 import { requireAuth, requireMod } from '../middleware';
 import { connect, disconnect, getCurrentChannelId } from '../../audio/audioPlayer';
-import { getDiscordClient } from '../../discord/discordBot';
 import { csrfProtection } from '../csrf';
 import { getAvailableVoiceChannels } from '../../discord/discordUtils';
 import { getGuildById } from '../../db';
 import { normalizeDiscordId } from './shared';
+import { getReadyDiscordClientOrRespond } from './streamdeckGuildResolution';
 
 const log = createLogger('API');
 const router = Router();
@@ -84,11 +84,8 @@ router.post('/voice/join', requireMod, csrfProtection, async (req, res) => {
   const guildId = getSessionGuildId(req, res);
   if (!guildId) return;
 
-  const discordClient = getDiscordClient();
-  if (!discordClient) {
-    res.status(503).json({ ok: false, error: 'Discord client not ready' });
-    return;
-  }
+  const discordClient = getReadyDiscordClientOrRespond(res);
+  if (!discordClient) return;
   try {
     const { channelId } = req.body as { channelId?: unknown };
     if (channelId !== undefined && typeof channelId !== 'string') {

--- a/src/web/routes/channelPointsAdminMutations.ts
+++ b/src/web/routes/channelPointsAdminMutations.ts
@@ -5,15 +5,18 @@ import { requireAuth } from '../middleware';
 import { updatePricingCooldownForReward } from '../../db';
 import { createCustomReward, updateCustomReward } from '../../twitch/twitchApi';
 import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
-import { logAndRedirectError } from './shared';
+import { logAndRedirectError, requireStreamer, parseRewardIdParam } from './shared';
 import {
-  requireStreamer, parseRewardIdParam, parseRewardFields, effectiveCooldownSeconds, handleRewardDeleteAction,
+  parseRewardFields, effectiveCooldownSeconds, handleRewardDeleteAction,
 } from './channelPointsAdminShared';
 import { deleteRewardAndPricing } from '../../twitch/pricing/rewardPricingService';
 import { router as pricingMutationsRouter } from './channelPointsAdminPricingMutations';
 
 const log = createLogger('ChannelPointsAdminMutations');
 export const router = Router();
+
+/** Redirect target used when the requester isn't a streamer, scoped to the channel-points admin page. */
+const NOT_A_STREAMER_REDIRECT = '/channel-points?error=not_a_streamer';
 
 /**
  * POST /channel-points/rewards — creates a new custom reward on Twitch.
@@ -25,7 +28,7 @@ export const router = Router();
  */
 router.post('/rewards', requireAuth, csrfProtection, async (req, res) => {
   try {
-    const streamer = await requireStreamer(req, res);
+    const streamer = await requireStreamer(req, res, NOT_A_STREAMER_REDIRECT);
     if (!streamer) return;
 
     const input = parseRewardFields(req.body as Record<string, string | string[] | undefined>);
@@ -55,7 +58,7 @@ router.post('/rewards', requireAuth, csrfProtection, async (req, res) => {
  */
 router.post('/rewards/:twitchRewardId', requireAuth, csrfProtection, async (req, res) => {
   try {
-    const streamer = await requireStreamer(req, res);
+    const streamer = await requireStreamer(req, res, NOT_A_STREAMER_REDIRECT);
     if (!streamer) return;
 
     const twitchRewardId = parseRewardIdParam(req.params.twitchRewardId);

--- a/src/web/routes/channelPointsAdminPricingMutations.ts
+++ b/src/web/routes/channelPointsAdminPricingMutations.ts
@@ -8,15 +8,18 @@ import {
 } from '../../db';
 import { getCustomRewards } from '../../twitch/twitchApi';
 import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
-import { logAndRedirectError } from './shared';
+import { logAndRedirectError, requireStreamer, parsePositiveIntId, parseRewardIdParam } from './shared';
 import {
-  requireStreamer, parsePositiveIntField, parseNonNegativeNumberField, parsePositiveNumberField,
-  parseCheckboxField, parseRoundToNearestField, parseRewardIdParam, effectiveCooldownSeconds, handleRewardDeleteAction,
+  parseNonNegativeNumberField, parsePositiveNumberField,
+  parseCheckboxField, parseRoundToNearestField, effectiveCooldownSeconds, handleRewardDeleteAction,
 } from './channelPointsAdminShared';
 import { applyDecayTick, resetAndDeletePricing } from '../../twitch/pricing/rewardPricingService';
 
 const log = createLogger('ChannelPointsAdminPricingMutations');
 export const router = Router();
+
+/** Redirect target used when the requester isn't a streamer, scoped to the channel-points admin page. */
+const NOT_A_STREAMER_REDIRECT = '/channel-points?error=not_a_streamer';
 
 /**
  * Determines the `cooldown_seconds` a saved pricing config should use: the reward's live Twitch
@@ -55,14 +58,14 @@ async function resolveCooldownSecondsForPricing(streamer: DbStreamerEventSub, tw
  */
 router.post('/rewards/:twitchRewardId/pricing', requireAuth, csrfProtection, async (req, res) => {
   try {
-    const streamer = await requireStreamer(req, res);
+    const streamer = await requireStreamer(req, res, NOT_A_STREAMER_REDIRECT);
     if (!streamer) return;
 
     const twitchRewardId = parseRewardIdParam(req.params.twitchRewardId);
     if (twitchRewardId === null) return res.redirect('/channel-points?error=invalid_reward_id');
 
     const body = req.body as Record<string, string | string[] | undefined>;
-    const baseCost = parsePositiveIntField(body.base_cost);
+    const baseCost = parsePositiveIntId(body.base_cost);
     const maxMultiplier = parseNonNegativeNumberField(body.max_multiplier);
     const curve = parsePositiveNumberField(body.curve);
     const roundToNearest = parseRoundToNearestField(body.round_to_nearest);
@@ -119,7 +122,7 @@ router.post('/rewards/:twitchRewardId/pricing/delete', requireAuth, csrfProtecti
  */
 router.post('/settings/pricing', requireAuth, csrfProtection, async (req, res) => {
   try {
-    const streamer = await requireStreamer(req, res);
+    const streamer = await requireStreamer(req, res, NOT_A_STREAMER_REDIRECT);
     if (!streamer) return;
 
     const body = req.body as Record<string, string | string[] | undefined>;

--- a/src/web/routes/channelPointsAdminShared.test.ts
+++ b/src/web/routes/channelPointsAdminShared.test.ts
@@ -4,8 +4,8 @@ vi.mock('../../db', () => ({ getStreamerByDiscordId: vi.fn(), DEFAULT_PRICING_CO
 
 import { getStreamerByDiscordId } from '../../db';
 import {
-  requireStreamer, parsePositiveIntField, parseNonNegativeNumberField, parsePositiveNumberField,
-  parseCheckboxField, parseHexColorField, parseRoundToNearestField, parseRewardIdParam, parseRewardFields,
+  parseNonNegativeNumberField, parsePositiveNumberField,
+  parseCheckboxField, parseHexColorField, parseRoundToNearestField, parseRewardFields,
   effectiveCooldownSeconds, handleRewardDeleteAction,
 } from './channelPointsAdminShared';
 
@@ -16,30 +16,8 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe('requireStreamer', () => {
-  function makeReqRes(discordId = '123') {
-    const req = { session: { user: { discordId } } } as any;
-    const res = { redirect: vi.fn() } as any;
-    return { req, res };
-  }
-
-  it('returns the streamer when found', async () => {
-    const streamer = { id: 1 };
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(streamer as any);
-    const { req, res } = makeReqRes();
-    const result = await requireStreamer(req, res);
-    expect(result).toBe(streamer);
-    expect(res.redirect).not.toHaveBeenCalled();
-  });
-
-  it('redirects to /channel-points?error=not_a_streamer and returns null when not found', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
-    const { req, res } = makeReqRes();
-    const result = await requireStreamer(req, res);
-    expect(result).toBeNull();
-    expect(res.redirect).toHaveBeenCalledWith('/channel-points?error=not_a_streamer');
-  });
-});
+// requireStreamer and parseRewardIdParam now live in (and are tested by) shared.test.ts —
+// this file only covers channelPointsAdminShared's own helpers plus their usage below.
 
 describe('handleRewardDeleteAction', () => {
   const streamer = { id: 1 };
@@ -84,36 +62,6 @@ describe('handleRewardDeleteAction', () => {
     await handleRewardDeleteAction(req, res, action, opts);
     expect(opts.log.error).toHaveBeenCalledWith(opts.errorLogLabel, expect.any(Error));
     expect(res.redirect).toHaveBeenCalledWith('/channel-points?error=delete_failed');
-  });
-});
-
-describe('parsePositiveIntField', () => {
-  it('accepts a positive integer string', () => {
-    expect(parsePositiveIntField('200')).toBe(200);
-  });
-
-  it('rejects an array (repeated field)', () => {
-    expect(parsePositiveIntField(['1', '2'])).toBeNull();
-  });
-
-  it('rejects zero', () => {
-    expect(parsePositiveIntField('0')).toBeNull();
-  });
-
-  it('rejects non-numeric input', () => {
-    expect(parsePositiveIntField('abc')).toBeNull();
-  });
-
-  it('rejects a decimal', () => {
-    expect(parsePositiveIntField('1.5')).toBeNull();
-  });
-
-  it('rejects undefined', () => {
-    expect(parsePositiveIntField(undefined)).toBeNull();
-  });
-
-  it('rejects an empty string', () => {
-    expect(parsePositiveIntField('')).toBeNull();
   });
 });
 
@@ -266,20 +214,6 @@ describe('effectiveCooldownSeconds', () => {
 
   it('falls back to the default when the reward has no global cooldown enabled', () => {
     expect(effectiveCooldownSeconds({ global_cooldown_setting: { is_enabled: false, global_cooldown_seconds: 999 } })).toBe(60);
-  });
-});
-
-describe('parseRewardIdParam', () => {
-  it('accepts a valid UUID', () => {
-    expect(parseRewardIdParam(VALID_REWARD_ID)).toBe(VALID_REWARD_ID);
-  });
-
-  it('rejects an array (repeated param)', () => {
-    expect(parseRewardIdParam([VALID_REWARD_ID, VALID_REWARD_ID])).toBeNull();
-  });
-
-  it('rejects a malformed string', () => {
-    expect(parseRewardIdParam('not-a-uuid')).toBeNull();
   });
 });
 

--- a/src/web/routes/channelPointsAdminShared.ts
+++ b/src/web/routes/channelPointsAdminShared.ts
@@ -1,24 +1,14 @@
 import type { Request, Response } from 'express';
 import type { Logger } from 'winston';
-import { getStreamerByDiscordId, DEFAULT_PRICING_COOLDOWN_SECONDS } from '../../db';
+import { DEFAULT_PRICING_COOLDOWN_SECONDS } from '../../db';
 import type { DbStreamerEventSub } from '../../db';
 import type { CustomRewardInput, TwitchCustomReward } from '../../twitch/twitchApi';
-import { trimField, logAndRedirectError } from './shared';
+import {
+  trimField, logAndRedirectError, requireStreamer, parsePositiveIntId, parseRewardIdParam,
+} from './shared';
 
-/**
- * Loads the requesting user's streamer record, redirecting to
- * `/channel-points?error=not_a_streamer` if they aren't one. Kept separate from
- * overlayAdminShared's requireStreamer (which redirects to `/overlay/settings`), so the two
- * admin pages stay fully decoupled.
- */
-export async function requireStreamer(req: Request, res: Response): Promise<DbStreamerEventSub | null> {
-  const streamer = await getStreamerByDiscordId(req.session.user!.discordId);
-  if (!streamer) {
-    res.redirect('/channel-points?error=not_a_streamer');
-    return null;
-  }
-  return streamer;
-}
+/** Redirect target used when the requester isn't a streamer, scoped to the channel-points admin page. */
+const NOT_A_STREAMER_REDIRECT = '/channel-points?error=not_a_streamer';
 
 /**
  * Shared body for reward-scoped "delete" routes (deleting a reward entirely, or just turning
@@ -34,7 +24,7 @@ export async function handleRewardDeleteAction(
   opts: { log: Logger; successCode: string; errorLogLabel: string; errorCode: string },
 ): Promise<void> {
   try {
-    const streamer = await requireStreamer(req, res);
+    const streamer = await requireStreamer(req, res, NOT_A_STREAMER_REDIRECT);
     if (!streamer) return;
 
     const twitchRewardId = parseRewardIdParam(req.params.twitchRewardId);
@@ -67,17 +57,6 @@ export function parseHexColorField(value: string | string[] | undefined): string
   const trimmed = typeof value === 'string' ? value.trim() : '';
   if (trimmed === '') return undefined;
   return /^#[0-9A-Fa-f]{6}$/.test(trimmed) ? trimmed : null;
-}
-
-/**
- * Parses a required positive integer form field (e.g. base_cost, cooldown_seconds).
- * Rejects arrays (repeated fields), non-numeric input, and non-positive values.
- */
-export function parsePositiveIntField(value: string | string[] | undefined): number | null {
-  if (Array.isArray(value)) return null;
-  if (typeof value !== 'string' || !/^\d+$/.test(value)) return null;
-  const parsed = Number(value);
-  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
 }
 
 /**
@@ -127,15 +106,8 @@ export function effectiveCooldownSeconds(reward: Pick<TwitchCustomReward, 'globa
     : DEFAULT_PRICING_COOLDOWN_SECONDS;
 }
 
-const REWARD_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const TITLE_MAX_LENGTH = 45; // Twitch's own limit for a custom reward's title
 const PROMPT_MAX_LENGTH = 200; // Twitch's own limit for a custom reward's prompt
-
-/** Extracts and validates a `:twitchRewardId` route param, or null if malformed/repeated. */
-export function parseRewardIdParam(value: string | string[]): string | null {
-  if (Array.isArray(value)) return null;
-  return REWARD_ID_RE.test(value) ? value : null;
-}
 
 /** True unless `condition` holds without `requirement` also holding — e.g. a limit's checkbox is checked but its numeric field is missing. */
 function impliesTruth(condition: boolean, requirement: boolean): boolean {
@@ -150,16 +122,16 @@ function impliesTruth(condition: boolean, requirement: boolean): boolean {
  */
 export function parseRewardFields(body: Record<string, string | string[] | undefined>): CustomRewardInput | null {
   const title = trimField(body.title);
-  const cost = parsePositiveIntField(body.cost);
+  const cost = parsePositiveIntId(body.cost);
   const prompt = trimField(body.prompt);
   const isUserInputRequired = parseCheckboxField(body.is_user_input_required);
   const backgroundColor = parseHexColorField(body.background_color); // null = malformed; undefined = not provided (fine)
   const isMaxPerStreamEnabled = parseCheckboxField(body.is_max_per_stream_enabled);
-  const maxPerStream = parsePositiveIntField(body.max_per_stream);
+  const maxPerStream = parsePositiveIntId(body.max_per_stream);
   const isMaxPerUserPerStreamEnabled = parseCheckboxField(body.is_max_per_user_per_stream_enabled);
-  const maxPerUserPerStream = parsePositiveIntField(body.max_per_user_per_stream);
+  const maxPerUserPerStream = parsePositiveIntId(body.max_per_user_per_stream);
   const isGlobalCooldownEnabled = parseCheckboxField(body.is_global_cooldown_enabled);
-  const globalCooldownSeconds = parsePositiveIntField(body.global_cooldown_seconds);
+  const globalCooldownSeconds = parsePositiveIntId(body.global_cooldown_seconds);
 
   const isValid = [
     title !== '' && title.length <= TITLE_MAX_LENGTH,

--- a/src/web/routes/commandMonitor.test.ts
+++ b/src/web/routes/commandMonitor.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Isolates this test from the real DB module — required at runtime only by shared.ts's
-// requireStreamer/handleReservedOrConflictCommandError, neither of which this route uses,
-// but a real (unmocked) import would otherwise try to build a live connection pool.
+/**
+ * Isolates this test from the real DB module — required at runtime only by shared.ts's
+ * requireStreamer/handleReservedOrConflictCommandError, neither of which this route uses,
+ * but a real (unmocked) import would otherwise try to build a live connection pool.
+ */
 vi.mock('../../db', () => ({}));
 
 vi.mock('../../commands/commandMonitorStore', () => ({

--- a/src/web/routes/commandMonitor.test.ts
+++ b/src/web/routes/commandMonitor.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+// Isolates this test from the real DB module — required at runtime only by shared.ts's
+// requireStreamer/handleReservedOrConflictCommandError, neither of which this route uses,
+// but a real (unmocked) import would otherwise try to build a live connection pool.
+vi.mock('../../db', () => ({}));
+
 vi.mock('../../commands/commandMonitorStore', () => ({
   getRecentCommandTestEntries: vi.fn().mockReturnValue([]),
 }));

--- a/src/web/routes/commandMutations.ts
+++ b/src/web/routes/commandMutations.ts
@@ -1,13 +1,11 @@
 import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
-import type { Response } from 'express';
 import {
   addCustomCommand,
   assignUserToCommand,
   CommandConflictError,
   CommandNotFoundError,
   isMysqlDuplicateEntryError,
-  ReservedCommandError,
   findUser,
   removeCustomCommand,
   updateCustomCommand,
@@ -20,22 +18,14 @@ import {
   normalizeSingleTokenRequiredText,
   parsePositiveIntId,
   normalizeDiscordId,
+  handleReservedOrConflictCommandError,
 } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
 
-function handleCommandWriteError(err: unknown, res: Response): boolean {
-  if (err instanceof ReservedCommandError) {
-    res.redirect('/commands?error=reserved_command');
-    return true;
-  }
-  if (err instanceof CommandConflictError || isMysqlDuplicateEntryError(err)) {
-    res.redirect('/commands?error=command_taken');
-    return true;
-  }
-  return false;
-}
+/** `handleReservedOrConflictCommandError` options scoped to the commands admin page. */
+const COMMAND_WRITE_ERROR_OPTIONS = { basePath: '/commands', conflictErrorCode: 'command_taken' };
 
 /** Assigns users to a newly created command.  On any failure, deletes the command
  *  to avoid leaving it in a partially-assigned state.  Returns an error code, or
@@ -87,7 +77,7 @@ router.post('/commands/add', requireMod, csrfProtection, async (req, res) => {
   try {
     commandId = await addCustomCommand(normalizedTriggerString, normalizedOutput, isDiscordEnabled, isMultiTwitch);
   } catch (err) {
-    if (handleCommandWriteError(err, res)) return;
+    if (handleReservedOrConflictCommandError(err, res, COMMAND_WRITE_ERROR_OPTIONS)) return;
     return logAndRedirectError({ res, log, logLabel: 'Add custom command error:', err, basePath: '/commands', errorCode: 'add_failed' });
   }
 
@@ -135,7 +125,7 @@ router.post('/commands/update', requireMod, csrfProtection, async (req, res) => 
     if (err instanceof CommandNotFoundError) {
       return res.redirect('/commands?error=command_not_found');
     }
-    if (handleCommandWriteError(err, res)) return;
+    if (handleReservedOrConflictCommandError(err, res, COMMAND_WRITE_ERROR_OPTIONS)) return;
     return logAndRedirectError({ res, log, logLabel: 'Update custom command error:', err, basePath: '/commands', errorCode: 'update_failed' });
   }
 

--- a/src/web/routes/counters.ts
+++ b/src/web/routes/counters.ts
@@ -1,12 +1,8 @@
 import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
-import type { Response } from 'express';
 import {
   addCounter,
-  CommandConflictError,
   CounterNotFoundError,
-  isMysqlDuplicateEntryError,
-  ReservedCommandError,
   getAllCounters,
   isCounterCommandTaken,
   removeCounter,
@@ -23,22 +19,14 @@ import {
   renderError,
   filterQueryParam,
   renderView,
+  handleReservedOrConflictCommandError,
 } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
 
-function handleCounterWriteError(err: unknown, res: Response): boolean {
-  if (err instanceof ReservedCommandError) {
-    res.redirect('/counters?error=reserved_command');
-    return true;
-  }
-  if (err instanceof CommandConflictError || isMysqlDuplicateEntryError(err)) {
-    res.redirect('/counters?error=duplicate_command');
-    return true;
-  }
-  return false;
-}
+/** `handleReservedOrConflictCommandError` options scoped to the counters admin page. */
+const COUNTER_WRITE_ERROR_OPTIONS = { basePath: '/counters', conflictErrorCode: 'duplicate_command' };
 
 const KNOWN_ERRORS = new Set([
   'missing_fields',
@@ -150,7 +138,7 @@ router.post('/counters/add', requireMod, csrfProtection, async (req, res) => {
       form.resetYearly,
     );
   } catch (err) {
-    if (handleCounterWriteError(err, res)) return;
+    if (handleReservedOrConflictCommandError(err, res, COUNTER_WRITE_ERROR_OPTIONS)) return;
     return logAndRedirectError({ res, log, logLabel: 'Add counter error:', err, basePath: '/counters', errorCode: 'add_failed' });
   }
 
@@ -202,7 +190,7 @@ router.post('/counters/update', requireMod, csrfProtection, async (req, res) => 
     if (err instanceof CounterNotFoundError) {
       return res.redirect('/counters?error=counter_not_found');
     }
-    if (handleCounterWriteError(err, res)) return;
+    if (handleReservedOrConflictCommandError(err, res, COUNTER_WRITE_ERROR_OPTIONS)) return;
     return logAndRedirectError({ res, log, logLabel: 'Update counter error:', err, basePath: '/counters', errorCode: 'update_failed' });
   }
 

--- a/src/web/routes/overlayAdminMutations.ts
+++ b/src/web/routes/overlayAdminMutations.ts
@@ -10,14 +10,16 @@ import { requireAuth } from '../middleware';
 import type { DbStreamerEventSub } from '../../db';
 import { addVideo, deleteVideo } from '../../db';
 import { OVERLAY_FOLDER, OVERLAY_MAX_FILE_MB } from '../../shared/config';
-import { logAndRedirectError, parsePositiveIntId } from './shared';
+import {
+  logAndRedirectError, parsePositiveIntId, requireStreamer, createMulterErrorRedirectHandler,
+} from './shared';
 import { safeResolve } from '../../shared/pathUtils';
-import { requireStreamer } from './overlayAdminShared';
-
-export { requireStreamer, toStringArray, parseWeight } from './overlayAdminShared';
 
 const log = createLogger('OverlayAdmin');
 export const router = Router();
+
+/** Redirect target used when the requester isn't a streamer, scoped to the overlay admin page. */
+const NOT_A_STREAMER_REDIRECT = '/overlay/settings?error=not_a_streamer';
 
 /** Maximum upload size in megabytes, passed to templates to avoid direct process.env access in EJS. */
 export const MAX_UPLOAD_MB = OVERLAY_MAX_FILE_MB;
@@ -73,16 +75,7 @@ async function saveVideoFile(streamer: DbStreamerEventSub, file: Express.Multer.
  * @returns true when `err` was an error and a redirect was sent (caller should
  *   stop); false when there was no error (caller should continue).
  */
-export function handleUploadError(err: unknown, res: Response): boolean {
-  if (!err) return false;
-  if (err instanceof multer.MulterError && err.code === 'LIMIT_FILE_SIZE') {
-    res.redirect('/overlay/settings?error=file_too_large');
-    return true;
-  }
-  log.error('Overlay upload middleware error:', err);
-  res.redirect('/overlay/settings?error=upload_failed');
-  return true;
-}
+export const handleUploadError = createMulterErrorRedirectHandler('/overlay/settings', log, 'Overlay upload middleware error:');
 
 /**
  * Express middleware that runs Multer's single-file (`video`) parser and, on a
@@ -117,7 +110,7 @@ function uploadVideo(req: Request, res: Response, next: NextFunction): void {
  */
 router.post('/settings/videos/upload', requireAuth, csrfProtection, uploadVideo, async (req, res) => {
   try {
-    const streamer = await requireStreamer(req, res);
+    const streamer = await requireStreamer(req, res, NOT_A_STREAMER_REDIRECT);
     if (!streamer) return;
     if (!req.file) return res.redirect('/overlay/settings?error=invalid_file');
     const name = (typeof req.body?.name === 'string' ? req.body.name.trim().slice(0, 100) : '') || req.file.originalname.trim().slice(0, 100);
@@ -142,7 +135,7 @@ router.post('/settings/videos/upload', requireAuth, csrfProtection, uploadVideo,
  */
 router.post('/settings/videos/:id/delete', requireAuth, csrfProtection, async (req, res) => {
   try {
-    const streamer = await requireStreamer(req, res);
+    const streamer = await requireStreamer(req, res, NOT_A_STREAMER_REDIRECT);
     if (!streamer) return;
 
     const videoId = parsePositiveIntId(req.params.id);

--- a/src/web/routes/overlayAdminRewardMutations.ts
+++ b/src/web/routes/overlayAdminRewardMutations.ts
@@ -3,11 +3,16 @@ import { Router } from 'express';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
 import { upsertReward, setRewardVideos, deleteReward } from '../../db';
-import { logAndRedirectError, parsePositiveIntId } from './shared';
-import { requireStreamer, toStringArray, parseWeight } from './overlayAdminShared';
+import {
+  logAndRedirectError, parsePositiveIntId, requireStreamer, parseWeight, parseRewardIdParam,
+} from './shared';
+import { toStringArray } from './overlayAdminShared';
 
 const log = createLogger('OverlayAdminReward');
 export const router = Router();
+
+/** Redirect target used when the requester isn't a streamer, scoped to the overlay admin page. */
+const NOT_A_STREAMER_REDIRECT = '/overlay/settings?error=not_a_streamer';
 
 /**
  * POST /overlay/settings/rewards — creates or updates a reward assignment,
@@ -22,13 +27,14 @@ export const router = Router();
  */
 router.post('/settings/rewards', requireAuth, csrfProtection, async (req, res) => {
   try {
-    const streamer = await requireStreamer(req, res);
+    const streamer = await requireStreamer(req, res, NOT_A_STREAMER_REDIRECT);
     if (!streamer) return;
 
     const body = req.body as Record<string, string | string[] | undefined>;
-    const twitchRewardId = (typeof body.twitch_reward_id === 'string' ? body.twitch_reward_id : '').trim();
+    const rawTwitchRewardId = (typeof body.twitch_reward_id === 'string' ? body.twitch_reward_id : '').trim();
+    const twitchRewardId = parseRewardIdParam(rawTwitchRewardId);
 
-    if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(twitchRewardId)) {
+    if (twitchRewardId === null) {
       return res.redirect('/overlay/settings?error=invalid_reward_id');
     }
 
@@ -60,7 +66,7 @@ router.post('/settings/rewards', requireAuth, csrfProtection, async (req, res) =
  */
 router.post('/settings/rewards/:id/delete', requireAuth, csrfProtection, async (req, res) => {
   try {
-    const streamer = await requireStreamer(req, res);
+    const streamer = await requireStreamer(req, res, NOT_A_STREAMER_REDIRECT);
     if (!streamer) return;
 
     const rewardId = parsePositiveIntId(req.params.id);

--- a/src/web/routes/overlayAdminShared.test.ts
+++ b/src/web/routes/overlayAdminShared.test.ts
@@ -1,60 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 
-vi.mock('../../db', () => ({
-  getStreamerByDiscordId: vi.fn(),
-}));
-vi.mock('../../shared/logger', () => ({
-  createLogger: () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn() }),
-}));
+import { toStringArray } from './overlayAdminShared';
 
-import { getStreamerByDiscordId } from '../../db';
-import { requireStreamer, toStringArray, parseWeight } from './overlayAdminShared';
-import type { Request, Response } from 'express';
-
-function makeReq(discordId: string): Request {
-  return {
-    session: { user: { discordId } },
-  } as unknown as Request;
-}
-
-function makeRes() {
-  const redirect = vi.fn();
-  return { res: { redirect } as unknown as Response, redirect };
-}
-
-// ─── requireStreamer ──────────────────────────────────────────────────────────
-
-describe('requireStreamer', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it('returns the streamer when found', async () => {
-    const streamer = { id: 1, twitch_name: 'mystreamer' };
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(streamer as any);
-    const req = makeReq('100000000000000001');
-    const { res } = makeRes();
-    const result = await requireStreamer(req, res);
-    expect(result).toBe(streamer);
-  });
-
-  it('redirects and returns null when streamer is not found', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
-    const req = makeReq('100000000000000001');
-    const { res, redirect } = makeRes();
-    const result = await requireStreamer(req, res);
-    expect(result).toBeNull();
-    expect(redirect).toHaveBeenCalledWith('/overlay/settings?error=not_a_streamer');
-  });
-
-  it('calls getStreamerByDiscordId with the session user\'s discordId', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
-    const req = makeReq('200000000000000002');
-    const { res } = makeRes();
-    await requireStreamer(req, res);
-    expect(getStreamerByDiscordId).toHaveBeenCalledWith('200000000000000002');
-  });
-});
+// requireStreamer and parseWeight now live in (and are tested by) shared.test.ts.
 
 // ─── toStringArray ────────────────────────────────────────────────────────────
 
@@ -77,57 +25,5 @@ describe('toStringArray', () => {
 
   it('preserves an empty array input', () => {
     expect(toStringArray([])).toEqual([]);
-  });
-});
-
-// ─── parseWeight ─────────────────────────────────────────────────────────────
-
-describe('parseWeight', () => {
-  it('returns null for undefined', () => {
-    expect(parseWeight(undefined)).toBeNull();
-  });
-
-  it('returns null for a non-numeric string', () => {
-    expect(parseWeight('abc')).toBeNull();
-  });
-
-  it('returns null for zero', () => {
-    expect(parseWeight('0')).toBeNull();
-  });
-
-  it('returns null for a negative number', () => {
-    expect(parseWeight('-5')).toBeNull();
-  });
-
-  it('returns the parsed integer for a valid positive number', () => {
-    expect(parseWeight('10')).toBe(10);
-  });
-
-  it('floors a float string', () => {
-    expect(parseWeight('3.9')).toBe(3);
-  });
-
-  it('floors a float close to the next integer', () => {
-    expect(parseWeight('2.99')).toBe(2);
-  });
-
-  it('returns null for an array (repeated field)', () => {
-    expect(parseWeight(['7', '99'])).toBeNull();
-  });
-
-  it('returns null for an array with a non-numeric first element', () => {
-    expect(parseWeight(['abc'])).toBeNull();
-  });
-
-  it('returns null for an empty array', () => {
-    expect(parseWeight([])).toBeNull();
-  });
-
-  it('returns null for Infinity (not finite)', () => {
-    expect(parseWeight('Infinity')).toBeNull();
-  });
-
-  it('returns null for a single-element array (repeated field)', () => {
-    expect(parseWeight(['7'])).toBeNull();
   });
 });

--- a/src/web/routes/overlayAdminShared.ts
+++ b/src/web/routes/overlayAdminShared.ts
@@ -1,32 +1,10 @@
-import type { Request, Response } from 'express';
-import { getStreamerByDiscordId } from '../../db';
-import type { DbStreamerEventSub } from '../../db';
-
-export async function requireStreamer(req: Request, res: Response): Promise<DbStreamerEventSub | null> {
-  const streamer = await getStreamerByDiscordId(req.session.user!.discordId);
-  if (!streamer) {
-    res.redirect('/overlay/settings?error=not_a_streamer');
-    return null;
-  }
-  return streamer;
-}
-
+/**
+ * Normalizes a form field that may arrive as a single string or an array of strings
+ * (Express's behaviour for repeated field names) into a string array.
+ * @param value - Raw value from a form field.
+ * @returns The value as a string array; empty when `value` is missing/blank.
+ */
 export function toStringArray(value: string | string[] | undefined): string[] {
   if (Array.isArray(value)) return value;
   return value ? [value] : [];
-}
-
-/**
- * Parse a weight form field into a positive integer ≥ 1 (floored), or null when
- * the value is missing, non-numeric, not positive, or an array (repeated field).
- * Rejecting arrays is consistent with parsePositiveIntId — a duplicated weight
- * field can't slip through silently.
- * @param raw - Raw value from a form field.
- * @returns A positive integer weight, or null when invalid.
- */
-export function parseWeight(raw: string | string[] | undefined): number | null {
-  if (Array.isArray(raw)) return null;
-  const n = Number(raw);
-  if (!Number.isFinite(n) || n < 1) return null;
-  return Math.floor(n);
 }

--- a/src/web/routes/privacy.test.ts
+++ b/src/web/routes/privacy.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-// Isolates this test from the real DB module — required at runtime only by shared.ts's
-// requireStreamer/handleReservedOrConflictCommandError, neither of which this route uses,
-// but a real (unmocked) import would otherwise try to build a live connection pool.
+/**
+ * Isolates this test from the real DB module — required at runtime only by shared.ts's
+ * requireStreamer/handleReservedOrConflictCommandError, neither of which this route uses,
+ * but a real (unmocked) import would otherwise try to build a live connection pool.
+ */
 vi.mock('../../db', () => ({}));
 
 import express from 'express';

--- a/src/web/routes/privacy.test.ts
+++ b/src/web/routes/privacy.test.ts
@@ -1,4 +1,10 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Isolates this test from the real DB module — required at runtime only by shared.ts's
+// requireStreamer/handleReservedOrConflictCommandError, neither of which this route uses,
+// but a real (unmocked) import would otherwise try to build a live connection pool.
+vi.mock('../../db', () => ({}));
+
 import express from 'express';
 import supertest from 'supertest';
 import privacyRouter from './privacy';

--- a/src/web/routes/sfxFileMutations.ts
+++ b/src/web/routes/sfxFileMutations.ts
@@ -4,7 +4,7 @@ import { updateSfxFile, deleteSfxFile } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireMod } from '../middleware';
 import { logAndRedirectError, parsePositiveIntId } from './shared';
-import { removeSfxFiles, parseWeight } from './sfxMutationsShared';
+import { removeSfxFiles } from './sfxMutationsShared';
 
 const log = createLogger('Web');
 const router = Router();
@@ -21,7 +21,7 @@ router.post('/sfx/file/update', requireMod, csrfProtection, async (req, res) => 
   const fileId = parsePositiveIntId(req.body.file_id);
   if (fileId === null) return res.redirect('/sfx?error=invalid_id');
 
-  const weight = parseWeight(req.body.weight);
+  const weight = parsePositiveIntId(req.body.weight);
   if (weight === null) return res.redirect('/sfx?error=invalid_weight');
   const hidden = req.body.file_hidden === 'on';
 

--- a/src/web/routes/sfxFileUpload.ts
+++ b/src/web/routes/sfxFileUpload.ts
@@ -9,8 +9,7 @@ import { csrfProtection } from '../csrf';
 import { requireMod } from '../middleware';
 import { SFX_FOLDER, SFX_MAX_FILE_MB } from '../../shared/config';
 import { safeResolve } from '../../shared/pathUtils';
-import { parsePositiveIntId } from './shared';
-import { parseWeight } from './sfxMutationsShared';
+import { parsePositiveIntId, createMulterErrorRedirectHandler } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
@@ -196,16 +195,7 @@ async function persistUploadedSound(
  * @returns true when `err` was an error and a redirect was sent (caller should
  *   stop); false when there was no error (caller should continue).
  */
-export function handleUploadError(err: unknown, res: Response): boolean {
-  if (!err) return false;
-  if (err instanceof multer.MulterError && err.code === 'LIMIT_FILE_SIZE') {
-    res.redirect('/sfx?error=file_too_large');
-    return true;
-  }
-  log.error('SFX upload middleware error:', err);
-  res.redirect('/sfx?error=upload_failed');
-  return true;
-}
+export const handleUploadError = createMulterErrorRedirectHandler('/sfx', log, 'SFX upload middleware error:');
 
 /**
  * Express middleware that runs Multer's single-file (`sound`) parser and, on a
@@ -239,7 +229,7 @@ router.post('/sfx/file/upload', requireMod, csrfProtection, uploadSound, async (
   if (triggerId === null) return res.redirect('/sfx?error=invalid_id');
   if (!req.file) return res.redirect('/sfx?error=invalid_file');
 
-  const weight = parseWeight(req.body.weight);
+  const weight = parsePositiveIntId(req.body.weight);
   if (weight === null) return res.redirect('/sfx?error=invalid_weight');
   const hidden = req.body.file_hidden === 'on';
 

--- a/src/web/routes/sfxMutationsShared.ts
+++ b/src/web/routes/sfxMutationsShared.ts
@@ -22,18 +22,3 @@ export async function removeSfxFiles(files: string[]): Promise<void> {
   }
 }
 
-/**
- * Parse a weight form field into a positive integer, or null when the value is
- * missing/non-numeric/non-positive. Requires the whole string to be digits (an
- * exact integer) so partially-numeric input like `1abc` or `1.5` is rejected
- * rather than truncated to 1 by `parseInt`. Returning null (rather than
- * defaulting to 1) lets callers reject a malformed update instead of silently
- * overwriting the stored weight.
- * @param value Raw `weight` form field.
- * @returns A positive integer weight, or null when invalid.
- */
-export function parseWeight(value: unknown): number | null {
-  if (typeof value !== 'string' || !/^\d+$/.test(value)) return null;
-  const parsed = Number(value);
-  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
-}

--- a/src/web/routes/shared.test.ts
+++ b/src/web/routes/shared.test.ts
@@ -1,10 +1,28 @@
 import { describe, it, expect, vi } from 'vitest';
+import multer from 'multer';
 import type { Response } from 'express';
 import type { SessionUser } from '../../types/express';
 
 vi.mock('../../db/users', () => ({ AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 } }));
 
+vi.mock('../../db', () => {
+  class ReservedCommandError extends Error {}
+  class CommandConflictError extends Error {}
+  return {
+    getStreamerByDiscordId: vi.fn(),
+    ReservedCommandError,
+    CommandConflictError,
+    isMysqlDuplicateEntryError: vi.fn().mockReturnValue(false),
+  };
+});
+
 import { AccessLevel } from '../../db/users';
+import {
+  getStreamerByDiscordId,
+  ReservedCommandError,
+  CommandConflictError,
+  isMysqlDuplicateEntryError,
+} from '../../db';
 import {
   parsePositiveIntId,
   trimField,
@@ -15,6 +33,11 @@ import {
   renderView,
   filterQueryParam,
   logAndRedirectError,
+  requireStreamer,
+  parseWeight,
+  parseRewardIdParam,
+  handleReservedOrConflictCommandError,
+  createMulterErrorRedirectHandler,
 } from './shared';
 
 describe('parsePositiveIntId', () => {
@@ -361,5 +384,191 @@ describe('logAndRedirectError', () => {
     logAndRedirectError({ res, log, logLabel: 'Remove error:', err: 'not an error object', basePath: '/counters', errorCode: 'remove_failed' });
     expect(error).toHaveBeenCalledWith('Remove error:', 'not an error object');
     expect(redirect).toHaveBeenCalledWith('/counters?error=remove_failed');
+  });
+});
+
+describe('requireStreamer', () => {
+  function makeReqRes(discordId = '123') {
+    const req = { session: { user: { discordId } } } as any;
+    const res = { redirect: vi.fn() } as any;
+    return { req, res };
+  }
+
+  it('returns the streamer when found', async () => {
+    const streamer = { id: 1 };
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(streamer as any);
+    const { req, res } = makeReqRes();
+    const result = await requireStreamer(req, res, '/channel-points?error=not_a_streamer');
+    expect(result).toBe(streamer);
+    expect(res.redirect).not.toHaveBeenCalled();
+  });
+
+  it('redirects to the caller-supplied path and returns null when not found', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
+    const { req, res } = makeReqRes();
+    const result = await requireStreamer(req, res, '/overlay/settings?error=not_a_streamer');
+    expect(result).toBeNull();
+    expect(res.redirect).toHaveBeenCalledWith('/overlay/settings?error=not_a_streamer');
+  });
+
+  it("calls getStreamerByDiscordId with the session user's discordId", async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
+    const { req, res } = makeReqRes('200000000000000002');
+    await requireStreamer(req, res, '/channel-points?error=not_a_streamer');
+    expect(getStreamerByDiscordId).toHaveBeenCalledWith('200000000000000002');
+  });
+});
+
+describe('parseWeight', () => {
+  it('returns null for undefined', () => {
+    expect(parseWeight(undefined)).toBeNull();
+  });
+
+  it('returns null for a non-numeric string', () => {
+    expect(parseWeight('abc')).toBeNull();
+  });
+
+  it('returns null for zero', () => {
+    expect(parseWeight('0')).toBeNull();
+  });
+
+  it('returns null for a negative number', () => {
+    expect(parseWeight('-5')).toBeNull();
+  });
+
+  it('returns the parsed integer for a valid positive number', () => {
+    expect(parseWeight('10')).toBe(10);
+  });
+
+  it('floors a float string', () => {
+    expect(parseWeight('3.9')).toBe(3);
+  });
+
+  it('floors a float close to the next integer', () => {
+    expect(parseWeight('2.99')).toBe(2);
+  });
+
+  it('returns null for an array (repeated field)', () => {
+    expect(parseWeight(['7', '99'])).toBeNull();
+  });
+
+  it('returns null for an array with a non-numeric first element', () => {
+    expect(parseWeight(['abc'])).toBeNull();
+  });
+
+  it('returns null for an empty array', () => {
+    expect(parseWeight([])).toBeNull();
+  });
+
+  it('returns null for Infinity (not finite)', () => {
+    expect(parseWeight('Infinity')).toBeNull();
+  });
+
+  it('returns null for a single-element array (repeated field)', () => {
+    expect(parseWeight(['7'])).toBeNull();
+  });
+});
+
+describe('parseRewardIdParam', () => {
+  const VALID_REWARD_ID = '12345678-1234-1234-8234-123456789abc';
+
+  it('accepts a valid UUID', () => {
+    expect(parseRewardIdParam(VALID_REWARD_ID)).toBe(VALID_REWARD_ID);
+  });
+
+  it('rejects an array (repeated param)', () => {
+    expect(parseRewardIdParam([VALID_REWARD_ID, VALID_REWARD_ID])).toBeNull();
+  });
+
+  it('rejects a malformed string', () => {
+    expect(parseRewardIdParam('not-a-uuid')).toBeNull();
+  });
+});
+
+describe('handleReservedOrConflictCommandError', () => {
+  function mockRes() {
+    const redirect = vi.fn();
+    return { res: { redirect } as unknown as Response, redirect };
+  }
+
+  const OPTIONS = { basePath: '/commands', conflictErrorCode: 'command_taken' };
+
+  it('redirects to basePath?error=reserved_command for a ReservedCommandError and returns true', () => {
+    const { res, redirect } = mockRes();
+    const handled = handleReservedOrConflictCommandError(new ReservedCommandError('reserved'), res, OPTIONS);
+    expect(handled).toBe(true);
+    expect(redirect).toHaveBeenCalledWith('/commands?error=reserved_command');
+  });
+
+  it('redirects to basePath?error=<conflictErrorCode> for a CommandConflictError and returns true', () => {
+    const { res, redirect } = mockRes();
+    const handled = handleReservedOrConflictCommandError(new CommandConflictError(['conflict']), res, OPTIONS);
+    expect(handled).toBe(true);
+    expect(redirect).toHaveBeenCalledWith('/commands?error=command_taken');
+  });
+
+  it('redirects to basePath?error=<conflictErrorCode> for a raw MySQL duplicate-entry error and returns true', () => {
+    vi.mocked(isMysqlDuplicateEntryError).mockReturnValueOnce(true);
+    const { res, redirect } = mockRes();
+    const handled = handleReservedOrConflictCommandError(new Error('ER_DUP_ENTRY'), res, OPTIONS);
+    expect(handled).toBe(true);
+    expect(redirect).toHaveBeenCalledWith('/commands?error=command_taken');
+  });
+
+  it('returns false and does not redirect for an unrelated error', () => {
+    const { res, redirect } = mockRes();
+    const handled = handleReservedOrConflictCommandError(new Error('boom'), res, OPTIONS);
+    expect(handled).toBe(false);
+    expect(redirect).not.toHaveBeenCalled();
+  });
+
+  it('uses the caller-supplied basePath and conflictErrorCode', () => {
+    const { res, redirect } = mockRes();
+    handleReservedOrConflictCommandError(
+      new CommandConflictError(['conflict']),
+      res,
+      { basePath: '/counters', conflictErrorCode: 'duplicate_command' },
+    );
+    expect(redirect).toHaveBeenCalledWith('/counters?error=duplicate_command');
+  });
+});
+
+describe('createMulterErrorRedirectHandler', () => {
+  function mockRes() {
+    const redirect = vi.fn();
+    return { res: { redirect } as unknown as Response, redirect };
+  }
+
+  function mockLog() {
+    const error = vi.fn();
+    return { log: { error } as unknown as import('winston').Logger, error };
+  }
+
+  it('returns false and does not redirect when there is no error', () => {
+    const { log } = mockLog();
+    const { res, redirect } = mockRes();
+    const handler = createMulterErrorRedirectHandler('/sfx', log, 'SFX upload middleware error:');
+    expect(handler(null, res)).toBe(false);
+    expect(redirect).not.toHaveBeenCalled();
+  });
+
+  it('redirects oversized files to file_too_large without logging', () => {
+    const { log, error } = mockLog();
+    const { res, redirect } = mockRes();
+    const handler = createMulterErrorRedirectHandler('/sfx', log, 'SFX upload middleware error:');
+    const err = new multer.MulterError('LIMIT_FILE_SIZE', 'sound');
+    expect(handler(err, res)).toBe(true);
+    expect(redirect).toHaveBeenCalledWith('/sfx?error=file_too_large');
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it('logs and redirects other errors to upload_failed, using the caller-supplied basePath and log label', () => {
+    const { log, error } = mockLog();
+    const { res, redirect } = mockRes();
+    const handler = createMulterErrorRedirectHandler('/overlay/settings', log, 'Overlay upload middleware error:');
+    const err = new Error('boom');
+    expect(handler(err, res)).toBe(true);
+    expect(error).toHaveBeenCalledWith('Overlay upload middleware error:', err);
+    expect(redirect).toHaveBeenCalledWith('/overlay/settings?error=upload_failed');
   });
 });

--- a/src/web/routes/shared.ts
+++ b/src/web/routes/shared.ts
@@ -1,8 +1,16 @@
 import fs from 'fs';
 import path from 'path';
-import type { Response } from 'express';
+import multer from 'multer';
+import type { Request, Response } from 'express';
 import type { Logger } from 'winston';
 import type { SessionUser } from '../../types/express';
+import {
+  getStreamerByDiscordId,
+  ReservedCommandError,
+  CommandConflictError,
+  isMysqlDuplicateEntryError,
+} from '../../db';
+import type { DbStreamerEventSub } from '../../db';
 
 const VIEWS_DIR = path.join(__dirname, '../../../views');
 let knownViews: Set<string> | undefined;
@@ -41,6 +49,45 @@ export function parsePositiveBigIntId(value: string | string[] | undefined): big
   if (typeof value !== 'string' || !/^\d+$/.test(value)) return null;
   const parsed = BigInt(value);
   return parsed > 0n ? parsed : null;
+}
+
+/**
+ * Loads the requesting user's streamer record, redirecting to `notAStreamerRedirectPath`
+ * if they aren't one. Shared by every streamer-scoped admin page (channel points, overlay
+ * settings), each of which passes its own not-a-streamer error redirect so the pages stay
+ * decoupled from one another.
+ * @param req - Express request; reads `session.user.discordId`.
+ * @param res - Express response, used to redirect on failure.
+ * @param notAStreamerRedirectPath - Full redirect target (path + query string) to use when
+ *   the requester has no streamer record.
+ * @returns The streamer record, or `null` if the response has already been redirected.
+ */
+export async function requireStreamer(
+  req: Request,
+  res: Response,
+  notAStreamerRedirectPath: string,
+): Promise<DbStreamerEventSub | null> {
+  const streamer = await getStreamerByDiscordId(req.session.user!.discordId);
+  if (!streamer) {
+    res.redirect(notAStreamerRedirectPath);
+    return null;
+  }
+  return streamer;
+}
+
+/**
+ * Parse a weight form field into a positive integer ≥ 1 (floored), or null when
+ * the value is missing, non-numeric, not positive, or an array (repeated field).
+ * Rejecting arrays is consistent with `parsePositiveIntId` — a duplicated weight
+ * field can't slip through silently.
+ * @param raw - Raw value from a form field.
+ * @returns A positive integer weight, or null when invalid.
+ */
+export function parseWeight(raw: string | string[] | undefined): number | null {
+  if (Array.isArray(raw)) return null;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 1) return null;
+  return Math.floor(n);
 }
 
 /**
@@ -244,4 +291,80 @@ export function logAndRedirectError({
 }: LogAndRedirectErrorOptions): void {
   log.error(logLabel, err);
   res.redirect(`${basePath}?error=${errorCode}`);
+}
+
+/**
+ * Regex for a Twitch custom reward's UUID (v1–v5, RFC 4122 variant), used to validate
+ * `:twitchRewardId` route params and reward-id form fields.
+ */
+const REWARD_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/** Extracts and validates a Twitch reward UUID, or null if malformed/repeated (an array value). */
+export function parseRewardIdParam(value: string | string[]): string | null {
+  if (Array.isArray(value)) return null;
+  return REWARD_ID_RE.test(value) ? value : null;
+}
+
+/** Arguments for {@link handleReservedOrConflictCommandError}. */
+export interface ReservedOrConflictCommandErrorOptions {
+  /** Path to redirect to, without query string (e.g. `/commands`). */
+  basePath: string;
+  /** Value for the `error` query parameter used when the trigger is already taken
+   *  (e.g. `command_taken`, `duplicate_command`). */
+  conflictErrorCode: string;
+}
+
+/**
+ * Handles the two "expected" write errors shared by commands and counters — a reserved
+ * trigger name, or a trigger already taken by another command/counter (either a thrown
+ * `CommandConflictError` or a raw MySQL duplicate-entry error) — redirecting to
+ * `basePath?error=reserved_command` or `basePath?error=<conflictErrorCode>` respectively.
+ * @param err - The caught error.
+ * @param res - Express response, used to redirect when `err` is one of the handled cases.
+ * @param options - See {@link ReservedOrConflictCommandErrorOptions}.
+ * @returns true when `err` was handled and a redirect was sent (caller should stop);
+ *   false when `err` is some other error the caller should still handle itself.
+ */
+export function handleReservedOrConflictCommandError(
+  err: unknown,
+  res: Response,
+  { basePath, conflictErrorCode }: ReservedOrConflictCommandErrorOptions,
+): boolean {
+  if (err instanceof ReservedCommandError) {
+    res.redirect(`${basePath}?error=reserved_command`);
+    return true;
+  }
+  if (err instanceof CommandConflictError || isMysqlDuplicateEntryError(err)) {
+    res.redirect(`${basePath}?error=${conflictErrorCode}`);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Builds a Multer error-handling callback that translates an oversized-file error
+ * (`LIMIT_FILE_SIZE`) into a `file_too_large` redirect, and any other Multer/middleware
+ * error into a logged `upload_failed` redirect — instead of letting either reach the
+ * centralised 500 handler. Shared by every file-upload route (SFX sounds, overlay videos).
+ * @param basePath - Path to redirect to, without query string (e.g. `/sfx`).
+ * @param log - Logger to record non-size-limit errors on.
+ * @param logLabel - Message prefix passed to `log.error`.
+ * @returns A handler: true when `err` was an error and a redirect was sent (caller should
+ *   stop); false when there was no error (caller should continue).
+ */
+export function createMulterErrorRedirectHandler(
+  basePath: string,
+  log: Logger,
+  logLabel: string,
+): (err: unknown, res: Response) => boolean {
+  return (err: unknown, res: Response): boolean => {
+    if (!err) return false;
+    if (err instanceof multer.MulterError && err.code === 'LIMIT_FILE_SIZE') {
+      res.redirect(`${basePath}?error=file_too_large`);
+      return true;
+    }
+    log.error(logLabel, err);
+    res.redirect(`${basePath}?error=upload_failed`);
+    return true;
+  };
 }

--- a/src/web/routes/shared.ts
+++ b/src/web/routes/shared.ts
@@ -299,7 +299,11 @@ export function logAndRedirectError({
  */
 const REWARD_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-/** Extracts and validates a Twitch reward UUID, or null if malformed/repeated (an array value). */
+/**
+ * Extracts and validates a Twitch reward UUID.
+ * @param value - The `:twitchRewardId` route param or form field value.
+ * @returns The validated UUID, or null if malformed or repeated (an array value).
+ */
 export function parseRewardIdParam(value: string | string[]): string | null {
   if (Array.isArray(value)) return null;
   return REWARD_ID_RE.test(value) ? value : null;

--- a/src/web/routes/streamdeckGuildResolution.test.ts
+++ b/src/web/routes/streamdeckGuildResolution.test.ts
@@ -8,13 +8,19 @@ vi.mock('../../discord/voicePresence', () => ({
   getActiveGuildForUser: vi.fn(),
 }));
 
+vi.mock('../../discord/discordBot', () => ({
+  getDiscordClient: vi.fn(),
+}));
+
 import { isKeyApprovedForGuild } from '../../db';
 import { getActiveGuildForUser } from '../../discord/voicePresence';
+import { getDiscordClient } from '../../discord/discordBot';
 import {
   resolveGuildIdFromChannelId,
   ensureGuildApproved,
   resolveChannelGuildOrRespond,
   resolvePresenceGuildOrRespond,
+  getReadyDiscordClientOrRespond,
 } from './streamdeckGuildResolution';
 
 const API_KEY_OWNER = 'user-1';
@@ -120,5 +126,23 @@ describe('resolvePresenceGuildOrRespond', () => {
     const client = makeClient();
     await expect(resolvePresenceGuildOrRespond(req, res, client)).resolves.toBeNull();
     expect(res.status).toHaveBeenCalledWith(403);
+  });
+});
+
+describe('getReadyDiscordClientOrRespond', () => {
+  it('returns the client when it is ready', () => {
+    const client = makeClient();
+    vi.mocked(getDiscordClient).mockReturnValue(client);
+    const { res } = makeReqRes();
+    expect(getReadyDiscordClientOrRespond(res)).toBe(client);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('returns null and sends 503 when the client is not ready', () => {
+    vi.mocked(getDiscordClient).mockReturnValue(null);
+    const { res } = makeReqRes();
+    expect(getReadyDiscordClientOrRespond(res)).toBeNull();
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith({ ok: false, error: 'Discord client not ready' });
   });
 });

--- a/src/web/routes/streamdeckGuildResolution.ts
+++ b/src/web/routes/streamdeckGuildResolution.ts
@@ -2,6 +2,23 @@ import { Request, Response } from 'express';
 import { Client } from 'discord.js';
 import { isKeyApprovedForGuild } from '../../db';
 import { getActiveGuildForUser } from '../../discord/voicePresence';
+import { getDiscordClient } from '../../discord/discordBot';
+
+/**
+ * Returns the ready Discord client, or sends a 503 JSON error response and returns
+ * null if the client isn't connected yet. Consolidates the "Discord client not ready"
+ * check duplicated across the REST API and Streamdeck voice/SFX routes.
+ * @param res - Express response, used to send the 503 when the client isn't ready.
+ * @returns The ready Discord client, or null if a 503 response was already sent.
+ */
+export function getReadyDiscordClientOrRespond(res: Response): Client | null {
+  const client = getDiscordClient();
+  if (!client) {
+    res.status(503).json({ ok: false, error: 'Discord client not ready' });
+    return null;
+  }
+  return client;
+}
 
 /**
  * Resolves which guild a voice-channel ID belongs to, or null if the channel

--- a/src/web/routes/streamdeckSfx.ts
+++ b/src/web/routes/streamdeckSfx.ts
@@ -5,8 +5,7 @@ import { pickWeightedRandom } from '../../commands/soundSelector';
 import { playFile, VoiceNotConnectedError } from '../../audio/sfxPlayer';
 import { setVoicePlaying } from '../../shared/statusStore';
 import { requireApiKey } from '../middleware';
-import { getDiscordClient } from '../../discord/discordBot';
-import { resolvePresenceGuildOrRespond } from './streamdeckGuildResolution';
+import { resolvePresenceGuildOrRespond, getReadyDiscordClientOrRespond } from './streamdeckGuildResolution';
 
 const log = createLogger('Streamdeck');
 const router = Router();
@@ -43,11 +42,8 @@ router.post('/sfx', requireApiKey, async (req, res) => {
     return;
   }
 
-  const discordClient = getDiscordClient();
-  if (!discordClient) {
-    res.status(503).json({ ok: false, error: 'Discord client not ready' });
-    return;
-  }
+  const discordClient = getReadyDiscordClientOrRespond(res);
+  if (!discordClient) return;
   const guildId = await resolvePresenceGuildOrRespond(req, res, discordClient);
   if (!guildId) return;
 

--- a/src/web/routes/streamdeckVoice.ts
+++ b/src/web/routes/streamdeckVoice.ts
@@ -4,12 +4,12 @@ import { getApprovedGuildIdsForKey } from '../../db';
 import { requireApiKey } from '../middleware';
 import { getAvailableVoiceChannels } from '../../discord/discordUtils';
 import { connect, disconnect } from '../../audio/audioPlayer';
-import { getDiscordClient } from '../../discord/discordBot';
 import { normalizeDiscordId } from './shared';
 import {
   resolveChannelGuildOrRespond,
   resolvePresenceGuildOrRespond,
   ensureGuildApproved,
+  getReadyDiscordClientOrRespond,
 } from './streamdeckGuildResolution';
 
 const log = createLogger('Streamdeck');
@@ -52,11 +52,8 @@ router.post('/voice/join', requireApiKey, async (req, res) => {
     return;
   }
 
-  const discordClient = getDiscordClient();
-  if (!discordClient) {
-    res.status(503).json({ ok: false, error: 'Discord client not ready' });
-    return;
-  }
+  const discordClient = getReadyDiscordClientOrRespond(res);
+  if (!discordClient) return;
 
   const guildId = await resolveChannelGuildOrRespond(req, res, discordClient, normalizedChannelId);
   if (!guildId) return;
@@ -88,11 +85,8 @@ router.post('/voice/leave', requireApiKey, async (req, res) => {
 
   let guildId = explicitGuildId;
   if (!guildId) {
-    const discordClient = getDiscordClient();
-    if (!discordClient) {
-      res.status(503).json({ ok: false, error: 'Discord client not ready' });
-      return;
-    }
+    const discordClient = getReadyDiscordClientOrRespond(res);
+    if (!discordClient) return;
     guildId = normalizedChannelId
       ? await resolveChannelGuildOrRespond(req, res, discordClient, normalizedChannelId)
       : await resolvePresenceGuildOrRespond(req, res, discordClient);

--- a/src/web/routes/streamsErrors.test.ts
+++ b/src/web/routes/streamsErrors.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { Response } from 'express';
 
-// Isolates this test from the real DB module — required at runtime only by shared.ts's
-// requireStreamer/handleReservedOrConflictCommandError, neither of which this file uses,
-// but a real (unmocked) import would otherwise try to build a live connection pool.
+/**
+ * Isolates this test from the real DB module — required at runtime only by shared.ts's
+ * requireStreamer/handleReservedOrConflictCommandError, neither of which this file uses,
+ * but a real (unmocked) import would otherwise try to build a live connection pool.
+ */
 vi.mock('../../db', () => ({}));
 
 import {

--- a/src/web/routes/streamsErrors.test.ts
+++ b/src/web/routes/streamsErrors.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { Response } from 'express';
+
+// Isolates this test from the real DB module — required at runtime only by shared.ts's
+// requireStreamer/handleReservedOrConflictCommandError, neither of which this file uses,
+// but a real (unmocked) import would otherwise try to build a live connection pool.
+vi.mock('../../db', () => ({}));
+
 import {
   STREAMS_ERROR_CODES,
   STREAMS_ERROR_MESSAGES,

--- a/src/web/routes/tos.test.ts
+++ b/src/web/routes/tos.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-// Isolates this test from the real DB module — required at runtime only by shared.ts's
-// requireStreamer/handleReservedOrConflictCommandError, neither of which this route uses,
-// but a real (unmocked) import would otherwise try to build a live connection pool.
+/**
+ * Isolates this test from the real DB module — required at runtime only by shared.ts's
+ * requireStreamer/handleReservedOrConflictCommandError, neither of which this route uses,
+ * but a real (unmocked) import would otherwise try to build a live connection pool.
+ */
 vi.mock('../../db', () => ({}));
 
 import express from 'express';

--- a/src/web/routes/tos.test.ts
+++ b/src/web/routes/tos.test.ts
@@ -1,4 +1,10 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Isolates this test from the real DB module — required at runtime only by shared.ts's
+// requireStreamer/handleReservedOrConflictCommandError, neither of which this route uses,
+// but a real (unmocked) import would otherwise try to build a live connection pool.
+vi.mock('../../db', () => ({}));
+
 import express from 'express';
 import supertest from 'supertest';
 import tosRouter from './tos';


### PR DESCRIPTION
## Summary

Part of the project-wide de-duplication review, scoped to `src/web/routes/*.ts`, `src/web/middleware.ts`, `src/web/csrf.ts`, `src/web/rateLimits.ts`.

- **Positive-int / weight parsers**: `channelPointsAdminShared.ts`'s `parsePositiveIntField` was byte-for-byte identical to `shared.ts`'s `parsePositiveIntId` — deleted, callers (`channelPointsAdminMutations.ts`, `channelPointsAdminPricingMutations.ts`) now import `parsePositiveIntId` directly. `sfxMutationsShared.ts`'s `parseWeight` was also functionally identical to `parsePositiveIntId` (same regex/range check, just typed `unknown`) — deleted; `sfxFileUpload.ts`/`sfxFileMutations.ts` now use `parsePositiveIntId`. `overlayAdminShared.ts`'s `parseWeight` genuinely floors decimals (different behavior), so it moved into `shared.ts` as the one remaining canonical `parseWeight`, used by `overlayAdminRewardMutations.ts`.
- **`requireStreamer`**: was duplicated verbatim (differing only in the not-a-streamer redirect path) in `channelPointsAdminShared.ts` and `overlayAdminShared.ts`. Now one `requireStreamer(req, res, notAStreamerRedirectPath)` in `shared.ts`; each call site passes its own page's redirect path.
- **Twitch reward-UUID regex**: `REWARD_ID_RE`/`parseRewardIdParam` moved from `channelPointsAdminShared.ts` into `shared.ts`; `overlayAdminRewardMutations.ts` now uses it instead of inlining the same regex.
- **Command/counter write-error handling**: `handleCommandWriteError` (commands) and `handleCounterWriteError` (counters) merged into one `handleReservedOrConflictCommandError(err, res, { basePath, conflictErrorCode })` in `shared.ts`.
- **Upload-error handling**: the two Multer `handleUploadError` implementations (`sfxFileUpload.ts`, `overlayAdminMutations.ts`) now both delegate to a `createMulterErrorRedirectHandler(basePath, log, logLabel)` factory in `shared.ts`; each file keeps its own `handleUploadError` export (built from the factory) so existing imports/tests are unaffected.
- **"Discord client not ready" 503 check**: was duplicated identically in `api.ts`, `streamdeckSfx.ts`, and twice in `streamdeckVoice.ts`. Added `getReadyDiscordClientOrRespond(res)` to `streamdeckGuildResolution.ts` (already imported by 3 of the 4 call sites, and already holds the `Client` type import), used at all 4 sites.
- **`discordIdError`**: now derives its answer from `shared.ts`'s `normalizeDiscordId` instead of maintaining a second snowflake regex in `adminUserValidation.ts`.

### Fallout fixed along the way
`shared.ts` now imports real functions from `src/db.ts` (for `requireStreamer` and the merged write-error handler). A handful of route tests that previously never needed to mock `../../db` (`privacy.test.ts`, `tos.test.ts`, `streamsErrors.test.ts`, `commandMonitor.test.ts`) started failing because the real `db.ts` → `db/pool.ts` → `shared/config.ts` chain throws on missing env vars (e.g. `DISCORD_TOKEN`) outside a real runtime. Added a minimal `vi.mock('../../db', () => ({}))` to each of those four test files to keep them isolated — matches the mocking convention already used everywhere else in this suite.

### Decided not to change
- `channelPointsAdminMutations.ts` / `channelPointsAdminPricingMutations.ts` / `overlayAdminRewardMutations.ts` / `overlayAdminMutations.ts` each define their own `NOT_A_STREAMER_REDIRECT` constant rather than sharing one — `requireStreamer`'s whole point post-refactor is that each page owns its own redirect target, so a shared constant would just reintroduce coupling between pages.
- Left `overlayAdminMutations.ts`'s stale `export { requireStreamer, toStringArray, parseWeight } from './overlayAdminShared'` removed rather than kept — nothing else in the codebase imported those three from `overlayAdminMutations.ts` (confirmed via grep), so it was dead re-export clutter even before this PR.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 129/129 test files, 2329/2329 tests passing
- [x] Added/updated Vitest coverage for every new or moved shared helper: `requireStreamer`, `parseWeight`, `parseRewardIdParam`, `handleReservedOrConflictCommandError`, `createMulterErrorRedirectHandler`, `discordIdError`, `getReadyDiscordClientOrRespond`
- [x] Removed now-redundant duplicate test blocks from `channelPointsAdminShared.test.ts` and `overlayAdminShared.test.ts` (coverage moved to `shared.test.ts`)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01RBKcCSsAKKoryf1Zrv31dR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RBKcCSsAKKoryf1Zrv31dR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for Discord IDs, reward IDs, pricing values, and SFX weights.
  * Added clearer redirects when access requires streamer status.
  * Standardized handling for duplicate commands, oversized uploads, and upload failures.
  * Improved Discord readiness responses for voice and Streamdeck actions, returning a consistent service-unavailable message when unavailable.

* **Tests**
  * Expanded coverage for validation, authorization, upload errors, duplicate handling, and Discord readiness.
  * Improved test isolation to prevent external database connections during route tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->