### PR TITLE
test: raise adminUserMutations.ts coverage to 100% stmts/funcs/lines

### DIFF
--- a/src/web/routes/adminUserMutations.test.ts
+++ b/src/web/routes/adminUserMutations.test.ts
@@ -26,6 +26,8 @@ import {
   removeUserMutation,
   toggleTwitchMutation,
   DuplicateTwitchNameError,
+  isLockWaitTimeoutDbError,
+  isDuplicateTwitchNameDbError,
 } from './adminUserMutations';
 import {
   findUser,
@@ -36,6 +38,7 @@ import {
   getTwitchEnabledChannels,
 } from '../../db';
 import { joinTwitchChannel, partTwitchChannel } from '../../twitch/twitchChannelMembership';
+import { normalizeTwitchChannelName } from '../../twitch/twitchChannelName';
 import { AccessLevel } from '../../db/users';
 
 type MockDbUser = {
@@ -178,6 +181,131 @@ describe('removeUserMutation — rollback on partTwitchChannel failure', () => {
   });
 });
 
+describe('removeUserMutation — early exits', () => {
+  it('returns after removeUser when the user had the Twitch bot disabled', async () => {
+    const existingUser: MockDbUser = {
+      ...BASE_USER,
+      twitch_name: 'streamerchan',
+      is_twitch_bot_enabled: false,
+    };
+    vi.mocked(findUser).mockResolvedValue(existingUser as any);
+
+    await expect(removeUserMutation('111')).resolves.toBeUndefined();
+
+    expect(vi.mocked(removeUser)).toHaveBeenCalledWith('111');
+    expect(vi.mocked(getTwitchEnabledChannels)).not.toHaveBeenCalled();
+    expect(vi.mocked(partTwitchChannel)).not.toHaveBeenCalled();
+  });
+
+  it('returns after removeUser when the user has no Twitch name', async () => {
+    vi.mocked(findUser).mockResolvedValue({ ...BASE_USER, twitch_name: null, is_twitch_bot_enabled: true } as any);
+
+    await expect(removeUserMutation('111')).resolves.toBeUndefined();
+
+    expect(vi.mocked(partTwitchChannel)).not.toHaveBeenCalled();
+  });
+
+  it('throws when the stored Twitch channel normalizes to an invalid value', async () => {
+    const existingUser: MockDbUser = {
+      ...BASE_USER,
+      twitch_name: 'bad chan!!',
+      is_twitch_bot_enabled: true,
+    };
+    vi.mocked(findUser).mockResolvedValue(existingUser as any);
+    vi.mocked(normalizeTwitchChannelName).mockReturnValueOnce(null);
+
+    await expect(removeUserMutation('111')).rejects.toThrow('Removed user has an invalid Twitch channel');
+
+    expect(vi.mocked(partTwitchChannel)).not.toHaveBeenCalled();
+  });
+
+  it('returns without parting when the channel is still enabled for another user', async () => {
+    const existingUser: MockDbUser = {
+      ...BASE_USER,
+      twitch_name: 'streamerchan',
+      is_twitch_bot_enabled: true,
+    };
+    vi.mocked(findUser).mockResolvedValue(existingUser as any);
+    vi.mocked(getTwitchEnabledChannels).mockResolvedValue(['streamerchan']);
+
+    await expect(removeUserMutation('111')).resolves.toBeUndefined();
+
+    expect(vi.mocked(partTwitchChannel)).not.toHaveBeenCalled();
+  });
+});
+
+describe('removeUserMutation — rollback itself fails', () => {
+  it('logs when the rollback upsertUser call also fails, and still rethrows the original error', async () => {
+    const existingUser: MockDbUser = {
+      ...BASE_USER,
+      twitch_name: 'streamerchan',
+      is_twitch_bot_enabled: true,
+    };
+
+    vi.mocked(findUser).mockResolvedValue(existingUser as any);
+    vi.mocked(partTwitchChannel).mockRejectedValue(new Error('Part failed'));
+    vi.mocked(upsertUser).mockRejectedValue(new Error('Rollback upsert failed'));
+
+    await expect(removeUserMutation('111')).rejects.toThrow('Part failed');
+
+    expect(vi.mocked(upsertUser)).toHaveBeenCalled();
+  });
+});
+
+describe('toggleTwitchMutation — validation and no-op', () => {
+  it('throws when the target user does not exist', async () => {
+    vi.mocked(findUser).mockResolvedValue(null as any);
+
+    await expect(toggleTwitchMutation('111', true)).rejects.toThrow(
+      'Toggle target user is missing or has no Twitch channel',
+    );
+  });
+
+  it('throws when the target user has no Twitch channel', async () => {
+    vi.mocked(findUser).mockResolvedValue({ ...BASE_USER, twitch_name: null } as any);
+
+    await expect(toggleTwitchMutation('111', true)).rejects.toThrow(
+      'Toggle target user is missing or has no Twitch channel',
+    );
+  });
+
+  it('throws when the Twitch channel normalizes to an invalid value', async () => {
+    vi.mocked(findUser).mockResolvedValue({ ...BASE_USER, twitch_name: 'bad chan!!' } as any);
+    vi.mocked(normalizeTwitchChannelName).mockReturnValueOnce(null);
+
+    await expect(toggleTwitchMutation('111', true)).rejects.toThrow(
+      'Toggle target user has an invalid Twitch channel',
+    );
+  });
+
+  it('is a no-op when the requested state matches the current state', async () => {
+    vi.mocked(findUser).mockResolvedValue({
+      ...BASE_USER,
+      twitch_name: 'streamerchan',
+      is_twitch_bot_enabled: true,
+    } as any);
+
+    await expect(toggleTwitchMutation('111', true)).resolves.toBeUndefined();
+
+    expect(vi.mocked(updateTwitchBotEnabled)).not.toHaveBeenCalled();
+    expect(vi.mocked(getTwitchEnabledChannels)).not.toHaveBeenCalled();
+  });
+
+  it('parts the channel when it is not in the enabled list', async () => {
+    vi.mocked(findUser).mockResolvedValue({
+      ...BASE_USER,
+      twitch_name: 'streamerchan',
+      is_twitch_bot_enabled: false,
+    } as any);
+    vi.mocked(getTwitchEnabledChannels).mockResolvedValue([]);
+
+    await expect(toggleTwitchMutation('111', true)).resolves.toBeUndefined();
+
+    expect(vi.mocked(partTwitchChannel)).toHaveBeenCalledWith('streamerchan');
+    expect(vi.mocked(joinTwitchChannel)).not.toHaveBeenCalled();
+  });
+});
+
 describe('toggleTwitchMutation — rollback on join/part failure', () => {
   it('reverts updateTwitchBotEnabled when joinTwitchChannel throws', async () => {
     const user: MockDbUser = {
@@ -189,6 +317,26 @@ describe('toggleTwitchMutation — rollback on join/part failure', () => {
     vi.mocked(findUser).mockResolvedValue(user as any);
     vi.mocked(getTwitchEnabledChannels).mockResolvedValue(['streamerchan']);
     vi.mocked(joinTwitchChannel).mockRejectedValue(new Error('Join failed'));
+
+    await expect(toggleTwitchMutation('111', true)).rejects.toThrow('Join failed');
+
+    expect(vi.mocked(updateTwitchBotEnabled)).toHaveBeenNthCalledWith(1, '111', true);
+    expect(vi.mocked(updateTwitchBotEnabled)).toHaveBeenNthCalledWith(2, '111', false);
+  });
+
+  it('logs when the rollback updateTwitchBotEnabled call also fails, and still rethrows the original error', async () => {
+    const user: MockDbUser = {
+      ...BASE_USER,
+      twitch_name: 'streamerchan',
+      is_twitch_bot_enabled: false,
+    };
+
+    vi.mocked(findUser).mockResolvedValue(user as any);
+    vi.mocked(getTwitchEnabledChannels).mockResolvedValue(['streamerchan']);
+    vi.mocked(joinTwitchChannel).mockRejectedValue(new Error('Join failed'));
+    vi.mocked(updateTwitchBotEnabled)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('Rollback update failed'));
 
     await expect(toggleTwitchMutation('111', true)).rejects.toThrow('Join failed');
 
@@ -245,6 +393,240 @@ describe('addOrUpdateUserMutation — upsertUser throws', () => {
 
     expect(vi.mocked(joinTwitchChannel)).not.toHaveBeenCalled();
     expect(vi.mocked(partTwitchChannel)).not.toHaveBeenCalled();
+  });
+});
+
+describe('isLockWaitTimeoutDbError', () => {
+  it('returns false for non-object errors', () => {
+    expect(isLockWaitTimeoutDbError(null)).toBe(false);
+    expect(isLockWaitTimeoutDbError('boom')).toBe(false);
+  });
+
+  it('returns true when errno is 1205', () => {
+    expect(isLockWaitTimeoutDbError({ errno: 1205 })).toBe(true);
+  });
+
+  it('returns true when code is ER_LOCK_WAIT_TIMEOUT', () => {
+    expect(isLockWaitTimeoutDbError({ code: 'ER_LOCK_WAIT_TIMEOUT' })).toBe(true);
+  });
+
+  it('returns false for an unrelated error object', () => {
+    expect(isLockWaitTimeoutDbError({ errno: 500, code: 'OTHER' })).toBe(false);
+  });
+});
+
+describe('isDuplicateTwitchNameDbError', () => {
+  it('returns false for non-object errors', () => {
+    expect(isDuplicateTwitchNameDbError(null)).toBe(false);
+    expect(isDuplicateTwitchNameDbError('boom')).toBe(false);
+  });
+
+  it('returns true when code is ER_DUP_ENTRY and message references the Twitch name index', () => {
+    expect(
+      isDuplicateTwitchNameDbError({ code: 'ER_DUP_ENTRY', message: "Duplicate entry for key 'ux_user_twitch_name'" }),
+    ).toBe(true);
+  });
+
+  it('returns false when code is ER_DUP_ENTRY but message references a different index', () => {
+    expect(
+      isDuplicateTwitchNameDbError({ code: 'ER_DUP_ENTRY', message: "Duplicate entry for key 'other_index'" }),
+    ).toBe(false);
+  });
+
+  it('returns false when code is ER_DUP_ENTRY but message is missing', () => {
+    expect(isDuplicateTwitchNameDbError({ code: 'ER_DUP_ENTRY' })).toBe(false);
+  });
+
+  it('returns false when code is not ER_DUP_ENTRY', () => {
+    expect(isDuplicateTwitchNameDbError({ code: 'ER_OTHER', message: 'ux_user_twitch_name' })).toBe(false);
+  });
+});
+
+describe('addOrUpdateUserMutation — successful Twitch channel clear (no rollback)', () => {
+  it('resolves without throwing and skips partTwitchChannel when the channel is still enabled elsewhere', async () => {
+    const existingUser: MockDbUser = {
+      ...BASE_USER,
+      twitch_name: 'oldchan',
+      is_twitch_bot_enabled: true,
+    };
+
+    vi.mocked(findUser)
+      .mockResolvedValueOnce(existingUser as any)
+      .mockResolvedValueOnce({ ...existingUser, twitch_name: null } as any);
+    vi.mocked(getTwitchEnabledChannels).mockResolvedValue(['oldchan']);
+
+    await expect(
+      addOrUpdateUserMutation({
+        discordId: '111',
+        discordName: 'TestUser',
+        level: AccessLevel.USER,
+        normalizedTwitchName: null,
+        shouldClearTwitchName: true,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(vi.mocked(partTwitchChannel)).not.toHaveBeenCalled();
+    expect(vi.mocked(updateTwitchBotEnabled)).toHaveBeenCalledWith('111', false);
+  });
+});
+
+describe('addOrUpdateUserMutation — brand new user with a Twitch channel', () => {
+  it('joins the channel for a newly created user (no previous channel to part)', async () => {
+    vi.mocked(findUser)
+      .mockResolvedValueOnce(null) // no pre-existing user
+      .mockResolvedValueOnce({ ...BASE_USER, twitch_name: 'newchan', is_twitch_bot_enabled: true } as any);
+    vi.mocked(findUserByTwitchName).mockResolvedValue(null);
+    vi.mocked(getTwitchEnabledChannels).mockResolvedValue(['newchan']);
+
+    await expect(
+      addOrUpdateUserMutation({
+        discordId: '111',
+        discordName: 'TestUser',
+        level: AccessLevel.USER,
+        normalizedTwitchName: 'newchan',
+        shouldClearTwitchName: false,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(vi.mocked(joinTwitchChannel)).toHaveBeenCalledWith('newchan');
+    expect(vi.mocked(partTwitchChannel)).not.toHaveBeenCalled();
+  });
+});
+
+describe('addOrUpdateUserMutation — updating a user without touching the Twitch name', () => {
+  it('passes undefined for the Twitch name to upsertUser and leaves Twitch channels untouched', async () => {
+    const existingUser: MockDbUser = {
+      ...BASE_USER,
+      twitch_name: null,
+      is_twitch_bot_enabled: false,
+    };
+    vi.mocked(findUser)
+      .mockResolvedValueOnce(existingUser as any)
+      .mockResolvedValueOnce(existingUser as any);
+
+    await expect(
+      addOrUpdateUserMutation({
+        discordId: '111',
+        discordName: 'TestUser',
+        level: AccessLevel.MOD,
+        normalizedTwitchName: null,
+        shouldClearTwitchName: false,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(vi.mocked(upsertUser)).toHaveBeenCalledWith('111', 'TestUser', AccessLevel.MOD, undefined);
+    expect(vi.mocked(joinTwitchChannel)).not.toHaveBeenCalled();
+    expect(vi.mocked(partTwitchChannel)).not.toHaveBeenCalled();
+  });
+});
+
+describe('addOrUpdateUserMutation — successful Twitch channel change (no rollback)', () => {
+  it('joins the new channel and parts the old one when both succeed', async () => {
+    const existingUser: MockDbUser = {
+      ...BASE_USER,
+      twitch_name: 'oldchan',
+      is_twitch_bot_enabled: true,
+    };
+    const afterUpsert: MockDbUser = {
+      ...BASE_USER,
+      twitch_name: 'newchan',
+      is_twitch_bot_enabled: true,
+    };
+
+    vi.mocked(findUser)
+      .mockResolvedValueOnce(existingUser as any)
+      .mockResolvedValueOnce(afterUpsert as any);
+    vi.mocked(findUserByTwitchName).mockResolvedValue(null);
+    vi.mocked(getTwitchEnabledChannels).mockResolvedValue(['newchan']);
+
+    await expect(
+      addOrUpdateUserMutation({
+        discordId: '111',
+        discordName: 'TestUser',
+        level: AccessLevel.USER,
+        normalizedTwitchName: 'newchan',
+        shouldClearTwitchName: false,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(vi.mocked(joinTwitchChannel)).toHaveBeenCalledWith('newchan');
+    expect(vi.mocked(partTwitchChannel)).toHaveBeenCalledWith('oldchan');
+  });
+
+  it('does not part the previous channel when it is still enabled for another user', async () => {
+    const existingUser: MockDbUser = {
+      ...BASE_USER,
+      twitch_name: 'oldchan',
+      is_twitch_bot_enabled: true,
+    };
+    const afterUpsert: MockDbUser = {
+      ...BASE_USER,
+      twitch_name: 'newchan',
+      is_twitch_bot_enabled: true,
+    };
+
+    vi.mocked(findUser)
+      .mockResolvedValueOnce(existingUser as any)
+      .mockResolvedValueOnce(afterUpsert as any);
+    vi.mocked(findUserByTwitchName).mockResolvedValue(null);
+    vi.mocked(getTwitchEnabledChannels).mockResolvedValue(['newchan', 'oldchan']);
+
+    await expect(
+      addOrUpdateUserMutation({
+        discordId: '111',
+        discordName: 'TestUser',
+        level: AccessLevel.USER,
+        normalizedTwitchName: 'newchan',
+        shouldClearTwitchName: false,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(vi.mocked(joinTwitchChannel)).toHaveBeenCalledWith('newchan');
+    expect(vi.mocked(partTwitchChannel)).not.toHaveBeenCalled();
+  });
+});
+
+describe('addOrUpdateUserMutation — handleChangeTwitchChannel rollback also fails', () => {
+  it('rejoins the previous channel, reparts the committed channel, logs when that rollback also fails, and rethrows the original error', async () => {
+    const existingUser: MockDbUser = {
+      ...BASE_USER,
+      twitch_name: 'oldchan',
+      is_twitch_bot_enabled: true,
+    };
+    const afterUpsert: MockDbUser = {
+      ...BASE_USER,
+      twitch_name: 'newchan',
+      is_twitch_bot_enabled: true,
+    };
+
+    vi.mocked(findUser)
+      .mockResolvedValueOnce(existingUser as any)
+      .mockResolvedValueOnce(afterUpsert as any);
+    vi.mocked(findUserByTwitchName).mockResolvedValue(null);
+
+    // Main try: newchan not enabled (no join), oldchan not enabled either => part(oldchan) is attempted and fails.
+    // Rollback: oldchan is enabled (rejoin) and newchan is not (repart), but the repart also fails.
+    vi.mocked(getTwitchEnabledChannels)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(['oldchan']);
+    vi.mocked(partTwitchChannel)
+      .mockRejectedValueOnce(new Error('Part failed'))
+      .mockRejectedValueOnce(new Error('Rollback part failed'));
+    vi.mocked(joinTwitchChannel).mockResolvedValue(undefined);
+
+    await expect(
+      addOrUpdateUserMutation({
+        discordId: '111',
+        discordName: 'TestUser',
+        level: AccessLevel.USER,
+        normalizedTwitchName: 'newchan',
+        shouldClearTwitchName: false,
+      }),
+    ).rejects.toThrow('Part failed');
+
+    expect(vi.mocked(joinTwitchChannel)).toHaveBeenCalledWith('oldchan');
+    expect(vi.mocked(partTwitchChannel)).toHaveBeenNthCalledWith(1, 'oldchan');
+    expect(vi.mocked(partTwitchChannel)).toHaveBeenNthCalledWith(2, 'newchan');
   });
 });
 


### PR DESCRIPTION
## Summary
- Coverage of `src/web/routes/adminUserMutations.ts` was 75.5% statements / 56.8% branches / 75% functions / 76.3% lines. It's now 100% / 95.1% / 100% / 100%.
- Added tests for the previously-untested `isLockWaitTimeoutDbError` and `isDuplicateTwitchNameDbError` helpers.
- Added tests for early-return/validation branches in `removeUserMutation` and `toggleTwitchMutation` (missing/disabled user, invalid normalized Twitch channel, channel already enabled elsewhere, no-op toggle).
- Added success-path tests (no rollback triggered) for `handleClearTwitchChannel` and `handleChangeTwitchChannel`, including a brand-new-user-with-Twitch-channel case and an update-without-touching-Twitch-name case.
- Added rollback-also-fails tests for `handleChangeTwitchChannel` and `removeUserMutation` so the logged-and-rethrown-original-error paths are exercised.
- The 4 remaining uncovered branches are defensive `?? fallback` guards that are unreachable through the public API given the function's existing invariants (e.g. `existingUser` is always truthy wherever `existingUser?.is_twitch_bot_enabled ?? false` is evaluated).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (2522 tests passed)
- [x] `npx vitest run src/web/routes/adminUserMutations.test.ts --coverage` confirms 100% stmts/funcs/lines, 95.06% branches


---
_Generated by [Claude Code](https://claude.ai/code/session_01NhQ6DbCFxaZsJ5fqJjXM4i)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for Twitch channel validation, normalization, and no-op scenarios.
  * Added verification for user removal, bot toggling, channel updates, and rollback behavior.
  * Confirmed original errors remain visible when recovery actions fail.
  * Added coverage for database error classification and channel-sharing edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->