### PR TITLE
Batch DB writes, cut redundant round-trips, and drop hot-path allocations

### DIFF
--- a/src/commands/commandRouter.ts
+++ b/src/commands/commandRouter.ts
@@ -9,6 +9,7 @@ import { setVoicePlaying } from '../shared/statusStore';
 import { safeResolve } from '../shared/pathUtils';
 import { recordCommandTestEntry } from './commandMonitorStore';
 import { getOrCreate } from '../shared/mapUtils';
+import { extractCommand } from './commandUtils';
 
 const log = createLogger('CommandRouter');
 
@@ -135,11 +136,9 @@ export async function handleCommand(
   source: 'twitch' | 'discord' | 'tiktok',
   guildId: string | null,
 ): Promise<void> {
-  const trimmed = rawMessage.trim();
-
   // Extract the first word of the message — this is matched directly against
   // trigger_command in the DB, which already includes whatever prefix is used
-  const command = trimmed.split(/\s+/)[0].toLowerCase();
+  const command = extractCommand(rawMessage);
   if (!command) return;
 
   if (guildId === null) {

--- a/src/commands/customCommandHandler.test.ts
+++ b/src/commands/customCommandHandler.test.ts
@@ -270,6 +270,29 @@ describe('executeCustomCommandForTwitch', () => {
     expect(mockRuntime.send).toHaveBeenCalledWith('#chan', 'args=[] arg=[]');
   });
 
+  it('only checks registration for channels in the active multi-twitch group, not every active channel', async () => {
+    // Source channel is #a; #b is in the group, #c is active but not in the group.
+    vi.mocked(getCustomCommandForTwitchChannel).mockResolvedValue({
+      output: 'Multi!',
+      is_multi_twitch: true,
+    } as any);
+    vi.mocked(getMultiTwitchDataForChannel).mockReturnValue({
+      url: 'multitwitch.tv/a/b',
+      participants: ['#a', '#b'],
+    } as any);
+    mockRuntime.getActiveChannels.mockReturnValue(new Set(['#a', '#b', '#c']));
+
+    await executeCustomCommandForTwitch('#a', '!multi', null);
+
+    expect(mockRuntime.send).toHaveBeenCalledWith('#a', 'Multi!');
+    expect(mockRuntime.send).toHaveBeenCalledWith('#b', 'Multi!');
+    expect(mockRuntime.send).not.toHaveBeenCalledWith('#c', 'Multi!');
+    const checkedChannels = vi.mocked(getCustomCommandForTwitchChannel).mock.calls.map((call) => call[0]);
+    expect(checkedChannels).toContain('#a');
+    expect(checkedChannels).toContain('#b');
+    expect(checkedChannels).not.toContain('#c');
+  });
+
   it('reuses the same filled response for every channel in a multi-twitch broadcast', async () => {
     vi.mocked(getCustomCommandForTwitchChannel).mockResolvedValue({
       output: '{user} said {args}',

--- a/src/commands/customCommandHandler.ts
+++ b/src/commands/customCommandHandler.ts
@@ -138,21 +138,22 @@ async function broadcastToActiveChannels(sourceChannel: string, command: string,
   const activeChannels = getActiveChannels();
   const loginUserIds = getLoginUserIds();
 
-  // Build ordered list: source channel first, then the rest
-  const candidates = [sourceChannel, ...Array.from(activeChannels).filter((ch) => ch !== sourceChannel)];
+  // Restrict candidates to the active multi-twitch group before checking registration, so the
+  // (more expensive) per-channel cache lookup below only runs for channels that could possibly
+  // be targets. When the source channel is not in an active group (e.g. offline), fall back to
+  // the source channel only so the command does not broadcast to unrelated channels.
+  const groupInfo = getMultiTwitchDataForChannel(sourceChannel);
+  const groupParticipantSet = groupInfo ? new Set([sourceChannel, ...groupInfo.participants]) : new Set([sourceChannel]);
+
+  // Build ordered list: source channel first, then the rest, restricted to the group.
+  const candidates = [
+    sourceChannel,
+    ...Array.from(activeChannels).filter((ch) => ch !== sourceChannel && groupParticipantSet.has(ch)),
+  ];
 
   // Only send to channels where the command is registered (in-memory cache lookup)
   const registrationResults = await Promise.all(candidates.map((ch) => getCustomCommandForTwitchChannel(ch, command)));
-  const registered = candidates.filter((_, i) => registrationResults[i] !== null);
-
-  // Restrict to the active multi-twitch group. When the source channel is not in an
-  // active group (e.g. offline), fall back to the source channel only so the command
-  // does not broadcast to unrelated channels.
-  const groupInfo = getMultiTwitchDataForChannel(sourceChannel);
-  const groupParticipantSet = groupInfo ? new Set(groupInfo.participants) : null;
-  const targets = registered.filter((ch) =>
-    ch === sourceChannel || (groupParticipantSet !== null && groupParticipantSet.has(ch)),
-  );
+  const targets = candidates.filter((_, i) => registrationResults[i] !== null);
 
   return sendDedupedBySession(targets, loginUserIds, output, send, resolveSharedChatSessionId);
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -128,7 +128,7 @@ import { invalidateCustomCommandLookupCache } from './db/customCommandCache';
 export {
   getAllCustomCommandsWithAssignments,
   addCustomCommand, updateCustomCommand, removeCustomCommand,
-  assignUserToCommand, unassignUserFromCommand,
+  assignUserToCommand, assignUsersToCommand, unassignUserFromCommand,
 } from './db/customCommands';
 export type {
   DbCustomCommand, DbCustomCommandAssignedUser, DbCustomCommandWithAssignments,

--- a/src/db/commandConflicts.test.ts
+++ b/src/db/commandConflicts.test.ts
@@ -384,44 +384,6 @@ describe('assignUserToCommandWithinTransaction', () => {
     await expect(assignUserToCommandWithinTransaction(connection, 1, 'user1')).resolves.toBeUndefined();
   });
 
-  it('runs the trigger-string and eligibility reads concurrently rather than sequentially', async () => {
-    let triggerStarted = false;
-    let eligibilityStarted = false;
-    let triggerResolve!: (v: [unknown[], unknown[]]) => void;
-    let eligibilityResolve!: (v: [unknown[], unknown[]]) => void;
-
-    const execute = vi.fn()
-      .mockImplementationOnce(() => {
-        triggerStarted = true;
-        return new Promise((resolve) => { triggerResolve = resolve; });
-      })
-      .mockImplementationOnce(() => {
-        eligibilityStarted = true;
-        return new Promise((resolve) => { eligibilityResolve = resolve; });
-      })
-      .mockResolvedValueOnce([[], []]); // insertUserCommandAssignment
-    const connection = {
-      execute,
-      beginTransaction: vi.fn().mockResolvedValue(undefined),
-      commit: vi.fn().mockResolvedValue(undefined),
-      rollback: vi.fn().mockResolvedValue(undefined),
-    };
-
-    const runPromise = assignUserToCommandWithinTransaction(connection as any, 1, 'user1');
-
-    // Both reads should have been issued before either resolves — proving they were
-    // pipelined via Promise.all rather than awaited one after the other.
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(triggerStarted).toBe(true);
-    expect(eligibilityStarted).toBe(true);
-
-    triggerResolve([[{ trigger_string: '!clap' }], []]);
-    eligibilityResolve([[{ twitch_name: null, is_twitch_bot_enabled: 0 }], []]);
-
-    await runPromise;
-    expect(connection.commit).toHaveBeenCalledOnce();
-  });
 });
 
 // ─── getUserTwitchEligibilityBatch ─────────────────────────────────────────────

--- a/src/db/commandConflicts.test.ts
+++ b/src/db/commandConflicts.test.ts
@@ -26,6 +26,7 @@ vi.mock('./commandStringUtils', () => ({
     const normalized = command.trim().toLowerCase();
     return normalized.length > 0 ? normalized : null;
   }),
+  buildInClausePlaceholders: vi.fn((count: number) => Array(count).fill('?').join(', ')),
 }));
 
 import {
@@ -35,8 +36,11 @@ import {
   assertNoTwitchChannelTriggerConflict,
   getCommandTriggerStringById,
   getUserTwitchEligibility,
+  getUserTwitchEligibilityBatch,
   insertUserCommandAssignment,
+  insertUserCommandAssignments,
   assignUserToCommandWithinTransaction,
+  assignUsersToCommandWithinTransaction,
 } from './commandConflicts';
 import { CommandConflictError } from './commandStringUtils';
 import { normalizeTwitchChannelName } from '../twitch/twitchChannelName';
@@ -360,6 +364,7 @@ describe('assignUserToCommandWithinTransaction', () => {
   it('still releases the lock in the finally block when acquiring it failed', async () => {
     const connection = makeConnection([
       [{ trigger_string: '!clap' }],
+      [{ twitch_name: null, is_twitch_bot_enabled: 0 }],
     ]);
     vi.mocked(acquireNamedLock).mockRejectedValueOnce(new Error('lock timeout'));
 
@@ -377,5 +382,213 @@ describe('assignUserToCommandWithinTransaction', () => {
     vi.mocked(releaseNamedLock).mockRejectedValueOnce(new Error('release failed'));
 
     await expect(assignUserToCommandWithinTransaction(connection, 1, 'user1')).resolves.toBeUndefined();
+  });
+
+  it('runs the trigger-string and eligibility reads concurrently rather than sequentially', async () => {
+    let triggerStarted = false;
+    let eligibilityStarted = false;
+    let triggerResolve!: (v: [unknown[], unknown[]]) => void;
+    let eligibilityResolve!: (v: [unknown[], unknown[]]) => void;
+
+    const execute = vi.fn()
+      .mockImplementationOnce(() => {
+        triggerStarted = true;
+        return new Promise((resolve) => { triggerResolve = resolve; });
+      })
+      .mockImplementationOnce(() => {
+        eligibilityStarted = true;
+        return new Promise((resolve) => { eligibilityResolve = resolve; });
+      })
+      .mockResolvedValueOnce([[], []]); // insertUserCommandAssignment
+    const connection = {
+      execute,
+      beginTransaction: vi.fn().mockResolvedValue(undefined),
+      commit: vi.fn().mockResolvedValue(undefined),
+      rollback: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const runPromise = assignUserToCommandWithinTransaction(connection as any, 1, 'user1');
+
+    // Both reads should have been issued before either resolves — proving they were
+    // pipelined via Promise.all rather than awaited one after the other.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(triggerStarted).toBe(true);
+    expect(eligibilityStarted).toBe(true);
+
+    triggerResolve([[{ trigger_string: '!clap' }], []]);
+    eligibilityResolve([[{ twitch_name: null, is_twitch_bot_enabled: 0 }], []]);
+
+    await runPromise;
+    expect(connection.commit).toHaveBeenCalledOnce();
+  });
+});
+
+// ─── getUserTwitchEligibilityBatch ─────────────────────────────────────────────
+
+describe('getUserTwitchEligibilityBatch', () => {
+  it('returns an empty map without querying when discordIds is empty', async () => {
+    const exec = makeExecutor();
+    const result = await getUserTwitchEligibilityBatch(exec, []);
+    expect(result.size).toBe(0);
+    expect(exec.execute).not.toHaveBeenCalled();
+  });
+
+  it('maps each returned row by discord_id, normalizing twitch_name', async () => {
+    vi.mocked(normalizeTwitchChannelName).mockImplementation((s: string) => s.toLowerCase());
+    const exec = makeExecutor([
+      { discord_id: 'user1', twitch_name: 'Alice', is_twitch_bot_enabled: 1 },
+      { discord_id: 'user2', twitch_name: null, is_twitch_bot_enabled: 0 },
+    ]);
+    const result = await getUserTwitchEligibilityBatch(exec, ['user1', 'user2']);
+    expect(result.get('user1')).toEqual({ normalizedTwitchName: 'alice', isTwitchBotEnabled: true });
+    expect(result.get('user2')).toEqual({ normalizedTwitchName: null, isTwitchBotEnabled: false });
+  });
+
+  it('omits discordIds with no matching row', async () => {
+    const exec = makeExecutor([{ discord_id: 'user1', twitch_name: null, is_twitch_bot_enabled: 0 }]);
+    const result = await getUserTwitchEligibilityBatch(exec, ['user1', 'missing']);
+    expect(result.has('missing')).toBe(false);
+    expect(result.size).toBe(1);
+  });
+
+  it('queries with a single IN clause covering all discordIds', async () => {
+    const exec = makeExecutor([]);
+    await getUserTwitchEligibilityBatch(exec, ['a', 'b', 'c']);
+    expect(exec.execute).toHaveBeenCalledOnce();
+    const [sql, params] = exec.execute.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('IN (?, ?, ?)');
+    expect(params).toEqual(['a', 'b', 'c']);
+  });
+});
+
+// ─── insertUserCommandAssignments ──────────────────────────────────────────────
+
+describe('insertUserCommandAssignments', () => {
+  it('does not query when discordIds is empty', async () => {
+    const exec = makeExecutor();
+    await insertUserCommandAssignments(exec, 5, []);
+    expect(exec.execute).not.toHaveBeenCalled();
+  });
+
+  it('issues a single multi-row INSERT covering all discordIds', async () => {
+    const exec = makeExecutor();
+    await insertUserCommandAssignments(exec, 5, ['user1', 'user2', 'user3']);
+    expect(exec.execute).toHaveBeenCalledOnce();
+    const [sql, params] = exec.execute.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('INSERT INTO twitch_user_commands');
+    expect(sql).toContain('AS new_row');
+    expect(params).toEqual([5, 'user1', 5, 'user2', 5, 'user3']);
+  });
+});
+
+// ─── assignUsersToCommandWithinTransaction ─────────────────────────────────────
+
+describe('assignUsersToCommandWithinTransaction', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function makeConnection(executeResults: unknown[][]): any {
+    const execute = vi.fn();
+    for (const result of executeResults) {
+      execute.mockResolvedValueOnce([result, []]);
+    }
+    return {
+      execute,
+      beginTransaction: vi.fn().mockResolvedValue(undefined),
+      commit: vi.fn().mockResolvedValue(undefined),
+      rollback: vi.fn().mockResolvedValue(undefined),
+    };
+  }
+
+  it('no-ops without opening a transaction when discordIds is empty', async () => {
+    const connection = makeConnection([]);
+    await assignUsersToCommandWithinTransaction(connection, 1, []);
+    expect(connection.beginTransaction).not.toHaveBeenCalled();
+    expect(acquireNamedLock).not.toHaveBeenCalled();
+  });
+
+  it('acquires the lock once, inserts all users in one batch, and commits', async () => {
+    const connection = makeConnection([
+      [{ trigger_string: '!clap' }], // getCommandTriggerStringById
+      [
+        { discord_id: 'user1', twitch_name: null, is_twitch_bot_enabled: 0 },
+        { discord_id: 'user2', twitch_name: null, is_twitch_bot_enabled: 0 },
+      ], // getUserTwitchEligibilityBatch
+      [], // insertUserCommandAssignments
+    ]);
+
+    await assignUsersToCommandWithinTransaction(connection, 1, ['user1', 'user2']);
+
+    expect(connection.beginTransaction).toHaveBeenCalledOnce();
+    expect(connection.commit).toHaveBeenCalledOnce();
+    expect(connection.execute).toHaveBeenCalledTimes(3);
+    expect(acquireNamedLock).toHaveBeenCalledOnce();
+    expect(releaseNamedLock).toHaveBeenCalledOnce();
+  });
+
+  it('runs a channel trigger conflict check for each eligible user', async () => {
+    const connection = makeConnection([
+      [{ trigger_string: '!clap' }],
+      [
+        { discord_id: 'user1', twitch_name: 'alice', is_twitch_bot_enabled: 1 },
+        { discord_id: 'user2', twitch_name: 'bob', is_twitch_bot_enabled: 1 },
+      ],
+      [], // conflict check for user1
+      [], // conflict check for user2
+      [], // insert
+    ]);
+
+    await assignUsersToCommandWithinTransaction(connection, 1, ['user1', 'user2']);
+
+    expect(connection.commit).toHaveBeenCalledOnce();
+    expect(connection.execute).toHaveBeenCalledTimes(5);
+  });
+
+  it('rolls back and throws CommandConflictError when any eligible user has a channel conflict', async () => {
+    const connection = makeConnection([
+      [{ trigger_string: '!clap' }],
+      [{ discord_id: 'user1', twitch_name: 'alice', is_twitch_bot_enabled: 1 }],
+      [{ command_id: 99 }], // conflict row found
+    ]);
+
+    await expect(assignUsersToCommandWithinTransaction(connection, 1, ['user1'])).rejects.toBeInstanceOf(CommandConflictError);
+    expect(connection.rollback).toHaveBeenCalledOnce();
+    expect(connection.commit).not.toHaveBeenCalled();
+  });
+
+  it('rolls back and throws when a discordId has no matching user', async () => {
+    const connection = makeConnection([
+      [{ trigger_string: '!clap' }],
+      [], // no rows for either user — nobody found
+    ]);
+
+    await expect(assignUsersToCommandWithinTransaction(connection, 1, ['ghost'])).rejects.toThrow('User not found: ghost');
+    expect(connection.rollback).toHaveBeenCalledOnce();
+    expect(releaseNamedLock).toHaveBeenCalledOnce();
+  });
+
+  it('retries once on a deadlock and succeeds on the second attempt, acquiring the lock only once', async () => {
+    const deadlockErr = new Error('deadlock');
+    const triggerRow = [{ trigger_string: '!clap' }];
+    const eligibilityRows = [{ discord_id: 'user1', twitch_name: null, is_twitch_bot_enabled: 0 }];
+    const execute = vi.fn()
+      .mockResolvedValueOnce([triggerRow, []])
+      .mockResolvedValueOnce([eligibilityRows, []])
+      .mockRejectedValueOnce(deadlockErr) // attempt 1: insert fails
+      .mockResolvedValueOnce([triggerRow, []])
+      .mockResolvedValueOnce([eligibilityRows, []])
+      .mockResolvedValueOnce([[], []]); // attempt 2: insert succeeds
+    const connection = {
+      execute,
+      beginTransaction: vi.fn().mockResolvedValue(undefined),
+      commit: vi.fn().mockResolvedValue(undefined),
+      rollback: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(isDeadlockError).mockReturnValueOnce(true);
+
+    await assignUsersToCommandWithinTransaction(connection as any, 1, ['user1']);
+
+    expect(connection.beginTransaction).toHaveBeenCalledTimes(2);
+    expect(connection.commit).toHaveBeenCalledOnce();
+    expect(acquireNamedLock).toHaveBeenCalledOnce();
   });
 });

--- a/src/db/commandConflicts.ts
+++ b/src/db/commandConflicts.ts
@@ -3,7 +3,7 @@ import mysql from 'mysql2/promise';
 
 const log = createLogger('DB');
 import { normalizeTwitchChannelName } from '../twitch/twitchChannelName';
-import { type SqlExecutor, CommandConflictError, normalizeCommand } from './commandStringUtils';
+import { type SqlExecutor, CommandConflictError, normalizeCommand, buildInClausePlaceholders } from './commandStringUtils';
 import {
   acquireNamedLock,
   releaseNamedLock,
@@ -193,7 +193,7 @@ export async function getCommandTriggerStringById(executor: SqlExecutor, command
   return normalizeCommand(String(commandRows[0].trigger_string)) ?? '';
 }
 
-interface UserTwitchEligibility {
+export interface UserTwitchEligibility {
   normalizedTwitchName: string | null;
   isTwitchBotEnabled: boolean;
 }
@@ -220,6 +220,36 @@ export async function getUserTwitchEligibility(executor: SqlExecutor, discordId:
     normalizedTwitchName: twitchName ? normalizeTwitchChannelName(twitchName) : null,
     isTwitchBotEnabled: fromBit(userRows[0].is_twitch_bot_enabled),
   };
+}
+
+/**
+ * Looks up multiple users' normalized Twitch channel names and Twitch-bot-enabled flags in one
+ * query, used by the batch assignment path to avoid a per-user round trip.
+ * @param executor Pool or transaction connection to query with.
+ * @param discordIds Discord snowflakes of the users to look up.
+ * @returns A map from `discordId` to its eligibility. `discordId`s with no matching user are omitted.
+ */
+export async function getUserTwitchEligibilityBatch(
+  executor: SqlExecutor,
+  discordIds: string[],
+): Promise<Map<string, UserTwitchEligibility>> {
+  const result = new Map<string, UserTwitchEligibility>();
+  if (discordIds.length === 0) return result;
+
+  const [userRows] = await executor.execute<mysql.RowDataPacket[]>(
+    `SELECT discord_id, twitch_name, is_twitch_bot_enabled FROM \`user\` WHERE discord_id IN (${buildInClausePlaceholders(discordIds.length)})`,
+    discordIds,
+  );
+
+  for (const row of userRows) {
+    const twitchName = row.twitch_name ? String(row.twitch_name) : null;
+    result.set(String(row.discord_id), {
+      normalizedTwitchName: twitchName ? normalizeTwitchChannelName(twitchName) : null,
+      isTwitchBotEnabled: fromBit(row.is_twitch_bot_enabled),
+    });
+  }
+
+  return result;
 }
 
 /**
@@ -322,14 +352,18 @@ export async function assignUserToCommandWithinTransaction(
     for (let attempt = 0; attempt < MAX_DEADLOCK_RETRIES; attempt++) {
       await connection.beginTransaction();
       try {
-        const normalizedTriggerString = await getCommandTriggerStringById(connection, commandId);
+        // These two reads are independent (different tables, no data dependency), so pipeline
+        // them over the same connection instead of paying two sequential round trips.
+        const [normalizedTriggerString, userEligibility] = await Promise.all([
+          getCommandTriggerStringById(connection, commandId),
+          getUserTwitchEligibility(connection, discordId),
+        ]);
 
         if (!lockNameByTrigger) {
           lockNameByTrigger = getCommandWriteLockName(normalizedTriggerString);
           await acquireNamedLock(connection, lockNameByTrigger);
         }
 
-        const userEligibility = await getUserTwitchEligibility(connection, discordId);
         if (userEligibility.normalizedTwitchName && userEligibility.isTwitchBotEnabled) {
           await assertNoTwitchChannelTriggerConflict(
             connection,
@@ -353,6 +387,104 @@ export async function assignUserToCommandWithinTransaction(
     }
 
     throw new Error('[DB] Deadlock retry limit reached in assignUserToCommandWithinTransaction.');
+  } finally {
+    if (lockNameByTrigger) {
+      try { await releaseNamedLock(connection, lockNameByTrigger); } catch (err) { log.warn('Failed to release named lock:', err); }
+    }
+  }
+}
+
+/**
+ * Inserts (or no-ops if already present) assignments linking multiple Discord users to a custom
+ * command for single-Twitch triggering, in one multi-row upsert.
+ * @param executor Pool or transaction connection to query with.
+ * @param commandId Command id being assigned.
+ * @param discordIds Discord snowflakes of the users being assigned.
+ */
+export async function insertUserCommandAssignments(
+  executor: SqlExecutor,
+  commandId: number,
+  discordIds: string[],
+): Promise<void> {
+  if (discordIds.length === 0) return;
+
+  const placeholders = discordIds.map(() => '(?, ?)').join(', ');
+  const params = discordIds.flatMap((discordId) => [commandId, discordId]);
+  await executor.execute(
+    `INSERT INTO twitch_user_commands (command_id, discord_id)
+     VALUES ${placeholders} AS new_row
+     ON DUPLICATE KEY UPDATE
+       command_id = new_row.command_id`,
+    params,
+  );
+}
+
+/**
+ * Assigns multiple Discord users to a custom command for single-Twitch triggering in a single
+ * transaction guarded by a named lock on the command's trigger string, mirroring
+ * {@link assignUserToCommandWithinTransaction} but batching the eligibility lookup, conflict
+ * checks, and insert across all users instead of paying a lock/transaction/round-trip per user.
+ * Retries on deadlock up to `MAX_DEADLOCK_RETRIES` times, re-acquiring the transaction each attempt
+ * while holding the same session-scoped lock across attempts.
+ * @param connection Transaction-capable pool connection to run the work on.
+ * @param commandId Command id being assigned.
+ * @param discordIds Discord snowflakes of the users being assigned.
+ * @throws {CommandConflictError} If any assignment would create a Twitch-channel trigger conflict.
+ * @throws If a `discordId` has no matching user, or the deadlock retry limit is reached.
+ */
+export async function assignUsersToCommandWithinTransaction(
+  connection: mysql.PoolConnection,
+  commandId: number,
+  discordIds: string[],
+): Promise<void> {
+  if (discordIds.length === 0) return;
+
+  let lockNameByTrigger: string | null = null;
+
+  try {
+    for (let attempt = 0; attempt < MAX_DEADLOCK_RETRIES; attempt++) {
+      await connection.beginTransaction();
+      try {
+        const [normalizedTriggerString, eligibilityByDiscordId] = await Promise.all([
+          getCommandTriggerStringById(connection, commandId),
+          getUserTwitchEligibilityBatch(connection, discordIds),
+        ]);
+
+        if (!lockNameByTrigger) {
+          lockNameByTrigger = getCommandWriteLockName(normalizedTriggerString);
+          await acquireNamedLock(connection, lockNameByTrigger);
+        }
+
+        await Promise.all(discordIds.map((discordId) => {
+          const eligibility = eligibilityByDiscordId.get(discordId);
+          if (!eligibility) {
+            throw new Error(`User not found: ${discordId}`);
+          }
+          if (eligibility.normalizedTwitchName && eligibility.isTwitchBotEnabled) {
+            return assertNoTwitchChannelTriggerConflict(
+              connection,
+              commandId,
+              normalizedTriggerString,
+              eligibility.normalizedTwitchName,
+            );
+          }
+          return undefined;
+        }));
+
+        await insertUserCommandAssignments(connection, commandId, discordIds);
+        await connection.commit();
+        return;
+      } catch (error) {
+        await connection.rollback();
+        if (isDeadlockError(error) && attempt < MAX_DEADLOCK_RETRIES - 1) {
+          log.warn(`Deadlock in assignUsersToCommand, retrying (attempt ${attempt + 1}/${MAX_DEADLOCK_RETRIES}).`);
+          continue;
+        }
+        throw error;
+      }
+    }
+
+    throw new Error('[DB] Deadlock retry limit reached in assignUsersToCommandWithinTransaction.');
   } finally {
     if (lockNameByTrigger) {
       try { await releaseNamedLock(connection, lockNameByTrigger); } catch (err) { log.warn('Failed to release named lock:', err); }

--- a/src/db/commandConflicts.ts
+++ b/src/db/commandConflicts.ts
@@ -352,12 +352,8 @@ export async function assignUserToCommandWithinTransaction(
     for (let attempt = 0; attempt < MAX_DEADLOCK_RETRIES; attempt++) {
       await connection.beginTransaction();
       try {
-        // These two reads are independent (different tables, no data dependency), so pipeline
-        // them over the same connection instead of paying two sequential round trips.
-        const [normalizedTriggerString, userEligibility] = await Promise.all([
-          getCommandTriggerStringById(connection, commandId),
-          getUserTwitchEligibility(connection, discordId),
-        ]);
+        const normalizedTriggerString = await getCommandTriggerStringById(connection, commandId);
+        const userEligibility = await getUserTwitchEligibility(connection, discordId);
 
         if (!lockNameByTrigger) {
           lockNameByTrigger = getCommandWriteLockName(normalizedTriggerString);
@@ -447,7 +443,10 @@ async function assertUserAssignable(
 }
 
 /**
- * Runs {@link assertUserAssignable} concurrently for every `discordId`.
+ * Runs {@link assertUserAssignable} for every `discordId`, in order. A single MySQL connection
+ * only ever has one command in flight (mysql2 queues, rather than pipelines, queries issued
+ * without awaiting the previous one), so these checks are issued sequentially rather than via
+ * `Promise.all` — that would add complexity without reducing round trips.
  * @param connection Transaction-capable pool connection to query with.
  * @param commandId Command id being assigned.
  * @param discordIds Discord snowflakes of the users being checked.
@@ -463,9 +462,9 @@ async function assertAllUsersAssignable(
   normalizedTriggerString: string,
   eligibilityByDiscordId: Map<string, UserTwitchEligibility>,
 ): Promise<void> {
-  await Promise.all(discordIds.map((discordId) => assertUserAssignable(
-    connection, commandId, discordId, normalizedTriggerString, eligibilityByDiscordId,
-  )));
+  for (const discordId of discordIds) {
+    await assertUserAssignable(connection, commandId, discordId, normalizedTriggerString, eligibilityByDiscordId);
+  }
 }
 
 /**
@@ -494,10 +493,8 @@ export async function assignUsersToCommandWithinTransaction(
     for (let attempt = 0; attempt < MAX_DEADLOCK_RETRIES; attempt++) {
       await connection.beginTransaction();
       try {
-        const [normalizedTriggerString, eligibilityByDiscordId] = await Promise.all([
-          getCommandTriggerStringById(connection, commandId),
-          getUserTwitchEligibilityBatch(connection, discordIds),
-        ]);
+        const normalizedTriggerString = await getCommandTriggerStringById(connection, commandId);
+        const eligibilityByDiscordId = await getUserTwitchEligibilityBatch(connection, discordIds);
 
         if (!lockNameByTrigger) {
           lockNameByTrigger = getCommandWriteLockName(normalizedTriggerString);

--- a/src/db/commandConflicts.ts
+++ b/src/db/commandConflicts.ts
@@ -420,6 +420,55 @@ export async function insertUserCommandAssignments(
 }
 
 /**
+ * Throws if `discordId` has no matching eligibility entry, or if it's eligible for a
+ * Twitch-channel conflict check and that check finds one.
+ * @param connection Transaction-capable pool connection to query with.
+ * @param commandId Command id being assigned.
+ * @param discordId Discord snowflake of the user being checked.
+ * @param normalizedTriggerString Normalized trigger string being assigned.
+ * @param eligibilityByDiscordId Batch-fetched eligibility, keyed by `discordId`.
+ * @throws {CommandConflictError} If the user's Twitch channel would create a trigger conflict.
+ * @throws If `discordId` has no matching entry in `eligibilityByDiscordId`.
+ */
+async function assertUserAssignable(
+  connection: mysql.PoolConnection,
+  commandId: number,
+  discordId: string,
+  normalizedTriggerString: string,
+  eligibilityByDiscordId: Map<string, UserTwitchEligibility>,
+): Promise<void> {
+  const eligibility = eligibilityByDiscordId.get(discordId);
+  if (!eligibility) {
+    throw new Error(`User not found: ${discordId}`);
+  }
+  if (eligibility.normalizedTwitchName && eligibility.isTwitchBotEnabled) {
+    await assertNoTwitchChannelTriggerConflict(connection, commandId, normalizedTriggerString, eligibility.normalizedTwitchName);
+  }
+}
+
+/**
+ * Runs {@link assertUserAssignable} concurrently for every `discordId`.
+ * @param connection Transaction-capable pool connection to query with.
+ * @param commandId Command id being assigned.
+ * @param discordIds Discord snowflakes of the users being checked.
+ * @param normalizedTriggerString Normalized trigger string being assigned.
+ * @param eligibilityByDiscordId Batch-fetched eligibility, keyed by `discordId`.
+ * @throws {CommandConflictError} If any user's Twitch channel would create a trigger conflict.
+ * @throws If any `discordId` has no matching entry in `eligibilityByDiscordId`.
+ */
+async function assertAllUsersAssignable(
+  connection: mysql.PoolConnection,
+  commandId: number,
+  discordIds: string[],
+  normalizedTriggerString: string,
+  eligibilityByDiscordId: Map<string, UserTwitchEligibility>,
+): Promise<void> {
+  await Promise.all(discordIds.map((discordId) => assertUserAssignable(
+    connection, commandId, discordId, normalizedTriggerString, eligibilityByDiscordId,
+  )));
+}
+
+/**
  * Assigns multiple Discord users to a custom command for single-Twitch triggering in a single
  * transaction guarded by a named lock on the command's trigger string, mirroring
  * {@link assignUserToCommandWithinTransaction} but batching the eligibility lookup, conflict
@@ -455,22 +504,7 @@ export async function assignUsersToCommandWithinTransaction(
           await acquireNamedLock(connection, lockNameByTrigger);
         }
 
-        await Promise.all(discordIds.map((discordId) => {
-          const eligibility = eligibilityByDiscordId.get(discordId);
-          if (!eligibility) {
-            throw new Error(`User not found: ${discordId}`);
-          }
-          if (eligibility.normalizedTwitchName && eligibility.isTwitchBotEnabled) {
-            return assertNoTwitchChannelTriggerConflict(
-              connection,
-              commandId,
-              normalizedTriggerString,
-              eligibility.normalizedTwitchName,
-            );
-          }
-          return undefined;
-        }));
-
+        await assertAllUsersAssignable(connection, commandId, discordIds, normalizedTriggerString, eligibilityByDiscordId);
         await insertUserCommandAssignments(connection, commandId, discordIds);
         await connection.commit();
         return;

--- a/src/db/customCommandCache.test.ts
+++ b/src/db/customCommandCache.test.ts
@@ -117,12 +117,11 @@ describe('getCustomCommandForDiscord', () => {
     expect(result?.output).toBe('first');
   });
 
-  it('returns a copy — mutating result does not affect subsequent lookups', async () => {
+  it('returns the cache entry directly (frozen), not a defensive copy — mutating it throws', async () => {
     vi.mocked(getAllCustomCommandsWithAssignments).mockResolvedValue([makeCommand()] as any);
-    const first = await getCustomCommandForDiscord('!clap', GUILD);
-    (first as any).output = 'mutated';
-    const second = await getCustomCommandForDiscord('!clap', GUILD);
-    expect(second?.output).toBe('*claps*');
+    const result = await getCustomCommandForDiscord('!clap', GUILD);
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(() => { (result as any).output = 'mutated'; }).toThrow();
   });
 });
 
@@ -171,6 +170,16 @@ describe('getCustomCommandForDiscord — per-guild overrides', () => {
     ] as any);
     expect((await getCustomCommandForDiscord('!clap', GUILD))?.output).toBe('only here');
     expect((await getCustomCommandForDiscord('!clap', 'other-guild'))?.output).toBe('*claps*');
+  });
+
+  it('the override-output branch returns a distinct, unfrozen object with only output replaced', async () => {
+    vi.mocked(getAllCustomCommandsWithAssignments).mockResolvedValue([makeCommand()] as any);
+    vi.mocked(getAllOverrides).mockResolvedValue([
+      { guild_id: GUILD, command_id: 1, is_disabled: false, output: 'guild text' },
+    ] as any);
+    const result = await getCustomCommandForDiscord('!clap', GUILD);
+    expect(result).toEqual(expect.objectContaining({ output: 'guild text', trigger_string: '!clap' }));
+    expect(Object.isFrozen(result)).toBe(false);
   });
 });
 
@@ -292,7 +301,7 @@ describe('getCustomCommandForTwitchChannel', () => {
     expect(await getCustomCommandForTwitchChannel('#MyChan', '!clap')).not.toBeNull();
   });
 
-  it('returns a copy — mutating result does not affect subsequent lookups', async () => {
+  it('returns the cache entry directly (frozen), not a defensive copy — mutating it throws', async () => {
     vi.mocked(getAllCustomCommandsWithAssignments).mockResolvedValue([
       makeCommand({
         assigned_users: [
@@ -300,9 +309,8 @@ describe('getCustomCommandForTwitchChannel', () => {
         ],
       }),
     ] as any);
-    const first = await getCustomCommandForTwitchChannel('mychan', '!clap');
-    (first as any).output = 'mutated';
-    const second = await getCustomCommandForTwitchChannel('mychan', '!clap');
-    expect(second?.output).toBe('*claps*');
+    const result = await getCustomCommandForTwitchChannel('mychan', '!clap');
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(() => { (result as any).output = 'mutated'; }).toThrow();
   });
 });

--- a/src/db/customCommandCache.ts
+++ b/src/db/customCommandCache.ts
@@ -302,13 +302,17 @@ function buildCustomCommandLookupCache(
       continue;
     }
 
-    const baseCommand = {
+    // Frozen once here (not copied per-lookup in getCustomCommandFor*) since callers only ever
+    // read this object; freezing turns any future accidental mutation into a loud failure
+    // instead of silently corrupting the shared cache entry. Shared by reference across
+    // discordByTrigger and every Twitch-candidate cache key that resolves to this command.
+    const baseCommand = Object.freeze({
       command_id: command.command_id,
       trigger_string: command.trigger_string,
       output: command.output,
       is_discord_enabled: command.is_discord_enabled,
       is_multi_twitch: command.is_multi_twitch,
-    };
+    });
 
     registerDiscordCommand(discordByTrigger, normalizedTriggerString, baseCommand);
     registerMultiTwitchCandidates(
@@ -377,8 +381,7 @@ export async function getCustomCommandForTwitchChannel(channelName: string, trig
   }
 
   const cache = await customCommandLookupCacheState.getCache();
-  const cachedCommand = cache.twitchByChannelAndTrigger.get(cacheKey);
-  return cachedCommand ? { ...cachedCommand } : null;
+  return cache.twitchByChannelAndTrigger.get(cacheKey) ?? null;
 }
 
 /**
@@ -418,5 +421,5 @@ export async function getCustomCommandForDiscord(
     }
   }
 
-  return { ...cachedCommand };
+  return cachedCommand;
 }

--- a/src/db/customCommands.test.ts
+++ b/src/db/customCommands.test.ts
@@ -16,6 +16,7 @@ vi.mock('./commandConflicts', () => ({
   assertMultiTwitchTriggerAvailable: vi.fn().mockResolvedValue(undefined),
   assertNoSingleTwitchAssignmentOverlap: vi.fn().mockResolvedValue(undefined),
   assignUserToCommandWithinTransaction: vi.fn().mockResolvedValue(undefined),
+  assignUsersToCommandWithinTransaction: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock('./customCommandCache', () => ({
   invalidateCustomCommandLookupCache: vi.fn(),
@@ -38,6 +39,7 @@ import {
   updateCustomCommand,
   removeCustomCommand,
   assignUserToCommand,
+  assignUsersToCommand,
   unassignUserFromCommand,
 } from './customCommands';
 import { runSerializedCommandWrite, acquireNamedLock, releaseNamedLock } from './commandLocks';
@@ -46,6 +48,7 @@ import {
   assertMultiTwitchTriggerAvailable,
   assertNoSingleTwitchAssignmentOverlap,
   assignUserToCommandWithinTransaction,
+  assignUsersToCommandWithinTransaction,
 } from './commandConflicts';
 import { invalidateCustomCommandLookupCache } from './customCommandCache';
 import { assertNotReservedCommand } from './reservedCommands';
@@ -360,6 +363,45 @@ describe('assignUserToCommand', () => {
     vi.mocked(getPool).mockReturnValue(pool as any);
     vi.mocked(assignUserToCommandWithinTransaction).mockRejectedValueOnce(new Error('conflict'));
     await expect(assignUserToCommand(3, 'user1')).rejects.toThrow('conflict');
+    expect(releaseNamedLock).toHaveBeenCalled();
+    expect(pool._conn.release).toHaveBeenCalled();
+  });
+});
+
+// ─── assignUsersToCommand ──────────────────────────────────────────────────────
+
+describe('assignUsersToCommand', () => {
+  it('no-ops without opening a connection when discordIds is empty', async () => {
+    vi.mocked(getPool).mockClear();
+    await assignUsersToCommand(3, []);
+    expect(getPool).not.toHaveBeenCalled();
+    expect(assignUsersToCommandWithinTransaction).not.toHaveBeenCalled();
+  });
+
+  it('acquires lock once, calls assignUsersToCommandWithinTransaction with all ids, releases lock and connection', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await assignUsersToCommand(3, ['user1', 'user2']);
+    expect(acquireNamedLock).toHaveBeenCalledTimes(1);
+    expect(acquireNamedLock).toHaveBeenCalledWith(conn, 'bcuk_cmdid_3');
+    expect(assignUsersToCommandWithinTransaction).toHaveBeenCalledWith(conn, 3, ['user1', 'user2']);
+    expect(releaseNamedLock).toHaveBeenCalledWith(conn, 'bcuk_cmdid_3');
+    expect(conn.release).toHaveBeenCalled();
+  });
+
+  it('calls invalidateCustomCommandLookupCache once on success', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    vi.mocked(invalidateCustomCommandLookupCache).mockClear();
+    await assignUsersToCommand(3, ['user1', 'user2']);
+    expect(invalidateCustomCommandLookupCache).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases lock and connection even when assignUsersToCommandWithinTransaction throws', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    vi.mocked(assignUsersToCommandWithinTransaction).mockRejectedValueOnce(new Error('conflict'));
+    await expect(assignUsersToCommand(3, ['user1'])).rejects.toThrow('conflict');
     expect(releaseNamedLock).toHaveBeenCalled();
     expect(pool._conn.release).toHaveBeenCalled();
   });

--- a/src/db/customCommands.ts
+++ b/src/db/customCommands.ts
@@ -8,7 +8,7 @@ import { requireTrimmedString, CommandNotFoundError, type SqlExecutor } from './
 import { acquireNamedLock, releaseNamedLock, commandExists, runSerializedCommandWrite } from './commandLocks';
 import {
   assertDiscordTriggerAvailable, assertMultiTwitchTriggerAvailable, assertNoSingleTwitchAssignmentOverlap,
-  assignUserToCommandWithinTransaction,
+  assignUserToCommandWithinTransaction, assignUsersToCommandWithinTransaction,
 } from './commandConflicts';
 import { invalidateCustomCommandLookupCache } from './customCommandCache';
 
@@ -259,6 +259,34 @@ export async function assignUserToCommand(commandId: number, discordId: string):
     invalidateCustomCommandLookupCache();
   } finally {
     // Always release the id lock
+    await releaseNamedLock(connection, lockNameById);
+    connection.release();
+  }
+}
+
+/**
+ * Assign multiple Discord users to a custom command's Twitch streamer list in one transaction.
+ * Acquires the command ID's named lock once, then delegates to
+ * {@link assignUsersToCommandWithinTransaction} to check cross-command conflicts and insert all
+ * assignments before invalidating the lookup cache once. A no-op (no connection opened) when
+ * `discordIds` is empty.
+ *
+ * @param commandId - ID of the command to assign the users to.
+ * @param discordIds - Discord snowflakes of the users to assign.
+ */
+export async function assignUsersToCommand(commandId: number, discordIds: string[]): Promise<void> {
+  if (discordIds.length === 0) return;
+
+  const connection = await getPool().getConnection();
+
+  const lockNameById = `bcuk_cmdid_${commandId}`;
+  try {
+    await acquireNamedLock(connection, lockNameById);
+
+    await assignUsersToCommandWithinTransaction(connection, commandId, discordIds);
+
+    invalidateCustomCommandLookupCache();
+  } finally {
     await releaseNamedLock(connection, lockNameById);
     connection.release();
   }

--- a/src/db/overlayVideos.test.ts
+++ b/src/db/overlayVideos.test.ts
@@ -246,6 +246,7 @@ describe('setRewardVideos', () => {
     conn.execute
       .mockResolvedValueOnce([[{ id: 1 }], []])         // ownership check: rows
       .mockResolvedValueOnce([{ affectedRows: 1 }, []])  // DELETE: ResultSetHeader
+      .mockResolvedValueOnce([[{ id: 5 }], []])          // validate-SELECT IN: owned video ids
       .mockResolvedValueOnce([{ affectedRows: 1 }, []]);  // INSERT: ResultSetHeader
     vi.mocked(getPool).mockReturnValue(pool as any);
     await setRewardVideos(1, 1, [{ videoId: 5, weight: 2 }]);
@@ -258,7 +259,7 @@ describe('setRewardVideos', () => {
     conn.execute
       .mockResolvedValueOnce([[{ id: 1 }], []])         // ownership check: rows
       .mockResolvedValueOnce([{ affectedRows: 1 }, []])  // DELETE: ResultSetHeader
-      .mockResolvedValueOnce([{ affectedRows: 0 }, []]);  // INSERT: affectedRows=0 → wrong streamer
+      .mockResolvedValueOnce([[], []]);                  // validate-SELECT IN: no owned videos match
     vi.mocked(getPool).mockReturnValue(pool as any);
     await expect(setRewardVideos(1, 1, [{ videoId: 999, weight: 1 }])).rejects.toThrow('does not belong to streamer');
     expect(conn.rollback).toHaveBeenCalled();
@@ -281,11 +282,42 @@ describe('setRewardVideos', () => {
     conn.execute
       .mockResolvedValueOnce([[{ id: 1 }], []])         // ownership check
       .mockResolvedValueOnce([{ affectedRows: 1 }, []])  // DELETE
+      .mockResolvedValueOnce([[{ id: 5 }], []])          // validate-SELECT IN
       .mockResolvedValueOnce([{ affectedRows: 1 }, []]); // INSERT
     vi.mocked(getPool).mockReturnValue(pool as any);
     await setRewardVideos(1, 1, [{ videoId: 5, weight: 0 }]);
-    const insertParams: unknown[] = conn.execute.mock.calls[2][1];
-    expect(insertParams[1]).toBe(1);  // Math.max(1, 0) = 1
+    const insertParams: unknown[] = conn.execute.mock.calls[3][1];
+    expect(insertParams[2]).toBe(1);  // Math.max(1, 0) = 1
+  });
+
+  it('issues a single validate query and a single multi-row insert regardless of video count', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute
+      .mockResolvedValueOnce([[{ id: 1 }], []])                              // ownership check
+      .mockResolvedValueOnce([{ affectedRows: 1 }, []])                       // DELETE
+      .mockResolvedValueOnce([[{ id: 5 }, { id: 6 }, { id: 7 }], []])         // validate-SELECT IN
+      .mockResolvedValueOnce([{ affectedRows: 3 }, []]);                      // INSERT
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await setRewardVideos(1, 1, [
+      { videoId: 5, weight: 1 },
+      { videoId: 6, weight: 2 },
+      { videoId: 7, weight: 3 },
+    ]);
+    expect(conn.execute).toHaveBeenCalledTimes(4);
+    expect(conn.commit).toHaveBeenCalled();
+  });
+
+  it('does not query or insert when videos is empty', async () => {
+    const pool = makePool();
+    const conn = pool._conn;
+    conn.execute
+      .mockResolvedValueOnce([[{ id: 1 }], []])         // ownership check
+      .mockResolvedValueOnce([{ affectedRows: 1 }, []]); // DELETE
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await setRewardVideos(1, 1, []);
+    expect(conn.execute).toHaveBeenCalledTimes(2);
+    expect(conn.commit).toHaveBeenCalled();
   });
 });
 

--- a/src/db/overlayVideos.ts
+++ b/src/db/overlayVideos.ts
@@ -194,18 +194,24 @@ export async function setRewardVideos(
         throw new RewardNotFound();
       }
       await conn.execute(`DELETE FROM overlay_reward_video WHERE reward_id = ?`, [rewardId]);
-      for (const v of videos) {
-        const [insert] = await conn.execute<mysql.ResultSetHeader>(
-          `INSERT INTO overlay_reward_video (reward_id, video_id, weight)
-           SELECT ?, ov.id, ?
-           FROM overlay_video ov
-           WHERE ov.id = ? AND ov.streamer_id = ?`,
-          [rewardId, Math.max(1, v.weight), v.videoId, streamerId],
-        );
-        if (insert.affectedRows !== 1) {
-          throw new Error(`Video ${v.videoId} does not belong to streamer ${streamerId}`);
-        }
+      if (videos.length === 0) return;
+
+      const [ownedRows] = await conn.execute<mysql.RowDataPacket[]>(
+        `SELECT id FROM overlay_video WHERE streamer_id = ? AND id IN (${videos.map(() => '?').join(', ')})`,
+        [streamerId, ...videos.map((v) => v.videoId)],
+      );
+      const ownedIds = new Set<number>(ownedRows.map((r) => r.id));
+      const invalid = videos.find((v) => !ownedIds.has(v.videoId));
+      if (invalid) {
+        throw new Error(`Video ${invalid.videoId} does not belong to streamer ${streamerId}`);
       }
+
+      const placeholders = videos.map(() => '(?, ?, ?)').join(', ');
+      const params = videos.flatMap((v) => [rewardId, v.videoId, Math.max(1, v.weight)]);
+      await conn.execute(
+        `INSERT INTO overlay_reward_video (reward_id, video_id, weight) VALUES ${placeholders}`,
+        params,
+      );
     });
   } catch (err) {
     if (err instanceof RewardNotFound) return;

--- a/src/db/sfxCache.test.ts
+++ b/src/db/sfxCache.test.ts
@@ -113,18 +113,17 @@ describe('findCachedSfxTrigger', () => {
     expect(result!.files[0].hidden).toBe(true);
   });
 
-  it('returns a copy — mutating the result does not affect subsequent lookups', async () => {
+  it('returns the cache entry directly (frozen), not a defensive copy — mutating it throws', async () => {
     const row = makeTriggerRow('1', '!bang', [{ id: 10, file: 'bang.mp3', weight: 1, hidden: false }]);
     vi.mocked(getAllSfxTriggers).mockResolvedValue([row]);
 
-    const first = await findCachedSfxTrigger('!bang');
-    expect(first).not.toBeNull();
-    first!.files[0].weight = 999;
-
-    const second = await findCachedSfxTrigger('!bang');
-    expect(second).not.toBeNull();
-    expect(second!.files).not.toBe(first!.files);
-    expect(second!.files[0].weight).toBe(1);
+    const result = await findCachedSfxTrigger('!bang');
+    expect(result).not.toBeNull();
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(Object.isFrozen(result!.trigger)).toBe(true);
+    expect(Object.isFrozen(result!.files)).toBe(true);
+    expect(Object.isFrozen(result!.files[0])).toBe(true);
+    expect(() => { result!.files[0].weight = 999; }).toThrow();
   });
 
   it('collision — lower id wins when two triggers normalize to the same command', async () => {

--- a/src/db/sfxCache.ts
+++ b/src/db/sfxCache.ts
@@ -63,15 +63,19 @@ function buildSfxLookupCache(triggers: Awaited<ReturnType<typeof getAllSfxTrigge
       continue;
     }
 
-    byTrigger.set(normalizedTriggerCommand, {
-      trigger: {
+    // Frozen once here (not copied per-lookup in findCachedSfxTrigger) since callers only ever
+    // read these objects; freezing turns any future accidental mutation into a loud failure
+    // instead of silently corrupting the shared cache entry. Cast back to the mutable interface
+    // shape (Object.freeze's return type is Readonly<T>) since callers never mutate in practice.
+    const result: SfxLookupResult = {
+      trigger: Object.freeze({
         id: BigInt(row.triggerId),
         trigger_command: row.triggerCommand,
         category_id: row.categoryId,
         hidden: row.hidden,
         description: row.description,
-      },
-      files: row.files.map((file) => ({
+      }),
+      files: Object.freeze(row.files.map((file) => Object.freeze({
         id: file.id,
         trigger_id: BigInt(row.triggerId),
         file: file.file,
@@ -79,8 +83,9 @@ function buildSfxLookupCache(triggers: Awaited<ReturnType<typeof getAllSfxTrigge
         weight: file.weight,
         hidden: file.hidden,
         category_id: row.categoryId,
-      })),
-    });
+      }))) as SfxFile[],
+    };
+    byTrigger.set(normalizedTriggerCommand, Object.freeze(result));
   }
 
   return { loadedAt: Date.now(), byTrigger };
@@ -115,6 +120,5 @@ export async function findCachedSfxTrigger(command: string): Promise<SfxLookupRe
   if (!normalizedCommand) return null;
 
   const cache = await sfxLookupCacheState.getCache();
-  const cached = cache.byTrigger.get(normalizedCommand);
-  return cached ? { trigger: { ...cached.trigger }, files: cached.files.map((file) => ({ ...file })) } : null;
+  return cache.byTrigger.get(normalizedCommand) ?? null;
 }

--- a/src/shared/mapUtils.test.ts
+++ b/src/shared/mapUtils.test.ts
@@ -58,4 +58,17 @@ describe('getOrCreate', () => {
       expect(makeDefault).not.toHaveBeenCalled();
     },
   );
+
+  it('treats a stored undefined as a miss — calls makeDefault and overwrites it', () => {
+    // Documented edge case: a single map.get(key) can't distinguish "no entry" from
+    // "entry holding undefined", so this is intentional, not a regression.
+    const map = new Map<string, unknown>([['a', undefined]]);
+    const makeDefault = vi.fn().mockReturnValue('overwritten');
+
+    const result = getOrCreate(map, 'a', makeDefault);
+
+    expect(result).toBe('overwritten');
+    expect(map.get('a')).toBe('overwritten');
+    expect(makeDefault).toHaveBeenCalledOnce();
+  });
 });

--- a/src/shared/mapUtils.ts
+++ b/src/shared/mapUtils.ts
@@ -4,16 +4,20 @@
  * `statusStore.ts`, `commandRouter.ts`, and `audioPlayer.ts` for their
  * per-guild/per-channel lazy-init state maps.
  *
+ * A stored `undefined` is treated the same as an absent key — `makeDefault()` runs and
+ * overwrites it — since a single `map.get(key)` can't distinguish "no entry" from "entry
+ * holding `undefined`". None of this helper's callers ever store `undefined`, so this is
+ * not a concern in practice.
+ *
  * @param map - Map to look up (and potentially insert into).
  * @param key - Key to look up.
  * @param makeDefault - Builds the default value to insert when `key` is absent.
  * @returns The existing value for `key`, or the newly-created and inserted default.
  */
 export function getOrCreate<K, V>(map: Map<K, V>, key: K, makeDefault: () => V): V {
-  if (!map.has(key)) {
-    const value = makeDefault();
-    map.set(key, value);
-    return value;
-  }
-  return map.get(key) as V;
+  const existing = map.get(key);
+  if (existing !== undefined) return existing;
+  const value = makeDefault();
+  map.set(key, value);
+  return value;
 }

--- a/src/twitch/monitor/twitchMonitor.ts
+++ b/src/twitch/monitor/twitchMonitor.ts
@@ -1,7 +1,7 @@
 import { createLogger } from '../../shared/logger';
 import { getAllStreamersWithGroups, DbStreamerFull } from '../../db';
 import { getUsers, getStreams } from '../twitchApi';
-import { LiveState } from './twitchMonitorTypes';
+import { LiveStateMap } from './twitchMonitorTypes';
 import {
   DiscordMessagePreview,
   buildMessagePreview,
@@ -21,8 +21,8 @@ const log = createLogger('TwitchMonitor');
 
 // ─── Module-level state ──────────────────────────────────────────────────────
 
-/** Keyed by lowercase broadcaster login */
-const liveStates = new Map<string, LiveState>();
+/** Keyed by streamer DB row id; also indexed by login via {@link LiveStateMap.getByLogin}. */
+const liveStates = new LiveStateMap();
 let loginToUserId = new Map<string, string>();
 let streamersData: DbStreamerFull[] = [];
 
@@ -189,7 +189,7 @@ export async function restartTwitchMonitor(): Promise<void> {
  */
 export function getMultiTwitchDataForChannel(login: string): MultiTwitchGroupInfo | null {
   const loginLower = login.toLowerCase();
-  const state = Array.from(liveStates.values()).find((s) => s.login === loginLower);
+  const state = liveStates.getByLogin(loginLower);
   if (!state) return null;
 
   const groupLive = Array.from(liveStates.values()).filter((s) => s.groupId === state.groupId);

--- a/src/twitch/monitor/twitchMonitorTypes.test.ts
+++ b/src/twitch/monitor/twitchMonitorTypes.test.ts
@@ -153,15 +153,30 @@ describe('LiveStateMap', () => {
     expect(map.has('10')).toBe(false);
   });
 
-  it('delete does not clear a login index entry that now points at a different key', () => {
-    // Reproduces the case where login "alice" moved from key "10" to key "11" (a streamer
-    // re-registering under a new DB row id) before the stale key "10" is cleaned up.
+  it('set() evicts a stale entry under a different key when the same login moves without delete()', () => {
+    // A login moving from key "10" to key "11" (a streamer re-registering under a new DB
+    // row id) without an intervening delete("10") must not leave two Map entries for the
+    // same login.
+    const map = new LiveStateMap();
+    const first = makeState({ login: 'alice' });
+    const second = makeState({ login: 'alice' });
+    map.set('10', first);
+    map.set('11', second);
+
+    expect(map.has('10')).toBe(false);
+    expect(map.get('11')).toBe(second);
+    expect(map.getByLogin('alice')).toBe(second);
+    expect(map.size).toBe(1);
+  });
+
+  it('delete on a key already evicted by a later set() is a harmless no-op', () => {
     const map = new LiveStateMap();
     map.set('10', makeState({ login: 'alice' }));
-    map.set('11', makeState({ login: 'alice' }));
+    map.set('11', makeState({ login: 'alice' })); // evicts key "10" already
     map.delete('10');
 
     expect(map.getByLogin('alice')).toBe(map.get('11'));
+    expect(map.size).toBe(1);
   });
 
   it('clear empties both the map and the login index', () => {

--- a/src/twitch/monitor/twitchMonitorTypes.test.ts
+++ b/src/twitch/monitor/twitchMonitorTypes.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { DbStreamGroup, DbStreamerFull } from '../../db';
 import type { TwitchStream } from '../twitchApi';
-import { makeLiveState } from './twitchMonitorTypes';
+import { makeLiveState, LiveStateMap, type LiveState } from './twitchMonitorTypes';
 
 function makeGroup(overrides: Partial<DbStreamGroup> = {}): DbStreamGroup {
   return {
@@ -91,5 +91,85 @@ describe('makeLiveState', () => {
     const stream = makeStream();
     const state = makeLiveState(makeStreamer(), stream, null, null);
     expect(state.currentStream).toBe(stream);
+  });
+});
+
+// ─── LiveStateMap ───────────────────────────────────────────────────────────────
+
+function makeState(overrides: Partial<LiveState> = {}): LiveState {
+  return {
+    streamerId: 1,
+    login: 'alice',
+    groupId: 10,
+    currentGame: 'Minecraft',
+    title: 'Playing',
+    currentStream: {} as TwitchStream,
+    messageId: 'msg1',
+    channelId: 'chan1',
+    offlineTimer: null,
+    group: makeGroup(),
+    ...overrides,
+  };
+}
+
+describe('LiveStateMap', () => {
+  it('getByLogin returns undefined for an unknown login', () => {
+    const map = new LiveStateMap();
+    expect(map.getByLogin('nobody')).toBeUndefined();
+  });
+
+  it('getByLogin resolves a state in O(1) via the login index after set', () => {
+    const map = new LiveStateMap();
+    const state = makeState({ login: 'alice' });
+    map.set('10', state);
+    expect(map.getByLogin('alice')).toBe(state);
+  });
+
+  it('behaves as a normal Map for get/has/values by key', () => {
+    const map = new LiveStateMap();
+    const state = makeState({ login: 'alice' });
+    map.set('10', state);
+    expect(map.get('10')).toBe(state);
+    expect(map.has('10')).toBe(true);
+    expect(Array.from(map.values())).toEqual([state]);
+  });
+
+  it('re-setting the same key with a different login moves the login index', () => {
+    const map = new LiveStateMap();
+    map.set('10', makeState({ login: 'alice' }));
+    const updated = makeState({ login: 'bob' });
+    map.set('10', updated);
+
+    expect(map.getByLogin('bob')).toBe(updated);
+    expect(map.getByLogin('alice')).toBeUndefined();
+  });
+
+  it('delete removes the login index entry', () => {
+    const map = new LiveStateMap();
+    map.set('10', makeState({ login: 'alice' }));
+    map.delete('10');
+
+    expect(map.getByLogin('alice')).toBeUndefined();
+    expect(map.has('10')).toBe(false);
+  });
+
+  it('delete does not clear a login index entry that now points at a different key', () => {
+    // Reproduces the case where login "alice" moved from key "10" to key "11" (a streamer
+    // re-registering under a new DB row id) before the stale key "10" is cleaned up.
+    const map = new LiveStateMap();
+    map.set('10', makeState({ login: 'alice' }));
+    map.set('11', makeState({ login: 'alice' }));
+    map.delete('10');
+
+    expect(map.getByLogin('alice')).toBe(map.get('11'));
+  });
+
+  it('clear empties both the map and the login index', () => {
+    const map = new LiveStateMap();
+    map.set('10', makeState({ login: 'alice' }));
+    map.clear();
+
+    expect(map.size).toBe(0);
+    expect(map.getByLogin('alice')).toBeUndefined();
   });
 });

--- a/src/twitch/monitor/twitchMonitorTypes.ts
+++ b/src/twitch/monitor/twitchMonitorTypes.ts
@@ -33,3 +33,43 @@ export function makeLiveState(
     offlineTimer: null,
   };
 }
+
+/**
+ * A `Map<string, LiveState>` keyed by streamer DB row id, that also maintains a private
+ * `login -> key` index so a state can be looked up by its (lowercased) Twitch login in O(1)
+ * instead of a linear scan over every entry. Structurally compatible with plain
+ * `Map<string, LiveState>` — every other module's `.get`/`.has`/`.values()`/`.entries()` calls
+ * keep working unchanged; only `getByLogin` is new.
+ */
+export class LiveStateMap extends Map<string, LiveState> {
+  private readonly loginIndex = new Map<string, string>();
+
+  override set(key: string, value: LiveState): this {
+    const existing = this.get(key);
+    if (existing && existing.login !== value.login && this.loginIndex.get(existing.login) === key) {
+      this.loginIndex.delete(existing.login);
+    }
+    super.set(key, value);
+    this.loginIndex.set(value.login, key);
+    return this;
+  }
+
+  override delete(key: string): boolean {
+    const existing = this.get(key);
+    if (existing && this.loginIndex.get(existing.login) === key) {
+      this.loginIndex.delete(existing.login);
+    }
+    return super.delete(key);
+  }
+
+  override clear(): void {
+    super.clear();
+    this.loginIndex.clear();
+  }
+
+  /** Looks up the live state for a (lowercased) Twitch login in O(1), or undefined if not live. */
+  getByLogin(login: string): LiveState | undefined {
+    const key = this.loginIndex.get(login);
+    return key === undefined ? undefined : this.get(key);
+  }
+}

--- a/src/twitch/monitor/twitchMonitorTypes.ts
+++ b/src/twitch/monitor/twitchMonitorTypes.ts
@@ -44,16 +44,37 @@ export function makeLiveState(
 export class LiveStateMap extends Map<string, LiveState> {
   private readonly loginIndex = new Map<string, string>();
 
+  /**
+   * Sets the entry for `key`, keeping the login index in sync: cleans up `key`'s previous
+   * login (if any), and evicts any stale entry under a *different* key that previously held
+   * `value.login` — so a login can never resolve to two `Map` entries, even if the caller
+   * moves a login to a new key without an intervening `delete()`.
+   * @param key Streamer DB row id.
+   * @param value Live state to store; `value.login` becomes the login index's target for `key`.
+   * @returns This map, per the standard `Map.set` contract.
+   */
   override set(key: string, value: LiveState): this {
-    const existing = this.get(key);
-    if (existing && existing.login !== value.login && this.loginIndex.get(existing.login) === key) {
-      this.loginIndex.delete(existing.login);
+    const existingAtKey = this.get(key);
+    if (existingAtKey && existingAtKey.login !== value.login && this.loginIndex.get(existingAtKey.login) === key) {
+      this.loginIndex.delete(existingAtKey.login);
     }
+
+    const previousKeyForLogin = this.loginIndex.get(value.login);
+    if (previousKeyForLogin !== undefined && previousKeyForLogin !== key) {
+      super.delete(previousKeyForLogin);
+    }
+
     super.set(key, value);
     this.loginIndex.set(value.login, key);
     return this;
   }
 
+  /**
+   * Deletes the entry for `key`, removing its login index entry if the index still points at
+   * `key` (it may not, if a later `set()` already moved that login to a different key).
+   * @param key Streamer DB row id to remove.
+   * @returns True if an entry for `key` existed and was removed, per the standard `Map.delete` contract.
+   */
   override delete(key: string): boolean {
     const existing = this.get(key);
     if (existing && this.loginIndex.get(existing.login) === key) {
@@ -62,6 +83,7 @@ export class LiveStateMap extends Map<string, LiveState> {
     return super.delete(key);
   }
 
+  /** Clears both the map and the login index. */
   override clear(): void {
     super.clear();
     this.loginIndex.clear();

--- a/src/web/routes/commandMutations.test.ts
+++ b/src/web/routes/commandMutations.test.ts
@@ -10,7 +10,7 @@ vi.mock('../../db', () => {
     addCustomCommand: vi.fn().mockResolvedValue(1),
     updateCustomCommand: vi.fn().mockResolvedValue(undefined),
     removeCustomCommand: vi.fn().mockResolvedValue(undefined),
-    assignUserToCommand: vi.fn().mockResolvedValue(undefined),
+    assignUsersToCommand: vi.fn().mockResolvedValue(undefined),
     findUsersByIds: vi.fn().mockResolvedValue(new Map()),
     CommandConflictError,
     CommandNotFoundError,
@@ -29,7 +29,7 @@ import supertest from 'supertest';
 import router from './commandMutations';
 import {
   addCustomCommand, updateCustomCommand, removeCustomCommand,
-  assignUserToCommand, findUsersByIds,
+  assignUsersToCommand, findUsersByIds,
   CommandConflictError, CommandNotFoundError, ReservedCommandError,
   isMysqlDuplicateEntryError,
 } from '../../db';
@@ -48,7 +48,7 @@ beforeEach(() => {
   vi.mocked(addCustomCommand).mockResolvedValue(1);
   vi.mocked(updateCustomCommand).mockResolvedValue(undefined);
   vi.mocked(removeCustomCommand).mockResolvedValue(undefined);
-  vi.mocked(assignUserToCommand).mockResolvedValue(undefined);
+  vi.mocked(assignUsersToCommand).mockResolvedValue(undefined);
   vi.mocked(findUsersByIds).mockResolvedValue(new Map());
   vi.mocked(isMysqlDuplicateEntryError).mockReturnValue(false);
 });
@@ -105,7 +105,7 @@ describe('POST /commands/add', () => {
       .post('/commands/add')
       .send(`trigger_string=!clap&output=Clap&discord_ids=${VALID_DISCORD_ID}`);
     expect(res.headers.location).toBe('/commands');
-    expect(assignUserToCommand).toHaveBeenCalledWith(1, VALID_DISCORD_ID);
+    expect(assignUsersToCommand).toHaveBeenCalledWith(1, [VALID_DISCORD_ID]);
   });
 
   it('skips assigning user when findUsersByIds does not return a matching entry', async () => {
@@ -114,14 +114,14 @@ describe('POST /commands/add', () => {
       .post('/commands/add')
       .send(`trigger_string=!clap&output=Clap&discord_ids=${VALID_DISCORD_ID}`);
     expect(res.headers.location).toBe('/commands');
-    expect(assignUserToCommand).not.toHaveBeenCalled();
+    expect(assignUsersToCommand).toHaveBeenCalledWith(1, []);
   });
 
-  it('redirects to ?error=command_taken when assignUserToCommand throws CommandConflictError', async () => {
+  it('redirects to ?error=command_taken when assignUsersToCommand throws CommandConflictError', async () => {
     vi.mocked(findUsersByIds).mockResolvedValue(new Map([
       [VALID_DISCORD_ID, { discord_id: VALID_DISCORD_ID, twitch_name: 'alice', discord_name: null, is_twitch_bot_enabled: false, access_level: AccessLevel.USER } as any],
     ]));
-    vi.mocked(assignUserToCommand).mockRejectedValueOnce(new (CommandConflictError as any)('conflict'));
+    vi.mocked(assignUsersToCommand).mockRejectedValueOnce(new (CommandConflictError as any)('conflict'));
     const res = await supertest(buildApp())
       .post('/commands/add')
       .send(`trigger_string=!clap&output=Clap&discord_ids=${VALID_DISCORD_ID}`);
@@ -133,7 +133,7 @@ describe('POST /commands/add', () => {
     vi.mocked(findUsersByIds).mockResolvedValue(new Map([
       [VALID_DISCORD_ID, { discord_id: VALID_DISCORD_ID, twitch_name: 'alice', discord_name: null, is_twitch_bot_enabled: false, access_level: AccessLevel.USER } as any],
     ]));
-    vi.mocked(assignUserToCommand).mockRejectedValueOnce(new Error('DB error'));
+    vi.mocked(assignUsersToCommand).mockRejectedValueOnce(new Error('DB error'));
     const res = await supertest(buildApp())
       .post('/commands/add')
       .send(`trigger_string=!clap&output=Clap&discord_ids=${VALID_DISCORD_ID}`);

--- a/src/web/routes/commandMutations.ts
+++ b/src/web/routes/commandMutations.ts
@@ -2,7 +2,7 @@ import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import {
   addCustomCommand,
-  assignUserToCommand,
+  assignUsersToCommand,
   CommandConflictError,
   CommandNotFoundError,
   isMysqlDuplicateEntryError,
@@ -34,11 +34,11 @@ const COMMAND_WRITE_ERROR_OPTIONS = { basePath: '/commands', conflictErrorCode: 
 async function assignUsersToNewCommand(commandId: number, discordIds: string[]): Promise<string | null> {
   try {
     const users = await findUsersByIds(discordIds);
-    for (const discordId of discordIds) {
+    const eligibleDiscordIds = discordIds.filter((discordId) => {
       const user = users.get(discordId);
-      if (!user || !user.twitch_name) continue;
-      await assignUserToCommand(commandId, discordId);
-    }
+      return !!user && !!user.twitch_name;
+    });
+    await assignUsersToCommand(commandId, eligibleDiscordIds);
   } catch (err) {
     try {
       await removeCustomCommand(commandId);

--- a/src/web/routes/commands.test.ts
+++ b/src/web/routes/commands.test.ts
@@ -17,6 +17,7 @@ vi.mock('../../db', () => {
     updateCustomCommand: vi.fn().mockResolvedValue(undefined),
     removeCustomCommand: vi.fn().mockResolvedValue(undefined),
     assignUserToCommand: vi.fn().mockResolvedValue(undefined),
+    assignUsersToCommand: vi.fn().mockResolvedValue(undefined),
     unassignUserFromCommand: vi.fn().mockResolvedValue(undefined),
     findUser: vi.fn().mockResolvedValue(null),
     findUsersByIds: vi.fn().mockResolvedValue(new Map()),
@@ -58,6 +59,7 @@ import {
   updateCustomCommand,
   removeCustomCommand,
   assignUserToCommand,
+  assignUsersToCommand,
   unassignUserFromCommand,
   findUser,
   findUsersByIds,
@@ -91,6 +93,7 @@ beforeEach(() => {
   vi.mocked(updateCustomCommand).mockResolvedValue(undefined);
   vi.mocked(removeCustomCommand).mockResolvedValue(undefined);
   vi.mocked(assignUserToCommand).mockResolvedValue(undefined);
+  vi.mocked(assignUsersToCommand).mockResolvedValue(undefined);
   vi.mocked(unassignUserFromCommand).mockResolvedValue(undefined);
   vi.mocked(findUser).mockResolvedValue(null);
   vi.mocked(findUsersByIds).mockResolvedValue(new Map());
@@ -166,10 +169,10 @@ describe('POST /commands/add', () => {
       .send({ trigger_string: '!hello', output: 'Hello!', discord_ids: '123456789012345678' });
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/commands');
-    expect(vi.mocked(assignUserToCommand)).not.toHaveBeenCalled();
+    expect(vi.mocked(assignUsersToCommand)).toHaveBeenCalledWith(1, []);
   });
 
-  it('8. calls assignUserToCommand and redirects /commands when user has twitch_name', async () => {
+  it('8. calls assignUsersToCommand and redirects /commands when user has twitch_name', async () => {
     vi.mocked(findUsersByIds).mockResolvedValue(new Map([
       ['123456789012345678', { discord_id: '123456789012345678', twitch_name: 'streamer' } as any],
     ]));
@@ -179,7 +182,7 @@ describe('POST /commands/add', () => {
       .send({ trigger_string: '!hello', output: 'Hello!', discord_ids: '123456789012345678' });
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/commands');
-    expect(vi.mocked(assignUserToCommand)).toHaveBeenCalledWith(1, '123456789012345678');
+    expect(vi.mocked(assignUsersToCommand)).toHaveBeenCalledWith(1, ['123456789012345678']);
   });
 });
 
@@ -402,11 +405,11 @@ describe('POST /commands/add — additional coverage', () => {
     expect(res.headers.location).toBe('/commands?error=add_failed');
   });
 
-  it('28. redirects ?error=command_taken when assignUserToCommand throws CommandConflictError during add', async () => {
+  it('28. redirects ?error=command_taken when assignUsersToCommand throws CommandConflictError during add', async () => {
     vi.mocked(findUsersByIds).mockResolvedValue(new Map([
       ['123456789012345678', { discord_id: '123456789012345678', twitch_name: 'streamer' } as any],
     ]));
-    vi.mocked(assignUserToCommand).mockRejectedValue(new CommandConflictError(['conflict']));
+    vi.mocked(assignUsersToCommand).mockRejectedValue(new CommandConflictError(['conflict']));
     const res = await supertest(buildApp())
       .post('/commands/add')
       .type('form')
@@ -415,11 +418,11 @@ describe('POST /commands/add — additional coverage', () => {
     expect(res.headers.location).toBe('/commands?error=command_taken');
   });
 
-  it('29. redirects ?error=assign_failed when assignUserToCommand throws generic error during add', async () => {
+  it('29. redirects ?error=assign_failed when assignUsersToCommand throws generic error during add', async () => {
     vi.mocked(findUsersByIds).mockResolvedValue(new Map([
       ['123456789012345678', { discord_id: '123456789012345678', twitch_name: 'streamer' } as any],
     ]));
-    vi.mocked(assignUserToCommand).mockRejectedValue(new Error('db error'));
+    vi.mocked(assignUsersToCommand).mockRejectedValue(new Error('db error'));
     const res = await supertest(buildApp())
       .post('/commands/add')
       .type('form')
@@ -626,6 +629,6 @@ describe('POST /commands/add — array discord_ids', () => {
       .send('trigger_string=!hello&output=Hello!&discord_ids=111111111111111111&discord_ids=222222222222222222');
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/commands');
-    expect(vi.mocked(assignUserToCommand)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(assignUsersToCommand)).toHaveBeenCalledWith(1, ['111111111111111111', '222222222222222222']);
   });
 });

--- a/src/web/routes/sfxMutationsShared.test.ts
+++ b/src/web/routes/sfxMutationsShared.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// A single shared logger instance (rather than test-utils/loggerMock's per-call factory) so the
+// test can capture the same `log` reference that sfxMutationsShared.ts's module-level
+// `const log = createLogger('Web')` receives, and assert on it.
+vi.mock('../../shared/logger', () => {
+  const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  return { createLogger: () => logger };
+});
+
+vi.mock('../../shared/config', () => ({
+  SFX_FOLDER: '/app/sfx',
+}));
+
+vi.mock('fs', () => ({
+  default: {
+    promises: {
+      rm: vi.fn(),
+    },
+  },
+}));
+
+import fs from 'fs';
+import { createLogger } from '../../shared/logger';
+import { removeSfxFiles } from './sfxMutationsShared';
+
+const sharedLog = createLogger('Web');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(fs.promises.rm).mockResolvedValue(undefined);
+});
+
+describe('removeSfxFiles', () => {
+  it('removes every file when all succeed', async () => {
+    await removeSfxFiles(['a.mp3', 'b.mp3']);
+
+    expect(fs.promises.rm).toHaveBeenCalledTimes(2);
+    expect(fs.promises.rm).toHaveBeenCalledWith('/app/sfx/a.mp3', { force: true });
+    expect(fs.promises.rm).toHaveBeenCalledWith('/app/sfx/b.mp3', { force: true });
+    expect(sharedLog.error).not.toHaveBeenCalled();
+  });
+
+  it('still removes the other files and logs when one removal fails', async () => {
+    vi.mocked(fs.promises.rm)
+      .mockRejectedValueOnce(new Error('disk error'))
+      .mockResolvedValueOnce(undefined);
+
+    await removeSfxFiles(['bad.mp3', 'good.mp3']);
+
+    expect(fs.promises.rm).toHaveBeenCalledTimes(2);
+    expect(sharedLog.error).toHaveBeenCalledWith('Failed to remove SFX file bad.mp3:', expect.any(Error));
+  });
+
+  it('resolves without throwing even when every removal fails', async () => {
+    vi.mocked(fs.promises.rm).mockRejectedValue(new Error('disk error'));
+
+    await expect(removeSfxFiles(['a.mp3', 'b.mp3'])).resolves.toBeUndefined();
+    expect(sharedLog.error).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips an unsafe (path-traversal) filename without calling rm or logging', async () => {
+    await removeSfxFiles(['../../etc/passwd']);
+
+    expect(fs.promises.rm).not.toHaveBeenCalled();
+    expect(sharedLog.error).not.toHaveBeenCalled();
+  });
+
+  it('runs removals concurrently rather than one at a time', async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    vi.mocked(fs.promises.rm).mockImplementation(async () => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await Promise.resolve();
+      inFlight--;
+    });
+
+    await removeSfxFiles(['a.mp3', 'b.mp3', 'c.mp3']);
+
+    expect(maxInFlight).toBeGreaterThan(1);
+  });
+});

--- a/src/web/routes/sfxMutationsShared.ts
+++ b/src/web/routes/sfxMutationsShared.ts
@@ -6,19 +6,23 @@ import { safeResolve } from '../../shared/pathUtils';
 const log = createLogger('Web');
 
 /**
- * Remove a list of relative sound-file paths from disk, resolving each safely
- * within SFX_FOLDER. Logs and swallows individual failures so a missing file
- * never blocks the surrounding DB operation.
+ * Remove a list of relative sound-file paths from disk in parallel, resolving each safely
+ * within SFX_FOLDER. Logs and swallows individual failures so a missing file never blocks
+ * the surrounding DB operation, or the removal of any other file in the list.
  */
 export async function removeSfxFiles(files: string[]): Promise<void> {
-  for (const file of files) {
-    const fullPath = safeResolve(SFX_FOLDER, file);
-    if (!fullPath) continue;
-    try {
+  const results = await Promise.allSettled(
+    files.map(async (file) => {
+      const fullPath = safeResolve(SFX_FOLDER, file);
+      if (!fullPath) return;
       await fs.promises.rm(fullPath, { force: true });
-    } catch (err) {
-      log.error(`Failed to remove SFX file ${file}:`, err);
+    }),
+  );
+
+  results.forEach((result, i) => {
+    if (result.status === 'rejected') {
+      log.error(`Failed to remove SFX file ${files[i]}:`, result.reason);
     }
-  }
+  });
 }
 


### PR DESCRIPTION
## Summary

A codebase-wide efficiency review (DB layer, command/audio/discord/twitch handling, web routes) turned up several concrete inefficiencies — N+1 write patterns, redundant DB round-trips, per-lookup allocations on hot paths, and O(n) scans where O(1) is achievable. This PR implements the lower-risk fixes; a separate PR handles the one higher-risk change (consolidating the voice adapter's per-guild gateway listeners), so it can get isolated review.

- **`setRewardVideos`** (`src/db/overlayVideos.ts`): replaced the per-video `INSERT...SELECT` loop with one validation `SELECT ... IN (...)` plus one multi-row `INSERT`, so assigning N videos no longer costs N round trips.
- **Batch user-to-command assignment** (`src/db/commandConflicts.ts`, `src/db/customCommands.ts`, `src/web/routes/commandMutations.ts`): added a batched path (`assignUsersToCommand`) that acquires the command lock once, checks eligibility/conflicts for all users in one pass, and does a single multi-row insert + cache invalidation, instead of one lock/transaction/cache-invalidation cycle per user. The existing single-user path is unchanged (still used by the one-at-a-time "assign to existing command" UI flow).
- **`broadcastToActiveChannels`** (`src/commands/customCommandHandler.ts`): now restricts candidates to the active multi-twitch group *before* checking command registration, instead of checking every active channel and filtering afterward.
- **`LiveStateMap`** (`src/twitch/monitor/twitchMonitorTypes.ts`): a `Map` subclass that maintains a login→key index, so `getMultiTwitchDataForChannel` no longer does two linear scans over every live streamer on every call.
- **`sfxCache` / `customCommandCache`**: cache lookups now return the frozen cache entry directly instead of deep-copying on every call (verified no caller mutates the result); objects are frozen once at cache-build time as a safety net.
- **`mapUtils.getOrCreate`**: single `map.get` instead of `has` + `get` (two hash lookups on the hit path).
- **`commandRouter.handleCommand`**: reuses the shared `extractCommand` helper instead of re-implementing the same parsing inline.
- **`removeSfxFiles`**: removes files in parallel via `Promise.allSettled` instead of one at a time, preserving per-file error handling.

One additional candidate finding — two `findUser` calls in `admin.ts`'s user-edit routes — was investigated and found to be an intentional guard against a race condition (the second call re-reads fresh state after entering the per-user mutation queue), not redundancy, so it's excluded from this PR.

**Update:** an earlier revision of this PR also wrapped independent reads within a single transaction (trigger string + user eligibility lookups) in `Promise.all`, on the assumption that this would pipeline the two queries. A CodeRabbit review comment correctly pointed out this doesn't hold for `mysql2`: a `PoolConnection` only ever has one command in flight — `addCommand()` queues any additional command issued before the current one resolves, dispatching it only once the prior response arrives (verified directly in `mysql2`'s `connection.js`). So `Promise.all` over queries on the same connection doesn't reduce round trips, it just adds complexity. Those spots have been reverted to plain sequential `await`s.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (2493 tests)
- [x] Added/updated Vitest coverage for every behavior change, including new tests proving: batched assignment round-trip counts, `LiveStateMap`'s login index (including key-reuse edge cases), frozen cache entries throwing on mutation attempts, and parallel file removal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk assignment of users to custom commands.
  * Improved multi-channel command delivery so messages target only eligible channels in the active group.
  * Added faster live-channel state lookup.

* **Bug Fixes**
  * Improved validation when assigning reward videos, including clearer handling of invalid videos.
  * Made sound-effect and video file cleanup continue when individual removals fail.
  * Improved command trigger parsing and cache consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->