### PR TITLE
Add companion API endpoint to list known channel-point rewards

### DIFF
--- a/src/web/routes/companionRewards.test.ts
+++ b/src/web/routes/companionRewards.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mockLogger } from '../../test-utils/loggerMock';
+import type { DbStreamerEventSub } from '../../db';
+import type { TwitchCustomReward } from '../../twitch/twitchApi';
+
+const DISCORD_ID = 'user-1';
+
+vi.mock('../middleware', () => ({
+  requireCompanionKey: (req: any, _res: any, next: any) => {
+    req.companionDiscordId = DISCORD_ID;
+    next();
+  },
+}));
+
+vi.mock('../../db', () => ({
+  getStreamerByDiscordId: vi.fn(),
+}));
+
+vi.mock('../../twitch/twitchApi', () => ({
+  getCustomRewards: vi.fn(),
+}));
+
+vi.mock('../../twitch/eventsub/twitchApiEventSub', () => ({
+  getValidToken: vi.fn(),
+}));
+
+vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
+
+import supertest from 'supertest';
+import router from './companionRewards';
+import { getStreamerByDiscordId } from '../../db';
+import { getCustomRewards } from '../../twitch/twitchApi';
+import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
+import { buildTestApp } from '../../test-utils/expressTestApp';
+
+/** Builds a supertest-ready app: the companion-rewards router with no session stub (key-authenticated). */
+function buildApp() {
+  return buildTestApp({ router });
+}
+
+const STREAMER = { id: 1, twitch_user_id: 'twitch-1' } as DbStreamerEventSub;
+
+const REWARD: TwitchCustomReward = {
+  id: 'r1',
+  title: 'Hydrate',
+  cost: 500,
+  is_enabled: true,
+  prompt: 'Drink water on stream',
+  is_user_input_required: false,
+  background_color: '#ff0000',
+  is_paused: false,
+  is_in_stock: true,
+  should_redemptions_skip_request_queue: false,
+  max_per_stream_setting: { is_enabled: false, max_per_stream: 0 },
+  max_per_user_per_stream_setting: { is_enabled: false, max_per_user_per_stream: 0 },
+  global_cooldown_setting: { is_enabled: false, global_cooldown_seconds: 0 },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getStreamerByDiscordId).mockResolvedValue(STREAMER);
+  vi.mocked(getValidToken).mockResolvedValue('valid-token');
+  vi.mocked(getCustomRewards).mockResolvedValue([REWARD]);
+});
+
+describe('GET /rewards', () => {
+  it('returns the mapped list of known rewards', async () => {
+    const res = await supertest(buildApp()).get('/rewards').expect(200);
+
+    expect(res.body).toEqual({
+      ok: true,
+      rewards: [{
+        id: 'r1',
+        title: 'Hydrate',
+        prompt: 'Drink water on stream',
+        cost: 500,
+        backgroundColor: '#ff0000',
+        isEnabled: true,
+        isUserInputRequired: false,
+      }],
+    });
+    expect(getCustomRewards).toHaveBeenCalledWith('twitch-1', 'valid-token');
+  });
+
+  it('returns an empty list when the discord ID has no streamer', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
+
+    const res = await supertest(buildApp()).get('/rewards').expect(200);
+
+    expect(res.body).toEqual({ ok: true, rewards: [] });
+    expect(getCustomRewards).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty list when the streamer has no twitch_user_id', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue({ ...STREAMER, twitch_user_id: null });
+
+    const res = await supertest(buildApp()).get('/rewards').expect(200);
+
+    expect(res.body).toEqual({ ok: true, rewards: [] });
+    expect(getCustomRewards).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty list when there is no valid Twitch token', async () => {
+    vi.mocked(getValidToken).mockResolvedValue(null);
+
+    const res = await supertest(buildApp()).get('/rewards').expect(200);
+
+    expect(res.body).toEqual({ ok: true, rewards: [] });
+    expect(getCustomRewards).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when the streamer lookup throws', async () => {
+    vi.mocked(getStreamerByDiscordId).mockRejectedValue(new Error('DB gone'));
+
+    const res = await supertest(buildApp()).get('/rewards').expect(500);
+
+    expect(res.body).toMatchObject({ ok: false });
+  });
+
+  it('returns 500 when the Twitch fetch throws', async () => {
+    vi.mocked(getCustomRewards).mockRejectedValue(new Error('Twitch down'));
+
+    const res = await supertest(buildApp()).get('/rewards').expect(500);
+
+    expect(res.body).toMatchObject({ ok: false });
+  });
+});

