### PR TITLE
Dedup Multer upload-middleware wrappers into a shared factory

### DIFF
--- a/src/web/routes/alertsAssetMutations.ts
+++ b/src/web/routes/alertsAssetMutations.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
-import type { Request, Response, NextFunction } from 'express';
+import type { Request, Response } from 'express';
 import multer from 'multer';
 import fs from 'fs';
 import { randomUUID } from 'crypto';
@@ -10,7 +10,7 @@ import { setAlertImage, setAlertSound } from '../../db';
 import type { AlertEventType, DbStreamerEventSub } from '../../db';
 import { ALERT_ASSETS_FOLDER, ALERT_MAX_IMAGE_MB, ALERT_MAX_SOUND_MB } from '../../shared/config';
 import { safeResolve } from '../../shared/pathUtils';
-import { logAndRedirectError, requireStreamer, createMulterErrorRedirectHandler } from './shared';
+import { logAndRedirectError, requireStreamer, createMulterErrorRedirectHandler, makeUploadMiddleware } from './shared';
 import { detectAudioType } from './sfxFileUpload';
 import { NOT_A_STREAMER_REDIRECT, parseEventType } from './alertsShared';
 
@@ -201,20 +201,10 @@ function makeDeleteHandler(
 const handleUploadError = createMulterErrorRedirectHandler('/alerts/settings', log, 'Alert upload middleware error:');
 
 /** Express middleware running Multer's single-file (`image`) parser, redirecting on error. */
-function uploadImage(req: Request, res: Response, next: NextFunction): void {
-  imageUpload.single('image')(req, res, (err: unknown) => {
-    if (handleUploadError(err, res)) return;
-    next();
-  });
-}
+const uploadImage = makeUploadMiddleware(imageUpload, 'image', handleUploadError);
 
 /** Express middleware running Multer's single-file (`sound`) parser, redirecting on error. */
-function uploadSound(req: Request, res: Response, next: NextFunction): void {
-  soundUpload.single('sound')(req, res, (err: unknown) => {
-    if (handleUploadError(err, res)) return;
-    next();
-  });
-}
+const uploadSound = makeUploadMiddleware(soundUpload, 'sound', handleUploadError);
 
 /**
  * POST /alerts/settings/:eventType/image — uploads an image/GIF (magic-byte validated) for one

--- a/src/web/routes/overlayAdminMutations.ts
+++ b/src/web/routes/overlayAdminMutations.ts
@@ -1,6 +1,5 @@
 import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
-import type { Request, Response, NextFunction } from 'express';
 import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
@@ -11,7 +10,7 @@ import type { DbStreamerEventSub } from '../../db';
 import { addVideo, deleteVideo } from '../../db';
 import { OVERLAY_FOLDER, OVERLAY_MAX_FILE_MB } from '../../shared/config';
 import {
-  logAndRedirectError, parsePositiveIntId, requireStreamer, createMulterErrorRedirectHandler,
+  logAndRedirectError, parsePositiveIntId, requireStreamer, createMulterErrorRedirectHandler, makeUploadMiddleware,
 } from './shared';
 import { safeResolve } from '../../shared/pathUtils';
 
@@ -77,21 +76,8 @@ async function saveVideoFile(streamer: DbStreamerEventSub, file: Express.Multer.
  */
 export const handleUploadError = createMulterErrorRedirectHandler('/overlay/settings', log, 'Overlay upload middleware error:');
 
-/**
- * Express middleware that runs Multer's single-file (`video`) parser and, on a
- * Multer error (e.g. an oversized file), redirects via `handleUploadError`
- * instead of letting it fall through to the centralised 500 handler.
- * @param req - Express request carrying the multipart upload.
- * @param res - Express response (used for the error redirect).
- * @param next - Called to continue to the route handler when parsing succeeds.
- * @returns {void}
- */
-function uploadVideo(req: Request, res: Response, next: NextFunction): void {
-  upload.single('video')(req, res, (err: unknown) => {
-    if (handleUploadError(err, res)) return;
-    next();
-  });
-}
+/** Express middleware running Multer's single-file (`video`) parser, redirecting on error. */
+const uploadVideo = makeUploadMiddleware(upload, 'video', handleUploadError);
 
 /**
  * POST /overlay/settings/videos/upload — uploads a video file (webm/mp4,

--- a/src/web/routes/sfxFileUpload.ts
+++ b/src/web/routes/sfxFileUpload.ts
@@ -1,6 +1,5 @@
 import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
-import type { Request, Response, NextFunction } from 'express';
 import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
@@ -9,7 +8,7 @@ import { csrfProtection } from '../csrf';
 import { requireMod } from '../middleware';
 import { SFX_FOLDER, SFX_MAX_FILE_MB } from '../../shared/config';
 import { safeResolve } from '../../shared/pathUtils';
-import { parsePositiveIntId, createMulterErrorRedirectHandler, parseCheckboxField } from './shared';
+import { parsePositiveIntId, createMulterErrorRedirectHandler, makeUploadMiddleware, parseCheckboxField } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
@@ -197,21 +196,8 @@ async function persistUploadedSound(
  */
 export const handleUploadError = createMulterErrorRedirectHandler('/sfx', log, 'SFX upload middleware error:');
 
-/**
- * Express middleware that runs Multer's single-file (`sound`) parser and, on a
- * Multer error (e.g. an oversized file), redirects via `handleUploadError`
- * instead of letting it fall through to the centralised 500 handler.
- * @param req - Express request carrying the multipart upload.
- * @param res - Express response (used for the error redirect).
- * @param next - Called to continue to the route handler when parsing succeeds.
- * @returns {void}
- */
-function uploadSound(req: Request, res: Response, next: NextFunction): void {
-  upload.single('sound')(req, res, (err: unknown) => {
-    if (handleUploadError(err, res)) return;
-    next();
-  });
-}
+/** Express middleware running Multer's single-file (`sound`) parser, redirecting on error. */
+const uploadSound = makeUploadMiddleware(upload, 'sound', handleUploadError);
 
 // csrfProtection runs BEFORE uploadSound so a bad token is rejected before Multer
 // buffers the file. The client (sfx.js) sends the token in an X-CSRF-Token header

--- a/src/web/routes/shared.ts
+++ b/src/web/routes/shared.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import multer from 'multer';
-import type { Request, Response } from 'express';
+import type { Request, Response, NextFunction } from 'express';
 import type { Logger } from 'winston';
 import type { SessionUser } from '../../types/express';
 import {
@@ -379,5 +379,29 @@ export function createMulterErrorRedirectHandler(
     log.error(logLabel, err);
     res.redirect(`${basePath}?error=upload_failed`);
     return true;
+  };
+}
+
+/**
+ * Builds Express middleware that runs Multer's single-file parser for `field` and, on a Multer
+ * error (e.g. an oversized file), redirects via `handleUploadError` instead of letting it fall
+ * through to the centralised 500 handler. Shared by every file-upload route (SFX sounds, overlay
+ * videos, alert images/sounds) — they previously each defined their own copy of this wrapper,
+ * differing only in the Multer instance and field name.
+ * @param upload - Multer instance configured for this upload (storage + size limit).
+ * @param field - Form field name Multer should parse as the single uploaded file.
+ * @param handleUploadError - Error handler from `createMulterErrorRedirectHandler`, run on a Multer error.
+ * @returns Express middleware: parses `field` via Multer, then calls `next()` on success.
+ */
+export function makeUploadMiddleware(
+  upload: multer.Multer,
+  field: string,
+  handleUploadError: (err: unknown, res: Response) => boolean,
+): (req: Request, res: Response, next: NextFunction) => void {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    upload.single(field)(req, res, (err: unknown) => {
+      if (handleUploadError(err, res)) return;
+      next();
+    });
   };
 }


