### PR TITLE
Dedup: shared Express/mysql test harness

### DIFF
--- a/src/db/commandConflicts.test.ts
+++ b/src/db/commandConflicts.test.ts
@@ -36,11 +36,12 @@ import {
 import { CommandConflictError } from './commandStringUtils';
 import { normalizeTwitchChannelName } from '../twitch/twitchChannelName';
 import { acquireNamedLock, releaseNamedLock, isDeadlockError } from './commandLocks';
+import { makeMockPool } from '../test-utils/mockMysqlPool';
 
 // Cast to any to satisfy SqlExecutor (Pool | PoolConnection) without importing full mysql types
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function makeExecutor(rows: unknown[] = []): any {
-  return { execute: vi.fn().mockResolvedValue([[...rows], []]) };
+  return makeMockPool({ rows });
 }
 
 beforeEach(() => {

--- a/src/db/commandConflicts.test.ts
+++ b/src/db/commandConflicts.test.ts
@@ -38,6 +38,7 @@ import { normalizeTwitchChannelName } from '../twitch/twitchChannelName';
 import { acquireNamedLock, releaseNamedLock, isDeadlockError } from './commandLocks';
 import { makeMockPool } from '../test-utils/mockMysqlPool';
 
+/** Builds a fake mysql pool/executor resolving `execute`/`query` to the given rows. */
 // Cast to any to satisfy SqlExecutor (Pool | PoolConnection) without importing full mysql types
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function makeExecutor(rows: unknown[] = []): any {

--- a/src/db/companionOAuthCodes.test.ts
+++ b/src/db/companionOAuthCodes.test.ts
@@ -6,6 +6,7 @@ vi.mock('mysql2/promise', () => ({ default: {} }));
 import { getPool } from './pool';
 import { createCode, consumeCode, exchangeCodeForToken } from './companionOAuthCodes';
 import { createHash } from 'crypto';
+import { makeMockConnection } from '../test-utils/mockMysqlPool';
 
 function sha256hex(s: string) {
   return createHash('sha256').update(s).digest('hex');
@@ -81,16 +82,7 @@ describe('consumeCode', () => {
 
 // ─── exchangeCodeForToken ───────────────────────────────────────────────────
 
-function buildConn(overrides: Partial<Record<string, unknown>> = {}) {
-  return {
-    beginTransaction: vi.fn().mockResolvedValue(undefined),
-    commit: vi.fn().mockResolvedValue(undefined),
-    rollback: vi.fn().mockResolvedValue(undefined),
-    release: vi.fn(),
-    execute: vi.fn(),
-    ...overrides,
-  };
-}
+const buildConn = makeMockConnection;
 
 describe('exchangeCodeForToken', () => {
   it('rolls back and returns null when the UPDATE affects no rows (invalid/expired/used code)', async () => {

--- a/src/db/companionOAuthCodes.test.ts
+++ b/src/db/companionOAuthCodes.test.ts
@@ -8,6 +8,7 @@ import { createCode, consumeCode, exchangeCodeForToken } from './companionOAuthC
 import { createHash } from 'crypto';
 import { makeMockConnection } from '../test-utils/mockMysqlPool';
 
+/** Hashes a string with SHA-256 and returns it as a hex digest, matching the stored-code hashing scheme. */
 function sha256hex(s: string) {
   return createHash('sha256').update(s).digest('hex');
 }

--- a/src/db/companionTokens.test.ts
+++ b/src/db/companionTokens.test.ts
@@ -8,10 +8,12 @@ import { issueToken, findDiscordIdByTokenHash, getTokenStatus, revokeToken } fro
 import { createHash } from 'crypto';
 import { makeMockPool } from '../test-utils/mockMysqlPool';
 
+/** Builds a fake mysql pool whose `execute`/`query` resolve to the given rows. */
 function makePool(rows: unknown[] = []) {
   return makeMockPool({ rows });
 }
 
+/** Hashes a string with SHA-256 and returns it as a hex digest, matching the stored-token hashing scheme. */
 function sha256hex(s: string) {
   return createHash('sha256').update(s).digest('hex');
 }

--- a/src/db/companionTokens.test.ts
+++ b/src/db/companionTokens.test.ts
@@ -6,9 +6,10 @@ vi.mock('mysql2/promise', () => ({ default: {} }));
 import { getPool } from './pool';
 import { issueToken, findDiscordIdByTokenHash, getTokenStatus, revokeToken } from './companionTokens';
 import { createHash } from 'crypto';
+import { makeMockPool } from '../test-utils/mockMysqlPool';
 
 function makePool(rows: unknown[] = []) {
-  return { execute: vi.fn().mockResolvedValue([[...rows], []]) };
+  return makeMockPool({ rows });
 }
 
 function sha256hex(s: string) {

--- a/src/db/counters.test.ts
+++ b/src/db/counters.test.ts
@@ -25,14 +25,10 @@ vi.mock('./counterCache', () => ({
   invalidateCounterLookupCache: vi.fn(),
 }));
 
+import { makeMockConnection } from '../test-utils/mockMysqlPool';
+
 // Shared mock connection used by runSerializedCommandWrite
-const mockConnection = {
-  execute: vi.fn(),
-  beginTransaction: vi.fn().mockResolvedValue(undefined),
-  commit: vi.fn().mockResolvedValue(undefined),
-  rollback: vi.fn().mockResolvedValue(undefined),
-  release: vi.fn(),
-};
+const mockConnection = makeMockConnection();
 
 import { getPool } from './pool';
 import {
@@ -50,21 +46,11 @@ import {
 import { runSerializedCommandWrite } from './commandLocks';
 import { assertNotReservedCommand } from './reservedCommands';
 import { invalidateCounterLookupCache } from './counterCache';
+import { makeMockPool } from '../test-utils/mockMysqlPool';
 
+/** Builds a fake pool via the shared helper, matching this file's historical `(rows, meta)` call shape. */
 function makePool(rows: unknown[] = [], meta: unknown = {}) {
-  const conn = {
-    execute: vi.fn(),
-    beginTransaction: vi.fn().mockResolvedValue(undefined),
-    commit: vi.fn().mockResolvedValue(undefined),
-    rollback: vi.fn().mockResolvedValue(undefined),
-    release: vi.fn(),
-  };
-  return {
-    execute: vi.fn().mockResolvedValue([[...rows], meta]),
-    query: vi.fn().mockResolvedValue([[], meta]),
-    getConnection: vi.fn().mockResolvedValue(conn),
-    _conn: conn,
-  };
+  return makeMockPool({ rows, meta });
 }
 
 beforeEach(() => {

--- a/src/db/customCommands.test.ts
+++ b/src/db/customCommands.test.ts
@@ -49,13 +49,16 @@ import { invalidateCustomCommandLookupCache } from './customCommandCache';
 import { assertNotReservedCommand } from './reservedCommands';
 import { makeMockPool } from '../test-utils/mockMysqlPool';
 
+/** Builds a fake mysql pool with default (empty-row) `execute`/`query` behaviour. */
 function makePool() {
   return makeMockPool();
 }
 
-// Bespoke: replays a queue of results by call index (falling back to a generic success
-// result) rather than the strict per-call `mockResolvedValueOnce` chaining the shared
-// helper assumes, so it's kept local instead of being folded into makeMockConnection.
+/**
+ * Builds a fake write connection that replays a queue of results by call index (falling back to
+ * a generic success result) rather than the strict per-call `mockResolvedValueOnce` chaining the
+ * shared helper assumes, so it's kept local instead of being folded into makeMockConnection.
+ */
 function makeWriteConn(executeResults: unknown[] = []) {
   let callIndex = 0;
   return {

--- a/src/db/customCommands.test.ts
+++ b/src/db/customCommands.test.ts
@@ -47,22 +47,15 @@ import {
 } from './commandConflicts';
 import { invalidateCustomCommandLookupCache } from './customCommandCache';
 import { assertNotReservedCommand } from './reservedCommands';
+import { makeMockPool } from '../test-utils/mockMysqlPool';
 
 function makePool() {
-  const conn = {
-    execute: vi.fn(),
-    beginTransaction: vi.fn().mockResolvedValue(undefined),
-    commit: vi.fn().mockResolvedValue(undefined),
-    rollback: vi.fn().mockResolvedValue(undefined),
-    release: vi.fn(),
-  };
-  return {
-    execute: vi.fn().mockResolvedValue([[], []]),
-    getConnection: vi.fn().mockResolvedValue(conn),
-    _conn: conn,
-  };
+  return makeMockPool();
 }
 
+// Bespoke: replays a queue of results by call index (falling back to a generic success
+// result) rather than the strict per-call `mockResolvedValueOnce` chaining the shared
+// helper assumes, so it's kept local instead of being folded into makeMockConnection.
 function makeWriteConn(executeResults: unknown[] = []) {
   let callIndex = 0;
   return {

--- a/src/db/eventSub.test.ts
+++ b/src/db/eventSub.test.ts
@@ -25,10 +25,12 @@ import {
 } from './eventSub';
 import { makeMockPool } from '../test-utils/mockMysqlPool';
 
+/** Builds a fake mysql pool whose `execute`/`query` resolve to the given rows. */
 function makePool(rows: unknown[] = []) {
   return makeMockPool({ rows });
 }
 
+/** Builds a fake `streamer` table row with EventSub config columns defaulted to null (disabled), pass `overrides` to customize. */
 function makeRow(overrides: object = {}): Record<string, unknown> {
   return {
     id: 1,
@@ -51,6 +53,7 @@ function makeRow(overrides: object = {}): Record<string, unknown> {
   };
 }
 
+/** Builds a fake `streamer` table row with a fully-populated (enabled) EventSub config, pass `overrides` to customize. */
 function makeRowWithConfig(overrides: object = {}): Record<string, unknown> {
   return makeRow({
     follow_enabled: 1,

--- a/src/db/eventSub.test.ts
+++ b/src/db/eventSub.test.ts
@@ -23,9 +23,10 @@ import {
   initEventConfig,
   saveEventConfig,
 } from './eventSub';
+import { makeMockPool } from '../test-utils/mockMysqlPool';
 
 function makePool(rows: unknown[] = []) {
-  return { execute: vi.fn().mockResolvedValue([[...rows], []]) };
+  return makeMockPool({ rows });
 }
 
 function makeRow(overrides: object = {}): Record<string, unknown> {

--- a/src/db/guildCommandOverrides.test.ts
+++ b/src/db/guildCommandOverrides.test.ts
@@ -10,16 +10,13 @@ import {
   upsertOverride,
   removeOverride,
 } from './guildCommandOverrides';
+import { makeMockPool, type MockPool } from '../test-utils/mockMysqlPool';
 
-function makePool() {
-  return { execute: vi.fn().mockResolvedValue([[], []]) };
-}
-
-let pool: ReturnType<typeof makePool>;
+let pool: MockPool;
 
 beforeEach(() => {
   vi.clearAllMocks();
-  pool = makePool();
+  pool = makeMockPool();
   vi.mocked(getPool).mockReturnValue(pool as never);
 });
 

--- a/src/db/guildMembers.test.ts
+++ b/src/db/guildMembers.test.ts
@@ -16,16 +16,13 @@ import {
   removeGuildMember,
   getEffectiveAccessLevel,
 } from './guildMembers';
+import { makeMockPool, type MockPool } from '../test-utils/mockMysqlPool';
 
-function makePool() {
-  return { execute: vi.fn().mockResolvedValue([[], []]) };
-}
-
-let pool: ReturnType<typeof makePool>;
+let pool: MockPool;
 
 beforeEach(() => {
   vi.clearAllMocks();
-  pool = makePool();
+  pool = makeMockPool();
   vi.mocked(getPool).mockReturnValue(pool as never);
 });
 

--- a/src/db/guilds.test.ts
+++ b/src/db/guilds.test.ts
@@ -5,16 +5,13 @@ vi.mock('mysql2/promise', () => ({ default: {} }));
 
 import { getPool } from './pool';
 import { getAllGuilds, getProvisionedGuilds, getGuildById, getGuildsForMember, upsertGuild, setGuildVoiceChannel } from './guilds';
+import { makeMockPool, type MockPool } from '../test-utils/mockMysqlPool';
 
-function makePool() {
-  return { execute: vi.fn().mockResolvedValue([[], []]) };
-}
-
-let pool: ReturnType<typeof makePool>;
+let pool: MockPool;
 
 beforeEach(() => {
   vi.clearAllMocks();
-  pool = makePool();
+  pool = makeMockPool();
   vi.mocked(getPool).mockReturnValue(pool as never);
 });
 

--- a/src/db/overlayVideos.test.ts
+++ b/src/db/overlayVideos.test.ts
@@ -15,20 +15,10 @@ import {
   deleteReward,
   getVideosForReward,
 } from './overlayVideos';
+import { makeMockPool } from '../test-utils/mockMysqlPool';
 
 function makePool(rows: unknown[] = [], meta: unknown = {}) {
-  const conn = {
-    execute: vi.fn(),
-    beginTransaction: vi.fn().mockResolvedValue(undefined),
-    commit: vi.fn().mockResolvedValue(undefined),
-    rollback: vi.fn().mockResolvedValue(undefined),
-    release: vi.fn(),
-  };
-  return {
-    execute: vi.fn().mockResolvedValue([[...rows], meta]),
-    getConnection: vi.fn().mockResolvedValue(conn),
-    _conn: conn,
-  };
+  return makeMockPool({ rows, meta });
 }
 
 beforeEach(() => {

--- a/src/db/overlayVideos.test.ts
+++ b/src/db/overlayVideos.test.ts
@@ -17,6 +17,7 @@ import {
 } from './overlayVideos';
 import { makeMockPool } from '../test-utils/mockMysqlPool';
 
+/** Builds a fake mysql pool whose `execute`/`query` resolve to the given rows/meta. */
 function makePool(rows: unknown[] = [], meta: unknown = {}) {
   return makeMockPool({ rows, meta });
 }

--- a/src/db/rewardPricing.test.ts
+++ b/src/db/rewardPricing.test.ts
@@ -19,6 +19,7 @@ import {
 } from './rewardPricing';
 import { makeMockPool } from '../test-utils/mockMysqlPool';
 
+/** Builds a fake mysql pool whose `execute`/`query` resolve to the given rows/meta. */
 function makePool(rows: unknown[] = [], meta: unknown = {}) {
   return makeMockPool({ rows, meta });
 }

--- a/src/db/rewardPricing.test.ts
+++ b/src/db/rewardPricing.test.ts
@@ -17,11 +17,10 @@ import {
   getPricingSettingsForStreamer,
   savePricingSettingsForStreamer,
 } from './rewardPricing';
+import { makeMockPool } from '../test-utils/mockMysqlPool';
 
 function makePool(rows: unknown[] = [], meta: unknown = {}) {
-  return {
-    execute: vi.fn().mockResolvedValue([[...rows], meta]),
-  };
+  return makeMockPool({ rows, meta });
 }
 
 beforeEach(() => {

--- a/src/db/rewardPricingHistory.test.ts
+++ b/src/db/rewardPricingHistory.test.ts
@@ -5,11 +5,10 @@ vi.mock('mysql2/promise', () => ({ default: {} }));
 
 import { getPool } from './pool';
 import { recordPricingHistory, getPricingHistory } from './rewardPricingHistory';
+import { makeMockPool } from '../test-utils/mockMysqlPool';
 
 function makePool(rows: unknown[] = [], meta: unknown = {}) {
-  return {
-    execute: vi.fn().mockResolvedValue([[...rows], meta]),
-  };
+  return makeMockPool({ rows, meta });
 }
 
 beforeEach(() => {

--- a/src/db/rewardPricingHistory.test.ts
+++ b/src/db/rewardPricingHistory.test.ts
@@ -7,6 +7,7 @@ import { getPool } from './pool';
 import { recordPricingHistory, getPricingHistory } from './rewardPricingHistory';
 import { makeMockPool } from '../test-utils/mockMysqlPool';
 
+/** Builds a fake mysql pool whose `execute`/`query` resolve to the given rows/meta. */
 function makePool(rows: unknown[] = [], meta: unknown = {}) {
   return makeMockPool({ rows, meta });
 }

--- a/src/db/sfx.test.ts
+++ b/src/db/sfx.test.ts
@@ -10,27 +10,21 @@ import {
   createSfxTrigger, updateSfxTrigger, deleteSfxTrigger,
   addSfxFile, updateSfxFile, deleteSfxFile,
 } from './sfx';
+import { makeMockPool } from '../test-utils/mockMysqlPool';
 
 /** Pool whose top-level execute returns row data (for SELECT queries). */
 function makePool(rows: unknown[] = []) {
-  return { execute: vi.fn().mockResolvedValue([[...rows], []]) };
+  return makeMockPool({ rows });
 }
 
 /** Pool whose top-level execute returns a ResultSetHeader (for INSERT/UPDATE/DELETE). */
 function makeResultPool(result: unknown = { insertId: 0, affectedRows: 1 }) {
-  return { execute: vi.fn().mockResolvedValue([result, []]) };
+  return makeMockPool({ executeResult: [result, []] });
 }
 
 /** Pool exposing a transaction connection whose execute resolves queued results in order. */
 function makeTxPool() {
-  const conn = {
-    beginTransaction: vi.fn().mockResolvedValue(undefined),
-    commit: vi.fn().mockResolvedValue(undefined),
-    rollback: vi.fn().mockResolvedValue(undefined),
-    release: vi.fn(),
-    execute: vi.fn(),
-  };
-  return { getConnection: vi.fn().mockResolvedValue(conn), _conn: conn };
+  return makeMockPool();
 }
 
 beforeEach(() => {

--- a/src/db/streamMonitor.test.ts
+++ b/src/db/streamMonitor.test.ts
@@ -20,6 +20,7 @@ import { makeMockConnection, makeMockPool } from '../test-utils/mockMysqlPool';
 
 const GUILD_ID = 'guild-1';
 
+/** Builds a fake mysql pool whose `execute`/`query` resolve to the given rows. */
 function makePool(rows: unknown[] = []) {
   return makeMockPool({ rows });
 }

--- a/src/db/streamMonitor.test.ts
+++ b/src/db/streamMonitor.test.ts
@@ -16,11 +16,12 @@ import {
   setStreamerLive,
   clearStreamerLive,
 } from './streamMonitor';
+import { makeMockConnection, makeMockPool } from '../test-utils/mockMysqlPool';
 
 const GUILD_ID = 'guild-1';
 
 function makePool(rows: unknown[] = []) {
-  return { execute: vi.fn().mockResolvedValue([[...rows], []]) };
+  return makeMockPool({ rows });
 }
 
 beforeEach(() => {
@@ -146,19 +147,12 @@ describe('updateStreamGroup', () => {
 
 /** Pool mock whose getConnection() returns a fake transactional connection. */
 function makeTransactionalPool(streamerAffectedRows: number, groupAffectedRows: number) {
-  const conn = {
+  const connection = makeMockConnection({
     execute: vi.fn()
       .mockResolvedValueOnce([{ affectedRows: streamerAffectedRows }, []])
       .mockResolvedValueOnce([{ affectedRows: groupAffectedRows }, []]),
-    beginTransaction: vi.fn().mockResolvedValue(undefined),
-    commit: vi.fn().mockResolvedValue(undefined),
-    rollback: vi.fn().mockResolvedValue(undefined),
-    release: vi.fn(),
-  };
-  return {
-    getConnection: vi.fn().mockResolvedValue(conn),
-    _conn: conn,
-  };
+  });
+  return makeMockPool({ connection });
 }
 
 describe('removeStreamGroupAndStreamers', () => {
@@ -192,13 +186,7 @@ describe('removeStreamGroupAndStreamers', () => {
   });
 
   it('rolls back and releases the connection when a delete throws', async () => {
-    const conn = {
-      execute: vi.fn().mockRejectedValue(new Error('DB down')),
-      beginTransaction: vi.fn().mockResolvedValue(undefined),
-      commit: vi.fn().mockResolvedValue(undefined),
-      rollback: vi.fn().mockResolvedValue(undefined),
-      release: vi.fn(),
-    };
+    const conn = makeMockConnection({ execute: vi.fn().mockRejectedValue(new Error('DB down')) });
     vi.mocked(getPool).mockReturnValue({ getConnection: vi.fn().mockResolvedValue(conn) } as any);
 
     await expect(removeStreamGroupAndStreamers(7, GUILD_ID)).rejects.toThrow('DB down');

--- a/src/db/streamdeckKeys.test.ts
+++ b/src/db/streamdeckKeys.test.ts
@@ -26,6 +26,7 @@ import {
 import { createHash } from 'crypto';
 import { makeMockPool } from '../test-utils/mockMysqlPool';
 
+/** Builds a fake mysql pool whose `execute`/`query` resolve to the given rows. */
 function makePool(rows: unknown[] = []) {
   return makeMockPool({ rows });
 }
@@ -35,6 +36,7 @@ function makeTransactionalPool() {
   return makeMockPool();
 }
 
+/** Hashes a string with SHA-256 and returns it as a hex digest, matching the stored-key hashing scheme. */
 function sha256hex(s: string) {
   return createHash('sha256').update(s).digest('hex');
 }

--- a/src/db/streamdeckKeys.test.ts
+++ b/src/db/streamdeckKeys.test.ts
@@ -24,25 +24,15 @@ import {
   getAllApiKeys,
 } from './streamdeckKeys';
 import { createHash } from 'crypto';
+import { makeMockPool } from '../test-utils/mockMysqlPool';
 
 function makePool(rows: unknown[] = []) {
-  return { execute: vi.fn().mockResolvedValue([[...rows], []]) };
+  return makeMockPool({ rows });
 }
 
 /** Pool mock whose getConnection() returns a fake transactional connection, matching the overlayVideos.ts test convention. */
 function makeTransactionalPool() {
-  const conn = {
-    execute: vi.fn().mockResolvedValue([[], []]),
-    beginTransaction: vi.fn().mockResolvedValue(undefined),
-    commit: vi.fn().mockResolvedValue(undefined),
-    rollback: vi.fn().mockResolvedValue(undefined),
-    release: vi.fn(),
-  };
-  return {
-    execute: vi.fn().mockResolvedValue([[], []]),
-    getConnection: vi.fn().mockResolvedValue(conn),
-    _conn: conn,
-  };
+  return makeMockPool();
 }
 
 function sha256hex(s: string) {

--- a/src/db/users.test.ts
+++ b/src/db/users.test.ts
@@ -24,21 +24,12 @@ import {
   AccessLevel,
 } from './users';
 import { normalizeTwitchChannelName } from '../twitch/twitchChannelName';
+import { makeMockConnection, makeMockPool } from '../test-utils/mockMysqlPool';
 
-function makeConnection(executeResult: unknown = [[], []]) {
-  return {
-    execute: vi.fn().mockResolvedValue(executeResult),
-    release: vi.fn(),
-  };
-}
-
+/** Builds a fake pool via the shared helper, matching this file's historical `(executeResult, connectionExecuteResult)` call shape. */
 function makePool(executeResult: unknown = [[], []], connectionExecuteResult?: unknown) {
-  const conn = makeConnection(connectionExecuteResult ?? [[], []]);
-  return {
-    execute: vi.fn().mockResolvedValue(executeResult),
-    getConnection: vi.fn().mockResolvedValue(conn),
-    _conn: conn,
-  };
+  const connection = makeMockConnection({ execute: vi.fn().mockResolvedValue(connectionExecuteResult ?? [[], []]) });
+  return makeMockPool({ executeResult, connection });
 }
 
 beforeEach(() => {

--- a/src/test-utils/expressTestApp.test.ts
+++ b/src/test-utils/expressTestApp.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import supertest from 'supertest';
+import { buildTestApp } from './expressTestApp';
+
+/** A tiny router used to exercise buildTestApp: echoes session/body state and can trigger res.render. */
+function makeRouter() {
+  const router = express.Router();
+  router.get('/session', (req, res) => {
+    res.json({ session: (req as unknown as { session?: unknown }).session ?? null });
+  });
+  router.post('/body', (req, res) => {
+    res.json({ body: req.body });
+  });
+  router.get('/render', (req, res) => {
+    res.render('some-view', { a: 1, b: 2 });
+  });
+  return router;
+}
+
+describe('buildTestApp', () => {
+  it('mounts the router with no middleware when no options are given beyond router', async () => {
+    const app = buildTestApp({ router: makeRouter() });
+    const res = await supertest(app).get('/session');
+    expect(res.body).toEqual({ session: null });
+  });
+
+  it('stubs req.session.user from sessionUser', async () => {
+    const app = buildTestApp({ router: makeRouter(), sessionUser: { discordId: '1' } });
+    const res = await supertest(app).get('/session');
+    expect(res.body).toEqual({ session: { user: { discordId: '1' } } });
+  });
+
+  it('stubs req.session verbatim from session, taking precedence over sessionUser', async () => {
+    const app = buildTestApp({ router: makeRouter(), session: { foo: 'bar' }, sessionUser: { discordId: 'ignored' } });
+    const res = await supertest(app).get('/session');
+    expect(res.body).toEqual({ session: { foo: 'bar' } });
+  });
+
+  it('installs a json body parser when bodyParser is "json"', async () => {
+    const app = buildTestApp({ router: makeRouter(), bodyParser: 'json' });
+    const res = await supertest(app).post('/body').send({ x: 1 });
+    expect(res.body).toEqual({ body: { x: 1 } });
+  });
+
+  it('installs a urlencoded body parser when bodyParser is "urlencoded"', async () => {
+    const app = buildTestApp({ router: makeRouter(), bodyParser: 'urlencoded' });
+    const res = await supertest(app).post('/body').send('x=1');
+    expect(res.body).toEqual({ body: { x: '1' } });
+  });
+
+  it('mockRender "spread" flattens locals onto the JSON body alongside view', async () => {
+    const app = buildTestApp({ router: makeRouter(), mockRender: 'spread' });
+    const res = await supertest(app).get('/render');
+    expect(res.body).toEqual({ view: 'some-view', a: 1, b: 2 });
+  });
+
+  it('mockRender "nested" nests locals under a locals key', async () => {
+    const app = buildTestApp({ router: makeRouter(), mockRender: 'nested' });
+    const res = await supertest(app).get('/render');
+    expect(res.body).toEqual({ view: 'some-view', locals: { a: 1, b: 2 } });
+  });
+
+  it('mockRender "text" sends a plain "rendered:<view>" string, ignoring locals', async () => {
+    const app = buildTestApp({ router: makeRouter(), mockRender: 'text' });
+    const res = await supertest(app).get('/render');
+    expect(res.text).toBe('rendered:some-view');
+  });
+
+  it('mockRender accepts a custom function for one-off shapes', async () => {
+    const app = buildTestApp({
+      router: makeRouter(),
+      mockRender: (view, locals, res) => res.status(201).json({ customView: view, customLocals: locals }),
+    });
+    const res = await supertest(app).get('/render');
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ customView: 'some-view', customLocals: { a: 1, b: 2 } });
+  });
+
+  it('accepts an array of routers, mounting each in order', async () => {
+    const other = express.Router();
+    other.get('/other', (_req, res) => res.json({ ok: true }));
+    const app = buildTestApp({ router: [makeRouter(), other] });
+    const res = await supertest(app).get('/other');
+    expect(res.body).toEqual({ ok: true });
+  });
+});

--- a/src/test-utils/expressTestApp.ts
+++ b/src/test-utils/expressTestApp.ts
@@ -1,0 +1,65 @@
+import express, { type Express, type RequestHandler, type Response } from 'express';
+
+/** Named `res.render` stub shapes covering the common conventions used across `src/web/routes/*.test.ts`. */
+export type MockRenderPreset = 'spread' | 'nested' | 'text';
+
+export interface BuildTestAppOptions {
+  /** Router(s) mounted last, after any body parser and the session/render stub middleware. */
+  router: RequestHandler | RequestHandler[];
+  /** Body parser installed before the session/render stub. Omit for none. */
+  bodyParser?: 'json' | 'urlencoded' | 'both';
+  /**
+   * Value attached as `req.session.user`. Pass the key explicitly (even `sessionUser: undefined`)
+   * to install the stub — omitting the option entirely skips session stubbing. For a session shape
+   * that isn't `{ user: sessionUser }` (e.g. no `user` key, or extra sibling keys), use `session` instead.
+   */
+  sessionUser?: unknown;
+  /** Full `req.session` value, verbatim. Takes precedence over `sessionUser` when both are given. */
+  session?: unknown;
+  /**
+   * Stub for `res.render()`. `'spread'` → `res.json({ view, ...locals })`; `'nested'` →
+   * `res.json({ view, locals })`; `'text'` → `res.send(\`rendered:${view}\`)` (locals ignored); or
+   * a custom `(view, locals, res) => void` for one-off shapes (e.g. forcing a status code). Omit to
+   * leave `res.render` untouched.
+   */
+  mockRender?: MockRenderPreset | ((view: string, locals: unknown, res: Response) => void);
+}
+
+/**
+ * Builds a minimal Express app for router-level supertest coverage: an optional body parser, an
+ * optional `req.session` stub, an optional `res.render` stub that echoes the view/locals back
+ * (as JSON or plain text) instead of rendering a real EJS template, and the router(s) under test
+ * mounted last. Mirrors the hand-rolled `buildApp()` helpers previously duplicated across
+ * `src/web/routes/*.test.ts`.
+ */
+export function buildTestApp(options: BuildTestAppOptions): Express {
+  const { router, bodyParser, mockRender } = options;
+  const hasSessionUser = Object.prototype.hasOwnProperty.call(options, 'sessionUser');
+  const hasSession = Object.prototype.hasOwnProperty.call(options, 'session');
+  const app = express();
+
+  if (bodyParser === 'json' || bodyParser === 'both') app.use(express.json());
+  if (bodyParser === 'urlencoded' || bodyParser === 'both') app.use(express.urlencoded({ extended: false }));
+
+  if (hasSession || hasSessionUser || mockRender) {
+    app.use((req, res, next) => {
+      if (hasSession) {
+        (req as unknown as { session: unknown }).session = options.session;
+      } else if (hasSessionUser) {
+        (req as unknown as { session: unknown }).session = { user: options.sessionUser };
+      }
+      if (mockRender) {
+        res.render = ((view: string, locals?: Record<string, unknown>) => {
+          if (mockRender === 'spread') return res.json({ view, ...locals });
+          if (mockRender === 'nested') return res.json({ view, locals });
+          if (mockRender === 'text') return res.send(`rendered:${view}`);
+          return mockRender(view, locals, res);
+        }) as Response['render'];
+      }
+      next();
+    });
+  }
+
+  for (const r of Array.isArray(router) ? router : [router]) app.use(r);
+  return app;
+}

--- a/src/test-utils/expressTestApp.ts
+++ b/src/test-utils/expressTestApp.ts
@@ -25,6 +25,49 @@ export interface BuildTestAppOptions {
   mockRender?: MockRenderPreset | ((view: string, locals: unknown, res: Response) => void);
 }
 
+/** Installs the body parser(s) requested via `BuildTestAppOptions.bodyParser`. */
+function applyBodyParser(app: Express, bodyParser: BuildTestAppOptions['bodyParser']): void {
+  if (bodyParser === 'json' || bodyParser === 'both') app.use(express.json());
+  if (bodyParser === 'urlencoded' || bodyParser === 'both') app.use(express.urlencoded({ extended: false }));
+}
+
+/** Builds the `req.session` value for a request, from `session` (verbatim) or `sessionUser` (wrapped as `{ user }`). */
+function resolveSessionValue(options: BuildTestAppOptions): unknown {
+  if (Object.prototype.hasOwnProperty.call(options, 'session')) return options.session;
+  return { user: options.sessionUser };
+}
+
+/** Builds the `res.render` replacement for a given `mockRender` preset or custom function, bound to one response. */
+function makeRenderStub(
+  mockRender: NonNullable<BuildTestAppOptions['mockRender']>,
+  res: Response,
+): Response['render'] {
+  return ((view: string, locals?: Record<string, unknown>) => {
+    if (mockRender === 'spread') return res.json({ view, ...locals });
+    if (mockRender === 'nested') return res.json({ view, locals });
+    if (mockRender === 'text') return res.send(`rendered:${view}`);
+    return mockRender(view, locals, res);
+  }) as unknown as Response['render'];
+}
+
+/** Installs the `req.session`/`res.render` stub middleware for the options that requested one. */
+function applySessionAndRenderStub(app: Express, options: BuildTestAppOptions): void {
+  const hasSessionUser = Object.prototype.hasOwnProperty.call(options, 'sessionUser');
+  const hasSession = Object.prototype.hasOwnProperty.call(options, 'session');
+  const { mockRender } = options;
+  if (!hasSession && !hasSessionUser && !mockRender) return;
+
+  app.use((req, res, next) => {
+    if (hasSession || hasSessionUser) {
+      (req as unknown as { session: unknown }).session = resolveSessionValue(options);
+    }
+    if (mockRender) {
+      res.render = makeRenderStub(mockRender, res);
+    }
+    next();
+  });
+}
+
 /**
  * Builds a minimal Express app for router-level supertest coverage: an optional body parser, an
  * optional `req.session` stub, an optional `res.render` stub that echoes the view/locals back
@@ -33,33 +76,9 @@ export interface BuildTestAppOptions {
  * `src/web/routes/*.test.ts`.
  */
 export function buildTestApp(options: BuildTestAppOptions): Express {
-  const { router, bodyParser, mockRender } = options;
-  const hasSessionUser = Object.prototype.hasOwnProperty.call(options, 'sessionUser');
-  const hasSession = Object.prototype.hasOwnProperty.call(options, 'session');
   const app = express();
-
-  if (bodyParser === 'json' || bodyParser === 'both') app.use(express.json());
-  if (bodyParser === 'urlencoded' || bodyParser === 'both') app.use(express.urlencoded({ extended: false }));
-
-  if (hasSession || hasSessionUser || mockRender) {
-    app.use((req, res, next) => {
-      if (hasSession) {
-        (req as unknown as { session: unknown }).session = options.session;
-      } else if (hasSessionUser) {
-        (req as unknown as { session: unknown }).session = { user: options.sessionUser };
-      }
-      if (mockRender) {
-        res.render = ((view: string, locals?: Record<string, unknown>) => {
-          if (mockRender === 'spread') return res.json({ view, ...locals });
-          if (mockRender === 'nested') return res.json({ view, locals });
-          if (mockRender === 'text') return res.send(`rendered:${view}`);
-          return mockRender(view, locals, res);
-        }) as Response['render'];
-      }
-      next();
-    });
-  }
-
-  for (const r of Array.isArray(router) ? router : [router]) app.use(r);
+  applyBodyParser(app, options.bodyParser);
+  applySessionAndRenderStub(app, options);
+  for (const r of Array.isArray(options.router) ? options.router : [options.router]) app.use(r);
   return app;
 }

--- a/src/test-utils/fixtures.test.ts
+++ b/src/test-utils/fixtures.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { makeSessionUser, makeDbGuild } from './fixtures';
+
+describe('makeSessionUser', () => {
+  it('returns a default level-0 test user when called with no overrides', () => {
+    expect(makeSessionUser()).toEqual({
+      discordId: '100000000000000001',
+      discordName: 'TestUser',
+      discordAvatar: null,
+      accessLevel: 0,
+    });
+  });
+
+  it('applies overrides on top of the defaults', () => {
+    const user = makeSessionUser({ accessLevel: 3, currentGuildId: 'g1', isOwner: true });
+    expect(user).toEqual({
+      discordId: '100000000000000001',
+      discordName: 'TestUser',
+      discordAvatar: null,
+      accessLevel: 3,
+      currentGuildId: 'g1',
+      isOwner: true,
+    });
+  });
+});
+
+describe('makeDbGuild', () => {
+  it('returns a default guild row with a null voice channel when called with no overrides', () => {
+    expect(makeDbGuild()).toEqual({
+      guild_id: '900000000000000001',
+      name: 'Test Guild',
+      voice_channel_id: null,
+    });
+  });
+
+  it('applies overrides on top of the defaults', () => {
+    expect(makeDbGuild({ guild_id: '42', voice_channel_id: '99' })).toEqual({
+      guild_id: '42',
+      name: 'Test Guild',
+      voice_channel_id: '99',
+    });
+  });
+});

--- a/src/test-utils/fixtures.test.ts
+++ b/src/test-utils/fixtures.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+// `fixtures.ts` imports `AccessLevel` from `../db/users` at runtime, which transitively pulls in
+// `../db/pool` (and its required env vars). Mock it out, matching the convention used across
+// `src/web/routes/*.test.ts` (e.g. `rateLimits.test.ts`, `shared.test.ts`).
+vi.mock('../db/users', () => ({ AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 } }));
+
 import { makeSessionUser, makeDbGuild } from './fixtures';
+import { AccessLevel } from '../db/users';
 
 describe('makeSessionUser', () => {
   it('returns a default level-0 test user when called with no overrides', () => {
@@ -7,17 +14,17 @@ describe('makeSessionUser', () => {
       discordId: '100000000000000001',
       discordName: 'TestUser',
       discordAvatar: null,
-      accessLevel: 0,
+      accessLevel: AccessLevel.USER,
     });
   });
 
   it('applies overrides on top of the defaults', () => {
-    const user = makeSessionUser({ accessLevel: 3, currentGuildId: 'g1', isOwner: true });
+    const user = makeSessionUser({ accessLevel: AccessLevel.ADMIN, currentGuildId: 'g1', isOwner: true });
     expect(user).toEqual({
       discordId: '100000000000000001',
       discordName: 'TestUser',
       discordAvatar: null,
-      accessLevel: 3,
+      accessLevel: AccessLevel.ADMIN,
       currentGuildId: 'g1',
       isOwner: true,
     });

--- a/src/test-utils/fixtures.ts
+++ b/src/test-utils/fixtures.ts
@@ -1,4 +1,4 @@
-import type { AccessLevelValue } from '../db/users';
+import { AccessLevel, type AccessLevelValue } from '../db/users';
 
 /** Shape of the `req.session.user` object used across `src/web/routes/*.test.ts` session stubs. */
 export interface SessionUserFixture {
@@ -20,7 +20,7 @@ export function makeSessionUser(overrides: Partial<SessionUserFixture> = {}): Se
     discordId: '100000000000000001',
     discordName: 'TestUser',
     discordAvatar: null,
-    accessLevel: 0,
+    accessLevel: AccessLevel.USER,
     ...overrides,
   };
 }

--- a/src/test-utils/fixtures.ts
+++ b/src/test-utils/fixtures.ts
@@ -1,0 +1,46 @@
+import type { AccessLevelValue } from '../db/users';
+
+/** Shape of the `req.session.user` object used across `src/web/routes/*.test.ts` session stubs. */
+export interface SessionUserFixture {
+  discordId: string;
+  discordName: string;
+  discordAvatar: string | null;
+  accessLevel: AccessLevelValue;
+  currentGuildId?: string;
+  isOwner?: boolean;
+}
+
+/**
+ * Builds a fake session user matching the shape hand-rolled across `src/web/routes/*.test.ts`
+ * (`{ discordId, discordName, discordAvatar, accessLevel, ... }`). Pass `overrides` to customize
+ * any field, e.g. `makeSessionUser({ accessLevel: AccessLevel.ADMIN, currentGuildId: GUILD_ID })`.
+ */
+export function makeSessionUser(overrides: Partial<SessionUserFixture> = {}): SessionUserFixture {
+  return {
+    discordId: '100000000000000001',
+    discordName: 'TestUser',
+    discordAvatar: null,
+    accessLevel: 0,
+    ...overrides,
+  };
+}
+
+/** Shape of a `guild` table row as returned by `src/db/guilds.ts` (BIGINT columns pre-stringified). */
+export interface DbGuildFixture {
+  guild_id: string;
+  name: string;
+  voice_channel_id: string | null;
+}
+
+/**
+ * Builds a fake `guild` row matching the shape returned by `src/db/guilds.ts` query functions
+ * (e.g. `getGuildById`, `getAllGuilds`). Pass `overrides` to customize any field.
+ */
+export function makeDbGuild(overrides: Partial<DbGuildFixture> = {}): DbGuildFixture {
+  return {
+    guild_id: '900000000000000001',
+    name: 'Test Guild',
+    voice_channel_id: null,
+    ...overrides,
+  };
+}

--- a/src/test-utils/mockMysqlPool.test.ts
+++ b/src/test-utils/mockMysqlPool.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { makeMockConnection, makeMockPool } from './mockMysqlPool';
+
+describe('makeMockConnection', () => {
+  it('defaults execute to resolve an empty rows/meta tuple', async () => {
+    const conn = makeMockConnection();
+    await expect(conn.execute('SELECT 1')).resolves.toEqual([[], []]);
+  });
+
+  it('defaults beginTransaction/commit/rollback to resolve undefined and release to a plain spy', async () => {
+    const conn = makeMockConnection();
+    await expect(conn.beginTransaction()).resolves.toBeUndefined();
+    await expect(conn.commit()).resolves.toBeUndefined();
+    await expect(conn.rollback()).resolves.toBeUndefined();
+    conn.release();
+    expect(conn.release).toHaveBeenCalledOnce();
+  });
+
+  it('applies overrides wholesale for a given field', async () => {
+    const conn = makeMockConnection({ execute: makeMockConnection().execute });
+    conn.execute.mockResolvedValueOnce([[{ id: 1 }], []]);
+    await expect(conn.execute('SELECT 1')).resolves.toEqual([[{ id: 1 }], []]);
+  });
+});
+
+describe('makeMockPool', () => {
+  it('defaults execute and query to resolve an empty rows/meta tuple', async () => {
+    const pool = makeMockPool();
+    await expect(pool.execute('SELECT 1')).resolves.toEqual([[], []]);
+    await expect(pool.query('SELECT 1')).resolves.toEqual([[], []]);
+  });
+
+  it('wraps rows/meta options into the [rows, meta] tuple execute/query resolve to', async () => {
+    const rows = [{ id: 1 }, { id: 2 }];
+    const pool = makeMockPool({ rows, meta: { fields: [] } });
+    await expect(pool.execute('SELECT 1')).resolves.toEqual([rows, { fields: [] }]);
+    await expect(pool.query('SELECT 1')).resolves.toEqual([rows, { fields: [] }]);
+  });
+
+  it('uses executeResult verbatim, bypassing the rows/meta wrapping, for ResultSetHeader-shaped results', async () => {
+    const pool = makeMockPool({ executeResult: [{ insertId: 42, affectedRows: 1 }, []] });
+    await expect(pool.execute('INSERT ...')).resolves.toEqual([{ insertId: 42, affectedRows: 1 }, []]);
+  });
+
+  it('getConnection resolves to a fake connection also exposed as _conn', async () => {
+    const pool = makeMockPool();
+    await expect(pool.getConnection()).resolves.toBe(pool._conn);
+  });
+
+  it('accepts a pre-built connection to back getConnection()/_conn', async () => {
+    const connection = makeMockConnection();
+    connection.execute.mockResolvedValueOnce([[{ id: 9 }], []]);
+    const pool = makeMockPool({ connection });
+    expect(pool._conn).toBe(connection);
+    await expect((await pool.getConnection()).execute()).resolves.toEqual([[{ id: 9 }], []]);
+  });
+});

--- a/src/test-utils/mockMysqlPool.ts
+++ b/src/test-utils/mockMysqlPool.ts
@@ -1,0 +1,69 @@
+import { vi, type Mock } from 'vitest';
+
+/** A hand-rolled fake of a mysql2 `PoolConnection`, covering the subset used across `src/db/*.test.ts`. */
+export interface MockConnection {
+  execute: Mock;
+  beginTransaction: Mock;
+  commit: Mock;
+  rollback: Mock;
+  release: Mock;
+}
+
+/**
+ * Builds a fake mysql2 `PoolConnection`. `execute` resolves to `[[], []]` by
+ * default — override it (or pass `overrides.execute`) with
+ * `mockResolvedValue`/`mockResolvedValueOnce` for specific row/result data.
+ * `beginTransaction`/`commit`/`rollback` resolve to `undefined`; `release` is a
+ * plain spy. Pass `overrides` to replace any field wholesale.
+ */
+export function makeMockConnection(overrides: Partial<MockConnection> = {}): MockConnection {
+  return {
+    execute: vi.fn().mockResolvedValue([[], []]),
+    beginTransaction: vi.fn().mockResolvedValue(undefined),
+    commit: vi.fn().mockResolvedValue(undefined),
+    rollback: vi.fn().mockResolvedValue(undefined),
+    release: vi.fn(),
+    ...overrides,
+  };
+}
+
+/** A hand-rolled fake of a mysql2 `Pool`, covering the subset used across `src/db/*.test.ts`. */
+export interface MockPool {
+  execute: Mock;
+  query: Mock;
+  getConnection: Mock;
+  /** The fake connection `getConnection()` resolves to — assert on it directly, e.g. `pool._conn.commit`. */
+  _conn: MockConnection;
+}
+
+export interface MakeMockPoolOptions {
+  /** Rows resolved by `execute`/`query` when no `executeResult` override is given. Defaults to `[]`. */
+  rows?: unknown[];
+  /** The metadata/field-packet half of the `execute`/`query` result tuple. Defaults to `[]`. */
+  meta?: unknown;
+  /**
+   * Full `[result, meta]` (or ResultSetHeader-shaped `[header, meta]`) tuple to resolve
+   * `execute`/`query` with, bypassing the `rows`/`meta` wrapping. Use this for INSERT/UPDATE/DELETE
+   * results (`insertId`/`affectedRows`) or for pre-built row tuples like `[[row]]`.
+   */
+  executeResult?: unknown;
+  /** Fake connection returned by `getConnection()`. Defaults to a fresh `makeMockConnection()`. */
+  connection?: MockConnection;
+}
+
+/**
+ * Builds a fake mysql2 `Pool` covering the shapes used across `src/db/*.test.ts`: a top-level
+ * `execute`/`query` resolving to row data, and `getConnection()` resolving to a fake transactional
+ * connection (also exposed as `_conn` for direct assertions, e.g. `pool._conn.commit`).
+ */
+export function makeMockPool(options: MakeMockPoolOptions = {}): MockPool {
+  const { rows = [], meta = [], executeResult, connection } = options;
+  const result = executeResult !== undefined ? executeResult : [[...rows], meta];
+  const conn = connection ?? makeMockConnection();
+  return {
+    execute: vi.fn().mockResolvedValue(result),
+    query: vi.fn().mockResolvedValue(result),
+    getConnection: vi.fn().mockResolvedValue(conn),
+    _conn: conn,
+  };
+}

--- a/src/web/routes/admin.test.ts
+++ b/src/web/routes/admin.test.ts
@@ -66,7 +66,6 @@ vi.mock('../../shared/logger', () => ({
 
 vi.mock('../../db/users', () => ({ AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 } }));
 
-import express from 'express';
 import supertest from 'supertest';
 import router from './admin';
 import { findUser, getMemberAccessLevel, getGuildMemberUsers, setMemberAccessLevel, removeGuildMember } from '../../db';
@@ -80,6 +79,7 @@ import {
   addOrUpdateUserMutation,
   toggleTwitchMutation,
 } from './adminUserMutations';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
 type SessionUser = {
   discordId: string;
@@ -94,16 +94,9 @@ const GUILD_ID = '900000000000000001';
 const ADMIN: SessionUser = { discordId: '100000000000000001', discordName: 'AdminUser', discordAvatar: null, isOwner: false, accessLevel: AccessLevel.ADMIN, currentGuildId: GUILD_ID };
 const VALID_ID = '300000000000000001';
 
+/** Builds a supertest-ready app: the admin router with a stubbed session and a render mock that flattens locals into the JSON body. */
 function buildApp(sessionUser: SessionUser = ADMIN) {
-  const app = express();
-  app.use(express.urlencoded({ extended: false }));
-  app.use((req: any, res: any, next: any) => {
-    req.session = { user: sessionUser };
-    res.render = (view: string, locals?: any) => res.json({ view, ...locals });
-    next();
-  });
-  app.use(router);
-  return app;
+  return buildTestApp({ router, bodyParser: 'urlencoded', sessionUser, mockRender: 'spread' });
 }
 
 beforeEach(() => {

--- a/src/web/routes/adminRefresh.test.ts
+++ b/src/web/routes/adminRefresh.test.ts
@@ -29,6 +29,7 @@ import router, { refreshStates, getRefreshState, forgetGuildRefreshState } from 
 const GUILD_ID = '900000000000000001';
 const OTHER_GUILD_ID = '900000000000000002';
 
+/** Builds a supertest-ready app: the admin-refresh router with a manager-level session stubbed to the given guild. */
 function buildApp(currentGuildId: string = GUILD_ID) {
   const app = buildTestApp({
     router,

--- a/src/web/routes/adminRefresh.test.ts
+++ b/src/web/routes/adminRefresh.test.ts
@@ -20,8 +20,8 @@ vi.mock('../../shared/logger', () => ({
 
 import { getGuildMemberUsers, updateDiscordName } from '../../db';
 import { getDiscordClient, fetchMemberDisplayName } from '../../discord/discordBot';
-import express from 'express';
 import supertest from 'supertest';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
 // Import module last so mocks are in place before module-level code runs
 import router, { refreshStates, getRefreshState, forgetGuildRefreshState } from './adminRefresh';
@@ -30,14 +30,11 @@ const GUILD_ID = '900000000000000001';
 const OTHER_GUILD_ID = '900000000000000002';
 
 function buildApp(currentGuildId: string = GUILD_ID) {
-  const app = express();
-  app.use(express.json());
-  app.use(express.urlencoded({ extended: false }));
-  app.use((req: any, _res: any, next: any) => {
-    req.session = { user: { discordId: 'u1', currentGuildId, accessLevel: 2 } };
-    next();
+  const app = buildTestApp({
+    router,
+    bodyParser: 'both',
+    sessionUser: { discordId: 'u1', currentGuildId, accessLevel: 2 },
   });
-  app.use(router);
   return supertest(app);
 }
 

--- a/src/web/routes/api.test.ts
+++ b/src/web/routes/api.test.ts
@@ -39,7 +39,6 @@ vi.mock('../../shared/logger', () => ({
   createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
 }));
 
-import express from 'express';
 import supertest from 'supertest';
 import router from './api';
 import { getStatus } from '../../shared/statusStore';
@@ -47,19 +46,13 @@ import { connect, disconnect, getCurrentChannelId } from '../../audio/audioPlaye
 import { getDiscordClient } from '../../discord/discordBot';
 import { getAvailableVoiceChannels } from '../../discord/discordUtils';
 import { getGuildById } from '../../db';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
 const GUILD_ID = '900000000000000001';
 
 // Injects a session with the current guild so the guild-scoped voice routes resolve.
 function buildApp(currentGuildId: string | null = GUILD_ID) {
-  const app = express();
-  app.use(express.json());
-  app.use((req: any, _res: any, next: any) => {
-    req.session = { user: { discordId: 'u1', currentGuildId } };
-    next();
-  });
-  app.use(router);
-  return app;
+  return buildTestApp({ router, bodyParser: 'json', sessionUser: { discordId: 'u1', currentGuildId } });
 }
 
 beforeEach(() => {

--- a/src/web/routes/api.test.ts
+++ b/src/web/routes/api.test.ts
@@ -50,7 +50,7 @@ import { buildTestApp } from '../../test-utils/expressTestApp';
 
 const GUILD_ID = '900000000000000001';
 
-// Injects a session with the current guild so the guild-scoped voice routes resolve.
+/** Builds a supertest-ready app: the API router with a session injecting the current guild so the guild-scoped voice routes resolve. */
 function buildApp(currentGuildId: string | null = GUILD_ID) {
   return buildTestApp({ router, bodyParser: 'json', sessionUser: { discordId: 'u1', currentGuildId } });
 }

--- a/src/web/routes/channelPointsAdmin.test.ts
+++ b/src/web/routes/channelPointsAdmin.test.ts
@@ -44,32 +44,26 @@ vi.mock('./channelPointsEvents', async () => {
   return { default: Router() };
 });
 
-import express from 'express';
 import supertest from 'supertest';
 import router from './channelPointsAdmin';
 import { getStreamerByDiscordId, getPricingConfigsForStreamer, getPricingSettingsForStreamer, getPricingHistory } from '../../db';
 import { getCustomRewards } from '../../twitch/twitchApi';
 import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
 import { hasAuthFailedSubs } from '../../twitch/eventsub/twitchEventSubSubscriptions';
+import { buildTestApp } from '../../test-utils/expressTestApp';
+import { makeSessionUser, type SessionUserFixture } from '../../test-utils/fixtures';
 
-type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3; isOwner: boolean };
-const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: 0, isOwner: false };
+type SessionUser = SessionUserFixture;
+const USER: SessionUser = makeSessionUser({ isOwner: false });
 
 const MOCK_STREAMER = {
   id: 123, twitch_user_id: 'twitch123', twitch_name: 'teststreamer', discord_id: USER.discordId,
   eventsub_access_token: 'encrypted-token',
 };
 
+/** Builds a supertest-ready app: the channel points admin router with a stubbed session and a render mock that flattens locals into the JSON body. */
 function buildApp(sessionUser: SessionUser = USER) {
-  const app = express();
-  app.use(express.urlencoded({ extended: false }));
-  app.use((req: any, res: any, next: any) => {
-    req.session = { user: sessionUser };
-    res.render = (view: string, locals?: any) => res.json({ view, ...locals });
-    next();
-  });
-  app.use(router);
-  return app;
+  return buildTestApp({ router, bodyParser: 'urlencoded', sessionUser, mockRender: 'spread' });
 }
 
 beforeEach(() => {

--- a/src/web/routes/channelPointsAdmin.test.ts
+++ b/src/web/routes/channelPointsAdmin.test.ts
@@ -18,6 +18,11 @@ vi.mock('../middleware', () => ({
   requireAuth: (_req: any, _res: any, next: any) => next(),
 }));
 
+// `makeSessionUser` (from `test-utils/fixtures`) imports `AccessLevel` from `../../db/users` at
+// runtime, which transitively pulls in `../../db/pool` and its required env vars. Mock it out,
+// matching the convention used elsewhere (e.g. `streamGroups.test.ts`).
+vi.mock('../../db/users', () => ({ AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 } }));
+
 vi.mock('../../twitch/twitchApi', () => ({
   getCustomRewards: vi.fn(),
 }));

--- a/src/web/routes/channelPointsAdminMutations.test.ts
+++ b/src/web/routes/channelPointsAdminMutations.test.ts
@@ -40,13 +40,13 @@ vi.mock('./channelPointsAdminPricingMutations', async () => {
   return { router: Router() };
 });
 
-import express from 'express';
 import supertest from 'supertest';
 import { router } from './channelPointsAdminMutations';
 import { getStreamerByDiscordId, updatePricingCooldownForReward } from '../../db';
 import { createCustomReward, updateCustomReward } from '../../twitch/twitchApi';
 import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
 import { deleteRewardAndPricing } from '../../twitch/pricing/rewardPricingService';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
 type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3; isOwner: boolean };
 const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: 0, isOwner: false };
@@ -59,15 +59,9 @@ const VALID_REWARD_FORM = {
   title: 'Cool Reward', cost: '200', prompt: '', background_color: '',
 };
 
+/** Builds a supertest-ready app: the channel points admin mutations router with a stubbed session (no render stub — these routes redirect). */
 function buildApp(sessionUser: SessionUser = USER) {
-  const app = express();
-  app.use(express.urlencoded({ extended: false }));
-  app.use((req: any, _res: any, next: any) => {
-    req.session = { user: sessionUser };
-    next();
-  });
-  app.use(router);
-  return app;
+  return buildTestApp({ router, bodyParser: 'urlencoded', sessionUser });
 }
 
 const VALID_REWARD_TWITCH_DATA = { id: VALID_REWARD_ID, global_cooldown_setting: { is_enabled: true, global_cooldown_seconds: 300 } };

--- a/src/web/routes/channelPointsAdminPricingMutations.test.ts
+++ b/src/web/routes/channelPointsAdminPricingMutations.test.ts
@@ -36,13 +36,13 @@ vi.mock('../../twitch/pricing/rewardPricingService', () => ({
   resetAndDeletePricing: vi.fn().mockResolvedValue(undefined),
 }));
 
-import express from 'express';
 import supertest from 'supertest';
 import { router } from './channelPointsAdminPricingMutations';
 import { getStreamerByDiscordId, upsertPricingConfig, getPricingForReward, savePricingSettingsForStreamer } from '../../db';
 import { getCustomRewards } from '../../twitch/twitchApi';
 import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
 import { applyDecayTick, resetAndDeletePricing } from '../../twitch/pricing/rewardPricingService';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
 type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3; isOwner: boolean };
 const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: 0, isOwner: false };
@@ -52,15 +52,9 @@ const MOCK_STREAMER = { id: 123, twitch_user_id: 'twitch123', twitch_name: 'test
 const VALID_REWARD_ID = '12345678-1234-1234-8234-123456789abc';
 const VALID_REWARD_TWITCH_DATA = { id: VALID_REWARD_ID, global_cooldown_setting: { is_enabled: true, global_cooldown_seconds: 300 } };
 
+/** Builds a supertest-ready app: the channel points pricing mutations router with a stubbed session (no render stub — these routes redirect). */
 function buildApp(sessionUser: SessionUser = USER) {
-  const app = express();
-  app.use(express.urlencoded({ extended: false }));
-  app.use((req: any, _res: any, next: any) => {
-    req.session = { user: sessionUser };
-    next();
-  });
-  app.use(router);
-  return app;
+  return buildTestApp({ router, bodyParser: 'urlencoded', sessionUser });
 }
 
 beforeEach(() => {

--- a/src/web/routes/channelPointsEvents.test.ts
+++ b/src/web/routes/channelPointsEvents.test.ts
@@ -16,6 +16,7 @@ import express from 'express';
 import supertest from 'supertest';
 import router, { MAX_SSE_CONNECTIONS_PER_STREAMER, connections, pushPricingUpdate } from './channelPointsEvents';
 import { getStreamerByDiscordId } from '../../db';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
 /** Finds a route's handler function directly from the router's internal stack, bypassing HTTP entirely — needed to control fake timers and the request's 'close' event deterministically. */
 function getRouteHandler(routePath: string): (req: any, res: any, next: any) => void {
@@ -47,13 +48,7 @@ function makeSseReq(discordId: string) {
 }
 
 function buildApp() {
-  const app = express();
-  app.use((req: any, _res, next) => {
-    req.session = { user: { discordId: 'discord1' } };
-    next();
-  });
-  app.use(router);
-  return app;
+  return buildTestApp({ router, sessionUser: { discordId: 'discord1' } });
 }
 
 beforeEach(() => {

--- a/src/web/routes/channelPointsEvents.test.ts
+++ b/src/web/routes/channelPointsEvents.test.ts
@@ -24,6 +24,7 @@ function getRouteHandler(routePath: string): (req: any, res: any, next: any) => 
   return layer.route.stack[0].handle;
 }
 
+/** Builds a fake Express `res` covering the SSE-specific methods (`setHeader`, `flushHeaders`, `write`, `end`) used by the events route handler. */
 function makeSseRes() {
   return {
     setHeader: vi.fn(),
@@ -34,6 +35,7 @@ function makeSseRes() {
   };
 }
 
+/** Builds a fake Express `req` with a session for `discordId` and a `close`-event hook, plus a `triggerClose()` helper to simulate the client disconnecting. */
 function makeSseReq(discordId: string) {
   let closeCb: (() => void) | undefined;
   return {
@@ -47,6 +49,7 @@ function makeSseReq(discordId: string) {
   };
 }
 
+/** Builds a supertest-ready app: the channel-points-events router with a stubbed session user. */
 function buildApp() {
   return buildTestApp({ router, sessionUser: { discordId: 'discord1' } });
 }

--- a/src/web/routes/commandAssignments.test.ts
+++ b/src/web/routes/commandAssignments.test.ts
@@ -23,17 +23,15 @@ vi.mock('../../db/users', () => ({
   AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
 }));
 
-import express from 'express';
 import supertest from 'supertest';
 import router from './commandAssignments';
 import { assignUserToCommand, unassignUserFromCommand, findUser, CommandConflictError, isMysqlDuplicateEntryError } from '../../db';
 import { AccessLevel } from '../../db/users';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
+/** Builds a supertest-ready app: the command assignments router with a urlencoded body parser (no session or render stub needed). */
 function buildApp() {
-  const app = express();
-  app.use(express.urlencoded({ extended: false }));
-  app.use(router);
-  return app;
+  return buildTestApp({ router, bodyParser: 'urlencoded' });
 }
 
 const VALID_COMMAND_ID = '5';

--- a/src/web/routes/commandGuildOverrides.test.ts
+++ b/src/web/routes/commandGuildOverrides.test.ts
@@ -11,10 +11,10 @@ vi.mock('../middleware', () => ({
 }));
 vi.mock('../../shared/logger', () => ({ createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }) }));
 
-import express from 'express';
 import supertest from 'supertest';
 import router from './commandGuildOverrides';
 import { upsertOverride, removeOverride } from '../../db';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
 const GUILD_ID = '900000000000000001';
 
@@ -23,14 +23,7 @@ const GUILD_ID = '900000000000000001';
  * current guild to GUILD_ID. Pass `null` to simulate no guild in session.
  */
 function buildApp(currentGuildId: string | null = GUILD_ID) {
-  const app = express();
-  app.use(express.urlencoded({ extended: false }));
-  app.use((req: any, _res: any, next: any) => {
-    req.session = { user: { discordId: 'u1', currentGuildId } };
-    next();
-  });
-  app.use(router);
-  return app;
+  return buildTestApp({ router, bodyParser: 'urlencoded', sessionUser: { discordId: 'u1', currentGuildId } });
 }
 
 beforeEach(() => {

--- a/src/web/routes/commandMonitor.test.ts
+++ b/src/web/routes/commandMonitor.test.ts
@@ -19,24 +19,14 @@ vi.mock('../../shared/logger', () => ({
   createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
 }));
 
-import express from 'express';
 import supertest from 'supertest';
 import router from './commandMonitor';
 import { getRecentCommandTestEntries } from '../../commands/commandMonitorStore';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
 /** Builds a minimal Express app wired with the command-monitor router and a fake session user. */
 function buildApp() {
-  const app = express();
-  app.use((_req: any, res: any, next: any) => {
-    res.render = (view: string, locals: unknown) => res.json({ view, locals });
-    next();
-  });
-  app.use((req: any, _res: any, next: any) => {
-    req.session = { user: { discordId: '1', discordName: 'TestUser' } };
-    next();
-  });
-  app.use(router);
-  return app;
+  return buildTestApp({ router, sessionUser: { discordId: '1', discordName: 'TestUser' }, mockRender: 'nested' });
 }
 
 beforeEach(() => {

--- a/src/web/routes/commandMutations.test.ts
+++ b/src/web/routes/commandMutations.test.ts
@@ -23,7 +23,6 @@ vi.mock('../csrf', () => ({ csrfProtection: (_req: any, _res: any, next: any) =>
 vi.mock('../middleware', () => ({ requireMod: (_req: any, _res: any, next: any) => next() }));
 vi.mock('../../shared/logger', () => ({ createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }) }));
 
-import express from 'express';
 import supertest from 'supertest';
 import router from './commandMutations';
 import {
@@ -33,12 +32,11 @@ import {
   isMysqlDuplicateEntryError,
 } from '../../db';
 import { AccessLevel } from '../../db/users';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
+/** Builds a supertest-ready app: the command mutations router with a urlencoded body parser (no session or render stub needed). */
 function buildApp() {
-  const app = express();
-  app.use(express.urlencoded({ extended: false }));
-  app.use(router);
-  return app;
+  return buildTestApp({ router, bodyParser: 'urlencoded' });
 }
 
 const VALID_DISCORD_ID = '123456789012345678';

--- a/src/web/routes/commands.test.ts
+++ b/src/web/routes/commands.test.ts
@@ -62,20 +62,16 @@ import {
   ReservedCommandError,
 } from '../../db';
 import { AccessLevel } from '../../db/users';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
+/** Builds a supertest-ready app: the commands router with a stubbed session and a render mock that sends `rendered:<view>` (locals ignored). */
 function buildApp() {
-  const app = express();
-  app.use(express.urlencoded({ extended: false }));
-  app.use((_req: any, res: any, next: any) => {
-    res.render = (view: string) => res.send(`rendered:${view}`);
-    next();
+  return buildTestApp({
+    router,
+    bodyParser: 'urlencoded',
+    sessionUser: { discord_id: '1', discord_name: 'TestUser', access_level: AccessLevel.MANAGER },
+    mockRender: 'text',
   });
-  app.use((req: any, _res: any, next: any) => {
-    req.session = { user: { discord_id: '1', discord_name: 'TestUser', access_level: AccessLevel.MANAGER } };
-    next();
-  });
-  app.use(router);
-  return app;
 }
 
 beforeEach(() => {

--- a/src/web/routes/companionAuth.rateLimit.test.ts
+++ b/src/web/routes/companionAuth.rateLimit.test.ts
@@ -7,20 +7,14 @@ vi.mock('../../shared/logger', () => ({
   createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
 }));
 
-import express from 'express';
 import supertest from 'supertest';
 import router from './companionAuth';
 import { authLimiter } from '../rateLimits';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
+/** Builds a supertest-ready app: the companion auth router with a JSON body parser and an empty (no-user) session. */
 function buildApp() {
-  const app = express();
-  app.use(express.json());
-  app.use((req: any, _res: any, next: any) => {
-    req.session = {};
-    next();
-  });
-  app.use(router);
-  return app;
+  return buildTestApp({ router, bodyParser: 'json', session: {} });
 }
 
 // authLimiter is a process-wide singleton (shared with /auth's routes), so reset its

--- a/src/web/routes/companionAuth.test.ts
+++ b/src/web/routes/companionAuth.test.ts
@@ -17,21 +17,15 @@ import express from 'express';
 import supertest from 'supertest';
 import router from './companionAuth';
 import { exchangeCodeForToken } from '../../db';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
 function buildApp(sessionOverrides: Record<string, unknown> = {}) {
-  const app = express();
-  app.use(express.json());
-  app.use((req: any, _res: any, next: any) => {
-    req.session = { ...sessionOverrides };
-    next();
+  return buildTestApp({
+    router,
+    bodyParser: 'json',
+    session: { ...sessionOverrides },
+    mockRender: (view, locals, res) => res.status(res.statusCode || 200).json({ view, locals }),
   });
-  app.use((req: any, res: any, next: any) => {
-    res.render = (view: string, locals: unknown) =>
-      res.status((res as any).statusCode || 200).json({ view, locals });
-    next();
-  });
-  app.use(router);
-  return app;
 }
 
 beforeEach(() => {

--- a/src/web/routes/companionAuth.test.ts
+++ b/src/web/routes/companionAuth.test.ts
@@ -19,6 +19,7 @@ import router from './companionAuth';
 import { exchangeCodeForToken } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 
+/** Builds a supertest-ready app: the companion-auth router with a customizable raw session and a render mock that returns the view/locals as JSON. */
 function buildApp(sessionOverrides: Record<string, unknown> = {}) {
   return buildTestApp({
     router,

--- a/src/web/routes/companionEvents.test.ts
+++ b/src/web/routes/companionEvents.test.ts
@@ -23,14 +23,13 @@ vi.mock('../middleware', () => ({
   },
 }));
 
-import express from 'express';
 import supertest from 'supertest';
 import router, { pushCompanionEvent, MAX_SSE_CONNECTIONS_PER_TOKEN, connections, type CompanionEvent } from './companionEvents';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
+/** Builds a supertest-ready app: the companion events router with no body parser or session stub (auth is driven via a test header, see requireCompanionKey mock above). */
 function buildApp() {
-  const app = express();
-  app.use(router);
-  return app;
+  return buildTestApp({ router });
 }
 
 const sampleEvent: CompanionEvent = {

--- a/src/web/routes/companionKeys.test.ts
+++ b/src/web/routes/companionKeys.test.ts
@@ -21,6 +21,7 @@ import supertest from 'supertest';
 import router from './companionKeys';
 import { issueToken, getTokenStatus, revokeToken } from '../../db';
 import { AccessLevel } from '../../db/users';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
 const GUILD_ID = '900000000000000001';
 const SESSION_USER = {
@@ -32,19 +33,9 @@ const SESSION_USER = {
   guilds: [{ guildId: GUILD_ID, name: 'Test Guild' }],
 };
 
+/** Builds a supertest-ready app: the companion keys router with a stubbed session and a render mock that nests locals under a `locals` key. */
 function buildApp(sessionUser = SESSION_USER) {
-  const app = express();
-  app.use(express.urlencoded({ extended: false }));
-  app.use((req: any, _res: any, next: any) => {
-    req.session = { user: sessionUser };
-    next();
-  });
-  app.use((req: any, res: any, next: any) => {
-    res.render = (view: string, locals: unknown) => res.json({ view, locals });
-    next();
-  });
-  app.use(router);
-  return app;
+  return buildTestApp({ router, bodyParser: 'urlencoded', sessionUser, mockRender: 'nested' });
 }
 
 beforeEach(() => {

--- a/src/web/routes/counterHistory.test.ts
+++ b/src/web/routes/counterHistory.test.ts
@@ -21,25 +21,20 @@ vi.mock('../../shared/logger', () => ({
 
 vi.mock('../../db/users', () => ({ AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 } }));
 
-import express from 'express';
 import supertest from 'supertest';
 import router from './counterHistory';
 import { getCounterHistory } from '../../db';
 import { AccessLevel } from '../../db/users';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
+/** Builds a supertest-ready app: the counter history router with a stubbed session and a render mock that sends `rendered:<view>` (locals ignored). */
 function buildApp() {
-  const app = express();
-  app.use(express.urlencoded({ extended: false }));
-  app.use((_req: any, res: any, next: any) => {
-    res.render = (view: string) => res.send(`rendered:${view}`);
-    next();
+  return buildTestApp({
+    router,
+    bodyParser: 'urlencoded',
+    sessionUser: { discord_id: '1', discord_name: 'TestUser', access_level: AccessLevel.USER },
+    mockRender: 'text',
   });
-  app.use((req: any, _res: any, next: any) => {
-    req.session = { user: { discord_id: '1', discord_name: 'TestUser', access_level: AccessLevel.USER } };
-    next();
-  });
-  app.use(router);
-  return app;
 }
 
 beforeEach(() => {

--- a/src/web/routes/counters.test.ts
+++ b/src/web/routes/counters.test.ts
@@ -37,7 +37,6 @@ vi.mock('../../logger', () => ({
 
 vi.mock('../../db/users', () => ({ AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 } }));
 
-import express from 'express';
 import supertest from 'supertest';
 import router from './counters';
 import {
@@ -53,20 +52,16 @@ import {
   ReservedCommandError,
 } from '../../db';
 import { AccessLevel } from '../../db/users';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
+/** Builds a supertest-ready app: the counters router with a stubbed session and a render mock that sends `rendered:<view>` (locals ignored). */
 function buildApp() {
-  const app = express();
-  app.use(express.urlencoded({ extended: false }));
-  app.use((_req: any, res: any, next: any) => {
-    res.render = (view: string) => res.send(`rendered:${view}`);
-    next();
+  return buildTestApp({
+    router,
+    bodyParser: 'urlencoded',
+    sessionUser: { discord_id: '1', discord_name: 'TestUser', access_level: AccessLevel.MANAGER },
+    mockRender: 'text',
   });
-  app.use((req: any, _res: any, next: any) => {
-    req.session = { user: { discord_id: '1', discord_name: 'TestUser', access_level: AccessLevel.MANAGER } };
-    next();
-  });
-  app.use(router);
-  return app;
 }
 
 const VALID_ADD = {

--- a/src/web/routes/dashboard.test.ts
+++ b/src/web/routes/dashboard.test.ts
@@ -23,12 +23,12 @@ vi.mock('../csrf', () => ({
   },
 }));
 
-import express from 'express';
 import supertest from 'supertest';
 import router from './dashboard';
 import { getStatus } from '../../shared/statusStore';
 import { getStreamerByDiscordId } from '../../db';
 import { hasAuthFailedSubs } from '../../twitch/eventsub/twitchEventSubSubscriptions';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
 const STATUS = { discord: { ready: true }, voice: {}, twitch: {}, tiktok: {} };
 
@@ -37,15 +37,8 @@ const STATUS = { discord: { ready: true }, voice: {}, twitch: {}, tiktok: {} };
  * @param sessionUser - The session user to attach to each request, or undefined for an anonymous session.
  * @returns The configured Express app, ready to be driven with supertest.
  */
-function buildApp(sessionUser: any = undefined) {
-  const app = express();
-  app.use((req: any, res: any, next: any) => {
-    req.session = { user: sessionUser };
-    res.render = (view: string, locals?: any) => res.json({ view, ...locals });
-    next();
-  });
-  app.use(router);
-  return app;
+function buildApp(sessionUser: unknown = undefined) {
+  return buildTestApp({ router, sessionUser, mockRender: 'spread' });
 }
 
 beforeEach(() => {

--- a/src/web/routes/eventsubAdmin.test.ts
+++ b/src/web/routes/eventsubAdmin.test.ts
@@ -26,11 +26,11 @@ vi.mock('../middleware', () => ({
   },
 }));
 
-import express from 'express';
 import supertest from 'supertest';
 import router from './eventsubAdmin';
 import { clearStreamerToken } from '../../db';
 import { reloadEventSubSubscriptions } from '../../twitch/eventsub/twitchEventSub';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
 /**
  * Builds a minimal Express app with the eventsub admin router mounted, a stubbed session, and res.render captured as JSON.
@@ -38,14 +38,7 @@ import { reloadEventSubSubscriptions } from '../../twitch/eventsub/twitchEventSu
  * @returns The configured Express app, ready to be driven with supertest.
  */
 function buildApp(accessLevel = 3) {
-  const app = express();
-  app.use((req: any, res: any, next: any) => {
-    req.session = { user: { discordId: '1', accessLevel } };
-    res.render = (view: string, locals?: any) => res.json({ view, ...locals });
-    next();
-  });
-  app.use(router);
-  return app;
+  return buildTestApp({ router, sessionUser: { discordId: '1', accessLevel }, mockRender: 'spread' });
 }
 
 beforeEach(() => {

--- a/src/web/routes/eventsubCallback.test.ts
+++ b/src/web/routes/eventsubCallback.test.ts
@@ -47,6 +47,7 @@ const MOCK_STREAMER = {
 
 const SESSION_USER: SessionUser = makeSessionUser({ discordId: MOCK_STREAMER.discord_id, accessLevel: AccessLevel.MOD });
 
+/** Builds a supertest-ready app: the EventSub-callback router with a valid OAuth-state session for `MOCK_STREAMER`, customizable via `sessionOverrides`. */
 function buildApp(sessionOverrides: Record<string, any> = {}) {
   return buildTestApp({
     router,

--- a/src/web/routes/eventsubCallback.test.ts
+++ b/src/web/routes/eventsubCallback.test.ts
@@ -32,9 +32,11 @@ import supertest from 'supertest';
 import router from './eventsubCallback';
 import { getStreamerById, saveStreamerToken, initEventConfig } from '../../db';
 import { exchangeCode, getUserFromToken } from '../../twitch/eventsub/twitchApiEventSub';
-import { AccessLevel, AccessLevelValue } from '../../db/users';
+import { AccessLevel } from '../../db/users';
+import { buildTestApp } from '../../test-utils/expressTestApp';
+import { makeSessionUser, type SessionUserFixture } from '../../test-utils/fixtures';
 
-type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: AccessLevelValue };
+type SessionUser = SessionUserFixture;
 
 const MOCK_STREAMER = {
   id: 1,
@@ -43,26 +45,18 @@ const MOCK_STREAMER = {
   twitch_user_id: 'twitch123',
 };
 
-const SESSION_USER: SessionUser = {
-  discordId: MOCK_STREAMER.discord_id,
-  discordName: 'TestUser',
-  discordAvatar: null,
-  accessLevel: AccessLevel.MOD,
-};
+const SESSION_USER: SessionUser = makeSessionUser({ discordId: MOCK_STREAMER.discord_id, accessLevel: AccessLevel.MOD });
 
 function buildApp(sessionOverrides: Record<string, any> = {}) {
-  const app = express();
-  app.use((req: any, _res: any, next: any) => {
-    req.session = {
+  return buildTestApp({
+    router,
+    session: {
       eventsubOAuthState: { value: 'valid-state-abc', expiresAt: Date.now() + 60_000 },
       eventsubStreamerId: MOCK_STREAMER.id,
       user: SESSION_USER,
       ...sessionOverrides,
-    };
-    next();
+    },
   });
-  app.use(router);
-  return app;
 }
 
 beforeEach(() => {

--- a/src/web/routes/overlayAdmin.test.ts
+++ b/src/web/routes/overlayAdmin.test.ts
@@ -41,27 +41,21 @@ vi.mock('./overlayAdminMutations', async () => {
   return { router: Router(), MAX_UPLOAD_MB: 100 };
 });
 
-import express from 'express';
 import supertest from 'supertest';
 import router from './overlayAdmin';
 import { getStreamerByDiscordId, getVideosForStreamer, getRewardsForStreamer } from '../../db';
 import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
 import { getCustomRewards } from '../../twitch/twitchApi';
 import { AccessLevel } from '../../db/users';
+import { buildTestApp } from '../../test-utils/expressTestApp';
+import { makeSessionUser, type SessionUserFixture } from '../../test-utils/fixtures';
 
-type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3 };
-const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: AccessLevel.MOD };
+type SessionUser = SessionUserFixture;
+const USER: SessionUser = makeSessionUser({ accessLevel: AccessLevel.MOD });
 
+/** Builds a supertest-ready app: the overlay admin router with a stubbed session and a render mock that flattens locals into the JSON body. */
 function buildApp(sessionUser: SessionUser = USER) {
-  const app = express();
-  app.use(express.urlencoded({ extended: false }));
-  app.use((req: any, res: any, next: any) => {
-    req.session = { user: sessionUser };
-    res.render = (view: string, locals?: any) => res.json({ view, ...locals });
-    next();
-  });
-  app.use(router);
-  return app;
+  return buildTestApp({ router, bodyParser: 'urlencoded', sessionUser, mockRender: 'spread' });
 }
 
 beforeEach(() => {

--- a/src/web/routes/overlayAdminMutations.test.ts
+++ b/src/web/routes/overlayAdminMutations.test.ts
@@ -40,7 +40,6 @@ vi.mock('fs', () => ({
   },
 }));
 
-import express from 'express';
 import supertest from 'supertest';
 import multer from 'multer';
 import { router, detectVideoType, handleUploadError } from './overlayAdminMutations';
@@ -48,6 +47,7 @@ import { getStreamerByDiscordId, addVideo, deleteVideo } from '../../db';
 import { AccessLevel } from '../../db/users';
 import fs from 'fs';
 import { csrfProtection } from '../csrf';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
 // Minimal buffers with correct magic bytes for each format
 const WEBM_BUF = Buffer.from([0x1a, 0x45, 0xdf, 0xa3, 0x00, 0x00, 0x00, 0x00]);
@@ -63,15 +63,9 @@ const MOCK_STREAMER = {
   discord_id: USER.discordId,
 };
 
+/** Builds a supertest-ready app: the overlay admin mutations router with a stubbed session (no render stub — these routes redirect). */
 function buildApp(sessionUser: SessionUser = USER) {
-  const app = express();
-  app.use(express.urlencoded({ extended: false }));
-  app.use((req: any, res: any, next: any) => {
-    req.session = { user: sessionUser };
-    next();
-  });
-  app.use(router);
-  return app;
+  return buildTestApp({ router, bodyParser: 'urlencoded', sessionUser });
 }
 
 beforeEach(() => {

--- a/src/web/routes/overlayAdminRewardMutations.test.ts
+++ b/src/web/routes/overlayAdminRewardMutations.test.ts
@@ -29,11 +29,11 @@ vi.mock('../../config', () => ({
 
 vi.mock('../../db/users', () => ({ AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 } }));
 
-import express from 'express';
 import supertest from 'supertest';
 import { router } from './overlayAdminRewardMutations';
 import { getStreamerByDiscordId, upsertReward, setRewardVideos, deleteReward } from '../../db';
 import { AccessLevel } from '../../db/users';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
 type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3 };
 const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: AccessLevel.USER };
@@ -45,15 +45,9 @@ const MOCK_STREAMER = {
   discord_id: USER.discordId,
 };
 
+/** Builds a supertest-ready app: the overlay admin reward mutations router with a stubbed session (no render stub — these routes redirect). */
 function buildApp(sessionUser: SessionUser = USER) {
-  const app = express();
-  app.use(express.urlencoded({ extended: false }));
-  app.use((req: any, res: any, next: any) => {
-    req.session = { user: sessionUser };
-    next();
-  });
-  app.use(router);
-  return app;
+  return buildTestApp({ router, bodyParser: 'urlencoded', sessionUser });
 }
 
 beforeEach(() => {

--- a/src/web/routes/privacy.test.ts
+++ b/src/web/routes/privacy.test.ts
@@ -1,21 +1,11 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import express from 'express';
 import supertest from 'supertest';
 import privacyRouter from './privacy';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
 /** Builds a minimal Express app wired with the privacy router, a fake session, and a `res.render` stub that echoes its arguments as JSON instead of rendering EJS. */
 function buildApp(sessionUser: unknown = null) {
-  const app = express();
-  app.use((req: any, _res: any, next: any) => {
-    req.session = { user: sessionUser };
-    next();
-  });
-  app.use((req: any, res: any, next: any) => {
-    res.render = (view: string, locals: unknown) => res.json({ view, locals });
-    next();
-  });
-  app.use(privacyRouter);
-  return app;
+  return buildTestApp({ router: privacyRouter, sessionUser, mockRender: 'nested' });
 }
 
 describe('GET /privacy', () => {

--- a/src/web/routes/sfx.test.ts
+++ b/src/web/routes/sfx.test.ts
@@ -18,11 +18,11 @@ vi.mock('../../db/users', () => ({
   AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
 }));
 
-import express from 'express';
 import supertest from 'supertest';
 import router from './sfx';
 import { getAllSfxTriggers, getAllCategories } from '../../db';
 import { AccessLevel } from '../../db/users';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
 /**
  * Build a supertest GET request against the SFX view router with a stubbed session
@@ -31,17 +31,8 @@ import { AccessLevel } from '../../db/users';
  * @param query Optional query string appended to `/sfx` (e.g. `?error=invalid_id`).
  * @returns A supertest request for `GET /sfx`.
  */
-function buildApp(sessionUser: any = { discordId: '1', accessLevel: AccessLevel.USER }, query = '') {
-  const app = express();
-  app.use((req: any, _res: any, next: any) => {
-    req.session = { user: sessionUser };
-    next();
-  });
-  app.use((_req: any, res: any, next: any) => {
-    res.render = (view: string, locals: unknown) => res.json({ view, locals });
-    next();
-  });
-  app.use(router);
+function buildApp(sessionUser: unknown = { discordId: '1', accessLevel: AccessLevel.USER }, query = '') {
+  const app = buildTestApp({ router, sessionUser, mockRender: 'nested' });
   return supertest(app).get('/sfx' + query);
 }
 

--- a/src/web/routes/sfxMutations.test.ts
+++ b/src/web/routes/sfxMutations.test.ts
@@ -48,7 +48,6 @@ vi.mock('fs', () => ({
   },
 }));
 
-import express from 'express';
 import supertest from 'supertest';
 import router from './sfxMutations';
 import {
@@ -66,6 +65,7 @@ import {
 import { requireMod } from '../middleware';
 import { csrfProtection } from '../csrf';
 import fs from 'fs';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
 // Minimal buffers with correct magic bytes for each accepted format
 const MP3_ID3 = Buffer.from([0x49, 0x44, 0x33, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
@@ -78,14 +78,7 @@ const WAV_BUF = Buffer.from([0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x5
  * @returns The configured Express app.
  */
 function buildApp() {
-  const app = express();
-  app.use(express.urlencoded({ extended: false }));
-  app.use((req: any, _res: any, next: any) => {
-    req.session = { user: { discordId: '1', accessLevel: 1 } };
-    next();
-  });
-  app.use(router);
-  return app;
+  return buildTestApp({ router, bodyParser: 'urlencoded', sessionUser: { discordId: '1', accessLevel: 1 } });
 }
 
 beforeEach(() => {

--- a/src/web/routes/sfxPublic.test.ts
+++ b/src/web/routes/sfxPublic.test.ts
@@ -20,6 +20,7 @@ import { buildTestApp } from '../../test-utils/expressTestApp';
 
 let router: any;
 
+/** Builds a supertest-ready app: the public-SFX router with a stubbed session user and a nested-JSON render mock. */
 function buildApp(sessionUser: unknown = { discordId: '1', discordName: 'Test', accessLevel: AccessLevel.USER }) {
   return buildTestApp({ router, sessionUser, mockRender: 'nested' });
 }

--- a/src/web/routes/sfxPublic.test.ts
+++ b/src/web/routes/sfxPublic.test.ts
@@ -13,25 +13,15 @@ vi.mock('../../db/users', () => ({
   AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
 }));
 
-import express from 'express';
 import supertest from 'supertest';
 import { getPublicSfxTriggers } from '../../db';
 import { AccessLevel } from '../../db/users';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
 let router: any;
 
 function buildApp(sessionUser: unknown = { discordId: '1', discordName: 'Test', accessLevel: AccessLevel.USER }) {
-  const app = express();
-  app.use((req: any, _res: any, next: any) => {
-    req.session = { user: sessionUser };
-    next();
-  });
-  app.use((req: any, res: any, next: any) => {
-    res.render = (view: string, locals: unknown) => res.json({ view, locals });
-    next();
-  });
-  app.use(router);
-  return app;
+  return buildTestApp({ router, sessionUser, mockRender: 'nested' });
 }
 
 beforeEach(async () => {

--- a/src/web/routes/streamGroups.test.ts
+++ b/src/web/routes/streamGroups.test.ts
@@ -31,12 +31,13 @@ import supertest from 'supertest';
 import router from './streamGroups';
 import { addStreamGroup, updateStreamGroup, removeStreamGroupAndStreamers } from '../../db';
 import { restartTwitchMonitor } from '../../twitch/monitor/twitchMonitor';
-import { AccessLevel, AccessLevelValue } from '../../db/users';
+import { AccessLevel } from '../../db/users';
 import { buildTestApp } from '../../test-utils/expressTestApp';
+import { makeSessionUser, type SessionUserFixture } from '../../test-utils/fixtures';
 
 const GUILD_ID = '900000000000000001';
-type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: AccessLevelValue; currentGuildId: string };
-const MANAGER: SessionUser = { discordId: '200000000000000001', discordName: 'ManagerUser', discordAvatar: null, accessLevel: AccessLevel.MANAGER, currentGuildId: GUILD_ID };
+type SessionUser = SessionUserFixture;
+const MANAGER: SessionUser = makeSessionUser({ accessLevel: AccessLevel.MANAGER, currentGuildId: GUILD_ID });
 
 /** Builds a supertest-ready app: the stream groups router with a stubbed session and a render mock that flattens locals into the JSON body. */
 function buildApp(sessionUser: SessionUser = MANAGER) {

--- a/src/web/routes/streamGroups.test.ts
+++ b/src/web/routes/streamGroups.test.ts
@@ -27,27 +27,20 @@ vi.mock('../../shared/logger', () => ({
 
 vi.mock('../../db/users', () => ({ AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 } }));
 
-import express from 'express';
 import supertest from 'supertest';
 import router from './streamGroups';
 import { addStreamGroup, updateStreamGroup, removeStreamGroupAndStreamers } from '../../db';
 import { restartTwitchMonitor } from '../../twitch/monitor/twitchMonitor';
 import { AccessLevel, AccessLevelValue } from '../../db/users';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
 const GUILD_ID = '900000000000000001';
 type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: AccessLevelValue; currentGuildId: string };
 const MANAGER: SessionUser = { discordId: '200000000000000001', discordName: 'ManagerUser', discordAvatar: null, accessLevel: AccessLevel.MANAGER, currentGuildId: GUILD_ID };
 
+/** Builds a supertest-ready app: the stream groups router with a stubbed session and a render mock that flattens locals into the JSON body. */
 function buildApp(sessionUser: SessionUser = MANAGER) {
-  const app = express();
-  app.use(express.urlencoded({ extended: false }));
-  app.use((req: any, res: any, next: any) => {
-    req.session = { user: sessionUser };
-    res.render = (view: string, locals?: any) => res.json({ view, ...locals });
-    next();
-  });
-  app.use(router);
-  return app;
+  return buildTestApp({ router, bodyParser: 'urlencoded', sessionUser, mockRender: 'spread' });
 }
 
 beforeEach(() => {

--- a/src/web/routes/streamStreamers.test.ts
+++ b/src/web/routes/streamStreamers.test.ts
@@ -27,27 +27,20 @@ vi.mock('../../shared/logger', () => ({
 
 vi.mock('../../db/users', () => ({ AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 } }));
 
-import express from 'express';
 import supertest from 'supertest';
 import router from './streamStreamers';
 import { addStreamer, removeStreamer, findUser } from '../../db';
 import { restartTwitchMonitor } from '../../twitch/monitor/twitchMonitor';
 import { AccessLevel, AccessLevelValue } from '../../db/users';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
 const GUILD_ID = '900000000000000001';
 type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: AccessLevelValue; currentGuildId: string };
 const MANAGER: SessionUser = { discordId: '200000000000000001', discordName: 'ManagerUser', discordAvatar: null, accessLevel: AccessLevel.MANAGER, currentGuildId: GUILD_ID };
 
+/** Builds a supertest-ready app: the stream streamers router with a stubbed session and a render mock that flattens locals into the JSON body. */
 function buildApp(sessionUser: SessionUser = MANAGER) {
-  const app = express();
-  app.use(express.urlencoded({ extended: false }));
-  app.use((req: any, res: any, next: any) => {
-    req.session = { user: sessionUser };
-    res.render = (view: string, locals?: any) => res.json({ view, ...locals });
-    next();
-  });
-  app.use(router);
-  return app;
+  return buildTestApp({ router, bodyParser: 'urlencoded', sessionUser, mockRender: 'spread' });
 }
 
 beforeEach(() => {

--- a/src/web/routes/streamdeck.test.ts
+++ b/src/web/routes/streamdeck.test.ts
@@ -58,6 +58,7 @@ import router from './streamdeck';
 import { getAllSfxTriggers, getApprovedGuildIdsForKey } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 
+/** Builds a supertest-ready app: the streamdeck router with a JSON body parser and no session stub (routes are key-authenticated). */
 function buildApp() {
   return buildTestApp({ router, bodyParser: 'json' });
 }

--- a/src/web/routes/streamdeck.test.ts
+++ b/src/web/routes/streamdeck.test.ts
@@ -53,16 +53,13 @@ vi.mock('../../shared/logger', () => ({
   createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
 }));
 
-import express from 'express';
 import supertest from 'supertest';
 import router from './streamdeck';
 import { getAllSfxTriggers, getApprovedGuildIdsForKey } from '../../db';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
 function buildApp() {
-  const app = express();
-  app.use(express.json());
-  app.use(router);
-  return app;
+  return buildTestApp({ router, bodyParser: 'json' });
 }
 
 beforeEach(() => {

--- a/src/web/routes/streamdeckKeys.test.ts
+++ b/src/web/routes/streamdeckKeys.test.ts
@@ -33,6 +33,7 @@ import {
   approveApiKey, denyApiKey, getAllApiKeys, getPendingRequests,
 } from '../../db';
 import { AccessLevel } from '../../db/users';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
 const GUILD_ID = '900000000000000001';
 const SESSION_USER = {
@@ -45,19 +46,9 @@ const SESSION_USER = {
 };
 const VALID_DISCORD_ID = '123456789012345678';
 
+/** Builds a supertest-ready app: the streamdeck keys router with a stubbed session and a render mock that nests locals under a `locals` key. */
 function buildApp(sessionUser = SESSION_USER) {
-  const app = express();
-  app.use(express.urlencoded({ extended: false }));
-  app.use((req: any, _res: any, next: any) => {
-    req.session = { user: sessionUser };
-    next();
-  });
-  app.use((req: any, res: any, next: any) => {
-    res.render = (view: string, locals: unknown) => res.json({ view, locals });
-    next();
-  });
-  app.use(router);
-  return app;
+  return buildTestApp({ router, bodyParser: 'urlencoded', sessionUser, mockRender: 'nested' });
 }
 
 beforeEach(() => {

--- a/src/web/routes/streamdeckSfx.test.ts
+++ b/src/web/routes/streamdeckSfx.test.ts
@@ -72,6 +72,7 @@ function makeClient() {
   return { channels: { fetch: vi.fn() } } as any;
 }
 
+/** Builds a supertest-ready app: the streamdeck-SFX router with a JSON body parser and no session stub (routes are key-authenticated). */
 function buildApp() {
   return buildTestApp({ router, bodyParser: 'json' });
 }

--- a/src/web/routes/streamdeckSfx.test.ts
+++ b/src/web/routes/streamdeckSfx.test.ts
@@ -45,7 +45,6 @@ vi.mock('../../shared/logger', () => ({
   createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
 }));
 
-import express from 'express';
 import supertest from 'supertest';
 import router from './streamdeckSfx';
 import { findTrigger, findSoundFiles, getAllSfxTriggers, isKeyApprovedForGuild, getApprovedGuildIdsForKey } from '../../db';
@@ -54,6 +53,7 @@ import { playFile, VoiceNotConnectedError } from '../../audio/sfxPlayer';
 import { setVoicePlaying } from '../../shared/statusStore';
 import { getDiscordClient } from '../../discord/discordBot';
 import { getActiveGuildForUser } from '../../discord/voicePresence';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
 const TRIGGER: SfxTrigger = {
   id: BigInt(1),
@@ -73,10 +73,7 @@ function makeClient() {
 }
 
 function buildApp() {
-  const app = express();
-  app.use(express.json());
-  app.use(router);
-  return app;
+  return buildTestApp({ router, bodyParser: 'json' });
 }
 
 beforeEach(() => {

--- a/src/web/routes/streamdeckVoice.test.ts
+++ b/src/web/routes/streamdeckVoice.test.ts
@@ -35,7 +35,6 @@ vi.mock('../../shared/logger', () => ({
   createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
 }));
 
-import express from 'express';
 import supertest from 'supertest';
 import router from './streamdeckVoice';
 import { isKeyApprovedForGuild, getApprovedGuildIdsForKey } from '../../db';
@@ -43,6 +42,7 @@ import { getAvailableVoiceChannels } from '../../discord/discordUtils';
 import { connect, disconnect } from '../../audio/audioPlayer';
 import { getDiscordClient } from '../../discord/discordBot';
 import { getActiveGuildForUser } from '../../discord/voicePresence';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
 /** Fake Discord client whose channels.fetch resolves any channel to the given guildId. */
 function makeClient(channelGuildId: string | null = 'guild-123') {
@@ -56,10 +56,7 @@ function makeClient(channelGuildId: string | null = 'guild-123') {
 }
 
 function buildApp() {
-  const app = express();
-  app.use(express.json());
-  app.use(router);
-  return app;
+  return buildTestApp({ router, bodyParser: 'json' });
 }
 
 beforeEach(() => {

--- a/src/web/routes/streamdeckVoice.test.ts
+++ b/src/web/routes/streamdeckVoice.test.ts
@@ -55,6 +55,7 @@ function makeClient(channelGuildId: string | null = 'guild-123') {
   } as any;
 }
 
+/** Builds a supertest-ready app: the streamdeck-voice router with a JSON body parser and no session stub (routes are key-authenticated). */
 function buildApp() {
   return buildTestApp({ router, bodyParser: 'json' });
 }

--- a/src/web/routes/streams.test.ts
+++ b/src/web/routes/streams.test.ts
@@ -45,21 +45,15 @@ import {
 } from '../../db';
 import { getLiveStates } from '../../twitch/monitor/twitchMonitor';
 import { AccessLevel, AccessLevelValue } from '../../db/users';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
 const GUILD_ID = '900000000000000001';
 type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: AccessLevelValue; currentGuildId: string };
 const MANAGER: SessionUser = { discordId: '200000000000000001', discordName: 'ManagerUser', discordAvatar: null, accessLevel: AccessLevel.MANAGER, currentGuildId: GUILD_ID };
 
+/** Builds a supertest-ready app: the streams router with a stubbed session and a render mock that flattens locals into the JSON body. */
 function buildApp(sessionUser: SessionUser = MANAGER) {
-  const app = express();
-  app.use(express.urlencoded({ extended: false }));
-  app.use((req: any, res: any, next: any) => {
-    req.session = { user: sessionUser };
-    res.render = (view: string, locals?: any) => res.json({ view, ...locals });
-    next();
-  });
-  app.use(router);
-  return app;
+  return buildTestApp({ router, bodyParser: 'urlencoded', sessionUser, mockRender: 'spread' });
 }
 
 beforeEach(() => {

--- a/src/web/routes/tos.test.ts
+++ b/src/web/routes/tos.test.ts
@@ -1,21 +1,11 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import express from 'express';
 import supertest from 'supertest';
 import tosRouter from './tos';
+import { buildTestApp } from '../../test-utils/expressTestApp';
 
 /** Builds a minimal Express app wired with the tos router, a fake session, and a `res.render` stub that echoes its arguments as JSON instead of rendering EJS. */
 function buildApp(sessionUser: unknown = null) {
-  const app = express();
-  app.use((req: any, _res: any, next: any) => {
-    req.session = { user: sessionUser };
-    next();
-  });
-  app.use((req: any, res: any, next: any) => {
-    res.render = (view: string, locals: unknown) => res.json({ view, locals });
-    next();
-  });
-  app.use(tosRouter);
-  return app;
+  return buildTestApp({ router: tosRouter, sessionUser, mockRender: 'nested' });
 }
 
 describe('GET /tos', () => {

--- a/src/web/routes/userSettings.test.ts
+++ b/src/web/routes/userSettings.test.ts
@@ -42,20 +42,15 @@ import router from './userSettings';
 import { findUser, getStreamerByDiscordId, saveEventConfig, clearStreamerToken } from '../../db';
 import { reloadEventSubSubscriptions } from '../../twitch/eventsub/twitchEventSub';
 import { AccessLevel } from '../../db/users';
+import { buildTestApp } from '../../test-utils/expressTestApp';
+import { makeSessionUser, type SessionUserFixture } from '../../test-utils/fixtures';
 
-type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3 };
-const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: AccessLevel.MOD };
+type SessionUser = SessionUserFixture;
+const USER: SessionUser = makeSessionUser({ accessLevel: AccessLevel.MOD });
 
+/** Builds a supertest-ready app: the user settings router (or an override) with a stubbed session and a render mock that flattens locals into the JSON body. */
 function buildApp(sessionUser: SessionUser = USER, routerOverride: typeof router = router) {
-  const app = express();
-  app.use(express.urlencoded({ extended: false }));
-  app.use((req: any, res: any, next: any) => {
-    req.session = { user: sessionUser };
-    res.render = (view: string, locals?: any) => res.json({ view, ...locals });
-    next();
-  });
-  app.use(routerOverride);
-  return app;
+  return buildTestApp({ router: routerOverride, bodyParser: 'urlencoded', sessionUser, mockRender: 'spread' });
 }
 
 beforeEach(() => {


### PR DESCRIPTION
## Summary

Part of the project-wide de-duplication review, scoped to test-file mock/harness boilerplate only — no production code changes.

Adds three helpers under `src/test-utils/` (following the existing `deferredPromise.ts`/`flushMicrotasks.ts` style, each with its own co-located `*.test.ts`):

- **`mockMysqlPool.ts`** — `makeMockConnection(overrides?)` / `makeMockPool({ rows?, meta?, executeResult?, connection? })` cover the mysql2 `Pool`/`PoolConnection` fakes (`execute`, `query`, `getConnection`, and the connection's `execute`/`beginTransaction`/`commit`/`rollback`/`release`) hand-rolled across `src/db/*.test.ts`.
- **`expressTestApp.ts`** — `buildTestApp({ router, bodyParser?, sessionUser?, session?, mockRender? })` composes the body-parser + `req.session` stub + `res.render` stub (`'spread'` / `'nested'` / `'text'` presets, or a custom function) + router-mount pattern hand-rolled across `src/web/routes/*.test.ts`.
- **`fixtures.ts`** — `makeSessionUser(overrides?)` / `makeDbGuild(overrides?)` factories for the most commonly-duplicated fixture shapes, wired into 4 real call sites.

No behavior or assertion changes anywhere — every migrated file's test expectations are byte-for-byte the same; only the setup boilerplate was replaced.

## File counts

- **`src/db/*.test.ts`**: 16 of 24 migrated to `mockMysqlPool`.
  - Skipped (8): `commandLocks.test.ts`, `commandStringUtils.test.ts`, `counterCache.test.ts`, `customCommandCache.test.ts`, `lookupCache.test.ts`, `pool.test.ts`, `reservedCommands.test.ts`, `utils.test.ts` — either no `getPool`/mysql mocking at all (pure unit tests), or (in `commandLocks.test.ts`'s case) one-off inline fakes with SQL-string-conditional branching that don't fit the shared shape.
- **`src/web/routes/*.test.ts`**: 37 of 49 migrated to `expressTestApp`.
  - Skipped, no Express app under test (9): `adminUserMutations.test.ts`, `adminUserValidation.test.ts`, `channelPointsAdminShared.test.ts`, `overlayAdminShared.test.ts`, `sfxFileUpload.test.ts`, `shared.test.ts`, `streamRestart.test.ts`, `streamdeckGuildResolution.test.ts`, `streamsErrors.test.ts`.
  - Skipped, bespoke harness (3): `auth.test.ts` (self-referential `req.session.save/destroy/regenerate` mocks), `guild.test.ts` (router mounted at a `/guild` path prefix + inline `req.csrfToken`, used consistently across 8 inline app instances), `overlaySource.test.ts` (needs an extra `res.sendFile` stub beyond `res.render`).
  - In files with multiple `buildApp()`-style helpers (`commands.test.ts`, `companionAuth.test.ts`, `companionKeys.test.ts`, `eventsubCallback.test.ts`, `streamdeckKeys.test.ts`, `streams.test.ts`, `userSettings.test.ts`), only the primary shared `buildApp()` was migrated; one-off inline apps built inside individual `it()` blocks for edge cases were left as-is.
- **`src/test-utils/fixtures.ts`**: added after 1 and 2, wired into 4 call sites (`channelPointsAdmin.test.ts`, `overlayAdmin.test.ts`, `userSettings.test.ts`, `eventsubCallback.test.ts`).

## Note on sibling PR

`claude/dedup-test-mocks` (not yet merged) separately consolidates `createLogger`/`AccessLevel` mocks in some of the same files. This PR was built independently off `origin/main`; a human will reconcile/rebase the two at merge time.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (132 files / 2350 tests, all green)
- [x] Diffed each migrated file's test output before/after to confirm identical pass counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBKcCSsAKKoryf1Zrv31dR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RBKcCSsAKKoryf1Zrv31dR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized database and Express test setup with shared mock pools, fixtures, and application builders.
  * Simplified route test configuration while preserving existing coverage and assertions.

* **Tests**
  * Added coverage for shared test utilities, including database mocks, session fixtures, rendering behavior, body parsing, and router mounting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->