### PR TITLE
Simplify duplicated code across DB, command/twitch, and web layers

### DIFF
--- a/src/commands/commandRouter.ts
+++ b/src/commands/commandRouter.ts
@@ -84,6 +84,41 @@ async function lookupAndPlay(
 }
 
 /**
+ * Checks a guild's cooldown and in-flight state and, if both checks pass, claims the slot
+ * (sets `state.inFlight = true`) so a concurrent handler can't also start playing. Callers
+ * that get `true` back must reset `state.inFlight = false` once done (typically in a
+ * `finally`).
+ *
+ * @param guildId - Guild being checked; used only for logging.
+ * @param source - Where the command came from; used for logging.
+ * @param command - The trigger command being attempted; used for logging.
+ * @param state - The guild's cooldown/in-flight state.
+ * @returns True if the slot was claimed; false if the guild is on cooldown or already
+ *   playing/in-flight, in which case `state` is left untouched.
+ */
+function tryClaimGuildSlot(
+  guildId: string,
+  source: 'twitch' | 'discord' | 'tiktok',
+  command: string,
+  state: GuildCommandState,
+): boolean {
+  const now = Date.now();
+  if (now - state.lastPlayedAt < GLOBAL_COOLDOWN_MS) {
+    log.info(`[${source}] Cooldown active for guild ${guildId}, ignoring '${command}'`);
+    return false;
+  }
+
+  if (isPlaying(guildId) || state.inFlight) {
+    log.info(`[${source}] Already playing in guild ${guildId}, ignoring '${command}'`);
+    return false;
+  }
+
+  // Claim the slot before any await so concurrent message handlers see the flag.
+  state.inFlight = true;
+  return true;
+}
+
+/**
  * Handle a raw chat message from Twitch, Discord, or TikTok.
  * Performs all checks (prefix, cooldown, playing state, DB lookup) before playing.
  * Cooldown and in-flight state are tracked per guild so a trigger in one guild
@@ -113,22 +148,8 @@ export async function handleCommand(
   }
 
   const state = getGuildCommandState(guildId);
+  if (!tryClaimGuildSlot(guildId, source, command, state)) return;
 
-  // Per-guild cooldown check
-  const now = Date.now();
-  if (now - state.lastPlayedAt < GLOBAL_COOLDOWN_MS) {
-    log.info(`[${source}] Cooldown active for guild ${guildId}, ignoring '${command}'`);
-    return;
-  }
-
-  // Ignore if this guild is already playing or another handler is mid-lookup
-  if (isPlaying(guildId) || state.inFlight) {
-    log.info(`[${source}] Already playing in guild ${guildId}, ignoring '${command}'`);
-    return;
-  }
-
-  // Claim the slot before any await so concurrent message handlers see the flag.
-  state.inFlight = true;
   try {
     await lookupAndPlay(command, source, guildId, state);
   } finally {

--- a/src/commands/commandUtils.test.ts
+++ b/src/commands/commandUtils.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { extractCommand, extractArgs } from './commandUtils';
+import { describe, it, expect, vi } from 'vitest';
+import { extractCommand, extractArgs, fireAndForget } from './commandUtils';
 
 describe('extractCommand', () => {
   it('returns null for an empty string', () => {
@@ -50,5 +50,26 @@ describe('extractArgs', () => {
 
   it('preserves original casing of the args', () => {
     expect(extractArgs('!Cmd Hello World')).toBe('Hello World');
+  });
+});
+
+describe('fireAndForget', () => {
+  it('does not log when the promise resolves', async () => {
+    const log = { error: vi.fn() };
+    fireAndForget(Promise.resolve(), 'context', log);
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(log.error).not.toHaveBeenCalled();
+  });
+
+  it('logs the context and error when the promise rejects', async () => {
+    const log = { error: vi.fn() };
+    const err = new Error('boom');
+    fireAndForget(Promise.reject(err), 'Custom command error', log);
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(log.error).toHaveBeenCalledWith('Custom command error:', err);
+  });
+
+  it('does not throw synchronously for a rejecting promise', () => {
+    expect(() => fireAndForget(Promise.reject(new Error('boom')), 'context', { error: vi.fn() })).not.toThrow();
   });
 });

--- a/src/commands/commandUtils.ts
+++ b/src/commands/commandUtils.ts
@@ -1,3 +1,21 @@
+/** Minimal logger contract accepted by {@link fireAndForget} — matches `shared/logger`'s `createLogger()` return shape. */
+interface ErrorLogger {
+  error: (message: string, err: unknown) => void;
+}
+
+/**
+ * Runs `promise` without awaiting it, logging (rather than throwing) if it rejects. Used so
+ * one command handler's failure can't block or delay independent handlers dispatched
+ * alongside it (e.g. Twitch/Discord message handling firing several handlers per message).
+ *
+ * @param promise - The in-flight promise to observe.
+ * @param context - Log-line prefix identifying which handler the promise belongs to.
+ * @param log - Logger to report the rejection to, so the log line keeps the caller's module tag.
+ */
+export function fireAndForget(promise: Promise<void>, context: string, log: ErrorLogger): void {
+  promise.catch((err) => log.error(`${context}:`, err));
+}
+
 /**
  * Extracts the command token from a raw message: the first whitespace-delimited
  * token, lowercased. Leading/trailing whitespace is trimmed before splitting.

--- a/src/commands/twitchRuntime.ts
+++ b/src/commands/twitchRuntime.ts
@@ -14,18 +14,18 @@ export interface TwitchBroadcastRuntime extends TwitchSendRuntime {
 }
 
 /**
- * Creates a private module-level singleton slot for a Twitch command runtime of
- * type `T`, along with `register`/`get` accessors. Factors out the
+ * Creates a private module-level singleton slot for an injected runtime of type
+ * `T`, along with `register`/`get` accessors. Factors out the
  * `let _runtime: T | null = null; registerXRuntime(); getXRuntime()` boilerplate
- * that each command handler (countdown, counter, shoutout, custom command,
- * multi-command) previously duplicated for its own runtime shape — handlers with
- * extra fields (e.g. `getActiveChannels`/`getLoginUserIds`) just parameterize `T`
- * with their richer interface.
+ * that command handlers (countdown, counter, shoutout, custom command,
+ * multi-command) and other runtime-injection sites (EventSub overlay/companion/chat
+ * push, reward pricing) previously duplicated for their own runtime shape — any
+ * plain runtime interface can parameterize `T`, not just ones with a `send` method.
  *
  * @returns `register(runtime)` to store the runtime, and `get()` to retrieve the
  *   currently registered runtime, or null if none has been registered yet.
  */
