### PR TITLE
Share one raw-gateway listener per client across guild voice adapters

### DIFF
--- a/src/audio/voiceAdapter.test.ts
+++ b/src/audio/voiceAdapter.test.ts
@@ -1,124 +1,164 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createVoiceAdapterFactory } from './voiceAdapter';
 
-// Minimal fake voice channel exposing only what the adapter touches.
-// getMaxListeners/setMaxListeners are stateful so the incremental cap bookkeeping
-// can be tested accurately.
-function makeChannel() {
+/** Minimal fake voice channel exposing only what the adapter touches. */
+function makeChannel(client: { on: ReturnType<typeof vi.fn> }, guildId: string) {
   const shardSend = vi.fn();
-  let cap = 10;
-  const client = {
-    on: vi.fn(),
-    off: vi.fn(),
-    getMaxListeners: vi.fn(() => cap),
-    setMaxListeners: vi.fn((n: number) => { cap = n; }),
-  };
-  const channel = { client, guild: { shard: { send: shardSend } } };
-  return { channel, client, shardSend };
+  const channel = { client, guild: { id: guildId, shard: { send: shardSend } } };
+  return { channel, shardSend };
 }
 
-const methods = {
-  onVoiceStateUpdate: vi.fn(),
-  onVoiceServerUpdate: vi.fn(),
-} as never;
+/** A fake discord.js Client that captures its single registered 'raw' handler. */
+function makeClient() {
+  return { on: vi.fn() };
+}
+
+function makeMethods() {
+  return { onVoiceStateUpdate: vi.fn(), onVoiceServerUpdate: vi.fn() };
+}
+
+/** Retrieves the shared 'raw' handler registered on `client`. */
+function getRawHandler(client: ReturnType<typeof makeClient>): (packet: unknown) => void {
+  return client.on.mock.calls[0][1] as (packet: unknown) => void;
+}
 
 describe('createVoiceAdapterFactory', () => {
-  it('registers a raw listener and raises the max-listener cap on build', () => {
-    const { channel, client } = makeChannel();
+  it('registers a single raw listener on first build', () => {
+    const client = makeClient();
+    const { channel } = makeChannel(client, 'guild-a');
     const factory = createVoiceAdapterFactory();
 
-    factory.build(channel as never)(methods);
+    factory.build(channel as never)(makeMethods() as never);
 
+    expect(client.on).toHaveBeenCalledTimes(1);
     expect(client.on).toHaveBeenCalledWith('raw', expect.any(Function));
-    expect(client.setMaxListeners).toHaveBeenCalledWith(11);
   });
 
-  it('tears down the previous adapter before registering a new one (no listener accumulation)', () => {
-    const { channel, client } = makeChannel();
-    const factory = createVoiceAdapterFactory();
+  it('reuses the same raw listener across multiple guilds sharing a client', () => {
+    const client = makeClient();
+    const { channel: channelA } = makeChannel(client, 'guild-a');
+    const { channel: channelB } = makeChannel(client, 'guild-b');
 
-    factory.build(channel as never)(methods);
-    expect(client.off).not.toHaveBeenCalled();
+    createVoiceAdapterFactory().build(channelA as never)(makeMethods() as never);
+    createVoiceAdapterFactory().build(channelB as never)(makeMethods() as never);
 
-    // Second build for the same guild must clean up the first listener.
-    factory.build(channel as never)(methods);
-    expect(client.off).toHaveBeenCalledWith('raw', expect.any(Function));
-    expect(client.setMaxListeners).toHaveBeenLastCalledWith(11);
+    // Only one 'raw' listener total, regardless of how many guilds/factories share the client.
+    expect(client.on).toHaveBeenCalledTimes(1);
   });
 
-  it('destroy() removes the listener and restores the original cap', () => {
-    const { channel, client } = makeChannel();
+  it('routes a VOICE_STATE_UPDATE/VOICE_SERVER_UPDATE packet to the matching guild only', () => {
+    const client = makeClient();
+    const { channel: channelA } = makeChannel(client, 'guild-a');
+    const { channel: channelB } = makeChannel(client, 'guild-b');
+    const methodsA = makeMethods();
+    const methodsB = makeMethods();
+
+    createVoiceAdapterFactory().build(channelA as never)(methodsA as never);
+    createVoiceAdapterFactory().build(channelB as never)(methodsB as never);
+    const onRaw = getRawHandler(client);
+
+    onRaw({ t: 'VOICE_STATE_UPDATE', d: { guild_id: 'guild-a', a: 1 } });
+    onRaw({ t: 'VOICE_SERVER_UPDATE', d: { guild_id: 'guild-b', b: 2 } });
+
+    expect(methodsA.onVoiceStateUpdate).toHaveBeenCalledWith({ guild_id: 'guild-a', a: 1 });
+    expect(methodsA.onVoiceServerUpdate).not.toHaveBeenCalled();
+    expect(methodsB.onVoiceServerUpdate).toHaveBeenCalledWith({ guild_id: 'guild-b', b: 2 });
+    expect(methodsB.onVoiceStateUpdate).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-voice packets and packets with no guild_id', () => {
+    const client = makeClient();
+    const { channel } = makeChannel(client, 'guild-a');
+    const methods = makeMethods();
+
+    createVoiceAdapterFactory().build(channel as never)(methods as never);
+    const onRaw = getRawHandler(client);
+
+    onRaw({ t: 'SOMETHING_ELSE', d: { guild_id: 'guild-a' } });
+    onRaw({ t: 'VOICE_STATE_UPDATE', d: {} });
+
+    expect(methods.onVoiceStateUpdate).not.toHaveBeenCalled();
+    expect(methods.onVoiceServerUpdate).not.toHaveBeenCalled();
+  });
+
+  it('tears down the previous registration before a new build for the same guild (latest methods win)', () => {
+    const client = makeClient();
+    const { channel } = makeChannel(client, 'guild-a');
+    const oldMethods = makeMethods();
+    const newMethods = makeMethods();
     const factory = createVoiceAdapterFactory();
 
-    const adapter = factory.build(channel as never)(methods);
+    factory.build(channel as never)(oldMethods as never);
+    factory.build(channel as never)(newMethods as never);
+    const onRaw = getRawHandler(client);
+
+    onRaw({ t: 'VOICE_STATE_UPDATE', d: { guild_id: 'guild-a' } });
+
+    expect(oldMethods.onVoiceStateUpdate).not.toHaveBeenCalled();
+    expect(newMethods.onVoiceStateUpdate).toHaveBeenCalledOnce();
+  });
+
+  it('destroy() stops routing packets to that guild', () => {
+    const client = makeClient();
+    const { channel } = makeChannel(client, 'guild-a');
+    const methods = makeMethods();
+    const factory = createVoiceAdapterFactory();
+
+    const adapter = factory.build(channel as never)(methods as never);
     adapter.destroy();
+    const onRaw = getRawHandler(client);
 
-    expect(client.off).toHaveBeenCalledWith('raw', expect.any(Function));
-    expect(client.setMaxListeners).toHaveBeenLastCalledWith(10);
+    onRaw({ t: 'VOICE_STATE_UPDATE', d: { guild_id: 'guild-a' } });
+
+    expect(methods.onVoiceStateUpdate).not.toHaveBeenCalled();
+  });
+
+  it('destroy() does not affect a different guild sharing the same client', () => {
+    const client = makeClient();
+    const { channel: channelA } = makeChannel(client, 'guild-a');
+    const { channel: channelB } = makeChannel(client, 'guild-b');
+    const methodsA = makeMethods();
+    const methodsB = makeMethods();
+
+    const adapterA = createVoiceAdapterFactory().build(channelA as never)(methodsA as never);
+    createVoiceAdapterFactory().build(channelB as never)(methodsB as never);
+    adapterA.destroy();
+    const onRaw = getRawHandler(client);
+
+    onRaw({ t: 'VOICE_STATE_UPDATE', d: { guild_id: 'guild-b' } });
+
+    expect(methodsB.onVoiceStateUpdate).toHaveBeenCalledOnce();
+  });
+
+  it('a stale destroy() cannot clobber a newer registration for the same guild', () => {
+    // Simulates an out-of-order destroy: two independent registrations for the same
+    // guildId (e.g. from overlapping reconnect attempts), where the OLD adapter's
+    // destroy() fires after the NEW one already took over the guild's slot.
+    const client = makeClient();
+    const { channel } = makeChannel(client, 'guild-a');
+    const oldMethods = makeMethods();
+    const newMethods = makeMethods();
+
+    const oldAdapter = createVoiceAdapterFactory().build(channel as never)(oldMethods as never);
+    createVoiceAdapterFactory().build(channel as never)(newMethods as never);
+    oldAdapter.destroy();
+    const onRaw = getRawHandler(client);
+
+    onRaw({ t: 'VOICE_STATE_UPDATE', d: { guild_id: 'guild-a' } });
+
+    expect(newMethods.onVoiceStateUpdate).toHaveBeenCalledOnce();
   });
 
   it('sendPayload routes through the guild shard and reports success/failure', () => {
-    const { channel, shardSend } = makeChannel();
+    const client = makeClient();
+    const { channel, shardSend } = makeChannel(client, 'guild-a');
     const factory = createVoiceAdapterFactory();
-    const adapter = factory.build(channel as never)(methods);
+    const adapter = factory.build(channel as never)(makeMethods() as never);
 
     expect(adapter.sendPayload({ op: 4 })).toBe(true);
     expect(shardSend).toHaveBeenCalledWith({ op: 4 });
 
     shardSend.mockImplementationOnce(() => { throw new Error('shard down'); });
     expect(adapter.sendPayload({ op: 4 })).toBe(false);
-  });
-
-  it('leaves an unlimited (0) max-listener cap untouched', () => {
-    const { channel, client } = makeChannel();
-    client.getMaxListeners.mockReturnValue(0);
-    const factory = createVoiceAdapterFactory();
-
-    factory.build(channel as never)(methods);
-
-    expect(client.setMaxListeners).not.toHaveBeenCalled();
-  });
-
-  it('two guild adapters sharing a client restore the baseline cap regardless of destroy order', () => {
-    let cap = 10;
-    const sharedClient = {
-      on: vi.fn(),
-      off: vi.fn(),
-      getMaxListeners: vi.fn(() => cap),
-      setMaxListeners: vi.fn((n: number) => { cap = n; }),
-    };
-    const channelA = { client: sharedClient, guild: { shard: { send: vi.fn() } } };
-    const channelB = { client: sharedClient, guild: { shard: { send: vi.fn() } } };
-
-    const factoryA = createVoiceAdapterFactory();
-    const factoryB = createVoiceAdapterFactory();
-    const adapterA = factoryA.build(channelA as never)(methods);
-    const adapterB = factoryB.build(channelB as never)(methods);
-    expect(cap).toBe(12);
-
-    // Destroy A first — the snapshot approach would leave cap at 11 after B also
-    // destroys (B's snapshot was 11, not the true baseline of 10).
-    adapterA.destroy();
-    expect(cap).toBe(11);
-    adapterB.destroy();
-    expect(cap).toBe(10);
-  });
-
-  it('forwards raw voice packets to the matching gateway method', () => {
-    const { channel, client } = makeChannel();
-    const factory = createVoiceAdapterFactory();
-    const localMethods = { onVoiceStateUpdate: vi.fn(), onVoiceServerUpdate: vi.fn() } as never;
-
-    factory.build(channel as never)(localMethods);
-    const onRaw = client.on.mock.calls[0][1] as (p: unknown) => void;
-
-    onRaw({ t: 'VOICE_STATE_UPDATE', d: { a: 1 } });
-    onRaw({ t: 'VOICE_SERVER_UPDATE', d: { b: 2 } });
-    onRaw({ t: 'SOMETHING_ELSE', d: {} });
-
-    expect((localMethods as { onVoiceStateUpdate: ReturnType<typeof vi.fn> }).onVoiceStateUpdate)
-      .toHaveBeenCalledWith({ a: 1 });
-    expect((localMethods as { onVoiceServerUpdate: ReturnType<typeof vi.fn> }).onVoiceServerUpdate)
-      .toHaveBeenCalledWith({ b: 2 });
   });
 });

--- a/src/audio/voiceAdapter.ts
+++ b/src/audio/voiceAdapter.ts
@@ -3,51 +3,63 @@ import type {
   DiscordGatewayAdapterImplementerMethods,
   DiscordGatewayAdapterLibraryMethods,
 } from '@discordjs/voice';
-import type { VoiceBasedChannel } from 'discord.js';
+import type { Client, VoiceBasedChannel } from 'discord.js';
 
 // ─── Voice adapter ────────────────────────────────────────────────────────────
 // Bypasses discord.js's built-in voiceAdapterCreator to avoid type/version
 // incompatibilities with discord.js v14. Listens to raw gateway events instead.
+//
+// Every guild connected to voice shares ONE 'raw' listener per Client (registered
+// lazily on first use, tracked in `dispatchers` below) instead of each guild adding
+// its own — with N guilds in voice, every gateway dispatch event (not just voice
+// ones) would otherwise fan out to N separate handlers. The shared listener routes
+// each VOICE_STATE_UPDATE/VOICE_SERVER_UPDATE packet to the right guild's methods
+// by `packet.d.guild_id`.
 //
 // The pieces are kept as flat module-level helpers (rather than closures nested
 // inside the factory) so each stays simple and independently testable.
 
 type RawPacket = { t: string; d: Record<string, unknown> };
 
-/** Tracks the cleanup for a guild's currently-registered adapter listener. */
+/** Tracks the cleanup for a guild's currently-registered adapter methods. */
 interface AdapterCleanupState {
   activeCleanup: (() => void) | null;
 }
 
-/** Creates the raw-gateway event handler that routes voice state and server update packets to the library. */
-function makeOnRaw(methods: DiscordGatewayAdapterLibraryMethods): (packet: RawPacket) => void {
-  return function onRaw(packet: RawPacket): void {
-    if (packet.t === 'VOICE_STATE_UPDATE') {
-      methods.onVoiceStateUpdate(packet.d as unknown as Parameters<typeof methods.onVoiceStateUpdate>[0]);
-    }
-    if (packet.t === 'VOICE_SERVER_UPDATE') {
-      methods.onVoiceServerUpdate(packet.d as unknown as Parameters<typeof methods.onVoiceServerUpdate>[0]);
-    }
-  };
+/** Per-`Client` dispatch state: the guilds currently registered for voice packet routing. */
+interface ClientDispatcher {
+  guildMethods: Map<string, DiscordGatewayAdapterLibraryMethods>;
 }
 
-/** Builds the idempotent cleanup that removes the raw listener and decrements the cap. */
-function makeCleanup(
-  channel: VoiceBasedChannel,
-  onRaw: (packet: RawPacket) => void,
-  increment: number,
-  state: AdapterCleanupState,
-): () => void {
-  let cleanedUp = false;
-  return function cleanup(): void {
-    if (cleanedUp) return;
-    cleanedUp = true;
-    channel.client.off('raw', onRaw);
-    // Decrement rather than restore to a snapshot so that cross-guild adapters
-    // sharing the same client do not race each other's cap bookkeeping.
-    if (increment > 0) channel.client.setMaxListeners(channel.client.getMaxListeners() - increment);
-    state.activeCleanup = null;
-  };
+// WeakMap so a client that's discarded (e.g. in tests) doesn't keep its dispatcher alive.
+const dispatchers = new WeakMap<Client, ClientDispatcher>();
+
+/** Routes one raw gateway packet to its guild's registered methods, if any. No-ops for non-voice packets or unregistered guilds. */
+function dispatchRawPacket(dispatcher: ClientDispatcher, packet: RawPacket): void {
+  if (packet.t !== 'VOICE_STATE_UPDATE' && packet.t !== 'VOICE_SERVER_UPDATE') return;
+
+  const guildId = (packet.d as { guild_id?: string }).guild_id;
+  if (!guildId) return;
+
+  const methods = dispatcher.guildMethods.get(guildId);
+  if (!methods) return;
+
+  if (packet.t === 'VOICE_STATE_UPDATE') {
+    methods.onVoiceStateUpdate(packet.d as unknown as Parameters<typeof methods.onVoiceStateUpdate>[0]);
+  } else {
+    methods.onVoiceServerUpdate(packet.d as unknown as Parameters<typeof methods.onVoiceServerUpdate>[0]);
+  }
+}
+
+/** Returns `client`'s shared dispatcher, registering its single 'raw' listener on first use. */
+function getOrCreateDispatcher(client: Client): ClientDispatcher {
+  const existing = dispatchers.get(client);
+  if (existing) return existing;
+
+  const dispatcher: ClientDispatcher = { guildMethods: new Map() };
+  client.on('raw', (packet: RawPacket) => dispatchRawPacket(dispatcher, packet));
+  dispatchers.set(client, dispatcher);
+  return dispatcher;
 }
 
 /** Creates the gateway payload sender that routes voice data through the channel's guild shard. */
@@ -65,7 +77,7 @@ function makeSendPayload(channel: VoiceBasedChannel): (payload: unknown) => bool
 
 /**
  * Registers a raw-gateway adapter for one connection, tearing down the guild's
- * previous adapter first so listeners do not accumulate across reconnects.
+ * previous adapter first so registrations do not accumulate across reconnects.
  */
 function registerAdapter(
   channel: VoiceBasedChannel,
@@ -74,14 +86,21 @@ function registerAdapter(
 ): DiscordGatewayAdapterImplementerMethods {
   if (state.activeCleanup) state.activeCleanup();
 
-  const onRaw = makeOnRaw(methods);
-  const currentMax = channel.client.getMaxListeners();
-  // 0 means unlimited — don't touch it.
-  const increment = currentMax !== 0 ? 1 : 0;
-  if (increment > 0) channel.client.setMaxListeners(currentMax + 1);
-  channel.client.on('raw', onRaw);
+  const dispatcher = getOrCreateDispatcher(channel.client);
+  const guildId = channel.guild.id;
+  dispatcher.guildMethods.set(guildId, methods);
 
-  const cleanup = makeCleanup(channel, onRaw, increment, state);
+  let cleanedUp = false;
+  const cleanup = (): void => {
+    if (cleanedUp) return;
+    cleanedUp = true;
+    // Only remove this guild's entry if it still points at these methods — a newer
+    // registration's cleanup must never be able to clobber a more recent one.
+    if (dispatcher.guildMethods.get(guildId) === methods) {
+      dispatcher.guildMethods.delete(guildId);
+    }
+    state.activeCleanup = null;
+  };
   state.activeCleanup = cleanup;
 
   return { sendPayload: makeSendPayload(channel), destroy: cleanup };

--- a/src/audio/voiceAdapter.ts
+++ b/src/audio/voiceAdapter.ts
@@ -57,6 +57,7 @@ function getOrCreateDispatcher(client: Client): ClientDispatcher {
   if (existing) return existing;
 
   const dispatcher: ClientDispatcher = { guildMethods: new Map() };
+  /** Forwards each raw gateway packet from `client` to this dispatcher's routing logic. */
   client.on('raw', (packet: RawPacket) => dispatchRawPacket(dispatcher, packet));
   dispatchers.set(client, dispatcher);
   return dispatcher;
@@ -91,6 +92,10 @@ function registerAdapter(
   dispatcher.guildMethods.set(guildId, methods);
 
   let cleanedUp = false;
+  /**
+   * Removes this registration's entry from the dispatcher, but only if it hasn't already
+   * been superseded by a newer registration for the same guild. Idempotent.
+   */
   const cleanup = (): void => {
     if (cleanedUp) return;
     cleanedUp = true;


### PR DESCRIPTION
## Summary

Split out from #392 (the broader efficiency-review PR) as its own PR for isolated review, since it's the highest-risk change of the batch: it changes the Discord gateway-dispatch mechanism on a hot path shared by every guild's voice connection.

`src/audio/voiceAdapter.ts`'s `createVoiceAdapterFactory()` is called once per guild (in `audioPlayer.ts`'s lazily-created per-guild state), and each guild's `registerAdapter` call previously added its own `channel.client.on('raw', onRaw)` listener. With N guilds connected to voice simultaneously, **every** gateway dispatch event — not just voice-related ones — was redispatched to N separate handlers, each independently checking `packet.t`.

This PR replaces that with a single shared `'raw'` listener per Discord `Client` (tracked in a module-level `WeakMap<Client, ClientDispatcher>`, created lazily on first use), which routes `VOICE_STATE_UPDATE`/`VOICE_SERVER_UPDATE` packets to the correct guild's registered methods by `packet.d.guild_id`. A guild's `destroy()` now removes just that guild's entry from the shared dispatcher's `Map`, instead of calling `client.off('raw', ...)`.

The `setMaxListeners`/`getMaxListeners` increment-decrement bookkeeping is removed as a direct consequence — it only existed to avoid Node's max-listener warning when listeners accumulated per guild; with exactly one shared listener per client regardless of guild count, it's no longer reachable. This is an intentional cleanup of now-dead code, not a dropped feature.

A `destroy()` from a stale/superseded registration is guarded against clobbering a newer one for the same guild (covered by a dedicated test) — relevant if two registrations for the same guild id ever briefly overlap (e.g. overlapping reconnect attempts).

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (2462 tests)
- [x] Rewrote `src/audio/voiceAdapter.test.ts`'s assertions, which previously tested the per-guild-listener/max-listener mechanism directly, to instead prove: exactly one `'raw'` listener is registered regardless of guild count; packets route to the correct guild's methods only; a guild's `destroy()` doesn't affect another guild sharing the client; and a stale `destroy()` can't clobber a newer registration for the same guild.
- [x] Manually traced the multi-guild scenario (two guilds joining voice on the same client, one disconnecting) against the new dispatch logic to confirm packet routing and cleanup stay correct.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ML2dHt5MQSvYFZKe7XnovJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voice event routing across multiple guilds sharing the same client.
  * Prevented stale or destroyed adapters from affecting newer registrations or other guilds.
  * Ensured only relevant voice gateway events are processed.
  * Improved payload sending reliability and success reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->