### PR TITLE
Remove unsafe-inline from CSP style-src

### DIFF
--- a/public/commands.js
+++ b/public/commands.js
@@ -1,5 +1,17 @@
 registerToggleEditHandler('btn-toggle-command-edit', 'data-command-id', 'command-edit-');
 
+// Per-user badge color is a hash of the Discord ID, applied via the CSSOM (element.style)
+// rather than an inline style="" attribute, so it works under CSP style-src without 'unsafe-inline'.
+document.querySelectorAll('.badge-user-hue[data-user-hue]').forEach(function (el) {
+  var discordId = el.dataset.userHue;
+  var h = 5381;
+  for (var i = 0; i < discordId.length; i++) {
+    h = ((h << 5) + h) ^ discordId.charCodeAt(i);
+    h >>>= 0;
+  }
+  el.style.setProperty('--hue', h % 360);
+});
+
 document.addEventListener('submit', function (event) {
   var target = event.target;
   if (!(target instanceof HTMLFormElement)) return;

--- a/public/controllerOverlay.css
+++ b/public/controllerOverlay.css
@@ -1,0 +1,6 @@
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body { background: transparent; }
+#root { position: relative; display: inline-block; padding: 6px; font-family: 'Segoe UI', sans-serif; }
+#status { position: absolute; z-index: 10; top: 50%; left: 50%; transform: translate(-50%, -50%); white-space: nowrap; text-align: center; font-size: 16px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: #ffffff; background: rgba(0,0,0,0.85); border: 1px solid rgba(255,255,255,0.15); padding: 10px 20px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.5); }
+#status.connected { visibility: hidden; }
+#ctrl { display: block; }

--- a/public/overlaySource.css
+++ b/public/overlaySource.css
@@ -1,0 +1,3 @@
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { background: transparent; overflow: hidden; width: 1920px; height: 1080px; }
+video { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }

--- a/public/style.css
+++ b/public/style.css
@@ -380,3 +380,86 @@ textarea.input, .stream-textarea { width: 100%; resize: vertical; font-family: v
   transition: transform .15s ease;
 }
 details[open] > .disclosure-toggle::before { transform: rotate(90deg); }
+
+/* ── Utility classes ───────────────────────────────────────
+   Small atomic helpers replacing one-off inline style="" attributes, which
+   CSP's style-src can't allow without 'unsafe-inline'. */
+.mt-025 { margin-top: .25rem; }
+.mt-04  { margin-top: .4rem; }
+.mt-05  { margin-top: .5rem; }
+.mt-075 { margin-top: .75rem; }
+.mt-1   { margin-top: 1rem; }
+.mt-125 { margin-top: 1.25rem; }
+.mb-04  { margin-bottom: .4rem; }
+.mb-075 { margin-bottom: .75rem; }
+.mb-1   { margin-bottom: 1rem; }
+.ml-1   { margin-left: 1rem; }
+.m-0    { margin: 0; }
+.p-0    { padding: 0; }
+.pt-0   { padding-top: 0; }
+
+.w-auto  { width: auto; }
+.w-5rem  { width: 5rem; }
+.w-6rem  { width: 6rem; }
+.w-7rem  { width: 7rem; }
+.w-8rem  { width: 8rem; }
+.w-14rem { width: 14rem; }
+.max-w-28rem { max-width: 28rem; }
+.min-w-120   { min-width: 120px; }
+
+.d-flex   { display: flex; }
+.d-inline { display: inline; }
+.d-block  { display: block; }
+.items-center     { align-items: center; }
+.items-end        { align-items: flex-end; }
+.justify-between  { justify-content: space-between; }
+.justify-center   { justify-content: center; }
+.flex-wrap { flex-wrap: wrap; }
+.gap-04  { gap: .4rem; }
+.gap-05  { gap: .5rem; }
+.gap-075 { gap: .75rem; }
+.flex-1  { flex: 1; }
+.flex-3  { flex: 3; }
+
+.fs-075 { font-size: .75rem; }
+.fs-08  { font-size: .8rem; }
+.fs-08em { font-size: .8em; }
+.nowrap { white-space: nowrap; }
+
+.visually-hidden { position: absolute; left: -10000px; width: 1px; height: 1px; overflow: hidden; }
+.avatar-lg { width: 48px; height: 48px; border-radius: 50%; }
+.token-display { font-size: .85rem; word-break: break-all; flex: 1; min-width: 0; }
+.event-feed-sample { font-size: .8rem; white-space: pre-wrap; }
+.overlay-url-display { display: block; margin-top: .4rem; user-select: all; word-break: break-all; overflow-wrap: anywhere; }
+.reward-id-display { word-break: break-all; overflow-wrap: anywhere; }
+
+/* ── Reconnect modal (dashboard) ──────────────────────── */
+.reconnect-modal-overlay {
+  position: fixed; inset: 0; z-index: 9999; display: flex;
+  align-items: center; justify-content: center;
+  background: rgba(0,0,0,.85); padding: 1.5rem;
+}
+.reconnect-modal-card {
+  background: var(--bg-card); border: 1px solid var(--danger); border-radius: var(--radius);
+  max-width: 480px; width: 100%; padding: 2rem; text-align: center;
+}
+.reconnect-modal-icon    { font-size: 2.5rem; margin-bottom: .75rem; }
+.reconnect-modal-title   { color: var(--danger); margin-bottom: .75rem; font-size: 1.25rem; }
+.reconnect-modal-text    { color: var(--text); margin-bottom: .5rem; }
+.reconnect-modal-subtext { color: var(--muted); font-size: .875rem; margin-bottom: 1.5rem; }
+.reconnect-modal-actions { display: flex; gap: .75rem; justify-content: center; flex-wrap: wrap; }
+
+.subsection-divider { margin-top: .75rem; border-top: 1px solid var(--border); padding-top: .75rem; }
+
+/* ── Key/value instruction table (streamdeck-keys) ────── */
+.kv-table { margin: .75rem 0; border-collapse: collapse; font-size: .85rem; width: 100%; }
+.kv-table td.kv-label { padding: .35rem .75rem .35rem 0; white-space: nowrap; font-weight: 600; vertical-align: top; }
+.kv-table td.kv-label-w { width: 5rem; }
+.kv-table td.kv-value { padding: .35rem 0; }
+
+/* ── Assigned-user badge (commands page) ──────────────────
+   Hue is a per-user hash computed and applied via CSSOM (element.style.setProperty)
+   in commands.js rather than an inline style attribute, so it works under CSP
+   style-src without 'unsafe-inline'. */
+.badge-user-hue { color: hsl(var(--hue, 0), 65%, 60%); background: hsla(var(--hue, 0), 65%, 60%, 0.12); }
+.badge-user-hue.badge-user-self { color: hsl(var(--hue, 0), 90%, 78%); background: hsla(var(--hue, 0), 90%, 78%, 0.22); }

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -178,6 +178,13 @@ describe('CSP header', () => {
     expect(csp).toContain("font-src 'self'");
     expect(csp).not.toMatch(/font-src[^;]*https:/);
   });
+
+  it('restricts style-src to self, without allowing unsafe-inline', async () => {
+    const res = await request(app).get('/__marker_dashboard');
+    const csp = res.headers['content-security-policy'];
+    expect(csp).toContain("style-src 'self'");
+    expect(csp).not.toMatch(/style-src[^;]*unsafe-inline/);
+  });
 });
 
 describe('HSTS header', () => {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -62,7 +62,7 @@ app.use(
         defaultSrc: ["'self'"],
         scriptSrc: ["'self'"],
         scriptSrcAttr: ["'none'"],
-        styleSrc: ["'self'", "'unsafe-inline'"],
+        styleSrc: ["'self'"],
         imgSrc: ["'self'", 'data:', 'https://cdn.discordapp.com', 'https://static-cdn.jtvnw.net'],
         fontSrc: ["'self'"],
         connectSrc: ["'self'"],

--- a/views/channelPointsAdmin.ejs
+++ b/views/channelPointsAdmin.ejs
@@ -59,7 +59,7 @@
         <% } else { %>
         Your Twitch connection is missing required permissions. Reconnect to manage Channel Point rewards.
         <% } %>
-        <a href="/user/settings/twitch-connect" class="btn btn-sm" style="margin-left:1rem;">Reconnect Twitch</a>
+        <a href="/user/settings/twitch-connect" class="btn btn-sm ml-1">Reconnect Twitch</a>
       </div>
     </section>
     <% } else { %>
@@ -67,14 +67,14 @@
     <!-- ── Pricing Settings ────────────────────────────────────────── -->
     <section class="section">
       <h2 class="section-title">Pricing Settings</h2>
-      <p class="hint" style="margin-bottom:0.75rem;">
+      <p class="hint mb-075">
         Shared by every one of your rewards' demand calculations.
       </p>
       <div class="card">
         <div class="card-body">
           <form method="POST" action="/channel-points/settings/pricing">
             <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-            <div class="form-row-wrap" style="align-items:flex-end;">
+            <div class="form-row-wrap items-end">
               <div>
                 <label class="hint hint-compact" for="half-life-minutes">Demand half-life (minutes)</label>
                 <input id="half-life-minutes" class="input" type="number" step="0.5" min="0.5" name="half_life_minutes"
@@ -109,7 +109,7 @@
                 max_per_user_per_stream_setting: { is_enabled: false, max_per_user_per_stream: 1 },
                 global_cooldown_setting: { is_enabled: false, global_cooldown_seconds: 60 },
               } }) %>
