### PR TITLE
Replace req.session.user! assertions with a getSessionUser() helper

### DIFF
--- a/src/web/middleware.ts
+++ b/src/web/middleware.ts
@@ -12,6 +12,11 @@ import {
 } from '../db';
 import { renderView } from './routes/shared';
 
+// Re-exported so existing `import { ..., getSessionUser } from '../middleware'` call sites
+// work; defined in ./session (not here) because ./routes/shared imports from this file, and
+// routes/shared.ts itself needs getSessionUser — defining it here would be circular.
+export { getSessionUser } from './session';
+
 /**
  * Ensures the request has a logged-in session user, redirecting to login otherwise.
  * @param req - Express request; checked for `req.session.user`.

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -10,6 +10,7 @@ import {
 import { reloadGuildRegistry } from '../../discord/guildRegistry';
 import { csrfProtection } from '../csrf';
 import { requireManager, requireAdmin } from '../middleware';
+import { getSessionUser } from '../session';
 import { trimField, renderError, filterQueryParam, renderView } from './shared';
 import { userMutationQueue } from './adminUserMutationQueue';
 import adminRefreshRouter, { getRefreshState } from './adminRefresh';
@@ -48,7 +49,7 @@ const KNOWN_ERRORS = new Set([
  *   loading members fails.
  */
 router.get('/users', requireManager, csrfProtection, async (req, res) => {
-  const guildId = req.session.user!.currentGuildId!;
+  const guildId = getSessionUser(req).currentGuildId!;
   try {
     const users = await getGuildMemberUsers(guildId);
     renderView(res, 'admin', {
@@ -92,7 +93,7 @@ async function reloadRegistrySafe(): Promise<void> {
  *   `duplicate_twitch_name`) or a DB failure (`add_failed`).
  */
 router.post('/users/add', requireManager, csrfProtection, async (req, res) => {
-  const guildId = req.session.user!.currentGuildId!;
+  const guildId = getSessionUser(req).currentGuildId!;
 
   const { discord_id, discord_name, access_level, twitch_name, clear_twitch_name } = req.body as {
     discord_id?: string;
@@ -112,7 +113,7 @@ router.post('/users/add', requireManager, csrfProtection, async (req, res) => {
   const { normalizedTwitchName, shouldClearTwitchName, error: twitchErr } = parseTwitchNameInput(twitch_name, clear_twitch_name);
   if (twitchErr) return res.redirect(`/admin/users?error=${twitchErr}`);
 
-  const addAuthErr = await checkManagerEditAuth(req.session.user!, trimmedDiscordId, level, guildId);
+  const addAuthErr = await checkManagerEditAuth(getSessionUser(req), trimmedDiscordId, level, guildId);
   if (addAuthErr) return res.redirect(`/admin/users?error=${addAuthErr}`);
   try {
     const trimmedDiscordName = trimField(discord_name);
@@ -151,7 +152,7 @@ router.post('/users/add', requireManager, csrfProtection, async (req, res) => {
  *   failure (`update_failed`).
  */
 router.post('/users/update', requireManager, csrfProtection, async (req, res) => {
-  const guildId = req.session.user!.currentGuildId!;
+  const guildId = getSessionUser(req).currentGuildId!;
 
   const { discord_id, access_level } = req.body as { discord_id?: string; access_level?: string };
   if (access_level === undefined) return res.redirect('/admin/users');
@@ -162,7 +163,7 @@ router.post('/users/update', requireManager, csrfProtection, async (req, res) =>
   if (levelErr) return res.redirect(`/admin/users?error=${levelErr}`);
 
   const level = Number(access_level);
-  const updateAuthErr = await checkManagerEditAuth(req.session.user!, trimmedDiscordId, level, guildId);
+  const updateAuthErr = await checkManagerEditAuth(getSessionUser(req), trimmedDiscordId, level, guildId);
   if (updateAuthErr) return res.redirect(`/admin/users?error=${updateAuthErr}`);
   try {
     await userMutationQueue.run(trimmedDiscordId, () => setMemberAccessLevel(guildId, trimmedDiscordId, level));
@@ -186,13 +187,13 @@ router.post('/users/update', requireManager, csrfProtection, async (req, res) =>
  *   (`remove_failed`).
  */
 router.post('/users/remove', requireAdmin, csrfProtection, async (req, res) => {
-  const guildId = req.session.user!.currentGuildId!;
+  const guildId = getSessionUser(req).currentGuildId!;
 
   const { discord_id } = req.body as { discord_id?: string };
   const trimmedDiscordId = resolveValidDiscordId(res, discord_id);
   if (!trimmedDiscordId) return;
 
-  if (trimmedDiscordId === req.session.user!.discordId) {
+  if (trimmedDiscordId === getSessionUser(req).discordId) {
     return res.redirect('/admin/users?error=self_remove_forbidden');
   }
   try {
@@ -217,7 +218,7 @@ router.post('/users/remove', requireAdmin, csrfProtection, async (req, res) => {
  *   `invalid_twitch_state`) or a DB failure (`toggle_failed`).
  */
 router.post('/users/toggle-twitch', requireManager, csrfProtection, async (req, res) => {
-  const guildId = req.session.user!.currentGuildId!;
+  const guildId = getSessionUser(req).currentGuildId!;
 
   const { discord_id, is_twitch_bot_enabled } = req.body as {
     discord_id?: string;
@@ -226,7 +227,7 @@ router.post('/users/toggle-twitch', requireManager, csrfProtection, async (req, 
   const trimmedDiscordId = resolveValidDiscordId(res, discord_id);
   if (!trimmedDiscordId) return;
 
-  const nextEnabled = await resolveToggleTwitchInputs(res, req.session.user!, guildId, trimmedDiscordId, is_twitch_bot_enabled);
+  const nextEnabled = await resolveToggleTwitchInputs(res, getSessionUser(req), guildId, trimmedDiscordId, is_twitch_bot_enabled);
   if (nextEnabled === null) return;
 
   try {

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -43,7 +43,7 @@ const KNOWN_ERRORS = new Set([
 /**
  * GET /admin/users — renders the member-management page for the current guild,
  * listing every member with their access level and Twitch state.
- * @param req - Express request; reads `req.session.user.currentGuildId` and the
+ * @param req - Express request; reads `getSessionUser(req).currentGuildId` and the
  *   `error` query param.
  * @param res - Express response; renders the `admin` view, or a 500 error page if
  *   loading members fails.
@@ -86,7 +86,7 @@ async function reloadRegistrySafe(): Promise<void> {
  * may provision a previously-inert guild.
  * @param req - Express request; reads `discord_id`, `discord_name`, `access_level`,
  *   `twitch_name`, and `clear_twitch_name` from `req.body`, plus the acting manager's
- *   `req.session.user` and current guild.
+ *   `getSessionUser(req)` and current guild.
  * @param res - Express response; redirects to `/admin/users` on success, or to
  *   `/admin/users?error=<code>` for validation failures (e.g. `invalid_discord_id`,
  *   `invalid_access_level`, `access_level_too_high`, `invalid_twitch_name`,

--- a/src/web/routes/adminRefresh.ts
+++ b/src/web/routes/adminRefresh.ts
@@ -3,6 +3,7 @@ import { Router } from 'express';
 import { getGuildMemberUsers, updateDiscordName } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireManager } from '../middleware';
+import { getSessionUser } from '../session';
 import { getDiscordClient, fetchMemberDisplayName } from '../../discord/discordBot';
 import { userMutationQueue } from './adminUserMutationQueue';
 
@@ -110,7 +111,7 @@ const router = Router();
  *   as JSON.
  */
 router.get('/users/refresh-status', requireManager, (req, res) => {
-  res.json(getRefreshState(req.session.user!.currentGuildId!));
+  res.json(getRefreshState(getSessionUser(req).currentGuildId!));
 });
 
 /**
@@ -122,7 +123,7 @@ router.get('/users/refresh-status', requireManager, (req, res) => {
  *   the refresh itself runs asynchronously and is polled via `/users/refresh-status`.
  */
 router.post('/users/refresh-names', requireManager, csrfProtection, async (req, res) => {
-  const guildId = req.session.user!.currentGuildId!;
+  const guildId = getSessionUser(req).currentGuildId!;
   if (getRefreshState(guildId).outcome === 'running') {
     return res.redirect('/admin/users');
   }

--- a/src/web/routes/adminRefresh.ts
+++ b/src/web/routes/adminRefresh.ts
@@ -106,7 +106,7 @@ const router = Router();
 /**
  * GET /admin/users/refresh-status — polling endpoint for the current guild's
  * in-progress (or most recent) Discord-name-refresh job.
- * @param req - Express request; reads `req.session.user.currentGuildId`.
+ * @param req - Express request; reads `getSessionUser(req).currentGuildId`.
  * @param res - Express response; always responds 200 with the guild's `RefreshState`
  *   as JSON.
  */
@@ -118,7 +118,7 @@ router.get('/users/refresh-status', requireManager, (req, res) => {
  * POST /admin/users/refresh-names — kicks off a background job that re-fetches each
  * guild member's Discord display name and updates it if changed. No-ops if a refresh
  * is already running for the guild.
- * @param req - Express request; reads `req.session.user.currentGuildId`.
+ * @param req - Express request; reads `getSessionUser(req).currentGuildId`.
  * @param res - Express response; always redirects to `/admin/users` immediately —
  *   the refresh itself runs asynchronously and is polled via `/users/refresh-status`.
  */

--- a/src/web/routes/adminUserValidation.ts
+++ b/src/web/routes/adminUserValidation.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import { createLogger } from '../../shared/logger';
 import { findUser, getMemberAccessLevel, AccessLevel } from '../../db';
 import { trimField, normalizeDiscordId } from './shared';
+import { getSessionUser } from '../session';
 import { normalizeTwitchChannelName } from '../../twitch/twitchChannelName';
 import { isLockWaitTimeoutDbError } from './adminUserMutations';
 
@@ -15,7 +16,7 @@ const log = createLogger('Web');
  * @param res The response, used to redirect when no guild is set.
  */
 export function resolveGuildId(req: Request, res: Response): string | null {
-  const guildId = req.session.user!.currentGuildId;
+  const guildId = getSessionUser(req).currentGuildId;
   if (!guildId) {
     res.redirect('/guild/select');
     return null;

--- a/src/web/routes/adminUserValidation.ts
+++ b/src/web/routes/adminUserValidation.ts
@@ -12,7 +12,7 @@ const log = createLogger('Web');
  * Resolves the acting user's current guild from the session.
  * Redirects to the guild picker and returns null when no guild is selected.
  *
- * @param req The incoming request (reads `session.user.currentGuildId`).
+ * @param req The incoming request (reads `getSessionUser(req).currentGuildId`).
  * @param res The response, used to redirect when no guild is set.
  */
 export function resolveGuildId(req: Request, res: Response): string | null {

--- a/src/web/routes/channelPointsAdmin.ts
+++ b/src/web/routes/channelPointsAdmin.ts
@@ -2,6 +2,7 @@ import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
+import { getSessionUser } from '../session';
 import { getStreamerByDiscordId } from '../../db';
 import type { DbStreamerEventSub } from '../../db';
 import { getPricingConfigsForStreamer, getPricingSettingsForStreamer, getPricingHistoryForRewards } from '../../db';
@@ -132,7 +133,7 @@ async function fetchTwitchRewards(streamer: DbStreamerEventSub): Promise<TwitchC
  */
 router.get('/', requireAuth, csrfProtection, async (req, res) => {
   try {
-    const streamer = await getStreamerByDiscordId(req.session.user!.discordId);
+    const streamer = await getStreamerByDiscordId(getSessionUser(req).discordId);
     const isConnected = !!streamer?.eventsub_access_token;
     const needsReconnect = isConnected && !!streamer?.twitch_name && hasAuthFailedSubs(streamer.twitch_name);
 

--- a/src/web/routes/channelPointsEvents.ts
+++ b/src/web/routes/channelPointsEvents.ts
@@ -2,6 +2,7 @@ import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import { getStreamerByDiscordId } from '../../db';
 import { CHANNEL_POINTS_MAX_SSE_PER_STREAMER } from '../../shared/config';
+import { getSessionUser } from '../session';
 
 const log = createLogger('ChannelPointsEvents');
 const router = Router();
@@ -51,7 +52,7 @@ export function pushPricingUpdate(streamerId: number, event: PricingUpdateEvent)
 router.get('/events', async (req, res) => {
   let streamer;
   try {
-    streamer = await getStreamerByDiscordId(req.session.user!.discordId);
+    streamer = await getStreamerByDiscordId(getSessionUser(req).discordId);
   } catch (err) {
     log.error('Failed to resolve streamer for SSE events:', err);
     res.status(500).end();

--- a/src/web/routes/commandGuildOverrides.ts
+++ b/src/web/routes/commandGuildOverrides.ts
@@ -3,6 +3,7 @@ import { Router } from 'express';
 import { upsertOverride, removeOverride } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireMod, requireGuildContext } from '../middleware';
+import { getSessionUser } from '../session';
 import { logAndRedirectError, parsePositiveIntId, trimField } from './shared';
 
 const log = createLogger('Web');
@@ -17,7 +18,7 @@ const router = Router();
  * no custom output), the override row is removed instead of upserted.
  */
 router.post('/commands/guild-override', requireGuildContext, requireMod, csrfProtection, async (req, res) => {
-  const guildId = req.session.user!.currentGuildId!;
+  const guildId = getSessionUser(req).currentGuildId!;
   const body = req.body as Record<string, unknown>;
   const commandId = parsePositiveIntId(body.command_id as string | string[] | undefined);
   if (!commandId) return res.redirect('/commands?error=invalid_id');
@@ -44,7 +45,7 @@ router.post('/commands/guild-override', requireGuildContext, requireMod, csrfPro
  * Accepts `command_id`. Guild ID is always taken from the session.
  */
 router.post('/commands/guild-override/reset', requireGuildContext, requireMod, csrfProtection, async (req, res) => {
-  const guildId = req.session.user!.currentGuildId!;
+  const guildId = getSessionUser(req).currentGuildId!;
   const body = req.body as Record<string, unknown>;
   const commandId = parsePositiveIntId(body.command_id as string | string[] | undefined);
   if (!commandId) return res.redirect('/commands?error=invalid_id');

--- a/src/web/routes/companionKeys.ts
+++ b/src/web/routes/companionKeys.ts
@@ -3,6 +3,7 @@ import { Router } from 'express';
 import { issueToken, getTokenStatus, revokeToken } from '../../db';
 import { csrfProtection } from '../csrf';
 import { logAndRedirectError, renderError, filterQueryParam, renderView } from './shared';
+import { getSessionUser } from '../session';
 
 const log = createLogger('Web');
 const router = Router();
@@ -12,7 +13,7 @@ const KNOWN_ERRORS = new Set(['request_failed', 'revoke_failed']);
 /** Renders the current user's companion app token status page. */
 router.get('/companion-key', csrfProtection, async (req, res) => {
   try {
-    const tokenStatus = await getTokenStatus(req.session.user!.discordId);
+    const tokenStatus = await getTokenStatus(getSessionUser(req).discordId);
     renderView(res, 'companion-keys', {
       user: req.session.user,
       csrfToken: req.csrfToken(),
@@ -36,7 +37,7 @@ router.get('/companion-key', csrfProtection, async (req, res) => {
 router.post('/companion-key/request', csrfProtection, async (req, res) => {
   let plain: string;
   try {
-    plain = await issueToken(req.session.user!.discordId);
+    plain = await issueToken(getSessionUser(req).discordId);
   } catch (err) {
     logAndRedirectError({ res, log, logLabel: 'Companion key request error:', err, basePath: '/companion-key', errorCode: 'request_failed' });
     return;
@@ -44,7 +45,7 @@ router.post('/companion-key/request', csrfProtection, async (req, res) => {
 
   let tokenStatus;
   try {
-    tokenStatus = await getTokenStatus(req.session.user!.discordId);
+    tokenStatus = await getTokenStatus(getSessionUser(req).discordId);
   } catch (err) {
     log.error('Companion key status refresh after issue failed:', err);
     tokenStatus = { hasToken: true, createdAt: new Date() };
@@ -62,7 +63,7 @@ router.post('/companion-key/request', csrfProtection, async (req, res) => {
 /** Revokes the current user's companion app token. */
 router.post('/companion-key/revoke', csrfProtection, async (req, res) => {
   try {
-    await revokeToken(req.session.user!.discordId);
+    await revokeToken(getSessionUser(req).discordId);
     res.redirect('/companion-key');
   } catch (err) {
     logAndRedirectError({ res, log, logLabel: 'Companion key revoke error:', err, basePath: '/companion-key', errorCode: 'revoke_failed' });

--- a/src/web/routes/guild.ts
+++ b/src/web/routes/guild.ts
@@ -3,6 +3,7 @@ import { Router } from 'express';
 import { AccessLevel, findUser, getAllGuilds, getEffectiveAccessLevelForUser, getGuildsForMember } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
+import { getSessionUser } from '../session';
 import { normalizeDiscordId, renderView } from './shared';
 
 const log = createLogger('Web');
@@ -21,7 +22,7 @@ const router = Router();
  *   has at most one guild (single-guild users are sent straight to the dashboard).
  */
 router.get('/select', requireAuth, csrfProtection, (req, res) => {
-  const user = req.session.user!;
+  const user = getSessionUser(req);
   if (user.guilds.length <= 1) {
     return res.redirect('/');
   }
@@ -40,7 +41,7 @@ router.get('/select', requireAuth, csrfProtection, (req, res) => {
  * reflects the current guild, never the previous one.
  */
 router.post('/select', requireAuth, csrfProtection, async (req, res) => {
-  const user = req.session.user!;
+  const user = getSessionUser(req);
   const { guild_id } = req.body as { guild_id?: unknown };
   const requestedGuildId = typeof guild_id === 'string' ? normalizeDiscordId(guild_id) : null;
 

--- a/src/web/routes/overlayAdmin.ts
+++ b/src/web/routes/overlayAdmin.ts
@@ -2,6 +2,7 @@ import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
+import { getSessionUser } from '../session';
 import { getStreamerByDiscordId } from '../../db';
 import type { DbStreamerEventSub } from '../../db';
 import { getVideosForStreamer, getRewardsForStreamer } from '../../db';
@@ -47,7 +48,7 @@ async function fetchTwitchRewards(streamer: DbStreamerEventSub): Promise<TwitchC
  */
 router.get('/settings', requireAuth, csrfProtection, async (req, res) => {
   try {
-    const streamer = await getStreamerByDiscordId(req.session.user!.discordId);
+    const streamer = await getStreamerByDiscordId(getSessionUser(req).discordId);
     const [videos, rewards, twitchRewards] = streamer
       ? await Promise.all([
           getVideosForStreamer(streamer.id),

--- a/src/web/routes/shared.ts
+++ b/src/web/routes/shared.ts
@@ -11,6 +11,7 @@ import {
   isMysqlDuplicateEntryError,
 } from '../../db';
 import type { DbStreamerEventSub } from '../../db';
+import { getSessionUser } from '../session';
 
 const VIEWS_DIR = path.join(__dirname, '../../../views');
 let knownViews: Set<string> | undefined;
@@ -75,7 +76,7 @@ export async function requireStreamer(
   res: Response,
   notAStreamerRedirectPath: string,
 ): Promise<DbStreamerEventSub | null> {
-  const streamer = await getStreamerByDiscordId(req.session.user!.discordId);
+  const streamer = await getStreamerByDiscordId(getSessionUser(req).discordId);
   if (!streamer) {
     res.redirect(notAStreamerRedirectPath);
     return null;

--- a/src/web/routes/streamGroups.ts
+++ b/src/web/routes/streamGroups.ts
@@ -3,6 +3,7 @@ import { Router } from 'express';
 import { addStreamGroup, updateStreamGroup, removeStreamGroupAndStreamers } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireManager } from '../middleware';
+import { getSessionUser } from '../session';
 import { parsePositiveIntId, parseCheckboxField } from './shared';
 import { redirectStreamsInvalid, redirectStreamsFailure } from './streamsErrors';
 import { triggerRestart } from './streamRestart';
@@ -36,7 +37,7 @@ router.post('/streams/groups/add', requireManager, csrfProtection, async (req, r
 
   try {
     await addStreamGroup({
-      guildId: req.session.user!.currentGuildId!,
+      guildId: getSessionUser(req).currentGuildId!,
       name: name!.trim().slice(0, 100),
       discordChannel: discord_channel!.trim().slice(0, 20),
       liveMessage: live_message!.trim().slice(0, 2000),
@@ -76,7 +77,7 @@ router.post('/streams/groups/update', requireManager, csrfProtection, async (req
   try {
     const updated = await updateStreamGroup({
       id: parsedGroupId,
-      guildId: req.session.user!.currentGuildId!,
+      guildId: getSessionUser(req).currentGuildId!,
       name: name!.trim().slice(0, 100),
       discordChannel: discord_channel!.trim().slice(0, 20),
       liveMessage: live_message!.trim().slice(0, 2000),
@@ -107,7 +108,7 @@ router.post('/streams/groups/remove', requireManager, csrfProtection, async (req
   if (parsedGroupId === null) return redirectStreamsInvalid(res, 'invalid_id');
 
   try {
-    const guildId = req.session.user!.currentGuildId!;
+    const guildId = getSessionUser(req).currentGuildId!;
     const removed = await removeStreamGroupAndStreamers(parsedGroupId, guildId);
     if (!removed) return redirectStreamsInvalid(res, 'remove_group_failed');
     triggerRestart();

--- a/src/web/routes/streamStreamers.ts
+++ b/src/web/routes/streamStreamers.ts
@@ -3,6 +3,7 @@ import { Router } from 'express';
 import { addStreamer, removeStreamer, findUser } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireManager } from '../middleware';
+import { getSessionUser } from '../session';
 import { parsePositiveIntId, normalizeDiscordId } from './shared';
 import { redirectStreamsInvalid, redirectStreamsFailure } from './streamsErrors';
 import { triggerRestart } from './streamRestart';
@@ -32,7 +33,7 @@ router.post('/streams/streamers/add', requireManager, csrfProtection, async (req
   try {
     const user = await findUser(discordId);
     if (!user?.twitch_name) return redirectStreamsInvalid(res, 'missing_fields');
-    await addStreamer(discordId, parsedGroupId, req.session.user!.currentGuildId!);
+    await addStreamer(discordId, parsedGroupId, getSessionUser(req).currentGuildId!);
     triggerRestart();
   } catch (err) {
     return redirectStreamsFailure(res, log, 'Add streamer error:', err, 'add_streamer_failed');
@@ -55,7 +56,7 @@ router.post('/streams/streamers/remove', requireManager, csrfProtection, async (
   if (parsedStreamerId === null) return redirectStreamsInvalid(res, 'invalid_id');
 
   try {
-    const removed = await removeStreamer(parsedStreamerId, req.session.user!.currentGuildId!);
+    const removed = await removeStreamer(parsedStreamerId, getSessionUser(req).currentGuildId!);
     if (!removed) return redirectStreamsInvalid(res, 'remove_streamer_failed');
     triggerRestart();
   } catch (err) {

--- a/src/web/routes/streamdeckKeys.ts
+++ b/src/web/routes/streamdeckKeys.ts
@@ -15,6 +15,7 @@ import {
 } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireAdmin } from '../middleware';
+import { getSessionUser } from '../session';
 import { WEB_PORT } from '../../shared/config';
 import { logAndRedirectError, normalizeDiscordId, renderError, filterQueryParam, renderView } from './shared';
 import { userMutationQueue } from './adminUserMutationQueue';
@@ -59,7 +60,7 @@ const USER_KNOWN_ERRORS = new Set(['request_failed', 'rotate_failed', 'revoke_fa
  */
 router.get('/streamdeck-key', csrfProtection, async (req, res) => {
   try {
-    const keyRow = await getGuildStatusForKey(req.session.user!.discordId, req.session.user!.currentGuildId!);
+    const keyRow = await getGuildStatusForKey(getSessionUser(req).discordId, getSessionUser(req).currentGuildId!);
     renderView(res, 'streamdeck-keys', {
       user: req.session.user,
       csrfToken: req.csrfToken(),
@@ -98,9 +99,9 @@ router.get('/streamdeck-key', csrfProtection, async (req, res) => {
  * @returns A promise that resolves once the view has been rendered or the error redirect issued.
  */
 router.post('/streamdeck-key/request', csrfProtection, async (req, res) => {
-  const discordId = req.session.user!.discordId;
-  const accessLevel = req.session.user!.accessLevel;
-  const guildId = req.session.user!.currentGuildId!;
+  const discordId = getSessionUser(req).discordId;
+  const accessLevel = getSessionUser(req).accessLevel;
+  const guildId = getSessionUser(req).currentGuildId!;
   try {
     const { plain, keyRow } = await userMutationQueue.run(discordId, async () => {
       const existingGuildStatus = await getGuildStatusForKey(discordId, guildId);
@@ -183,8 +184,8 @@ export function __resetRecentRotationsForTests(): void {
  * @returns A promise that resolves once the view has been rendered or the error redirect issued.
  */
 router.post('/streamdeck-key/rotate', csrfProtection, async (req, res) => {
-  const discordId = req.session.user!.discordId;
-  const guildId = req.session.user!.currentGuildId!;
+  const discordId = getSessionUser(req).discordId;
+  const guildId = getSessionUser(req).currentGuildId!;
   try {
     const keyRow = await getGuildStatusForKey(discordId, guildId);
     const plain = await userMutationQueue.run(discordId, async () => {
@@ -217,7 +218,7 @@ router.post('/streamdeck-key/rotate', csrfProtection, async (req, res) => {
  */
 router.post('/streamdeck-key/revoke', csrfProtection, async (req, res) => {
   try {
-    await revokeApiKey(req.session.user!.discordId, req.session.user!.currentGuildId!);
+    await revokeApiKey(getSessionUser(req).discordId, getSessionUser(req).currentGuildId!);
     res.redirect('/streamdeck-key');
   } catch (err) {
     logAndRedirectError({ res, log, logLabel: 'Streamdeck key revoke error:', err, basePath: '/streamdeck-key', errorCode: 'revoke_failed' });
@@ -231,7 +232,7 @@ const ADMIN_KNOWN_ERRORS = new Set(['approve_failed', 'deny_failed', 'revoke_fai
 /** Renders the admin Streamdeck key management page, listing pending and all key requests for the admin's current guild. */
 router.get('/admin/streamdeck-keys', requireAdmin, csrfProtection, async (req, res) => {
   try {
-    const guildId = req.session.user!.currentGuildId!;
+    const guildId = getSessionUser(req).currentGuildId!;
     const [pending, all] = await Promise.all([getPendingRequests(guildId), getAllApiKeys(guildId)]);
     renderView(res, 'streamdeck-keys-admin', {
       user: req.session.user,
@@ -251,7 +252,7 @@ router.post('/admin/streamdeck-keys/approve', requireAdmin, csrfProtection, asyn
   const validId = normalizeDiscordId((req.body as { discord_id?: string }).discord_id);
   if (!validId) return res.redirect('/admin/streamdeck-keys?error=invalid_discord_id');
   try {
-    await approveApiKey(validId, req.session.user!.discordId, req.session.user!.currentGuildId!);
+    await approveApiKey(validId, getSessionUser(req).discordId, getSessionUser(req).currentGuildId!);
     res.redirect('/admin/streamdeck-keys');
   } catch (err) {
     logAndRedirectError({ res, log, logLabel: 'Streamdeck key approve error:', err, basePath: '/admin/streamdeck-keys', errorCode: 'approve_failed' });
@@ -263,7 +264,7 @@ router.post('/admin/streamdeck-keys/deny', requireAdmin, csrfProtection, async (
   const validId = normalizeDiscordId((req.body as { discord_id?: string }).discord_id);
   if (!validId) return res.redirect('/admin/streamdeck-keys?error=invalid_discord_id');
   try {
-    await denyApiKey(validId, req.session.user!.currentGuildId!);
+    await denyApiKey(validId, getSessionUser(req).currentGuildId!);
     res.redirect('/admin/streamdeck-keys');
   } catch (err) {
     logAndRedirectError({ res, log, logLabel: 'Streamdeck key deny error:', err, basePath: '/admin/streamdeck-keys', errorCode: 'deny_failed' });
@@ -275,7 +276,7 @@ router.post('/admin/streamdeck-keys/revoke', requireAdmin, csrfProtection, async
   const validId = normalizeDiscordId((req.body as { discord_id?: string }).discord_id);
   if (!validId) return res.redirect('/admin/streamdeck-keys?error=invalid_discord_id');
   try {
-    await revokeApiKey(validId, req.session.user!.currentGuildId!);
+    await revokeApiKey(validId, getSessionUser(req).currentGuildId!);
     res.redirect('/admin/streamdeck-keys');
   } catch (err) {
     logAndRedirectError({ res, log, logLabel: 'Streamdeck key admin revoke error:', err, basePath: '/admin/streamdeck-keys', errorCode: 'revoke_failed' });

--- a/src/web/routes/streams.ts
+++ b/src/web/routes/streams.ts
@@ -3,6 +3,7 @@ import { Router } from 'express';
 import { getStreamGroupsForGuild, getStreamersForGuild, getAllEventSubStreamers, getAllUsers } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireManager } from '../middleware';
+import { getSessionUser } from '../session';
 import { getLiveStates } from '../../twitch/monitor/twitchMonitor';
 import { AccessLevel } from '../../db';
 import { filterQueryParam, renderView, renderError } from './shared';
@@ -35,7 +36,7 @@ function getFriendlyError(key: string): string {
 router.get('/streams', requireManager, csrfProtection, async (req, res) => {
   try {
     const isAdmin = (req.session.user?.accessLevel ?? 0) >= AccessLevel.ADMIN;
-    const guildId = req.session.user!.currentGuildId!;
+    const guildId = getSessionUser(req).currentGuildId!;
     const [groups, streamers, eventSubStreamers, allUsers] = await Promise.all([
       getStreamGroupsForGuild(guildId),
       getStreamersForGuild(guildId),
@@ -80,7 +81,7 @@ router.get('/streams', requireManager, csrfProtection, async (req, res) => {
  * @param res - Express response; returns `{ streams }` from `getLiveStates(guildId)`.
  */
 router.get('/streams/live', requireManager, (req, res) => {
-  res.json({ streams: getLiveStates(req.session.user!.currentGuildId!) });
+  res.json({ streams: getLiveStates(getSessionUser(req).currentGuildId!) });
 });
 
 router.use(groupsRouter);

--- a/src/web/routes/userSettings.ts
+++ b/src/web/routes/userSettings.ts
@@ -4,6 +4,7 @@ import { randomBytes } from 'crypto';
 import { findUser, getStreamerByDiscordId, saveEventConfig, clearStreamerToken, EventSubConfig } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
+import { getSessionUser } from '../session';
 import { logAndRedirectError, trimField, renderError, filterQueryParam, renderView } from './shared';
 import { reloadEventSubSubscriptions } from '../../twitch/eventsub/twitchEventSub';
 import { hasAuthFailedSubs } from '../../twitch/eventsub/twitchEventSubSubscriptions';
@@ -56,7 +57,7 @@ function getFriendlyError(key: string): string {
  */
 router.get('/', requireAuth, csrfProtection, async (req, res) => {
   try {
-    const discordId = req.session.user!.discordId;
+    const discordId = getSessionUser(req).discordId;
     const [dbUser, streamer] = await Promise.all([
       findUser(discordId),
       getStreamerByDiscordId(discordId),
@@ -110,7 +111,7 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
  */
 router.get('/twitch-connect', requireAuth, async (req, res) => {
   try {
-    const discordId = req.session.user!.discordId;
+    const discordId = getSessionUser(req).discordId;
 
     const [dbUser, streamer] = await Promise.all([
       findUser(discordId),
@@ -156,7 +157,7 @@ router.get('/twitch-connect', requireAuth, async (req, res) => {
  */
 router.post('/twitch-disconnect', requireAuth, csrfProtection, async (req, res) => {
   try {
-    const discordId = req.session.user!.discordId;
+    const discordId = getSessionUser(req).discordId;
     const streamer = await getStreamerByDiscordId(discordId);
     if (!streamer) return res.redirect('/user/settings?error=no_streamer_record');
 
@@ -185,7 +186,7 @@ router.post('/twitch-disconnect', requireAuth, csrfProtection, async (req, res) 
  */
 router.post('/eventsub-config', requireAuth, csrfProtection, async (req, res) => {
   try {
-    const discordId = req.session.user!.discordId;
+    const discordId = getSessionUser(req).discordId;
 
     const [dbUser, streamer] = await Promise.all([
       findUser(discordId),

--- a/src/web/session.test.ts
+++ b/src/web/session.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { getSessionUser } from './session';
+
+function makeReq(overrides: object = {}): any {
+  return {
+    session: {},
+    ...overrides,
+  };
+}
+
+describe('getSessionUser', () => {
+  it('returns the session user when present', () => {
+    const user = { discordId: '1', accessLevel: 0 };
+    const req = makeReq({ session: { user } });
+    expect(getSessionUser(req)).toBe(user);
+  });
+
+  it('throws when session.user is absent', () => {
+    const req = makeReq({ session: {} });
+    expect(() => getSessionUser(req)).toThrow(/authenticated session/);
+  });
+});

--- a/src/web/session.test.ts
+++ b/src/web/session.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { getSessionUser } from './session';
+import { ACCESS_LEVEL_MOCK } from '../test-utils/accessLevelMock';
 
+/** Builds a minimal fake Express request for exercising `getSessionUser`. */
 function makeReq(overrides: object = {}): any {
   return {
     session: {},
@@ -10,7 +12,7 @@ function makeReq(overrides: object = {}): any {
 
 describe('getSessionUser', () => {
   it('returns the session user when present', () => {
-    const user = { discordId: '1', accessLevel: 0 };
+    const user = { discordId: '1', accessLevel: ACCESS_LEVEL_MOCK.USER };
     const req = makeReq({ session: { user } });
     expect(getSessionUser(req)).toBe(user);
   });

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -1,0 +1,21 @@
+import type { Request } from 'express';
+import type { SessionUser } from '../types/express';
+
+/**
+ * Reads the current session user, throwing if absent. Safe to call unconditionally in any
+ * route handler mounted behind `requireAuth` (directly, or transitively via
+ * `requireGuildContext`/`requireMod`/`requireManager`/`requireAdmin`, all of which require
+ * a session user first) — replaces the `req.session.user!` non-null assertion previously
+ * repeated at every call site with a single, compiler-checked invariant point.
+ * @param req - Express request.
+ * @returns The current session user.
+ * @throws If `req.session.user` is not set, i.e. this was called from a route handler
+ *   that is missing its auth-guarding middleware.
+ */
+export function getSessionUser(req: Request): SessionUser {
+  const user = req.session.user;
+  if (!user) {
+    throw new Error('getSessionUser called without an authenticated session — route is missing requireAuth');
+  }
+  return user;
+}


### PR DESCRIPTION
## Summary

Part of a codebase-improvement audit — `req.session.user!` (non-null assertion) was repeated **46 times** across 15 route files, relying on `requireAuth` (directly, or transitively via `requireGuildContext`/`requireMod`/`requireManager`/`requireAdmin`) having already run before the handler executes. That's correct in practice, but it's an invariant enforced only by convention — nothing stops a future route from reading `req.session.user!` without the guarding middleware actually being wired up, and the compiler can't catch it.

- Adds `getSessionUser(req): SessionUser` in a new `src/web/session.ts`, which reads `req.session.user` and throws if it's absent.
- Replaces all 46 `req.session.user!` call sites (and their variants — `.currentGuildId!`, `.discordId`, `.accessLevel`, bare `req.session.user!`) across the 15 affected route files with `getSessionUser(req)`.
- `middleware.ts` re-exports it (`export { getSessionUser } from './session'`) so existing `import { ... } from '../middleware'` call sites keep working — it isn't defined in `middleware.ts` itself because `middleware.ts` imports from `routes/shared.ts`, and `routes/shared.ts` needed `getSessionUser` too, which would've been circular.

Non-asserted reads of `req.session.user` (e.g. passing it straight to `renderView`, or the `req.session?.user` truthiness checks in `requireAccessLevel`) are untouched — only the `!`-asserted call sites changed, since those are the ones expressing "I know this is set" without the compiler backing that up.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (2498/2498, including 2 new tests for `getSessionUser`'s throw-when-absent behavior)
- [x] Manually traced each of the 15 route files' mount points in `server.ts` to confirm they all sit behind `requireAuth` (directly or via a parent router), so `getSessionUser`'s invariant genuinely holds at every call site touched


---
_Generated by [Claude Code](https://claude.ai/code/session_01NNtcNfUiM87qV6742itmUU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authenticated session handling across administration, guild selection, streaming, channel points, settings, and key-management pages by consistently deriving the logged-in user identity.
  - Added clearer failure behavior when the login session is missing, reducing inconsistent access errors.

- **Refactor**
  - Standardized how the signed-in account and current guild identifiers are sourced across routes while preserving existing redirects, permissions, and workflows.

- **Tests**
  - Added unit tests for `getSessionUser` to verify correct returns and missing-session error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->