### PR TITLE
Efficiency improvements: SFX lookup cache, batched queries, startup parallelism

### DIFF
--- a/src/audio/sfxPlayer.test.ts
+++ b/src/audio/sfxPlayer.test.ts
@@ -18,9 +18,11 @@ vi.mock('ffmpeg-static', () => ({ default: null }));
 
 vi.mock('fs', () => ({
   default: {
-    existsSync: vi.fn(),
     realpathSync: vi.fn(),
-    statSync: vi.fn(),
+    promises: {
+      realpath: vi.fn(),
+      stat: vi.fn(),
+    },
   },
 }));
 
@@ -29,59 +31,71 @@ import { isConnected, startPlayback } from './audioPlayer';
 import { createAudioResource } from '@discordjs/voice';
 import fs from 'fs';
 
+/** Builds an ENOENT-style error, matching what fs.promises.realpath throws for a missing path. */
+function enoent(): NodeJS.ErrnoException {
+  const err = new Error('ENOENT') as NodeJS.ErrnoException;
+  err.code = 'ENOENT';
+  return err;
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
-  // Default: realpathSync is an identity function (no symlinks)
+  // Default: realpathSync/realpath are identity functions (no symlinks)
   vi.mocked(fs.realpathSync).mockImplementation((p) => p as string);
+  vi.mocked(fs.promises.realpath).mockImplementation(async (p) => p as string);
 });
 
 describe('playFile', () => {
-  it('throws VoiceNotConnectedError when not connected to the given guild\'s voice channel', () => {
+  it('throws VoiceNotConnectedError when not connected to the given guild\'s voice channel', async () => {
     vi.mocked(isConnected).mockReturnValue(false);
-    expect(() => playFile(path.posix.join(SFX_ROOT, 'ding.mp3'), 'guild-A')).toThrow(VoiceNotConnectedError);
+    await expect(playFile(path.posix.join(SFX_ROOT, 'ding.mp3'), 'guild-A')).rejects.toThrow(VoiceNotConnectedError);
     expect(vi.mocked(isConnected)).toHaveBeenCalledWith('guild-A');
   });
 
-  it('blocks a path that resolves outside the SFX folder', () => {
+  it('blocks a path that resolves outside the SFX folder', async () => {
     vi.mocked(isConnected).mockReturnValue(true);
-    expect(() => playFile('/etc/passwd', 'guild-A')).toThrow('Path traversal blocked');
+    await expect(playFile('/etc/passwd', 'guild-A')).rejects.toThrow('Path traversal blocked');
   });
 
-  it('blocks a symlink whose real path resolves outside the SFX folder', () => {
+  it('blocks a symlink whose real path resolves outside the SFX folder', async () => {
     vi.mocked(isConnected).mockReturnValue(true);
-    vi.mocked(fs.existsSync).mockReturnValue(true);
     const outsidePath = '/etc/passwd';
     // Symlink inside SFX_ROOT points to a file outside it
-    vi.mocked(fs.realpathSync).mockImplementation((p) =>
+    vi.mocked(fs.promises.realpath).mockImplementation(async (p) =>
       String(p) === SFX_ROOT ? SFX_ROOT : outsidePath,
     );
-    expect(() => playFile(path.posix.join(SFX_ROOT, 'evil.mp3'), 'guild-A')).toThrow('Path traversal blocked');
+    await expect(playFile(path.posix.join(SFX_ROOT, 'evil.mp3'), 'guild-A')).rejects.toThrow('Path traversal blocked');
   });
 
-  it('starts playback in the given guild for a valid file inside the SFX folder', () => {
+  it('starts playback in the given guild for a valid file inside the SFX folder', async () => {
     vi.mocked(isConnected).mockReturnValue(true);
-    vi.mocked(fs.existsSync).mockReturnValue(true);
-    vi.mocked(fs.statSync).mockReturnValue({ isFile: () => true } as ReturnType<typeof fs.statSync>);
+    vi.mocked(fs.promises.stat).mockResolvedValue({ isFile: () => true } as Awaited<ReturnType<typeof fs.promises.stat>>);
 
     const filePath = path.posix.join(SFX_ROOT, 'ding.mp3');
-    playFile(filePath, 'guild-A');
+    await playFile(filePath, 'guild-A');
 
     expect(vi.mocked(createAudioResource)).toHaveBeenCalledWith(filePath);
     expect(vi.mocked(startPlayback)).toHaveBeenCalledWith(expect.anything(), 'guild-A');
   });
 
-  it('throws when the sound file does not exist on disk', () => {
+  it('throws when the sound file does not exist on disk', async () => {
     vi.mocked(isConnected).mockReturnValue(true);
-    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(fs.promises.realpath).mockRejectedValue(enoent());
 
-    expect(() => playFile(path.posix.join(SFX_ROOT, 'missing.mp3'), 'guild-A')).toThrow('Sound file not found');
+    await expect(playFile(path.posix.join(SFX_ROOT, 'missing.mp3'), 'guild-A')).rejects.toThrow('Sound file not found');
   });
 
-  it('throws when the resolved path is a directory, not a file', () => {
+  it('propagates a non-ENOENT realpath error rather than misreporting it as a missing file', async () => {
     vi.mocked(isConnected).mockReturnValue(true);
-    vi.mocked(fs.existsSync).mockReturnValue(true);
-    vi.mocked(fs.statSync).mockReturnValue({ isFile: () => false } as ReturnType<typeof fs.statSync>);
+    vi.mocked(fs.promises.realpath).mockRejectedValue(new Error('EACCES'));
 
-    expect(() => playFile(path.posix.join(SFX_ROOT, 'notafile'), 'guild-A')).toThrow('Sound path is not a file');
+    await expect(playFile(path.posix.join(SFX_ROOT, 'locked.mp3'), 'guild-A')).rejects.toThrow('EACCES');
+  });
+
+  it('throws when the resolved path is a directory, not a file', async () => {
+    vi.mocked(isConnected).mockReturnValue(true);
+    vi.mocked(fs.promises.stat).mockResolvedValue({ isFile: () => false } as Awaited<ReturnType<typeof fs.promises.stat>>);
+
+    await expect(playFile(path.posix.join(SFX_ROOT, 'notafile'), 'guild-A')).rejects.toThrow('Sound path is not a file');
   });
 });

--- a/src/audio/sfxPlayer.ts
+++ b/src/audio/sfxPlayer.ts
@@ -40,7 +40,7 @@ function getRealSfxRoot(): string {
  * @param filePath - Sound file path, relative to the SFX folder.
  * @param guildId - Guild whose voice connection to play the file into.
  */
-export function playFile(filePath: string, guildId: string): void {
+export async function playFile(filePath: string, guildId: string): Promise<void> {
   if (!isConnected(guildId)) {
     throw new VoiceNotConnectedError();
   }
@@ -50,18 +50,22 @@ export function playFile(filePath: string, guildId: string): void {
     throw new Error(`Path traversal blocked: ${filePath} resolves outside SFX folder`);
   }
 
-  if (!fs.existsSync(candidatePath)) {
-    throw new Error(`Sound file not found: ${candidatePath}`);
+  let resolved: string;
+  try {
+    resolved = await fs.promises.realpath(candidatePath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(`Sound file not found: ${candidatePath}`);
+    }
+    throw err;
   }
-
-  const resolved = fs.realpathSync(candidatePath);
 
   // Resolve symlinks and verify the final real path is still inside the SFX root.
   if (!safeResolve(getRealSfxRoot(), resolved)) {
     throw new Error(`Path traversal blocked: ${filePath} resolves outside SFX folder`);
   }
 
-  const fileStats = fs.statSync(resolved);
+  const fileStats = await fs.promises.stat(resolved);
   if (!fileStats.isFile()) {
     throw new Error(`Sound path is not a file: ${resolved}`);
   }

--- a/src/commands/commandRouter.test.ts
+++ b/src/commands/commandRouter.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import path from 'path';
-import type { SfxTrigger, SfxFile } from '../db';
+import type { SfxTrigger, SfxFile, SfxLookupResult } from '../db';
 
 const SFX_ROOT = '/sfx';
 
@@ -10,8 +10,7 @@ vi.mock('../shared/config', () => ({
 }));
 
 vi.mock('../db', () => ({
-  findTrigger: vi.fn(),
-  findSoundFiles: vi.fn(),
+  findCachedSfxTrigger: vi.fn(),
 }));
 
 vi.mock('../audio/audioPlayer', () => ({
@@ -34,7 +33,7 @@ vi.mock('../shared/statusStore', () => ({
 }));
 
 import { handleCommand, forgetGuildCommandState } from './commandRouter';
-import { findTrigger, findSoundFiles } from '../db';
+import { findCachedSfxTrigger } from '../db';
 import { isPlaying } from '../audio/audioPlayer';
 import { playFile, VoiceNotConnectedError } from '../audio/sfxPlayer';
 import { pickWeightedRandom } from './soundSelector';
@@ -53,13 +52,14 @@ beforeEach(() => {
 
 const TRIGGER: SfxTrigger = { id: 42n, trigger_command: '!ding', category_id: null, hidden: false, description: null };
 const FILES: SfxFile[] = [{ id: 1, trigger_id: 42n, file: 'ding.mp3', trigger_command: null, weight: 1, hidden: false, category_id: null }];
+const LOOKUP: SfxLookupResult = { trigger: TRIGGER, files: FILES };
 const GUILD_A = 'guild-A';
 const GUILD_B = 'guild-B';
 
 describe('handleCommand', () => {
   it('does nothing for an unrecognised command', async () => {
     vi.mocked(isPlaying).mockReturnValue(false);
-    vi.mocked(findTrigger).mockResolvedValue(null);
+    vi.mocked(findCachedSfxTrigger).mockResolvedValue(null);
 
     await handleCommand('!unknown', 'twitch', GUILD_A);
 
@@ -69,7 +69,7 @@ describe('handleCommand', () => {
   it('skips with a warning and does not look anything up when no guild is resolved', async () => {
     await handleCommand('!ding', 'twitch', null);
 
-    expect(vi.mocked(findTrigger)).not.toHaveBeenCalled();
+    expect(vi.mocked(findCachedSfxTrigger)).not.toHaveBeenCalled();
     expect(vi.mocked(playFile)).not.toHaveBeenCalled();
   });
 
@@ -78,7 +78,7 @@ describe('handleCommand', () => {
 
     await handleCommand('!ding', 'twitch', GUILD_A);
 
-    expect(vi.mocked(findTrigger)).not.toHaveBeenCalled();
+    expect(vi.mocked(findCachedSfxTrigger)).not.toHaveBeenCalled();
     expect(vi.mocked(playFile)).not.toHaveBeenCalled();
     expect(vi.mocked(isPlaying)).toHaveBeenCalledWith(GUILD_A);
   });
@@ -86,8 +86,7 @@ describe('handleCommand', () => {
   it('ignores the command while the per-guild cooldown is active', async () => {
     // First call plays successfully and sets this guild's lastPlayedAt = mockNow
     vi.mocked(isPlaying).mockReturnValue(false);
-    vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
-    vi.mocked(findSoundFiles).mockResolvedValue(FILES);
+    vi.mocked(findCachedSfxTrigger).mockResolvedValue(LOOKUP);
     vi.mocked(pickWeightedRandom).mockReturnValue('ding.mp3');
 
     await handleCommand('!ding', 'twitch', GUILD_A);
@@ -99,14 +98,13 @@ describe('handleCommand', () => {
 
     await handleCommand('!ding', 'twitch', GUILD_A);
 
-    expect(vi.mocked(findTrigger)).not.toHaveBeenCalled();
+    expect(vi.mocked(findCachedSfxTrigger)).not.toHaveBeenCalled();
     expect(vi.mocked(playFile)).not.toHaveBeenCalled();
   });
 
   it('does not apply one guild\'s cooldown to another guild', async () => {
     vi.mocked(isPlaying).mockReturnValue(false);
-    vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
-    vi.mocked(findSoundFiles).mockResolvedValue(FILES);
+    vi.mocked(findCachedSfxTrigger).mockResolvedValue(LOOKUP);
     vi.mocked(pickWeightedRandom).mockReturnValue('ding.mp3');
 
     await handleCommand('!ding', 'twitch', GUILD_A);
@@ -120,8 +118,7 @@ describe('handleCommand', () => {
 
   it('forgetGuildCommandState resets a guild\'s cooldown so a subsequent command fires immediately', async () => {
     vi.mocked(isPlaying).mockReturnValue(false);
-    vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
-    vi.mocked(findSoundFiles).mockResolvedValue(FILES);
+    vi.mocked(findCachedSfxTrigger).mockResolvedValue(LOOKUP);
     vi.mocked(pickWeightedRandom).mockReturnValue('ding.mp3');
 
     await handleCommand('!ding', 'twitch', GUILD_A);
@@ -140,13 +137,12 @@ describe('handleCommand', () => {
 
   it('plays the correct file and updates status for a known command', async () => {
     vi.mocked(isPlaying).mockReturnValue(false);
-    vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
-    vi.mocked(findSoundFiles).mockResolvedValue(FILES);
+    vi.mocked(findCachedSfxTrigger).mockResolvedValue(LOOKUP);
     vi.mocked(pickWeightedRandom).mockReturnValue('ding.mp3');
 
     await handleCommand('!ding discord', 'discord', GUILD_A);
 
-    expect(vi.mocked(findTrigger)).toHaveBeenCalledWith('!ding');
+    expect(vi.mocked(findCachedSfxTrigger)).toHaveBeenCalledWith('!ding');
     expect(vi.mocked(playFile)).toHaveBeenCalledWith(path.posix.join(SFX_ROOT, 'ding.mp3'), GUILD_A);
     expect(vi.mocked(setVoicePlaying)).toHaveBeenCalledWith(GUILD_A, 'ding.mp3', '!ding', 'discord');
   });
@@ -154,23 +150,22 @@ describe('handleCommand', () => {
   it('blocks a second concurrent call via the inFlight flag', async () => {
     vi.mocked(isPlaying).mockReturnValue(false);
 
-    // findTrigger resolves immediately for the first call, but the second call
+    // findCachedSfxTrigger resolves immediately for the first call, but the second call
     // arrives while the first is still awaiting — simulate by running both
     // handleCommand calls concurrently without awaiting the first.
-    let resolveFirst!: (value: typeof TRIGGER) => void;
-    const firstTriggerPromise = new Promise<typeof TRIGGER>((resolve) => { resolveFirst = resolve; });
-    vi.mocked(findTrigger).mockReturnValueOnce(firstTriggerPromise as ReturnType<typeof findTrigger>);
+    let resolveFirst!: (value: SfxLookupResult) => void;
+    const firstLookupPromise = new Promise<SfxLookupResult>((resolve) => { resolveFirst = resolve; });
+    vi.mocked(findCachedSfxTrigger).mockReturnValueOnce(firstLookupPromise as ReturnType<typeof findCachedSfxTrigger>);
 
     const first = handleCommand('!ding', 'twitch', GUILD_A);
 
-    // Second call arrives while first is suspended inside findTrigger
+    // Second call arrives while first is suspended inside findCachedSfxTrigger
     await handleCommand('!ding', 'twitch', GUILD_A);
-    expect(vi.mocked(findTrigger)).toHaveBeenCalledTimes(1); // second was blocked
+    expect(vi.mocked(findCachedSfxTrigger)).toHaveBeenCalledTimes(1); // second was blocked
 
     // Let the first call complete
-    vi.mocked(findSoundFiles).mockResolvedValue(FILES);
     vi.mocked(pickWeightedRandom).mockReturnValue('ding.mp3');
-    resolveFirst(TRIGGER);
+    resolveFirst(LOOKUP);
     await first;
 
     expect(vi.mocked(playFile)).toHaveBeenCalledTimes(1);
@@ -178,8 +173,7 @@ describe('handleCommand', () => {
 
   it('logs a warning and returns when a trigger has no associated sound files', async () => {
     vi.mocked(isPlaying).mockReturnValue(false);
-    vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
-    vi.mocked(findSoundFiles).mockResolvedValue([]);
+    vi.mocked(findCachedSfxTrigger).mockResolvedValue({ trigger: TRIGGER, files: [] });
 
     await handleCommand('!ding', 'twitch', GUILD_A);
 
@@ -188,8 +182,7 @@ describe('handleCommand', () => {
 
   it('logs an error for non-VoiceNotConnectedError playback failures', async () => {
     vi.mocked(isPlaying).mockReturnValue(false);
-    vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
-    vi.mocked(findSoundFiles).mockResolvedValue(FILES);
+    vi.mocked(findCachedSfxTrigger).mockResolvedValue(LOOKUP);
     vi.mocked(pickWeightedRandom).mockReturnValue('ding.mp3');
     vi.mocked(playFile).mockImplementation(() => { throw new Error('FFMPEG crashed'); });
 
@@ -205,8 +198,7 @@ describe('handleCommand', () => {
 
   it('does not log an error when not connected to a voice channel', async () => {
     vi.mocked(isPlaying).mockReturnValue(false);
-    vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
-    vi.mocked(findSoundFiles).mockResolvedValue(FILES);
+    vi.mocked(findCachedSfxTrigger).mockResolvedValue(LOOKUP);
     vi.mocked(pickWeightedRandom).mockReturnValue('ding.mp3');
     vi.mocked(playFile).mockImplementation(() => { throw new VoiceNotConnectedError(); });
 
@@ -221,8 +213,7 @@ describe('handleCommand', () => {
   describe('path traversal security', () => {
     it('rejects path traversal with ../ sequences', async () => {
       vi.mocked(isPlaying).mockReturnValue(false);
-      vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
-      vi.mocked(findSoundFiles).mockResolvedValue(FILES);
+      vi.mocked(findCachedSfxTrigger).mockResolvedValue(LOOKUP);
       vi.mocked(pickWeightedRandom).mockReturnValue('../../../etc/passwd');
 
       await handleCommand('!exploit', 'twitch', GUILD_A);
@@ -233,8 +224,7 @@ describe('handleCommand', () => {
 
     it('rejects path traversal with encoded ../ sequences', async () => {
       vi.mocked(isPlaying).mockReturnValue(false);
-      vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
-      vi.mocked(findSoundFiles).mockResolvedValue(FILES);
+      vi.mocked(findCachedSfxTrigger).mockResolvedValue(LOOKUP);
       vi.mocked(pickWeightedRandom).mockReturnValue('..%2F..%2Fetc%2Fpasswd');
 
       await handleCommand('!exploit', 'twitch', GUILD_A);
@@ -245,8 +235,7 @@ describe('handleCommand', () => {
 
     it('rejects absolute paths', async () => {
       vi.mocked(isPlaying).mockReturnValue(false);
-      vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
-      vi.mocked(findSoundFiles).mockResolvedValue(FILES);
+      vi.mocked(findCachedSfxTrigger).mockResolvedValue(LOOKUP);
       vi.mocked(pickWeightedRandom).mockReturnValue('/etc/passwd');
 
       await handleCommand('!exploit', 'twitch', GUILD_A);
@@ -257,10 +246,9 @@ describe('handleCommand', () => {
 
     it('allows valid filenames within the SFX folder', async () => {
       vi.mocked(isPlaying).mockReturnValue(false);
-      vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
-      vi.mocked(findSoundFiles).mockResolvedValue(FILES);
+      vi.mocked(findCachedSfxTrigger).mockResolvedValue(LOOKUP);
       vi.mocked(pickWeightedRandom).mockReturnValue('valid-sound.mp3');
-      vi.mocked(playFile).mockImplementation(() => {}); // Reset to no-op
+      vi.mocked(playFile).mockResolvedValue(undefined); // Reset to no-op
 
       await handleCommand('!safe', 'twitch', GUILD_A);
 
@@ -270,10 +258,9 @@ describe('handleCommand', () => {
 
     it('allows valid filenames in subdirectories within the SFX folder', async () => {
       vi.mocked(isPlaying).mockReturnValue(false);
-      vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
-      vi.mocked(findSoundFiles).mockResolvedValue(FILES);
+      vi.mocked(findCachedSfxTrigger).mockResolvedValue(LOOKUP);
       vi.mocked(pickWeightedRandom).mockReturnValue('category/sound.mp3');
-      vi.mocked(playFile).mockImplementation(() => {}); // Reset to no-op
+      vi.mocked(playFile).mockResolvedValue(undefined); // Reset to no-op
 
       await handleCommand('!safe', 'twitch', GUILD_A);
 

--- a/src/commands/commandRouter.ts
+++ b/src/commands/commandRouter.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { createLogger } from '../shared/logger';
-import { findTrigger, findSoundFiles } from '../db';
+import { findCachedSfxTrigger } from '../db';
 import { pickWeightedRandom } from './soundSelector';
 import { isPlaying } from '../audio/audioPlayer';
 import { playFile, VoiceNotConnectedError } from '../audio/sfxPlayer';
@@ -52,10 +52,9 @@ async function lookupAndPlay(
   guildId: string,
   state: GuildCommandState,
 ): Promise<void> {
-  const trigger = await findTrigger(command);
-  if (!trigger) return;
-
-  const files = await findSoundFiles(trigger.id);
+  const lookup = await findCachedSfxTrigger(command);
+  if (!lookup) return;
+  const { files } = lookup;
   if (files.length === 0) {
     log.warn(`[${source}] Trigger '${command}' has no sound files in DB`);
     return;
@@ -71,7 +70,7 @@ async function lookupAndPlay(
   log.info(`[${source}] Playing '${filename}' for trigger '${command}' in guild ${guildId}`);
 
   try {
-    playFile(fullPath, guildId);
+    await playFile(fullPath, guildId);
     state.lastPlayedAt = Date.now();
     setVoicePlaying(guildId, filename, command, source);
     recordCommandTestEntry({ source, command, response: filename, channel: null, user: null });

--- a/src/db.ts
+++ b/src/db.ts
@@ -15,7 +15,7 @@ export type { DbGuild } from './db/guilds';
 
 export {
   getGuildMembers, getMemberAccessLevel, setMemberAccessLevel,
-  removeGuildMember, getEffectiveAccessLevel,
+  removeGuildMember, getEffectiveAccessLevel, getEffectiveAccessLevelForUser,
 } from './db/guildMembers';
 export type { DbGuildMember } from './db/guildMembers';
 
@@ -61,7 +61,7 @@ export async function removeOverride(guildId: string, commandId: number): Promis
 
 export {
   AccessLevel, ACCESS_LEVEL_LABELS,
-  findUser, findUserByTwitchName, findOwnerUser, getAllUsers, getGuildMemberUsers,
+  findUser, findUsersByIds, findUserByTwitchName, findOwnerUser, getAllUsers, getGuildMemberUsers,
   updateDiscordName, getTwitchEnabledChannels, getAllTwitchLinkedUsers, updateAccessLevel,
 } from './db/users';
 export type { AccessLevelValue, DbUser, TwitchLinkedUser } from './db/users';
@@ -176,6 +176,8 @@ export {
   createSfxTrigger, updateSfxTrigger, deleteSfxTrigger,
   addSfxFile, updateSfxFile, deleteSfxFile,
 } from './db/sfx';
+export type { SfxLookupResult } from './db/sfxCache';
+export { findCachedSfxTrigger, invalidateSfxLookupCache } from './db/sfxCache';
 
 // ─── Overlay videos ─────────────────────────────────────────────────────────
 
@@ -197,7 +199,7 @@ export {
 } from './db/rewardPricing';
 
 export type { RewardPricingHistoryPoint } from './db/rewardPricingHistory';
-export { recordPricingHistory, getPricingHistory } from './db/rewardPricingHistory';
+export { recordPricingHistory, getPricingHistory, getPricingHistoryForRewards } from './db/rewardPricingHistory';
 
 // ─── Streamdeck API keys ─────────────────────────────────────────────────────
 

--- a/src/db/guildMembers.test.ts
+++ b/src/db/guildMembers.test.ts
@@ -16,6 +16,7 @@ import {
   setMemberAccessLevel,
   removeGuildMember,
   getEffectiveAccessLevel,
+  getEffectiveAccessLevelForUser,
 } from './guildMembers';
 import { makeMockPool, type MockPool } from '../test-utils/mockMysqlPool';
 
@@ -125,5 +126,34 @@ describe('getEffectiveAccessLevel', () => {
     vi.mocked(findUser).mockResolvedValueOnce({ ...baseUser });
     pool.execute.mockResolvedValueOnce([[], []]);
     expect(await getEffectiveAccessLevel('g1', '222')).toBe(AccessLevel.USER);
+  });
+});
+
+describe('getEffectiveAccessLevelForUser', () => {
+  const baseUser = {
+    discord_id: '222',
+    discord_name: 'Alice',
+    is_twitch_bot_enabled: false,
+    twitch_name: null,
+    access_level: 0,
+    is_owner: false,
+  };
+
+  it('returns ADMIN (3) for a bot owner regardless of membership, without a DB call', async () => {
+    expect(await getEffectiveAccessLevelForUser('g1', { ...baseUser, is_owner: true })).toBe(AccessLevel.ADMIN);
+    expect(pool.execute).not.toHaveBeenCalled();
+  });
+
+  it('reads the per-guild level from guild_member for a non-owner', async () => {
+    pool.execute.mockResolvedValueOnce([[{ access_level: 2 }], []]);
+    expect(await getEffectiveAccessLevelForUser('g1', { ...baseUser })).toBe(AccessLevel.MANAGER);
+    const [sql, params] = pool.execute.mock.calls[0];
+    expect(sql).toContain('FROM guild_member');
+    expect(params).toEqual(['g1', '222']);
+  });
+
+  it('defaults to USER (0) when a non-owner has no membership in the guild', async () => {
+    pool.execute.mockResolvedValueOnce([[], []]);
+    expect(await getEffectiveAccessLevelForUser('g1', { ...baseUser })).toBe(AccessLevel.USER);
   });
 });

--- a/src/db/guildMembers.ts
+++ b/src/db/guildMembers.ts
@@ -1,6 +1,6 @@
 import mysql from 'mysql2/promise';
 import { getPool } from './pool';
-import { AccessLevel, findUser } from './users';
+import { AccessLevel, findUser, type DbUser } from './users';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -93,13 +93,31 @@ export async function removeGuildMember(guildId: string, discordId: string): Pro
 // ─── Effective access-level resolution ─────────────────────────────────────────
 
 /**
- * Resolves a user's effective access level within a guild.
+ * Resolves an already-fetched user's effective access level within a guild.
  *
- * Resolution order (PR 3): a non-whitelisted user is User (0); a bot owner
- * (`user.is_owner`) is Admin everywhere regardless of membership; otherwise the
- * level comes from the user's `guild_member` row for that guild, defaulting to
- * User (0) when they have no membership there. The web panel writes `guild_member`
- * for the current guild, so this is the single source of truth for authorization.
+ * Resolution order (PR 3): a bot owner (`user.is_owner`) is Admin everywhere
+ * regardless of membership; otherwise the level comes from the user's
+ * `guild_member` row for that guild, defaulting to User (0) when they have no
+ * membership there. The web panel writes `guild_member` for the current guild,
+ * so this is the single source of truth for authorization.
+ *
+ * Use this instead of {@link getEffectiveAccessLevel} when the caller already has
+ * a fresh `DbUser` in hand (e.g. from its own `findUser` call moments earlier),
+ * to avoid re-querying the same row.
+ *
+ * @param guildId Guild snowflake as a string.
+ * @param user The user to resolve an access level for.
+ * @returns The user's access level (0–3) for the guild.
+ */
+export async function getEffectiveAccessLevelForUser(guildId: string, user: DbUser): Promise<number> {
+  if (user.is_owner) return AccessLevel.ADMIN;
+  return (await getMemberAccessLevel(guildId, user.discord_id)) ?? AccessLevel.USER;
+}
+
+/**
+ * Resolves a user's effective access level within a guild. A non-whitelisted user
+ * (no `user` row) is User (0) — see {@link getEffectiveAccessLevelForUser} for the
+ * resolution rules once a user row exists.
  *
  * @param guildId Guild snowflake as a string.
  * @param discordId User snowflake as a string.
@@ -108,6 +126,5 @@ export async function removeGuildMember(guildId: string, discordId: string): Pro
 export async function getEffectiveAccessLevel(guildId: string, discordId: string): Promise<number> {
   const user = await findUser(discordId);
   if (!user) return AccessLevel.USER;
-  if (user.is_owner) return AccessLevel.ADMIN;
-  return (await getMemberAccessLevel(guildId, discordId)) ?? AccessLevel.USER;
+  return getEffectiveAccessLevelForUser(guildId, user);
 }

--- a/src/db/rewardPricingHistory.test.ts
+++ b/src/db/rewardPricingHistory.test.ts
@@ -4,7 +4,7 @@ vi.mock('./pool', () => ({ getPool: vi.fn() }));
 vi.mock('mysql2/promise', () => ({ default: {} }));
 
 import { getPool } from './pool';
-import { recordPricingHistory, getPricingHistory } from './rewardPricingHistory';
+import { recordPricingHistory, getPricingHistory, getPricingHistoryForRewards } from './rewardPricingHistory';
 import { makeMockPool } from '../test-utils/mockMysqlPool';
 
 /** Builds a fake mysql pool whose `execute`/`query` resolve to the given rows/meta. */
@@ -54,5 +54,48 @@ describe('getPricingHistory', () => {
     await getPricingHistory(5, 1_700_000_000_000);
     expect(pool.execute.mock.calls[0][1]).toEqual([5, 1_700_000_000_000]);
     expect(pool.execute.mock.calls[0][0]).toContain('ORDER BY recorded_at ASC');
+  });
+});
+
+describe('getPricingHistoryForRewards', () => {
+  it('returns an empty map without querying when given an empty array', async () => {
+    const pool = makePool([]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await getPricingHistoryForRewards([], 1_700_000_000_000);
+    expect(result.size).toBe(0);
+    expect(pool.execute).not.toHaveBeenCalled();
+  });
+
+  it('groups points by reward_pricing_id', async () => {
+    const rows = [
+      { reward_pricing_id: 5, recorded_at: '1700100000000', cost: 350, demand: '0.42' },
+      { reward_pricing_id: 5, recorded_at: '1700200000000', cost: 400, demand: '0.55' },
+      { reward_pricing_id: 9, recorded_at: '1700100000000', cost: 100, demand: '0.10' },
+    ];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+
+    const result = await getPricingHistoryForRewards([5, 9], 1_700_000_000_000);
+
+    expect(result.size).toBe(2);
+    expect(result.get(5)).toEqual([
+      { recorded_at: '1700100000000', cost: 350, demand: 0.42 },
+      { recorded_at: '1700200000000', cost: 400, demand: 0.55 },
+    ]);
+    expect(result.get(9)).toEqual([{ recorded_at: '1700100000000', cost: 100, demand: 0.1 }]);
+  });
+
+  it('omits reward ids with no points rather than including an empty array', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([]) as any);
+    const result = await getPricingHistoryForRewards([5], 1_700_000_000_000);
+    expect(result.has(5)).toBe(false);
+  });
+
+  it('builds an IN clause with one placeholder per id, plus sinceMs', async () => {
+    const pool = makePool([]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await getPricingHistoryForRewards([5, 9, 12], 1_700_000_000_000);
+    const [sql, params] = pool.execute.mock.calls[0];
+    expect(sql).toContain('reward_pricing_id IN (?, ?, ?)');
+    expect(params).toEqual([5, 9, 12, 1_700_000_000_000]);
   });
 });

--- a/src/db/rewardPricingHistory.ts
+++ b/src/db/rewardPricingHistory.ts
@@ -1,5 +1,6 @@
 import mysql from 'mysql2/promise';
 import { getPool } from './pool';
+import { buildInClausePlaceholders } from './commandStringUtils';
 
 /** One recorded price/demand point for a reward, at a point in time. */
 export interface RewardPricingHistoryPoint {
@@ -61,4 +62,39 @@ export async function getPricingHistory(rewardPricingId: number, sinceMs: number
     cost: r.cost,
     demand: Number(r.demand),
   }));
+}
+
+/**
+ * Returns recorded price/demand points for multiple rewards at or after `sinceMs` in a
+ * single query, grouped by `reward_pricing_id` (oldest first within each group). Used by
+ * the Channel Points admin page to chart every reward's history without one query per
+ * reward.
+ *
+ * @param rewardPricingIds - Primary keys of the `reward_pricing` rows to fetch history for.
+ * @param sinceMs - Epoch ms lower bound (inclusive) for returned points.
+ * @returns A map from `reward_pricing_id` to its points; ids with no points are absent.
+ */
+export async function getPricingHistoryForRewards(
+  rewardPricingIds: number[],
+  sinceMs: number,
+): Promise<Map<number, RewardPricingHistoryPoint[]>> {
+  const byRewardId = new Map<number, RewardPricingHistoryPoint[]>();
+  if (rewardPricingIds.length === 0) return byRewardId;
+
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT reward_pricing_id, recorded_at, cost, demand FROM reward_pricing_history
+     WHERE reward_pricing_id IN (${buildInClausePlaceholders(rewardPricingIds.length)}) AND recorded_at >= ?
+     ORDER BY reward_pricing_id, recorded_at ASC`,
+    [...rewardPricingIds, sinceMs],
+  );
+
+  for (const r of rows) {
+    const rewardPricingId = r.reward_pricing_id as number;
+    const point: RewardPricingHistoryPoint = { recorded_at: String(r.recorded_at), cost: r.cost, demand: Number(r.demand) };
+    const existing = byRewardId.get(rewardPricingId);
+    if (existing) existing.push(point);
+    else byRewardId.set(rewardPricingId, [point]);
+  }
+
+  return byRewardId;
 }

--- a/src/db/sfx.test.ts
+++ b/src/db/sfx.test.ts
@@ -25,6 +25,9 @@ vi.mock('./pool', () => {
   };
 });
 vi.mock('mysql2/promise', () => ({ default: {} }));
+vi.mock('./sfxCache', () => ({
+  invalidateSfxLookupCache: vi.fn(),
+}));
 
 import { getPool } from './pool';
 import {
@@ -33,6 +36,7 @@ import {
   createSfxTrigger, updateSfxTrigger, deleteSfxTrigger,
   addSfxFile, updateSfxFile, deleteSfxFile,
 } from './sfx';
+import { invalidateSfxLookupCache } from './sfxCache';
 import { makeMockPool } from '../test-utils/mockMysqlPool';
 
 /** Pool whose top-level execute returns row data (for SELECT queries). */
@@ -306,6 +310,13 @@ describe('createSfxTrigger', () => {
     await createSfxTrigger('!bang', null, null, false);
     expect(pool.execute.mock.calls[0][1]).toEqual(['!bang', null, null, 0]);
   });
+
+  it('calls invalidateSfxLookupCache on success', async () => {
+    const pool = makeResultPool({ insertId: 1 });
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await createSfxTrigger('!bang', null, null, false);
+    expect(invalidateSfxLookupCache).toHaveBeenCalledOnce();
+  });
 });
 
 describe('updateSfxTrigger', () => {
@@ -324,6 +335,7 @@ describe('updateSfxTrigger', () => {
       .mockResolvedValueOnce([[], []]); // fallback SELECT — id not found
     vi.mocked(getPool).mockReturnValue(pool as any);
     expect(await updateSfxTrigger(999n, '!clap', null, null, false)).toBe(false);
+    expect(invalidateSfxLookupCache).not.toHaveBeenCalled();
   });
 
   it('returns true on a no-op update (all fields unchanged) when the row exists', async () => {
@@ -333,6 +345,13 @@ describe('updateSfxTrigger', () => {
       .mockResolvedValueOnce([[{ id: '5' }], []]); // fallback SELECT — id exists
     vi.mocked(getPool).mockReturnValue(pool as any);
     expect(await updateSfxTrigger(5n, '!clap', 2, 'desc', false)).toBe(true);
+  });
+
+  it('calls invalidateSfxLookupCache when a row matched', async () => {
+    const pool = makeResultPool({ affectedRows: 1 });
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await updateSfxTrigger(5n, '!clap', 2, 'desc', false);
+    expect(invalidateSfxLookupCache).toHaveBeenCalledOnce();
   });
 });
 
@@ -354,6 +373,7 @@ describe('deleteSfxTrigger', () => {
     expect(pool._conn.execute.mock.calls[1][0]).toContain('FOR UPDATE');
     expect(pool._conn.commit).toHaveBeenCalled();
     expect(pool._conn.release).toHaveBeenCalled();
+    expect(invalidateSfxLookupCache).toHaveBeenCalledOnce();
   });
 
   it('rolls back and returns null when the trigger row does not exist', async () => {
@@ -368,6 +388,7 @@ describe('deleteSfxTrigger', () => {
     expect(pool._conn.release).toHaveBeenCalled();
     // No child queries should run once the lock finds no trigger.
     expect(pool._conn.execute).toHaveBeenCalledTimes(1);
+    expect(invalidateSfxLookupCache).not.toHaveBeenCalled();
   });
 
   it('rolls back and rethrows on error', async () => {
@@ -378,6 +399,7 @@ describe('deleteSfxTrigger', () => {
     await expect(deleteSfxTrigger(7n)).rejects.toThrow('boom');
     expect(pool._conn.rollback).toHaveBeenCalled();
     expect(pool._conn.release).toHaveBeenCalled();
+    expect(invalidateSfxLookupCache).not.toHaveBeenCalled();
   });
 });
 
@@ -390,6 +412,13 @@ describe('addSfxFile', () => {
     const id = await addSfxFile(7n, 'clap.mp3', 2, false);
     expect(id).toBe(100);
     expect(pool.execute.mock.calls[0][1]).toEqual(['7', 'clap.mp3', 2, 0]);
+  });
+
+  it('calls invalidateSfxLookupCache on success', async () => {
+    const pool = makeResultPool({ insertId: 100 });
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await addSfxFile(7n, 'clap.mp3', 2, false);
+    expect(invalidateSfxLookupCache).toHaveBeenCalledOnce();
   });
 });
 
@@ -409,6 +438,7 @@ describe('updateSfxFile', () => {
       .mockResolvedValueOnce([[], []]); // fallback SELECT — id not found
     vi.mocked(getPool).mockReturnValue(pool as any);
     expect(await updateSfxFile(999, 3, true)).toBe(false);
+    expect(invalidateSfxLookupCache).not.toHaveBeenCalled();
   });
 
   it('returns true on a no-op update (weight/hidden unchanged) when the row exists', async () => {
@@ -418,6 +448,13 @@ describe('updateSfxFile', () => {
       .mockResolvedValueOnce([[{ id: 11 }], []]); // fallback SELECT — id exists
     vi.mocked(getPool).mockReturnValue(pool as any);
     expect(await updateSfxFile(11, 3, true)).toBe(true);
+  });
+
+  it('calls invalidateSfxLookupCache when a row matched', async () => {
+    const pool = makeResultPool({ affectedRows: 1 });
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await updateSfxFile(11, 3, true);
+    expect(invalidateSfxLookupCache).toHaveBeenCalledOnce();
   });
 });
 
@@ -432,6 +469,7 @@ describe('deleteSfxFile', () => {
     const file = await deleteSfxFile(11);
     expect(file).toBe('clap.mp3');
     expect(pool._conn.commit).toHaveBeenCalled();
+    expect(invalidateSfxLookupCache).toHaveBeenCalledOnce();
   });
 
   it('returns null and rolls back when no row exists', async () => {
@@ -443,6 +481,7 @@ describe('deleteSfxFile', () => {
     expect(file).toBeNull();
     expect(pool._conn.rollback).toHaveBeenCalled();
     expect(pool._conn.commit).not.toHaveBeenCalled();
+    expect(invalidateSfxLookupCache).not.toHaveBeenCalled();
   });
 
   it('returns null and rolls back when the row is deleted concurrently between the locked SELECT and DELETE', async () => {
@@ -456,6 +495,7 @@ describe('deleteSfxFile', () => {
     expect(file).toBeNull();
     expect(pool._conn.rollback).toHaveBeenCalled();
     expect(pool._conn.commit).not.toHaveBeenCalled();
+    expect(invalidateSfxLookupCache).not.toHaveBeenCalled();
   });
 
   it('rolls back, releases and rethrows on error', async () => {
@@ -466,5 +506,6 @@ describe('deleteSfxFile', () => {
     await expect(deleteSfxFile(11)).rejects.toThrow('boom');
     expect(pool._conn.rollback).toHaveBeenCalled();
     expect(pool._conn.release).toHaveBeenCalled();
+    expect(invalidateSfxLookupCache).not.toHaveBeenCalled();
   });
 });

--- a/src/db/sfx.ts
+++ b/src/db/sfx.ts
@@ -1,6 +1,10 @@
 import mysql from 'mysql2/promise';
 import { getPool, withTransaction } from './pool';
 import { fromBit, affectedOrExists } from './utils';
+// sfxCache imports getAllSfxTriggers from this module; this module imports
+// invalidateSfxLookupCache from sfxCache. Both calls happen inside function
+// bodies, so CommonJS resolves the cycle correctly.
+import { invalidateSfxLookupCache } from './sfxCache';
 
 export interface SfxTrigger {
   id: bigint;
@@ -175,6 +179,7 @@ export async function createSfxTrigger(
      VALUES (?, ?, ?, ?)`,
     [command, categoryId, description, hidden ? 1 : 0],
   );
+  invalidateSfxLookupCache();
   return BigInt(result.insertId);
 }
 
@@ -204,13 +209,15 @@ export async function updateSfxTrigger(
      WHERE id = ?`,
     [command, categoryId, description, hidden ? 1 : 0, id.toString()],
   );
-  return affectedOrExists(result.affectedRows, async () => {
+  const updated = await affectedOrExists(result.affectedRows, async () => {
     const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
       `SELECT id FROM sfxtrigger WHERE id = ?`,
       [id.toString()],
     );
     return rows.length > 0;
   });
+  if (updated) invalidateSfxLookupCache();
+  return updated;
 }
 
 /**
@@ -230,7 +237,7 @@ export async function updateSfxTrigger(
 export async function deleteSfxTrigger(id: bigint): Promise<{ files: string[] } | null> {
   class TriggerNotFound extends Error {}
   try {
-    return await withTransaction(async (conn) => {
+    const result = await withTransaction(async (conn) => {
       const [triggerRows] = await conn.execute<mysql.RowDataPacket[]>(
         `SELECT id FROM sfxtrigger WHERE id = ? FOR UPDATE`,
         [id.toString()],
@@ -247,6 +254,8 @@ export async function deleteSfxTrigger(id: bigint): Promise<{ files: string[] } 
       await conn.execute(`DELETE FROM sfxtrigger WHERE id = ?`, [id.toString()]);
       return { files };
     });
+    invalidateSfxLookupCache();
+    return result;
   } catch (err) {
     if (err instanceof TriggerNotFound) return null;
     throw err;
@@ -270,6 +279,7 @@ export async function addSfxFile(
     `INSERT INTO sfx (trigger_id, file, weight, hidden) VALUES (?, ?, ?, ?)`,
     [triggerId.toString(), file, weight, hidden ? 1 : 0],
   );
+  invalidateSfxLookupCache();
   return result.insertId;
 }
 
@@ -289,10 +299,12 @@ export async function updateSfxFile(id: number, weight: number, hidden: boolean)
     `UPDATE sfx SET weight = ?, hidden = ? WHERE id = ?`,
     [weight, hidden ? 1 : 0, id],
   );
-  return affectedOrExists(result.affectedRows, async () => {
+  const updated = await affectedOrExists(result.affectedRows, async () => {
     const [rows] = await getPool().execute<mysql.RowDataPacket[]>(`SELECT id FROM sfx WHERE id = ?`, [id]);
     return rows.length > 0;
   });
+  if (updated) invalidateSfxLookupCache();
+  return updated;
 }
 
 /**
@@ -308,7 +320,7 @@ export async function updateSfxFile(id: number, weight: number, hidden: boolean)
 export async function deleteSfxFile(id: number): Promise<string | null> {
   class FileNotFound extends Error {}
   try {
-    return await withTransaction(async (conn) => {
+    const file = await withTransaction(async (conn) => {
       const [rows] = await conn.execute<mysql.RowDataPacket[]>(
         `SELECT file FROM sfx WHERE id = ? FOR UPDATE`,
         [id],
@@ -323,6 +335,8 @@ export async function deleteSfxFile(id: number): Promise<string | null> {
       }
       return file;
     });
+    invalidateSfxLookupCache();
+    return file;
   } catch (err) {
     if (err instanceof FileNotFound) return null;
     throw err;

--- a/src/db/sfxCache.test.ts
+++ b/src/db/sfxCache.test.ts
@@ -13,9 +13,17 @@ vi.mock('../shared/logger', () => ({
   createLogger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn() }),
 }));
 
-import { findCachedSfxTrigger } from './sfxCache';
+import { findCachedSfxTrigger, invalidateSfxLookupCache } from './sfxCache';
+import { createManagedLookupCache } from './lookupCache';
 import { getAllSfxTriggers } from './sfx';
 import type { SfxTriggerRow } from './sfx';
+
+// sfxCache.ts calls createManagedLookupCache exactly once at module load, before any
+// `vi.clearAllMocks()` in beforeEach can wipe its call history — so the mocked cache
+// manager instance (and its `invalidate` spy) must be captured here, once, up front.
+const mockedCacheManager = vi.mocked(createManagedLookupCache).mock.results[0]?.value as
+  | { invalidate: ReturnType<typeof vi.fn> }
+  | undefined;
 
 function makeTriggerRow(triggerId: string, triggerCommand: string, files: SfxTriggerRow['files'] = []): SfxTriggerRow {
   return {
@@ -144,5 +152,12 @@ describe('findCachedSfxTrigger', () => {
     const result = await findCachedSfxTrigger('!anything');
 
     expect(result).toBeNull();
+  });
+});
+
+describe('invalidateSfxLookupCache', () => {
+  it('delegates to the underlying cache manager\'s invalidate', () => {
+    invalidateSfxLookupCache();
+    expect(mockedCacheManager?.invalidate).toHaveBeenCalledOnce();
   });
 });

--- a/src/db/sfxCache.test.ts
+++ b/src/db/sfxCache.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./lookupCache', () => ({
+  createManagedLookupCache: vi.fn(({ loadCache }: { loadCache: () => Promise<unknown> }) => ({
+    getCache: () => loadCache(),
+    invalidate: vi.fn(),
+  })),
+}));
+vi.mock('./sfx', () => ({
+  getAllSfxTriggers: vi.fn(),
+}));
+vi.mock('../shared/logger', () => ({
+  createLogger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn() }),
+}));
+
+import { findCachedSfxTrigger } from './sfxCache';
+import { getAllSfxTriggers } from './sfx';
+import type { SfxTriggerRow } from './sfx';
+
+function makeTriggerRow(triggerId: string, triggerCommand: string, files: SfxTriggerRow['files'] = []): SfxTriggerRow {
+  return {
+    triggerId,
+    triggerCommand,
+    description: null,
+    hidden: false,
+    categoryId: null,
+    categoryName: null,
+    files,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getAllSfxTriggers).mockResolvedValue([]);
+});
+
+describe('findCachedSfxTrigger', () => {
+  it('returns null for an empty string without making a DB call', async () => {
+    const result = await findCachedSfxTrigger('');
+    expect(result).toBeNull();
+    expect(getAllSfxTriggers).not.toHaveBeenCalled();
+  });
+
+  it('returns null for a whitespace-only string without making a DB call', async () => {
+    const result = await findCachedSfxTrigger('   ');
+    expect(result).toBeNull();
+    expect(getAllSfxTriggers).not.toHaveBeenCalled();
+  });
+
+  it('finds a trigger and its files by command', async () => {
+    const row = makeTriggerRow('1', '!bang', [{ id: 10, file: 'bang.mp3', weight: 1, hidden: false }]);
+    vi.mocked(getAllSfxTriggers).mockResolvedValue([row]);
+
+    const result = await findCachedSfxTrigger('!bang');
+
+    expect(result).not.toBeNull();
+    expect(result!.trigger.id).toBe(1n);
+    expect(result!.trigger.trigger_command).toBe('!bang');
+    expect(result!.files).toHaveLength(1);
+    expect(result!.files[0].file).toBe('bang.mp3');
+    expect(result!.files[0].trigger_id).toBe(1n);
+  });
+
+  it('performs a case-insensitive lookup', async () => {
+    const row = makeTriggerRow('1', '!bang');
+    vi.mocked(getAllSfxTriggers).mockResolvedValue([row]);
+
+    const result = await findCachedSfxTrigger('!BANG');
+
+    expect(result).not.toBeNull();
+    expect(result!.trigger.id).toBe(1n);
+  });
+
+  it('trims whitespace from the lookup string', async () => {
+    const row = makeTriggerRow('1', '!bang');
+    vi.mocked(getAllSfxTriggers).mockResolvedValue([row]);
+
+    const result = await findCachedSfxTrigger('  !bang  ');
+
+    expect(result).not.toBeNull();
+  });
+
+  it('returns null when no trigger matches the command', async () => {
+    vi.mocked(getAllSfxTriggers).mockResolvedValue([makeTriggerRow('1', '!bang')]);
+
+    const result = await findCachedSfxTrigger('!unknown');
+
+    expect(result).toBeNull();
+  });
+
+  it('includes hidden triggers and hidden files — hidden only affects public listing, not playback', async () => {
+    const row: SfxTriggerRow = {
+      ...makeTriggerRow('1', '!secret', [{ id: 10, file: 'secret.mp3', weight: 1, hidden: true }]),
+      hidden: true,
+    };
+    vi.mocked(getAllSfxTriggers).mockResolvedValue([row]);
+
+    const result = await findCachedSfxTrigger('!secret');
+
+    expect(result).not.toBeNull();
+    expect(result!.trigger.hidden).toBe(true);
+    expect(result!.files[0].hidden).toBe(true);
+  });
+
+  it('returns a copy — mutating the result does not affect subsequent lookups', async () => {
+    const row = makeTriggerRow('1', '!bang', [{ id: 10, file: 'bang.mp3', weight: 1, hidden: false }]);
+    vi.mocked(getAllSfxTriggers).mockResolvedValue([row]);
+
+    const first = await findCachedSfxTrigger('!bang');
+    expect(first).not.toBeNull();
+    first!.files[0].weight = 999;
+
+    const second = await findCachedSfxTrigger('!bang');
+    expect(second).not.toBeNull();
+    expect(second!.files).not.toBe(first!.files);
+    expect(second!.files[0].weight).toBe(1);
+  });
+
+  it('collision — lower id wins when two triggers normalize to the same command', async () => {
+    const winner = makeTriggerRow('1', '!bang');
+    const loser = makeTriggerRow('2', '!BANG');
+    vi.mocked(getAllSfxTriggers).mockResolvedValue([winner, loser]);
+
+    const result = await findCachedSfxTrigger('!bang');
+
+    expect(result).not.toBeNull();
+    expect(result!.trigger.id).toBe(1n);
+  });
+
+  it('sorts by id before processing so lower id still wins even when given in reverse order', async () => {
+    const loser = makeTriggerRow('2', '!bang');
+    const winner = makeTriggerRow('1', '!bang');
+    vi.mocked(getAllSfxTriggers).mockResolvedValue([loser, winner]);
+
+    const result = await findCachedSfxTrigger('!bang');
+
+    expect(result).not.toBeNull();
+    expect(result!.trigger.id).toBe(1n);
+  });
+
+  it('returns null for any command when the trigger list is empty', async () => {
+    vi.mocked(getAllSfxTriggers).mockResolvedValue([]);
+
+    const result = await findCachedSfxTrigger('!anything');
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/db/sfxCache.ts
+++ b/src/db/sfxCache.ts
@@ -1,0 +1,118 @@
+import { createLogger } from '../shared/logger';
+import { createManagedLookupCache, type RefreshingLookupCache } from './lookupCache';
+import { normalizeCommand } from './commandStringUtils';
+import { getAllSfxTriggers, type SfxTrigger, type SfxFile } from './sfx';
+
+const log = createLogger('DB');
+
+/** An SFX trigger paired with its playable sound files, as served from the lookup cache. */
+export interface SfxLookupResult {
+  trigger: SfxTrigger;
+  files: SfxFile[];
+}
+
+interface SfxLookupCache extends RefreshingLookupCache {
+  byTrigger: Map<string, SfxLookupResult>;
+}
+
+/**
+ * Creates an empty, already-stale SFX lookup cache used as the initial/fallback state
+ * before the first successful refresh.
+ * @returns An empty `SfxLookupCache` with `loadedAt` set to 0.
+ */
+function createEmptySfxLookupCache(): SfxLookupCache {
+  return {
+    // Keep the fallback cache immediately stale so a new refresh can start as soon
+    // as the backoff window expires rather than waiting for the normal TTL.
+    loadedAt: 0,
+    byTrigger: new Map<string, SfxLookupResult>(),
+  };
+}
+
+/**
+ * Builds an SFX lookup cache keyed by normalized trigger command, from the admin-panel
+ * trigger+files listing. `sfxtrigger.trigger_command` has no DB-level uniqueness
+ * constraint, so triggers are processed in ascending id order and a collision (two
+ * triggers normalizing to the same command) logs a warning and keeps the lower-id
+ * trigger, matching the collision-resolution convention used by the custom-command
+ * and counter lookup caches.
+ * @param triggers All SFX triggers with their associated sound files.
+ * @returns The populated `SfxLookupCache`.
+ */
+function buildSfxLookupCache(triggers: Awaited<ReturnType<typeof getAllSfxTriggers>>): SfxLookupCache {
+  const byTrigger = new Map<string, SfxLookupResult>();
+  const sortedTriggers = [...triggers].sort((left, right) => {
+    const leftId = BigInt(left.triggerId);
+    const rightId = BigInt(right.triggerId);
+    return leftId < rightId ? -1 : leftId > rightId ? 1 : 0;
+  });
+
+  for (const row of sortedTriggers) {
+    const normalizedTriggerCommand = normalizeCommand(row.triggerCommand);
+    if (!normalizedTriggerCommand) continue;
+
+    const existing = byTrigger.get(normalizedTriggerCommand);
+    if (existing) {
+      log.warn(`SFX trigger collision: '${normalizedTriggerCommand}' is already registered (trigger id=${existing.trigger.id}); ignoring duplicate from trigger id=${row.triggerId}.`);
+      continue;
+    }
+
+    byTrigger.set(normalizedTriggerCommand, {
+      trigger: {
+        id: BigInt(row.triggerId),
+        trigger_command: row.triggerCommand,
+        category_id: row.categoryId,
+        hidden: row.hidden,
+        description: row.description,
+      },
+      files: row.files.map((file) => ({
+        id: file.id,
+        trigger_id: BigInt(row.triggerId),
+        file: file.file,
+        trigger_command: row.triggerCommand,
+        weight: file.weight,
+        hidden: file.hidden,
+        category_id: row.categoryId,
+      })),
+    });
+  }
+
+  return { loadedAt: Date.now(), byTrigger };
+}
+
+// ─── Cache state ──────────────────────────────────────────────────────────────
+
+const CACHE_TTL_MS = 300_000;
+const CACHE_REFRESH_FAILURE_BACKOFF_MS = 5_000;
+const CACHE_REFRESH_FAILURE_MAX_BACKOFF_MS = 60_000;
+
+const sfxLookupCacheState = createManagedLookupCache<SfxLookupCache>({
+  cacheName: 'sfx cache',
+  ttlMs: CACHE_TTL_MS,
+  refreshFailureBackoffMs: CACHE_REFRESH_FAILURE_BACKOFF_MS,
+  refreshFailureMaxBackoffMs: CACHE_REFRESH_FAILURE_MAX_BACKOFF_MS,
+  createEmptyCache: createEmptySfxLookupCache,
+  loadCache: async () => buildSfxLookupCache(await getAllSfxTriggers()),
+});
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/** Marks the SFX lookup cache as stale so the next read triggers a refresh. */
+export function invalidateSfxLookupCache(): void {
+  sfxLookupCacheState.invalidate();
+}
+
+/**
+ * Looks up an SFX trigger and its sound files by command string (case-insensitive).
+ * Hidden triggers/files ARE included — the hidden flag only affects public listing, not playback.
+ * @param command Trigger command string to match, matched case-insensitively.
+ * @returns The matching trigger and its files, or null if none matches or the input is blank.
+ */
+export async function findCachedSfxTrigger(command: string): Promise<SfxLookupResult | null> {
+  const normalizedCommand = normalizeCommand(command);
+  if (!normalizedCommand) return null;
+
+  const cache = await sfxLookupCacheState.getCache();
+  const cached = cache.byTrigger.get(normalizedCommand);
+  return cached ? { trigger: { ...cached.trigger }, files: cached.files.map((file) => ({ ...file })) } : null;
+}

--- a/src/db/users.test.ts
+++ b/src/db/users.test.ts
@@ -11,6 +11,7 @@ vi.mock('../twitch/twitchChannelName', () => ({
 import { getPool } from './pool';
 import {
   findUser,
+  findUsersByIds,
   findUserByTwitchName,
   findOwnerUser,
   getAllUsers,
@@ -92,6 +93,47 @@ describe('findUser', () => {
     const plainRow = { discord_id: '2', discord_name: 'User', is_twitch_bot_enabled: 0, twitch_name: null, access_level: 0, is_owner: 0 };
     vi.mocked(getPool).mockReturnValue(makePool([[plainRow]]) as any);
     expect((await findUser('2'))!.is_owner).toBe(false);
+  });
+});
+
+// ─── findUsersByIds ───────────────────────────────────────────────────────────
+
+describe('findUsersByIds', () => {
+  it('returns an empty map without querying when given an empty array', async () => {
+    const pool = makePool([[]]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await findUsersByIds([]);
+    expect(result.size).toBe(0);
+    expect(pool.execute).not.toHaveBeenCalled();
+  });
+
+  it('returns a map keyed by discord_id for all matching rows', async () => {
+    const rows = [
+      { discord_id: '1', discord_name: 'Alice', is_twitch_bot_enabled: 1, twitch_name: 'alice', access_level: 0 },
+      { discord_id: '2', discord_name: 'Bob', is_twitch_bot_enabled: 0, twitch_name: null, access_level: 1 },
+    ];
+    vi.mocked(getPool).mockReturnValue(makePool([rows]) as any);
+    const result = await findUsersByIds(['1', '2']);
+    expect(result.size).toBe(2);
+    expect(result.get('1')!.discord_name).toBe('Alice');
+    expect(result.get('2')!.is_twitch_bot_enabled).toBe(false);
+  });
+
+  it('omits ids with no matching row rather than including a null entry', async () => {
+    const rows = [{ discord_id: '1', discord_name: 'Alice', is_twitch_bot_enabled: 0, twitch_name: null, access_level: 0 }];
+    vi.mocked(getPool).mockReturnValue(makePool([rows]) as any);
+    const result = await findUsersByIds(['1', '999']);
+    expect(result.size).toBe(1);
+    expect(result.has('999')).toBe(false);
+  });
+
+  it('builds an IN clause with one placeholder per id', async () => {
+    const pool = makePool([[]]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await findUsersByIds(['1', '2', '3']);
+    const [sql, params] = vi.mocked(pool.execute).mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('discord_id IN (?, ?, ?)');
+    expect(params).toEqual(['1', '2', '3']);
   });
 });
 

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -3,6 +3,7 @@ import { normalizeTwitchChannelName } from '../twitch/twitchChannelName';
 import { getPool } from './pool';
 import { createLogger } from '../shared/logger';
 import { fromBit } from './utils';
+import { buildInClausePlaceholders } from './commandStringUtils';
 
 const log = createLogger('DB');
 
@@ -57,6 +58,24 @@ export async function findUser(discordId: string): Promise<DbUser | null> {
     [discordId],
   );
   return rows.length === 0 ? null : mapUser(rows[0]);
+}
+
+/**
+ * Look up multiple users by Discord ID in a single query. Discord IDs with no
+ * matching row are simply absent from the returned map.
+ * @param discordIds - Discord snowflakes to look up.
+ * @returns A map from Discord ID to user row, containing only the IDs that matched.
+ */
+export async function findUsersByIds(discordIds: string[]): Promise<Map<string, DbUser>> {
+  if (discordIds.length === 0) return new Map();
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT ${USER_SELECT} FROM \`user\` WHERE discord_id IN (${buildInClausePlaceholders(discordIds.length)})`,
+    discordIds,
+  );
+  return new Map(rows.map((r) => {
+    const user = mapUser(r);
+    return [user.discord_id, user] as const;
+  }));
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,8 +88,7 @@ async function main(): Promise<void> {
 
   setChannelJoinedHook(() => reloadEventSubSubscriptions());
   startDiscordBot();
-  await startTwitchBot();
-  await startTikTokBot();
+  await Promise.all([startTwitchBot(), startTikTokBot()]);
   startWebPanel();
   startCounterScheduler();
   startRewardPricingScheduler();

--- a/src/twitch/pricing/rewardPricingScheduler.test.ts
+++ b/src/twitch/pricing/rewardPricingScheduler.test.ts
@@ -7,16 +7,19 @@ const { mockLogger } = vi.hoisted(() => ({
 
 /** Mocks the shared logger so the scheduler's log calls don't produce real output during tests. */
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
-vi.mock('../../db', () => ({ getAllEnabledPricingRows: vi.fn() }));
+vi.mock('../../db', () => ({ getAllEnabledPricingRows: vi.fn(), getPricingSettingsForStreamer: vi.fn() }));
 vi.mock('./rewardPricingService', () => ({ applyDecayTick: vi.fn() }));
 
-import { getAllEnabledPricingRows } from '../../db';
+import { getAllEnabledPricingRows, getPricingSettingsForStreamer } from '../../db';
 import { applyDecayTick } from './rewardPricingService';
 import { runDecayTick, startRewardPricingScheduler, stopRewardPricingScheduler } from './rewardPricingScheduler';
+
+const settings = { half_life_seconds: 1800, time_to_max_multiplier: 2 };
 
 beforeEach(() => {
   vi.clearAllMocks();
   vi.useFakeTimers();
+  vi.mocked(getPricingSettingsForStreamer).mockResolvedValue(settings);
 });
 
 afterEach(async () => {
@@ -34,8 +37,43 @@ describe('runDecayTick', () => {
 
     await runDecayTick();
 
-    expect(applyDecayTick).toHaveBeenCalledWith(1, 'r1');
-    expect(applyDecayTick).toHaveBeenCalledWith(2, 'r2');
+    expect(applyDecayTick).toHaveBeenCalledWith(1, 'r1', settings);
+    expect(applyDecayTick).toHaveBeenCalledWith(2, 'r2', settings);
+  });
+
+  it('fetches settings once per distinct streamer, not once per reward', async () => {
+    vi.mocked(getAllEnabledPricingRows).mockResolvedValue([
+      { streamer_id: 1, twitch_reward_id: 'r1' },
+      { streamer_id: 1, twitch_reward_id: 'r2' },
+      { streamer_id: 2, twitch_reward_id: 'r3' },
+    ] as any);
+    vi.mocked(applyDecayTick).mockResolvedValue(undefined);
+
+    await runDecayTick();
+
+    expect(getPricingSettingsForStreamer).toHaveBeenCalledTimes(2);
+    expect(getPricingSettingsForStreamer).toHaveBeenCalledWith(1);
+    expect(getPricingSettingsForStreamer).toHaveBeenCalledWith(2);
+    expect(applyDecayTick).toHaveBeenCalledWith(1, 'r1', settings);
+    expect(applyDecayTick).toHaveBeenCalledWith(1, 'r2', settings);
+    expect(applyDecayTick).toHaveBeenCalledWith(2, 'r3', settings);
+  });
+
+  it('falls back to an undefined settings hint for a streamer whose settings prefetch fails, without blocking other streamers', async () => {
+    vi.mocked(getAllEnabledPricingRows).mockResolvedValue([
+      { streamer_id: 1, twitch_reward_id: 'r1' },
+      { streamer_id: 2, twitch_reward_id: 'r2' },
+    ] as any);
+    vi.mocked(getPricingSettingsForStreamer).mockImplementation(async (streamerId) => {
+      if (streamerId === 1) throw new Error('settings db down');
+      return settings;
+    });
+    vi.mocked(applyDecayTick).mockResolvedValue(undefined);
+
+    await expect(runDecayTick()).resolves.toBeUndefined();
+
+    expect(applyDecayTick).toHaveBeenCalledWith(1, 'r1', undefined);
+    expect(applyDecayTick).toHaveBeenCalledWith(2, 'r2', settings);
   });
 
   it('continues to the next row when one fails', async () => {
@@ -73,8 +111,12 @@ describe('runDecayTick', () => {
     });
 
     const tick = runDecayTick();
-    await Promise.resolve();
-    await Promise.resolve();
+    // Flush microtasks until the second row starts (or give up after a bounded number of
+    // ticks) — the batched per-streamer settings prefetch now adds a variable number of
+    // hops before applyDecayTick is reached, so a fixed tick count is too fragile here.
+    for (let i = 0; i < 20 && !secondStarted; i++) {
+      await Promise.resolve();
+    }
 
     expect(secondStarted).toBe(true); // second row started without waiting for the first to resolve
 

--- a/src/twitch/pricing/rewardPricingScheduler.ts
+++ b/src/twitch/pricing/rewardPricingScheduler.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '../../shared/logger';
-import { getAllEnabledPricingRows } from '../../db';
+import { getAllEnabledPricingRows, getPricingSettingsForStreamer, type StreamerPricingSettings } from '../../db';
 import { applyDecayTick } from './rewardPricingService';
 
 const log = createLogger('RewardPricingScheduler');
@@ -16,8 +16,11 @@ let currentTickPromise: Promise<void> = Promise.resolve();
  * Rows are processed concurrently — `applyDecayTick` already serializes work per reward via
  * its own mutation queue, so different rows are independent and don't need to wait on each
  * other, keeping tick duration from growing linearly with the number of enabled rewards.
- * No-ops (re-uses the in-flight promise) if a tick is already running, so a slow tick
- * can't overlap with the next interval firing.
+ * A streamer's pricing settings are fetched once per tick and shared across all of that
+ * streamer's rewards (rather than once per reward) — settings aren't part of the
+ * per-reward concurrency-sensitive state `applyDecayTick` re-reads fresh, so a tick-old
+ * value is harmless. No-ops (re-uses the in-flight promise) if a tick is already running,
+ * so a slow tick can't overlap with the next interval firing.
  */
 export async function runDecayTick(): Promise<void> {
   if (tickRunning) return currentTickPromise;
@@ -25,9 +28,26 @@ export async function runDecayTick(): Promise<void> {
   currentTickPromise = (async () => {
     try {
       const rows = await getAllEnabledPricingRows();
+      const distinctStreamerIds = [...new Set(rows.map((row) => row.streamer_id))];
+      // Settled (not Promise.all) so one streamer's settings-fetch failure doesn't abort
+      // the whole tick — that streamer's rewards simply fall back to fetching their own
+      // settings inside applyDecayTick, isolated by the per-row .catch below like before.
+      const settingsResults = await Promise.allSettled(
+        distinctStreamerIds.map(async (streamerId): Promise<[number, StreamerPricingSettings]> =>
+          [streamerId, await getPricingSettingsForStreamer(streamerId)]),
+      );
+      const settingsByStreamerId = new Map<number, StreamerPricingSettings>();
+      for (const result of settingsResults) {
+        if (result.status === 'fulfilled') {
+          settingsByStreamerId.set(...result.value);
+        } else {
+          log.error('Failed to pre-fetch pricing settings for a streamer during decay tick:', result.reason);
+        }
+      }
+
       await Promise.allSettled(
         rows.map((row) =>
-          applyDecayTick(row.streamer_id, row.twitch_reward_id).catch((err) => {
+          applyDecayTick(row.streamer_id, row.twitch_reward_id, settingsByStreamerId.get(row.streamer_id)).catch((err) => {
             log.error(`Decay tick failed for reward ${row.twitch_reward_id} (streamer ${row.streamer_id}):`, err);
           }),
         ),

--- a/src/twitch/pricing/rewardPricingService.test.ts
+++ b/src/twitch/pricing/rewardPricingService.test.ts
@@ -201,6 +201,28 @@ describe('applyDecayTick', () => {
     // decay(0.5, ~300s elapsed, half_life=1800s) = 0.5 * 2^(-300/1800)
     expect(demandArg).toBeCloseTo(0.5 * Math.pow(2, -300 / 1800), 2);
   });
+
+  it('fetches settings itself when no settingsHint is passed', async () => {
+    vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0.5, last_pushed_cost: null }));
+    await applyDecayTick(1, 'rwd1');
+    expect(getPricingSettingsForStreamer).toHaveBeenCalledWith(1);
+  });
+
+  it('uses the provided settingsHint instead of fetching settings', async () => {
+    vi.mocked(getPricingForReward).mockResolvedValue(makeRow({
+      demand: 0.5,
+      demand_updated_at: String(Date.now() - 300_000),
+      last_pushed_cost: null,
+    }));
+    const hintSettings = { half_life_seconds: 60, time_to_max_multiplier: 2 };
+
+    await applyDecayTick(1, 'rwd1', hintSettings);
+
+    expect(getPricingSettingsForStreamer).not.toHaveBeenCalled();
+    const [, , demandArg] = vi.mocked(recordPricingUpdate).mock.calls[0];
+    // decay(0.5, ~300s elapsed, half_life=60s from the hint, not the default 1800s) ≈ 0
+    expect(demandArg).toBeCloseTo(0.5 * Math.pow(2, -300 / 60), 4);
+  });
 });
 
 describe('round_to_nearest', () => {

--- a/src/twitch/pricing/rewardPricingService.ts
+++ b/src/twitch/pricing/rewardPricingService.ts
@@ -1,7 +1,7 @@
 import { createMutationQueue } from '../../shared/mutationQueue';
 import {
   getPricingForReward, recordPricingUpdate, recordPricingHistory, markPricingUnsupported, deletePricingConfig,
-  getPricingSettingsForStreamer, getStreamerById,
+  getPricingSettingsForStreamer, getStreamerById, type StreamerPricingSettings,
 } from '../../db';
 import { getValidToken } from '../eventsub/twitchApiEventSub';
 import { updateRewardCost, deleteCustomReward, TwitchRewardUnsupportedError, TwitchRewardAuthError } from '../twitchApi';
@@ -123,12 +123,17 @@ async function pushRewardCostUpdate(
  * @param streamerId - DB row ID of the owning streamer.
  * @param twitchRewardId - Twitch reward UUID.
  * @param applyIncrement - True for a redemption (decay + increment); false for a decay-only tick.
+ * @param settingsHint - Optional pre-fetched settings, passed by the decay scheduler when it has
+ *   already loaded a streamer's settings once for this tick — avoids re-querying the same row for
+ *   every one of that streamer's enabled rewards. Fetched fresh when omitted.
  */
-async function syncRewardPrice(streamerId: number, twitchRewardId: string, applyIncrement: boolean): Promise<void> {
+async function syncRewardPrice(
+  streamerId: number, twitchRewardId: string, applyIncrement: boolean, settingsHint?: StreamerPricingSettings,
+): Promise<void> {
   const row = await getPricingForReward(streamerId, twitchRewardId);
   if (!row || !row.enabled) return;
 
-  const settings = await getPricingSettingsForStreamer(streamerId);
+  const settings = settingsHint ?? await getPricingSettingsForStreamer(streamerId);
   const now = Date.now();
   const elapsedSeconds = Math.max(0, (now - Number(row.demand_updated_at)) / 1000);
   const newDemand = applyIncrement
@@ -186,9 +191,10 @@ export async function applyRedemptionPricing(streamerId: number, twitchRewardId:
  *
  * @param streamerId - DB row ID of the owning streamer.
  * @param twitchRewardId - Twitch reward UUID.
+ * @param settingsHint - Optional pre-fetched settings for this streamer; see {@link syncRewardPrice}.
  */
-export async function applyDecayTick(streamerId: number, twitchRewardId: string): Promise<void> {
-  await pricingQueue.run(queueKey(streamerId, twitchRewardId), () => syncRewardPrice(streamerId, twitchRewardId, false));
+export async function applyDecayTick(streamerId: number, twitchRewardId: string, settingsHint?: StreamerPricingSettings): Promise<void> {
+  await pricingQueue.run(queueKey(streamerId, twitchRewardId), () => syncRewardPrice(streamerId, twitchRewardId, false, settingsHint));
 }
 
 /**

--- a/src/web/middleware.test.ts
+++ b/src/web/middleware.test.ts
@@ -4,7 +4,7 @@ import { ACCESS_LEVEL_MOCK } from '../test-utils/accessLevelMock';
 vi.mock('../db', () => ({
   findKeyByHash: vi.fn(),
   findDiscordIdByTokenHash: vi.fn(),
-  getEffectiveAccessLevel: vi.fn(),
+  getEffectiveAccessLevelForUser: vi.fn(),
   findUser: vi.fn(),
   getAllGuilds: vi.fn(),
   getGuildsForMember: vi.fn(),
@@ -16,7 +16,7 @@ vi.mock('./csrf', () => ({
 
 import { createHash } from 'crypto';
 import { requireAuth, requireManager, requireMod, requireAdmin, requireApiKey, requireCompanionKey, requireGuildContext } from './middleware';
-import { findKeyByHash, findDiscordIdByTokenHash, getEffectiveAccessLevel, findUser, getAllGuilds, getGuildsForMember, AccessLevel } from '../db';
+import { findKeyByHash, findDiscordIdByTokenHash, getEffectiveAccessLevelForUser, findUser, getAllGuilds, getGuildsForMember, AccessLevel } from '../db';
 
 function makeReq(overrides: object = {}): any {
   return {
@@ -320,20 +320,20 @@ describe('requireGuildContext', () => {
   });
 
   it('calls next() when a valid current guild is already selected, refreshing the access level', async () => {
-    vi.mocked(getEffectiveAccessLevel).mockResolvedValue(AccessLevel.ADMIN);
+    vi.mocked(getEffectiveAccessLevelForUser).mockResolvedValue(AccessLevel.ADMIN);
     vi.mocked(getGuildsForMember).mockResolvedValue([{ guild_id: 'g1', name: 'A', voice_channel_id: null }] as any);
     const user = { discordId: 'u1', currentGuildId: 'g1', accessLevel: AccessLevel.MANAGER, guilds: [{ guildId: 'g1', name: 'A' }] };
     const req = makeReq({ session: { user } });
     await requireGuildContext(req, makeRes(), next);
     expect(next).toHaveBeenCalledOnce();
-    expect(vi.mocked(getEffectiveAccessLevel)).toHaveBeenCalledWith('g1', 'u1');
+    expect(vi.mocked(getEffectiveAccessLevelForUser)).toHaveBeenCalledWith('g1', { discord_id: 'u1', is_owner: false });
     expect(user.accessLevel).toBe(AccessLevel.ADMIN);
   });
 
   it('re-derives guild membership from the database, ignoring a stale session guild list', async () => {
     // Session cache claims membership in g2 too, but the live DB lookup only returns g1 —
     // the live data must win so a revoked membership takes effect immediately.
-    vi.mocked(getEffectiveAccessLevel).mockResolvedValue(AccessLevel.MOD);
+    vi.mocked(getEffectiveAccessLevelForUser).mockResolvedValue(AccessLevel.MOD);
     vi.mocked(getGuildsForMember).mockResolvedValue([{ guild_id: 'g1', name: 'A', voice_channel_id: null }] as any);
     const user = {
       discordId: 'u1',
@@ -350,7 +350,7 @@ describe('requireGuildContext', () => {
   it('uses getAllGuilds instead of getGuildsForMember when the database reports the user as owner', async () => {
     vi.mocked(findUser).mockResolvedValue({ discord_id: 'u1', is_owner: true } as any);
     vi.mocked(getAllGuilds).mockResolvedValue([{ guild_id: 'g1', name: 'A', voice_channel_id: null }] as any);
-    vi.mocked(getEffectiveAccessLevel).mockResolvedValue(AccessLevel.ADMIN);
+    vi.mocked(getEffectiveAccessLevelForUser).mockResolvedValue(AccessLevel.ADMIN);
     const user = { discordId: 'u1', currentGuildId: 'g1', accessLevel: AccessLevel.USER, isOwner: false, guilds: [{ guildId: 'g1', name: 'A' }] };
     const req = makeReq({ session: { user } });
     await requireGuildContext(req, makeRes(), next);
@@ -360,7 +360,7 @@ describe('requireGuildContext', () => {
   });
 
   it('auto-selects and recomputes the level when the user has exactly one guild', async () => {
-    vi.mocked(getEffectiveAccessLevel).mockResolvedValue(AccessLevel.ADMIN);
+    vi.mocked(getEffectiveAccessLevelForUser).mockResolvedValue(AccessLevel.ADMIN);
     vi.mocked(getGuildsForMember).mockResolvedValue([{ guild_id: 'g1', name: 'A', voice_channel_id: null }] as any);
     const user = { discordId: 'u1', currentGuildId: null, accessLevel: AccessLevel.USER, guilds: [{ guildId: 'g1', name: 'A' }] };
     const req = makeReq({ session: { user } });

--- a/src/web/middleware.ts
+++ b/src/web/middleware.ts
@@ -7,7 +7,7 @@ import {
   findDiscordIdByTokenHash,
   findUser,
   getAllGuilds,
-  getEffectiveAccessLevel,
+  getEffectiveAccessLevelForUser,
   getGuildsForMember,
 } from '../db';
 import { renderView } from './routes/shared';
@@ -78,7 +78,7 @@ export async function requireGuildContext(req: Request, res: Response, next: Nex
     }
   }
 
-  user.accessLevel = (await getEffectiveAccessLevel(user.currentGuildId, user.discordId)) as (typeof AccessLevel)[keyof typeof AccessLevel];
+  user.accessLevel = (await getEffectiveAccessLevelForUser(user.currentGuildId, dbUser)) as (typeof AccessLevel)[keyof typeof AccessLevel];
 
   next();
 }

--- a/src/web/routes/auth.test.ts
+++ b/src/web/routes/auth.test.ts
@@ -12,7 +12,7 @@ vi.mock('../../db', () => ({
   updateDiscordName: vi.fn().mockResolvedValue(undefined),
   getAllGuilds: vi.fn().mockResolvedValue([]),
   getGuildsForMember: vi.fn().mockResolvedValue([]),
-  getEffectiveAccessLevel: vi.fn().mockResolvedValue(0),
+  getEffectiveAccessLevelForUser: vi.fn().mockResolvedValue(0),
   createCode: vi.fn().mockResolvedValue('plain-auth-code'),
   AccessLevel: ACCESS_LEVEL_MOCK,
 }));
@@ -35,7 +35,7 @@ import {
   updateDiscordName,
   getAllGuilds,
   getGuildsForMember,
-  getEffectiveAccessLevel,
+  getEffectiveAccessLevelForUser,
   createCode,
   AccessLevel,
 } from '../../db';
@@ -81,7 +81,7 @@ beforeEach(() => {
   vi.mocked(fetchMemberDisplayName).mockResolvedValue(null);
   vi.mocked(getAllGuilds).mockResolvedValue([]);
   vi.mocked(getGuildsForMember).mockResolvedValue([]);
-  vi.mocked(getEffectiveAccessLevel).mockResolvedValue(0);
+  vi.mocked(getEffectiveAccessLevelForUser).mockResolvedValue(0);
   vi.mocked(createCode).mockResolvedValue('plain-auth-code');
 });
 
@@ -211,7 +211,7 @@ describe('GET /discord/callback', () => {
     ]);
     vi.mocked(findUser).mockResolvedValue({ discord_id: '111', discord_name: 'alice', is_twitch_bot_enabled: false, twitch_name: null, access_level: AccessLevel.USER, is_owner: false } as any);
     vi.mocked(getGuildsForMember).mockResolvedValue([{ guild_id: '555', name: 'Guild', voice_channel_id: null }] as any);
-    vi.mocked(getEffectiveAccessLevel).mockResolvedValue(AccessLevel.MOD);
+    vi.mocked(getEffectiveAccessLevelForUser).mockResolvedValue(AccessLevel.MOD);
 
     let capturedSession: any;
     const app = buildApp(

--- a/src/web/routes/auth.ts
+++ b/src/web/routes/auth.ts
@@ -7,7 +7,7 @@ import {
   updateDiscordName,
   getAllGuilds,
   getGuildsForMember,
-  getEffectiveAccessLevel,
+  getEffectiveAccessLevelForUser,
   createCode,
   AccessLevel,
   type DbGuild,
@@ -163,7 +163,7 @@ router.get('/discord/callback', async (req, res) => {
     // by leaving currentGuildId null (accessLevel stays 0 until a guild is chosen).
     const currentGuildId = accessibleGuilds.length === 1 ? accessibleGuilds[0].guild_id : null;
     const accessLevel = currentGuildId
-      ? ((await getEffectiveAccessLevel(currentGuildId, profile.id)) as (typeof AccessLevel)[keyof typeof AccessLevel])
+      ? ((await getEffectiveAccessLevelForUser(currentGuildId, dbUser)) as (typeof AccessLevel)[keyof typeof AccessLevel])
       : AccessLevel.USER;
 
     // 5. Save to session — regenerate the session ID first to prevent session fixation.

--- a/src/web/routes/channelPointsAdmin.test.ts
+++ b/src/web/routes/channelPointsAdmin.test.ts
@@ -5,7 +5,7 @@ vi.mock('../../db', () => ({
   getStreamerByDiscordId: vi.fn(),
   getPricingConfigsForStreamer: vi.fn(),
   getPricingSettingsForStreamer: vi.fn(),
-  getPricingHistory: vi.fn(),
+  getPricingHistoryForRewards: vi.fn(),
 }));
 
 vi.mock('../csrf', () => ({
@@ -50,7 +50,7 @@ vi.mock('./channelPointsEvents', async () => {
 
 import supertest from 'supertest';
 import router from './channelPointsAdmin';
-import { getStreamerByDiscordId, getPricingConfigsForStreamer, getPricingSettingsForStreamer, getPricingHistory } from '../../db';
+import { getStreamerByDiscordId, getPricingConfigsForStreamer, getPricingSettingsForStreamer, getPricingHistoryForRewards } from '../../db';
 import { getCustomRewards } from '../../twitch/twitchApi';
 import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
 import { hasAuthFailedSubs } from '../../twitch/eventsub/twitchEventSubSubscriptions';
@@ -78,7 +78,7 @@ beforeEach(() => {
   vi.mocked(getValidToken).mockResolvedValue('token');
   vi.mocked(hasAuthFailedSubs).mockReturnValue(false);
   vi.mocked(getPricingSettingsForStreamer).mockResolvedValue({ half_life_seconds: 1800, time_to_max_multiplier: 2 });
-  vi.mocked(getPricingHistory).mockResolvedValue([]);
+  vi.mocked(getPricingHistoryForRewards).mockResolvedValue(new Map());
 });
 
 describe('GET /', () => {
@@ -254,8 +254,8 @@ describe('GET /', () => {
       const after = Date.now();
 
       expect(res.body.historyHours).toBe(3);
-      expect(getPricingHistory).toHaveBeenCalledWith(1, expect.any(Number));
-      const sinceMs = vi.mocked(getPricingHistory).mock.calls[0][1];
+      expect(getPricingHistoryForRewards).toHaveBeenCalledWith([1], expect.any(Number));
+      const sinceMs = vi.mocked(getPricingHistoryForRewards).mock.calls[0][1];
       expect(sinceMs).toBeGreaterThanOrEqual(before - 3 * 60 * 60 * 1000);
       expect(sinceMs).toBeLessThanOrEqual(after - 3 * 60 * 60 * 1000);
     });
@@ -263,7 +263,7 @@ describe('GET /', () => {
     it('respects a valid hours query param', async () => {
       const res = await supertest(buildApp()).get('/?hours=6');
       expect(res.body.historyHours).toBe(6);
-      const sinceMs = vi.mocked(getPricingHistory).mock.calls[0][1];
+      const sinceMs = vi.mocked(getPricingHistoryForRewards).mock.calls[0][1];
       expect(Date.now() - sinceMs).toBeCloseTo(6 * 60 * 60 * 1000, -3);
     });
 
@@ -273,7 +273,7 @@ describe('GET /', () => {
     });
 
     it('renders a chart string for a reward with a config (with points, and without), and null without a config', async () => {
-      vi.mocked(getPricingHistory).mockResolvedValue([{ recorded_at: '1700000000000', cost: 300, demand: 0.5 }]);
+      vi.mocked(getPricingHistoryForRewards).mockResolvedValue(new Map([[1, [{ recorded_at: '1700000000000', cost: 300, demand: 0.5 }]]]));
       const res = await supertest(buildApp()).get('/');
       expect(typeof res.body.rewards[0].historyChartSafeHtml).toBe('string');
       expect(res.body.rewards[0].historyChartSafeHtml).toContain('<svg');
@@ -290,7 +290,7 @@ describe('GET /', () => {
 
     it('renders a chart for an unlinked (orphaned) reward too', async () => {
       vi.mocked(getCustomRewards).mockResolvedValue([]);
-      vi.mocked(getPricingHistory).mockResolvedValue([{ recorded_at: '1700000000000', cost: 300, demand: 0.5 }]);
+      vi.mocked(getPricingHistoryForRewards).mockResolvedValue(new Map([[1, [{ recorded_at: '1700000000000', cost: 300, demand: 0.5 }]]]));
       const res = await supertest(buildApp()).get('/');
       expect(res.body.rewards[0].twitchReward).toBeNull();
       expect(res.body.rewards[0].historyChartSafeHtml).toContain('<svg');

--- a/src/web/routes/channelPointsAdmin.ts
+++ b/src/web/routes/channelPointsAdmin.ts
@@ -4,7 +4,7 @@ import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
 import { getStreamerByDiscordId } from '../../db';
 import type { DbStreamerEventSub } from '../../db';
-import { getPricingConfigsForStreamer, getPricingSettingsForStreamer, getPricingHistory } from '../../db';
+import { getPricingConfigsForStreamer, getPricingSettingsForStreamer, getPricingHistoryForRewards } from '../../db';
 import type { RewardPricingRow, StreamerPricingSettings } from '../../db';
 import { getCustomRewards, TwitchCustomReward } from '../../twitch/twitchApi';
 import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
@@ -144,8 +144,11 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
     const rangeEndMs = Date.now();
     const rangeStartMs = rangeEndMs - historyHours * 60 * 60 * 1000;
 
-    async function buildHistoryChart(config: RewardPricingRow): Promise<string> {
-      const points = await getPricingHistory(config.id, rangeStartMs);
+    // One query for every config's history instead of one query per config.
+    const historyByRewardId = await getPricingHistoryForRewards(pricingConfigs.map((c) => c.id), rangeStartMs);
+
+    function buildHistoryChart(config: RewardPricingRow): string {
+      const points = historyByRewardId.get(config.id) ?? [];
       return renderPriceHistoryChart(points.map((p) => ({ t: Number(p.recorded_at), cost: p.cost })), rangeStartMs, rangeEndMs);
     }
 
@@ -159,33 +162,31 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
     const configByRewardId = new Map(pricingConfigs.map((c) => [c.twitch_reward_id, c]));
     const matchedRewardIds = new Set(twitchRewards.map((tr) => tr.id));
 
-    const rewards: ChannelPointRewardRow[] = await Promise.all(twitchRewards.map(async (tr) => {
+    const rewards: ChannelPointRewardRow[] = twitchRewards.map((tr) => {
       const config = configByRewardId.get(tr.id) ?? null;
       return {
         rewardId: tr.id,
         twitchReward: tr,
         config,
         previewPrice: config ? previewPriceFor(config) : null,
-        historyChartSafeHtml: config ? await buildHistoryChart(config) : null,
+        historyChartSafeHtml: config ? buildHistoryChart(config) : null,
         ...(config ? buildSimulation(config) : { simulationChartSafeHtml: null, simulationSummary: null }),
       };
-    }));
+    });
 
     // Configs whose reward no longer appears on Twitch (deleted, or the streamer's token
     // lacks the scope to list it) still get processed by the decay scheduler — surface them
     // as "unlinked" rows so they aren't invisible/unmanageable from this page.
-    const unlinkedRows = await Promise.all(
-      pricingConfigs
-        .filter((config) => !matchedRewardIds.has(config.twitch_reward_id))
-        .map(async (config) => ({
-          rewardId: config.twitch_reward_id,
-          twitchReward: null,
-          config,
-          previewPrice: previewPriceFor(config),
-          historyChartSafeHtml: await buildHistoryChart(config),
-          ...buildSimulation(config),
-        })),
-    );
+    const unlinkedRows = pricingConfigs
+      .filter((config) => !matchedRewardIds.has(config.twitch_reward_id))
+      .map((config) => ({
+        rewardId: config.twitch_reward_id,
+        twitchReward: null,
+        config,
+        previewPrice: previewPriceFor(config),
+        historyChartSafeHtml: buildHistoryChart(config),
+        ...buildSimulation(config),
+      }));
     rewards.push(...unlinkedRows);
 
     renderView(res, 'channelPointsAdmin', {

--- a/src/web/routes/commandMutations.test.ts
+++ b/src/web/routes/commandMutations.test.ts
@@ -148,6 +148,16 @@ describe('POST /commands/add', () => {
     expect(res.headers.location).toBe('/commands?error=assign_failed');
     expect(removeCustomCommand).toHaveBeenCalledWith(1); // cleanup
   });
+
+  it('still redirects to ?error=assign_failed when the cleanup delete itself also fails', async () => {
+    vi.mocked(findUsersByIds).mockRejectedValueOnce(new Error('DB down'));
+    vi.mocked(removeCustomCommand).mockRejectedValueOnce(new Error('cleanup also failed'));
+    const res = await supertest(buildApp())
+      .post('/commands/add')
+      .send(`trigger_string=!clap&output=Clap&discord_ids=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/commands?error=assign_failed');
+    expect(removeCustomCommand).toHaveBeenCalledWith(1);
+  });
 });
 
 // ─── POST /commands/update ────────────────────────────────────────────────────

--- a/src/web/routes/commandMutations.test.ts
+++ b/src/web/routes/commandMutations.test.ts
@@ -11,7 +11,7 @@ vi.mock('../../db', () => {
     updateCustomCommand: vi.fn().mockResolvedValue(undefined),
     removeCustomCommand: vi.fn().mockResolvedValue(undefined),
     assignUserToCommand: vi.fn().mockResolvedValue(undefined),
-    findUser: vi.fn().mockResolvedValue(null),
+    findUsersByIds: vi.fn().mockResolvedValue(new Map()),
     CommandConflictError,
     CommandNotFoundError,
     ReservedCommandError,
@@ -29,7 +29,7 @@ import supertest from 'supertest';
 import router from './commandMutations';
 import {
   addCustomCommand, updateCustomCommand, removeCustomCommand,
-  assignUserToCommand, findUser,
+  assignUserToCommand, findUsersByIds,
   CommandConflictError, CommandNotFoundError, ReservedCommandError,
   isMysqlDuplicateEntryError,
 } from '../../db';
@@ -49,7 +49,7 @@ beforeEach(() => {
   vi.mocked(updateCustomCommand).mockResolvedValue(undefined);
   vi.mocked(removeCustomCommand).mockResolvedValue(undefined);
   vi.mocked(assignUserToCommand).mockResolvedValue(undefined);
-  vi.mocked(findUser).mockResolvedValue(null);
+  vi.mocked(findUsersByIds).mockResolvedValue(new Map());
   vi.mocked(isMysqlDuplicateEntryError).mockReturnValue(false);
 });
 
@@ -98,7 +98,9 @@ describe('POST /commands/add', () => {
   });
 
   it('assigns users when discord_ids are provided and user has twitch_name', async () => {
-    vi.mocked(findUser).mockResolvedValue({ discord_id: VALID_DISCORD_ID, discord_name: 'Alice', is_twitch_bot_enabled: false, twitch_name: 'alice', access_level: AccessLevel.USER } as any);
+    vi.mocked(findUsersByIds).mockResolvedValue(new Map([
+      [VALID_DISCORD_ID, { discord_id: VALID_DISCORD_ID, discord_name: 'Alice', is_twitch_bot_enabled: false, twitch_name: 'alice', access_level: AccessLevel.USER } as any],
+    ]));
     const res = await supertest(buildApp())
       .post('/commands/add')
       .send(`trigger_string=!clap&output=Clap&discord_ids=${VALID_DISCORD_ID}`);
@@ -106,8 +108,8 @@ describe('POST /commands/add', () => {
     expect(assignUserToCommand).toHaveBeenCalledWith(1, VALID_DISCORD_ID);
   });
 
-  it('skips assigning user when findUser returns null', async () => {
-    vi.mocked(findUser).mockResolvedValue(null);
+  it('skips assigning user when findUsersByIds does not return a matching entry', async () => {
+    vi.mocked(findUsersByIds).mockResolvedValue(new Map());
     const res = await supertest(buildApp())
       .post('/commands/add')
       .send(`trigger_string=!clap&output=Clap&discord_ids=${VALID_DISCORD_ID}`);
@@ -116,7 +118,9 @@ describe('POST /commands/add', () => {
   });
 
   it('redirects to ?error=command_taken when assignUserToCommand throws CommandConflictError', async () => {
-    vi.mocked(findUser).mockResolvedValue({ discord_id: VALID_DISCORD_ID, twitch_name: 'alice', discord_name: null, is_twitch_bot_enabled: false, access_level: AccessLevel.USER } as any);
+    vi.mocked(findUsersByIds).mockResolvedValue(new Map([
+      [VALID_DISCORD_ID, { discord_id: VALID_DISCORD_ID, twitch_name: 'alice', discord_name: null, is_twitch_bot_enabled: false, access_level: AccessLevel.USER } as any],
+    ]));
     vi.mocked(assignUserToCommand).mockRejectedValueOnce(new (CommandConflictError as any)('conflict'));
     const res = await supertest(buildApp())
       .post('/commands/add')
@@ -126,12 +130,23 @@ describe('POST /commands/add', () => {
   });
 
   it('redirects to ?error=assign_failed on unexpected assign error', async () => {
-    vi.mocked(findUser).mockResolvedValue({ discord_id: VALID_DISCORD_ID, twitch_name: 'alice', discord_name: null, is_twitch_bot_enabled: false, access_level: AccessLevel.USER } as any);
+    vi.mocked(findUsersByIds).mockResolvedValue(new Map([
+      [VALID_DISCORD_ID, { discord_id: VALID_DISCORD_ID, twitch_name: 'alice', discord_name: null, is_twitch_bot_enabled: false, access_level: AccessLevel.USER } as any],
+    ]));
     vi.mocked(assignUserToCommand).mockRejectedValueOnce(new Error('DB error'));
     const res = await supertest(buildApp())
       .post('/commands/add')
       .send(`trigger_string=!clap&output=Clap&discord_ids=${VALID_DISCORD_ID}`);
     expect(res.headers.location).toBe('/commands?error=assign_failed');
+  });
+
+  it('redirects to ?error=assign_failed when findUsersByIds itself throws', async () => {
+    vi.mocked(findUsersByIds).mockRejectedValueOnce(new Error('DB down'));
+    const res = await supertest(buildApp())
+      .post('/commands/add')
+      .send(`trigger_string=!clap&output=Clap&discord_ids=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/commands?error=assign_failed');
+    expect(removeCustomCommand).toHaveBeenCalledWith(1); // cleanup
   });
 });
 

--- a/src/web/routes/commandMutations.ts
+++ b/src/web/routes/commandMutations.ts
@@ -6,7 +6,7 @@ import {
   CommandConflictError,
   CommandNotFoundError,
   isMysqlDuplicateEntryError,
-  findUser,
+  findUsersByIds,
   removeCustomCommand,
   updateCustomCommand,
 } from '../../db';
@@ -31,21 +31,22 @@ const COMMAND_WRITE_ERROR_OPTIONS = { basePath: '/commands', conflictErrorCode: 
  *  to avoid leaving it in a partially-assigned state.  Returns an error code, or
  *  null on success. */
 async function assignUsersToNewCommand(commandId: number, discordIds: string[]): Promise<string | null> {
-  for (const discordId of discordIds) {
-    try {
-      const user = await findUser(discordId);
+  try {
+    const users = await findUsersByIds(discordIds);
+    for (const discordId of discordIds) {
+      const user = users.get(discordId);
       if (!user || !user.twitch_name) continue;
       await assignUserToCommand(commandId, discordId);
-    } catch (err) {
-      try {
-        await removeCustomCommand(commandId);
-      } catch (cleanupErr) {
-        log.error('Cleanup after failed assign error:', cleanupErr);
-      }
-      if (err instanceof CommandConflictError || isMysqlDuplicateEntryError(err)) return 'command_taken';
-      log.error('Assign user during command creation error:', err);
-      return 'assign_failed';
     }
+  } catch (err) {
+    try {
+      await removeCustomCommand(commandId);
+    } catch (cleanupErr) {
+      log.error('Cleanup after failed assign error:', cleanupErr);
+    }
+    if (err instanceof CommandConflictError || isMysqlDuplicateEntryError(err)) return 'command_taken';
+    log.error('Assign user during command creation error:', err);
+    return 'assign_failed';
   }
   return null;
 }

--- a/src/web/routes/commands.test.ts
+++ b/src/web/routes/commands.test.ts
@@ -19,6 +19,7 @@ vi.mock('../../db', () => {
     assignUserToCommand: vi.fn().mockResolvedValue(undefined),
     unassignUserFromCommand: vi.fn().mockResolvedValue(undefined),
     findUser: vi.fn().mockResolvedValue(null),
+    findUsersByIds: vi.fn().mockResolvedValue(new Map()),
     upsertOverride: vi.fn().mockResolvedValue(undefined),
     removeOverride: vi.fn().mockResolvedValue(undefined),
     CommandConflictError,
@@ -59,6 +60,7 @@ import {
   assignUserToCommand,
   unassignUserFromCommand,
   findUser,
+  findUsersByIds,
   getAllCustomCommandsWithAssignments,
   getAllUsers,
   getOverridesForGuild,
@@ -91,6 +93,7 @@ beforeEach(() => {
   vi.mocked(assignUserToCommand).mockResolvedValue(undefined);
   vi.mocked(unassignUserFromCommand).mockResolvedValue(undefined);
   vi.mocked(findUser).mockResolvedValue(null);
+  vi.mocked(findUsersByIds).mockResolvedValue(new Map());
   vi.mocked(isMysqlDuplicateEntryError).mockReturnValue(false);
 });
 
@@ -154,7 +157,9 @@ describe('POST /commands/add', () => {
   });
 
   it('7. skips assignment and redirects /commands when user has no twitch_name', async () => {
-    vi.mocked(findUser).mockResolvedValue({ discord_id: '123456789012345678', twitch_name: null } as any);
+    vi.mocked(findUsersByIds).mockResolvedValue(new Map([
+      ['123456789012345678', { discord_id: '123456789012345678', twitch_name: null } as any],
+    ]));
     const res = await supertest(buildApp())
       .post('/commands/add')
       .type('form')
@@ -165,7 +170,9 @@ describe('POST /commands/add', () => {
   });
 
   it('8. calls assignUserToCommand and redirects /commands when user has twitch_name', async () => {
-    vi.mocked(findUser).mockResolvedValue({ discord_id: '123456789012345678', twitch_name: 'streamer' } as any);
+    vi.mocked(findUsersByIds).mockResolvedValue(new Map([
+      ['123456789012345678', { discord_id: '123456789012345678', twitch_name: 'streamer' } as any],
+    ]));
     const res = await supertest(buildApp())
       .post('/commands/add')
       .type('form')
@@ -396,7 +403,9 @@ describe('POST /commands/add — additional coverage', () => {
   });
 
   it('28. redirects ?error=command_taken when assignUserToCommand throws CommandConflictError during add', async () => {
-    vi.mocked(findUser).mockResolvedValue({ discord_id: '123456789012345678', twitch_name: 'streamer' } as any);
+    vi.mocked(findUsersByIds).mockResolvedValue(new Map([
+      ['123456789012345678', { discord_id: '123456789012345678', twitch_name: 'streamer' } as any],
+    ]));
     vi.mocked(assignUserToCommand).mockRejectedValue(new CommandConflictError(['conflict']));
     const res = await supertest(buildApp())
       .post('/commands/add')
@@ -407,7 +416,9 @@ describe('POST /commands/add — additional coverage', () => {
   });
 
   it('29. redirects ?error=assign_failed when assignUserToCommand throws generic error during add', async () => {
-    vi.mocked(findUser).mockResolvedValue({ discord_id: '123456789012345678', twitch_name: 'streamer' } as any);
+    vi.mocked(findUsersByIds).mockResolvedValue(new Map([
+      ['123456789012345678', { discord_id: '123456789012345678', twitch_name: 'streamer' } as any],
+    ]));
     vi.mocked(assignUserToCommand).mockRejectedValue(new Error('db error'));
     const res = await supertest(buildApp())
       .post('/commands/add')
@@ -605,9 +616,10 @@ describe('GET /commands', () => {
 
 describe('POST /commands/add — array discord_ids', () => {
   it('38. handles multiple discord_ids sent as an array and assigns each valid user', async () => {
-    vi.mocked(findUser)
-      .mockResolvedValueOnce({ discord_id: '111111111111111111', twitch_name: 'user1' } as any)
-      .mockResolvedValueOnce({ discord_id: '222222222222222222', twitch_name: 'user2' } as any);
+    vi.mocked(findUsersByIds).mockResolvedValue(new Map([
+      ['111111111111111111', { discord_id: '111111111111111111', twitch_name: 'user1' } as any],
+      ['222222222222222222', { discord_id: '222222222222222222', twitch_name: 'user2' } as any],
+    ]));
     const res = await supertest(buildApp())
       .post('/commands/add')
       .type('form')

--- a/src/web/routes/guild.test.ts
+++ b/src/web/routes/guild.test.ts
@@ -3,7 +3,7 @@ import { mockLogger } from '../../test-utils/loggerMock';
 import { ACCESS_LEVEL_MOCK } from '../../test-utils/accessLevelMock';
 
 vi.mock('../../db', () => ({
-  getEffectiveAccessLevel: vi.fn().mockResolvedValue(0),
+  getEffectiveAccessLevelForUser: vi.fn().mockResolvedValue(0),
   getAllGuilds: vi.fn(),
   getGuildsForMember: vi.fn(),
   findUser: vi.fn(),
@@ -22,7 +22,7 @@ vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
 import express from 'express';
 import supertest from 'supertest';
 import router from './guild';
-import { findUser, getAllGuilds, getEffectiveAccessLevel, getGuildsForMember } from '../../db';
+import { findUser, getAllGuilds, getEffectiveAccessLevelForUser, getGuildsForMember } from '../../db';
 import { AccessLevel } from '../../db/users';
 
 const TWO_GUILDS = [
@@ -53,7 +53,7 @@ function buildApp(sessionUser: unknown) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(getEffectiveAccessLevel).mockResolvedValue(AccessLevel.USER);
+  vi.mocked(getEffectiveAccessLevelForUser).mockResolvedValue(AccessLevel.USER);
   vi.mocked(getGuildsForMember).mockResolvedValue(TWO_DB_GUILDS as any);
   vi.mocked(getAllGuilds).mockResolvedValue(TWO_DB_GUILDS as any);
   vi.mocked(findUser).mockResolvedValue({ discord_id: 'u1', is_owner: false } as any);
@@ -78,7 +78,7 @@ describe('GET /guild/select', () => {
 
 describe('POST /guild/select', () => {
   it('selects a guild the user belongs to and recomputes the access level', async () => {
-    vi.mocked(getEffectiveAccessLevel).mockResolvedValue(AccessLevel.MANAGER);
+    vi.mocked(getEffectiveAccessLevelForUser).mockResolvedValue(AccessLevel.MANAGER);
     const user: any = { discordId: 'u1', currentGuildId: null, accessLevel: AccessLevel.USER, guilds: TWO_GUILDS };
     const app = express();
     app.use(express.urlencoded({ extended: false }));
@@ -98,7 +98,7 @@ describe('POST /guild/select', () => {
     expect(res.headers.location).toBe('/');
     expect(user.currentGuildId).toBe('100000000000000002');
     expect(user.accessLevel).toBe(AccessLevel.MANAGER);
-    expect(vi.mocked(getEffectiveAccessLevel)).toHaveBeenCalledWith('100000000000000002', 'u1');
+    expect(vi.mocked(getEffectiveAccessLevelForUser)).toHaveBeenCalledWith('100000000000000002', { discord_id: 'u1', is_owner: false });
   });
 
   it('rejects a guild the user does not belong to (cross-guild IDOR guard)', async () => {
@@ -120,7 +120,7 @@ describe('POST /guild/select', () => {
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/guild/select');
     expect(user.currentGuildId).toBeNull();
-    expect(vi.mocked(getEffectiveAccessLevel)).not.toHaveBeenCalled();
+    expect(vi.mocked(getEffectiveAccessLevelForUser)).not.toHaveBeenCalled();
   });
 
   it('rejects a guild present in the stale session list but no longer returned by getGuildsForMember', async () => {
@@ -145,7 +145,7 @@ describe('POST /guild/select', () => {
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/guild/select');
     expect(user.currentGuildId).toBeNull();
-    expect(vi.mocked(getEffectiveAccessLevel)).not.toHaveBeenCalled();
+    expect(vi.mocked(getEffectiveAccessLevelForUser)).not.toHaveBeenCalled();
   });
 
   it('uses getAllGuilds (not getGuildsForMember) when the user is the bot owner', async () => {
@@ -240,7 +240,7 @@ describe('POST /guild/select', () => {
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/auth/login');
     expect(user.currentGuildId).toBeNull();
-    expect(vi.mocked(getEffectiveAccessLevel)).not.toHaveBeenCalled();
+    expect(vi.mocked(getEffectiveAccessLevelForUser)).not.toHaveBeenCalled();
   });
 
   it('redirects to login when the session user no longer exists in the database', async () => {
@@ -262,7 +262,7 @@ describe('POST /guild/select', () => {
 
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/auth/login');
-    expect(vi.mocked(getEffectiveAccessLevel)).not.toHaveBeenCalled();
+    expect(vi.mocked(getEffectiveAccessLevelForUser)).not.toHaveBeenCalled();
   });
 
   it('rejects a malformed guild ID', async () => {
@@ -283,11 +283,11 @@ describe('POST /guild/select', () => {
 
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/guild/select');
-    expect(vi.mocked(getEffectiveAccessLevel)).not.toHaveBeenCalled();
+    expect(vi.mocked(getEffectiveAccessLevelForUser)).not.toHaveBeenCalled();
   });
 
   it('redirects to the picker and does not mutate the session when an unexpected error occurs', async () => {
-    vi.mocked(getEffectiveAccessLevel).mockRejectedValue(new Error('DB unavailable'));
+    vi.mocked(getEffectiveAccessLevelForUser).mockRejectedValue(new Error('DB unavailable'));
     const user: any = { discordId: 'u1', currentGuildId: null, accessLevel: AccessLevel.USER, guilds: TWO_GUILDS };
     const app = buildApp(user);
 

--- a/src/web/routes/guild.ts
+++ b/src/web/routes/guild.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
-import { AccessLevel, findUser, getAllGuilds, getEffectiveAccessLevel, getGuildsForMember } from '../../db';
+import { AccessLevel, findUser, getAllGuilds, getEffectiveAccessLevelForUser, getGuildsForMember } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
 import { normalizeDiscordId, renderView } from './shared';
@@ -64,7 +64,7 @@ router.post('/select', requireAuth, csrfProtection, async (req, res) => {
     if (!liveGuilds.some((g) => g.guild_id === requestedGuildId)) {
       return res.redirect('/guild/select');
     }
-    const accessLevel = (await getEffectiveAccessLevel(requestedGuildId, user.discordId)) as (typeof AccessLevel)[keyof typeof AccessLevel];
+    const accessLevel = (await getEffectiveAccessLevelForUser(requestedGuildId, dbUser)) as (typeof AccessLevel)[keyof typeof AccessLevel];
     user.currentGuildId = requestedGuildId;
     user.accessLevel = accessLevel;
   } catch (err) {

--- a/src/web/routes/streamdeckSfx.test.ts
+++ b/src/web/routes/streamdeckSfx.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { SfxTrigger, SfxFile } from '../../db';
+import type { SfxTrigger, SfxFile, SfxLookupResult } from '../../db';
 import { mockLogger } from '../../test-utils/loggerMock';
 
 const API_KEY_OWNER = 'user-1';
@@ -12,8 +12,7 @@ vi.mock('../middleware', () => ({
 }));
 
 vi.mock('../../db', () => ({
-  findTrigger: vi.fn(),
-  findSoundFiles: vi.fn(),
+  findCachedSfxTrigger: vi.fn(),
   getAllSfxTriggers: vi.fn(),
   isKeyApprovedForGuild: vi.fn(),
   getApprovedGuildIdsForKey: vi.fn(),
@@ -46,7 +45,7 @@ vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
 
 import supertest from 'supertest';
 import router from './streamdeckSfx';
-import { findTrigger, findSoundFiles, getAllSfxTriggers, isKeyApprovedForGuild, getApprovedGuildIdsForKey } from '../../db';
+import { findCachedSfxTrigger, getAllSfxTriggers, isKeyApprovedForGuild, getApprovedGuildIdsForKey } from '../../db';
 import { pickWeightedRandom } from '../../commands/soundSelector';
 import { playFile, VoiceNotConnectedError } from '../../audio/sfxPlayer';
 import { setVoicePlaying } from '../../shared/statusStore';
@@ -66,6 +65,8 @@ const FILES: SfxFile[] = [
   { id: 1, trigger_id: BigInt(1), file: 'ding.mp3', trigger_command: null, weight: 1, hidden: false, category_id: null },
 ];
 
+const LOOKUP: SfxLookupResult = { trigger: TRIGGER, files: FILES };
+
 /** Fake Discord client; channel lookups aren't exercised by SFX routes. */
 function makeClient() {
   return { channels: { fetch: vi.fn() } } as any;
@@ -79,8 +80,7 @@ function buildApp() {
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(getAllSfxTriggers).mockResolvedValue([]);
-  vi.mocked(findTrigger).mockResolvedValue(null);
-  vi.mocked(findSoundFiles).mockResolvedValue([]);
+  vi.mocked(findCachedSfxTrigger).mockResolvedValue(null);
   vi.mocked(pickWeightedRandom).mockReturnValue('ding.mp3');
   vi.mocked(getDiscordClient).mockReturnValue(makeClient());
   vi.mocked(getActiveGuildForUser).mockReturnValue('guild-123');
@@ -90,8 +90,7 @@ beforeEach(() => {
 
 describe('POST /sfx', () => {
   it('calls playFile with the bare filename and the presence-resolved guild', async () => {
-    vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
-    vi.mocked(findSoundFiles).mockResolvedValue(FILES);
+    vi.mocked(findCachedSfxTrigger).mockResolvedValue(LOOKUP);
     vi.mocked(pickWeightedRandom).mockReturnValue('only1_v2.mp3');
 
     await supertest(buildApp())
@@ -104,8 +103,7 @@ describe('POST /sfx', () => {
   });
 
   it('returns 200 and the filename on success', async () => {
-    vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
-    vi.mocked(findSoundFiles).mockResolvedValue(FILES);
+    vi.mocked(findCachedSfxTrigger).mockResolvedValue(LOOKUP);
     vi.mocked(pickWeightedRandom).mockReturnValue('ding.mp3');
 
     const res = await supertest(buildApp())
@@ -118,15 +116,14 @@ describe('POST /sfx', () => {
   });
 
   it('normalises the command to lowercase before lookup', async () => {
-    vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
-    vi.mocked(findSoundFiles).mockResolvedValue(FILES);
+    vi.mocked(findCachedSfxTrigger).mockResolvedValue(LOOKUP);
 
     await supertest(buildApp())
       .post('/sfx')
       .send({ command: '!DING' })
       .expect(200);
 
-    expect(vi.mocked(findTrigger)).toHaveBeenCalledWith('!ding');
+    expect(vi.mocked(findCachedSfxTrigger)).toHaveBeenCalledWith('!ding');
   });
 
   it('returns 400 when command field is missing', async () => {
@@ -168,7 +165,7 @@ describe('POST /sfx', () => {
   });
 
   it('returns 404 when trigger is not found', async () => {
-    vi.mocked(findTrigger).mockResolvedValue(null);
+    vi.mocked(findCachedSfxTrigger).mockResolvedValue(null);
 
     const res = await supertest(buildApp())
       .post('/sfx')
@@ -179,8 +176,7 @@ describe('POST /sfx', () => {
   });
 
   it('returns 404 when trigger has no sound files', async () => {
-    vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
-    vi.mocked(findSoundFiles).mockResolvedValue([]);
+    vi.mocked(findCachedSfxTrigger).mockResolvedValue({ trigger: TRIGGER, files: [] });
 
     const res = await supertest(buildApp())
       .post('/sfx')
@@ -192,8 +188,7 @@ describe('POST /sfx', () => {
   });
 
   it('returns 503 when bot is not connected to a voice channel', async () => {
-    vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
-    vi.mocked(findSoundFiles).mockResolvedValue(FILES);
+    vi.mocked(findCachedSfxTrigger).mockResolvedValue(LOOKUP);
     vi.mocked(playFile).mockImplementation(() => { throw new VoiceNotConnectedError(); });
 
     const res = await supertest(buildApp())
@@ -205,8 +200,7 @@ describe('POST /sfx', () => {
   });
 
   it('returns 500 when playFile throws an unexpected error', async () => {
-    vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
-    vi.mocked(findSoundFiles).mockResolvedValue(FILES);
+    vi.mocked(findCachedSfxTrigger).mockResolvedValue(LOOKUP);
     vi.mocked(playFile).mockImplementation(() => { throw new Error('FFMPEG crashed'); });
 
     const res = await supertest(buildApp())
@@ -217,20 +211,8 @@ describe('POST /sfx', () => {
     expect(res.body).toMatchObject({ ok: false });
   });
 
-  it('returns 500 on DB error looking up trigger', async () => {
-    vi.mocked(findTrigger).mockRejectedValue(new Error('DB gone'));
-
-    const res = await supertest(buildApp())
-      .post('/sfx')
-      .send({ command: '!ding' })
-      .expect(500);
-
-    expect(res.body).toMatchObject({ ok: false });
-  });
-
-  it('returns 500 on DB error fetching sound files', async () => {
-    vi.mocked(findTrigger).mockResolvedValue(TRIGGER);
-    vi.mocked(findSoundFiles).mockRejectedValue(new Error('DB gone'));
+  it('returns 500 on DB error looking up the cached trigger', async () => {
+    vi.mocked(findCachedSfxTrigger).mockRejectedValue(new Error('DB gone'));
 
     const res = await supertest(buildApp())
       .post('/sfx')

--- a/src/web/routes/streamdeckSfx.ts
+++ b/src/web/routes/streamdeckSfx.ts
@@ -78,7 +78,7 @@ router.post('/sfx', requireApiKey, async (req, res) => {
   const filename = pickWeightedRandom(files);
 
   try {
-    playFile(filename, guildId);
+    await playFile(filename, guildId);
     setVoicePlaying(guildId, filename, normalizedCommand, 'streamdeck');
     log.info(`Playing '${filename.replace(/[\r\n]/g, '')}' for trigger '${normalizedCommand.replace(/[\r\n]/g, '')}' in guild ${guildId}`);
     res.json({ ok: true, file: filename });

--- a/src/web/routes/streamdeckSfx.ts
+++ b/src/web/routes/streamdeckSfx.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
-import { findTrigger, findSoundFiles, getAllSfxTriggers, getApprovedGuildIdsForKey } from '../../db';
+import { findCachedSfxTrigger, getAllSfxTriggers, getApprovedGuildIdsForKey } from '../../db';
 import { pickWeightedRandom } from '../../commands/soundSelector';
 import { playFile, VoiceNotConnectedError } from '../../audio/sfxPlayer';
 import { setVoicePlaying } from '../../shared/statusStore';
@@ -49,27 +49,19 @@ router.post('/sfx', requireApiKey, async (req, res) => {
 
   const normalizedCommand = command.trim().toLowerCase();
 
-  let trigger;
+  let lookup;
   try {
-    trigger = await findTrigger(normalizedCommand);
+    lookup = await findCachedSfxTrigger(normalizedCommand);
   } catch (err) {
     log.error('DB error looking up trigger:', err);
     res.status(500).json({ ok: false, error: 'Database error' });
     return;
   }
-  if (!trigger) {
+  if (!lookup) {
     res.status(404).json({ ok: false, error: 'Unknown command' });
     return;
   }
-
-  let files;
-  try {
-    files = await findSoundFiles(trigger.id);
-  } catch (err) {
-    log.error('DB error fetching sound files:', err);
-    res.status(500).json({ ok: false, error: 'Database error' });
-    return;
-  }
+  const { files } = lookup;
   if (files.length === 0) {
     res.status(404).json({ ok: false, error: 'No sound files for this command' });
     return;


### PR DESCRIPTION
## Summary

Following an efficiency review of the codebase, this implements the highest-impact findings plus several smaller wins:

- **SFX trigger lookup cache** (`src/db/sfxCache.ts`) — `findTrigger()` was hitting the DB with an unindexed, `LOWER()`-wrapped query on nearly every chat message across Discord/Twitch/TikTok. This adds a `createManagedLookupCache`-backed cache mirroring the existing custom-command and counter caches (5-minute TTL, invalidated on writes). `commandRouter.ts` now reads through the cache.
- **Reward-pricing decay tick** — `runDecayTick()` now fetches each streamer's pricing settings once per tick (batched by distinct `streamer_id`) instead of once per enabled reward. The per-reward `getPricingForReward` re-fetch inside `syncRewardPrice` is intentionally left alone — it's load-bearing for the read-modify-write concurrency guarantee against a same-reward redemption, not an oversight. The originally-suspected unbounded `reward_pricing_history` growth turned out to already be pruned on every insert — no change needed there.
- **Web admin auth dedup** — `requireGuildContext`, `POST /guild/select`, and the OAuth callback each re-queried `findUser()` a second time via `getEffectiveAccessLevel` even though they already had a fresh user row. Added `getEffectiveAccessLevelForUser(guildId, user)` and switched all three call sites to it.
- **Batched user lookup for bulk command assignment** — `assignUsersToNewCommand` looped `findUser()` per id; now uses a new `findUsersByIds()` with a single `WHERE discord_id IN (...)` query.
- **Batched price-history queries on the Channel Points admin page** — `getPricingHistoryForRewards()` fetches history for every reward config in one query instead of one per reward.
- **Parallel bot startup** — Twitch and TikTok bot logins in `src/index.ts` now run concurrently via `Promise.all` instead of sequentially.
- **Async SFX playback file checks** — `playFile()` used synchronous `fs.existsSync`/`realpathSync`/`statSync` on every sound trigger; now uses `fs.promises.realpath`/`stat`.

Two findings from the original review were deliberately **not** implemented (documented in the review): consolidating the per-guild `'raw'` gateway listener in `voiceAdapter.ts` (real but negligible gain vs. risk to working voice-connection plumbing), and resizing the DB pool (no evidence of actual pressure, especially once the SFX cache removes the one workload that could have caused it).

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` — all 136 test files / 2442 tests pass, including new coverage for `sfxCache.ts`, `findUsersByIds`, `getEffectiveAccessLevelForUser`, `getPricingHistoryForRewards`, the decay-tick settings batching, and the async `playFile`
- [ ] Manual: trigger an SFX sound in a test guild, then add/edit a trigger via the admin panel and confirm it takes effect (immediately via cache invalidation, or within 5 minutes via TTL)
- [ ] Manual: load `/channel-points` for a streamer with 2+ dynamic-pricing rewards and confirm history charts render correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_01HkCcw5GzUDPLP4fzQ7Q8Ev)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sound-effect playback validation with safer path handling (including symlink/traversal protection) and clearer missing-file errors.
  * Playback is now properly awaited before updating voice status, improving reliability.
  * Permission checks now use the latest account data when computing effective access.
  * Prevented a single streamer’s pricing-settings issue from disrupting other streamers’ decay updates.
* **Performance**
  * Added cached sound-effect command lookups to reduce repeated trigger/file resolution.
  * Reduced database work by using bulk user lookups and bulk reward pricing history retrieval.
  * Twitch and TikTok bot initialization now starts concurrently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->