### PR DESCRIPTION
## Summary
- `overlayAdminMutations.ts` (`uploadVideo`), `sfxFileUpload.ts` (`uploadSound`), and `alertsAssetMutations.ts` (`uploadImage`/`uploadSound`) each defined a near-identical wrapper around Multer's single-file parser that redirects via `handleUploadError` on failure — differing only in the Multer instance and field name.
- Extracted `makeUploadMiddleware(upload, field, handleUploadError)` into `src/web/routes/shared.ts`, next to the existing `createMulterErrorRedirectHandler` it composes with, and replaced all four call sites.
- Pure internal refactor — no behavior, route, or error-code change. Dropped now-unused `Request`/`NextFunction` (and in one file `Response`) type imports left over from the inlined wrapper functions.

## Test plan
- [x] `npx tsc --noEmit` — passes
- [x] `npm test` — 147 test files / 2736 tests pass unchanged
- [x] `npm run lint` — no new warnings (pre-existing unrelated warning in `twitchBot.ts` only)


---
_Generated by [Claude Code](https://claude.ai/code/session_01J2Hx2inzkFwNCmWPMM9cob)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency and reliability of image, audio, video, and sound-effect uploads.
  * Standardized upload error handling and redirection across supported upload routes.

* **Refactor**
  * Consolidated upload processing through shared middleware while preserving existing upload behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->