-export function createRuntimeRegistry<T extends TwitchSendRuntime>(): {
+export function createRuntimeRegistry<T>(): {
   register: (runtime: T) => void;
   get: () => T | null;
 } {

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -133,6 +133,7 @@ vi.mock('./db/streamdeckKeys', () => ({
 
 vi.mock('./db/lookupCache', () => ({
   createManagedLookupCache: vi.fn(),
+  DEFAULT_CACHE_TTL_MS: 300_000,
   DEFAULT_REFRESH_FAILURE_BACKOFF_MS: 5_000,
   DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS: 60_000,
 }));

--- a/src/db.ts
+++ b/src/db.ts
@@ -28,6 +28,19 @@ import {
 } from './db/guildCommandOverrides';
 
 /**
+ * Runs `operation`, then unconditionally invalidates the custom-command lookup cache.
+ * Shared by the facade wrappers below that always need a post-write invalidation —
+ * `users.ts`/`guildCommandOverrides.ts` are pure DB layers with no cache knowledge.
+ * @param operation - The DB write to perform.
+ * @returns The value returned by `operation`.
+ */
+async function withInvalidation<T>(operation: () => Promise<T>): Promise<T> {
+  const result = await operation();
+  invalidateCustomCommandLookupCache();
+  return result;
+}
+
+/**
  * Inserts or updates a guild's override for a catalog command and invalidates
  * the custom-command lookup cache, since overrides affect Discord command resolution.
  * @param guildId - BIGINT snowflake as a string.
@@ -41,8 +54,7 @@ export async function upsertOverride(
   commandId: number,
   override: { isDisabled: boolean; output: string | null },
 ): Promise<void> {
-  await upsertOverrideRecord(guildId, commandId, override);
-  invalidateCustomCommandLookupCache();
+  await withInvalidation(() => upsertOverrideRecord(guildId, commandId, override));
 }
 
 /**
@@ -53,8 +65,7 @@ export async function upsertOverride(
  * @returns Resolves once the deletion (and cache invalidation) completes.
  */
 export async function removeOverride(guildId: string, commandId: number): Promise<void> {
-  await removeOverrideRecord(guildId, commandId);
-  invalidateCustomCommandLookupCache();
+  await withInvalidation(() => removeOverrideRecord(guildId, commandId));
 }
 
 // ─── User / access-level ────────────────────────────────────────────────────
@@ -99,8 +110,7 @@ export async function upsertUser(
  * @returns Resolves once the update (and cache invalidation) completes.
  */
 export async function updateTwitchBotEnabled(discordId: string, enabled: boolean): Promise<void> {
-  await setTwitchBotEnabledRecord(discordId, enabled);
-  invalidateCustomCommandLookupCache();
+  await withInvalidation(() => setTwitchBotEnabledRecord(discordId, enabled));
 }
 
 /**
@@ -109,8 +119,7 @@ export async function updateTwitchBotEnabled(discordId: string, enabled: boolean
  * @returns Resolves once the deletion (and cache invalidation) completes.
  */
 export async function removeUser(discordId: string): Promise<void> {
-  await removeUserRecord(discordId);
-  invalidateCustomCommandLookupCache();
+  await withInvalidation(() => removeUserRecord(discordId));
 }
 
 // ─── Custom commands ────────────────────────────────────────────────────────

--- a/src/db/commandConflicts.ts
+++ b/src/db/commandConflicts.ts
@@ -16,6 +16,21 @@ import { fromBit } from './utils';
 // ─── Conflict assertions ──────────────────────────────────────────────────────
 
 /**
+ * Throws a {@link CommandConflictError} for `triggerString` if `checkFn` reports a conflict.
+ * Factors out the repeated "run a conflict check, throw if true" shape shared by
+ * {@link assertMultiTwitchTriggerAvailable}, {@link assertNoSingleTwitchAssignmentOverlap},
+ * and {@link assertNoTwitchChannelTriggerConflict}.
+ * @param triggerString Trigger string to include in the thrown error.
+ * @param checkFn Callback that resolves true if a conflicting command exists.
+ * @throws {CommandConflictError} If `checkFn` resolves true.
+ */
+async function assertConflictFree(triggerString: string, checkFn: () => Promise<boolean>): Promise<void> {
+  if (await checkFn()) {
+    throw new CommandConflictError([triggerString]);
+  }
+}
+
+/**
  * Throws if a Discord-enabled custom command already uses `triggerString`.
  * @param triggerString Trigger string to check for conflicts.
  * @param executor Pool or transaction connection to query with.
@@ -100,9 +115,7 @@ export async function assertMultiTwitchTriggerAvailable(
   triggerString: string,
   excludeCommandId?: number,
 ): Promise<void> {
-  if (await hasMultiTwitchTriggerConflict(executor, triggerString, excludeCommandId)) {
-    throw new CommandConflictError([triggerString]);
-  }
+  await assertConflictFree(triggerString, () => hasMultiTwitchTriggerConflict(executor, triggerString, excludeCommandId));
 }
 
 /**
@@ -158,9 +171,7 @@ export async function assertNoSingleTwitchAssignmentOverlap(
   commandId: number,
   triggerString: string,
 ): Promise<void> {
-  if (await hasSingleTwitchAssignmentOverlap(executor, commandId, triggerString)) {
-    throw new CommandConflictError([triggerString]);
-  }
+  await assertConflictFree(triggerString, () => hasSingleTwitchAssignmentOverlap(executor, commandId, triggerString));
 }
 
 /**
@@ -263,9 +274,7 @@ export async function assertNoTwitchChannelTriggerConflict(
   triggerString: string,
   normalizedTwitchName: string,
 ): Promise<void> {
-  if (await hasTwitchChannelTriggerConflict(executor, commandId, triggerString, normalizedTwitchName)) {
-    throw new CommandConflictError([triggerString]);
-  }
+  await assertConflictFree(triggerString, () => hasTwitchChannelTriggerConflict(executor, commandId, triggerString, normalizedTwitchName));
 }
 
 /**

--- a/src/db/commandLocks.test.ts
+++ b/src/db/commandLocks.test.ts
@@ -18,7 +18,7 @@ vi.mock('./commandStringUtils', () => ({
 }));
 
 import { getPool } from './pool';
-import { isDeadlockError, getCommandWriteLockName, acquireNamedLock, isAnyCommandTakenAcrossTables, runSerializedCommandWrite, MAX_DEADLOCK_RETRIES } from './commandLocks';
+import { isDeadlockError, getCommandWriteLockName, acquireNamedLock, isAnyCommandTakenAcrossTables, runSerializedCommandWrite, commandExists, MAX_DEADLOCK_RETRIES } from './commandLocks';
 import { CommandConflictError } from './commandStringUtils';
 
 describe('isDeadlockError', () => {
@@ -201,6 +201,43 @@ describe('isAnyCommandTakenAcrossTables', () => {
     const customCmdCall = pool.execute.mock.calls.find((args) => (args[0] as string).includes('custom_command'));
     expect(customCmdCall).toBeDefined();
     expect(customCmdCall![1]).toContain(7);
+  });
+});
+
+// ─── commandExists ────────────────────────────────────────────────────────────
+
+describe('commandExists', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns true when a matching custom_command row exists', async () => {
+    const pool = { execute: vi.fn().mockResolvedValue([[{ '1': 1 }], []]) };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    expect(await commandExists(1)).toBe(true);
+  });
+
+  it('returns false when no matching row exists', async () => {
+    const pool = { execute: vi.fn().mockResolvedValue([[], []]) };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    expect(await commandExists(999)).toBe(false);
+  });
+
+  it('queries custom_command by command_id', async () => {
+    const pool = { execute: vi.fn().mockResolvedValue([[], []]) };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await commandExists(42);
+    const [sql, params] = pool.execute.mock.calls[0];
+    expect(sql).toContain('custom_command');
+    expect(sql).toContain('command_id');
+    expect(params).toEqual([42]);
+  });
+
+  it('queries against a given executor instead of the default pool', async () => {
+    const conn = { execute: vi.fn().mockResolvedValue([[{ '1': 1 }], []]) };
+    const result = await commandExists(1, conn as any);
+    expect(result).toBe(true);
+    expect(getPool).not.toHaveBeenCalled();
   });
 });
 

--- a/src/db/commandLocks.ts
+++ b/src/db/commandLocks.ts
@@ -10,6 +10,7 @@ import {
   normalizeCommandInputs,
   buildInClausePlaceholders,
 } from './commandStringUtils';
+import { rowExists } from './utils';
 
 export type { SqlExecutor } from './commandStringUtils';
 export {
@@ -170,11 +171,7 @@ export async function isCustomCommandTriggerTaken(triggerString: string, exclude
 // ─── Serialized write ─────────────────────────────────────────────────────────
 
 export async function commandExists(id: number, executor: SqlExecutor = getPool()): Promise<boolean> {
-  const [rows] = await executor.execute<mysql.RowDataPacket[]>(
-    'SELECT 1 FROM custom_command WHERE command_id = ? LIMIT 1',
-    [id],
-  );
-  return rows.length > 0;
+  return rowExists(executor, 'custom_command', 'command_id', id);
 }
 
 export async function runSerializedCommandWrite<T>(

--- a/src/db/companionOAuthCodes.ts
+++ b/src/db/companionOAuthCodes.ts
@@ -27,17 +27,18 @@ export async function createCode(discordId: string): Promise<string> {
 }
 
 /**
- * Atomically consumes a companion OAuth code: marks it used and returns the
- * Discord ID it was issued for, but only if it exists, hasn't expired, and
- * hasn't already been consumed. The UPDATE's `used_at IS NULL AND expires_at >
- * NOW()` guard makes this safe against a code being redeemed twice concurrently.
+ * Marks a companion OAuth code hash used (if it exists, hasn't expired, and hasn't
+ * already been consumed) and returns the Discord ID it was issued for. The UPDATE's
+ * `used_at IS NULL AND expires_at > NOW()` guard makes this safe against the same code
+ * being redeemed twice concurrently. Shared by `consumeCode` (standalone) and
+ * `exchangeCodeForToken` (within a transaction), so both run identical mark-used-then-lookup SQL.
  *
- * @param code - Plaintext code presented by the companion app.
+ * @param executor - Pool or transaction connection to run the query on.
+ * @param hash - SHA-256 hash of the plaintext code.
  * @returns The Discord ID the code was issued for, or null if invalid/expired/already used.
  */
-export async function consumeCode(code: string): Promise<string | null> {
-  const hash = createHash('sha256').update(code).digest('hex');
-  const [result] = await getPool().execute<mysql.ResultSetHeader>(
+async function consumeCodeOnConnection(executor: mysql.Pool | mysql.PoolConnection, hash: string): Promise<string | null> {
+  const [result] = await executor.execute<mysql.ResultSetHeader>(
     `UPDATE companion_oauth_codes
      SET used_at = NOW()
      WHERE code_hash = ? AND used_at IS NULL AND expires_at > NOW()`,
@@ -45,11 +46,24 @@ export async function consumeCode(code: string): Promise<string | null> {
   );
   if (result.affectedRows === 0) return null;
 
-  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+  const [rows] = await executor.execute<mysql.RowDataPacket[]>(
     `SELECT discord_id FROM companion_oauth_codes WHERE code_hash = ?`,
     [hash],
   );
   return rows.length === 0 ? null : String(rows[0].discord_id);
+}
+
+/**
+ * Atomically consumes a companion OAuth code: marks it used and returns the
+ * Discord ID it was issued for, but only if it exists, hasn't expired, and
+ * hasn't already been consumed.
+ *
+ * @param code - Plaintext code presented by the companion app.
+ * @returns The Discord ID the code was issued for, or null if invalid/expired/already used.
+ */
+export async function consumeCode(code: string): Promise<string | null> {
+  const hash = createHash('sha256').update(code).digest('hex');
+  return consumeCodeOnConnection(getPool(), hash);
 }
 
 /**
@@ -67,25 +81,13 @@ export async function exchangeCodeForToken(code: string): Promise<string | null>
   class CodeNotFound extends Error {}
   try {
     return await withTransaction(async (conn) => {
-      const [result] = await conn.execute<mysql.ResultSetHeader>(
-        `UPDATE companion_oauth_codes
-         SET used_at = NOW()
-         WHERE code_hash = ? AND used_at IS NULL AND expires_at > NOW()`,
-        [hash],
-      );
-      if (result.affectedRows === 0) {
-        throw new CodeNotFound();
-      }
-
-      const [rows] = await conn.execute<mysql.RowDataPacket[]>(
-        `SELECT discord_id FROM companion_oauth_codes WHERE code_hash = ?`,
-        [hash],
-      );
-      if (rows.length === 0) {
-        throw new CodeNotFound();
-      }
-
-      return issueTokenOnConnection(conn, String(rows[0].discord_id));
+      const discordId = await consumeCodeOnConnection(conn, hash);
+      // Throwing (rather than returning null) rolls back the "used" mark applied by
+      // consumeCodeOnConnection above, so an invalid/expired/already-used code — or the
+      // edge case where the row vanishes between the UPDATE and the follow-up SELECT —
+      // doesn't permanently burn the code with no token to show for it.
+      if (!discordId) throw new CodeNotFound();
+      return issueTokenOnConnection(conn, discordId);
     });
   } catch (err) {
     if (err instanceof CodeNotFound) return null;

--- a/src/db/companionTokens.ts
+++ b/src/db/companionTokens.ts
@@ -1,6 +1,7 @@
-import { randomBytes, createHash, timingSafeEqual } from 'crypto';
+import { randomBytes, createHash } from 'crypto';
 import mysql from 'mysql2/promise';
 import { getPool } from './pool';
+import { hashesMatch } from './utils';
 
 export interface CompanionTokenStatus {
   hasToken: boolean;
@@ -64,10 +65,7 @@ export async function findDiscordIdByTokenHash(hash: string): Promise<string | n
     `SELECT discord_id, key_hash FROM companion_app_tokens WHERE key_hash = ? AND revoked_at IS NULL`,
     [hash],
   );
-  if (rows.length === 0) return null;
-  const stored = Buffer.from(String(rows[0].key_hash), 'hex');
-  const incoming = Buffer.from(hash, 'hex');
-  if (stored.length !== incoming.length || !timingSafeEqual(stored, incoming)) return null;
+  if (rows.length === 0 || !hashesMatch(String(rows[0].key_hash), hash)) return null;
   return String(rows[0].discord_id);
 }
 

--- a/src/db/counterCache.test.ts
+++ b/src/db/counterCache.test.ts
@@ -5,6 +5,9 @@ vi.mock('./lookupCache', () => ({
     getCache: () => loadCache(),
     invalidate: vi.fn(),
   })),
+  DEFAULT_CACHE_TTL_MS: 300_000,
+  DEFAULT_REFRESH_FAILURE_BACKOFF_MS: 5_000,
+  DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS: 60_000,
 }));
 vi.mock('./counters', () => ({
   getAllCounters: vi.fn(),

--- a/src/db/counterCache.ts
+++ b/src/db/counterCache.ts
@@ -1,5 +1,11 @@
 import { createLogger } from '../shared/logger';
-import { createManagedLookupCache, type RefreshingLookupCache } from './lookupCache';
+import {
+  createManagedLookupCache,
+  type RefreshingLookupCache,
+  DEFAULT_CACHE_TTL_MS,
+  DEFAULT_REFRESH_FAILURE_BACKOFF_MS,
+  DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS,
+} from './lookupCache';
 import { normalizeCommandList, normalizeCommand } from './commandStringUtils';
 import { isAnyCommandTakenAcrossTables } from './commandLocks';
 // counters imports invalidateCounterLookupCache from this module;
@@ -70,9 +76,9 @@ function buildCounterLookupCache(counters: DbCounter[]): CounterLookupCache {
 
 const counterLookupCacheState = createManagedLookupCache<CounterLookupCache>({
   cacheName: 'counter cache',
-  ttlMs: 300_000,
-  refreshFailureBackoffMs: 5_000,
-  refreshFailureMaxBackoffMs: 60_000,
+  ttlMs: DEFAULT_CACHE_TTL_MS,
+  refreshFailureBackoffMs: DEFAULT_REFRESH_FAILURE_BACKOFF_MS,
+  refreshFailureMaxBackoffMs: DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS,
   createEmptyCache: createEmptyCounterLookupCache,
   loadCache: async () => buildCounterLookupCache(await getAllCounters()),
 });

--- a/src/db/counters.test.ts
+++ b/src/db/counters.test.ts
@@ -47,6 +47,14 @@ vi.mock('./reservedCommands', () => ({
 }));
 vi.mock('./utils', () => ({
   fromBit: vi.fn((v: unknown) => (Buffer.isBuffer(v) ? v[0] === 1 : v == 1)),
+  rowExists: vi.fn(async (executor: any, table: string, column: string, value: unknown) => {
+    const [rows] = await executor.execute(`SELECT 1 FROM ${table} WHERE ${column} = ? LIMIT 1`, [value]);
+    return rows.length > 0;
+  }),
+  affectedOrExists: vi.fn(async (affectedRows: number, existsCheck: () => Promise<boolean>) => {
+    if (affectedRows > 0) return true;
+    return existsCheck();
+  }),
 }));
 vi.mock('./counterCache', () => ({
   invalidateCounterLookupCache: vi.fn(),

--- a/src/db/counters.ts
+++ b/src/db/counters.ts
@@ -3,9 +3,15 @@ import { getPool, withTransaction } from './pool';
 import { requireTrimmedString, normalizeCommand, type SqlExecutor } from './commandStringUtils';
 import { runSerializedCommandWrite } from './commandLocks';
 import { assertNotReservedCommand } from './reservedCommands';
-import { fromBit } from './utils';
+import { fromBit, rowExists, affectedOrExists } from './utils';
 import { invalidateCounterLookupCache } from './counterCache';
-import { createManagedLookupCache, type RefreshingLookupCache } from './lookupCache';
+import {
+  createManagedLookupCache,
+  type RefreshingLookupCache,
+  DEFAULT_CACHE_TTL_MS,
+  DEFAULT_REFRESH_FAILURE_BACKOFF_MS,
+  DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS,
+} from './lookupCache';
 
 // ─── Archive column allowlist ─────────────────────────────────────────────────
 // MySQL does not support parameterised column names. Rather than building the
@@ -138,9 +144,9 @@ interface ArchiveColumnsCache extends RefreshingLookupCache {
 
 const archiveColumnsCacheState = createManagedLookupCache<ArchiveColumnsCache>({
   cacheName: 'counter archive columns cache',
-  ttlMs: 300_000,
-  refreshFailureBackoffMs: 5_000,
-  refreshFailureMaxBackoffMs: 60_000,
+  ttlMs: DEFAULT_CACHE_TTL_MS,
+  refreshFailureBackoffMs: DEFAULT_REFRESH_FAILURE_BACKOFF_MS,
+  refreshFailureMaxBackoffMs: DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS,
   createEmptyCache: () => ({ loadedAt: 0, columns: [] }),
   loadCache: async () => {
     const [rows] = await getPool().query<mysql.RowDataPacket[]>(
@@ -274,11 +280,7 @@ export async function addCounter(
  * @returns True if the counter exists.
  */
 async function counterExists(id: number, executor: SqlExecutor = getPool()): Promise<boolean> {
-  const [rows] = await executor.execute<mysql.RowDataPacket[]>(
-    'SELECT 1 FROM counter WHERE id = ? LIMIT 1',
-    [id],
-  );
-  return rows.length > 0;
+  return rowExists(executor, 'counter', 'id', id);
 }
 
 /**
@@ -345,7 +347,7 @@ export async function updateCounter(input: UpdateCounterInput): Promise<void> {
         [fields.triggerCommand, fields.checkCommand, fields.message, fields.incrementMessage, resetYearly ? 1 : 0, id],
       );
 
-      if (result.affectedRows === 0 && !(await counterExists(id, connection))) {
+      if (!(await affectedOrExists(result.affectedRows, () => counterExists(id, connection)))) {
         throw new CounterNotFoundError(id);
       }
     },
@@ -389,8 +391,10 @@ export async function resetCounterCurrentValue(id: number): Promise<void> {
     [id],
   );
 
+  if (!(await affectedOrExists(result.affectedRows, () => counterExists(id)))) {
+    throw new CounterNotFoundError(id);
+  }
   if (result.affectedRows === 0) {
-    if (!(await counterExists(id))) throw new CounterNotFoundError(id);
     // Counter exists but value was already 0 — nothing changed, skip invalidation.
     return;
   }

--- a/src/db/customCommandCache.test.ts
+++ b/src/db/customCommandCache.test.ts
@@ -9,6 +9,9 @@ vi.mock('./lookupCache', () => ({
     getCache: () => loadCache(),
     invalidate: vi.fn(),
   })),
+  DEFAULT_CACHE_TTL_MS: 300_000,
+  DEFAULT_REFRESH_FAILURE_BACKOFF_MS: 5_000,
+  DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS: 60_000,
 }));
 
 vi.mock('./customCommands', () => ({

--- a/src/db/customCommandCache.ts
+++ b/src/db/customCommandCache.ts
@@ -1,6 +1,12 @@
 import { createLogger } from '../shared/logger';
 import { normalizeTwitchChannelName } from '../twitch/twitchChannelName';
-import { createManagedLookupCache, type RefreshingLookupCache } from './lookupCache';
+import {
+  createManagedLookupCache,
+  type RefreshingLookupCache,
+  DEFAULT_CACHE_TTL_MS,
+  DEFAULT_REFRESH_FAILURE_BACKOFF_MS,
+  DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS,
+} from './lookupCache';
 import { normalizeCommand } from './commandStringUtils';
 import { getTwitchEnabledChannels } from './users';
 // customCommands imports invalidateCustomCommandLookupCache from this module;
@@ -335,15 +341,11 @@ function buildCustomCommandLookupCache(
 
 // ─── Cache state ──────────────────────────────────────────────────────────────
 
-const CACHE_TTL_MS = 300_000;
-const CACHE_REFRESH_FAILURE_BACKOFF_MS = 5_000;
-const CACHE_REFRESH_FAILURE_MAX_BACKOFF_MS = 60_000;
-
 const customCommandLookupCacheState = createManagedLookupCache<CustomCommandLookupCache>({
   cacheName: 'custom command cache',
-  ttlMs: CACHE_TTL_MS,
-  refreshFailureBackoffMs: CACHE_REFRESH_FAILURE_BACKOFF_MS,
-  refreshFailureMaxBackoffMs: CACHE_REFRESH_FAILURE_MAX_BACKOFF_MS,
+  ttlMs: DEFAULT_CACHE_TTL_MS,
+  refreshFailureBackoffMs: DEFAULT_REFRESH_FAILURE_BACKOFF_MS,
+  refreshFailureMaxBackoffMs: DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS,
   createEmptyCache: createEmptyCustomCommandLookupCache,
   loadCache: async () => {
     const [commands, activeTwitchChannels, overrides] = await Promise.all([

--- a/src/db/lookupCache.ts
+++ b/src/db/lookupCache.ts
@@ -2,6 +2,9 @@ import { createLogger } from '../shared/logger';
 
 const log = createLogger('DB');
 
+/** Default freshness window (ms) before a cache triggers a background refresh. */
+export const DEFAULT_CACHE_TTL_MS = 300_000;
+
 /** Default backoff (ms) before retrying after a failed background refresh. */
 export const DEFAULT_REFRESH_FAILURE_BACKOFF_MS = 5_000;
 

--- a/src/db/sfx.ts
+++ b/src/db/sfx.ts
@@ -1,6 +1,6 @@
 import mysql from 'mysql2/promise';
 import { getPool, withTransaction } from './pool';
-import { fromBit, affectedOrExists } from './utils';
+import { fromBit, affectedOrExists, rowExists } from './utils';
 // sfxCache imports getAllSfxTriggers from this module; this module imports
 // invalidateSfxLookupCache from sfxCache. Both calls happen inside function
 // bodies, so CommonJS resolves the cycle correctly.
@@ -137,13 +137,7 @@ export async function renameCategory(id: number, name: string): Promise<boolean>
     `UPDATE sfxcategory SET name = ? WHERE id = ?`,
     [name, id],
   );
-  return affectedOrExists(result.affectedRows, async () => {
-    const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-      `SELECT id FROM sfxcategory WHERE id = ?`,
-      [id],
-    );
-    return rows.length > 0;
-  });
+  return affectedOrExists(result.affectedRows, () => rowExists(getPool(), 'sfxcategory', 'id', id));
 }
 
 /**
@@ -209,13 +203,7 @@ export async function updateSfxTrigger(
      WHERE id = ?`,
     [command, categoryId, description, hidden ? 1 : 0, id.toString()],
   );
-  const updated = await affectedOrExists(result.affectedRows, async () => {
-    const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-      `SELECT id FROM sfxtrigger WHERE id = ?`,
-      [id.toString()],
-    );
-    return rows.length > 0;
-  });
+  const updated = await affectedOrExists(result.affectedRows, () => rowExists(getPool(), 'sfxtrigger', 'id', id.toString()));
   if (updated) invalidateSfxLookupCache();
   return updated;
 }
@@ -299,10 +287,7 @@ export async function updateSfxFile(id: number, weight: number, hidden: boolean)
     `UPDATE sfx SET weight = ?, hidden = ? WHERE id = ?`,
     [weight, hidden ? 1 : 0, id],
   );
-  const updated = await affectedOrExists(result.affectedRows, async () => {
-    const [rows] = await getPool().execute<mysql.RowDataPacket[]>(`SELECT id FROM sfx WHERE id = ?`, [id]);
-    return rows.length > 0;
-  });
+  const updated = await affectedOrExists(result.affectedRows, () => rowExists(getPool(), 'sfx', 'id', id));
   if (updated) invalidateSfxLookupCache();
   return updated;
 }

--- a/src/db/sfxCache.test.ts
+++ b/src/db/sfxCache.test.ts
@@ -5,6 +5,9 @@ vi.mock('./lookupCache', () => ({
     getCache: () => loadCache(),
     invalidate: vi.fn(),
   })),
+  DEFAULT_CACHE_TTL_MS: 300_000,
+  DEFAULT_REFRESH_FAILURE_BACKOFF_MS: 5_000,
+  DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS: 60_000,
 }));
 vi.mock('./sfx', () => ({
   getAllSfxTriggers: vi.fn(),

--- a/src/db/sfxCache.ts
+++ b/src/db/sfxCache.ts
@@ -1,5 +1,11 @@
 import { createLogger } from '../shared/logger';
-import { createManagedLookupCache, type RefreshingLookupCache } from './lookupCache';
+import {
+  createManagedLookupCache,
+  type RefreshingLookupCache,
+  DEFAULT_CACHE_TTL_MS,
+  DEFAULT_REFRESH_FAILURE_BACKOFF_MS,
+  DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS,
+} from './lookupCache';
 import { normalizeCommand } from './commandStringUtils';
 import { getAllSfxTriggers, type SfxTrigger, type SfxFile } from './sfx';
 
@@ -82,15 +88,11 @@ function buildSfxLookupCache(triggers: Awaited<ReturnType<typeof getAllSfxTrigge
 
 // ─── Cache state ──────────────────────────────────────────────────────────────
 
-const CACHE_TTL_MS = 300_000;
-const CACHE_REFRESH_FAILURE_BACKOFF_MS = 5_000;
-const CACHE_REFRESH_FAILURE_MAX_BACKOFF_MS = 60_000;
-
 const sfxLookupCacheState = createManagedLookupCache<SfxLookupCache>({
   cacheName: 'sfx cache',
-  ttlMs: CACHE_TTL_MS,
-  refreshFailureBackoffMs: CACHE_REFRESH_FAILURE_BACKOFF_MS,
-  refreshFailureMaxBackoffMs: CACHE_REFRESH_FAILURE_MAX_BACKOFF_MS,
+  ttlMs: DEFAULT_CACHE_TTL_MS,
+  refreshFailureBackoffMs: DEFAULT_REFRESH_FAILURE_BACKOFF_MS,
+  refreshFailureMaxBackoffMs: DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS,
   createEmptyCache: createEmptySfxLookupCache,
   loadCache: async () => buildSfxLookupCache(await getAllSfxTriggers()),
 });

--- a/src/db/streamdeckKeys.ts
+++ b/src/db/streamdeckKeys.ts
@@ -1,7 +1,8 @@
-import { randomBytes, createHash, timingSafeEqual } from 'crypto';
+import { randomBytes, createHash } from 'crypto';
 import mysql from 'mysql2/promise';
 import { getPool, withTransaction } from './pool';
 import { AccessLevel } from './users';
+import { hashesMatch } from './utils';
 
 /** Per-guild approval state for a Streamdeck API key. */
 export interface StreamdeckKeyGuildStatusRow {
@@ -167,10 +168,7 @@ export async function findKeyByHash(hash: string): Promise<{ discordId: string }
     'SELECT discord_id, key_hash FROM streamdeck_api_keys WHERE key_hash = ?',
     [hash],
   );
-  if (rows.length === 0) return null;
-  const stored = Buffer.from(String(rows[0].key_hash), 'hex');
-  const incoming = Buffer.from(hash, 'hex');
-  if (stored.length !== incoming.length || !timingSafeEqual(stored, incoming)) return null;
+  if (rows.length === 0 || !hashesMatch(String(rows[0].key_hash), hash)) return null;
   return { discordId: String(rows[0].discord_id) };
 }
 

--- a/src/db/utils.test.ts
+++ b/src/db/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { fromBit, affectedOrExists } from './utils';
+import { fromBit, affectedOrExists, rowExists, hashesMatch } from './utils';
 
 describe('fromBit', () => {
   it('returns true for Buffer with first byte 1', () => {
@@ -50,5 +50,57 @@ describe('affectedOrExists', () => {
     const existsCheck = vi.fn().mockResolvedValue(false);
     const result = await affectedOrExists(0, existsCheck);
     expect(result).toBe(false);
+  });
+});
+
+describe('rowExists', () => {
+  it('returns true when the query returns a row', async () => {
+    const executor = { execute: vi.fn().mockResolvedValue([[{ '1': 1 }], []]) };
+    const result = await rowExists(executor as any, 'counter', 'id', 5);
+    expect(result).toBe(true);
+  });
+
+  it('returns false when the query returns no rows', async () => {
+    const executor = { execute: vi.fn().mockResolvedValue([[], []]) };
+    const result = await rowExists(executor as any, 'counter', 'id', 5);
+    expect(result).toBe(false);
+  });
+
+  it('builds SQL from the given table/column and passes value as the only param', async () => {
+    const executor = { execute: vi.fn().mockResolvedValue([[], []]) };
+    await rowExists(executor as any, 'custom_command', 'command_id', 42);
+    const [sql, params] = executor.execute.mock.calls[0];
+    expect(sql).toBe('SELECT 1 FROM custom_command WHERE command_id = ? LIMIT 1');
+    expect(params).toEqual([42]);
+  });
+
+  it('accepts a string value (e.g. a BIGINT id passed as a string)', async () => {
+    const executor = { execute: vi.fn().mockResolvedValue([[{ '1': 1 }], []]) };
+    const result = await rowExists(executor as any, 'sfxtrigger', 'id', '123456789012345');
+    expect(result).toBe(true);
+    expect(executor.execute.mock.calls[0][1]).toEqual(['123456789012345']);
+  });
+});
+
+describe('hashesMatch', () => {
+  it('returns true for identical hex hashes', () => {
+    const hash = 'a'.repeat(64);
+    expect(hashesMatch(hash, hash)).toBe(true);
+  });
+
+  it('returns false for hashes that differ', () => {
+    expect(hashesMatch('a'.repeat(64), 'b'.repeat(64))).toBe(false);
+  });
+
+  it('returns true when only hex casing differs — both decode to the same bytes, so a row matched loosely by a case-insensitive column collation still validates correctly', () => {
+    expect(hashesMatch('ABCDEF'.repeat(4), 'abcdef'.repeat(4))).toBe(true);
+  });
+
+  it('returns false for genuinely different bytes even if hex-decodable and same length', () => {
+    expect(hashesMatch('aa'.repeat(32), 'ab'.repeat(32))).toBe(false);
+  });
+
+  it('returns false for hashes of different lengths without throwing', () => {
+    expect(hashesMatch('ab', 'abcd')).toBe(false);
   });
 });

--- a/src/db/utils.ts
+++ b/src/db/utils.ts
@@ -30,11 +30,14 @@ export async function rowExists(
 }
 
 /**
- * Timing-safe-compares a stored hex-encoded hash against an incoming one, guarding against
- * a case-insensitive column collation matching hashes that differ only by case.
+ * Timing-safe-compares a stored hex-encoded hash against an incoming one by decoding both to
+ * bytes first. Byte-decoding (rather than a plain string compare) means a lookup row matched
+ * loosely by the hash column's case-insensitive collation is still validated correctly — the
+ * hex casing doesn't affect the underlying bytes — while anything that only matched due to
+ * some other collation quirk, but decodes to genuinely different bytes, is still rejected.
  * @param storedHex Hex-encoded hash value read from the database.
  * @param incomingHex Hex-encoded hash computed from the caller-supplied secret.
- * @returns True if the two hashes match exactly, including case.
+ * @returns True if the two hashes decode to the same bytes.
  */
 export function hashesMatch(storedHex: string, incomingHex: string): boolean {
   const stored = Buffer.from(storedHex, 'hex');

--- a/src/db/utils.ts
+++ b/src/db/utils.ts
@@ -1,7 +1,45 @@
+import mysql from 'mysql2/promise';
+import { timingSafeEqual } from 'node:crypto';
+import type { SqlExecutor } from './commandStringUtils';
+
 /** Converts a MySQL BIT(1) column value (Buffer, number, or boolean) to a boolean. */
 export function fromBit(value: unknown): boolean {
   if (Buffer.isBuffer(value)) return value[0] === 1;
   return value == 1;
+}
+
+/**
+ * Checks whether a row exists in `table` where `column` equals `value`.
+ * @param executor Pool or transaction connection to query with.
+ * @param table Table name — must be a fixed, trusted identifier, never derived from user input.
+ * @param column Column name — same trust requirement as `table`.
+ * @param value Value to match against `column`.
+ * @returns True if a matching row exists.
+ */
+export async function rowExists(
+  executor: SqlExecutor,
+  table: string,
+  column: string,
+  value: string | number,
+): Promise<boolean> {
+  const [rows] = await executor.execute<mysql.RowDataPacket[]>(
+    `SELECT 1 FROM ${table} WHERE ${column} = ? LIMIT 1`,
+    [value],
+  );
+  return rows.length > 0;
+}
+
+/**
+ * Timing-safe-compares a stored hex-encoded hash against an incoming one, guarding against
+ * a case-insensitive column collation matching hashes that differ only by case.
+ * @param storedHex Hex-encoded hash value read from the database.
+ * @param incomingHex Hex-encoded hash computed from the caller-supplied secret.
+ * @returns True if the two hashes match exactly, including case.
+ */
+export function hashesMatch(storedHex: string, incomingHex: string): boolean {
+  const stored = Buffer.from(storedHex, 'hex');
+  const incoming = Buffer.from(incomingHex, 'hex');
+  return stored.length === incoming.length && timingSafeEqual(stored, incoming);
 }
 
 /**

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -1,6 +1,7 @@
 import { Client, GatewayIntentBits, Guild } from 'discord.js';
 import { DISCORD_TOKEN } from '../shared/config';
 import { handleCommand, forgetGuildCommandState } from '../commands/commandRouter';
+import { fireAndForget } from '../commands/commandUtils';
 import { executeCustomCommandForDiscord } from '../commands/customCommandHandler';
 import { executeCounterCommandForDiscord } from '../commands/counterHandler';
 import { setDiscordReady, clearVoiceStatus } from '../shared/statusStore';
@@ -124,17 +125,9 @@ export function startDiscordBot(): void {
     const displayName = message.member?.displayName ?? message.author.username;
     const guildId = message.guildId;
 
-    executeCustomCommandForDiscord(message, displayName, guildId).catch((err) =>
-      log.error('Custom command error:', err),
-    );
-
-    executeCounterCommandForDiscord(message, displayName).catch((err) =>
-      log.error('Counter command error:', err),
-    );
-
-    handleCommand(message.content, 'discord', guildId).catch((err) =>
-      log.error('Command handler error:', err),
-    );
+    fireAndForget(executeCustomCommandForDiscord(message, displayName, guildId), 'Custom command error', log);
+    fireAndForget(executeCounterCommandForDiscord(message, displayName), 'Counter command error', log);
+    fireAndForget(handleCommand(message.content, 'discord', guildId), 'Command handler error', log);
   });
 
   // Bootstrap: when the bot is added to a server for the first time, record the

--- a/src/twitch/eventsub/twitchApiEventSub.test.ts
+++ b/src/twitch/eventsub/twitchApiEventSub.test.ts
@@ -149,11 +149,16 @@ describe('exchangeCode', () => {
     expect(tokens).toEqual(body);
   });
 
-  it('throws on a non-200 response', async () => {
+  it('throws TwitchAuthError on a 400 response', async () => {
     vi.mocked(twitchFetch).mockResolvedValue(mockFetch(400, {}));
-    await expect(exchangeCode('bad-code', 'https://example.com/callback')).rejects.toThrow(
-      'exchangeCode failed: 400',
-    );
+    await expect(exchangeCode('bad-code', 'https://example.com/callback')).rejects.toThrow(TwitchAuthError);
+  });
+
+  it('throws a generic Error on a 500 response', async () => {
+    vi.mocked(twitchFetch).mockResolvedValue(mockFetch(500, {}));
+    const err = await exchangeCode('code123', 'https://example.com/callback').catch((e) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).not.toBeInstanceOf(TwitchAuthError);
   });
 });
 

--- a/src/twitch/eventsub/twitchApiEventSub.ts
+++ b/src/twitch/eventsub/twitchApiEventSub.ts
@@ -47,38 +47,38 @@ export interface OAuthTokens {
   expires_in?: number;
 }
 
-export async function exchangeCode(code: string, redirectUri: string): Promise<OAuthTokens> {
+/**
+ * POSTs a form-encoded request to Twitch's OAuth token endpoint and returns the parsed tokens.
+ * Shared by `exchangeCode` and `refreshUserToken`, which only differ in the grant-type-specific
+ * params they send — `client_id`/`client_secret` are added here for both.
+ * @param grantParams - Grant-type-specific form params (e.g. `code`/`redirect_uri`, or `refresh_token`).
+ * @param label - Human-readable label used in the thrown error message on failure.
+ * @returns The parsed OAuth tokens.
+ * @throws {TwitchAuthError} If Twitch returns 400 or 401 (invalid/expired code or refresh token).
+ * @throws If Twitch returns any other non-OK status.
+ */
+async function postTokenRequest(grantParams: Record<string, string>, label: string): Promise<OAuthTokens> {
   const body = new URLSearchParams({
     client_id: TWITCH_CLIENT_ID,
     client_secret: TWITCH_CLIENT_SECRET,
-    code,
-    grant_type: 'authorization_code',
-    redirect_uri: redirectUri,
+    ...grantParams,
   });
   const res = await twitchFetch('https://id.twitch.tv/oauth2/token', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: body.toString(),
   });
-  if (!res.ok) throw new Error(`[TwitchAPI] exchangeCode failed: ${res.status}`);
+  if (res.status === 400 || res.status === 401) throw new TwitchAuthError(`[TwitchAPI] ${label}: invalid/expired credentials (${res.status})`);
+  if (!res.ok) throw new Error(`[TwitchAPI] ${label} failed: ${res.status}`);
   return res.json() as Promise<OAuthTokens>;
 }
 
+export async function exchangeCode(code: string, redirectUri: string): Promise<OAuthTokens> {
+  return postTokenRequest({ code, grant_type: 'authorization_code', redirect_uri: redirectUri }, 'exchangeCode');
+}
+
 export async function refreshUserToken(refreshToken: string): Promise<OAuthTokens> {
-  const body = new URLSearchParams({
-    client_id: TWITCH_CLIENT_ID,
-    client_secret: TWITCH_CLIENT_SECRET,
-    grant_type: 'refresh_token',
-    refresh_token: refreshToken,
-  });
-  const res = await twitchFetch('https://id.twitch.tv/oauth2/token', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: body.toString(),
-  });
-  if (res.status === 400 || res.status === 401) throw new TwitchAuthError(`[TwitchAPI] refreshUserToken: invalid/expired credentials (${res.status})`);
-  if (!res.ok) throw new Error(`[TwitchAPI] refreshUserToken failed: ${res.status}`);
-  return res.json() as Promise<OAuthTokens>;
+  return postTokenRequest({ grant_type: 'refresh_token', refresh_token: refreshToken }, 'refreshUserToken');
 }
 
 /** Validates a user access token and returns the owning user's ID and login, or null if invalid. */

--- a/src/twitch/eventsub/twitchApiEventSub.ts
+++ b/src/twitch/eventsub/twitchApiEventSub.ts
@@ -73,10 +73,25 @@ async function postTokenRequest(grantParams: Record<string, string>, label: stri
   return res.json() as Promise<OAuthTokens>;
 }
 
+/**
+ * Exchanges an authorization code from Twitch's OAuth redirect for an access/refresh token pair.
+ * @param code - Authorization code received from Twitch's OAuth redirect.
+ * @param redirectUri - The exact redirect URI used in the authorization request (must match).
+ * @returns The issued OAuth tokens.
+ * @throws {TwitchAuthError} If Twitch returns 400 or 401 (invalid/expired code).
+ * @throws If Twitch returns any other non-OK status.
+ */
 export async function exchangeCode(code: string, redirectUri: string): Promise<OAuthTokens> {
   return postTokenRequest({ code, grant_type: 'authorization_code', redirect_uri: redirectUri }, 'exchangeCode');
 }
 
+/**
+ * Exchanges a stored refresh token for a fresh access/refresh token pair.
+ * @param refreshToken - The previously-issued refresh token.
+ * @returns The refreshed OAuth tokens.
+ * @throws {TwitchAuthError} If Twitch returns 400 or 401 (invalid/expired refresh token).
+ * @throws If Twitch returns any other non-OK status.
+ */
 export async function refreshUserToken(refreshToken: string): Promise<OAuthTokens> {
   return postTokenRequest({ grant_type: 'refresh_token', refresh_token: refreshToken }, 'refreshUserToken');
 }

--- a/src/twitch/eventsub/twitchEventSubHandler.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.ts
@@ -7,6 +7,7 @@ import { createLogger } from '../../shared/logger';
 import { triggerImmediateLiveCheck } from '../monitor/twitchMonitor';
 import { fillTemplate } from '../../shared/textTemplate';
 import { applyRedemptionPricing } from '../pricing/rewardPricingService';
+import { createRuntimeRegistry } from '../../commands/twitchRuntime';
 
 const log = createLogger('EventSubHandler');
 
@@ -27,11 +28,11 @@ interface EventSubOverlayRuntime {
   pushOverlayEvent: (login: string, videoPath: string) => void;
 }
 
-let _overlayRuntime: EventSubOverlayRuntime | null = null;
+const overlayRuntimeRegistry = createRuntimeRegistry<EventSubOverlayRuntime>();
 
 /** Register the overlay push function. Called from index.ts after startWebPanel(). */
 export function registerEventSubOverlayRuntime(runtime: EventSubOverlayRuntime): void {
-  _overlayRuntime = runtime;
+  overlayRuntimeRegistry.register(runtime);
 }
 
 // Runtime injection for the companion app push function — same rationale as
@@ -51,11 +52,11 @@ interface EventSubCompanionRuntime {
   pushCompanionEvent: (discordId: string, event: import('../../web/routes/companionEvents').CompanionEvent) => void;
 }
 
-let _companionRuntime: EventSubCompanionRuntime | null = null;
+const companionRuntimeRegistry = createRuntimeRegistry<EventSubCompanionRuntime>();
 
 /** Register the companion app push function. Called from index.ts before startWebPanel(). */
 export function registerEventSubCompanionRuntime(runtime: EventSubCompanionRuntime): void {
-  _companionRuntime = runtime;
+  companionRuntimeRegistry.register(runtime);
 }
 
 // Runtime injection for the Twitch chat send function — avoids a direct import
@@ -64,19 +65,18 @@ interface EventSubTwitchRuntime {
   send: (channel: string, message: string) => Promise<void>;
 }
 
-let _twitchRuntime: EventSubTwitchRuntime | null = null;
+const twitchRuntimeRegistry = createRuntimeRegistry<EventSubTwitchRuntime>();
 
 /**
  * Register the Twitch chat send function. Called from index.ts during initialisation,
  * before startTwitchBot(), so the runtime is in place before the first event arrives.
- * Stores the provided runtime in the module-level _twitchRuntime variable for later use.
  *
  * @param runtime - The {@link EventSubTwitchRuntime} to store; must supply a `send` function
  *   that delivers a chat message to the given channel.
  * @returns void
  */
 export function registerEventSubTwitchRuntime(runtime: EventSubTwitchRuntime): void {
-  _twitchRuntime = runtime;
+  twitchRuntimeRegistry.register(runtime);
 }
 
 export interface FollowEvent {
@@ -133,8 +133,8 @@ function tierName(tier: string): string {
 
 /**
  * Handle a channel.follow EventSub notification.
- * Sends a chat message to the broadcaster's channel using the injected `_twitchRuntime`.
- * No-ops when `config.follow_enabled` is false or `_twitchRuntime` has not been registered.
+ * Sends a chat message to the broadcaster's channel using the injected Twitch runtime.
+ * No-ops when `config.follow_enabled` is false or no Twitch runtime has been registered.
  *
  * @param login - Broadcaster login name (chat channel to send to).
  * @param event - Follow event payload from Twitch EventSub.
@@ -146,12 +146,12 @@ export async function handleFollow(login: string, event: FollowEvent, config: Ev
     username: event.user_login,
     display_name: event.user_name,
   });
-  await _twitchRuntime?.send(login, msg);
+  await twitchRuntimeRegistry.get()?.send(login, msg);
 }
 
 /**
  * Handle a channel.subscribe EventSub notification.
- * No-ops when `config.sub_enabled` is false, the subscription is a gift, or `_twitchRuntime` is absent.
+ * No-ops when `config.sub_enabled` is false, the subscription is a gift, or no Twitch runtime is registered.
  *
  * @param login - Broadcaster login name.
  * @param event - Subscribe event payload; gift subs are silently skipped (handled by handleGiftSub).
@@ -165,12 +165,12 @@ export async function handleSub(login: string, event: SubEvent, config: EventSub
     tier: event.tier,
     tier_name: tierName(event.tier),
   });
-  await _twitchRuntime?.send(login, msg);
+  await twitchRuntimeRegistry.get()?.send(login, msg);
 }
 
 /**
  * Handle a channel.subscription.message (resub) EventSub notification.
- * No-ops when `config.sub_enabled` is false or `_twitchRuntime` is absent.
+ * No-ops when `config.sub_enabled` is false or no Twitch runtime is registered.
  *
  * @param login - Broadcaster login name.
  * @param event - Resub event payload including cumulative and streak month counts.
@@ -186,13 +186,13 @@ export async function handleResub(login: string, event: ResubEvent, config: Even
     months: String(event.cumulative_months),
     streak: event.streak_months != null ? String(event.streak_months) : '0',
   });
-  await _twitchRuntime?.send(login, msg);
+  await twitchRuntimeRegistry.get()?.send(login, msg);
 }
 
 /**
  * Handle a channel.subscription.gift EventSub notification.
  * Anonymous gifters are reported as "anonymous" / "Anonymous".
- * No-ops when `config.sub_enabled` is false or `_twitchRuntime` is absent.
+ * No-ops when `config.sub_enabled` is false or no Twitch runtime is registered.
  *
  * @param login - Broadcaster login name.
  * @param event - Gift-sub event payload; `is_anonymous` controls gifter display name.
@@ -209,7 +209,7 @@ export async function handleGiftSub(login: string, event: GiftSubEvent, config: 
     tier: event.tier,
     tier_name: tierName(event.tier),
   });
-  await _twitchRuntime?.send(login, msg);
+  await twitchRuntimeRegistry.get()?.send(login, msg);
 }
 
 /**
@@ -221,7 +221,7 @@ export async function handleGiftSub(login: string, event: GiftSubEvent, config: 
  *    and sends the resulting shoutout, recording the match via `recordCommandTestEntry`
  *    for monitor-panel visibility. No-ops silently if the raiding channel can't be
  *    resolved on Twitch.
- * Both branches no-op when `_twitchRuntime` has not been registered.
+ * Both branches no-op when no Twitch runtime has been registered.
  *
  * @param login - Broadcaster login name (the raid target's channel).
  * @param event - Raid event payload including the raiding channel and viewer count.
@@ -234,13 +234,13 @@ export async function handleRaid(login: string, event: RaidEvent, config: EventS
       from_display: event.from_broadcaster_user_name,
       viewers: String(event.viewers),
     });
-    await _twitchRuntime?.send(login, msg);
+    await twitchRuntimeRegistry.get()?.send(login, msg);
   }
 
   if (config.raid_shoutout_enabled) {
     const shoutoutMsg = await buildShoutoutMessage(event.from_broadcaster_user_login);
     if (shoutoutMsg) {
-      await _twitchRuntime?.send(login, shoutoutMsg);
+      await twitchRuntimeRegistry.get()?.send(login, shoutoutMsg);
       recordCommandTestEntry({
         source: 'twitch',
         command: '!so (raid)',
@@ -258,7 +258,7 @@ export async function handleRaid(login: string, event: RaidEvent, config: EventS
  * is connected), fires off dynamic pricing for the redeemed reward (a no-op if the reward
  * doesn't have dynamic pricing enabled), then separately looks up videos configured for
  * the redeemed reward and triggers an overlay event if found. The overlay push still
- * no-ops when no videos are configured for the reward or `_overlayRuntime` is absent.
+ * no-ops when no videos are configured for the reward or no overlay runtime is registered.
  * The companion push is isolated in its own try/catch, and the pricing update is
  * intentionally not awaited (its errors are caught via `.catch` instead), so a failure or
  * network latency in either (e.g. a DB error, or a slow/failed Twitch price push) cannot
@@ -278,7 +278,7 @@ export async function handleRedemption(
   try {
     const streamer = await getStreamerById(streamerId);
     if (streamer) {
-      _companionRuntime?.pushCompanionEvent(streamer.discord_id, {
+      companionRuntimeRegistry.get()?.pushCompanionEvent(streamer.discord_id, {
         type: 'channel_points_redemption',
         rewardId: event.reward.id,
         rewardTitle: event.reward.title,
@@ -303,7 +303,7 @@ export async function handleRedemption(
 
   const filename = pickWeightedRandom(videos);
   const videoPath = `/overlay/videos/${streamerId}/${filename}`;
-  _overlayRuntime?.pushOverlayEvent(login, videoPath);
+  overlayRuntimeRegistry.get()?.pushOverlayEvent(login, videoPath);
   log.info(`Overlay triggered for ${login}: reward="${event.reward.title}" video=${filename}`);
 }
 

--- a/src/twitch/eventsub/twitchEventSubHandler.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.ts
@@ -30,7 +30,11 @@ interface EventSubOverlayRuntime {
 
 const overlayRuntimeRegistry = createRuntimeRegistry<EventSubOverlayRuntime>();
 
-/** Register the overlay push function. Called from index.ts after startWebPanel(). */
+/**
+ * Register the overlay push function. Called from index.ts after startWebPanel().
+ * @param runtime - The {@link EventSubOverlayRuntime} to store.
+ * @returns void
+ */
 export function registerEventSubOverlayRuntime(runtime: EventSubOverlayRuntime): void {
   overlayRuntimeRegistry.register(runtime);
 }
@@ -54,7 +58,11 @@ interface EventSubCompanionRuntime {
 
 const companionRuntimeRegistry = createRuntimeRegistry<EventSubCompanionRuntime>();
 
-/** Register the companion app push function. Called from index.ts before startWebPanel(). */
+/**
+ * Register the companion app push function. Called from index.ts before startWebPanel().
+ * @param runtime - The {@link EventSubCompanionRuntime} to store.
+ * @returns void
+ */
 export function registerEventSubCompanionRuntime(runtime: EventSubCompanionRuntime): void {
   companionRuntimeRegistry.register(runtime);
 }

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -82,7 +82,16 @@ async function resolveBroadcasterId(streamer: DbStreamerEventSub, config: EventS
 
 /** One gated group of EventSub subscriptions: created together whenever `enabled` passes. */
 interface SubscriptionGroup {
+  /**
+   * Returns true if this group's subscriptions should be created for the streamer.
+   * @param config - The streamer's event response configuration, or null if unset.
+   */
   enabled: (config: EventSubConfig | null) => boolean;
+  /**
+   * Builds this group's subscription specs.
+   * @param uid - The broadcaster's Twitch user ID.
+   * @returns The subscription specs to create for this group.
+   */
   specs: (uid: string) => SubSpec[];
 }
 

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -80,6 +80,53 @@ async function resolveBroadcasterId(streamer: DbStreamerEventSub, config: EventS
   }
 }
 
+/** One gated group of EventSub subscriptions: created together whenever `enabled` passes. */
+interface SubscriptionGroup {
+  enabled: (config: EventSubConfig | null) => boolean;
+  specs: (uid: string) => SubSpec[];
+}
+
+// Every group also requires a broadcaster token (WebSocket transport only works with a user
+// token, not an app token — see createSubscriptionsForStreamer's upfront `!token` check).
+const SUBSCRIPTION_GROUPS: SubscriptionGroup[] = [
+  {
+    enabled: (config) => Boolean(config?.follow_enabled),
+    specs: (uid) => [{ type: 'channel.follow', version: '2', condition: { broadcaster_user_id: uid, moderator_user_id: uid } }],
+  },
+  {
+    enabled: (config) => Boolean(config?.sub_enabled),
+    specs: (uid) => [
+      { type: 'channel.subscribe', version: '1', condition: { broadcaster_user_id: uid } },
+      { type: 'channel.subscription.message', version: '1', condition: { broadcaster_user_id: uid } },
+      { type: 'channel.subscription.gift', version: '1', condition: { broadcaster_user_id: uid } },
+    ],
+  },
+  {
+    // Subscribe when either the welcome message or the auto-shoutout toggle is on —
+    // handleRaid gates its own two behaviours independently, but the subscription itself
+    // must exist for either to fire.
+    enabled: (config) => Boolean(config?.raid_enabled || config?.raid_shoutout_enabled),
+    specs: (uid) => [{ type: 'channel.raid', version: '1', condition: { to_broadcaster_user_id: uid } }],
+  },
+  {
+    // Gated on config (not just token) to keep subscription and dispatch aligned —
+    // dispatchNotification early-exits without config.
+    enabled: (config) => Boolean(config),
+    specs: (uid) => [{ type: 'channel.channel_points_custom_reward_redemption.add', version: '1', condition: { broadcaster_user_id: uid } }],
+  },
+  {
+    // stream.online/offline and channel.update require no scope beyond a valid token, so
+    // subscribe whenever EventSub is connected at all — this drives an immediate live-check
+    // that supplements (not replaces) the 60s poller.
+    enabled: (config) => Boolean(config),
+    specs: (uid) => [
+      { type: 'stream.online', version: '1', condition: { broadcaster_user_id: uid } },
+      { type: 'stream.offline', version: '1', condition: { broadcaster_user_id: uid } },
+      { type: 'channel.update', version: '2', condition: { broadcaster_user_id: uid } },
+    ],
+  },
+];
+
 /** Creates all desired EventSub subscriptions for a single streamer and returns the desired-types set. */
 async function createSubscriptionsForStreamer(
   sid: string, uid: string, token: string | null, config: EventSubConfig | null, name: string,
@@ -91,52 +138,14 @@ async function createSubscriptionsForStreamer(
   }
 
   const desired = new Set<string>();
+  if (!token) return desired;
 
-  if (config?.follow_enabled && token) {
-    desired.add('channel.follow');
-    await subscribe(sid, { type: 'channel.follow', version: '2',
-      condition: { broadcaster_user_id: uid, moderator_user_id: uid } }, token, name);
-  }
-
-  if (config?.sub_enabled && token) {
-    desired.add('channel.subscribe');
-    desired.add('channel.subscription.message');
-    desired.add('channel.subscription.gift');
-    await subscribe(sid, { type: 'channel.subscribe', version: '1', condition: { broadcaster_user_id: uid } }, token, name);
-    await subscribe(sid, { type: 'channel.subscription.message', version: '1', condition: { broadcaster_user_id: uid } }, token, name);
-    await subscribe(sid, { type: 'channel.subscription.gift', version: '1', condition: { broadcaster_user_id: uid } }, token, name);
-  }
-
-  // WebSocket transport requires a user token — app tokens only work with webhook transport.
-  // Raids therefore also require the broadcaster's OAuth token. Subscribe when either the
-  // welcome message or the auto-shoutout toggle is on — handleRaid gates its own two
-  // behaviours independently, but the subscription itself must exist for either to fire.
-  if ((config?.raid_enabled || config?.raid_shoutout_enabled) && token) {
-    desired.add('channel.raid');
-    await subscribe(sid, { type: 'channel.raid', version: '1', condition: { to_broadcaster_user_id: uid } }, token, name);
-  }
-
-  // Subscribe to channel points redemptions when a broadcaster token and config are available.
-  // Gated on config to keep subscription and dispatch aligned (dispatchNotification early-exits without config).
-  if (config && token) {
-    desired.add('channel.channel_points_custom_reward_redemption.add');
-    await subscribe(sid, {
-      type: 'channel.channel_points_custom_reward_redemption.add',
-      version: '1',
-      condition: { broadcaster_user_id: uid },
-    }, token, name);
-  }
-
-  // stream.online/offline and channel.update require no scope beyond a valid token, so
-  // subscribe whenever EventSub is connected at all — this drives an immediate live-check
-  // that supplements (not replaces) the 60s poller.
-  if (config && token) {
-    desired.add('stream.online');
-    desired.add('stream.offline');
-    desired.add('channel.update');
-    await subscribe(sid, { type: 'stream.online', version: '1', condition: { broadcaster_user_id: uid } }, token, name);
-    await subscribe(sid, { type: 'stream.offline', version: '1', condition: { broadcaster_user_id: uid } }, token, name);
-    await subscribe(sid, { type: 'channel.update', version: '2', condition: { broadcaster_user_id: uid } }, token, name);
+  for (const group of SUBSCRIPTION_GROUPS) {
+    if (!group.enabled(config)) continue;
+    for (const spec of group.specs(uid)) {
+      desired.add(spec.type);
+      await subscribe(sid, spec, token, name);
+    }
   }
 
   return desired;

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -124,9 +124,10 @@ const SUBSCRIPTION_GROUPS: SubscriptionGroup[] = [
     specs: (uid) => [{ type: 'channel.channel_points_custom_reward_redemption.add', version: '1', condition: { broadcaster_user_id: uid } }],
   },
   {
-    // stream.online/offline and channel.update require no scope beyond a valid token, so
-    // subscribe whenever EventSub is connected at all — this drives an immediate live-check
-    // that supplements (not replaces) the 60s poller.
+    // stream.online/offline and channel.update require no scope beyond a valid token — but,
+    // like the redemption group above, still gated on config (not just token) to keep
+    // subscription and dispatch aligned, since dispatchNotification early-exits without
+    // config. This drives an immediate live-check that supplements (not replaces) the 60s poller.
     enabled: (config) => Boolean(config),
     specs: (uid) => [
       { type: 'stream.online', version: '1', condition: { broadcaster_user_id: uid } },

--- a/src/twitch/monitor/twitchMonitorAnnouncements.ts
+++ b/src/twitch/monitor/twitchMonitorAnnouncements.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '../../shared/logger';
-import { TextChannel } from 'discord.js';
+import { TextChannel, EmbedBuilder } from 'discord.js';
 
 const log = createLogger('TwitchMonitor');
 import { getDiscordClient } from '../../discord/discordBot';
@@ -58,6 +58,21 @@ export async function postAnnouncement(
 }
 
 /**
+ * Sends a fresh announcement message and records its location on `state`. Shared by
+ * `editAnnouncement`'s delete-and-repost and edit-fallback-repost branches.
+ * @param textChannel - Discord channel to post into.
+ * @param content - Rendered message content.
+ * @param embed - Rendered stream embed.
+ * @param state - Live state to update with the new message's id/channel.
+ * @returns Resolves once the message is sent and `state` is updated.
+ */
+async function repost(textChannel: TextChannel, content: string, embed: EmbedBuilder, state: LiveState): Promise<void> {
+  const msg = await textChannel.send({ content, embeds: [embed] });
+  state.messageId = msg.id;
+  state.channelId = msg.channelId;
+}
+
+/**
  * Updates an existing "now live" announcement to reflect a new game/title.
  * Delete+repost (when the group has `delete_old_posts` enabled) is reserved
  * for actual game changes (`templateKey === 'new_game_message'`) — title-only
@@ -99,20 +114,18 @@ export async function editAnnouncement(
     const textChannel = channel as TextChannel;
 
     if (group.delete_old_posts && templateKey === 'new_game_message') {
-      const msg = await textChannel.send({ content, embeds: [embed] });
+      const staleMessageId = state.messageId;
+      const staleChannelId = state.channelId;
+      await repost(textChannel, content, embed, state);
       try {
-        await tryDeleteDiscordMessage(state.channelId, state.messageId);
+        await tryDeleteDiscordMessage(staleChannelId, staleMessageId);
       } catch (err) {
         log.error(`Failed to delete old announcement for ${state.login}, continuing:`, err);
       }
-      state.messageId = msg.id;
-      state.channelId = msg.channelId;
     } else {
       const edited = await tryEditDiscordMessage(discordClient, state.channelId, state.messageId, { content, embeds: [embed] });
       if (!edited) {
-        const msg = await textChannel.send({ content, embeds: [embed] });
-        state.messageId = msg.id;
-        state.channelId = msg.channelId;
+        await repost(textChannel, content, embed, state);
       }
     }
 

--- a/src/twitch/pricing/rewardPricingService.ts
+++ b/src/twitch/pricing/rewardPricingService.ts
@@ -17,7 +17,11 @@ interface RewardPricingRuntime {
 }
 const runtimeRegistry = createRuntimeRegistry<RewardPricingRuntime>();
 
-/** Registers the live-pricing-update push hook. Call once from index.ts after startup. */
+/**
+ * Registers the live-pricing-update push hook. Call once from index.ts after startup.
+ * @param runtime - The {@link RewardPricingRuntime} to store.
+ * @returns void
+ */
 export function registerRewardPricingRuntime(runtime: RewardPricingRuntime): void {
   runtimeRegistry.register(runtime);
 }

--- a/src/twitch/pricing/rewardPricingService.ts
+++ b/src/twitch/pricing/rewardPricingService.ts
@@ -1,12 +1,13 @@
 import { createMutationQueue } from '../../shared/mutationQueue';
 import {
   getPricingForReward, recordPricingUpdate, recordPricingHistory, markPricingUnsupported, deletePricingConfig,
-  getPricingSettingsForStreamer, getStreamerById, type StreamerPricingSettings,
+  getPricingSettingsForStreamer, getStreamerById, type StreamerPricingSettings, type DbStreamerEventSub,
 } from '../../db';
 import { getValidToken } from '../eventsub/twitchApiEventSub';
 import { updateRewardCost, deleteCustomReward, TwitchRewardUnsupportedError, TwitchRewardAuthError } from '../twitchApi';
 import { computePrice, decayDemand, applyRedemption, computeRedemptionIncrement } from './rewardPricingMath';
 import { createLogger } from '../../shared/logger';
+import { createRuntimeRegistry } from '../../commands/twitchRuntime';
 
 const log = createLogger('RewardPricing');
 
@@ -14,11 +15,11 @@ const log = createLogger('RewardPricing');
 interface RewardPricingRuntime {
   pushPricingUpdate: (streamerId: number, event: import('../../web/routes/channelPointsEvents').PricingUpdateEvent) => void;
 }
-let _runtime: RewardPricingRuntime | null = null;
+const runtimeRegistry = createRuntimeRegistry<RewardPricingRuntime>();
 
 /** Registers the live-pricing-update push hook. Call once from index.ts after startup. */
 export function registerRewardPricingRuntime(runtime: RewardPricingRuntime): void {
-  _runtime = runtime;
+  runtimeRegistry.register(runtime);
 }
 
 // Serializes read-modify-write cycles per reward, so a redemption and a concurrent
@@ -28,6 +29,27 @@ const pricingQueue = createMutationQueue<string>();
 
 function queueKey(streamerId: number, twitchRewardId: string): string {
   return `${streamerId}:${twitchRewardId}`;
+}
+
+/** A streamer paired with a currently-valid broadcaster token, as resolved by {@link resolveBroadcasterToken}. */
+interface ResolvedBroadcasterToken {
+  streamer: DbStreamerEventSub & { twitch_user_id: string };
+  token: string;
+}
+
+/**
+ * Looks up a streamer and their currently-valid broadcaster token together, since every
+ * reward-management call needs both. Shared by `pushRewardCostUpdate`, `resetAndDeletePricing`,
+ * and `deleteRewardAndPricing`.
+ * @param streamerId - DB row ID of the streamer.
+ * @returns The streamer (with `twitch_user_id` guaranteed non-null) and their valid token, or
+ *   null if the streamer doesn't exist, has no linked Twitch account, or has no usable token.
+ */
+async function resolveBroadcasterToken(streamerId: number): Promise<ResolvedBroadcasterToken | null> {
+  const streamer = await getStreamerById(streamerId);
+  const token = streamer ? await getValidToken(streamer) : null;
+  if (!streamer?.twitch_user_id || !token) return null;
+  return { streamer: streamer as DbStreamerEventSub & { twitch_user_id: string }, token };
 }
 
 // Caps how often a single reward's cost is actually pushed to Twitch, even if demand keeps
@@ -80,13 +102,12 @@ async function pushRewardCostUpdate(
     return { lastPushedCost: previousLastPushedCost, unsupported: false };
   }
   try {
-    const streamer = await getStreamerById(streamerId);
-    const token = streamer ? await getValidToken(streamer) : null;
-    if (!streamer?.twitch_user_id || !token) {
+    const resolved = await resolveBroadcasterToken(streamerId);
+    if (!resolved) {
       log.warn(`No valid broadcaster token for streamer ${streamerId} — skipping Twitch price push for reward ${twitchRewardId}`);
       return { lastPushedCost: previousLastPushedCost, unsupported: false };
     }
-    await updateRewardCost(streamer.twitch_user_id, twitchRewardId, newCost, token);
+    await updateRewardCost(resolved.streamer.twitch_user_id, twitchRewardId, newCost, resolved.token);
     lastPushedAt.set(key, Date.now());
     return { lastPushedCost: newCost, unsupported: false };
   } catch (err) {
@@ -166,7 +187,7 @@ async function syncRewardPrice(
   }
 
   try {
-    _runtime?.pushPricingUpdate(streamerId, { rewardId: twitchRewardId, cost: newCost, demand: newDemand, recordedAt: now });
+    runtimeRegistry.get()?.pushPricingUpdate(streamerId, { rewardId: twitchRewardId, cost: newCost, demand: newDemand, recordedAt: now });
   } catch (err) {
     log.warn(`Failed to push live price update for reward ${twitchRewardId}:`, err);
   }
@@ -216,10 +237,9 @@ export async function resetAndDeletePricing(streamerId: number, twitchRewardId: 
     if (!row) return;
     if (!row.twitch_unsupported) {
       try {
-        const streamer = await getStreamerById(streamerId);
-        const token = streamer ? await getValidToken(streamer) : null;
-        if (streamer?.twitch_user_id && token) {
-          await updateRewardCost(streamer.twitch_user_id, twitchRewardId, row.base_cost, token);
+        const resolved = await resolveBroadcasterToken(streamerId);
+        if (resolved) {
+          await updateRewardCost(resolved.streamer.twitch_user_id, twitchRewardId, row.base_cost, resolved.token);
         }
       } catch (err) {
         log.warn(`Failed to reset Twitch reward cost before deleting pricing config for reward ${twitchRewardId}:`, err);
@@ -245,12 +265,11 @@ export async function resetAndDeletePricing(streamerId: number, twitchRewardId: 
  */
 export async function deleteRewardAndPricing(streamerId: number, twitchRewardId: string): Promise<void> {
   await pricingQueue.run(queueKey(streamerId, twitchRewardId), async () => {
-    const streamer = await getStreamerById(streamerId);
-    const token = streamer ? await getValidToken(streamer) : null;
-    if (!streamer?.twitch_user_id || !token) {
+    const resolved = await resolveBroadcasterToken(streamerId);
+    if (!resolved) {
       throw new Error(`No valid broadcaster token for streamer ${streamerId} — cannot delete reward ${twitchRewardId}`);
     }
-    await deleteCustomReward(streamer.twitch_user_id, twitchRewardId, token);
+    await deleteCustomReward(resolved.streamer.twitch_user_id, twitchRewardId, resolved.token);
 
     const row = await getPricingForReward(streamerId, twitchRewardId);
     if (row) await deletePricingConfig(row.id, streamerId);

--- a/src/twitch/twitchApi.ts
+++ b/src/twitch/twitchApi.ts
@@ -137,6 +137,12 @@ export interface TwitchUser {
   id: string;
 }
 
+/**
+ * Looks up Twitch users by login name, via Helix, batched 100 per request.
+ * @param logins - Twitch login names to look up.
+ * @returns Matching users (login + id); logins Twitch doesn't recognize are simply omitted.
+ * @throws If any batch request returns a non-OK response.
+ */
 export async function getUsers(logins: string[]): Promise<TwitchUser[]> {
   const rows = await fetchHelixPaged<{ login: string; id: string }>('users', 'login', logins, 'getUsers');
   return rows.map((u) => ({ login: u.login, id: u.id }));
@@ -152,6 +158,12 @@ export interface TwitchStream {
   type: string;
 }
 
+/**
+ * Looks up live stream info for a set of Twitch user IDs, via Helix, batched 100 per request.
+ * @param userIds - Twitch user IDs to look up.
+ * @returns Stream info for currently-live channels among `userIds`; offline channels are omitted.
+ * @throws If any batch request returns a non-OK response.
+ */
 export async function getStreams(userIds: string[]): Promise<TwitchStream[]> {
   return fetchHelixPaged<TwitchStream>('streams', 'user_id', userIds, 'getStreams', '&first=100');
 }
@@ -163,6 +175,13 @@ export interface TwitchChannelInfo {
   title: string;
 }
 
+/**
+ * Looks up channel info (title/game) for a set of Twitch broadcaster IDs, via Helix, batched
+ * 100 per request.
+ * @param broadcasterIds - Twitch broadcaster (user) IDs to look up.
+ * @returns Channel info for each broadcaster Twitch recognizes; unknown ids are omitted.
+ * @throws If any batch request returns a non-OK response.
+ */
 export async function getChannelInfo(broadcasterIds: string[]): Promise<TwitchChannelInfo[]> {
   return fetchHelixPaged<TwitchChannelInfo>('channels', 'broadcaster_id', broadcasterIds, 'getChannelInfo');
 }

--- a/src/twitch/twitchApi.ts
+++ b/src/twitch/twitchApi.ts
@@ -96,26 +96,50 @@ async function fetchHelixWithRetry(url: string, headers: Record<string, string>)
   return res!;
 }
 
+/**
+ * Fetches every `data[]` row from a Helix list endpoint across as many requests as needed to
+ * cover all of `ids`, batching 100 per request (Helix's per-call cap) and querying each batch
+ * as repeated `paramName=id` query params. Shared by `getUsers`/`getStreams`/`getChannelInfo`,
+ * which only differ in endpoint path, query param name, and any extra fixed query string.
+ * @param path Helix endpoint path under `/helix/`, e.g. `'users'`.
+ * @param paramName Query parameter name repeated once per id, e.g. `'login'`.
+ * @param ids The ids/logins to fetch, batched 100 per request.
+ * @param label Human-readable label used in the thrown error message on failure.
+ * @param extraQuery Optional fixed query string suffix appended to every batch request (e.g. `'&first=100'`).
+ * @returns The concatenated `data[]` rows across all batches, in Helix's response shape.
+ * @throws If any batch request returns a non-OK response.
+ */
+async function fetchHelixPaged<T>(
+  path: string,
+  paramName: string,
+  ids: string[],
+  label: string,
+  extraQuery = '',
+): Promise<T[]> {
+  if (ids.length === 0) return [];
+  const token = await getAppToken();
+  const results: T[] = [];
+  for (const batch of chunks(ids, 100)) {
+    const params = batch.map((id) => `${paramName}=${encodeURIComponent(id)}`).join('&');
+    const res = await fetchHelixWithRetry(`https://api.twitch.tv/helix/${path}?${params}${extraQuery}`, authHeaders(token));
+    if (!res.ok) {
+      invalidateAppTokenIfUnauthorized(res);
+      throw new Error(`[TwitchAPI] ${label} failed: ${res.status}`);
+    }
+    const data = await res.json() as { data: T[] };
+    results.push(...data.data);
+  }
+  return results;
+}
+
 export interface TwitchUser {
   login: string;
   id: string;
 }
 
 export async function getUsers(logins: string[]): Promise<TwitchUser[]> {
-  if (logins.length === 0) return [];
-  const token = await getAppToken();
-  const results: TwitchUser[] = [];
-  for (const batch of chunks(logins, 100)) {
-    const params = batch.map((l) => `login=${encodeURIComponent(l)}`).join('&');
-    const res = await fetchHelixWithRetry(`https://api.twitch.tv/helix/users?${params}`, authHeaders(token));
-    if (!res.ok) {
-      invalidateAppTokenIfUnauthorized(res);
-      throw new Error(`[TwitchAPI] getUsers failed: ${res.status}`);
-    }
-    const data = await res.json() as { data: Array<{ login: string; id: string }> };
-    results.push(...data.data.map((u) => ({ login: u.login, id: u.id })));
-  }
-  return results;
+  const rows = await fetchHelixPaged<{ login: string; id: string }>('users', 'login', logins, 'getUsers');
+  return rows.map((u) => ({ login: u.login, id: u.id }));
 }
 
 export interface TwitchStream {
@@ -129,20 +153,7 @@ export interface TwitchStream {
 }
 
 export async function getStreams(userIds: string[]): Promise<TwitchStream[]> {
-  if (userIds.length === 0) return [];
-  const token = await getAppToken();
-  const results: TwitchStream[] = [];
-  for (const batch of chunks(userIds, 100)) {
-    const params = batch.map((id) => `user_id=${encodeURIComponent(id)}`).join('&');
-    const res = await fetchHelixWithRetry(`https://api.twitch.tv/helix/streams?${params}&first=100`, authHeaders(token));
-    if (!res.ok) {
-      invalidateAppTokenIfUnauthorized(res);
-      throw new Error(`[TwitchAPI] getStreams failed: ${res.status}`);
-    }
-    const data = await res.json() as { data: TwitchStream[] };
-    results.push(...data.data);
-  }
-  return results;
+  return fetchHelixPaged<TwitchStream>('streams', 'user_id', userIds, 'getStreams', '&first=100');
 }
 
 export interface TwitchChannelInfo {
@@ -153,20 +164,7 @@ export interface TwitchChannelInfo {
 }
 
 export async function getChannelInfo(broadcasterIds: string[]): Promise<TwitchChannelInfo[]> {
-  if (broadcasterIds.length === 0) return [];
-  const token = await getAppToken();
-  const results: TwitchChannelInfo[] = [];
-  for (const batch of chunks(broadcasterIds, 100)) {
-    const params = batch.map((id) => `broadcaster_id=${encodeURIComponent(id)}`).join('&');
-    const res = await fetchHelixWithRetry(`https://api.twitch.tv/helix/channels?${params}`, authHeaders(token));
-    if (!res.ok) {
-      invalidateAppTokenIfUnauthorized(res);
-      throw new Error(`[TwitchAPI] getChannelInfo failed: ${res.status}`);
-    }
-    const data = await res.json() as { data: TwitchChannelInfo[] };
-    results.push(...data.data);
-  }
-  return results;
+  return fetchHelixPaged<TwitchChannelInfo>('channels', 'broadcaster_id', broadcasterIds, 'getChannelInfo');
 }
 
 /** A custom reward's per-stream redemption limit, as returned by Twitch (`max_per_stream_setting`). */

--- a/src/twitch/twitchBot.ts
+++ b/src/twitch/twitchBot.ts
@@ -6,6 +6,7 @@ import { executeCounterCommandForTwitch } from '../commands/counterHandler';
 import { executeMultiCommandForTwitch } from '../commands/multiCommandHandler';
 import { executeShoutoutForTwitch } from '../commands/shoutoutHandler';
 import { executeCountdownForTwitch } from '../commands/countdownHandler';
+import { fireAndForget } from '../commands/commandUtils';
 import { setTwitchChannel } from '../shared/statusStore';
 import { normalizeTwitchChannelName } from './twitchChannelName';
 import { createLogger } from '../shared/logger';
@@ -89,16 +90,6 @@ async function resolveGuildIdForTwitchCommand(normalizedChannel: string): Promis
 }
 
 /**
- * Runs `promise` without awaiting it, logging (rather than throwing) if it rejects.
- * Used so one command handler's failure can't block or delay the others.
- * @param promise - The in-flight promise to observe.
- * @param context - Log-line prefix identifying which handler the promise belongs to.
- */
-function fireAndForget(promise: Promise<void>, context: string): void {
-  promise.catch((err) => log.error(`${context}:`, err));
-}
-
-/**
  * tmi.js `message` event handler: dispatches an incoming Twitch chat message to
  * every command handler (custom commands, counters, `!multi`, `!so`, the shared
  * command router, countdowns) in parallel via {@link fireAndForget}. Ignores the
@@ -131,15 +122,16 @@ function handleTwitchMessage(
     const displayName = tags['display-name'] ?? tags.username ?? null;
     const isMod = tags.mod === true || !!(tags.badges as Record<string, string> | null | undefined)?.broadcaster;
 
-    fireAndForget(executeCustomCommandForTwitch(normalizedChannel, message, displayName), 'Custom command error');
-    fireAndForget(executeCounterCommandForTwitch(normalizedChannel, message, displayName), 'Counter command error');
-    fireAndForget(executeMultiCommandForTwitch(normalizedChannel, message, displayName), 'Multi command error');
-    fireAndForget(executeShoutoutForTwitch(normalizedChannel, message, displayName, isMod), 'Shoutout error');
+    fireAndForget(executeCustomCommandForTwitch(normalizedChannel, message, displayName), 'Custom command error', log);
+    fireAndForget(executeCounterCommandForTwitch(normalizedChannel, message, displayName), 'Counter command error', log);
+    fireAndForget(executeMultiCommandForTwitch(normalizedChannel, message, displayName), 'Multi command error', log);
+    fireAndForget(executeShoutoutForTwitch(normalizedChannel, message, displayName, isMod), 'Shoutout error', log);
     fireAndForget(
       resolveGuildIdForTwitchCommand(normalizedChannel).then((guildId) => handleCommand(message, 'twitch', guildId)),
       'Command handler error',
+      log,
     );
-    fireAndForget(executeCountdownForTwitch(normalizedChannel, message), 'Countdown error');
+    fireAndForget(executeCountdownForTwitch(normalizedChannel, message), 'Countdown error', log);
   } catch (err) {
     log.error('Unexpected error in message handler:', err);
   }

--- a/src/web/middleware.ts
+++ b/src/web/middleware.ts
@@ -84,43 +84,67 @@ export async function requireGuildContext(req: Request, res: Response, next: Nex
 }
 
 /**
- * Ensures the current-guild access level is Manager or above, otherwise renders a 403.
- * @param req - Express request; reads `req.session.user.accessLevel`.
- * @param res - Express response; used to render the 403 error page on denial.
- * @param next - Called when the access level check passes.
- * @returns Nothing; either calls `next()` or renders an error response.
+ * Creates a middleware that ensures the current-guild access level is at least `level`,
+ * otherwise renders a 403. Shared factory behind `requireMod`/`requireManager`/`requireAdmin`.
+ * @param level - Minimum required `AccessLevel` value.
+ * @param label - Requirement described in the 403 message, e.g. `'Manager or above'`.
+ * @returns An Express middleware: calls `next()` when the session user meets `level`,
+ *   otherwise renders a 403 error page.
  */
-export function requireManager(req: Request, res: Response, next: NextFunction): void {
-  if (req.session.user && req.session.user.accessLevel >= AccessLevel.MANAGER) {
-    next();
-  } else {
-    res.status(403);
-    renderView(res, 'error', {
-      message: 'Access denied — Manager or above required.',
-      user: req.session.user ?? null,
-      csrfToken: req.session?.user ? ensureSessionCsrfToken(req) : '',
-    });
-  }
+function requireAccessLevel(level: number, label: string): (req: Request, res: Response, next: NextFunction) => void {
+  return (req, res, next) => {
+    if (req.session.user && req.session.user.accessLevel >= level) {
+      next();
+    } else {
+      res.status(403);
+      renderView(res, 'error', {
+        message: `Access denied — ${label} required.`,
+        user: req.session.user ?? null,
+        csrfToken: req.session?.user ? ensureSessionCsrfToken(req) : '',
+      });
+    }
+  };
 }
 
+/** Ensures the current-guild access level is Mod or above, otherwise renders a 403. */
+export const requireMod = requireAccessLevel(AccessLevel.MOD, 'Mod or above');
+
+/** Ensures the current-guild access level is Manager or above, otherwise renders a 403. */
+export const requireManager = requireAccessLevel(AccessLevel.MANAGER, 'Manager or above');
+
 /**
- * Ensures the current-guild access level is Mod or above, otherwise renders a 403.
- * @param req - Express request; reads `req.session.user.accessLevel`.
- * @param res - Express response; used to render the 403 error page on denial.
- * @param next - Called when the access level check passes.
- * @returns Nothing; either calls `next()` or renders an error response.
+ * Creates a middleware that authenticates a request via a `Bearer` token: hashes it with
+ * SHA-256, resolves the hash to an identity via `lookup`, and stores it on `req` via `assign`
+ * on success. Responds 401 when the header is missing/empty or `lookup` finds no match, and
+ * 500 on any other lookup failure. Shared factory behind `requireApiKey`/`requireCompanionKey`.
+ * @param lookup - Resolves a SHA-256 hex hash to the authenticated identity, or null if no match.
+ * @param assign - Stores the resolved identity on `req` for downstream handlers.
+ * @returns An Express middleware.
  */
-export function requireMod(req: Request, res: Response, next: NextFunction): void {
-  if (req.session.user && req.session.user.accessLevel >= AccessLevel.MOD) {
-    next();
-  } else {
-    res.status(403);
-    renderView(res, 'error', {
-      message: 'Access denied — Mod or above required.',
-      user: req.session.user ?? null,
-      csrfToken: req.session?.user ? ensureSessionCsrfToken(req) : '',
-    });
-  }
+function authenticateBearerToken<T>(
+  lookup: (hash: string) => Promise<T | null>,
+  assign: (req: Request, value: T) => void,
+): (req: Request, res: Response, next: NextFunction) => Promise<void> {
+  return async (req, res, next) => {
+    const authHeader = req.headers['authorization'];
+    const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : '';
+    if (!token) {
+      res.status(401).json({ ok: false, error: 'Unauthorized' });
+      return;
+    }
+    const hash = createHash('sha256').update(token).digest('hex');
+    try {
+      const value = await lookup(hash);
+      if (value === null) {
+        res.status(401).json({ ok: false, error: 'Unauthorized' });
+        return;
+      }
+      assign(req, value);
+      next();
+    } catch {
+      res.status(500).json({ ok: false, error: 'Internal server error' });
+    }
+  };
 }
 
 /**
@@ -128,78 +152,21 @@ export function requireMod(req: Request, res: Response, next: NextFunction): voi
  * up by identity only. On success, attaches the key owner's Discord ID to the request —
  * the same key may be approved for more than one guild (or none yet), so each route must
  * resolve its own target guild and check {@link isKeyApprovedForGuild} before acting.
- * @param req - Express request; reads the `Authorization` header.
- * @param res - Express response; used to respond 401/500 on failure.
- * @param next - Called once `req.apiKeyOwner` has been set.
- * @returns A promise that resolves once `next()` or an error response has been issued.
  */
-export async function requireApiKey(req: Request, res: Response, next: NextFunction): Promise<void> {
-  const authHeader = req.headers['authorization'];
-  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : '';
-  if (!token) {
-    res.status(401).json({ ok: false, error: 'Unauthorized' });
-    return;
-  }
-  const hash = createHash('sha256').update(token).digest('hex');
-  try {
-    const row = await findKeyByHash(hash);
-    if (!row) {
-      res.status(401).json({ ok: false, error: 'Unauthorized' });
-      return;
-    }
-    req.apiKeyOwner = row.discordId;
-    next();
-  } catch {
-    res.status(500).json({ ok: false, error: 'Internal server error' });
-  }
-}
+export const requireApiKey = authenticateBearerToken(
+  async (hash) => (await findKeyByHash(hash))?.discordId ?? null,
+  (req, discordId: string) => { req.apiKeyOwner = discordId; },
+);
 
 /**
  * Authenticates a companion app request via a `Bearer` token, hashing it and looking it
  * up against active (non-revoked) companion tokens. On success, attaches the token
  * owner's Discord ID to the request.
- * @param req - Express request; reads the `Authorization` header.
- * @param res - Express response; used to respond 401/500 on failure.
- * @param next - Called once `req.companionDiscordId` has been set.
- * @returns A promise that resolves once `next()` or an error response has been issued.
  */
-export async function requireCompanionKey(req: Request, res: Response, next: NextFunction): Promise<void> {
-  const authHeader = req.headers['authorization'];
-  const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : '';
-  if (!token) {
-    res.status(401).json({ ok: false, error: 'Unauthorized' });
-    return;
-  }
-  const hash = createHash('sha256').update(token).digest('hex');
-  try {
-    const discordId = await findDiscordIdByTokenHash(hash);
-    if (!discordId) {
-      res.status(401).json({ ok: false, error: 'Unauthorized' });
-      return;
-    }
-    req.companionDiscordId = discordId;
-    next();
-  } catch {
-    res.status(500).json({ ok: false, error: 'Internal server error' });
-  }
-}
+export const requireCompanionKey = authenticateBearerToken(
+  findDiscordIdByTokenHash,
+  (req, discordId: string) => { req.companionDiscordId = discordId; },
+);
 
-/**
- * Ensures the current-guild access level is Admin, otherwise renders a 403.
- * @param req - Express request; reads `req.session.user.accessLevel`.
- * @param res - Express response; used to render the 403 error page on denial.
- * @param next - Called when the access level check passes.
- * @returns Nothing; either calls `next()` or renders an error response.
- */
-export function requireAdmin(req: Request, res: Response, next: NextFunction): void {
-  if (req.session.user && req.session.user.accessLevel >= AccessLevel.ADMIN) {
-    next();
-  } else {
-    res.status(403);
-    renderView(res, 'error', {
-      message: 'Access denied — Admin required.',
-      user: req.session.user ?? null,
-      csrfToken: req.session?.user ? ensureSessionCsrfToken(req) : '',
-    });
-  }
-}
+/** Ensures the current-guild access level is Admin, otherwise renders a 403. */
+export const requireAdmin = requireAccessLevel(AccessLevel.ADMIN, 'Admin');

--- a/src/web/routes/channelPointsAdminPricingMutations.ts
+++ b/src/web/routes/channelPointsAdminPricingMutations.ts
@@ -8,10 +8,10 @@ import {
 } from '../../db';
 import { getCustomRewards } from '../../twitch/twitchApi';
 import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
-import { logAndRedirectError, requireStreamer, parsePositiveIntId, parseRewardIdParam } from './shared';
+import { logAndRedirectError, requireStreamer, parsePositiveIntId, parseRewardIdParam, parseCheckboxField } from './shared';
 import {
   parseNonNegativeNumberField, parsePositiveNumberField,
-  parseCheckboxField, parseRoundToNearestField, effectiveCooldownSeconds, handleRewardDeleteAction,
+  parseRoundToNearestField, effectiveCooldownSeconds, handleRewardDeleteAction,
 } from './channelPointsAdminShared';
 import { applyDecayTick, resetAndDeletePricing } from '../../twitch/pricing/rewardPricingService';
 

--- a/src/web/routes/channelPointsAdminShared.test.ts
+++ b/src/web/routes/channelPointsAdminShared.test.ts
@@ -5,7 +5,7 @@ vi.mock('../../db', () => ({ getStreamerByDiscordId: vi.fn(), DEFAULT_PRICING_CO
 import { getStreamerByDiscordId } from '../../db';
 import {
   parseNonNegativeNumberField, parsePositiveNumberField,
-  parseCheckboxField, parseHexColorField, parseRoundToNearestField, parseRewardFields,
+  parseHexColorField, parseRoundToNearestField, parseRewardFields,
   effectiveCooldownSeconds, handleRewardDeleteAction,
 } from './channelPointsAdminShared';
 
@@ -16,8 +16,9 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-// requireStreamer and parseRewardIdParam now live in (and are tested by) shared.test.ts —
-// this file only covers channelPointsAdminShared's own helpers plus their usage below.
+// requireStreamer, parseRewardIdParam, and parseCheckboxField now live in (and are tested
+// by) shared.test.ts — this file only covers channelPointsAdminShared's own helpers plus
+// their usage below.
 
 describe('handleRewardDeleteAction', () => {
   const streamer = { id: 1 };
@@ -122,24 +123,6 @@ describe('parsePositiveNumberField', () => {
 
   it('rejects a whitespace-only string instead of silently coercing to 0', () => {
     expect(parsePositiveNumberField('   ')).toBeNull();
-  });
-});
-
-describe('parseCheckboxField', () => {
-  it('returns true when the value is "on"', () => {
-    expect(parseCheckboxField('on')).toBe(true);
-  });
-
-  it('returns false when undefined (checkbox unchecked)', () => {
-    expect(parseCheckboxField(undefined)).toBe(false);
-  });
-
-  it('returns false for an array (repeated field)', () => {
-    expect(parseCheckboxField(['on', 'on'])).toBe(false);
-  });
-
-  it('returns false for any other string value', () => {
-    expect(parseCheckboxField('off')).toBe(false);
   });
 });
 

--- a/src/web/routes/channelPointsAdminShared.ts
+++ b/src/web/routes/channelPointsAdminShared.ts
@@ -4,7 +4,7 @@ import { DEFAULT_PRICING_COOLDOWN_SECONDS } from '../../db';
 import type { DbStreamerEventSub } from '../../db';
 import type { CustomRewardInput, TwitchCustomReward } from '../../twitch/twitchApi';
 import {
-  trimField, logAndRedirectError, requireStreamer, parsePositiveIntId, parseRewardIdParam,
+  trimField, logAndRedirectError, requireStreamer, parsePositiveIntId, parseRewardIdParam, parseCheckboxField,
 } from './shared';
 
 /** Redirect target used when the requester isn't a streamer, scoped to the channel-points admin page. */
@@ -36,14 +36,6 @@ export async function handleRewardDeleteAction(
   } catch (err) {
     logAndRedirectError({ res, log: opts.log, logLabel: opts.errorLogLabel, err, basePath: '/channel-points', errorCode: opts.errorCode });
   }
-}
-
-/**
- * Parses an HTML checkbox field: present and `'on'` means checked. Absent (checkbox
- * unchecked) or an array (repeated field) is treated as unchecked.
- */
-export function parseCheckboxField(value: string | string[] | undefined): boolean {
-  return !Array.isArray(value) && value === 'on';
 }
 
 /**

--- a/src/web/routes/commandMutations.ts
+++ b/src/web/routes/commandMutations.ts
@@ -17,6 +17,7 @@ import {
   normalizeRequiredText,
   normalizeSingleTokenRequiredText,
   parsePositiveIntId,
+  parseCheckboxField,
   normalizeDiscordId,
   handleReservedOrConflictCommandError,
 } from './shared';
@@ -65,8 +66,8 @@ async function assignUsersToNewCommand(commandId: number, discordIds: string[]):
  */
 router.post('/commands/add', requireMod, csrfProtection, async (req, res) => {
   const { trigger_string, output } = req.body as Record<string, string | undefined>;
-  const isDiscordEnabled = req.body.is_discord_enabled === 'on';
-  const isMultiTwitch = req.body.is_multi_twitch === 'on';
+  const isDiscordEnabled = parseCheckboxField(req.body.is_discord_enabled);
+  const isMultiTwitch = parseCheckboxField(req.body.is_multi_twitch);
   const normalizedTriggerString = normalizeSingleTokenRequiredText(trigger_string);
   const normalizedOutput = normalizeRequiredText(output);
 
@@ -106,8 +107,8 @@ router.post('/commands/add', requireMod, csrfProtection, async (req, res) => {
  */
 router.post('/commands/update', requireMod, csrfProtection, async (req, res) => {
   const { command_id, trigger_string, output } = req.body as Record<string, string | undefined>;
-  const isDiscordEnabled = req.body.is_discord_enabled === 'on';
-  const isMultiTwitch = req.body.is_multi_twitch === 'on';
+  const isDiscordEnabled = parseCheckboxField(req.body.is_discord_enabled);
+  const isMultiTwitch = parseCheckboxField(req.body.is_multi_twitch);
   const normalizedTriggerString = normalizeSingleTokenRequiredText(trigger_string);
   const normalizedOutput = normalizeRequiredText(output);
   const parsedCommandId = parsePositiveIntId(command_id);

--- a/src/web/routes/counters.ts
+++ b/src/web/routes/counters.ts
@@ -16,6 +16,7 @@ import {
   normalizeRequiredText,
   normalizeSingleTokenRequiredText,
   parsePositiveIntId,
+  parseCheckboxField,
   renderError,
   filterQueryParam,
   renderView,
@@ -61,7 +62,7 @@ function validateAndNormalizeCounterForm(
   const normalizedCheckCommand = normalizeSingleTokenRequiredText(rawForm.check_command);
   const normalizedMessage = normalizeRequiredText(rawForm.message);
   const normalizedIncrementMessage = normalizeRequiredText(rawForm.increment_message);
-  const resetYearly = rawForm.reset_yearly === 'on';
+  const resetYearly = parseCheckboxField(rawForm.reset_yearly);
 
   if (!normalizedTriggerCommand || !normalizedCheckCommand || !normalizedMessage || !normalizedIncrementMessage) {
     return { error: 'missing_fields' };

--- a/src/web/routes/sfxFileMutations.ts
+++ b/src/web/routes/sfxFileMutations.ts
@@ -3,7 +3,7 @@ import { Router } from 'express';
 import { updateSfxFile, deleteSfxFile } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireMod } from '../middleware';
-import { logAndRedirectError, parsePositiveIntId } from './shared';
+import { logAndRedirectError, parsePositiveIntId, parseCheckboxField } from './shared';
 import { removeSfxFiles } from './sfxMutationsShared';
 
 const log = createLogger('Web');
@@ -23,7 +23,7 @@ router.post('/sfx/file/update', requireMod, csrfProtection, async (req, res) => 
 
   const weight = parsePositiveIntId(req.body.weight);
   if (weight === null) return res.redirect('/sfx?error=invalid_weight');
-  const hidden = req.body.file_hidden === 'on';
+  const hidden = parseCheckboxField(req.body.file_hidden);
 
   try {
     const updated = await updateSfxFile(fileId, weight, hidden);

--- a/src/web/routes/sfxFileUpload.ts
+++ b/src/web/routes/sfxFileUpload.ts
@@ -9,7 +9,7 @@ import { csrfProtection } from '../csrf';
 import { requireMod } from '../middleware';
 import { SFX_FOLDER, SFX_MAX_FILE_MB } from '../../shared/config';
 import { safeResolve } from '../../shared/pathUtils';
-import { parsePositiveIntId, createMulterErrorRedirectHandler } from './shared';
+import { parsePositiveIntId, createMulterErrorRedirectHandler, parseCheckboxField } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
@@ -231,7 +231,7 @@ router.post('/sfx/file/upload', requireMod, csrfProtection, uploadSound, async (
 
   const weight = parsePositiveIntId(req.body.weight);
   if (weight === null) return res.redirect('/sfx?error=invalid_weight');
-  const hidden = req.body.file_hidden === 'on';
+  const hidden = parseCheckboxField(req.body.file_hidden);
 
   const stored = await storeUploadedSound(req.file);
   if ('errorCode' in stored) return res.redirect(`/sfx?error=${stored.errorCode}`);

--- a/src/web/routes/sfxTriggerMutations.ts
+++ b/src/web/routes/sfxTriggerMutations.ts
@@ -15,6 +15,7 @@ import {
   normalizeSingleTokenRequiredText,
   parsePositiveIntId,
   parsePositiveBigIntId,
+  parseCheckboxField,
 } from './shared';
 import { removeSfxFiles } from './sfxMutationsShared';
 
@@ -45,7 +46,7 @@ router.post('/sfx/trigger/add', requireMod, csrfProtection, async (req, res) => 
   const categoryId = parseCategoryId(req.body.category_id);
   if (categoryId === undefined) return res.redirect('/sfx?error=invalid_id');
   const description = normalizeRequiredText(req.body.description);
-  const hidden = req.body.hidden === 'on';
+  const hidden = parseCheckboxField(req.body.hidden);
 
   try {
     if (await findTrigger(command)) return res.redirect('/sfx?error=command_taken');
@@ -68,7 +69,7 @@ router.post('/sfx/trigger/update', requireMod, csrfProtection, async (req, res) 
   const categoryId = parseCategoryId(req.body.category_id);
   if (categoryId === undefined) return res.redirect('/sfx?error=invalid_id');
   const description = normalizeRequiredText(req.body.description);
-  const hidden = req.body.hidden === 'on';
+  const hidden = parseCheckboxField(req.body.hidden);
 
   try {
     const existing = await findTrigger(command);

--- a/src/web/routes/shared.test.ts
+++ b/src/web/routes/shared.test.ts
@@ -26,6 +26,7 @@ import {
 } from '../../db';
 import {
   parsePositiveIntId,
+  parseCheckboxField,
   trimField,
   normalizeRequiredText,
   normalizeSingleTokenRequiredText,
@@ -40,6 +41,24 @@ import {
   handleReservedOrConflictCommandError,
   createMulterErrorRedirectHandler,
 } from './shared';
+
+describe('parseCheckboxField', () => {
+  it('returns true when the value is "on"', () => {
+    expect(parseCheckboxField('on')).toBe(true);
+  });
+
+  it('returns false when undefined (checkbox unchecked)', () => {
+    expect(parseCheckboxField(undefined)).toBe(false);
+  });
+
+  it('returns false for an array (repeated field)', () => {
+    expect(parseCheckboxField(['on', 'on'])).toBe(false);
+  });
+
+  it('returns false for any other string value', () => {
+    expect(parseCheckboxField('off')).toBe(false);
+  });
+});
 
 describe('parsePositiveIntId', () => {
   it('returns null for undefined', () => {

--- a/src/web/routes/shared.ts
+++ b/src/web/routes/shared.ts
@@ -28,6 +28,14 @@ function getKnownViews(): Set<string> {
 }
 
 /**
+ * Parses an HTML checkbox form field: present-and-`'on'` means checked, anything else
+ * (absent, unchecked, or a repeated field arriving as an array) means unchecked.
+ */
+export function parseCheckboxField(value: string | string[] | undefined): boolean {
+  return !Array.isArray(value) && value === 'on';
+}
+
+/**
  * Parse a positive integer id form field. A repeated field (arriving as an array) is
  * rejected rather than silently taking the first value, so a duplicated/tampered id
  * can't slip past validation — mirrors `parsePositiveBigIntId`.

--- a/src/web/routes/streamGroups.ts
+++ b/src/web/routes/streamGroups.ts
@@ -3,7 +3,7 @@ import { Router } from 'express';
 import { addStreamGroup, updateStreamGroup, removeStreamGroupAndStreamers } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireManager } from '../middleware';
-import { parsePositiveIntId } from './shared';
+import { parsePositiveIntId, parseCheckboxField } from './shared';
 import { redirectStreamsInvalid, redirectStreamsFailure } from './streamsErrors';
 import { triggerRestart } from './streamRestart';
 
@@ -27,8 +27,8 @@ function hasMissingValues(...values: Array<string | undefined>): boolean {
  */
 router.post('/streams/groups/add', requireManager, csrfProtection, async (req, res) => {
   const { name, discord_channel, live_message, new_game_message } = req.body as Record<string, string | undefined>;
-  const multi_twitch = req.body.multi_twitch === 'on';
-  const delete_old_posts = req.body.delete_old_posts === 'on';
+  const multi_twitch = parseCheckboxField(req.body.multi_twitch);
+  const delete_old_posts = parseCheckboxField(req.body.delete_old_posts);
 
   if (hasMissingValues(name, discord_channel, live_message, new_game_message)) {
     return redirectStreamsInvalid(res, 'missing_fields');
@@ -63,8 +63,8 @@ router.post('/streams/groups/add', requireManager, csrfProtection, async (req, r
  */
 router.post('/streams/groups/update', requireManager, csrfProtection, async (req, res) => {
   const { group_id, name, discord_channel, live_message, new_game_message } = req.body as Record<string, string | undefined>;
-  const multi_twitch = req.body.multi_twitch === 'on';
-  const delete_old_posts = req.body.delete_old_posts === 'on';
+  const multi_twitch = parseCheckboxField(req.body.multi_twitch);
+  const delete_old_posts = parseCheckboxField(req.body.delete_old_posts);
 
   if (hasMissingValues(group_id, name, discord_channel, live_message, new_game_message)) {
     return redirectStreamsInvalid(res, 'missing_fields');

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -212,17 +212,32 @@ app.use('/overlay', requireAuth, overlayAdminRouter);
 app.use('/channel-points', requireAuth, channelPointsAdminRouter);
 
 /**
+ * Renders the `error` view with the given status and message, including a real CSRF
+ * token when a session user is present (needed for the logout form in `partials/nav`).
+ * Shared by the 404, CSRF-failure, and catch-all error handlers below — unlike
+ * `routes/shared.ts`'s `renderError`, which always passes an empty `csrfToken` and is
+ * meant for already-authenticated route handlers rather than this app-wide fallback tier.
+ * @param req - Express request; reads `req.session.user` if present.
+ * @param res - Express response; renders the `error` view with `status`.
+ * @param status - HTTP status code to set.
+ * @param message - Human-readable error message shown to the user.
+ */
+function renderErrorPage(req: express.Request, res: express.Response, status: number, message: string): void {
+  res.status(status);
+  renderView(res, 'error', {
+    message,
+    user: req.session.user ?? null,
+    csrfToken: req.session.user ? ensureSessionCsrfToken(req) : '',
+  });
+}
+
+/**
  * 404 handler — catches any request that fell through every mounted router.
  * @param req - Express request; reads `req.session.user` if present.
  * @param res - Express response; renders the `error` view with a 404 status.
  */
 app.use((req, res) => {
-  res.status(404);
-  renderView(res, 'error', {
-    message: 'Page not found.',
-    user: req.session.user ?? null,
-    csrfToken: req.session.user ? ensureSessionCsrfToken(req) : '',
-  });
+  renderErrorPage(req, res, 404, 'Page not found.');
 });
 
 /**
@@ -250,12 +265,7 @@ const csrfErrorHandler: ErrorRequestHandler = (err, req, res, next) => {
     return;
   }
 
-  res.status(403);
-  renderView(res, 'error', {
-    message: 'Your form session expired or the request could not be verified. Please reload the page and try again.',
-    user: req.session.user ?? null,
-    csrfToken: req.session.user ? ensureSessionCsrfToken(req) : '',
-  });
+  renderErrorPage(req, res, 403, 'Your form session expired or the request could not be verified. Please reload the page and try again.');
 };
 
 app.use(csrfErrorHandler);
@@ -269,12 +279,7 @@ app.use(csrfErrorHandler);
  */
 app.use((err: unknown, req: express.Request, res: express.Response, _next: express.NextFunction) => {
   log.error('Unhandled error:', err);
-  res.status(500);
-  renderView(res, 'error', {
-    message: 'An unexpected error occurred.',
-    user: req.session.user ?? null,
-    csrfToken: req.session.user ? ensureSessionCsrfToken(req) : '',
-  });
+  renderErrorPage(req, res, 500, 'An unexpected error occurred.');
 });
 
 // Exported so server.test.ts can drive the real route/middleware wiring with supertest


### PR DESCRIPTION
## Summary

Pure refactor — no behavior changes intended (see two deliberate exceptions below). Three explore passes surveyed the DB layer, command/twitch/discord handlers, and web routes/middleware for duplication and unnecessary complexity; this PR applies the verified findings.

**DB layer** (`src/db.ts`, `src/db/*`, `src/shared/*`)
- `counters.ts`'s `updateCounter`/`resetCounterCurrentValue` now use the existing `affectedOrExists` helper instead of hand-rolled exists checks.
- New `rowExists()` / `hashesMatch()` helpers in `db/utils.ts`, replacing duplicated exists-checks (`commandLocks.ts`, `counters.ts`, `sfx.ts`) and timing-safe hash comparisons (`streamdeckKeys.ts`, `companionTokens.ts`).
- `commandConflicts.ts`'s three assert+check pairs collapsed into one `assertConflictFree()` wrapper.
- All four lookup caches now share one `DEFAULT_CACHE_TTL_MS` instead of re-declaring `300_000`/`5_000`/`60_000` per file.
- `companionOAuthCodes.ts`'s `consumeCode`/`exchangeCodeForToken` share one `consumeCodeOnConnection()` for the mark-used+select SQL.
- `db.ts`'s facade wrappers use a `withInvalidation()` helper.
- Investigated but **not** changed: `mutationQueue.ts`'s duplicated wait/ignore block — deduping it via `.catch()`/an async wrapper adds a microtask tick that broke a real timing-sensitive test in `twitchChannelMembership.ts` (via `twitchBot.test.ts`). Left as-is; the duplication is intentional here. Also skipped a generic `createEmptyXCache()` factory across the three cache files — the shapes differ enough that a generic version would be more abstraction than the ~5 lines/file it'd save.

**Command/twitch layer** (`src/commands/*`, `src/twitch/*`, `src/discord/*`)
- `createRuntimeRegistry<T>()`'s generic constraint relaxed (was `T extends TwitchSendRuntime`) so EventSub overlay/companion/chat runtime injection and reward-pricing runtime injection can reuse it instead of hand-rolling their own register/get slot (4 call sites).
- New `fetchHelixPaged()` in `twitchApi.ts` for `getUsers`/`getStreams`/`getChannelInfo`'s shared batching logic.
- New `resolveBroadcasterToken()` in `rewardPricingService.ts` for the repeated streamer+token lookup (3 call sites).
- `createSubscriptionsForStreamer` now loops over a config-driven list instead of 4 copy-pasted conditional blocks.
- New `postTokenRequest()` in `twitchApiEventSub.ts` for `exchangeCode`/`refreshUserToken`'s shared OAuth POST. **Behavior note:** this also makes `exchangeCode` throw `TwitchAuthError` on 400/401, matching `refreshUserToken`'s existing behavior (previously it threw a generic `Error`) — verified no caller does an `instanceof` check that this would break; test updated.
- `commandRouter.ts`'s cooldown/in-flight guard extracted into `tryClaimGuildSlot()`.
- Twitch/Discord's duplicated fire-and-forget error logging consolidated into one `fireAndForget()` helper in `commandUtils.ts` (with tests).
- `twitchMonitorAnnouncements.ts`'s duplicated send-and-record-state tail extracted into `repost()`.

**Web layer** (`src/web/*`)
- `requireMod`/`requireManager`/`requireAdmin` collapsed into one `requireAccessLevel(level, label)` factory.
- `requireApiKey`/`requireCompanionKey` collapsed into one `authenticateBearerToken(lookup, assign)` factory.
- `server.ts`'s 404/CSRF-failure/catch-all handlers now share a local `renderErrorPage()` helper. **Deliberately not** reusing `routes/shared.ts`'s existing `renderError()` — that helper always passes an empty `csrfToken`, whereas `server.ts` correctly computes a real one via `ensureSessionCsrfToken()` when a session user is present (needed for the logout form in `partials/nav.ejs`); reusing it as originally considered would have silently broken logout from these error pages.
- `parseCheckboxField` moved from `channelPointsAdminShared.ts` to the general `routes/shared.ts` and used at every inline `=== 'on'` checkbox-parsing call site (`commandMutations.ts`, `sfxTriggerMutations.ts`, `sfxFileMutations.ts`, `sfxFileUpload.ts`, `streamGroups.ts`, `counters.ts`).
- Skipped a `tryRenderPage` wrapper for the ~15 GET-page handlers' try/catch shape — each already delegates to shared helpers, so the remaining duplication is genuinely cosmetic.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — all 2447 tests pass
- [x] Manually traced the two flagged behavior-adjacent changes (`exchangeCode`'s error type, `server.ts`'s CSRF token path) against their call sites/tests


---
_Generated by [Claude Code](https://claude.ai/code/session_01RcbMXqB8BYK3JCzZErGjjz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command handling to prevent duplicate or overlapping playback triggers.
  * Standardized Twitch authentication error responses for invalid credentials and server failures.
  * Improved safe handling and logging of background command errors.
  * Fixed checkbox form parsing across command, counter, stream group, and SFX settings.
  * Improved announcement reposting when Discord messages cannot be edited.
  * Strengthened token and hash validation behavior.

* **Improvements**
  * Improved cache refresh consistency and database update handling.
  * Simplified Twitch EventSub subscription configuration and runtime integrations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->