### PR TITLE
Update ToS/privacy pages to cover the companion app

### DIFF
--- a/views/privacy.ejs
+++ b/views/privacy.ejs
@@ -38,6 +38,8 @@
             OAuth access/refresh tokens needed to receive that data. Those tokens are encrypted at rest and
             are never stored in plain text.</p>
           <p>If you generate a Streamdeck API key, we store only a one-way hash of it — never the key itself.</p>
+          <p>If you request a companion app token (for the desktop companion app's login), we store only a
+            one-way hash of it — never the token itself.</p>
           <p>We do not record or transcribe voice channel audio, and we do not store the content of Discord
             messages or chat logs. A short list of the most recent bot command executions is kept in memory
             for moderators to review, but it is not written to a database and is lost on restart.</p>
@@ -58,8 +60,9 @@
         <div class="card-body">
           <p>Login sessions expire after 24 hours of being issued. Server logs are kept for 14 days and then
             deleted. If your account is removed from the system, your stored Discord/Twitch data — including
-            any encrypted Twitch tokens — is deleted along with it. Any Streamdeck API key you generated is
-            not automatically deleted; contact a server administrator to have it revoked.</p>
+            any encrypted Twitch tokens and your companion app token — is deleted along with it. Any Streamdeck
+            API key you generated is not automatically deleted; contact a server administrator to have it
+            revoked. You can revoke your own companion app token at any time from the dashboard.</p>
           <p>To request deletion of your data, contact a server administrator.</p>
         </div>
       </div>

--- a/views/tos.ejs
+++ b/views/tos.ejs
@@ -26,7 +26,7 @@
         <div class="card-body">
           <p>BCUK Bot is a community Discord bot with a companion web dashboard. Depending on what's enabled
             on your server, it can run chat commands, play sound effects (SFX), post stream notifications,
-            drive a stream overlay, and integrate with a Stream Deck.</p>
+            drive a stream overlay, and integrate with a Stream Deck or the desktop companion app.</p>
           <p>The service is provided for the benefit of the Discord communities that use it, on a best-effort
             basis, free of charge.</p>
         </div>


### PR DESCRIPTION
## Summary

Audited `views/privacy.ejs` and `views/tos.ejs` against the current codebase (session/cookie config, DB schema, auth flows) to check they still accurately describe what data is collected and how it's handled.

Found one real gap: the companion app (loopback OAuth login, self-service bearer token in `companion_app_tokens`) shipped without any mention on either page, even though it behaves like the existing Streamdeck API key (only a hash is stored, never the plaintext token).

- `views/privacy.ejs`: note that a companion app token is stored only as a one-way hash; clarify it's auto-deleted on account removal (`ON DELETE CASCADE` to `user`, unlike the Streamdeck key) and user-revocable from the dashboard at any time.
- `views/tos.ejs`: mention the desktop companion app alongside Stream Deck in the "What the service is" section.

Everything else checked out as accurate against current behavior: single `connect.sid` cookie (session config in `src/web/server.ts`), no CSRF cookie (token lives in session), Discord ID/name/avatar handling in `src/web/routes/auth.ts`, encrypted-at-rest Twitch EventSub tokens (`src/db/eventSub.ts`), Streamdeck key hashing and non-cascading deletion (`streamdeck_api_keys` has no FK to `user`), and the new dynamic Channel Point pricing tables (`reward_pricing*`) which only store aggregate demand/cost, not per-viewer redemption identity — so no changes needed there.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (138 files / 2499 tests passed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BxxG4vJpiLb4R13SytvjCa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Privacy Policy to explain how companion app tokens are securely stored and deleted.
  * Updated the Terms of Service to include integrations with the desktop companion app alongside Stream Deck.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->