### PR TITLE
Add test coverage for twitchChannelMembership.ts

### DIFF
--- a/src/twitch/twitchChannelMembership.test.ts
+++ b/src/twitch/twitchChannelMembership.test.ts
@@ -1,0 +1,384 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mockLogger } from '../test-utils/loggerMock';
+import { deferred } from '../test-utils/deferredPromise';
+import { flushMicrotasks } from '../test-utils/flushMicrotasks';
+
+vi.mock('../shared/logger', () => ({ createLogger: mockLogger }));
+vi.mock('../db', () => ({ getTwitchEnabledChannels: vi.fn() }));
+vi.mock('./twitchApi', () => ({ getUsers: vi.fn() }));
+vi.mock('../shared/statusStore', () => ({ setTwitchChannel: vi.fn() }));
+
+import {
+  setTmiClient,
+  setConnected,
+  setChannelJoinedHook,
+  reconcileJoinedChannels,
+  initializeActiveChannels,
+  joinTwitchChannel,
+  partTwitchChannel,
+  getActiveChannels,
+  getActiveChannelUserIds,
+  clearMembershipState,
+} from './twitchChannelMembership';
+import { getTwitchEnabledChannels } from '../db';
+import { getUsers } from './twitchApi';
+import { setTwitchChannel } from '../shared/statusStore';
+
+/** Builds a minimal fake tmi.js client, pre-seeded with the given already-joined channels. */
+function makeMockClient(channels: string[] = []) {
+  return {
+    getChannels: vi.fn(() => channels),
+    join: vi.fn().mockResolvedValue(undefined),
+    part: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  clearMembershipState();
+  setTmiClient(null);
+  setConnected(false);
+  setChannelJoinedHook(() => {});
+  vi.mocked(getUsers).mockResolvedValue([]);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ─── joinTwitchChannel ─────────────────────────────────────────────────────
+
+describe('joinTwitchChannel', () => {
+  it('throws on an invalid channel name and does not touch state', async () => {
+    await expect(joinTwitchChannel('!!invalid!!')).rejects.toThrow(/Invalid channel name/);
+    expect(getActiveChannels().size).toBe(0);
+  });
+
+  it('queues the channel locally without calling client.join when not connected', async () => {
+    setConnected(false);
+    await joinTwitchChannel('alice');
+    expect(getActiveChannels().has('alice')).toBe(true);
+    expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('alice', false);
+  });
+
+  it('joins via the client and marks the channel active when connected', async () => {
+    const client = makeMockClient();
+    setTmiClient(client as any);
+    setConnected(true);
+    const hook = vi.fn();
+    setChannelJoinedHook(hook);
+
+    await joinTwitchChannel('alice');
+
+    expect(client.join).toHaveBeenCalledWith('alice');
+    expect(getActiveChannels().has('alice')).toBe(true);
+    expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('alice', true);
+    expect(hook).toHaveBeenCalledWith('alice');
+  });
+
+  it('syncs local state without re-joining when the client already has the channel joined', async () => {
+    const client = makeMockClient(['alice']);
+    setTmiClient(client as any);
+    setConnected(true);
+    const hook = vi.fn();
+    setChannelJoinedHook(hook);
+
+    await joinTwitchChannel('alice');
+
+    expect(client.join).not.toHaveBeenCalled();
+    expect(getActiveChannels().has('alice')).toBe(true);
+    expect(hook).toHaveBeenCalledWith('alice');
+  });
+
+  it('rolls back local state and rethrows when client.join fails', async () => {
+    const client = makeMockClient();
+    client.join.mockRejectedValue(new Error('join failed'));
+    setTmiClient(client as any);
+    setConnected(true);
+
+    await expect(joinTwitchChannel('alice')).rejects.toThrow('join failed');
+
+    expect(getActiveChannels().has('alice')).toBe(false);
+    expect(vi.mocked(setTwitchChannel)).toHaveBeenLastCalledWith('alice', false);
+  });
+
+  it('caches the channel user ID via getUsers after joining', async () => {
+    const client = makeMockClient();
+    setTmiClient(client as any);
+    setConnected(true);
+    vi.mocked(getUsers).mockResolvedValue([{ login: 'alice', id: 'uid-alice' }]);
+
+    await joinTwitchChannel('alice');
+    await flushMicrotasks();
+
+    expect(getActiveChannelUserIds().get('alice')).toBe('uid-alice');
+  });
+
+  it('logs and does not throw when the joined-channel hook itself throws', async () => {
+    const client = makeMockClient();
+    setTmiClient(client as any);
+    setConnected(true);
+    setChannelJoinedHook(() => { throw new Error('hook boom'); });
+
+    await expect(joinTwitchChannel('alice')).resolves.toBeUndefined();
+
+    expect(getActiveChannels().has('alice')).toBe(true);
+  });
+});
+
+// ─── partTwitchChannel ─────────────────────────────────────────────────────
+
+describe('partTwitchChannel', () => {
+  it('is a no-op for an invalid channel name', async () => {
+    await expect(partTwitchChannel('!!invalid!!')).resolves.toBeUndefined();
+  });
+
+  it('is a no-op when the channel is neither active nor joined', async () => {
+    setTmiClient(makeMockClient() as any);
+    setConnected(true);
+
+    await partTwitchChannel('alice');
+
+    expect(vi.mocked(setTwitchChannel)).not.toHaveBeenCalled();
+  });
+
+  it('removes local state without calling client.part when not connected', async () => {
+    setConnected(false);
+    await joinTwitchChannel('alice');
+
+    await partTwitchChannel('alice');
+
+    expect(getActiveChannels().has('alice')).toBe(false);
+  });
+
+  it('parts via the client when connected and joined', async () => {
+    const client = makeMockClient(['alice']);
+    setTmiClient(client as any);
+    setConnected(true);
+    await joinTwitchChannel('alice');
+
+    await partTwitchChannel('alice');
+
+    expect(client.part).toHaveBeenCalledWith('alice');
+    expect(getActiveChannels().has('alice')).toBe(false);
+  });
+
+  it('keeps state removed and rethrows when client.part fails', async () => {
+    const client = makeMockClient(['alice']);
+    client.part.mockRejectedValue(new Error('part failed'));
+    setTmiClient(client as any);
+    setConnected(true);
+    await joinTwitchChannel('alice');
+
+    await expect(partTwitchChannel('alice')).rejects.toThrow('part failed');
+
+    expect(getActiveChannels().has('alice')).toBe(false);
+  });
+});
+
+// ─── membershipMutationQueue serialization ─────────────────────────────────
+
+describe('membershipMutationQueue serialization', () => {
+  it('serializes join then part on the same channel', async () => {
+    const client = makeMockClient();
+    setTmiClient(client as any);
+    setConnected(true);
+    const order: string[] = [];
+    const { promise: gate, resolve: openGate } = deferred();
+    client.join.mockImplementation(async (channel: string) => {
+      order.push('join-start');
+      await gate;
+      client.getChannels.mockReturnValue([channel]); // simulate the join taking effect
+      order.push('join-end');
+    });
+    client.part.mockImplementation(async () => { order.push('part'); });
+
+    const joinPromise = joinTwitchChannel('alice');
+    const partPromise = partTwitchChannel('alice');
+
+    openGate();
+    await Promise.all([joinPromise, partPromise]);
+
+    expect(order).toEqual(['join-start', 'join-end', 'part']);
+  });
+
+  it('runs operations on different channels independently', async () => {
+    const client = makeMockClient();
+    setTmiClient(client as any);
+    setConnected(true);
+    const order: string[] = [];
+    const { promise: gate, resolve: openGate } = deferred();
+    client.join.mockImplementation(async (channel: string) => {
+      if (channel === 'alice') await gate;
+      order.push(channel);
+    });
+
+    const alicePromise = joinTwitchChannel('alice'); // blocks on gate
+    await joinTwitchChannel('carol'); // must resolve without waiting for alice's gate
+    expect(order).toEqual(['carol']);
+
+    openGate();
+    await alicePromise;
+    expect(order).toEqual(['carol', 'alice']);
+  });
+});
+
+// ─── reconcileJoinedChannels ────────────────────────────────────────────────
+
+describe('reconcileJoinedChannels', () => {
+  it('no-ops when there is no client or the client is not connected', async () => {
+    setTmiClient(null);
+    setConnected(false);
+
+    await expect(reconcileJoinedChannels()).resolves.toBeUndefined();
+
+    expect(vi.mocked(setTwitchChannel)).not.toHaveBeenCalled();
+  });
+
+  it('parts a channel the client has joined but is no longer in activeChannels (stale)', async () => {
+    const client = makeMockClient(['#stale']);
+    setTmiClient(client as any);
+    setConnected(true);
+
+    const p = reconcileJoinedChannels();
+    await vi.runAllTimersAsync();
+    await p;
+
+    expect(client.part).toHaveBeenCalledWith('stale');
+    expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('stale', false);
+  });
+
+  it('continues reconciling other stale channels when parting one fails', async () => {
+    const client = makeMockClient(['#stale', '#other']);
+    setTmiClient(client as any);
+    setConnected(true);
+    client.part.mockImplementation(async (channel: string) => {
+      if (channel === 'stale') throw new Error('part failed');
+    });
+
+    const p = reconcileJoinedChannels();
+    await vi.runAllTimersAsync();
+    await p;
+
+    expect(client.part).toHaveBeenCalledWith('stale');
+    expect(client.part).toHaveBeenCalledWith('other');
+    expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('other', false);
+  });
+
+  it('refreshes status to online for a joined channel that is still in activeChannels', async () => {
+    const client = makeMockClient(['alice']);
+    setTmiClient(client as any);
+    setConnected(true);
+    await joinTwitchChannel('alice'); // already-joined branch — adds to activeChannels
+    vi.mocked(setTwitchChannel).mockClear();
+
+    const p = reconcileJoinedChannels();
+    await vi.runAllTimersAsync();
+    await p;
+
+    expect(client.part).not.toHaveBeenCalled();
+    expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('alice', true);
+  });
+
+  it('joins a queued-but-unjoined active channel, throttled by JOIN_THROTTLE_MS', async () => {
+    const client = makeMockClient([]);
+    setTmiClient(client as any);
+    setConnected(false);
+    await joinTwitchChannel('alice'); // queues into activeChannels without calling client.join
+    setConnected(true); // simulate reconnect
+
+    const p = reconcileJoinedChannels();
+    await vi.runAllTimersAsync();
+    await p;
+
+    expect(client.join).toHaveBeenCalledWith('alice');
+    expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('alice', true);
+  });
+
+  it('continues reconciling other channels when one fails to join', async () => {
+    const client = makeMockClient([]);
+    setTmiClient(client as any);
+    setConnected(false);
+    await joinTwitchChannel('alice');
+    await joinTwitchChannel('carol');
+    setConnected(true);
+    client.join.mockImplementation(async (channel: string) => {
+      if (channel === 'alice') throw new Error('join failed');
+    });
+
+    const p = reconcileJoinedChannels();
+    await vi.runAllTimersAsync();
+    await p;
+
+    expect(client.join).toHaveBeenCalledWith('carol');
+    expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('carol', true);
+    expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('alice', false);
+  });
+});
+
+// ─── initializeActiveChannels ───────────────────────────────────────────────
+
+describe('initializeActiveChannels', () => {
+  it('loads enabled channels from the DB, normalizes them, and marks them offline initially', async () => {
+    vi.mocked(getTwitchEnabledChannels).mockResolvedValue(['#Alice', 'CAROL']);
+
+    await initializeActiveChannels();
+
+    expect(getActiveChannels()).toEqual(new Set(['alice', 'carol']));
+    expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('alice', false);
+    expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('carol', false);
+  });
+
+  it('skips an invalid channel name from the DB without throwing', async () => {
+    vi.mocked(getTwitchEnabledChannels).mockResolvedValue(['good', '!!bad!!']);
+
+    await expect(initializeActiveChannels()).resolves.toBeUndefined();
+
+    expect(getActiveChannels()).toEqual(new Set(['good']));
+  });
+
+  it('warns and leaves activeChannels empty when there are no enabled channels', async () => {
+    vi.mocked(getTwitchEnabledChannels).mockResolvedValue([]);
+
+    await initializeActiveChannels();
+
+    expect(getActiveChannels().size).toBe(0);
+    expect(vi.mocked(getUsers)).not.toHaveBeenCalled();
+  });
+
+  it('populates the user ID cache from getUsers', async () => {
+    vi.mocked(getTwitchEnabledChannels).mockResolvedValue(['alice']);
+    vi.mocked(getUsers).mockResolvedValue([{ login: 'alice', id: 'uid-1' }]);
+
+    await initializeActiveChannels();
+
+    expect(getActiveChannelUserIds().get('alice')).toBe('uid-1');
+  });
+
+  it('logs and continues when getUsers fails', async () => {
+    vi.mocked(getTwitchEnabledChannels).mockResolvedValue(['alice']);
+    vi.mocked(getUsers).mockRejectedValue(new Error('API down'));
+
+    await expect(initializeActiveChannels()).resolves.toBeUndefined();
+
+    expect(getActiveChannelUserIds().size).toBe(0);
+  });
+});
+
+// ─── clearMembershipState ───────────────────────────────────────────────────
+
+describe('clearMembershipState', () => {
+  it('empties both active channels and cached user IDs', async () => {
+    vi.mocked(getTwitchEnabledChannels).mockResolvedValue(['alice']);
+    vi.mocked(getUsers).mockResolvedValue([{ login: 'alice', id: 'uid-1' }]);
+    await initializeActiveChannels();
+    expect(getActiveChannels().size).toBe(1);
+    expect(getActiveChannelUserIds().size).toBe(1);
+
+    clearMembershipState();
+
+    expect(getActiveChannels().size).toBe(0);
+    expect(getActiveChannelUserIds().size).toBe(0);
+  });
+});

--- a/src/twitch/twitchChannelMembership.test.ts
+++ b/src/twitch/twitchChannelMembership.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mockLogger } from '../test-utils/loggerMock';
 import { deferred } from '../test-utils/deferredPromise';
 import { flushMicrotasks } from '../test-utils/flushMicrotasks';
 
-vi.mock('../shared/logger', () => ({ createLogger: mockLogger }));
+// A single hoisted instance (rather than the shared mockLogger() factory, which mints a
+// fresh object per call) so tests can assert on it — the module captures `log` once at
+// import time, so every createLogger() call here must return the same object.
+const mockLog = vi.hoisted(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }));
+vi.mock('../shared/logger', () => ({ createLogger: () => mockLog }));
 vi.mock('../db', () => ({ getTwitchEnabledChannels: vi.fn() }));
 vi.mock('./twitchApi', () => ({ getUsers: vi.fn() }));
 vi.mock('../shared/statusStore', () => ({ setTwitchChannel: vi.fn() }));
