### PR TITLE
Document undocumented config.ts env vars in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,15 @@ TWITCH_USERNAME=your_bot_username
 TWITCH_CLIENT_ID=your_twitch_app_client_id
 TWITCH_CLIENT_SECRET=your_twitch_app_client_secret
 
+# Optional: Twitch EventSub follow/sub notifications and channel-points/reward tracking.
+# This is an opt-in per-streamer feature — leave both unset if no streamer will use it.
+# Redirect URI for the Twitch OAuth "connect" flow; must be registered in the Twitch
+# developer console for the same app as TWITCH_CLIENT_ID above.
+# TWITCH_EVENTSUB_REDIRECT_URI=http://localhost:3000/eventsub/callback
+# AES-256-GCM key for encrypting broadcaster OAuth tokens at rest — exactly 64 hex
+# characters (32 bytes). Generate with: openssl rand -hex 32
+# EVENTSUB_TOKEN_SECRET=your_64_char_hex_key_here
+
 # TikTok
 # Comma-separated list of TikTok streamer usernames to monitor (@ prefix optional)
 TIKTOK_CHANNELS=username1,username2
@@ -38,6 +47,16 @@ GLOBAL_COOLDOWN_MS=3000
 SFX_FOLDER=./sfx
 # Maximum size (in MB) for an SFX upload via the web panel
 SFX_MAX_FILE_MB=10
+# Optional: path to the folder containing overlay video files
+# OVERLAY_FOLDER=./overlay-videos
+# Optional: maximum size (in MB) for an overlay video upload via the web panel
+# OVERLAY_MAX_FILE_MB=100
+# Optional: maximum concurrent SSE connections per companion app token
+# COMPANION_MAX_SSE_PER_TOKEN=3
+# Optional: maximum concurrent SSE connections per overlay channel
+# OVERLAY_MAX_SSE_PER_CHANNEL=10
+# Optional: maximum concurrent SSE connections per channel-points streamer
+# CHANNEL_POINTS_MAX_SSE_PER_STREAMER=5
 
 # Web panel
 # Random secret string for signing session cookies — MUST be changed to a long random value


### PR DESCRIPTION
## Summary

Part of a codebase-improvement audit. `src/shared/config.ts` reads 7 env vars that `.env.example` never documented:

- `TWITCH_EVENTSUB_REDIRECT_URI`, `EVENTSUB_TOKEN_SECRET`
- `OVERLAY_FOLDER`, `OVERLAY_MAX_FILE_MB`
- `COMPANION_MAX_SSE_PER_TOKEN`, `OVERLAY_MAX_SSE_PER_CHANNEL`, `CHANNEL_POINTS_MAX_SSE_PER_STREAMER`

This is a **docs-only change** — `.env.example` additions, no source files touched, no behavior change.

**Note on `EVENTSUB_TOKEN_SECRET`:** I initially considered switching it from a soft `?? ''` default to a hard `require_env()` requirement (so a misconfiguration fails fast at startup instead of silently). Traced through `src/db/eventSub.ts` and `src/web/routes/userSettings.ts` and concluded that would be wrong — EventSub follow/sub notifications and channel-points tracking are an **opt-in per-streamer feature**, not core to the bot. A deployment running just the Discord bot, Twitch chat, and stream monitor never needs to set this. The existing soft-fail behavior is already deliberate and layered (silent no-op on read, explicit throw on write, graceful HTTP-level redirect at the OAuth entrypoint), so the two EventSub vars are documented as optional/feature-gated rather than required.

## Test plan

- [x] `npx tsc --noEmit` passes (no source changes)
- [x] `npm test` passes (2499/2499, no source changes)
- [x] `npm run lint` passes (no source changes)
- [x] Manually reviewed the diff for formatting consistency with the rest of `.env.example`


---
_Generated by [Claude Code](https://claude.ai/code/session_01NNtcNfUiM87qV6742itmUU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added optional configuration placeholders for Twitch EventSub and streamer tracking.
  * Added guidance for overlay settings and server-sent event concurrency limits.
  * Existing required configuration remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->