--- a/src/web/routes/companionRewards.ts
+++ b/src/web/routes/companionRewards.ts
@@ -1,0 +1,62 @@
+import { createLogger } from '../../shared/logger';
+import { Router } from 'express';
+import { requireCompanionKey } from '../middleware';
+import { getStreamerByDiscordId } from '../../db';
+import { getCustomRewards, TwitchCustomReward } from '../../twitch/twitchApi';
+import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
+
+const log = createLogger('CompanionRewards');
+const router = Router();
+
+/** A channel-point reward as surfaced to the companion app, so it knows what redemption events to expect. */
+export interface CompanionKnownReward {
+  id: string;
+  title: string;
+  prompt: string;
+  cost: number;
+  backgroundColor: string;
+  isEnabled: boolean;
+  isUserInputRequired: boolean;
+}
+
+/** Maps a Twitch custom reward to the shape exposed to the companion app. */
+function toCompanionReward(reward: TwitchCustomReward): CompanionKnownReward {
+  return {
+    id: reward.id,
+    title: reward.title,
+    prompt: reward.prompt,
+    cost: reward.cost,
+    backgroundColor: reward.background_color,
+    isEnabled: reward.is_enabled,
+    isUserInputRequired: reward.is_user_input_required,
+  };
+}
+
+/**
+ * GET /api/companion/rewards — bearer-token authenticated via `requireCompanionKey`. Lists the
+ * authenticated user's live Twitch custom channel-point rewards, so the companion app knows what
+ * `channel_points_redemption` events to expect from `/api/companion/events`. Responds with an
+ * empty list (not an error) when the user isn't a connected streamer or has no valid Twitch
+ * token, matching `fetchTwitchRewards` in the Channel Points admin page.
+ */
+router.get('/rewards', requireCompanionKey, async (req, res) => {
+  try {
+    const streamer = await getStreamerByDiscordId(req.companionDiscordId!);
+    if (!streamer?.twitch_user_id) {
+      res.json({ ok: true, rewards: [] });
+      return;
+    }
+    const token = await getValidToken(streamer);
+    if (!token) {
+      res.json({ ok: true, rewards: [] });
+      return;
+    }
+    const rewards = await getCustomRewards(streamer.twitch_user_id, token);
+    res.json({ ok: true, rewards: rewards.map(toCompanionReward) });
+  } catch (err) {
+    log.error('Failed to list rewards:', err);
+    res.status(500).json({ ok: false, error: 'Failed to fetch rewards' });
+  }
+});
+
+export default router;

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -105,6 +105,7 @@ vi.mock('./routes/overlayAdmin', () => ({ default: emptyRouter() }));
 vi.mock('./routes/channelPointsAdmin', () => ({ default: emptyRouter() }));
 vi.mock('./routes/companionAuth', () => ({ default: emptyRouter() }));
 vi.mock('./routes/companionEvents', () => ({ default: emptyRouter() }));
+vi.mock('./routes/companionRewards', () => ({ default: emptyRouter() }));
 vi.mock('./routes/companionKeys', () => ({ default: emptyRouter() }));
 
 import { app } from './server';

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -30,6 +30,7 @@ import streamdeckRouter from './routes/streamdeck';
 import streamdeckKeysRouter from './routes/streamdeckKeys';
 import companionAuthRouter from './routes/companionAuth';
 import companionEventsRouter from './routes/companionEvents';
+import companionRewardsRouter from './routes/companionRewards';
 import companionKeysRouter from './routes/companionKeys';
 import userSettingsRouter from './routes/userSettings';
 import overlaySourceRouter from './routes/overlaySource';
@@ -168,6 +169,7 @@ app.use('/overlay', overlaySourceRouter);
 // request on the site, not just the companion app's OAuth routes.
 app.use('/', companionAuthRouter);
 app.use('/api/companion', companionEventsRouter);
+app.use('/api/companion', companionRewardsRouter);
 app.use('/guild', requireAuth, guildRouter);
 app.use('/api', requireAuth, apiRouter);
 


### PR DESCRIPTION
## Summary

- Adds `GET /api/companion/rewards`, a bearer-token-authenticated (`requireCompanionKey`) endpoint that returns the authenticated user's live Twitch custom channel-point rewards.
- Lets the companion app fetch the reward catalog up front so it knows what `channel_points_redemption` events to expect from the existing `/api/companion/events` SSE stream.
- Mirrors the existing `fetchTwitchRewards` pattern in the Channel Points admin page: resolves the streamer via `getStreamerByDiscordId`, gets a valid token via `getValidToken`, then calls `getCustomRewards`. Returns an empty list (not an error) when the user isn't a connected streamer or has no valid Twitch token.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (140 files / 2558 tests)
- [x] Added `src/web/routes/companionRewards.test.ts` covering: successful mapping, no streamer, no `twitch_user_id`, no valid token, streamer-lookup error, and Twitch-fetch error
- [x] Updated `src/web/server.test.ts` to mock the new route module


---
_Generated by [Claude Code](https://claude.ai/code/session_01XGck8cvnpeyjShcrvkto7W)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated endpoint for retrieving connected streamers’ live Twitch channel-point rewards.
  * Returns available rewards in a companion-friendly format.
  * Gracefully returns an empty list when no streamer or valid connection is available.
  * Reports a clear error response when reward retrieval fails.

* **Tests**
  * Added coverage for successful responses, unavailable connections, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->