@@ -56,10 +59,15 @@ describe('joinTwitchChannel', () => {
   });
 
   it('queues the channel locally without calling client.join when not connected', async () => {
+    const client = makeMockClient();
+    setTmiClient(client as any); // client present but disconnected — isolates the !_connected guard
     setConnected(false);
+
     await joinTwitchChannel('alice');
+
     expect(getActiveChannels().has('alice')).toBe(true);
     expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('alice', false);
+    expect(client.join).not.toHaveBeenCalled();
   });
 
   it('joins via the client and marks the channel active when connected', async () => {
@@ -124,6 +132,7 @@ describe('joinTwitchChannel', () => {
     await expect(joinTwitchChannel('alice')).resolves.toBeUndefined();
 
     expect(getActiveChannels().has('alice')).toBe(true);
+    expect(mockLog.error).toHaveBeenCalledWith('Channel joined hook error:', expect.any(Error));
   });
 });
 
@@ -144,12 +153,15 @@ describe('partTwitchChannel', () => {
   });
 
   it('removes local state without calling client.part when not connected', async () => {
+    const client = makeMockClient();
+    setTmiClient(client as any); // client present but disconnected — isolates the !_connected guard
     setConnected(false);
     await joinTwitchChannel('alice');
 
     await partTwitchChannel('alice');
 
     expect(getActiveChannels().has('alice')).toBe(false);
+    expect(client.part).not.toHaveBeenCalled();
   });
 
   it('parts via the client when connected and joined', async () => {
@@ -227,12 +239,23 @@ describe('membershipMutationQueue serialization', () => {
 // ─── reconcileJoinedChannels ────────────────────────────────────────────────
 
 describe('reconcileJoinedChannels', () => {
-  it('no-ops when there is no client or the client is not connected', async () => {
+  it('no-ops when there is no client, even if connected is true', async () => {
     setTmiClient(null);
+    setConnected(true);
+
+    await expect(reconcileJoinedChannels()).resolves.toBeUndefined();
+
+    expect(vi.mocked(setTwitchChannel)).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when the client is not connected, even with a client present', async () => {
+    const client = makeMockClient(['#stale']);
+    setTmiClient(client as any);
     setConnected(false);
 
     await expect(reconcileJoinedChannels()).resolves.toBeUndefined();
 
+    expect(client.getChannels).not.toHaveBeenCalled();
     expect(vi.mocked(setTwitchChannel)).not.toHaveBeenCalled();
   });
 
@@ -345,6 +368,7 @@ describe('initializeActiveChannels', () => {
 
     expect(getActiveChannels().size).toBe(0);
     expect(vi.mocked(getUsers)).not.toHaveBeenCalled();
+    expect(mockLog.warn).toHaveBeenCalledWith('No enabled Twitch channels found in DB; connecting with no joined channels.');
   });
 
   it('populates the user ID cache from getUsers', async () => {
@@ -363,6 +387,10 @@ describe('initializeActiveChannels', () => {
     await expect(initializeActiveChannels()).resolves.toBeUndefined();
 
     expect(getActiveChannelUserIds().size).toBe(0);
+    expect(mockLog.error).toHaveBeenCalledWith(
+      'Failed to resolve channel user IDs (shared-chat dedup unavailable):',
+      expect.any(Error),
+    );
   });
 });
 

--- a/src/twitch/twitchChannelMembership.test.ts
+++ b/src/twitch/twitchChannelMembership.test.ts
@@ -144,12 +144,14 @@ describe('partTwitchChannel', () => {
   });
 
   it('is a no-op when the channel is neither active nor joined', async () => {
-    setTmiClient(makeMockClient() as any);
+    const client = makeMockClient();
+    setTmiClient(client as any);
     setConnected(true);
 
     await partTwitchChannel('alice');
 
     expect(vi.mocked(setTwitchChannel)).not.toHaveBeenCalled();
+    expect(client.part).not.toHaveBeenCalled();
   });
 
   it('removes local state without calling client.part when not connected', async () => {
@@ -290,7 +292,7 @@ describe('reconcileJoinedChannels', () => {
   });
 
   it('refreshes status to online for a joined channel that is still in activeChannels', async () => {
-    const client = makeMockClient(['alice']);
+    const client = makeMockClient(['#alice']); // real tmi.js channel names are #-prefixed
     setTmiClient(client as any);
     setConnected(true);
     await joinTwitchChannel('alice'); // already-joined branch — adds to activeChannels


### PR DESCRIPTION
## Summary

Part of a codebase-improvement audit. `src/twitch/twitchChannelMembership.ts` (232 lines) owns `membershipMutationQueue` (per-channel serialization via `createMutationQueue()`) and the `JOIN_THROTTLE_MS` throttle that keeps the bot under Twitch's IRC 20-joins/10s limit. It was only exercised indirectly, through `twitchBot.test.ts`'s integration-style tests (which import the real implementation but never isolate this module or its queue's concurrency behavior specifically).

Adds `src/twitch/twitchChannelMembership.test.ts` (26 tests) covering:
- `joinTwitchChannel`/`partTwitchChannel`: invalid channel names, connected/disconnected paths, already-joined sync, rollback-and-rethrow on client failure, the joined-hook firing (and its own error being caught rather than propagating), and the fire-and-forget user-ID cache populating via `getUsers`.
- `membershipMutationQueue` serialization specifically: same-channel join/part ordering (not exercised elsewhere), and cross-channel independence.
- `reconcileJoinedChannels`: parting stale channels, refreshing status for already-joined active channels, throttled joining of queued channels, and failure isolation in both the stale-part loop and the join loop (one channel's error doesn't block another's).
- `initializeActiveChannels`: DB-channel normalization, invalid-name skipping, empty-list handling, user-ID cache population, and `getUsers` failure handling.
- `clearMembershipState`.

Coverage on the target file: 93.18% statements / 90.56% branches / 96% functions — in line with this codebase's typical bar. The remaining uncovered branches are narrow defensive re-checks (e.g. a channel's local state changing between an iteration snapshot and the point its queued operation actually runs) that aren't reachable through the public API without artificial contrivance, given the module's single-threaded, per-key-serialized design.

Test file only — no production code changes.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (2525/2525)
- [x] `npm run lint` passes (0 errors, 1 pre-existing unrelated warning)
- [x] New test file passes in isolation and as part of the full suite (checked for cross-test state leakage on the module's singleton `activeChannels`/`membershipMutationQueue`, since a shared mutation queue key left pending by a failing test would otherwise hang later tests using the same channel name)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NNtcNfUiM87qV6742itmUU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive test suite for Twitch channel membership management.
  * Validates joining/leaving behavior across connected and disconnected states, including invalid-channel handling.
  * Covers reconciliation after reconnect, queued join throttling, and stale channel cleanup.
  * Verifies user ID caching, initialization from enabled channels, and membership state cleanup.
  * Ensures errors from the Twitch client or status updates don’t leave membership state inconsistent, and confirms join-then-part ordering on the same channel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->