### PR TITLE
Add runtime safety guard to price history chart SVG rendering

### DIFF
--- a/src/web/priceHistoryChart.test.ts
+++ b/src/web/priceHistoryChart.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { renderPriceHistoryChart } from './priceHistoryChart';
+import { renderPriceHistoryChart, assertSafeChartHtml } from './priceHistoryChart';
 
 describe('renderPriceHistoryChart', () => {
   it('renders a placeholder when there are no points', () => {
@@ -130,5 +130,29 @@ describe('renderPriceHistoryChart', () => {
       expect(svg).not.toContain('<script>');
       expect(svg).toContain('&lt;/text&gt;&lt;script&gt;alert(1)&lt;/script&gt;');
     });
+  });
+});
+
+describe('assertSafeChartHtml', () => {
+  it('passes through valid svg chart markup unchanged', () => {
+    const html = '<svg class="price-history-chart"><polyline points="1,2 3,4"/></svg>';
+    expect(assertSafeChartHtml(html)).toBe(html);
+  });
+
+  it('passes through the empty-state placeholder unchanged', () => {
+    const html = '<div class="hint price-history-empty" style="height:120px;">No price history yet for this range.</div>';
+    expect(assertSafeChartHtml(html)).toBe(html);
+  });
+
+  it('throws when the markup does not start with the expected svg or placeholder shape', () => {
+    expect(() => assertSafeChartHtml('<script>alert(1)</script>')).toThrow('unexpected HTML structure');
+  });
+
+  it('throws when a script tag is smuggled in after a valid-looking opening tag', () => {
+    expect(() => assertSafeChartHtml('<svg ><script>alert(1)</script></svg>')).toThrow('unsafe content');
+  });
+
+  it('is case-insensitive when detecting smuggled script tags', () => {
+    expect(() => assertSafeChartHtml('<svg ><SCRIPT>alert(1)</SCRIPT></svg>')).toThrow('unsafe content');
   });
 });

--- a/src/web/priceHistoryChart.ts
+++ b/src/web/priceHistoryChart.ts
@@ -19,6 +19,25 @@ function escapeHtml(value: string | number): string {
 }
 
 /**
+ * Asserts that generated chart markup is either the `<svg>` chart or the empty-state
+ * placeholder `<div>`, and contains no `<script` tag, before it's returned to callers that
+ * render it raw (`<%- %>`) in the view. `renderPriceHistoryChart` is the sole place responsible
+ * for escaping attacker-reachable content into that markup; this is a defense-in-depth backstop
+ * so a future change to this function that breaks escaping fails loudly instead of shipping XSS.
+ */
+export function assertSafeChartHtml(html: string): string {
+  const isSvg = html.startsWith('<svg ');
+  const isEmptyPlaceholder = html.startsWith('<div class="hint price-history-empty"');
+  if (!isSvg && !isEmptyPlaceholder) {
+    throw new Error('renderPriceHistoryChart produced unexpected HTML structure');
+  }
+  if (html.toLowerCase().includes('<script')) {
+    throw new Error('renderPriceHistoryChart produced unsafe content');
+  }
+  return html;
+}
+
+/**
  * Renders an inline SVG line chart of a reward's price over `[rangeStartMs, rangeEndMs]`.
  * A single series needs no legend (the card title above it already names what's plotted).
  * Embeds the plotted points as a `data-points` JSON attribute so `priceHistoryChart.js`
@@ -39,6 +58,9 @@ function escapeHtml(value: string | number): string {
  *   time (via a `data-elapsed` attribute), so `priceHistoryChart.js`'s hover tooltip formats it as
  *   a duration instead of a clock time.
  * @returns Self-contained `<svg>` markup, or a "no data yet" placeholder if `points` is empty.
+ * @throws If the generated markup doesn't match the expected shape (see `assertSafeChartHtml`) —
+ *   indicates a bug in this function that would otherwise risk shipping unescaped content to the
+ *   view's raw (`<%- %>`) output.
  */
 export function renderPriceHistoryChart(
   points: PriceHistoryPoint[],
@@ -47,7 +69,7 @@ export function renderPriceHistoryChart(
   options?: { ariaLabel?: string; elapsedTimeAxis?: boolean },
 ): string {
   if (points.length === 0) {
-    return `<div class="hint price-history-empty" style="height:${HEIGHT}px;display:flex;align-items:center;justify-content:center;">No price history yet for this range.</div>`;
+    return assertSafeChartHtml(`<div class="hint price-history-empty" style="height:${HEIGHT}px;display:flex;align-items:center;justify-content:center;">No price history yet for this range.</div>`);
   }
 
   const sorted = [...points].sort((a, b) => a.t - b.t);
@@ -79,7 +101,7 @@ export function renderPriceHistoryChart(
       ?? `Price history from ${new Date(rangeStartMs).toLocaleString()} to ${new Date(rangeEndMs).toLocaleString()}, ranging from ${minCost} to ${maxCost} points`
   );
 
-  return `
+  return assertSafeChartHtml(`
 <svg class="price-history-chart" viewBox="0 0 ${WIDTH} ${HEIGHT}" width="100%" height="${HEIGHT}" preserveAspectRatio="none"
      data-points='${escapeHtml(dataPoints)}'
      data-plot-left="${plotLeft}" data-plot-right="${plotRight}"
@@ -97,5 +119,5 @@ export function renderPriceHistoryChart(
     <line class="price-history-crosshair-line" y1="${plotTop}" y2="${plotBottom}" stroke="var(--muted)" stroke-width="1"/>
     <circle class="price-history-crosshair-dot" r="4" fill="var(--primary)" stroke="var(--bg-card)" stroke-width="2"/>
   </g>
-</svg>`.trim();
+</svg>`.trim());
 }


### PR DESCRIPTION
## Summary

Aikido flagged `views/channelPointsAdmin.ejs` for using EJS's unescaped `<%- %>` tag to render `historyChartSafeHtml` and `simulationChartSafeHtml`, both produced by `renderPriceHistoryChart()`. Auditing the data paths (chart coordinates, `aria-label`, `data-points`, tick/end labels, and the `cost`/`recorded_at` values feeding them) confirmed all attacker-reachable content already goes through `escapeHtml()`, and numeric-only interpolations are always genuine JS numbers, so there's no exploitable XSS today.

However, safety currently rests entirely on that escaping discipline inside `renderPriceHistoryChart()`, with nothing enforcing it if the function is edited later — the `SafeHtml` naming convention is a manual contract, not a runtime one.

- Add `assertSafeChartHtml()` in `src/web/priceHistoryChart.ts`, which verifies returned markup matches the expected `<svg>`/placeholder shape and contains no `<script` tag before it's handed to the view's raw output tag.
- Wrap both return points of `renderPriceHistoryChart()` with this guard, so any future regression that breaks escaping throws instead of silently rendering unsafe markup.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 2557 tests passing)
- [x] Added unit tests for `assertSafeChartHtml()` covering: valid svg passthrough, valid placeholder passthrough, invalid shape throws, smuggled `<script>` tag throws (including case-insensitive)


---
_Generated by [Claude Code](https://claude.ai/code/session_013avhpmj4cZycAizYGC5Ex3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for price history chart markup to help prevent unsafe script content from being rendered.
  * Added safeguards for unexpected chart output and preserved the expected empty-state display.
  * Chart rendering now reports an error when generated markup fails safety checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->