-              <div style="margin-top:0.75rem;">
+              <div class="mt-075">
                 <button type="submit" class="btn">Create Reward</button>
               </div>
             </form>
@@ -121,14 +121,14 @@
     <!-- ── Rewards ──────────────────────────────────────────────────── -->
     <section class="section">
       <h2 class="section-title">Channel Point Rewards</h2>
-      <p class="hint" style="margin-bottom:0.75rem;">
+      <p class="hint mb-075">
         Turn on dynamic pricing per reward to have its channel point cost automatically rise with usage and decay when idle.
       </p>
 
       <% if (rewards.some((r) => r.config)) { %>
-      <form method="GET" action="/channel-points" class="form-row-wrap" style="align-items:center;margin-bottom:0.75rem;">
-        <label class="hint hint-compact" for="history-hours" style="padding:0;">Price history range</label>
-        <select id="history-hours" class="input" name="hours" style="width:auto;">
+      <form method="GET" action="/channel-points" class="form-row-wrap items-center mb-075">
+        <label class="hint hint-compact p-0" for="history-hours">Price history range</label>
+        <select id="history-hours" class="input w-auto" name="hours">
           <% for (const h of historyHourOptions) { %>
           <option value="<%= h %>" <%= h === historyHours ? 'selected' : '' %>><%= h %>h</option>
           <% } %>
@@ -146,7 +146,7 @@
       <% for (const r of rewards) { %>
       <div class="card card-spaced">
         <div class="card-body">
-          <div class="form-row-wrap" style="align-items:center;justify-content:space-between;">
+          <div class="form-row-wrap items-center justify-between">
             <div>
               <% if (r.twitchReward) { %>
               <strong><%= r.twitchReward.title %></strong>
@@ -159,13 +159,13 @@
               <p class="hint hint-compact">No longer found on Twitch (deleted, or not visible with the current connection) — reward ID: <code class="mono"><%= r.rewardId %></code></p>
               <% } %>
               <% if (r.config && r.config.twitch_unsupported) { %>
-              <p class="hint hint-compact" style="color:var(--danger, #c0392b);">This reward can't be managed by the bot — it was created via the Twitch dashboard (or another app), and Twitch only allows the app that created a reward to change its cost. Dynamic pricing has been disabled.</p>
+              <p class="hint hint-compact text-danger">This reward can't be managed by the bot — it was created via the Twitch dashboard (or another app), and Twitch only allows the app that created a reward to change its cost. Dynamic pricing has been disabled.</p>
               <% } else if (r.config) { %>
               <p class="hint hint-compact">Demand: <span id="demand-<%= r.rewardId %>"><%= (r.config.demand * 100).toFixed(1) %>%</span> — computed price (updates live as demand changes): <span id="price-<%= r.rewardId %>"><%= r.previewPrice.toLocaleString() %></span> pts</p>
               <% } %>
             </div>
             <% if (r.twitchReward) { %>
-            <form method="POST" action="/channel-points/rewards/<%= r.rewardId %>/delete" style="margin:0;">
+            <form method="POST" action="/channel-points/rewards/<%= r.rewardId %>/delete" class="m-0">
               <input type="hidden" name="_csrf" value="<%= csrfToken %>">
               <button type="submit" class="btn btn-ghost btn-sm">Delete Reward</button>
             </form>
@@ -173,14 +173,14 @@
           </div>
 
           <% if (r.config) { %>
-          <div class="price-history-container" data-reward-id="<%= r.rewardId %>" data-range-ms="<%= historyHours * 60 * 60 * 1000 %>" style="margin-top:0.5rem;">
+          <div class="price-history-container mt-05" data-reward-id="<%= r.rewardId %>" data-range-ms="<%= historyHours * 60 * 60 * 1000 %>">
             <%# historyChartSafeHtml is pre-escaped SVG from renderPriceHistoryChart(); the "SafeHtml" suffix is the contract that the raw-output tag below is safe. %>
             <%- r.historyChartSafeHtml %>
           </div>
           <% } %>
 
           <% if (r.config && r.simulationChartSafeHtml) { %>
-          <div style="margin-top:0.75rem;">
+          <div class="mt-075">
             <p class="hint hint-compact">Simulated: constant use &rarr; cooldown</p>
             <%# simulationChartSafeHtml is pre-escaped SVG from renderPriceHistoryChart(); the "SafeHtml" suffix is the contract that the raw-output tag below is safe. %>
             <%- r.simulationChartSafeHtml %>
@@ -189,12 +189,12 @@
           <% } %>
 
           <% if (r.twitchReward) { %>
-          <details style="margin-top:0.5rem;">
+          <details class="mt-05">
             <summary class="hint hint-compact disclosure-toggle">Edit reward</summary>
-            <form method="POST" action="/channel-points/rewards/<%= r.rewardId %>" style="margin-top:0.5rem;">
+            <form method="POST" action="/channel-points/rewards/<%= r.rewardId %>" class="mt-05">
               <input type="hidden" name="_csrf" value="<%= csrfToken %>">
               <%- include('partials/rewardFields', { idPrefix: r.rewardId, values: r.twitchReward }) %>
-              <div style="margin-top:0.75rem;">
+              <div class="mt-075">
                 <button type="submit" class="btn">Save Changes</button>
               </div>
             </form>
@@ -202,49 +202,49 @@
           <% } %>
 
           <!-- Dynamic pricing sub-section -->
-          <div style="margin-top:0.75rem;border-top:1px solid var(--border);padding-top:0.75rem;">
-            <div class="form-row-wrap" style="align-items:center;justify-content:space-between;">
+          <div class="subsection-divider">
+            <div class="form-row-wrap items-center justify-between">
               <strong class="hint hint-compact">Dynamic pricing</strong>
               <% if (r.config) { %>
-              <form method="POST" action="/channel-points/rewards/<%= r.rewardId %>/pricing/delete" style="margin:0;">
+              <form method="POST" action="/channel-points/rewards/<%= r.rewardId %>/pricing/delete" class="m-0">
                 <input type="hidden" name="_csrf" value="<%= csrfToken %>">
                 <button type="submit" class="btn btn-ghost btn-sm">Disable Pricing</button>
               </form>
               <% } %>
             </div>
-            <form method="POST" action="/channel-points/rewards/<%= r.rewardId %>/pricing" style="margin-top:0.5rem;">
+            <form method="POST" action="/channel-points/rewards/<%= r.rewardId %>/pricing" class="mt-05">
               <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-              <div class="form-row-wrap" style="align-items:flex-end;">
-                <label style="display:flex;align-items:center;gap:0.4rem;">
+              <div class="form-row-wrap items-end">
+                <label class="checkbox-input-label">
                   <input type="checkbox" name="enabled" <%= r.config && r.config.enabled ? 'checked' : '' %>>
                   Enabled
                 </label>
                 <div>
                   <label class="hint hint-compact" for="base-cost-<%= r.rewardId %>">Base cost</label>
-                  <input id="base-cost-<%= r.rewardId %>" class="input" type="number" min="1" step="1" name="base_cost" style="width:7rem;"
+                  <input id="base-cost-<%= r.rewardId %>" class="input w-7rem" type="number" min="1" step="1" name="base_cost"
                     value="<%= r.config ? r.config.base_cost : (r.twitchReward ? r.twitchReward.cost : '') %>" required>
                 </div>
                 <div>
                   <span class="hint hint-compact">Cooldown (s)</span>
-                  <p class="hint hint-compact" style="margin:0;">
+                  <p class="hint hint-compact m-0">
                     <%= r.config ? r.config.cooldown_seconds : (r.twitchReward && r.twitchReward.global_cooldown_setting.is_enabled ? r.twitchReward.global_cooldown_setting.global_cooldown_seconds : 60) %>
                     (synced from the reward's Twitch global cooldown)
                   </p>
                 </div>
                 <div>
                   <label class="hint hint-compact" for="max-mult-<%= r.rewardId %>">Max multiplier</label>
-                  <input id="max-mult-<%= r.rewardId %>" class="input" type="number" step="0.1" min="0" name="max_multiplier" style="width:7rem;"
+                  <input id="max-mult-<%= r.rewardId %>" class="input w-7rem" type="number" step="0.1" min="0" name="max_multiplier"
                     value="<%= r.config ? r.config.max_multiplier : 1 %>" required>
                 </div>
                 <div>
                   <label class="hint hint-compact" for="curve-<%= r.rewardId %>">Curve</label>
-                  <input id="curve-<%= r.rewardId %>" class="input" type="number" step="0.1" min="0.1" name="curve" style="width:7rem;"
+                  <input id="curve-<%= r.rewardId %>" class="input w-7rem" type="number" step="0.1" min="0.1" name="curve"
                     value="<%= r.config ? r.config.curve : 1 %>" required>
                 </div>
                 <div>
                   <label class="hint hint-compact" for="round-to-nearest-<%= r.rewardId %>">Round to nearest</label>
                   <% const roundToNearest = r.config ? r.config.round_to_nearest : 0; %>
-                  <select id="round-to-nearest-<%= r.rewardId %>" class="input" name="round_to_nearest" style="width:7rem;">
+                  <select id="round-to-nearest-<%= r.rewardId %>" class="input w-7rem" name="round_to_nearest">
                     <option value="0" <%= roundToNearest === 0 ? 'selected' : '' %>>Off</option>
                     <option value="5" <%= roundToNearest === 5 ? 'selected' : '' %>>5</option>
                     <option value="10" <%= roundToNearest === 10 ? 'selected' : '' %>>10</option>

--- a/views/commands.ejs
+++ b/views/commands.ejs
@@ -88,18 +88,6 @@
               </tr>
             </thead>
             <tbody>
-              <%
-              function assignedUserStyle(discordId, isSelf) {
-                let h = 5381;
-                for (let i = 0; i < discordId.length; i++) {
-                  h = ((h << 5) + h) ^ discordId.charCodeAt(i);
-                  h >>>= 0;
-                }
-                const hue = h % 360;
-                if (isSelf) return `color:hsl(${hue},90%,78%);background:hsla(${hue},90%,78%,0.22)`;
-                return `color:hsl(${hue},65%,60%);background:hsla(${hue},65%,60%,0.12)`;
-              }
-              %>
               <% commands.forEach(function(command) { %>
               <tr class="sfx-row">
                 <td class="mono"><strong><%= command.trigger_string %></strong></td>
@@ -123,7 +111,7 @@
                     <div class="badge-list-wrap">
                       <% command.assigned_users.forEach(function(assignedUser) { %>
                         <% const isSelf = user && assignedUser.discord_id === user.discordId; %>
-                        <span class="badge" style="<%= assignedUserStyle(assignedUser.discord_id, isSelf) %>">
+                        <span class="badge badge-user-hue<%= isSelf ? ' badge-user-self' : '' %>" data-user-hue="<%= assignedUser.discord_id %>">
                           <%= assignedUser.discord_name || assignedUser.discord_id %>
                           <% if (assignedUser.twitch_name) { %>
                             (<%= assignedUser.twitch_name %>)

--- a/views/companion-keys.ejs
+++ b/views/companion-keys.ejs
@@ -27,8 +27,8 @@
       <% if (newToken) { %>
       <div class="card card-alert-success" role="alert">
         <p><strong>&#10003; Your companion app token has been generated.</strong> Copy it now — it will not be shown again.</p>
-        <div style="margin-top:.75rem;display:flex;gap:.5rem;align-items:center;flex-wrap:wrap;">
-          <code class="mono" id="new-token" style="font-size:.85rem;word-break:break-all;flex:1;min-width:0;"><%= newToken %></code>
+        <div class="mt-075 d-flex gap-05 items-center flex-wrap">
+          <code class="mono token-display" id="new-token"><%= newToken %></code>
           <button type="button" class="btn btn-sm" id="copy-token-btn">Copy</button>
         </div>
       </div>
@@ -43,20 +43,20 @@
         <p class="muted">The companion app normally logs in itself via Discord — it opens your browser, you log in, and it receives a token automatically. You should not normally need to generate or paste a token by hand.</p>
 
         <% if (!tokenStatus || !tokenStatus.hasToken) { %>
-        <p style="margin-top:.75rem;">You do not have an active companion app token.</p>
-        <form method="POST" action="/companion-key/request" style="margin-top:1rem;">
+        <p class="mt-075">You do not have an active companion app token.</p>
+        <form method="POST" action="/companion-key/request" class="mt-1">
           <input type="hidden" name="_csrf" value="<%= csrfToken %>">
           <button type="submit" class="btn btn-sm">Generate Token Manually (advanced)</button>
         </form>
 
         <% } else { %>
-        <div style="display:flex;align-items:center;gap:.75rem;flex-wrap:wrap;margin-bottom:1rem;">
+        <div class="d-flex items-center gap-075 flex-wrap mb-1">
           <span class="badge badge-active">Active</span>
-          <span class="muted" style="font-size:.85rem;">Issued <%= tokenStatus.createdAt.toLocaleDateString() %></span>
+          <span class="text-muted-sm">Issued <%= tokenStatus.createdAt.toLocaleDateString() %></span>
         </div>
         <p>Your companion app token is active. It is read-only — it can only receive your own channel-point redemption events.</p>
         <p class="muted">If you have lost your device or believe the token has leaked, you can revoke it. The companion app can log in again afterwards to get a fresh token.</p>
-        <div style="display:flex;gap:.5rem;flex-wrap:wrap;margin-top:1rem;">
+        <div class="d-flex gap-05 flex-wrap mt-1">
           <form method="POST" action="/companion-key/request">
             <input type="hidden" name="_csrf" value="<%= csrfToken %>">
             <button type="submit" class="btn btn-sm">Generate New Token Manually (advanced)</button>
@@ -84,9 +84,9 @@
         </ol>
         <p class="muted">Only loopback redirect URIs (<code>http://127.0.0.1:*</code> or <code>http://localhost:*</code>) are accepted.</p>
 
-        <p style="margin-top:1rem;"><strong>Event feed:</strong></p>
+        <p class="mt-1"><strong>Event feed:</strong></p>
         <p>Connect to <code>GET /api/companion/events</code> with <code>Authorization: Bearer &lt;token&gt;</code>. This is a Server-Sent Events stream that delivers one event per line as it happens:</p>
-        <pre class="mono" style="font-size:.8rem;white-space:pre-wrap;">data: {"type":"channel_points_redemption","rewardId":"...","rewardTitle":"...","userLogin":"...","userName":"...","userInput":"...","redeemedAt":"2026-01-01T00:00:00.000Z"}</pre>
+        <pre class="mono event-feed-sample">data: {"type":"channel_points_redemption","rewardId":"...","rewardTitle":"...","userLogin":"...","userName":"...","userInput":"...","redeemedAt":"2026-01-01T00:00:00.000Z"}</pre>
         <p class="muted">Events are only sent for redemptions on your own channel. What the companion app does with an event (play a sound, run a script, show a notification) is entirely up to it.</p>
       </div>
     </section>

--- a/views/controllerOverlay.ejs
+++ b/views/controllerOverlay.ejs
@@ -3,19 +3,13 @@
 <head>
   <meta charset="UTF-8">
   <title>Controller Overlay</title>
-  <style>
-    * { box-sizing: border-box; margin: 0; padding: 0; }
-    html, body { background: transparent; }
-    #root { position: relative; display: inline-block; padding: 6px; font-family: 'Segoe UI', sans-serif; }
-    #status { position: absolute; z-index: 10; top: 50%; left: 50%; transform: translate(-50%, -50%); white-space: nowrap; text-align: center; font-size: 16px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: #ffffff; background: rgba(0,0,0,0.85); border: 1px solid rgba(255,255,255,0.15); padding: 10px 20px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.5); }
-    #status.connected { visibility: hidden; }
-  </style>
+  <link rel="stylesheet" href="/controllerOverlay.css">
 </head>
 <body>
 <div id="root">
   <div id="status">No controller connected</div>
 
-  <svg id="ctrl" viewBox="0 0 320 200" xmlns="http://www.w3.org/2000/svg" width="320" style="display:block">
+  <svg id="ctrl" viewBox="0 0 320 200" xmlns="http://www.w3.org/2000/svg" width="320">
     <defs>
       <clipPath id="lt-clip"><rect x="5" y="5" width="140" height="42" rx="8"/></clipPath>
       <clipPath id="rt-clip"><rect x="175" y="5" width="140" height="42" rx="8"/></clipPath>

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -46,8 +46,8 @@ function htmlAttrJson(value) {
             <div class="stat-row"><span class="stat-label">State</span><span class="stat-value" id="voice-state">Idle</span></div>
             <% if (user && user.accessLevel >= 1) { %>
             <div class="stat-row stat-row-top-gap">
-              <div style="display: flex; gap: 0.5rem; align-items: center;">
-                <select class="btn btn-sm" id="voice-channel-select" style="flex: 1; min-width: 120px;">
+              <div class="d-flex gap-05 items-center">
+                <select class="btn btn-sm flex-1 min-w-120" id="voice-channel-select">
                   <option value="">Loading channels...</option>
                 </select>
                 <button class="btn btn-sm" id="btn-rejoin-voice"><%= status.voice.connected ? 'Leave Voice' : 'Join Voice' %></button>
@@ -98,13 +98,13 @@ function htmlAttrJson(value) {
   <script src="/app.js"></script>
 
   <% if (needsReconnect) { %>
-  <div id="reconnect-modal" style="position:fixed;inset:0;z-index:9999;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,0.85);padding:1.5rem;">
-    <div style="background:var(--bg-card);border:1px solid var(--danger);border-radius:var(--radius);max-width:480px;width:100%;padding:2rem;text-align:center;">
-      <div style="font-size:2.5rem;margin-bottom:0.75rem;">⚠️</div>
-      <h2 style="color:var(--danger);margin-bottom:0.75rem;font-size:1.25rem;">Twitch Reconnection Required</h2>
-      <p style="color:var(--text);margin-bottom:0.5rem;">Your Twitch connection is missing required permissions and some notifications are not working.</p>
-      <p style="color:var(--muted);font-size:0.875rem;margin-bottom:1.5rem;">Please reconnect your Twitch account to restore full functionality.</p>
-      <div style="display:flex;gap:0.75rem;justify-content:center;flex-wrap:wrap;">
+  <div id="reconnect-modal" class="reconnect-modal-overlay">
+    <div class="reconnect-modal-card">
+      <div class="reconnect-modal-icon">⚠️</div>
+      <h2 class="reconnect-modal-title">Twitch Reconnection Required</h2>
+      <p class="reconnect-modal-text">Your Twitch connection is missing required permissions and some notifications are not working.</p>
+      <p class="reconnect-modal-subtext">Please reconnect your Twitch account to restore full functionality.</p>
+      <div class="reconnect-modal-actions">
         <a href="/user/settings/twitch-connect" class="btn">Reconnect Twitch</a>
         <button id="dismiss-reconnect-modal" class="btn btn-ghost">Dismiss</button>
       </div>

--- a/views/overlayAdmin.ejs
+++ b/views/overlayAdmin.ejs
@@ -58,8 +58,8 @@
         <div class="card-body">
           <p class="hint hint-compact">Add this URL as a Browser Source in OBS (1920×1080, transparent background):</p>
           <% const login = streamer.twitch_name ? streamer.twitch_name.toLowerCase() : ''; %>
-          <code class="mono" style="display:block;margin-top:0.4rem;user-select:all;word-break:break-all;overflow-wrap:anywhere;"><%= baseUrl %>/overlay/<%= login %></code>
-          <p class="hint" style="margin-top:0.5rem;">In OBS: Sources → Add → Browser → check "Local file" OFF, paste the URL above.</p>
+          <code class="mono overlay-url-display"><%= baseUrl %>/overlay/<%= login %></code>
+          <p class="hint mt-05">In OBS: Sources → Add → Browser → check "Local file" OFF, paste the URL above.</p>
         </div>
       </div>
     </section>
@@ -70,8 +70,8 @@
       <div class="card">
         <div class="card-body">
           <p class="hint hint-compact">Add this URL as a Browser Source in OBS to display a gamepad input visualiser (throttle, brake, steering, handbrake):</p>
-          <code class="mono" style="display:block;margin-top:0.4rem;user-select:all;word-break:break-all;overflow-wrap:anywhere;"><%= baseUrl %>/overlay/controller</code>
-          <p class="hint" style="margin-top:0.5rem;">Works with any Xbox / PlayStation / generic controller. Transparent background — native size is <strong>332&times;212px</strong> (set the OBS browser source to these dimensions, then scale to taste).</p>
+          <code class="mono overlay-url-display"><%= baseUrl %>/overlay/controller</code>
+          <p class="hint mt-05">Works with any Xbox / PlayStation / generic controller. Transparent background — native size is <strong>332&times;212px</strong> (set the OBS browser source to these dimensions, then scale to taste).</p>
         </div>
       </div>
     </section>
@@ -86,12 +86,12 @@
                X-CSRF-Token header, so the session token is never placed in the URL
                (browser history / Referer). -->
           <form method="POST" action="/overlay/settings/videos/upload" enctype="multipart/form-data" class="js-overlay-upload">
-            <div class="form-row-wrap" style="align-items:flex-end;">
-              <div style="flex:1;">
+            <div class="form-row-wrap items-end">
+              <div class="flex-1">
                 <label class="hint hint-compact" for="video-name">Name</label>
                 <input id="video-name" class="input" type="text" name="name" maxlength="100" placeholder="e.g. Confetti Explosion">
               </div>
-              <div style="flex:1;">
+              <div class="flex-1">
                 <label class="hint hint-compact" for="video-file">Video file (WebM or MP4)</label>
                 <input id="video-file" class="input" type="file" name="video" accept="video/webm,video/mp4" required>
               </div>
@@ -99,7 +99,7 @@
                 <button type="submit" class="btn">Upload</button>
               </div>
             </div>
-            <p class="hint" style="margin-top:0.4rem;">WebM with alpha channel recommended for transparent overlays. Max <%= maxFileMb %> MB.</p>
+            <p class="hint mt-04">WebM with alpha channel recommended for transparent overlays. Max <%= maxFileMb %> MB.</p>
           </form>
         </div>
       </div>
@@ -113,7 +113,7 @@
       <% } else { %>
       <div class="card">
         <div class="table-scroll">
-          <table class="table" style="width:100%;">
+          <table class="table full-width">
             <thead>
               <tr>
                 <th>Name</th>
@@ -126,10 +126,10 @@
               <% for (const v of videos) { %>
               <tr>
                 <td><%= v.name %></td>
-                <td class="mono" style="font-size:0.8em;"><%= v.filename %></td>
+                <td class="mono fs-08em"><%= v.filename %></td>
                 <td><%= new Date(v.created_at).toLocaleDateString() %></td>
                 <td>
-                  <form method="POST" action="/overlay/settings/videos/<%= v.id %>/delete" style="margin:0;" class="js-confirm-delete-video">
+                  <form method="POST" action="/overlay/settings/videos/<%= v.id %>/delete" class="m-0 js-confirm-delete-video">
                     <input type="hidden" name="_csrf" value="<%= csrfToken %>">
                     <button type="submit" class="btn btn-ghost btn-sm">
                       Delete
@@ -148,7 +148,7 @@
     <!-- ── Reward Assignments ─────────────────────────────────────── -->
     <section class="section">
       <h2 class="section-title">Reward Assignments</h2>
-      <p class="hint" style="margin-bottom:0.75rem;">
+      <p class="hint mb-075">
         Assign channel point rewards to overlay videos. Each reward can have multiple videos — one is picked at random (weighted) when redeemed.
       </p>
 
@@ -164,7 +164,7 @@
         <div class="card-body">
           <form method="POST" action="/overlay/settings/rewards" id="reward-form">
             <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-            <div style="margin-bottom:0.75rem;">
+            <div class="mb-075">
               <label class="hint hint-compact" for="reward-id">Twitch Reward</label>
               <% if (twitchRewards.length > 0) { %>
               <select id="reward-id" class="input" name="twitch_reward_id" required>
@@ -177,25 +177,25 @@
               <input id="reward-id" class="input" type="text" name="twitch_reward_id"
                 pattern="[0-9a-fA-F\-]{36}" maxlength="36" required
                 placeholder="e.g. 12345678-abcd-1234-abcd-1234567890ab">
-              <p class="hint" style="margin-top:0.25rem;">Connect your Twitch account in <a href="/user/settings">User Settings</a> to pick rewards by name.</p>
+              <p class="hint mt-025">Connect your Twitch account in <a href="/user/settings">User Settings</a> to pick rewards by name.</p>
               <% } %>
             </div>
             <p class="hint hint-compact">Videos &amp; weights (higher weight = more likely):</p>
-            <div id="video-assignments" style="margin-top:0.4rem;">
+            <div id="video-assignments" class="mt-04">
               <% for (const v of videos) { %>
-              <div class="form-row-wrap" style="margin-bottom:0.4rem;align-items:center;">
-                <label style="flex:3;display:flex;align-items:center;gap:0.5rem;">
+              <div class="form-row-wrap mb-04 items-center">
+                <label class="flex-3 d-flex items-center gap-05">
                   <input type="checkbox" name="video_ids" value="<%= v.id %>">
                   <%= v.name %>
                 </label>
-                <div style="flex:1;display:flex;align-items:center;gap:0.4rem;">
-                  <span class="hint hint-compact" style="white-space:nowrap;">Weight</span>
-                  <input class="input" type="number" name="weight_<%= v.id %>" value="1" min="1" max="100" style="width:5rem;">
+                <div class="flex-1 d-flex items-center gap-04">
+                  <span class="hint hint-compact nowrap">Weight</span>
+                  <input class="input w-5rem" type="number" name="weight_<%= v.id %>" value="1" min="1" max="100">
                 </div>
               </div>
               <% } %>
             </div>
-            <div class="button-row-wrap" style="margin-top:0.75rem;">
+            <div class="button-row-wrap mt-075">
               <button type="submit" class="btn">Save Assignment</button>
             </div>
           </form>
@@ -209,12 +209,12 @@
       <% for (const r of rewards) { %>
       <div class="card card-spaced">
         <div class="card-body">
-          <div class="form-row-wrap" style="align-items:center;justify-content:space-between;">
+          <div class="form-row-wrap items-center justify-between">
             <div>
               <p class="hint hint-compact">Reward ID</p>
-              <code class="mono" style="word-break:break-all;overflow-wrap:anywhere;"><%= r.twitch_reward_id %></code>
+              <code class="mono reward-id-display"><%= r.twitch_reward_id %></code>
             </div>
-            <form method="POST" action="/overlay/settings/rewards/<%= r.id %>/delete" style="margin:0;" class="js-confirm-delete-reward">
+            <form method="POST" action="/overlay/settings/rewards/<%= r.id %>/delete" class="m-0 js-confirm-delete-reward">
               <input type="hidden" name="_csrf" value="<%= csrfToken %>">
               <button type="submit" class="btn btn-ghost btn-sm">
                 Remove
@@ -222,8 +222,8 @@
             </form>
           </div>
           <% if (r.videos.length > 0) { %>
-          <div class="table-scroll" style="margin-top:0.75rem;">
-            <table class="table" style="width:100%;">
+          <div class="table-scroll mt-075">
+            <table class="table full-width">
               <thead>
                 <tr><th>Video</th><th>Weight</th></tr>
               </thead>
@@ -238,7 +238,7 @@
             </table>
           </div>
           <% } else { %>
-          <p class="hint" style="margin-top:0.5rem;">No videos assigned.</p>
+          <p class="hint mt-05">No videos assigned.</p>
           <% } %>
         </div>
       </div>

--- a/views/overlaySource.ejs
+++ b/views/overlaySource.ejs
@@ -2,11 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <style>
-    * { margin: 0; padding: 0; box-sizing: border-box; }
-    body { background: transparent; overflow: hidden; width: 1920px; height: 1080px; }
-    video { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
-  </style>
+  <link rel="stylesheet" href="/overlaySource.css">
 </head>
 <body>
   <script src="/overlay-source.js" data-login="<%= login %>"></script>

--- a/views/partials/nav.ejs
+++ b/views/partials/nav.ejs
@@ -55,7 +55,7 @@
       <% } %>
       <span class="username"><%= user.discordName %></span>
       <span class="badge level-<%= user.accessLevel %>"><%= ['User','Mod','Manager','Admin'][user.accessLevel] || 'Unknown' %></span>
-      <form method="POST" action="/auth/logout" style="display:inline;margin:0">
+      <form method="POST" action="/auth/logout" class="d-inline m-0">
         <input type="hidden" name="_csrf" value="<%= csrfToken %>">
         <button type="submit" class="btn btn-ghost btn-sm">Logout</button>
       </form>

--- a/views/partials/rewardFields.ejs
+++ b/views/partials/rewardFields.ejs
@@ -3,64 +3,63 @@
      (an object shaped like TwitchCustomReward — title/cost/prompt/is_enabled/background_color/
      is_user_input_required/should_redemptions_skip_request_queue/max_per_stream_setting/
      max_per_user_per_stream_setting/global_cooldown_setting). -->
-<div class="form-row-wrap" style="align-items:flex-end;">
+<div class="form-row-wrap items-end">
   <div>
     <label class="hint hint-compact" for="title-<%= idPrefix %>">Title</label>
-    <input id="title-<%= idPrefix %>" class="input" type="text" name="title" maxlength="45" style="width:14rem;"
+    <input id="title-<%= idPrefix %>" class="input w-14rem" type="text" name="title" maxlength="45"
       value="<%= values.title %>" required>
   </div>
   <div>
     <label class="hint hint-compact" for="cost-<%= idPrefix %>">Cost</label>
-    <input id="cost-<%= idPrefix %>" class="input" type="number" min="1" step="1" name="cost" style="width:7rem;"
+    <input id="cost-<%= idPrefix %>" class="input w-7rem" type="number" min="1" step="1" name="cost"
       value="<%= values.cost %>" required>
   </div>
-  <label style="display:flex;align-items:center;gap:0.4rem;">
+  <label class="checkbox-input-label">
     <input type="checkbox" name="is_enabled" <%= values.is_enabled ? 'checked' : '' %>>
     Enabled
   </label>
 </div>
 
-<div style="margin-top:0.5rem;">
+<div class="mt-05">
   <label class="hint hint-compact" for="prompt-<%= idPrefix %>">Prompt (shown to viewers)</label>
-  <textarea id="prompt-<%= idPrefix %>" class="input" name="prompt" maxlength="200" rows="2"
-    style="width:100%;max-width:28rem;display:block;"><%= values.prompt %></textarea>
+  <textarea id="prompt-<%= idPrefix %>" class="input full-width max-w-28rem d-block" name="prompt" maxlength="200" rows="2"><%= values.prompt %></textarea>
 </div>
 
-<div class="form-row-wrap" style="align-items:center;margin-top:0.5rem;">
-  <label style="display:flex;align-items:center;gap:0.4rem;">
+<div class="form-row-wrap items-center mt-05">
+  <label class="checkbox-input-label">
     <input type="checkbox" name="is_user_input_required" <%= values.is_user_input_required ? 'checked' : '' %>>
     Require viewer text input
   </label>
-  <label style="display:flex;align-items:center;gap:0.4rem;">
+  <label class="checkbox-input-label">
     <input type="checkbox" name="should_redemptions_skip_request_queue" <%= values.should_redemptions_skip_request_queue ? 'checked' : '' %>>
     Skip request queue (auto-fulfill)
   </label>
   <div>
     <label class="hint hint-compact" for="bg-color-<%= idPrefix %>">Background color</label>
-    <input id="bg-color-<%= idPrefix %>" class="input" type="text" name="background_color" placeholder="#00E5CB" style="width:8rem;"
+    <input id="bg-color-<%= idPrefix %>" class="input w-8rem" type="text" name="background_color" placeholder="#00E5CB"
       value="<%= values.background_color || '' %>">
   </div>
 </div>
 
-<div class="form-row-wrap" style="align-items:center;margin-top:0.5rem;">
-  <label style="display:flex;align-items:center;gap:0.4rem;">
+<div class="form-row-wrap items-center mt-05">
+  <label class="checkbox-input-label">
     <input type="checkbox" name="is_max_per_stream_enabled" <%= values.max_per_stream_setting.is_enabled ? 'checked' : '' %>>
     Limit per stream
   </label>
-  <input class="input" type="number" min="1" step="1" name="max_per_stream" aria-label="Max redemptions per stream" style="width:6rem;"
+  <input class="input w-6rem" type="number" min="1" step="1" name="max_per_stream" aria-label="Max redemptions per stream"
     value="<%= values.max_per_stream_setting.max_per_stream %>">
 
-  <label style="display:flex;align-items:center;gap:0.4rem;">
+  <label class="checkbox-input-label">
     <input type="checkbox" name="is_max_per_user_per_stream_enabled" <%= values.max_per_user_per_stream_setting.is_enabled ? 'checked' : '' %>>
     Limit per user per stream
   </label>
-  <input class="input" type="number" min="1" step="1" name="max_per_user_per_stream" aria-label="Max redemptions per user per stream" style="width:6rem;"
+  <input class="input w-6rem" type="number" min="1" step="1" name="max_per_user_per_stream" aria-label="Max redemptions per user per stream"
     value="<%= values.max_per_user_per_stream_setting.max_per_user_per_stream %>">
 
-  <label style="display:flex;align-items:center;gap:0.4rem;">
+  <label class="checkbox-input-label">
     <input type="checkbox" name="is_global_cooldown_enabled" <%= values.global_cooldown_setting.is_enabled ? 'checked' : '' %>>
     Global cooldown (s)
   </label>
-  <input class="input" type="number" min="1" step="1" name="global_cooldown_seconds" aria-label="Global cooldown in seconds" style="width:6rem;"
+  <input class="input w-6rem" type="number" min="1" step="1" name="global_cooldown_seconds" aria-label="Global cooldown in seconds"
     value="<%= values.global_cooldown_setting.global_cooldown_seconds %>">
 </div>

--- a/views/sfx-public.ejs
+++ b/views/sfx-public.ejs
@@ -17,7 +17,7 @@
     <section class="section">
       <div class="section-header">
         <h2 class="section-title">SFX Commands (<span id="cmd-count"><%= triggers.length %></span>)</h2>
-        <label for="sfx-search" style="position:absolute;left:-10000px;width:1px;height:1px;overflow:hidden;">Filter SFX commands</label>
+        <label for="sfx-search" class="visually-hidden">Filter SFX commands</label>
         <input type="search" id="sfx-search" class="search-input" placeholder="Search commands…">
       </div>
 

--- a/views/sfx.ejs
+++ b/views/sfx.ejs
@@ -90,7 +90,7 @@
     <section class="section">
       <div class="section-header">
         <h2 class="section-title">SFX Commands (<span id="cmd-count"><%= triggers.length %></span>)</h2>
-        <label for="sfx-search" style="position:absolute;left:-10000px;width:1px;height:1px;overflow:hidden;">Filter SFX commands</label>
+        <label for="sfx-search" class="visually-hidden">Filter SFX commands</label>
         <input type="search" id="sfx-search" class="search-input" placeholder="Filter commands…">
       </div>
 
@@ -145,12 +145,12 @@
                     <tr>
                       <% if (canManage) { %>
                       <td colspan="<%= canManage ? 4 : 3 %>">
-                        <form method="POST" action="/sfx/file/update" class="form-row-wrap" style="align-items:flex-end;gap:0.5rem;">
+                        <form method="POST" action="/sfx/file/update" class="form-row-wrap items-end gap-05">
                           <input type="hidden" name="_csrf" value="<%= csrfToken %>">
                           <input type="hidden" name="file_id" value="<%= f.id %>">
                           <span class="mono form-col-grow"><%= f.file %></span>
                           <label class="form-label">Weight
-                            <input class="input" type="number" name="weight" min="1" value="<%= f.weight %>" style="width:6rem;">
+                            <input class="input w-6rem" type="number" name="weight" min="1" value="<%= f.weight %>">
                           </label>
                           <label class="input checkbox-input-label">
                             <input type="checkbox" name="file_hidden" <%= f.hidden ? 'checked' : '' %>> Hidden
@@ -166,7 +166,7 @@
                     </tr>
                     <% if (canManage) { %>
                     <tr>
-                      <td colspan="4" style="padding-top:0;">
+                      <td colspan="4" class="pt-0">
                         <form method="POST" action="/sfx/file/remove" class="inline-form-sm js-confirm-remove-file" data-file-name="<%= f.file %>">
                           <input type="hidden" name="_csrf" value="<%= csrfToken %>">
                           <input type="hidden" name="file_id" value="<%= f.id %>">
@@ -188,14 +188,14 @@
                        header, so the session token is never placed in the URL (history/Referer). -->
                   <form method="POST" action="/sfx/file/upload" enctype="multipart/form-data" class="js-sfx-upload">
                     <input type="hidden" name="trigger_id" value="<%= t.triggerId %>">
-                    <div class="form-row-wrap form-section-gap" style="align-items:flex-end;">
+                    <div class="form-row-wrap form-section-gap items-end">
                       <div class="form-col-grow">
                         <label class="form-label">Add sound <span class="muted">(mp3, ogg, wav — max <%= maxUploadMb %>MB)</span>
                           <input class="input full-width" type="file" name="sound" accept=".mp3,.ogg,.wav,audio/mpeg,audio/ogg,audio/wav" required>
                         </label>
                       </div>
                       <label class="form-label">Weight
-                        <input class="input" type="number" name="weight" min="1" value="1" style="width:6rem;">
+                        <input class="input w-6rem" type="number" name="weight" min="1" value="1">
                       </label>
                       <label class="input checkbox-input-label">
                         <input type="checkbox" name="file_hidden"> Hidden
@@ -264,7 +264,7 @@
       <div class="card card-spaced">
         <div class="card-header"><span class="card-icon">🏷️</span><span class="card-label">Categories</span></div>
         <div class="card-body">
-          <form method="POST" action="/sfx/category/add" class="form-row-wrap form-section-gap" style="align-items:flex-end;">
+          <form method="POST" action="/sfx/category/add" class="form-row-wrap form-section-gap items-end">
             <input type="hidden" name="_csrf" value="<%= csrfToken %>">
             <div class="form-col-grow">
               <label for="category_name" class="form-label">New Category</label>
@@ -280,7 +280,7 @@
               <% categories.forEach(function(c) { %>
               <tr>
                 <td>
-                  <form method="POST" action="/sfx/category/rename" class="form-row-wrap" style="align-items:flex-end;gap:0.5rem;">
+                  <form method="POST" action="/sfx/category/rename" class="form-row-wrap items-end gap-05">
                     <input type="hidden" name="_csrf" value="<%= csrfToken %>">
                     <input type="hidden" name="category_id" value="<%= c.id %>">
                     <input class="input form-col-grow" type="text" name="name" value="<%= c.name %>" aria-label="Category name" required>

--- a/views/streamdeck-keys-admin.ejs
+++ b/views/streamdeck-keys-admin.ejs
@@ -44,11 +44,11 @@
               <tr>
                 <td>
                   <%= row.user_name || row.discord_id %>
-                  <% if (row.user_name) { %><br><span class="mono muted" style="font-size:.75rem;"><%= row.discord_id %></span><% } %>
+                  <% if (row.user_name) { %><br><span class="mono muted fs-075"><%= row.discord_id %></span><% } %>
                 </td>
                 <td><%= row.requested_at.toLocaleString() %></td>
                 <td>
-                  <div style="display:flex;gap:.4rem;flex-wrap:wrap;">
+                  <div class="d-flex gap-04 flex-wrap">
                     <form method="POST" action="/admin/streamdeck-keys/approve" class="inline-form-sm">
                       <input type="hidden" name="_csrf" value="<%= csrfToken %>">
                       <input type="hidden" name="discord_id" value="<%= row.discord_id %>">
@@ -95,7 +95,7 @@
               <tr>
                 <td>
                   <%= row.user_name || row.discord_id %>
-                  <% if (row.user_name) { %><br><span class="mono muted" style="font-size:.75rem;"><%= row.discord_id %></span><% } %>
+                  <% if (row.user_name) { %><br><span class="mono muted fs-075"><%= row.discord_id %></span><% } %>
                 </td>
                 <td>
                   <% if (row.status === 'approved') { %>
@@ -112,14 +112,14 @@
                 <td>
                   <% if (row.approved_by) { %>
                   <%= row.approver_name || row.approved_by %>
-                  <% if (row.approver_name) { %><br><span class="mono muted" style="font-size:.75rem;"><%= row.approved_by %></span><% } %>
+                  <% if (row.approver_name) { %><br><span class="mono muted fs-075"><%= row.approved_by %></span><% } %>
                   <% } else { %>
                   <em class="muted">—</em>
                   <% } %>
                 </td>
                 <td>
                   <% if (row.status === 'pending') { %>
-                  <div style="display:flex;gap:.4rem;flex-wrap:wrap;">
+                  <div class="d-flex gap-04 flex-wrap">
                     <form method="POST" action="/admin/streamdeck-keys/approve" class="inline-form-sm">
                       <input type="hidden" name="_csrf" value="<%= csrfToken %>">
                       <input type="hidden" name="discord_id" value="<%= row.discord_id %>">

--- a/views/streamdeck-keys.ejs
+++ b/views/streamdeck-keys.ejs
@@ -28,12 +28,12 @@
       <% if (newKey) { %>
       <div class="card card-alert-success" role="alert">
         <p><strong>&#10003; Your API key has been generated.</strong> Copy it now — it will not be shown again.</p>
-        <div style="margin-top:.75rem;display:flex;gap:.5rem;align-items:center;flex-wrap:wrap;">
-          <code class="mono" id="new-key" style="font-size:.85rem;word-break:break-all;flex:1;min-width:0;"><%= newKey %></code>
+        <div class="mt-075 d-flex gap-05 items-center flex-wrap">
+          <code class="mono token-display" id="new-key"><%= newKey %></code>
           <button type="button" class="btn btn-sm" id="copy-key-btn">Copy</button>
         </div>
         <% if (keyRow && keyRow.status === 'pending') { %>
-        <p style="margin-top:.75rem;" class="muted">Your key is pending admin approval. It will become active once an Admin approves your request.</p>
+        <p class="muted mt-075">Your key is pending admin approval. It will become active once an Admin approves your request.</p>
         <% } %>
       </div>
       <% } %>
@@ -51,31 +51,31 @@
         <% } else { %>
         <p class="muted">Your request will be reviewed by an Admin before the key becomes active.</p>
         <% } %>
-        <form method="POST" action="/streamdeck-key/request" style="margin-top:1rem;">
+        <form method="POST" action="/streamdeck-key/request" class="mt-1">
           <input type="hidden" name="_csrf" value="<%= csrfToken %>">
           <button type="submit" class="btn">Request API Key</button>
         </form>
 
         <% } else if (keyRow.status === 'pending') { %>
-        <div style="display:flex;align-items:center;gap:.75rem;flex-wrap:wrap;margin-bottom:1rem;">
+        <div class="d-flex items-center gap-075 flex-wrap mb-1">
           <span class="badge badge-hidden">Pending Approval</span>
-          <span class="muted" style="font-size:.85rem;">Requested <%= keyRow.requested_at.toLocaleDateString() %></span>
+          <span class="text-muted-sm">Requested <%= keyRow.requested_at.toLocaleDateString() %></span>
         </div>
         <p>Your key is awaiting Admin approval. No further action is needed — the key you already copied will become active automatically once an Admin approves your request. Refresh this page to check the current status.</p>
-        <p class="muted" style="margin-top:.5rem;">Lost the key you copied? Generating a new one won't affect your approval status, but the old key will immediately stop working<%= user.guilds && user.guilds.length > 1 ? ' — in every server it was approved for, not just this one' : '' %>.</p>
-        <form method="POST" action="/streamdeck-key/rotate" class="js-confirm-rotate-key" style="margin-top:1rem;">
+        <p class="muted mt-05">Lost the key you copied? Generating a new one won't affect your approval status, but the old key will immediately stop working<%= user.guilds && user.guilds.length > 1 ? ' — in every server it was approved for, not just this one' : '' %>.</p>
+        <form method="POST" action="/streamdeck-key/rotate" class="js-confirm-rotate-key mt-1">
           <input type="hidden" name="_csrf" value="<%= csrfToken %>">
           <button type="submit" class="btn btn-sm btn-ghost">Lost your key?</button>
         </form>
 
         <% } else if (keyRow.status === 'approved') { %>
-        <div style="display:flex;align-items:center;gap:.75rem;flex-wrap:wrap;margin-bottom:1rem;">
+        <div class="d-flex items-center gap-075 flex-wrap mb-1">
           <span class="badge badge-active">Active</span>
-          <span class="muted" style="font-size:.85rem;">Approved <%= keyRow.approved_at ? keyRow.approved_at.toLocaleDateString() : '' %></span>
+          <span class="text-muted-sm">Approved <%= keyRow.approved_at ? keyRow.approved_at.toLocaleDateString() : '' %></span>
         </div>
         <p>Your API key is active. See the <strong>How to Use</strong> section below for setup instructions.</p>
         <p class="muted">If you have lost your key, you can generate a new one. The old key will immediately stop working<%= user.guilds && user.guilds.length > 1 ? ' — in every server it was approved for, not just this one' : '' %>.</p>
-        <div style="display:flex;gap:.5rem;flex-wrap:wrap;margin-top:1rem;">
+        <div class="d-flex gap-05 flex-wrap mt-1">
           <form method="POST" action="/streamdeck-key/rotate" class="js-confirm-rotate-key">
             <input type="hidden" name="_csrf" value="<%= csrfToken %>">
             <button type="submit" class="btn btn-sm btn-ghost">Lost your key?</button>
@@ -86,11 +86,11 @@
           </form>
         </div>
         <% if (user.guilds && user.guilds.length > 1) { %>
-        <p class="muted" style="margin-top:.5rem;">Revoking only removes access for this server — the key stays active in any other server it's approved for. Use <strong>Lost your key?</strong> to invalidate it everywhere.</p>
+        <p class="muted mt-05">Revoking only removes access for this server — the key stays active in any other server it's approved for. Use <strong>Lost your key?</strong> to invalidate it everywhere.</p>
         <% } %>
 
         <% } else if (keyRow.status === 'revoked') { %>
-        <div style="display:flex;align-items:center;gap:.75rem;flex-wrap:wrap;margin-bottom:1rem;">
+        <div class="d-flex items-center gap-075 flex-wrap mb-1">
           <span class="badge badge-offline">Revoked</span>
         </div>
         <p>Your API key has been revoked and is no longer active. You can request a new one.</p>
@@ -99,7 +99,7 @@
         <% } else { %>
         <p class="muted">A new request will need Admin approval.</p>
         <% } %>
-        <form method="POST" action="/streamdeck-key/request" style="margin-top:1rem;">
+        <form method="POST" action="/streamdeck-key/request" class="mt-1">
           <input type="hidden" name="_csrf" value="<%= csrfToken %>">
           <button type="submit" class="btn">Request New API Key</button>
         </form>
@@ -114,35 +114,35 @@
 
         <p><strong>1. Download &amp; install the plugin</strong></p>
         <p>Download the plugin file and double-click it to install it in the Streamdeck software:</p>
-        <p style="margin:.75rem 0;">
+        <p class="mt-075">
           <a href="/downloads/com.expiredminotaur.bcuk.streamDeckPlugin" class="btn" download>&#11015;&nbsp;Download Plugin</a>
         </p>
 
-        <p style="margin-top:1.25rem;"><strong>2. Add a Play SFX action</strong></p>
+        <p class="mt-125"><strong>2. Add a Play SFX action</strong></p>
         <p>Drag the <strong>Play SFX</strong> action from the BCUK Bot category onto a key, then open its Property Inspector and enter:</p>
-        <table style="margin:.75rem 0;border-collapse:collapse;font-size:.85rem;width:100%;">
+        <table class="kv-table">
           <tr>
-            <td style="padding:.35rem .75rem .35rem 0;white-space:nowrap;font-weight:600;vertical-align:top;width:5rem;">Host</td>
-            <td style="padding:.35rem 0;font-family:monospace;" id="sd-host-cell">–</td>
+            <td class="kv-label kv-label-w">Host</td>
+            <td class="kv-value mono" id="sd-host-cell">–</td>
           </tr>
           <tr>
-            <td style="padding:.35rem .75rem .35rem 0;white-space:nowrap;font-weight:600;vertical-align:top;">Port</td>
-            <td style="padding:.35rem 0;font-family:monospace;"><%= webPort %></td>
+            <td class="kv-label">Port</td>
+            <td class="kv-value mono"><%= webPort %></td>
           </tr>
           <tr>
-            <td style="padding:.35rem .75rem .35rem 0;white-space:nowrap;font-weight:600;vertical-align:top;">API Key</td>
-            <td style="padding:.35rem 0;">Paste your key from the Key Status section above</td>
+            <td class="kv-label">API Key</td>
+            <td class="kv-value">Paste your key from the Key Status section above</td>
           </tr>
         </table>
         <p class="muted">These settings are shared across all your BCUK Bot Streamdeck buttons — you only need to enter them once.</p>
 
-        <p style="margin-top:1.25rem;"><strong>3. Load your commands</strong></p>
+        <p class="mt-125"><strong>3. Load your commands</strong></p>
         <p>Press <strong>Refresh Commands</strong> in the Property Inspector. This connects to the bot and populates the command dropdown with all available sound effects. Then select the command you want this key to trigger.</p>
 
-        <p style="margin-top:1.25rem;"><strong>4. Press the key</strong></p>
+        <p class="mt-125"><strong>4. Press the key</strong></p>
         <p>If your API key is active the bot will play the sound effect in the Discord voice channel immediately.</p>
 
-        <p class="muted" style="margin-top:1.25rem;">Streamdeck triggers bypass the chat cooldown and will interrupt any currently playing sound.</p>
+        <p class="muted mt-125">Streamdeck triggers bypass the chat cooldown and will interrupt any currently playing sound.</p>
       </div>
     </section>
   </main>

--- a/views/userSettings.ejs
+++ b/views/userSettings.ejs
@@ -31,7 +31,7 @@
         <div class="card-body">
           <div class="form-row-wrap">
             <% if (user && user.discordAvatar) { %>
-            <img src="<%= user.discordAvatar %>?size=64" class="avatar" style="width:48px;height:48px;border-radius:50%;" alt="">
+            <img src="<%= user.discordAvatar %>?size=64" class="avatar-lg" alt="">
             <% } %>
             <div>
               <p class="hint hint-compact">Discord</p>
@@ -68,15 +68,15 @@
       <% } else { %>
 
       <% if (needsReconnect) { %>
-      <div class="card card-alert-danger" style="margin-bottom:0.75rem;">
+      <div class="card card-alert-danger mb-075">
         Your Twitch connection is missing required permissions. Please reconnect your Twitch account to restore channel point redemption notifications.
-        <a href="/user/settings/twitch-connect" class="btn btn-sm" style="margin-left:1rem;">Reconnect Twitch</a>
+        <a href="/user/settings/twitch-connect" class="btn btn-sm ml-1">Reconnect Twitch</a>
       </div>
       <% } %>
 
       <div class="card card-spaced">
         <div class="card-body">
-          <div class="form-row-wrap" style="align-items:center;">
+          <div class="form-row-wrap items-center">
             <div>
               <% if (isConnected) { %>
               <span class="badge badge-active">✓ Connected</span>
@@ -117,9 +117,9 @@
               </label>
               <p class="hint hint-compact">New sub — variables: <code>{username} {display_name} {tier} {tier_name}</code></p>
               <textarea class="input stream-textarea" name="sub_message" rows="2" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.sub_message) ? cfg.sub_message : 'Thanks {display_name} for subscribing! ({tier_name})' %></textarea>
-              <p class="hint hint-compact" style="margin-top:0.4rem;">Resub — variables: <code>{username} {display_name} {tier} {tier_name} {months} {streak}</code></p>
+              <p class="hint hint-compact mt-04">Resub — variables: <code>{username} {display_name} {tier} {tier_name} {months} {streak}</code></p>
               <textarea class="input stream-textarea" name="resub_message" rows="2" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.resub_message) ? cfg.resub_message : 'Thanks {display_name} for {months} months! ({tier_name})' %></textarea>
-              <p class="hint hint-compact" style="margin-top:0.4rem;">Gift sub — variables: <code>{gifter} {gifter_display} {count} {tier} {tier_name}</code></p>
+              <p class="hint hint-compact mt-04">Gift sub — variables: <code>{gifter} {gifter_display} {count} {tier} {tier_name}</code></p>
               <textarea class="input stream-textarea" name="giftsub_message" rows="2" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.giftsub_message) ? cfg.giftsub_message : '{gifter_display} gifted {count} sub(s) to the community!' %></textarea>
             </div>
 
@@ -130,7 +130,7 @@
               </label>
               <p class="hint hint-compact">Variables: <code>{from_channel} {from_display} {viewers}</code></p>
               <textarea class="input stream-textarea" name="raid_message" rows="2" maxlength="500" <%= !isConnected ? 'disabled' : '' %>><%= (cfg && cfg.raid_message) ? cfg.raid_message : 'Welcome raiders from {from_display}! Thank you for the {viewers} person raid!' %></textarea>
-              <label class="input checkbox-input-label" style="margin-top:0.4rem;">
+              <label class="input checkbox-input-label mt-04">
                 <input type="checkbox" name="raid_shoutout_enabled" <%= (cfg && cfg.raid_shoutout_enabled) ? 'checked' : '' %> <%= !isConnected ? 'disabled' : '' %>>
                 Auto-shoutout raiders <% if (!isConnected) { %><span class="hint">(requires Twitch connection)</span><% } %>
               </label>


### PR DESCRIPTION
## Summary

Aikido flagged the site's CSP as allowing inline CSS (`style-src 'self' 'unsafe-inline'`), which weakens XSS defense-in-depth — injected `style=""` attributes could otherwise be used for social-engineering/UI-redress attacks. This removes `'unsafe-inline'` from `style-src` and eliminates every inline style in the app so the tighter policy doesn't break anything.

- Replaced all `style="..."` attributes across the EJS views with classes — a new set of small atomic utilities (`mt-075`, `d-flex`, `items-center`, `w-7rem`, etc.) plus a handful of semantic component classes (reconnect modal, kv-table, `visually-hidden`, `avatar-lg`, ...) added to `public/style.css`.
- Extracted the `<style>` blocks in the two standalone overlay pages (`controllerOverlay.ejs`, `overlaySource.ejs`) into external stylesheets (`public/controllerOverlay.css`, `public/overlaySource.css`) linked via `<link rel="stylesheet">`.
- The one *dynamic* inline style — a per-user hash-based badge hue on the commands page — now uses `data-user-hue="<discordId>"` plus a small script in `commands.js` that computes the hash and sets a CSS custom property via `element.style.setProperty()` (CSSOM), which CSP's `style-src` doesn't gate, instead of writing an inline `style=""` attribute.
- `src/web/server.ts`: `styleSrc` is now `["'self'"]`.
- `src/web/server.test.ts`: added a CSP test asserting `style-src` no longer contains `unsafe-inline`.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` — all 137 test files / 2497 tests pass
- [x] All EJS views compile cleanly (`ejs.compile` smoke test)
- [x] Repo-wide grep confirms no `style="..."` attributes or `<style>` blocks remain in `views/`


---
_Generated by [Claude Code](https://claude.ai/code/session_014aWCHNyPD9my4YBer3uPTz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent class-based styling across settings, administration, commands, SFX, and API key pages.
  - Added deterministic user badge colors, including distinct styling for the signed-in user.
  - Added clearer reconnect modal, accordion editing, tables, and form layout improvements.
  - Added external styling for controller and video overlays.

- **Bug Fixes**
  - Strengthened style security by disallowing inline styles through the Content Security Policy.

- **Style**
  - Improved spacing, alignment, typography, responsive layouts, and accessibility-focused labels across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->