### PR TITLE
Dedup: consolidate bot/commands/twitch/discord boilerplate

### DIFF
--- a/src/audio/audioPlayer.ts
+++ b/src/audio/audioPlayer.ts
@@ -15,6 +15,7 @@ import { setVoiceConnected, setVoiceDisconnected, setVoiceIdle } from '../shared
 
 const log = createLogger('AudioPlayer');
 import { isPermanentVoiceMisconfigurationError } from '../discord/discordUtils';
+import { getOrCreate } from '../shared/mapUtils';
 import { createVoiceAdapterFactory, type VoiceAdapterFactory } from './voiceAdapter';
 import {
   type ConnectionHandlerDeps,
@@ -54,25 +55,20 @@ const states = new Map<string, GuildVoiceState>();
 
 /** Returns the voice state for a guild, creating an empty record on first use. */
 function getState(guildId: string): GuildVoiceState {
-  let state = states.get(guildId);
-  if (!state) {
-    state = {
-      guildId,
-      connection: null,
-      currentChannelId: null,
-      targetChannelId: undefined,
-      client: null,
-      reconnectTimer: null,
-      reconnectAttempts: 0,
-      shouldAutoReconnect: false,
-      currentAttemptId: 0,
-      adapterFactory: createVoiceAdapterFactory(),
-      player: null,
-      playing: false,
-    };
-    states.set(guildId, state);
-  }
-  return state;
+  return getOrCreate(states, guildId, () => ({
+    guildId,
+    connection: null,
+    currentChannelId: null,
+    targetChannelId: undefined,
+    client: null,
+    reconnectTimer: null,
+    reconnectAttempts: 0,
+    shouldAutoReconnect: false,
+    currentAttemptId: 0,
+    adapterFactory: createVoiceAdapterFactory(),
+    player: null,
+    playing: false,
+  }));
 }
 
 /** True if any guild currently holds a live voice connection. */

--- a/src/commands/commandRouter.ts
+++ b/src/commands/commandRouter.ts
@@ -8,6 +8,7 @@ import { SFX_FOLDER, GLOBAL_COOLDOWN_MS } from '../shared/config';
 import { setVoicePlaying } from '../shared/statusStore';
 import { safeResolve } from '../shared/pathUtils';
 import { recordCommandTestEntry } from './commandMonitorStore';
+import { getOrCreate } from '../shared/mapUtils';
 
 const log = createLogger('CommandRouter');
 
@@ -20,12 +21,7 @@ const guildStates = new Map<string, GuildCommandState>();
 
 /** Returns the cooldown/in-flight state for a guild, creating a fresh record on first use. */
 function getGuildCommandState(guildId: string): GuildCommandState {
-  let state = guildStates.get(guildId);
-  if (!state) {
-    state = { lastPlayedAt: 0, inFlight: false };
-    guildStates.set(guildId, state);
-  }
-  return state;
+  return getOrCreate(guildStates, guildId, () => ({ lastPlayedAt: 0, inFlight: false }));
 }
 
 /**

--- a/src/commands/countdownHandler.ts
+++ b/src/commands/countdownHandler.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '../shared/logger';
 import { extractCommand } from './commandUtils';
+import { createRuntimeRegistry, type TwitchSendRuntime } from './twitchRuntime';
 
 const log = createLogger('Twitch');
 
@@ -7,22 +8,32 @@ const COUNTDOWN_COMMAND = '!321';
 const STEPS = ['3', '2', '1', 'Go!'];
 const DELAY_MS = 1000;
 
+/** Delays for `ms` milliseconds. */
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-interface CountdownTwitchRuntime {
-  send: (channel: string, message: string) => Promise<void>;
-}
-let _twitchRuntime: CountdownTwitchRuntime | null = null;
+type CountdownTwitchRuntime = TwitchSendRuntime;
 
+const countdownRuntime = createRuntimeRegistry<CountdownTwitchRuntime>();
+
+/** Stores the Twitch chat runtime used to send `!321` countdown steps. Call once from index.ts after the Twitch bot is ready. */
 export function registerCountdownTwitchRuntime(runtime: CountdownTwitchRuntime): void {
-  _twitchRuntime = runtime;
+  countdownRuntime.register(runtime);
 }
 
+/**
+ * Handles a `!321` countdown command by sending each step ("3", "2", "1", "Go!")
+ * to `channel` with a one-second delay between steps. No-ops for other commands
+ * or if no runtime has been registered. Aborts the remaining steps (without
+ * throwing) if a send fails partway through.
+ *
+ * @param channel - Twitch channel to send the countdown steps to.
+ * @param rawMessage - Raw chat message text.
+ */
 export async function executeCountdownForTwitch(channel: string, rawMessage: string): Promise<void> {
   if (extractCommand(rawMessage) !== COUNTDOWN_COMMAND) return;
-  const runtime = _twitchRuntime;
+  const runtime = countdownRuntime.get();
   if (!runtime) return;
   for (let i = 0; i < STEPS.length; i++) {
     if (i > 0) await sleep(DELAY_MS);

--- a/src/commands/counterHandler.ts
+++ b/src/commands/counterHandler.ts
@@ -6,24 +6,23 @@ const log = createLogger('Counter');
 import { recordCommandTestEntry } from './commandMonitorStore';
 import { extractCommand } from './commandUtils';
 import { isDiscordNotFoundError } from '../discord/discordUtils';
+import { createRuntimeRegistry, type TwitchSendRuntime } from './twitchRuntime';
 
 // ─── Twitch runtime (registered from index.ts before startTwitchBot) ─────────
 //
 // Same pattern as customCommandHandler.ts to avoid a circular import between
 // twitchBot.ts and counterHandler.ts.
 
-interface TwitchSendRuntime {
-  send: (channel: string, message: string) => Promise<void>;
-}
+const counterRuntime = createRuntimeRegistry<TwitchSendRuntime>();
 
-let _twitchRuntime: TwitchSendRuntime | null = null;
-
+/** Stores the Twitch chat runtime used to send counter responses. Call once from index.ts after the Twitch bot is ready. */
 export function registerCounterTwitchRuntime(runtime: TwitchSendRuntime): void {
-  _twitchRuntime = runtime;
+  counterRuntime.register(runtime);
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
+/** Replaces every `%d` placeholder in `template` with `value`. */
 function formatCounterMessage(template: string, value: number): string {
   return template.replace(/%d/g, String(value));
 }
@@ -121,7 +120,7 @@ export async function executeCounterCommandForTwitch(
 
   if (!result.canReply) return;
 
-  const runtime = _twitchRuntime;
+  const runtime = counterRuntime.get();
   if (runtime) {
     try {
       await runtime.send(channel, result.response);

--- a/src/commands/counterHandler.ts
+++ b/src/commands/counterHandler.ts
@@ -33,6 +33,15 @@ interface CounterResult {
   canReply: boolean;
 }
 
+/**
+ * Looks up a counter by `command`, increments it if it's a trigger-type counter,
+ * and formats the resulting response message. Shared by the Discord and Twitch
+ * counter handlers so the lookup/increment/format logic isn't duplicated.
+ *
+ * @param command - The full command string (e.g. `!clap`) used to find the counter.
+ * @param errorPrefix - Log-line prefix identifying the calling platform (e.g. `[Discord]`).
+ * @returns The response text, display label, and whether it's safe to send it; null if no counter matches `command`.
+ */
 async function _buildCounterResponse(
   command: string,
   errorPrefix: string,
@@ -69,6 +78,15 @@ async function _buildCounterResponse(
 
 // ─── Execute functions ────────────────────────────────────────────────────────
 
+/**
+ * Handles a Discord message that may be a counter command or check: extracts the
+ * command, builds the counter response, records it for the monitor panel, and
+ * replies in-channel if the counter was safely resolved.
+ *
+ * @param message - The Discord message to check for a counter command.
+ * @param username - Display name of the sender, for monitor-panel logging.
+ * @returns Resolves once the reply (or a no-op) has completed.
+ */
 export async function executeCounterCommandForDiscord(
   message: Message,
   username?: string | null,
@@ -99,6 +117,16 @@ export async function executeCounterCommandForDiscord(
   }
 }
 
+/**
+ * Handles a Twitch chat message that may be a counter command or check: extracts
+ * the command, builds the counter response, records it for the monitor panel, and
+ * sends it to the channel via the registered Twitch runtime if safely resolved.
+ *
+ * @param channel - Twitch channel the message was sent in (also the send target).
+ * @param rawMessage - Raw chat message text.
+ * @param username - Twitch login of the sender, for monitor-panel logging.
+ * @returns Resolves once the send (or a no-op) has completed.
+ */
 export async function executeCounterCommandForTwitch(
   channel: string,
   rawMessage: string,

--- a/src/commands/customCommandHandler.ts
+++ b/src/commands/customCommandHandler.ts
@@ -9,23 +9,24 @@ import { extractCommand, extractArgs } from './commandUtils';
 import { isDiscordNotFoundError } from '../discord/discordUtils';
 import { getMultiTwitchDataForChannel } from '../twitch/monitor/twitchMonitor';
 import { fillTemplate } from '../shared/textTemplate';
+import { sendDedupedBySession } from './twitchBroadcast';
+import { createRuntimeRegistry, type TwitchSendRuntime } from './twitchRuntime';
 
 // ─── Twitch runtime (registered from index.ts before startTwitchBot) ─────────
 //
 // Avoids a circular import: twitchBot.ts → customCommandHandler.ts → twitchBot.ts.
 // index.ts wires the concrete implementations once both modules are loaded.
 
-interface TwitchChatRuntime {
-  send: (channel: string, message: string) => Promise<void>;
+interface TwitchChatRuntime extends TwitchSendRuntime {
   getActiveChannels: () => ReadonlySet<string>;
   getLoginUserIds: () => ReadonlyMap<string, string>;
 }
 
-let _twitchRuntime: TwitchChatRuntime | null = null;
+const twitchChatRuntime = createRuntimeRegistry<TwitchChatRuntime>();
 
 /** Stores the concrete Twitch chat runtime (send/getActiveChannels/getLoginUserIds) so Twitch custom commands can be sent and broadcast. Call once from index.ts after the Twitch bot is ready. */
 export function registerTwitchChatRuntime(runtime: TwitchChatRuntime): void {
-  _twitchRuntime = runtime;
+  twitchChatRuntime.register(runtime);
 }
 
 // ─── Lookup ───────────────────────────────────────────────────────────────────
@@ -128,16 +129,17 @@ export async function resolveSharedChatSessionId(userId: string): Promise<string
  * Sends a multi-twitch custom command's output to every active channel that has the
  * command registered and is part of the source channel's multi-twitch group (falling
  * back to the source channel only if it isn't currently in a group). Channels that
- * share a Twitch shared-chat session are de-duplicated so only one message is sent
- * per session. Returns true if at least one channel received the message.
+ * share a Twitch shared-chat session are de-duplicated via {@link sendDedupedBySession}
+ * so only one message is sent per session. Returns true if at least one channel
+ * received the message.
  */
 async function broadcastToActiveChannels(sourceChannel: string, command: string, output: string): Promise<boolean> {
-  if (!_twitchRuntime) return false;
+  const runtime = twitchChatRuntime.get();
+  if (!runtime) return false;
 
-  const { send, getActiveChannels, getLoginUserIds } = _twitchRuntime;
+  const { send, getActiveChannels, getLoginUserIds } = runtime;
   const activeChannels = getActiveChannels();
   const loginUserIds = getLoginUserIds();
-  const repliedSessionIds = new Set<string>();
 
   // Build ordered list: source channel first, then the rest
   const candidates = [sourceChannel, ...Array.from(activeChannels).filter((ch) => ch !== sourceChannel)];
@@ -155,27 +157,7 @@ async function broadcastToActiveChannels(sourceChannel: string, command: string,
     ch === sourceChannel || (groupParticipantSet !== null && groupParticipantSet.has(ch)),
   );
 
-  // Pre-resolve all session IDs in parallel to avoid serial Helix calls per channel
-  const userIds = [...new Set(targets.map((ch) => loginUserIds.get(ch)).filter((id): id is string => id !== undefined))];
-  const resolvedIds = await Promise.all(userIds.map((uid) => resolveSharedChatSessionId(uid)));
-  const sessionIdByUserId = new Map(userIds.map((uid, i) => [uid, resolvedIds[i]]));
-
-  let anySent = false;
-  for (const channel of targets) {
-    const userId = loginUserIds.get(channel);
-    const sessionId = userId ? (sessionIdByUserId.get(userId) ?? null) : null;
-
-    if (sessionId && repliedSessionIds.has(sessionId)) continue;
-
-    try {
-      await send(channel, output);
-      if (sessionId) repliedSessionIds.add(sessionId);
-      anySent = true;
-    } catch (err) {
-      log.error(`Failed to send to ${channel}:`, err);
-    }
-  }
-  return anySent;
+  return sendDedupedBySession(targets, loginUserIds, output, send, resolveSharedChatSessionId);
 }
 
 // ─── Execute functions ────────────────────────────────────────────────────────
@@ -275,7 +257,7 @@ export async function executeCustomCommandForTwitch(
     user: username ?? null,
   });
 
-  const runtime = _twitchRuntime;
+  const runtime = twitchChatRuntime.get();
   if (runtime) {
     if (result.isMultiTwitch) {
       try {

--- a/src/commands/customCommandHandler.ts
+++ b/src/commands/customCommandHandler.ts
@@ -10,17 +10,14 @@ import { isDiscordNotFoundError } from '../discord/discordUtils';
 import { getMultiTwitchDataForChannel } from '../twitch/monitor/twitchMonitor';
 import { fillTemplate } from '../shared/textTemplate';
 import { sendDedupedBySession } from './twitchBroadcast';
-import { createRuntimeRegistry, type TwitchSendRuntime } from './twitchRuntime';
+import { createRuntimeRegistry, type TwitchBroadcastRuntime } from './twitchRuntime';
 
 // ─── Twitch runtime (registered from index.ts before startTwitchBot) ─────────
 //
 // Avoids a circular import: twitchBot.ts → customCommandHandler.ts → twitchBot.ts.
 // index.ts wires the concrete implementations once both modules are loaded.
 
-interface TwitchChatRuntime extends TwitchSendRuntime {
-  getActiveChannels: () => ReadonlySet<string>;
-  getLoginUserIds: () => ReadonlyMap<string, string>;
-}
+type TwitchChatRuntime = TwitchBroadcastRuntime;
 
 const twitchChatRuntime = createRuntimeRegistry<TwitchChatRuntime>();
 

--- a/src/commands/multiCommandHandler.test.ts
+++ b/src/commands/multiCommandHandler.test.ts
@@ -112,6 +112,19 @@ describe('executeMultiCommandForTwitch', () => {
     expect(mockRuntime.send).toHaveBeenCalledTimes(1);
   });
 
+  it('does not throw and sends nothing when no participant channel is active', async () => {
+    vi.mocked(getMultiTwitchDataForChannel).mockReturnValue({
+      url: 'multitwitch.tv/a/b',
+      participants: ['#a', '#b'],
+    } as any);
+
+    // Neither the source channel nor its participants are active
+    mockRuntime.getActiveChannels.mockReturnValue(new Set<string>());
+
+    await expect(executeMultiCommandForTwitch('#a', '!multi', 'user1')).resolves.toBeUndefined();
+    expect(mockRuntime.send).not.toHaveBeenCalled();
+  });
+
   it('records the multitwitch URL in the command monitor entry', async () => {
     vi.mocked(getMultiTwitchDataForChannel).mockReturnValue({
       url: 'multitwitch.tv/a/b',

--- a/src/commands/multiCommandHandler.ts
+++ b/src/commands/multiCommandHandler.ts
@@ -5,6 +5,8 @@ const log = createLogger('MultiCmd');
 import { recordCommandTestEntry } from './commandMonitorStore';
 import { resolveSharedChatSessionId } from './customCommandHandler';
 import { extractCommand } from './commandUtils';
+import { sendDedupedBySession } from './twitchBroadcast';
+import { createRuntimeRegistry, type TwitchSendRuntime } from './twitchRuntime';
 
 const MULTI_COMMAND = '!multi';
 
@@ -13,20 +15,26 @@ const MULTI_COMMAND = '!multi';
 // Same injection pattern as customCommandHandler.ts to avoid a circular import
 // between twitchBot.ts and multiCommandHandler.ts.
 
-interface MultiTwitchRuntime {
-  send: (channel: string, message: string) => Promise<void>;
+interface MultiTwitchRuntime extends TwitchSendRuntime {
   getActiveChannels: () => ReadonlySet<string>;
   getLoginUserIds: () => ReadonlyMap<string, string>;
 }
 
-let _runtime: MultiTwitchRuntime | null = null;
+const multiTwitchRuntime = createRuntimeRegistry<MultiTwitchRuntime>();
 
+/** Stores the concrete Twitch chat runtime (send/getActiveChannels/getLoginUserIds) so `!multi` can be broadcast. Call once from index.ts after the Twitch bot is ready. */
 export function registerMultiTwitchRuntime(runtime: MultiTwitchRuntime): void {
-  _runtime = runtime;
+  multiTwitchRuntime.register(runtime);
 }
 
 // ─── Broadcast ────────────────────────────────────────────────────────────────
 
+/**
+ * Broadcasts `message` (the `!multi` URL) to the source channel plus every other
+ * participant channel the bot has currently joined, de-duplicating channels that
+ * share a Twitch shared-chat session via {@link sendDedupedBySession} so only one
+ * message is sent per session.
+ */
 async function broadcastToGroupChannels(
   sourceChannel: string,
   participants: string[],
@@ -41,26 +49,7 @@ async function broadcastToGroupChannels(
   const targets = [sourceChannel, ...participants.filter((p) => p !== sourceChannel)]
     .filter((ch) => activeChannels.has(ch));
 
-  // Pre-resolve all session IDs in parallel to avoid serial Helix calls per channel
-  const userIds = [...new Set(targets.map((ch) => loginUserIds.get(ch)).filter((id): id is string => id !== undefined))];
-  const resolvedIds = await Promise.all(userIds.map((uid) => resolveSharedChatSessionId(uid)));
-  const sessionIdByUserId = new Map(userIds.map((uid, i) => [uid, resolvedIds[i]]));
-
-  const repliedSessionIds = new Set<string>();
-
-  for (const channel of targets) {
-    const userId = loginUserIds.get(channel);
-    const sessionId = userId ? (sessionIdByUserId.get(userId) ?? null) : null;
-
-    if (sessionId && repliedSessionIds.has(sessionId)) continue;
-
-    try {
-      await send(channel, message);
-      if (sessionId) repliedSessionIds.add(sessionId);
-    } catch (err) {
-      log.error(`Failed to send to ${channel}:`, err);
-    }
-  }
+  await sendDedupedBySession(targets, loginUserIds, message, send, resolveSharedChatSessionId);
 }
 
 // ─── Execute ──────────────────────────────────────────────────────────────────
@@ -85,7 +74,7 @@ export async function executeMultiCommandForTwitch(
 
   if (!groupInfo) return;
 
-  const runtime = _runtime;
+  const runtime = multiTwitchRuntime.get();
   if (!runtime) return;
 
   try {

--- a/src/commands/multiCommandHandler.ts
+++ b/src/commands/multiCommandHandler.ts
@@ -6,7 +6,7 @@ import { recordCommandTestEntry } from './commandMonitorStore';
 import { resolveSharedChatSessionId } from './customCommandHandler';
 import { extractCommand } from './commandUtils';
 import { sendDedupedBySession } from './twitchBroadcast';
-import { createRuntimeRegistry, type TwitchSendRuntime } from './twitchRuntime';
+import { createRuntimeRegistry, type TwitchBroadcastRuntime } from './twitchRuntime';
 
 const MULTI_COMMAND = '!multi';
 
@@ -15,10 +15,7 @@ const MULTI_COMMAND = '!multi';
 // Same injection pattern as customCommandHandler.ts to avoid a circular import
 // between twitchBot.ts and multiCommandHandler.ts.
 
-interface MultiTwitchRuntime extends TwitchSendRuntime {
-  getActiveChannels: () => ReadonlySet<string>;
-  getLoginUserIds: () => ReadonlyMap<string, string>;
-}
+type MultiTwitchRuntime = TwitchBroadcastRuntime;
 
 const multiTwitchRuntime = createRuntimeRegistry<MultiTwitchRuntime>();
 
@@ -34,13 +31,14 @@ export function registerMultiTwitchRuntime(runtime: MultiTwitchRuntime): void {
  * participant channel the bot has currently joined, de-duplicating channels that
  * share a Twitch shared-chat session via {@link sendDedupedBySession} so only one
  * message is sent per session.
+ * @returns True if the message was sent to at least one channel/session.
  */
 async function broadcastToGroupChannels(
   sourceChannel: string,
   participants: string[],
   message: string,
   runtime: MultiTwitchRuntime,
-): Promise<void> {
+): Promise<boolean> {
   const { send, getActiveChannels, getLoginUserIds } = runtime;
   const activeChannels = getActiveChannels();
   const loginUserIds = getLoginUserIds();
@@ -49,11 +47,22 @@ async function broadcastToGroupChannels(
   const targets = [sourceChannel, ...participants.filter((p) => p !== sourceChannel)]
     .filter((ch) => activeChannels.has(ch));
 
-  await sendDedupedBySession(targets, loginUserIds, message, send, resolveSharedChatSessionId);
+  return sendDedupedBySession(targets, loginUserIds, message, send, resolveSharedChatSessionId);
 }
 
 // ─── Execute ──────────────────────────────────────────────────────────────────
 
+/**
+ * Handles a Twitch chat `!multi` command: looks up the multitwitch group for
+ * `channel`, records the outcome for the monitor panel, and — if the channel is
+ * part of an active group — broadcasts the multitwitch URL to the group via
+ * {@link broadcastToGroupChannels}.
+ *
+ * @param channel - Twitch channel the command was sent in.
+ * @param rawMessage - Raw chat message text.
+ * @param username - Twitch login of the sender, for monitor-panel logging.
+ * @returns Resolves once the broadcast (or a no-op) has completed.
+ */
 export async function executeMultiCommandForTwitch(
   channel: string,
   rawMessage: string,
@@ -78,8 +87,12 @@ export async function executeMultiCommandForTwitch(
   if (!runtime) return;
 
   try {
-    await broadcastToGroupChannels(channel, groupInfo.participants, groupInfo.url, runtime);
-    log.info(`[Twitch] Sent !multi in ${channel} — ${groupInfo.url}`);
+    const sent = await broadcastToGroupChannels(channel, groupInfo.participants, groupInfo.url, runtime);
+    if (sent) {
+      log.info(`[Twitch] Sent !multi in ${channel} — ${groupInfo.url}`);
+    } else {
+      log.info(`[Twitch] Broadcast !multi in ${channel} reached no channels.`);
+    }
   } catch (err) {
     log.error(`[Twitch] Failed to broadcast !multi in ${channel}:`, err);
   }

--- a/src/commands/shoutoutHandler.ts
+++ b/src/commands/shoutoutHandler.ts
@@ -29,6 +29,14 @@ function formatShoutoutMessage(login: string, gameName: string | null, isLive: b
   return `Go give @${login} a follow at ${url}!`;
 }
 
+/**
+ * Looks up `target` on Twitch and resolves the login, most recent/current game
+ * name, and live status needed to build a shoutout message. Channel info and
+ * stream lookups run independently so a failure in one doesn't block the other.
+ *
+ * @param target - Twitch login to look up.
+ * @returns The resolved shoutout data, or null if `target` isn't a valid Twitch user.
+ */
 async function resolveShoutoutData(
   target: string,
 ): Promise<{ login: string; gameName: string | null; isLive: boolean } | null> {
@@ -53,6 +61,13 @@ async function resolveShoutoutData(
   };
 }
 
+/**
+ * Sends a shoutout `message` to `channel` via the registered Twitch runtime.
+ *
+ * @param channel - Twitch channel to send the shoutout to.
+ * @param message - Shoutout text to send.
+ * @returns True if the message was sent; false if no runtime is registered or the send failed.
+ */
 async function dispatchShoutout(channel: string, message: string): Promise<boolean> {
   const runtime = shoutoutRuntime.get();
   if (!runtime) return false;

--- a/src/commands/shoutoutHandler.ts
+++ b/src/commands/shoutoutHandler.ts
@@ -4,23 +4,24 @@ import { getUsers, getChannelInfo, getStreams, TwitchChannelInfo, TwitchStream }
 const log = createLogger('Shoutout');
 import { recordCommandTestEntry } from './commandMonitorStore';
 import { extractCommand } from './commandUtils';
+import { createRuntimeRegistry, type TwitchSendRuntime } from './twitchRuntime';
 
 const SO_COMMAND = '!so';
 
 // ─── Twitch runtime (registered from index.ts before startTwitchBot) ─────────
 
-interface ShoutoutRuntime {
-  send: (channel: string, message: string) => Promise<void>;
-}
+type ShoutoutRuntime = TwitchSendRuntime;
 
-let _runtime: ShoutoutRuntime | null = null;
+const shoutoutRuntime = createRuntimeRegistry<ShoutoutRuntime>();
 
+/** Stores the Twitch chat runtime used to send `!so` shoutouts. Call once from index.ts after the Twitch bot is ready. */
 export function registerShoutoutRuntime(runtime: ShoutoutRuntime): void {
-  _runtime = runtime;
+  shoutoutRuntime.register(runtime);
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
+/** Builds the `!so` shoutout message text for `login`, tailored to whether they're currently live and/or have a known last-played game. */
 function formatShoutoutMessage(login: string, gameName: string | null, isLive: boolean): string {
   const url = `twitch.tv/${login}`;
   if (isLive && gameName) return `Go check out @${login}, they're live playing ${gameName}! ${url}`;
@@ -53,7 +54,7 @@ async function resolveShoutoutData(
 }
 
 async function dispatchShoutout(channel: string, message: string): Promise<boolean> {
-  const runtime = _runtime;
+  const runtime = shoutoutRuntime.get();
   if (!runtime) return false;
   try {
     await runtime.send(channel, message);

--- a/src/commands/twitchBroadcast.test.ts
+++ b/src/commands/twitchBroadcast.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../shared/logger', () => ({ createLogger: () => ({ info: vi.fn(), error: vi.fn() }) }));
+
+import { sendDedupedBySession } from './twitchBroadcast';
+
+describe('sendDedupedBySession', () => {
+  let send: ReturnType<typeof vi.fn<(channel: string, message: string) => Promise<void>>>;
+  let resolveSessionId: ReturnType<typeof vi.fn<(userId: string) => Promise<string | null>>>;
+
+  beforeEach(() => {
+    send = vi.fn().mockResolvedValue(undefined);
+    resolveSessionId = vi.fn().mockResolvedValue(null);
+  });
+
+  it('sends to every target when none share a session', async () => {
+    const loginUserIds = new Map([['#a', 'u1'], ['#b', 'u2']]);
+    resolveSessionId.mockImplementation(async (uid: string) => `session-${uid}`);
+
+    const result = await sendDedupedBySession(['#a', '#b'], loginUserIds, 'hello', send, resolveSessionId);
+
+    expect(send).toHaveBeenCalledWith('#a', 'hello');
+    expect(send).toHaveBeenCalledWith('#b', 'hello');
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(result).toBe(true);
+  });
+
+  it('skips a later channel that shares a session with an earlier one', async () => {
+    const loginUserIds = new Map([['#a', 'u1'], ['#b', 'u1']]);
+    resolveSessionId.mockResolvedValue('shared-session');
+
+    const result = await sendDedupedBySession(['#a', '#b'], loginUserIds, 'hi', send, resolveSessionId);
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith('#a', 'hi');
+    expect(result).toBe(true);
+  });
+
+  it('always sends to a channel absent from loginUserIds (no session to dedupe against)', async () => {
+    const loginUserIds = new Map<string, string>();
+
+    const result = await sendDedupedBySession(['#a', '#b'], loginUserIds, 'hi', send, resolveSessionId);
+
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(result).toBe(true);
+  });
+
+  it('resolves each unique user id session only once, in parallel', async () => {
+    const loginUserIds = new Map([['#a', 'u1'], ['#b', 'u1'], ['#c', 'u2']]);
+    resolveSessionId.mockImplementation(async (uid: string) => `session-${uid}`);
+
+    await sendDedupedBySession(['#a', '#b', '#c'], loginUserIds, 'hi', send, resolveSessionId);
+
+    expect(resolveSessionId).toHaveBeenCalledTimes(2);
+    expect(resolveSessionId).toHaveBeenCalledWith('u1');
+    expect(resolveSessionId).toHaveBeenCalledWith('u2');
+  });
+
+  it('logs and continues when a send fails for one channel', async () => {
+    const loginUserIds = new Map([['#a', 'u1'], ['#b', 'u2']]);
+    send.mockRejectedValueOnce(new Error('network blip'));
+
+    const result = await sendDedupedBySession(['#a', '#b'], loginUserIds, 'hi', send, resolveSessionId);
+
+    expect(send).toHaveBeenCalledTimes(2);
+    // '#a' failed, but '#b' still succeeded, so overall result is true.
+    expect(result).toBe(true);
+  });
+
+  it('returns false when every send fails', async () => {
+    const loginUserIds = new Map([['#a', 'u1']]);
+    send.mockRejectedValue(new Error('down'));
+
+    const result = await sendDedupedBySession(['#a'], loginUserIds, 'hi', send, resolveSessionId);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false for an empty target list', async () => {
+    const result = await sendDedupedBySession([], new Map(), 'hi', send, resolveSessionId);
+
+    expect(send).not.toHaveBeenCalled();
+    expect(result).toBe(false);
+  });
+
+  it('does not mark a session as replied when the first channel in it fails to send', async () => {
+    const loginUserIds = new Map([['#a', 'u1'], ['#b', 'u1']]);
+    resolveSessionId.mockResolvedValue('shared-session');
+    send.mockRejectedValueOnce(new Error('boom'));
+
+    const result = await sendDedupedBySession(['#a', '#b'], loginUserIds, 'hi', send, resolveSessionId);
+
+    // '#a' failed so the session was never marked replied — '#b' (same session) is still attempted.
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send).toHaveBeenCalledWith('#b', 'hi');
+    expect(result).toBe(true);
+  });
+});

--- a/src/commands/twitchBroadcast.test.ts
+++ b/src/commands/twitchBroadcast.test.ts
@@ -83,6 +83,21 @@ describe('sendDedupedBySession', () => {
     expect(result).toBe(false);
   });
 
+  it('treats a rejected session lookup as no session, sending anyway, instead of aborting all sends', async () => {
+    const loginUserIds = new Map([['#a', 'u1'], ['#b', 'u2']]);
+    resolveSessionId.mockImplementation(async (uid: string) => {
+      if (uid === 'u1') throw new Error('Helix lookup failed');
+      return `session-${uid}`;
+    });
+
+    const result = await sendDedupedBySession(['#a', '#b'], loginUserIds, 'hi', send, resolveSessionId);
+
+    expect(send).toHaveBeenCalledWith('#a', 'hi');
+    expect(send).toHaveBeenCalledWith('#b', 'hi');
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(result).toBe(true);
+  });
+
   it('does not mark a session as replied when the first channel in it fails to send', async () => {
     const loginUserIds = new Map([['#a', 'u1'], ['#b', 'u1']]);
     resolveSessionId.mockResolvedValue('shared-session');

--- a/src/commands/twitchBroadcast.ts
+++ b/src/commands/twitchBroadcast.ts
@@ -8,9 +8,9 @@ const log = createLogger('TwitchBroadcast');
  * received the message, later channels resolving to that same session are
  * skipped. Session IDs are resolved once per unique user ID (via `loginUserIds`
  * and `resolveSessionId`) in parallel before sending, to avoid a serial Helix
- * lookup per channel. A channel with no entry in `loginUserIds` is treated as
- * having no session and is always sent to. Per-channel send failures are
- * logged and do not abort the remaining sends.
+ * lookup per channel. A channel with no entry in `loginUserIds`, or whose
+ * session lookup rejects, is treated as having no session and is always sent
+ * to. Per-channel send failures are logged and do not abort the remaining sends.
  *
  * @param targets - Ordered list of channel logins to send to.
  * @param loginUserIds - Map from channel login to Twitch user ID, used to resolve shared-chat sessions.
@@ -28,7 +28,9 @@ export async function sendDedupedBySession(
 ): Promise<boolean> {
   // Pre-resolve all session IDs in parallel to avoid serial Helix calls per channel
   const userIds = [...new Set(targets.map((ch) => loginUserIds.get(ch)).filter((id): id is string => id !== undefined))];
-  const resolvedIds = await Promise.all(userIds.map((uid) => resolveSessionId(uid)));
+  const resolvedIds = await Promise.all(
+    userIds.map((uid) => resolveSessionId(uid).catch(() => null)),
+  );
   const sessionIdByUserId = new Map(userIds.map((uid, i) => [uid, resolvedIds[i]]));
 
   const repliedSessionIds = new Set<string>();

--- a/src/commands/twitchBroadcast.ts
+++ b/src/commands/twitchBroadcast.ts
@@ -1,0 +1,53 @@
+import { createLogger } from '../shared/logger';
+
+const log = createLogger('TwitchBroadcast');
+
+/**
+ * Sends `message` to each channel in `targets` via `send`, de-duplicating by
+ * Twitch shared-chat session: once a channel belonging to a given session has
+ * received the message, later channels resolving to that same session are
+ * skipped. Session IDs are resolved once per unique user ID (via `loginUserIds`
+ * and `resolveSessionId`) in parallel before sending, to avoid a serial Helix
+ * lookup per channel. A channel with no entry in `loginUserIds` is treated as
+ * having no session and is always sent to. Per-channel send failures are
+ * logged and do not abort the remaining sends.
+ *
+ * @param targets - Ordered list of channel logins to send to.
+ * @param loginUserIds - Map from channel login to Twitch user ID, used to resolve shared-chat sessions.
+ * @param message - The message to send to each (deduplicated) target channel.
+ * @param send - Sends `message` to a single channel.
+ * @param resolveSessionId - Resolves a Twitch user ID to its current shared-chat session ID (or null).
+ * @returns True if at least one channel received the message.
+ */
+export async function sendDedupedBySession(
+  targets: string[],
+  loginUserIds: ReadonlyMap<string, string>,
+  message: string,
+  send: (channel: string, message: string) => Promise<void>,
+  resolveSessionId: (userId: string) => Promise<string | null>,
+): Promise<boolean> {
+  // Pre-resolve all session IDs in parallel to avoid serial Helix calls per channel
+  const userIds = [...new Set(targets.map((ch) => loginUserIds.get(ch)).filter((id): id is string => id !== undefined))];
+  const resolvedIds = await Promise.all(userIds.map((uid) => resolveSessionId(uid)));
+  const sessionIdByUserId = new Map(userIds.map((uid, i) => [uid, resolvedIds[i]]));
+
+  const repliedSessionIds = new Set<string>();
+  let anySent = false;
+
+  for (const channel of targets) {
+    const userId = loginUserIds.get(channel);
+    const sessionId = userId ? (sessionIdByUserId.get(userId) ?? null) : null;
+
+    if (sessionId && repliedSessionIds.has(sessionId)) continue;
+
+    try {
+      await send(channel, message);
+      if (sessionId) repliedSessionIds.add(sessionId);
+      anySent = true;
+    } catch (err) {
+      log.error(`Failed to send to ${channel}:`, err);
+    }
+  }
+
+  return anySent;
+}

--- a/src/commands/twitchRuntime.test.ts
+++ b/src/commands/twitchRuntime.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createRuntimeRegistry, type TwitchSendRuntime } from './twitchRuntime';
+
+describe('createRuntimeRegistry', () => {
+  it('returns null from get() before anything is registered', () => {
+    const registry = createRuntimeRegistry<TwitchSendRuntime>();
+    expect(registry.get()).toBeNull();
+  });
+
+  it('returns the registered runtime from get()', () => {
+    const registry = createRuntimeRegistry<TwitchSendRuntime>();
+    const runtime = { send: vi.fn().mockResolvedValue(undefined) };
+
+    registry.register(runtime);
+
+    expect(registry.get()).toBe(runtime);
+  });
+
+  it('replaces a previously-registered runtime on re-register', () => {
+    const registry = createRuntimeRegistry<TwitchSendRuntime>();
+    const first = { send: vi.fn().mockResolvedValue(undefined) };
+    const second = { send: vi.fn().mockResolvedValue(undefined) };
+
+    registry.register(first);
+    registry.register(second);
+
+    expect(registry.get()).toBe(second);
+  });
+
+  it('supports runtimes with extra fields beyond send', () => {
+    interface RichRuntime extends TwitchSendRuntime {
+      getActiveChannels: () => ReadonlySet<string>;
+    }
+    const registry = createRuntimeRegistry<RichRuntime>();
+    const runtime: RichRuntime = {
+      send: vi.fn().mockResolvedValue(undefined),
+      getActiveChannels: () => new Set(['#a']),
+    };
+
+    registry.register(runtime);
+
+    expect(registry.get()).toBe(runtime);
+    expect(registry.get()?.getActiveChannels()).toEqual(new Set(['#a']));
+  });
+
+  it('keeps independent state across separate registry instances', () => {
+    const registryA = createRuntimeRegistry<TwitchSendRuntime>();
+    const registryB = createRuntimeRegistry<TwitchSendRuntime>();
+    const runtime = { send: vi.fn().mockResolvedValue(undefined) };
+
+    registryA.register(runtime);
+
+    expect(registryA.get()).toBe(runtime);
+    expect(registryB.get()).toBeNull();
+  });
+});

--- a/src/commands/twitchRuntime.ts
+++ b/src/commands/twitchRuntime.ts
@@ -4,6 +4,16 @@ export interface TwitchSendRuntime {
 }
 
 /**
+ * Runtime contract for handlers that broadcast to multiple channels and need to
+ * de-duplicate by Twitch shared-chat session — shared by `customCommandHandler.ts`
+ * and `multiCommandHandler.ts` to avoid two copies of the same interface.
+ */
+export interface TwitchBroadcastRuntime extends TwitchSendRuntime {
+  getActiveChannels: () => ReadonlySet<string>;
+  getLoginUserIds: () => ReadonlyMap<string, string>;
+}
+
+/**
  * Creates a private module-level singleton slot for a Twitch command runtime of
  * type `T`, along with `register`/`get` accessors. Factors out the
  * `let _runtime: T | null = null; registerXRuntime(); getXRuntime()` boilerplate

--- a/src/commands/twitchRuntime.ts
+++ b/src/commands/twitchRuntime.ts
@@ -1,0 +1,31 @@
+/** Minimal contract every Twitch command runtime must satisfy: a function to send a chat message to a channel. */
+export interface TwitchSendRuntime {
+  send: (channel: string, message: string) => Promise<void>;
+}
+
+/**
+ * Creates a private module-level singleton slot for a Twitch command runtime of
+ * type `T`, along with `register`/`get` accessors. Factors out the
+ * `let _runtime: T | null = null; registerXRuntime(); getXRuntime()` boilerplate
+ * that each command handler (countdown, counter, shoutout, custom command,
+ * multi-command) previously duplicated for its own runtime shape — handlers with
+ * extra fields (e.g. `getActiveChannels`/`getLoginUserIds`) just parameterize `T`
+ * with their richer interface.
+ *
+ * @returns `register(runtime)` to store the runtime, and `get()` to retrieve the
+ *   currently registered runtime, or null if none has been registered yet.
+ */
+export function createRuntimeRegistry<T extends TwitchSendRuntime>(): {
+  register: (runtime: T) => void;
+  get: () => T | null;
+} {
+  let runtime: T | null = null;
+  return {
+    /** Stores `runtime` as the current singleton, replacing any previously-registered one. */
+    register: (r: T): void => {
+      runtime = r;
+    },
+    /** Returns the currently-registered runtime, or null if none has been registered yet. */
+    get: (): T | null => runtime,
+  };
+}

--- a/src/discord/discordUtils.test.ts
+++ b/src/discord/discordUtils.test.ts
@@ -33,6 +33,8 @@ import {
   isPermanentVoiceMisconfigurationError,
   tryDeleteDiscordMessage,
   getAvailableVoiceChannels,
+  getTextChannel,
+  tryEditDiscordMessage,
 } from './discordUtils';
 import { DiscordAPIError } from 'discord.js';
 import { getDiscordClient } from './discordBot';
@@ -168,6 +170,79 @@ describe('tryDeleteDiscordMessage', () => {
     vi.mocked(getDiscordClient).mockReturnValue({ channels: { fetch: channelsFetch } } as any);
 
     await expect(tryDeleteDiscordMessage('chan1', 'msg1')).rejects.toThrow('network blip');
+  });
+});
+
+describe('getTextChannel', () => {
+  it('returns the channel when it is text-based', async () => {
+    const channel = { isTextBased: () => true };
+    const channelsFetch = vi.fn().mockResolvedValue(channel);
+    const client = { channels: { fetch: channelsFetch } } as any;
+
+    await expect(getTextChannel(client, 'chan1')).resolves.toBe(channel);
+    expect(channelsFetch).toHaveBeenCalledWith('chan1');
+  });
+
+  it('returns null when the channel is not text-based', async () => {
+    const channelsFetch = vi.fn().mockResolvedValue({ isTextBased: () => false });
+    const client = { channels: { fetch: channelsFetch } } as any;
+
+    await expect(getTextChannel(client, 'chan1')).resolves.toBeNull();
+  });
+
+  it('returns null when the channel fetch resolves to null', async () => {
+    const channelsFetch = vi.fn().mockResolvedValue(null);
+    const client = { channels: { fetch: channelsFetch } } as any;
+
+    await expect(getTextChannel(client, 'chan1')).resolves.toBeNull();
+  });
+});
+
+describe('tryEditDiscordMessage', () => {
+  it('returns false without fetching a message when the channel is not text-based', async () => {
+    const fetchMessage = vi.fn();
+    const channelsFetch = vi.fn().mockResolvedValue({ isTextBased: () => false, messages: { fetch: fetchMessage } });
+    const client = { channels: { fetch: channelsFetch } } as any;
+
+    await expect(tryEditDiscordMessage(client, 'chan1', 'msg1', { content: 'hi' })).resolves.toBe(false);
+    expect(fetchMessage).not.toHaveBeenCalled();
+  });
+
+  it('returns false when the channel fetch resolves to null', async () => {
+    const channelsFetch = vi.fn().mockResolvedValue(null);
+    const client = { channels: { fetch: channelsFetch } } as any;
+
+    await expect(tryEditDiscordMessage(client, 'chan1', 'msg1', { content: 'hi' })).resolves.toBe(false);
+  });
+
+  it('fetches and edits the message when the channel is text-based', async () => {
+    const editMessage = vi.fn().mockResolvedValue(undefined);
+    const fetchMessage = vi.fn().mockResolvedValue({ edit: editMessage });
+    const channelsFetch = vi.fn().mockResolvedValue({ isTextBased: () => true, messages: { fetch: fetchMessage } });
+    const client = { channels: { fetch: channelsFetch } } as any;
+
+    await expect(tryEditDiscordMessage(client, 'chan1', 'msg1', { content: 'hi' })).resolves.toBe(true);
+    expect(channelsFetch).toHaveBeenCalledWith('chan1');
+    expect(fetchMessage).toHaveBeenCalledWith('msg1');
+    expect(editMessage).toHaveBeenCalledWith({ content: 'hi' });
+  });
+
+  it('returns false without throwing on a not-found error', async () => {
+    const notFoundErr = new MockedDiscordAPIError({ code: UNKNOWN_MESSAGE, status: 200 });
+    const fetchMessage = vi.fn().mockRejectedValue(notFoundErr);
+    const channelsFetch = vi.fn().mockResolvedValue({ isTextBased: () => true, messages: { fetch: fetchMessage } });
+    const client = { channels: { fetch: channelsFetch } } as any;
+
+    await expect(tryEditDiscordMessage(client, 'chan1', 'msg1', { content: 'hi' })).resolves.toBe(false);
+  });
+
+  it('rethrows an unrelated error', async () => {
+    const otherErr = new Error('network blip');
+    const fetchMessage = vi.fn().mockRejectedValue(otherErr);
+    const channelsFetch = vi.fn().mockResolvedValue({ isTextBased: () => true, messages: { fetch: fetchMessage } });
+    const client = { channels: { fetch: channelsFetch } } as any;
+
+    await expect(tryEditDiscordMessage(client, 'chan1', 'msg1', { content: 'hi' })).rejects.toThrow('network blip');
   });
 });
 

--- a/src/discord/discordUtils.ts
+++ b/src/discord/discordUtils.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '../shared/logger';
-import { DiscordAPIError, RESTJSONErrorCodes, ChannelType } from 'discord.js';
+import { DiscordAPIError, RESTJSONErrorCodes, ChannelType, type Client, type MessageEditOptions, type TextBasedChannel } from 'discord.js';
 import { getDiscordClient } from './discordBot';
 
 const log = createLogger('Discord');
@@ -44,6 +44,54 @@ export async function tryDeleteDiscordMessage(channelId: string, messageId: stri
   } catch (err) {
     if (isDiscordNotFoundError(err)) return;
     log.error(`Failed to delete Discord message ${messageId} in channel ${channelId}:`, err);
+    throw err;
+  }
+}
+
+/**
+ * Fetches `channelId` from `client` and returns it only if it resolves to a
+ * text-based channel. Mirrors the fetch+`isTextBased()` guard duplicated across
+ * `twitchMonitorAnnouncements.ts`, `twitchMonitorMultitwitch.ts`, and
+ * `twitchMonitorStartup.ts` before sending or editing a Discord message.
+ *
+ * @param client - Discord client to fetch the channel from.
+ * @param channelId - ID of the channel to fetch.
+ * @returns The text-based channel, or null if it doesn't exist or isn't text-based.
+ */
+export async function getTextChannel(client: Client, channelId: string): Promise<TextBasedChannel | null> {
+  const channel = await client.channels.fetch(channelId);
+  if (!channel || !channel.isTextBased()) return null;
+  return channel;
+}
+
+/**
+ * Fetches `messageId` from `channelId` (via `client`) and edits it with `payload`.
+ * Returns false — without throwing — when the channel isn't text-based/doesn't
+ * exist, or the channel/message fetch fails with a Discord not-found error (see
+ * {@link isDiscordNotFoundError}), exactly like {@link tryDeleteDiscordMessage}'s
+ * not-found handling. Any other error is logged and rethrown.
+ *
+ * @param client - Discord client to fetch the channel/message from.
+ * @param channelId - ID of the channel containing the message.
+ * @param messageId - ID of the message to edit.
+ * @param payload - Edit payload passed through to `message.edit`.
+ * @returns True if the message was edited; false if the channel/message could not be found.
+ */
+export async function tryEditDiscordMessage(
+  client: Client,
+  channelId: string,
+  messageId: string,
+  payload: MessageEditOptions,
+): Promise<boolean> {
+  try {
+    const channel = await getTextChannel(client, channelId);
+    if (!channel) return false;
+    const message = await channel.messages.fetch(messageId);
+    await message.edit(payload);
+    return true;
+  } catch (err) {
+    if (isDiscordNotFoundError(err)) return false;
+    log.error(`Failed to edit Discord message ${messageId} in channel ${channelId}:`, err);
     throw err;
   }
 }

--- a/src/discord/discordUtils.ts
+++ b/src/discord/discordUtils.ts
@@ -4,6 +4,14 @@ import { getDiscordClient } from './discordBot';
 
 const log = createLogger('Discord');
 
+/**
+ * Checks whether `err` represents a Discord "not found" condition (unknown
+ * message/channel or an HTTP 404) that callers should treat as a benign no-op
+ * rather than a failure to log/retry.
+ *
+ * @param err - Caught error to inspect.
+ * @returns True if `err` is a Discord not-found error.
+ */
 export function isDiscordNotFoundError(err: unknown): boolean {
   return err instanceof DiscordAPIError && (
     err.code === RESTJSONErrorCodes.UnknownMessage ||
@@ -33,6 +41,15 @@ export function isPermanentVoiceMisconfigurationError(err: unknown): boolean {
   return isConfigError || isForbidden || isDiscordNotFoundError(err);
 }
 
+/**
+ * Fetches `messageId` from `channelId` and deletes it, if a Discord client is
+ * available and the channel is text-based. Not-found errors (message/channel
+ * already gone) are swallowed; any other error is logged and rethrown.
+ *
+ * @param channelId - ID of the channel containing the message.
+ * @param messageId - ID of the message to delete.
+ * @returns Resolves once the delete (or a no-op) has completed.
+ */
 export async function tryDeleteDiscordMessage(channelId: string, messageId: string): Promise<void> {
   const discordClient = getDiscordClient();
   if (!discordClient) return;

--- a/src/discord/voicePresence.test.ts
+++ b/src/discord/voicePresence.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('./guildRegistry', () => ({ getRegisteredGuildIds: vi.fn() }));
+vi.mock('./discordBot', () => ({ getDiscordClient: vi.fn() }));
 
 import { getRegisteredGuildIds } from './guildRegistry';
-import { getActiveGuildForUser } from './voicePresence';
+import { getDiscordClient } from './discordBot';
+import { getActiveGuildForUser, resolveGuildIdForDiscordId } from './voicePresence';
 
 function makeClient(guildVoiceChannels: Record<string, Record<string, string>>) {
   const cache = new Map(
@@ -65,5 +67,38 @@ describe('getActiveGuildForUser', () => {
     const client = makeClient({});
 
     expect(getActiveGuildForUser(client, 'user-1')).toBeNull();
+  });
+});
+
+describe('resolveGuildIdForDiscordId', () => {
+  it('returns null without touching the client when discordId is null', () => {
+    const client = makeClient({ 'guild-A': { 'user-1': 'chan-1' } });
+    vi.mocked(getDiscordClient).mockReturnValue(client);
+    vi.mocked(getRegisteredGuildIds).mockReturnValue(['guild-A']);
+
+    expect(resolveGuildIdForDiscordId(null)).toBeNull();
+    expect(getDiscordClient).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the discord client is not ready', () => {
+    vi.mocked(getDiscordClient).mockReturnValue(null);
+
+    expect(resolveGuildIdForDiscordId('user-1')).toBeNull();
+  });
+
+  it('returns the active guild for a resolved discordId', () => {
+    const client = makeClient({ 'guild-A': { 'user-1': 'chan-1' } });
+    vi.mocked(getDiscordClient).mockReturnValue(client);
+    vi.mocked(getRegisteredGuildIds).mockReturnValue(['guild-A']);
+
+    expect(resolveGuildIdForDiscordId('user-1')).toBe('guild-A');
+  });
+
+  it('returns null when the resolved discordId is not in voice anywhere', () => {
+    const client = makeClient({ 'guild-A': { 'user-2': 'chan-1' } });
+    vi.mocked(getDiscordClient).mockReturnValue(client);
+    vi.mocked(getRegisteredGuildIds).mockReturnValue(['guild-A']);
+
+    expect(resolveGuildIdForDiscordId('user-1')).toBeNull();
   });
 });

--- a/src/discord/voicePresence.ts
+++ b/src/discord/voicePresence.ts
@@ -1,5 +1,6 @@
 import { Client } from 'discord.js';
 import { getRegisteredGuildIds } from './guildRegistry';
+import { getDiscordClient } from './discordBot';
 
 /**
  * Returns the guild ID in which the given Discord user currently has a live
@@ -23,4 +24,25 @@ export function getActiveGuildForUser(client: Client, discordId: string): string
     if (channelId) return guildId;
   }
   return null;
+}
+
+/**
+ * Resolves which guild a chat command targeting `discordId` should be routed to:
+ * the guild in which that Discord user currently has a live voice-channel
+ * connection. Shared tail for `twitchBot.ts`'s and `tiktokBot.ts`'s guild
+ * resolution — each caller differs only in how it first arrives at a `discordId`
+ * (a per-channel cache for Twitch vs. a bot-owner cache for TikTok).
+ *
+ * Returns null if `discordId` is null/empty, the Discord client isn't ready yet
+ * (`getDiscordClient()` returns null), or the user isn't in voice anywhere — in
+ * every case the caller should treat that as "no target guild, no-op".
+ *
+ * @param discordId - Discord snowflake to resolve a target guild for, or null if unresolved.
+ * @returns The guild ID the user is currently in voice in, or null.
+ */
+export function resolveGuildIdForDiscordId(discordId: string | null): string | null {
+  if (!discordId) return null;
+  const discordClient = getDiscordClient();
+  if (!discordClient) return null;
+  return getActiveGuildForUser(discordClient, discordId);
 }

--- a/src/shared/mapUtils.test.ts
+++ b/src/shared/mapUtils.test.ts
@@ -41,4 +41,21 @@ describe('getOrCreate', () => {
 
     expect(second).toBe(first);
   });
+
+  it.each([0, false, '', null, NaN])(
+    'returns a stored falsy value (%p) without overwriting it',
+    (falsyValue) => {
+      const map = new Map<string, unknown>([['a', falsyValue]]);
+      const makeDefault = vi.fn().mockReturnValue('overwritten');
+
+      const result = getOrCreate(map, 'a', makeDefault);
+
+      if (typeof falsyValue === 'number' && Number.isNaN(falsyValue)) {
+        expect(Number.isNaN(result as number)).toBe(true);
+      } else {
+        expect(result).toBe(falsyValue);
+      }
+      expect(makeDefault).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/src/shared/mapUtils.test.ts
+++ b/src/shared/mapUtils.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getOrCreate } from './mapUtils';
+
+describe('getOrCreate', () => {
+  it('creates and inserts a default value when the key is absent', () => {
+    const map = new Map<string, number>();
+    const makeDefault = vi.fn().mockReturnValue(42);
+
+    const result = getOrCreate(map, 'a', makeDefault);
+
+    expect(result).toBe(42);
+    expect(map.get('a')).toBe(42);
+    expect(makeDefault).toHaveBeenCalledOnce();
+  });
+
+  it('returns the existing value without calling makeDefault when the key is present', () => {
+    const map = new Map<string, number>([['a', 7]]);
+    const makeDefault = vi.fn().mockReturnValue(42);
+
+    const result = getOrCreate(map, 'a', makeDefault);
+
+    expect(result).toBe(7);
+    expect(makeDefault).not.toHaveBeenCalled();
+  });
+
+  it('creates a fresh default independently for each new key', () => {
+    const map = new Map<string, { count: number }>();
+
+    const a = getOrCreate(map, 'a', () => ({ count: 0 }));
+    const b = getOrCreate(map, 'b', () => ({ count: 0 }));
+    a.count = 5;
+
+    expect(a).not.toBe(b);
+    expect(map.get('b')?.count).toBe(0);
+  });
+
+  it('returns the same object instance on repeated lookups of an existing key', () => {
+    const map = new Map<string, { count: number }>();
+    const first = getOrCreate(map, 'a', () => ({ count: 0 }));
+    const second = getOrCreate(map, 'a', () => ({ count: 99 }));
+
+    expect(second).toBe(first);
+  });
+});

--- a/src/shared/mapUtils.ts
+++ b/src/shared/mapUtils.ts
@@ -1,0 +1,19 @@
+/**
+ * Returns the value for `key` in `map`, creating and inserting `makeDefault()`
+ * if absent. Shared "look up, else create+set, then return" helper used by
+ * `statusStore.ts`, `commandRouter.ts`, and `audioPlayer.ts` for their
+ * per-guild/per-channel lazy-init state maps.
+ *
+ * @param map - Map to look up (and potentially insert into).
+ * @param key - Key to look up.
+ * @param makeDefault - Builds the default value to insert when `key` is absent.
+ * @returns The existing value for `key`, or the newly-created and inserted default.
+ */
+export function getOrCreate<K, V>(map: Map<K, V>, key: K, makeDefault: () => V): V {
+  let value = map.get(key);
+  if (!value) {
+    value = makeDefault();
+    map.set(key, value);
+  }
+  return value;
+}

--- a/src/shared/mapUtils.ts
+++ b/src/shared/mapUtils.ts
@@ -10,10 +10,10 @@
  * @returns The existing value for `key`, or the newly-created and inserted default.
  */
 export function getOrCreate<K, V>(map: Map<K, V>, key: K, makeDefault: () => V): V {
-  let value = map.get(key);
-  if (!value) {
-    value = makeDefault();
+  if (!map.has(key)) {
+    const value = makeDefault();
     map.set(key, value);
+    return value;
   }
-  return value;
+  return map.get(key) as V;
 }

--- a/src/shared/statusStore.ts
+++ b/src/shared/statusStore.ts
@@ -117,6 +117,15 @@ function defaultChannelStatus(): ChannelStatus {
   return { connected: false, lastConnectedAt: null, lastDisconnectedAt: null, isLive: false };
 }
 
+/**
+ * Updates a channel's connected flag within `map`, creating a default status
+ * record on first use and stamping `lastConnectedAt`/`lastDisconnectedAt`
+ * whenever the connected state actually transitions.
+ *
+ * @param map - The Twitch or TikTok channel-status map to update.
+ * @param key - Channel key to update.
+ * @param connected - New connected state for the channel.
+ */
 function updateChannel(map: Map<string, ChannelStatus>, key: string, connected: boolean): void {
   const existing = getOrCreate(map, key, defaultChannelStatus);
   if (connected && !existing.connected) existing.lastConnectedAt = new Date();

--- a/src/shared/statusStore.ts
+++ b/src/shared/statusStore.ts
@@ -1,3 +1,5 @@
+import { getOrCreate } from './mapUtils';
+
 /** Live connection and stream status for a single Twitch or TikTok channel. */
 export interface ChannelStatus {
   connected: boolean;
@@ -28,16 +30,6 @@ function defaultVoiceStatus(): VoiceStatus {
     lastSource: null,
     lastPlayedAt: null,
   };
-}
-
-/** Returns the value for `key` in `map`, creating and inserting `makeDefault()` if absent. */
-function getOrCreate<K, V>(map: Map<K, V>, key: K, makeDefault: () => V): V {
-  let value = map.get(key);
-  if (!value) {
-    value = makeDefault();
-    map.set(key, value);
-  }
-  return value;
 }
 
 const state = {

--- a/src/shared/textTemplate.test.ts
+++ b/src/shared/textTemplate.test.ts
@@ -25,4 +25,25 @@ describe('fillTemplate', () => {
   it('returns an empty string for an empty template', () => {
     expect(fillTemplate('', { user: 'alice' })).toBe('');
   });
+
+  it('defaults to the empty fallback when no fallback argument is given', () => {
+    expect(fillTemplate('Hi {unknown}!', {})).toBe(fillTemplate('Hi {unknown}!', {}, 'empty'));
+  });
+
+  it('replaces unknown placeholders with an empty string when fallback is explicitly "empty"', () => {
+    expect(fillTemplate('Hi {unknown}!', {}, 'empty')).toBe('Hi !');
+  });
+
+  it('leaves unknown placeholders as the literal {key} text when fallback is "keep"', () => {
+    expect(fillTemplate('Hi {unknown}!', {}, 'keep')).toBe('Hi {unknown}!');
+  });
+
+  it('still substitutes known placeholders when fallback is "keep"', () => {
+    expect(fillTemplate('{streamer} is playing {game}', { streamer: 'alice', game: 'Chess' }, 'keep'))
+      .toBe('alice is playing Chess');
+  });
+
+  it('mixes known substitutions and kept-literal unknowns in "keep" mode', () => {
+    expect(fillTemplate('{streamer} — {unknown}', { streamer: 'alice' }, 'keep')).toBe('alice — {unknown}');
+  });
 });

--- a/src/shared/textTemplate.ts
+++ b/src/shared/textTemplate.ts
@@ -1,11 +1,26 @@
+/** Strategy for handling `{key}` placeholders with no matching entry in `vars`. */
+export type FillTemplateFallback = 'empty' | 'keep';
+
 /**
  * Substitutes `{key}` placeholders in `template` with values from `vars`.
- * Unknown placeholders (keys not present in `vars`) are replaced with an empty string.
+ * Unknown placeholders (keys not present in `vars`) are handled per `fallback`:
+ * `'empty'` (the default) replaces them with an empty string; `'keep'` leaves the
+ * literal `{key}` text in place, which is useful for template-editor previews
+ * where a leftover placeholder should stay visible as a hint of a typo.
  *
  * @param template - Template string containing zero or more `{key}` placeholders.
  * @param vars - Map of placeholder names to their substitution values.
+ * @param fallback - How to handle placeholders with no matching key in `vars`. Defaults to `'empty'`.
  * @returns The template with all placeholders substituted.
  */
-export function fillTemplate(template: string, vars: Record<string, string>): string {
-  return template.replace(/\{(\w+)\}/g, (_, k: string) => vars[k] ?? '');
+export function fillTemplate(
+  template: string,
+  vars: Record<string, string>,
+  fallback: FillTemplateFallback = 'empty',
+): string {
+  return template.replace(/\{(\w+)\}/g, (match, k: string) => {
+    const value = vars[k];
+    if (value !== undefined) return value;
+    return fallback === 'keep' ? match : '';
+  });
 }

--- a/src/tiktok/tiktokBot.test.ts
+++ b/src/tiktok/tiktokBot.test.ts
@@ -75,12 +75,8 @@ vi.mock('../db', async () => {
   };
 });
 
-vi.mock('../discord/discordBot', () => ({
-  getDiscordClient: vi.fn(),
-}));
-
 vi.mock('../discord/voicePresence', () => ({
-  getActiveGuildForUser: vi.fn(),
+  resolveGuildIdForDiscordId: vi.fn(),
 }));
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -89,7 +85,6 @@ type TikTokBotModule = typeof import('./tiktokBot');
 type CommandRouterModule = typeof import('../commands/commandRouter');
 type StatusStoreModule = typeof import('../shared/statusStore');
 type DbModule = typeof import('../db');
-type DiscordBotModule = typeof import('../discord/discordBot');
 type VoicePresenceModule = typeof import('../discord/voicePresence');
 
 const RECONNECT_DELAY_MS = 30_000;
@@ -103,8 +98,7 @@ async function setup(
   handleCommand: CommandRouterModule['handleCommand'];
   setTikTokChannel: StatusStoreModule['setTikTokChannel'];
   findOwnerUser: DbModule['findOwnerUser'];
-  getDiscordClient: DiscordBotModule['getDiscordClient'];
-  getActiveGuildForUser: VoicePresenceModule['getActiveGuildForUser'];
+  resolveGuildIdForDiscordId: VoicePresenceModule['resolveGuildIdForDiscordId'];
 }> {
   vi.resetModules();
   vi.doMock('../shared/config', () => ({
@@ -114,19 +108,16 @@ async function setup(
   const commandRouter = await import('../commands/commandRouter.js') as CommandRouterModule;
   const statusStore = await import('../shared/statusStore.js') as StatusStoreModule;
   const db = await import('../db.js') as DbModule;
-  const discordBot = await import('../discord/discordBot.js') as DiscordBotModule;
   const voicePresence = await import('../discord/voicePresence.js') as VoicePresenceModule;
   const bot = await import('./tiktokBot.js') as TikTokBotModule;
   vi.mocked(db.findOwnerUser).mockResolvedValue({ discord_id: 'owner-discord-id' } as any);
-  vi.mocked(discordBot.getDiscordClient).mockReturnValue({} as any);
-  vi.mocked(voicePresence.getActiveGuildForUser).mockReturnValue('guild-A');
+  vi.mocked(voicePresence.resolveGuildIdForDiscordId).mockReturnValue('guild-A');
   return {
     bot,
     handleCommand: commandRouter.handleCommand,
     setTikTokChannel: statusStore.setTikTokChannel,
     findOwnerUser: db.findOwnerUser,
-    getDiscordClient: discordBot.getDiscordClient,
-    getActiveGuildForUser: voicePresence.getActiveGuildForUser,
+    resolveGuildIdForDiscordId: voicePresence.resolveGuildIdForDiscordId,
   };
 }
 
@@ -227,7 +218,7 @@ describe('startTikTokBot', () => {
 
 describe('chat handling', () => {
   it('forwards chat messages to handleCommand with the tiktok source, resolved via the bot owner\'s active voice guild', async () => {
-    const { bot, handleCommand, findOwnerUser, getActiveGuildForUser } = await setup(['alice']);
+    const { bot, handleCommand, findOwnerUser, resolveGuildIdForDiscordId } = await setup(['alice']);
     activeBot = bot;
 
     await bot.startTikTokBot();
@@ -236,7 +227,7 @@ describe('chat handling', () => {
     await vi.waitFor(() => expect(handleCommand).toHaveBeenCalledOnce());
     expect(handleCommand).toHaveBeenCalledWith('!clap', 'tiktok', 'guild-A');
     expect(findOwnerUser).toHaveBeenCalled();
-    expect(getActiveGuildForUser).toHaveBeenCalledWith(expect.anything(), 'owner-discord-id');
+    expect(resolveGuildIdForDiscordId).toHaveBeenCalledWith('owner-discord-id');
   });
 
   it('passes a null guildId when no bot owner is found', async () => {
@@ -276,7 +267,7 @@ describe('chat handling', () => {
   });
 
   it('re-resolves the owner after the cache TTL expires, picking up an ownership change', async () => {
-    const { bot, handleCommand, findOwnerUser, getActiveGuildForUser } = await setup(['alice']);
+    const { bot, handleCommand, findOwnerUser, resolveGuildIdForDiscordId } = await setup(['alice']);
     activeBot = bot;
 
     await bot.startTikTokBot();
@@ -297,7 +288,7 @@ describe('chat handling', () => {
     // A subsequent lookup picks up the refreshed owner.
     getConnection('alice').emit('chat', { content: '!third' });
     await vi.waitFor(() => expect(handleCommand).toHaveBeenCalledTimes(3));
-    expect(getActiveGuildForUser).toHaveBeenLastCalledWith(expect.anything(), 'new-owner-discord-id');
+    expect(resolveGuildIdForDiscordId).toHaveBeenLastCalledWith('new-owner-discord-id');
   });
 });
 

--- a/src/tiktok/tiktokBot.ts
+++ b/src/tiktok/tiktokBot.ts
@@ -16,8 +16,7 @@ import {
   findOwnerUser,
   type RefreshingLookupCache,
 } from '../db';
-import { getDiscordClient } from '../discord/discordBot';
-import { getActiveGuildForUser } from '../discord/voicePresence';
+import { resolveGuildIdForDiscordId } from '../discord/voicePresence';
 
 const log = createLogger('TikTok');
 
@@ -67,9 +66,7 @@ async function resolveOwnerDiscordId(): Promise<string | null> {
 async function resolveGuildIdForTikTokCommand(): Promise<string | null> {
   const ownerDiscordId = await resolveOwnerDiscordId();
   if (!ownerDiscordId) return null;
-  const discordClient = getDiscordClient();
-  if (!discordClient) return null;
-  return getActiveGuildForUser(discordClient, ownerDiscordId);
+  return resolveGuildIdForDiscordId(ownerDiscordId);
 }
 
 /** Test-only: clears the cached owner discord_id so each test starts from a clean slate. */

--- a/src/tiktok/tiktokBot.ts
+++ b/src/tiktok/tiktokBot.ts
@@ -95,6 +95,14 @@ const activeConnections = new Map<string, Connection>();
 const pendingReconnectTimers = new Set<ReturnType<typeof setTimeout>>();
 let stopped = false;
 
+/**
+ * Opens a TikTok Live connection for `username`, replacing any existing
+ * connection for that channel, and wires up event handlers for chat commands,
+ * status tracking, and automatic reconnection on disconnect/stream-end/error.
+ *
+ * @param username - TikTok channel username to connect to.
+ * @param modules - Dynamically-imported `tiktok-live-connector` classes/enums.
+ */
 function connectToChannel(username: string, modules: TikTokModules): void {
   const { TikTokLiveConnection, WebcastEvent, ControlEvent } = modules;
 
@@ -112,6 +120,14 @@ function connectToChannel(username: string, modules: TikTokModules): void {
   let permanentFailure = false;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
+  /**
+   * Schedules a reconnect attempt for this connection after `RECONNECT_DELAY_MS`,
+   * disconnecting the current connection first. No-ops if the bot has been
+   * stopped, a reconnect is already scheduled, or the connection hit a
+   * permanent failure. Only takes ownership of the `activeConnections` entry
+   * (and clears the timer set) if this connection is still the active one for
+   * `username`, so a newer connection that already replaced it isn't clobbered.
+   */
   function scheduleReconnect(): void {
     if (stopped || reconnectScheduled || permanentFailure) return;
     reconnectScheduled = true;
@@ -184,6 +200,13 @@ function connectToChannel(username: string, modules: TikTokModules): void {
     });
 }
 
+/**
+ * Starts the TikTok listener: connects to every channel configured in
+ * `TIKTOK_CHANNELS` (no-op if none are configured), marking each as
+ * disconnected before dialing in.
+ *
+ * @returns Resolves once a connection attempt has been kicked off for every configured channel.
+ */
 export async function startTikTokBot(): Promise<void> {
   stopped = false;
   if (TIKTOK_CHANNELS.length === 0) {
@@ -202,6 +225,10 @@ export async function startTikTokBot(): Promise<void> {
   }
 }
 
+/**
+ * Stops the TikTok listener: disconnects every active channel connection,
+ * clears pending reconnect timers, and prevents further reconnect attempts.
+ */
 export function stopTikTokBot(): void {
   stopped = true;
   for (const [username, conn] of activeConnections) {

--- a/src/twitch/monitor/twitchMonitorAnnouncements.test.ts
+++ b/src/twitch/monitor/twitchMonitorAnnouncements.test.ts
@@ -1,10 +1,37 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+// Shared with the discordUtils mock factory below so tests can still drive
+// isDiscordNotFoundError's return value directly, even though production code
+// now only calls it indirectly (from inside the mocked tryEditDiscordMessage).
+const { isDiscordNotFoundErrorMock } = vi.hoisted(() => ({
+  isDiscordNotFoundErrorMock: vi.fn().mockReturnValue(false),
+}));
+
 vi.mock('../../shared/logger', () => ({ createLogger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn() }) }));
 vi.mock('../../discord/discordBot', () => ({ getDiscordClient: vi.fn() }));
 vi.mock('../../discord/discordUtils', () => ({
-  isDiscordNotFoundError: vi.fn().mockReturnValue(false),
+  isDiscordNotFoundError: isDiscordNotFoundErrorMock,
   tryDeleteDiscordMessage: vi.fn().mockResolvedValue(undefined),
+  // Minimal re-implementations driven by the same mock Discord client/channel
+  // objects the tests already construct, so call-chain assertions (channel.send,
+  // channel._message.edit, etc.) keep working unchanged.
+  getTextChannel: vi.fn(async (client: any, channelId: string) => {
+    const channel = await client.channels.fetch(channelId);
+    if (!channel || !channel.isTextBased()) return null;
+    return channel;
+  }),
+  tryEditDiscordMessage: vi.fn(async (client: any, channelId: string, messageId: string, payload: any) => {
+    const channel = await client.channels.fetch(channelId);
+    if (!channel || !channel.isTextBased()) return false;
+    try {
+      const message = await channel.messages.fetch(messageId);
+      await message.edit(payload);
+      return true;
+    } catch (err) {
+      if (isDiscordNotFoundErrorMock(err)) return false;
+      throw err;
+    }
+  }),
 }));
 vi.mock('../../db', () => ({
   setStreamerLive: vi.fn().mockResolvedValue(undefined),
@@ -12,8 +39,10 @@ vi.mock('../../db', () => ({
 }));
 vi.mock('./twitchMonitorEmbed', () => ({
   buildEmbed: vi.fn().mockReturnValue({ title: 'embed' }),
-  fillTemplate: vi.fn().mockReturnValue('Live message'),
   templateVars: vi.fn().mockReturnValue({}),
+}));
+vi.mock('../../shared/textTemplate', () => ({
+  fillTemplate: vi.fn().mockReturnValue('Live message'),
 }));
 vi.mock('./twitchMonitorMultitwitch', () => ({
   updateMultitwitch: vi.fn().mockResolvedValue(undefined),

--- a/src/twitch/monitor/twitchMonitorAnnouncements.ts
+++ b/src/twitch/monitor/twitchMonitorAnnouncements.ts
@@ -15,6 +15,10 @@ import { fillTemplate } from '../../shared/textTemplate';
  * Posts a new "now live" announcement message for a streamer and records the
  * resulting message location in both the in-memory live-state map and the DB.
  * No-ops (storing a state with null message fields) if the Discord client isn't ready.
+ * @param liveStates - Map of live streamer states, keyed by streamer DB row id.
+ * @param streamerData - Full streamer record (including its stream group) from the database.
+ * @param stream - The live Twitch stream data.
+ * @returns Resolves once the announcement is posted (or skipped) and state is updated.
  */
 export async function postAnnouncement(
   liveStates: Map<string, LiveState>,
@@ -61,6 +65,11 @@ export async function postAnnouncement(
  * notifications during stream start-up can't repeatedly delete and repost the
  * announcement. If the previously-announced message is gone, falls back to
  * posting a fresh one instead of silently failing on every subsequent call.
+ * @param liveStates - Map of live streamer states, keyed by streamer DB row id.
+ * @param state - Current live state for the streamer being updated.
+ * @param stream - The updated Twitch stream data.
+ * @param templateKey - Which group template to render: 'live_message' or 'new_game_message'.
+ * @returns Resolves once the announcement is edited or reposted and state is updated.
  */
 export async function editAnnouncement(
   liveStates: Map<string, LiveState>,

--- a/src/twitch/monitor/twitchMonitorAnnouncements.ts
+++ b/src/twitch/monitor/twitchMonitorAnnouncements.ts
@@ -3,12 +3,13 @@ import { TextChannel } from 'discord.js';
 
 const log = createLogger('TwitchMonitor');
 import { getDiscordClient } from '../../discord/discordBot';
-import { isDiscordNotFoundError, tryDeleteDiscordMessage } from '../../discord/discordUtils';
+import { getTextChannel, tryDeleteDiscordMessage, tryEditDiscordMessage } from '../../discord/discordUtils';
 import { setStreamerLive, clearStreamerLive, DbStreamerFull } from '../../db';
 import { TwitchStream } from '../twitchApi';
 import { LiveState, makeLiveState } from './twitchMonitorTypes';
-import { buildEmbed, fillTemplate, templateVars } from './twitchMonitorEmbed';
+import { buildEmbed, templateVars } from './twitchMonitorEmbed';
 import { updateMultitwitch } from './twitchMonitorMultitwitch';
+import { fillTemplate } from '../../shared/textTemplate';
 
 /**
  * Posts a new "now live" announcement message for a streamer and records the
@@ -31,12 +32,12 @@ export async function postAnnouncement(
   }
 
   const vars = templateVars(stream.user_login, stream);
-  const content = fillTemplate(group.live_message, vars);
+  const content = fillTemplate(group.live_message, vars, 'keep');
   const embed = buildEmbed(stream);
 
   try {
-    const channel = await discordClient.channels.fetch(group.discord_channel);
-    if (!channel || !channel.isTextBased()) {
+    const channel = await getTextChannel(discordClient, group.discord_channel);
+    if (!channel) {
       log.error(`Channel ${group.discord_channel} not found or not text-based`);
       return;
     }
@@ -79,12 +80,13 @@ export async function editAnnouncement(
   const content = fillTemplate(
     templateKey === 'new_game_message' ? group.new_game_message : group.live_message,
     vars,
+    'keep',
   );
   const embed = buildEmbed(stream);
 
   try {
-    const channel = await discordClient.channels.fetch(state.channelId);
-    if (!channel || !channel.isTextBased()) return;
+    const channel = await getTextChannel(discordClient, state.channelId);
+    if (!channel) return;
     const textChannel = channel as TextChannel;
 
     if (group.delete_old_posts && templateKey === 'new_game_message') {
@@ -97,11 +99,8 @@ export async function editAnnouncement(
       state.messageId = msg.id;
       state.channelId = msg.channelId;
     } else {
-      try {
-        const message = await textChannel.messages.fetch(state.messageId);
-        await message.edit({ content, embeds: [embed] });
-      } catch (err) {
-        if (!isDiscordNotFoundError(err)) throw err;
+      const edited = await tryEditDiscordMessage(discordClient, state.channelId, state.messageId, { content, embeds: [embed] });
+      if (!edited) {
         const msg = await textChannel.send({ content, embeds: [embed] });
         state.messageId = msg.id;
         state.channelId = msg.channelId;

--- a/src/twitch/monitor/twitchMonitorEmbed.test.ts
+++ b/src/twitch/monitor/twitchMonitorEmbed.test.ts
@@ -16,7 +16,6 @@ vi.mock('../twitchApi', () => ({}));
 vi.mock('./twitchMonitorTypes', () => ({}));
 
 import {
-  fillTemplate,
   getStreamUrl,
   getThumbnailUrl,
   buildEmbedPreview,
@@ -39,25 +38,6 @@ function makeStream(overrides: Partial<TwitchStream> = {}): TwitchStream {
     ...overrides,
   };
 }
-
-describe('fillTemplate', () => {
-  it('replaces known variables', () => {
-    expect(fillTemplate('{streamer} is playing {game}', { streamer: 'alice', game: 'Chess' }))
-      .toBe('alice is playing Chess');
-  });
-
-  it('leaves unknown variables as-is (with braces)', () => {
-    expect(fillTemplate('{unknown}', {})).toBe('{unknown}');
-  });
-
-  it('handles template with no variables', () => {
-    expect(fillTemplate('Hello world', { streamer: 'alice' })).toBe('Hello world');
-  });
-
-  it('replaces multiple occurrences of the same variable', () => {
-    expect(fillTemplate('{a} and {a}', { a: 'x' })).toBe('x and x');
-  });
-});
 
 describe('getStreamUrl', () => {
   it('returns the correct Twitch channel URL', () => {
@@ -210,5 +190,19 @@ describe('buildMessagePreview', () => {
     const state = makeLiveState();
     const preview = buildMessagePreview(state, 'live_message', { url: null });
     expect(preview.embed.fields.map((f) => f.name)).not.toContain('MultiTwitch');
+  });
+
+  it('leaves an unknown placeholder as literal {key} text instead of blanking it', () => {
+    const state = makeLiveState({
+      group: {
+        id: 1,
+        live_message: 'Watch {streamer} play {typo_field}',
+        new_game_message: '{streamer} switched to {game}',
+        discord_channel_id: 'chan-1',
+        delete_old_posts: false,
+      } as any,
+    });
+    const preview = buildMessagePreview(state, 'live_message', { url: null });
+    expect(preview.content).toBe('Watch streamer1 play {typo_field}');
   });
 });

--- a/src/twitch/monitor/twitchMonitorEmbed.ts
+++ b/src/twitch/monitor/twitchMonitorEmbed.ts
@@ -1,6 +1,7 @@
 import { EmbedBuilder } from 'discord.js';
 import { TwitchStream } from '../twitchApi';
 import { LiveState } from './twitchMonitorTypes';
+import { fillTemplate } from '../../shared/textTemplate';
 
 // ─── Public types ─────────────────────────────────────────────────────────────
 
@@ -18,10 +19,6 @@ export interface DiscordMessagePreview {
 }
 
 // ─── Template helpers ─────────────────────────────────────────────────────────
-
-export function fillTemplate(template: string, vars: Record<string, string>): string {
-  return template.replace(/\{(\w+)\}/g, (_, key: string) => vars[key] ?? `{${key}}`);
-}
 
 export function getStreamUrl(login: string): string {
   return `https://www.twitch.tv/${login}`;
@@ -73,6 +70,20 @@ export function templateVars(login: string, stream: TwitchStream): Record<string
 
 // ─── Message preview ──────────────────────────────────────────────────────────
 
+/**
+ * Builds the admin-panel preview (message content + embed) for a streamer's
+ * live/new-game announcement template. Uses the `'keep'` {@link fillTemplate}
+ * fallback so a placeholder with a typo (no matching key in `templateVars`)
+ * stays visible in the preview as `{like_this}` instead of silently vanishing —
+ * a useful signal for whoever is editing the template. This mirrors the
+ * behaviour used when the same templates are actually posted/edited on
+ * Discord (see `twitchMonitorAnnouncements.ts` and `twitchMonitorStartup.ts`).
+ *
+ * @param state - Live state supplying the current stream and message templates.
+ * @param templateKey - Which of the group's templates to render.
+ * @param multiTwitch - Multi-twitch URL context; a non-null `url` adds a MultiTwitch field.
+ * @returns The rendered message content and embed preview.
+ */
 export function buildMessagePreview(
   state: LiveState,
   templateKey: 'live_message' | 'new_game_message',
@@ -85,7 +96,7 @@ export function buildMessagePreview(
   const vars = templateVars(state.login, stream);
 
   return {
-    content: fillTemplate(template, vars),
+    content: fillTemplate(template, vars, 'keep'),
     embed: buildEmbedPreview(stream, multiTwitch.url ?? undefined),
   };
 }

--- a/src/twitch/monitor/twitchMonitorEmbed.ts
+++ b/src/twitch/monitor/twitchMonitorEmbed.ts
@@ -20,16 +20,33 @@ export interface DiscordMessagePreview {
 
 // ─── Template helpers ─────────────────────────────────────────────────────────
 
+/**
+ * Builds the public Twitch channel URL for a streamer's login.
+ * @param login - Twitch login/username.
+ * @returns The `https://www.twitch.tv/<login>` URL.
+ */
 export function getStreamUrl(login: string): string {
   return `https://www.twitch.tv/${login}`;
 }
 
+/**
+ * Resolves `stream`'s thumbnail template URL to a concrete 640x360 image URL.
+ * @param stream - Twitch stream whose thumbnail URL should be resolved.
+ * @returns The thumbnail URL with `{width}`/`{height}` placeholders filled in.
+ */
 export function getThumbnailUrl(stream: TwitchStream): string {
   return stream.thumbnail_url
     .replace('{width}', '640')
     .replace('{height}', '360');
 }
 
+/**
+ * Builds the embed preview data (title, url, color, fields, image) for a live
+ * stream announcement, optionally adding a MultiTwitch field.
+ * @param stream - The live Twitch stream data.
+ * @param multitwitchUrl - MultiTwitch group URL to include as a field, if any.
+ * @returns The assembled embed preview.
+ */
 export function buildEmbedPreview(stream: TwitchStream, multitwitchUrl?: string): DiscordEmbedPreview {
   const fields: Array<{ name: string; value: string }> = [{ name: 'Game', value: stream.game_name || 'Unknown' }];
   if (multitwitchUrl) fields.push({ name: 'MultiTwitch', value: multitwitchUrl });
@@ -42,12 +59,25 @@ export function buildEmbedPreview(stream: TwitchStream, multitwitchUrl?: string)
   };
 }
 
+/**
+ * Parses a `#rrggbb` (or `rrggbb`) hex color string into a numeric color value
+ * usable by discord.js embeds, falling back to Twitch purple if invalid.
+ * @param color - Hex color string, with or without a leading `#`.
+ * @returns The parsed numeric color, or `0x9146ff` if `color` isn't valid 6-digit hex.
+ */
 export function parseHexColor(color: string): number {
   const normalized = color.trim().replace(/^#/, '');
   if (!/^[0-9a-fA-F]{6}$/.test(normalized)) return 0x9146ff;
   return parseInt(normalized, 16);
 }
 
+/**
+ * Builds the actual discord.js {@link EmbedBuilder} for a live stream
+ * announcement, from the same data used to build the admin-panel preview.
+ * @param stream - The live Twitch stream data.
+ * @param multitwitchUrl - MultiTwitch group URL to include as a field, if any.
+ * @returns The assembled embed, ready to send/edit on a Discord message.
+ */
 export function buildEmbed(stream: TwitchStream, multitwitchUrl?: string): EmbedBuilder {
   const preview = buildEmbedPreview(stream, multitwitchUrl);
 
@@ -59,6 +89,13 @@ export function buildEmbed(stream: TwitchStream, multitwitchUrl?: string): Embed
     .setImage(preview.imageUrl);
 }
 
+/**
+ * Builds the placeholder variables (`streamer`, `game`, `title`, `url`) available
+ * to a live/new-game announcement message template.
+ * @param login - Twitch login of the streamer.
+ * @param stream - The live Twitch stream data.
+ * @returns The template variable map, for use with {@link fillTemplate}.
+ */
 export function templateVars(login: string, stream: TwitchStream): Record<string, string> {
   return {
     streamer: login,

--- a/src/twitch/monitor/twitchMonitorMultitwitch.test.ts
+++ b/src/twitch/monitor/twitchMonitorMultitwitch.test.ts
@@ -1,10 +1,13 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../../shared/logger', () => ({ createLogger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn() }) }));
 vi.mock('../../discord/discordBot', () => ({ getDiscordClient: vi.fn().mockReturnValue(null) }));
-vi.mock('./twitchMonitorEmbed', () => ({ buildEmbed: vi.fn() }));
+vi.mock('../../discord/discordUtils', () => ({ tryEditDiscordMessage: vi.fn() }));
+vi.mock('./twitchMonitorEmbed', () => ({ buildEmbed: vi.fn().mockReturnValue({ title: 'embed' }) }));
 
-import { groupGameKey, buildMultiTwitchContext, getMultitwitchPreview } from './twitchMonitorMultitwitch';
+import { groupGameKey, buildMultiTwitchContext, getMultitwitchPreview, updateMultitwitch } from './twitchMonitorMultitwitch';
+import { getDiscordClient } from '../../discord/discordBot';
+import { tryEditDiscordMessage } from '../../discord/discordUtils';
 import type { LiveState } from './twitchMonitorTypes';
 
 function makeState(overrides: Partial<LiveState> = {}): LiveState {
@@ -170,5 +173,85 @@ describe('getMultitwitchPreview', () => {
     const state = makeState({ login: 'alice', groupId: 1, currentGame: 'Minecraft', group: { ...makeState().group, multi_twitch: false } });
     const result = getMultitwitchPreview(state, ctxWith([]));
     expect(result.enabled).toBe(false);
+  });
+});
+
+// ─── updateMultitwitch ────────────────────────────────────────────────────────
+
+describe('updateMultitwitch', () => {
+  const fakeClient = { id: 'fake-client' };
+
+  beforeEach(() => {
+    vi.mocked(getDiscordClient).mockReturnValue(fakeClient as any);
+    vi.mocked(tryEditDiscordMessage).mockReset();
+    vi.mocked(tryEditDiscordMessage).mockResolvedValue(true);
+  });
+
+  it('does nothing when there is no discord client', async () => {
+    vi.mocked(getDiscordClient).mockReturnValue(null);
+    const liveStates = new Map<string, LiveState>([['k', makeState()]]);
+
+    await updateMultitwitch(10, liveStates);
+
+    expect(tryEditDiscordMessage).not.toHaveBeenCalled();
+  });
+
+  it('skips states with no messageId or channelId', async () => {
+    const liveStates = new Map<string, LiveState>([
+      ['k', makeState({ messageId: null, channelId: null })],
+    ]);
+
+    await updateMultitwitch(10, liveStates);
+
+    expect(tryEditDiscordMessage).not.toHaveBeenCalled();
+  });
+
+  it('edits the announcement message for each live state in the group', async () => {
+    const liveStates = new Map<string, LiveState>([
+      ['k', makeState({ groupId: 10, channelId: 'chan1', messageId: 'msg1' })],
+    ]);
+
+    await updateMultitwitch(10, liveStates);
+
+    expect(tryEditDiscordMessage).toHaveBeenCalledWith(fakeClient, 'chan1', 'msg1', { embeds: [{ title: 'embed' }] });
+  });
+
+  it('only updates states belonging to the requested group', async () => {
+    const liveStates = new Map<string, LiveState>([
+      ['a', makeState({ groupId: 10, login: 'alice', channelId: 'chan-a', messageId: 'msg-a' })],
+      ['b', makeState({ groupId: 99, login: 'bob', channelId: 'chan-b', messageId: 'msg-b' })],
+    ]);
+
+    await updateMultitwitch(10, liveStates);
+
+    expect(tryEditDiscordMessage).toHaveBeenCalledTimes(1);
+    expect(tryEditDiscordMessage).toHaveBeenCalledWith(fakeClient, 'chan-a', 'msg-a', expect.anything());
+  });
+
+  it('silently skips a state whose message was not found (returns false), without logging or throwing', async () => {
+    vi.mocked(tryEditDiscordMessage).mockResolvedValueOnce(false);
+    const liveStates = new Map<string, LiveState>([
+      ['a', makeState({ groupId: 10, login: 'alice', channelId: 'chan-a', messageId: 'msg-a' })],
+      ['b', makeState({ groupId: 10, login: 'bob', channelId: 'chan-b', messageId: 'msg-b' })],
+    ]);
+
+    await expect(updateMultitwitch(10, liveStates)).resolves.toBeUndefined();
+
+    // Both states are still attempted — the not-found result for 'a' doesn't abort the loop.
+    expect(tryEditDiscordMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it('logs the error and continues updating the remaining states when a real error is thrown', async () => {
+    vi.mocked(tryEditDiscordMessage)
+      .mockRejectedValueOnce(new Error('network blip'))
+      .mockResolvedValueOnce(true);
+    const liveStates = new Map<string, LiveState>([
+      ['a', makeState({ groupId: 10, login: 'alice', channelId: 'chan-a', messageId: 'msg-a' })],
+      ['b', makeState({ groupId: 10, login: 'bob', channelId: 'chan-b', messageId: 'msg-b' })],
+    ]);
+
+    await expect(updateMultitwitch(10, liveStates)).resolves.toBeUndefined();
+
+    expect(tryEditDiscordMessage).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/twitch/monitor/twitchMonitorMultitwitch.ts
+++ b/src/twitch/monitor/twitchMonitorMultitwitch.ts
@@ -28,10 +28,24 @@ interface MultiTwitchContext {
 
 // ─── Multitwitch helpers ──────────────────────────────────────────────────────
 
+/**
+ * Builds the key used to bucket live states that could co-appear in the same
+ * MultiTwitch link: same stream group, same (case-insensitive) game.
+ * @param groupId - Stream group ID.
+ * @param game - Current game name being played.
+ * @returns A composite key combining `groupId` and the lowercased game name.
+ */
 export function groupGameKey(groupId: number, game: string): string {
   return `${groupId}::${game.toLowerCase()}`;
 }
 
+/**
+ * Buckets every live state by {@link groupGameKey} to find which streamers
+ * within the same group are currently playing the same game (and so are
+ * eligible to be linked together in a MultiTwitch URL).
+ * @param states - All currently-tracked live states.
+ * @returns Context mapping each group+game key to its sorted list of participant logins.
+ */
 export function buildMultiTwitchContext(states: Iterable<LiveState>): MultiTwitchContext {
   const participantSets = new Map<string, Set<string>>();
 
@@ -56,6 +70,14 @@ export function buildMultiTwitchContext(states: Iterable<LiveState>): MultiTwitc
   return { participantsByGroupAndGame };
 }
 
+/**
+ * Determines the MultiTwitch preview for a single streamer's live state: whether
+ * MultiTwitch applies (2+ co-streaming participants on the same game), whether
+ * it's enabled for the group, and the resulting URL if both are true.
+ * @param state - Live state for the streamer being previewed.
+ * @param context - Group+game participant context from {@link buildMultiTwitchContext}.
+ * @returns The MultiTwitch preview: enabled/applicable flags, participant logins, and URL (or null).
+ */
 export function getMultitwitchPreview(state: LiveState, context: MultiTwitchContext): MultiTwitchPreview {
   const participants = context.participantsByGroupAndGame.get(groupGameKey(state.groupId, state.currentGame));
   const applicable = !!participants && participants.length >= 2;

--- a/src/twitch/monitor/twitchMonitorMultitwitch.ts
+++ b/src/twitch/monitor/twitchMonitorMultitwitch.ts
@@ -2,6 +2,7 @@ import { createLogger } from '../../shared/logger';
 import { getDiscordClient } from '../../discord/discordBot';
 
 const log = createLogger('TwitchMonitor');
+import { tryEditDiscordMessage } from '../../discord/discordUtils';
 import { buildEmbed } from './twitchMonitorEmbed';
 import { LiveState } from './twitchMonitorTypes';
 
@@ -87,6 +88,19 @@ export function getMultitwitchPreview(state: LiveState, context: MultiTwitchCont
   };
 }
 
+/**
+ * Refreshes the MultiTwitch field on every live announcement embed in `groupId`
+ * to reflect the current set of co-streaming participants. Each announcement is
+ * edited independently via {@link tryEditDiscordMessage}, so a Discord not-found
+ * error for one streamer's message (deleted, channel gone, etc.) is silently
+ * skipped rather than logged — matching the not-found handling already used by
+ * the sibling announcement-editing paths in `twitchMonitorAnnouncements.ts` and
+ * `twitchMonitorStartup.ts` — while any other error is logged and does not stop
+ * the remaining states in the group from being updated.
+ *
+ * @param groupId - Stream group whose live announcements should be refreshed.
+ * @param liveStates - All currently-tracked live states, filtered down to `groupId`.
+ */
 export async function updateMultitwitch(groupId: number, liveStates: ReadonlyMap<string, LiveState>): Promise<void> {
   const discordClient = getDiscordClient();
   if (!discordClient) return;
@@ -98,13 +112,10 @@ export async function updateMultitwitch(groupId: number, liveStates: ReadonlyMap
     if (!state.messageId || !state.channelId) continue;
     const multiTwitch = getMultitwitchPreview(state, context);
     const multitwitchUrl = multiTwitch.url ?? undefined;
+    const updated = buildEmbed(state.currentStream, multitwitchUrl);
 
     try {
-      const channel = await discordClient.channels.fetch(state.channelId);
-      if (!channel || !channel.isTextBased()) continue;
-      const message = await channel.messages.fetch(state.messageId);
-      const updated = buildEmbed(state.currentStream, multitwitchUrl);
-      await message.edit({ embeds: [updated] });
+      await tryEditDiscordMessage(discordClient, state.channelId, state.messageId, { embeds: [updated] });
     } catch (err) {
       log.error(`Failed to update multitwitch for ${state.login}:`, err);
     }

--- a/src/twitch/monitor/twitchMonitorStartup.test.ts
+++ b/src/twitch/monitor/twitchMonitorStartup.test.ts
@@ -1,10 +1,36 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+// Shared with the discordUtils mock factory below so tests can still drive
+// isDiscordNotFoundError's return value directly, even though production code
+// now only calls it indirectly (from inside the mocked tryEditDiscordMessage).
+const { isDiscordNotFoundErrorMock } = vi.hoisted(() => ({
+  isDiscordNotFoundErrorMock: vi.fn().mockReturnValue(false),
+}));
+
 vi.mock('../../shared/logger', () => ({ createLogger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn() }) }));
 vi.mock('../../discord/discordBot', () => ({ getDiscordClient: vi.fn() }));
 vi.mock('../../discord/discordUtils', () => ({
-  isDiscordNotFoundError: vi.fn().mockReturnValue(false),
+  isDiscordNotFoundError: isDiscordNotFoundErrorMock,
   tryDeleteDiscordMessage: vi.fn().mockResolvedValue(undefined),
+  // Minimal re-implementations driven by the same mock Discord client/channel
+  // objects the tests already construct, so call-chain assertions keep working.
+  getTextChannel: vi.fn(async (client: any, channelId: string) => {
+    const channel = await client.channels.fetch(channelId);
+    if (!channel || !channel.isTextBased()) return null;
+    return channel;
+  }),
+  tryEditDiscordMessage: vi.fn(async (client: any, channelId: string, messageId: string, payload: any) => {
+    const channel = await client.channels.fetch(channelId);
+    if (!channel || !channel.isTextBased()) return false;
+    try {
+      const message = await channel.messages.fetch(messageId);
+      await message.edit(payload);
+      return true;
+    } catch (err) {
+      if (isDiscordNotFoundErrorMock(err)) return false;
+      throw err;
+    }
+  }),
 }));
 vi.mock('../../db', () => ({
   setStreamerLive: vi.fn().mockResolvedValue(undefined),
@@ -15,8 +41,10 @@ vi.mock('../twitchApi', () => ({
 }));
 vi.mock('./twitchMonitorEmbed', () => ({
   buildEmbed: vi.fn().mockReturnValue({}),
-  fillTemplate: vi.fn().mockReturnValue('message'),
   templateVars: vi.fn().mockReturnValue({}),
+}));
+vi.mock('../../shared/textTemplate', () => ({
+  fillTemplate: vi.fn().mockReturnValue('message'),
 }));
 vi.mock('./twitchMonitorMultitwitch', () => ({
   updateMultitwitch: vi.fn().mockResolvedValue(undefined),

--- a/src/twitch/monitor/twitchMonitorStartup.ts
+++ b/src/twitch/monitor/twitchMonitorStartup.ts
@@ -46,6 +46,17 @@ export async function tryEditStartupMessage(
   }
 }
 
+/**
+ * Handles a streamer found to already be live at bot startup: if a previous
+ * announcement message is recorded, tries to edit it in place via
+ * {@link tryEditStartupMessage}; otherwise (or if the edit isn't possible)
+ * falls back to posting a fresh announcement via {@link postAnnouncement}.
+ * @param liveStates - Map of live streamer states, keyed by streamer DB row id.
+ * @param streamer - Full streamer record (including its stream group) from the database.
+ * @param liveStream - The current live Twitch stream data.
+ * @param groupsWithChanges - Accumulator of stream group IDs whose MultiTwitch state needs refreshing.
+ * @returns Resolves once the streamer's announcement has been reconciled.
+ */
 export async function handleLiveStreamerOnStartup(
   liveStates: Map<string, LiveState>,
   streamer: DbStreamerFull,
@@ -70,6 +81,16 @@ export async function handleLiveStreamerOnStartup(
   await postAnnouncement(liveStates, streamer, liveStream);
 }
 
+/**
+ * Handles a streamer found to be offline at bot startup despite having a
+ * recorded live announcement: deletes the stale Discord message (best-effort)
+ * and clears the streamer's live state in the DB. `liveStates` is empty at
+ * startup, so {@link deleteAnnouncement}'s in-memory-map path can't be reused —
+ * the cleanup is done directly here instead.
+ * @param streamer - Full streamer record (including its stream group) from the database.
+ * @param groupsWithChanges - Accumulator of stream group IDs whose MultiTwitch state needs refreshing.
+ * @returns Resolves once the stale announcement is cleaned up (or skipped on delete failure).
+ */
 export async function handleOfflineStreamerOnStartup(
   streamer: DbStreamerFull,
   groupsWithChanges: Set<number>,
@@ -88,6 +109,17 @@ export async function handleOfflineStreamerOnStartup(
   groupsWithChanges.add(streamer.group.id);
 }
 
+/**
+ * Runs the one-time live-status reconciliation performed when the bot starts:
+ * fetches current live streams for all tracked streamers, reconciles each
+ * streamer's announcement state via {@link handleLiveStreamerOnStartup} or
+ * {@link handleOfflineStreamerOnStartup}, then refreshes MultiTwitch fields for
+ * every stream group that changed.
+ * @param liveStates - Map of live streamer states, keyed by streamer DB row id (mutated in place).
+ * @param loginToUserId - Map of lowercased Twitch login to Twitch user ID for all tracked streamers.
+ * @param streamersData - Full streamer records (including stream group) from the database.
+ * @returns Resolves once startup reconciliation and MultiTwitch refresh are complete.
+ */
 export async function performStartupLiveCheck(
   liveStates: Map<string, LiveState>,
   loginToUserId: Map<string, string>,

--- a/src/twitch/monitor/twitchMonitorStartup.ts
+++ b/src/twitch/monitor/twitchMonitorStartup.ts
@@ -2,14 +2,25 @@ import { createLogger } from '../../shared/logger';
 import { getDiscordClient } from '../../discord/discordBot';
 
 const log = createLogger('TwitchMonitor');
-import { isDiscordNotFoundError, tryDeleteDiscordMessage } from '../../discord/discordUtils';
+import { getTextChannel, tryDeleteDiscordMessage, tryEditDiscordMessage } from '../../discord/discordUtils';
 import { setStreamerLive, clearStreamerLive, DbStreamerFull } from '../../db';
 import { getStreams, TwitchStream } from '../twitchApi';
 import { LiveState, makeLiveState } from './twitchMonitorTypes';
-import { buildEmbed, fillTemplate, templateVars } from './twitchMonitorEmbed';
+import { buildEmbed, templateVars } from './twitchMonitorEmbed';
 import { updateMultitwitch } from './twitchMonitorMultitwitch';
 import { postAnnouncement } from './twitchMonitorAnnouncements';
+import { fillTemplate } from '../../shared/textTemplate';
 
+/**
+ * Tries to edit the streamer's existing startup-time "now live" message in place
+ * (used when the bot restarts while a streamer is already live and previously
+ * posted). Returns false — without throwing — if the client isn't ready, the
+ * streamer has no recorded message/channel, the channel isn't text-based, or the
+ * edit fails with a Discord not-found error (message/channel deleted while the
+ * bot was down); the caller falls back to {@link postAnnouncement} in that case.
+ * Any other error is logged (once here, and again inside
+ * {@link tryEditDiscordMessage} for the underlying Discord failure) and rethrown.
+ */
 export async function tryEditStartupMessage(
   liveStates: Map<string, LiveState>,
   streamer: DbStreamerFull,
@@ -19,18 +30,17 @@ export async function tryEditStartupMessage(
   if (!discordClient) return false;
   if (!streamer.discord_channel_id || !streamer.discord_message_id) return false;
   try {
-    const channel = await discordClient.channels.fetch(streamer.discord_channel_id);
-    if (!channel || !channel.isTextBased()) return false;
+    const channel = await getTextChannel(discordClient, streamer.discord_channel_id);
+    if (!channel) return false;
     const vars = templateVars(liveStream.user_login, liveStream);
-    const content = fillTemplate(streamer.group.live_message, vars);
+    const content = fillTemplate(streamer.group.live_message, vars, 'keep');
     const embed = buildEmbed(liveStream);
-    const message = await channel.messages.fetch(streamer.discord_message_id);
-    await message.edit({ content, embeds: [embed] });
+    const edited = await tryEditDiscordMessage(discordClient, streamer.discord_channel_id, streamer.discord_message_id, { content, embeds: [embed] });
+    if (!edited) return false;
     liveStates.set(String(streamer.id), makeLiveState(streamer, liveStream, streamer.discord_message_id, streamer.discord_channel_id));
     await setStreamerLive(streamer.id, streamer.discord_message_id, streamer.discord_channel_id, liveStream.game_name);
     return true;
   } catch (err) {
-    if (isDiscordNotFoundError(err)) return false;
     log.error(`Failed to edit startup message for ${streamer.twitch_name ?? 'unknown'}:`, err);
     throw err;
   }

--- a/src/twitch/twitchBot.test.ts
+++ b/src/twitch/twitchBot.test.ts
@@ -50,12 +50,8 @@ vi.mock('../db', async () => {
   };
 });
 
-vi.mock('../discord/discordBot', () => ({
-  getDiscordClient: vi.fn(),
-}));
-
 vi.mock('../discord/voicePresence', () => ({
-  getActiveGuildForUser: vi.fn(),
+  resolveGuildIdForDiscordId: vi.fn(),
 }));
 
 vi.mock('./twitchApi', () => ({
@@ -106,8 +102,7 @@ import {
   setChannelJoinedHook,
 } from './twitchChannelMembership';
 import { getTwitchEnabledChannels, getAllTwitchLinkedUsers, findUserByTwitchName } from '../db';
-import { getDiscordClient } from '../discord/discordBot';
-import { getActiveGuildForUser } from '../discord/voicePresence';
+import { resolveGuildIdForDiscordId } from '../discord/voicePresence';
 import { getUsers } from './twitchApi';
 import { setTwitchChannel } from '../shared/statusStore';
 import { executeCustomCommandForTwitch } from '../commands/customCommandHandler';
@@ -175,8 +170,7 @@ describe('handleTwitchMessage', () => {
     resetMockClient();
     vi.mocked(getAllTwitchLinkedUsers).mockResolvedValue([{ twitchName: 'streamer', discordId: 'streamer-discord-id' }]);
     vi.mocked(findUserByTwitchName).mockResolvedValue(null);
-    vi.mocked(getDiscordClient).mockReturnValue({} as any);
-    vi.mocked(getActiveGuildForUser).mockReturnValue('guild-A');
+    vi.mocked(resolveGuildIdForDiscordId).mockReturnValue('guild-A');
     __resetTwitchChannelDiscordIdCacheForTests();
   });
 
@@ -243,7 +237,7 @@ describe('handleTwitchMessage', () => {
 
     await vi.waitFor(() => expect(handleCommand).toHaveBeenCalledOnce());
     expect(getAllTwitchLinkedUsers).toHaveBeenCalled();
-    expect(getActiveGuildForUser).toHaveBeenCalledWith(expect.anything(), 'streamer-discord-id');
+    expect(resolveGuildIdForDiscordId).toHaveBeenCalledWith('streamer-discord-id');
   });
 
   it('passes a null guildId to handleCommand when the channel has no linked Discord user', async () => {
@@ -255,7 +249,7 @@ describe('handleTwitchMessage', () => {
 
     await vi.waitFor(() => expect(handleCommand).toHaveBeenCalledOnce());
     expect(handleCommand).toHaveBeenCalledWith('!cmd', 'twitch', null);
-    expect(getActiveGuildForUser).not.toHaveBeenCalled();
+    expect(resolveGuildIdForDiscordId).not.toHaveBeenCalled();
   });
 
   it('falls back to a live lookup when a channel is missing from the bulk cache, so a just-linked streamer works on the very next message', async () => {
@@ -269,7 +263,7 @@ describe('handleTwitchMessage', () => {
 
     await vi.waitFor(() => expect(handleCommand).toHaveBeenCalledOnce());
     expect(findUserByTwitchName).toHaveBeenCalledWith('streamer');
-    expect(getActiveGuildForUser).toHaveBeenCalledWith(expect.anything(), 'freshly-linked-discord-id');
+    expect(resolveGuildIdForDiscordId).toHaveBeenCalledWith('freshly-linked-discord-id');
   });
 
   it('does not fall back to a live lookup when the channel is already present in the bulk cache', async () => {
@@ -301,7 +295,7 @@ describe('handleTwitchMessage', () => {
     // A subsequent lookup picks up the refreshed mapping.
     sendMessage('#streamer', makeTags(), '!third');
     await vi.waitFor(() => expect(handleCommand).toHaveBeenCalledTimes(3));
-    expect(getActiveGuildForUser).toHaveBeenLastCalledWith(expect.anything(), 'new-streamer-discord-id');
+    expect(resolveGuildIdForDiscordId).toHaveBeenLastCalledWith('new-streamer-discord-id');
   });
 
   it('passes the normalized channel and message to executors', () => {

--- a/src/twitch/twitchBot.ts
+++ b/src/twitch/twitchBot.ts
@@ -17,8 +17,7 @@ import {
   findUserByTwitchName,
   type RefreshingLookupCache,
 } from '../db';
-import { getDiscordClient } from '../discord/discordBot';
-import { getActiveGuildForUser } from '../discord/voicePresence';
+import { resolveGuildIdForDiscordId } from '../discord/voicePresence';
 import {
   setTmiClient,
   setConnected,
@@ -86,9 +85,7 @@ export function __resetTwitchChannelDiscordIdCacheForTests(): void {
 async function resolveGuildIdForTwitchCommand(normalizedChannel: string): Promise<string | null> {
   const discordId = await resolveDiscordIdForTwitchChannel(normalizedChannel);
   if (!discordId) return null;
-  const discordClient = getDiscordClient();
-  if (!discordClient) return null;
-  return getActiveGuildForUser(discordClient, discordId);
+  return resolveGuildIdForDiscordId(discordId);
 }
 
 function fireAndForget(promise: Promise<void>, context: string): void {

--- a/src/twitch/twitchBot.ts
+++ b/src/twitch/twitchBot.ts
@@ -88,10 +88,28 @@ async function resolveGuildIdForTwitchCommand(normalizedChannel: string): Promis
   return resolveGuildIdForDiscordId(discordId);
 }
 
+/**
+ * Runs `promise` without awaiting it, logging (rather than throwing) if it rejects.
+ * Used so one command handler's failure can't block or delay the others.
+ * @param promise - The in-flight promise to observe.
+ * @param context - Log-line prefix identifying which handler the promise belongs to.
+ */
 function fireAndForget(promise: Promise<void>, context: string): void {
   promise.catch((err) => log.error(`${context}:`, err));
 }
 
+/**
+ * tmi.js `message` event handler: dispatches an incoming Twitch chat message to
+ * every command handler (custom commands, counters, `!multi`, `!so`, the shared
+ * command router, countdowns) in parallel via {@link fireAndForget}. Ignores the
+ * bot's own messages, messages from channels not in the active set, and messages
+ * shared into this channel from a partner channel in a Twitch shared-chat session
+ * (so each message is only handled once, in its source channel).
+ * @param channel - Twitch channel the message was received in (as `#channel`).
+ * @param tags - tmi.js chat user state (badges, mod status, display name, etc.) for the sender.
+ * @param message - Raw chat message text.
+ * @param self - Whether this message was sent by the bot's own account.
+ */
 function handleTwitchMessage(
   channel: string,
   tags: tmi.ChatUserstate,
@@ -127,6 +145,14 @@ function handleTwitchMessage(
   }
 }
 
+/**
+ * tmi.js `connected` event handler: marks the bot connected, logs the active
+ * channel list, pessimistically resets every active channel's status to
+ * disconnected, then kicks off an async reconciliation of actually-joined
+ * channels via {@link reconcileJoinedChannels}.
+ * @param addr - Address of the Twitch IRC server connected to.
+ * @param port - Port of the Twitch IRC server connected to.
+ */
 function onConnected(addr: string, port: number): void {
   connected = true;
   setConnected(true);
@@ -141,6 +167,13 @@ function onConnected(addr: string, port: number): void {
   });
 }
 
+/**
+ * tmi.js `disconnected` event handler: marks the bot disconnected, clears
+ * tmi.js's internal joined-channel list (which it doesn't reset on disconnect,
+ * to avoid double-joining every channel on reconnect), and marks every active
+ * channel's status as disconnected.
+ * @param reason - Reason string reported by tmi.js for the disconnect.
+ */
 function onDisconnected(reason: string): void {
   connected = false;
   setConnected(false);
@@ -153,6 +186,12 @@ function onDisconnected(reason: string): void {
   getActiveChannels().forEach((ch) => { setTwitchChannel(ch, false); });
 }
 
+/**
+ * Starts the Twitch bot: initializes the active-channel set, creates and
+ * configures the tmi.js client (identity, logging, auto-reconnect), wires up
+ * message/connected/disconnected handlers, and connects.
+ * @returns Resolves once the client has connected; rejects if the connection attempt fails.
+ */
 export async function startTwitchBot(): Promise<void> {
   await initializeActiveChannels();
 
@@ -187,6 +226,13 @@ export async function startTwitchBot(): Promise<void> {
   }
 }
 
+/**
+ * Sends `message` to a Twitch channel via the connected tmi.js client.
+ * @param channel - Twitch channel to send to (normalized before sending).
+ * @param message - Message text to send.
+ * @returns Resolves once the message has been sent.
+ * @throws If `channel` doesn't normalize to a valid channel name, or the client isn't connected.
+ */
 export async function sayInChannel(channel: string, message: string): Promise<void> {
   const normalized = normalizeTwitchChannelName(channel);
   if (!normalized) throw new Error(`[Twitch] Invalid channel name: ${channel}`);
@@ -194,6 +240,12 @@ export async function sayInChannel(channel: string, message: string): Promise<vo
   await client.say(normalized, message);
 }
 
+/**
+ * Stops the Twitch bot: disconnects the tmi.js client (marking channels
+ * disconnected if the disconnect itself fails), tears down the client
+ * reference, and clears channel-membership state.
+ * @returns Resolves once shutdown is complete.
+ */
 export async function stopTwitchBot(): Promise<void> {
   connected = false;
   setConnected(false);


### PR DESCRIPTION
## Summary

Part of the project-wide de-duplication review, scoped to `src/commands/*.ts`, `src/twitch/**/*.ts`, `src/discord/*.ts`, `src/audio/*.ts`, `src/tiktok/tiktokBot.ts`, `src/shared/*.ts`.

- **fillTemplate**: extended the shared `src/shared/textTemplate.ts` implementation with an optional `fallback: 'empty' | 'keep' = 'empty'` parameter, deleted the divergent duplicate in `twitchMonitorEmbed.ts`, and updated `twitchMonitorAnnouncements.ts` / `twitchMonitorStartup.ts` / `twitchMonitorEmbed.ts` to import the shared version with `'keep'` explicitly passed at each call site.
- **Shared broadcast dedup**: extracted `sendDedupedBySession` (new `src/commands/twitchBroadcast.ts`) from the near-identical dedup/send loops in `customCommandHandler.ts`'s `broadcastToActiveChannels` and `multiCommandHandler.ts`'s `broadcastToGroupChannels`.
- **Discord edit/fetch helpers**: added `getTextChannel` and `tryEditDiscordMessage` to `src/discord/discordUtils.ts` (mirroring the existing `tryDeleteDiscordMessage` not-found handling) and refactored `twitchMonitorAnnouncements.ts`, `twitchMonitorMultitwitch.ts`, and `twitchMonitorStartup.ts` to use them instead of hand-rolling channel-fetch + `isTextBased` + edit/not-found logic.
- **registerXRuntime consolidation**: factored the `let _runtime: T | null; registerXRuntime(); getXRuntime()` boilerplate duplicated across `countdownHandler.ts`, `counterHandler.ts`, `customCommandHandler.ts`, `multiCommandHandler.ts`, and `shoutoutHandler.ts` into a generic `createRuntimeRegistry<T>()` (new `src/commands/twitchRuntime.ts`). All five `registerXRuntime` exports keep their existing names/signatures, so **`src/index.ts` did not need to change at all**.
- **resolveGuildIdForDiscordId**: extracted the shared `discordId → getDiscordClient() → getActiveGuildForUser` tail from `twitchBot.ts`'s `resolveGuildIdForTwitchCommand` and `tiktokBot.ts`'s `resolveGuildIdForTikTokCommand` into `src/discord/voicePresence.ts`. Each bot keeps its own (differing) discordId-resolution step as caller-side logic before calling the shared helper.
- **getOrCreate promotion**: moved `statusStore.ts`'s private generic `getOrCreate<K, V>` map helper to a new `src/shared/mapUtils.ts` and pointed `statusStore.ts`, `commandRouter.ts` (`getGuildCommandState`), and `audioPlayer.ts` (`getState`) at the shared version.

## Behavior changes

Two intentional, narrowly-scoped behavior changes came out of this consolidation — everything else is a pure refactor with existing tests updated to match the new call chains, not new behavior:

1. **`fillTemplate` consolidation decision**: the two pre-existing implementations genuinely diverged — the shared `textTemplate.ts` version replaced an unmatched `{key}` with `''`, while `twitchMonitorEmbed.ts`'s local version left it as the literal `{key}` text. Rather than picking one behavior for every caller, I added a `fallback` parameter and **preserved each existing call site's behavior explicitly**:
   - `customCommandHandler.ts` / `twitchEventSubHandler.ts` (already on the shared version) — unchanged, default `'empty'`.
   - `twitchMonitorEmbed.ts`'s `buildMessagePreview` (admin-panel template preview), `twitchMonitorAnnouncements.ts` (`postAnnouncement`/`editAnnouncement`), and `twitchMonitorStartup.ts` (`tryEditStartupMessage`) — now call `fillTemplate(..., 'keep')` explicitly, preserving their prior "leave a typo'd placeholder visible" behavior. I decided **not** to change this to `'empty'`: for live-announcement templates and their preview, a leftover `{key}` is arguably a useful, visible signal that the streamer's template has a typo, so I treated the divergence as intentional-but-undocumented rather than a bug to silently fix. Flagging this decision explicitly for reviewers to weigh in on.

2. **`updateMultitwitch` not-found handling fix**: previously `updateMultitwitch` (in `twitchMonitorMultitwitch.ts`) caught *all* errors from the channel-fetch/message-fetch/edit chain generically and always logged `Failed to update multitwitch for ...`, unlike its siblings (`editAnnouncement`, `tryEditStartupMessage`) which already distinguished a Discord not-found error (message/channel deleted) from a real failure. Now that it goes through the shared `tryEditDiscordMessage` helper, it silently skips a not-found message (consistent with its siblings) and only logs for genuine errors. This is a small, deliberate behavior improvement, not just a refactor — flagging it here per the task instructions.

## Not changed / explicitly out of scope

- `src/index.ts` — no changes were necessary; all `registerXRuntime` call signatures stayed backward compatible.
- `tryDeleteDiscordMessage` itself was left as-is (not touched) — only the two *new* helpers (`getTextChannel`, `tryEditDiscordMessage`) were added alongside it.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (132 test files, 2365 tests)
- [x] Added/updated Vitest coverage for every new/changed piece:
  - `fillTemplate`'s new `fallback` parameter (`src/shared/textTemplate.test.ts`), plus a `buildMessagePreview` "keep" regression test in `twitchMonitorEmbed.test.ts`.
  - `sendDedupedBySession` (`src/commands/twitchBroadcast.test.ts`), and `customCommandHandler.test.ts` / `multiCommandHandler.test.ts` continue to pass unmodified against the refactored callers.
  - `getTextChannel` / `tryEditDiscordMessage` (`src/discord/discordUtils.test.ts`), plus new `updateMultitwitch` tests in `twitchMonitorMultitwitch.test.ts` covering the not-found-skip fix specifically.
  - `createRuntimeRegistry` (`src/commands/twitchRuntime.test.ts`).
  - `resolveGuildIdForDiscordId` (`src/discord/voicePresence.test.ts`), with `twitchBot.test.ts` / `tiktokBot.test.ts` mocks/assertions updated to the new call shape.
  - `getOrCreate` (`src/shared/mapUtils.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBKcCSsAKKoryf1Zrv31dR


---
_Generated by [Claude Code](https://claude.ai/code/session_01RBKcCSsAKKoryf1Zrv31dR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared Discord utilities for text-channel access and safe message editing.
  * Added Twitch message broadcasting with shared-chat deduplication.
  * Added configurable template handling to preserve or remove unknown placeholders.
  * Improved Twitch and TikTok command routing through active Discord voice connections.

* **Bug Fixes**
  * Discord message updates now handle missing channels or messages gracefully.
  * Broadcast failures no longer prevent delivery to other channels.

* **Tests**
  * Expanded coverage for broadcasting, runtime handling, Discord utilities, templates, and voice resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->