### PR TITLE
Dedup deadlock-retry/named-lock scaffolding in commandConflicts.ts

### DIFF
--- a/src/db/commandConflicts.test.ts
+++ b/src/db/commandConflicts.test.ts
@@ -347,6 +347,35 @@ describe('assignUserToCommandWithinTransaction', () => {
     expect(acquireNamedLock).toHaveBeenCalledOnce();
   });
 
+  it('throws the stable retry-limit error, not the raw driver error, when a deadlock persists through every attempt', async () => {
+    const deadlockErr = new Error('deadlock');
+    const eligibilityRow = [{ twitch_name: null, is_twitch_bot_enabled: 0 }];
+    const triggerRow = [{ trigger_string: '!clap' }];
+    const execute = vi.fn()
+      .mockResolvedValueOnce([triggerRow, []]).mockResolvedValueOnce([eligibilityRow, []]).mockRejectedValueOnce(deadlockErr)
+      .mockResolvedValueOnce([triggerRow, []]).mockResolvedValueOnce([eligibilityRow, []]).mockRejectedValueOnce(deadlockErr)
+      .mockResolvedValueOnce([triggerRow, []]).mockResolvedValueOnce([eligibilityRow, []]).mockRejectedValueOnce(deadlockErr);
+    const connection = {
+      execute,
+      beginTransaction: vi.fn().mockResolvedValue(undefined),
+      commit: vi.fn().mockResolvedValue(undefined),
+      rollback: vi.fn().mockResolvedValue(undefined),
+    };
+    // isDeadlockError reports true on every attempt, including the last — unlike the
+    // "no further retry" case above, where it reports false on the last attempt. Queued as
+    // one-time values (not a persistent mockReturnValue) so this doesn't leak into later tests.
+    vi.mocked(isDeadlockError).mockReturnValueOnce(true).mockReturnValueOnce(true).mockReturnValueOnce(true);
+
+    await expect(assignUserToCommandWithinTransaction(connection as any, 1, 'user1'))
+      .rejects.toThrow('[DB] Deadlock retry limit reached in assignUserToCommandWithinTransaction.');
+
+    expect(connection.beginTransaction).toHaveBeenCalledTimes(3);
+    expect(connection.rollback).toHaveBeenCalledTimes(3);
+    expect(connection.commit).not.toHaveBeenCalled();
+    expect(acquireNamedLock).toHaveBeenCalledOnce();
+    expect(releaseNamedLock).toHaveBeenCalledOnce();
+  });
+
   it('rethrows a non-deadlock error immediately without retrying', async () => {
     const connection = makeConnection([
       [{ trigger_string: '!clap' }],

--- a/src/db/commandConflicts.ts
+++ b/src/db/commandConflicts.ts
@@ -410,6 +410,12 @@ export async function assignUserToCommandWithinTransaction(
     commandId,
     'assignUserToCommand',
     'assignUserToCommandWithinTransaction',
+    /**
+     * Per-attempt body: checks the user's Twitch-channel trigger conflict (if eligible) and
+     * inserts the assignment row.
+     * @param normalizedTriggerString The command's normalized trigger string, looked up fresh each attempt.
+     * @returns Resolves once the conflict check (if any) and insert both succeed.
+     */
     async (normalizedTriggerString) => {
       const userEligibility = await getUserTwitchEligibility(connection, discordId);
 
@@ -529,6 +535,12 @@ export async function assignUsersToCommandWithinTransaction(
     commandId,
     'assignUsersToCommand',
     'assignUsersToCommandWithinTransaction',
+    /**
+     * Per-attempt body: batch-checks every user's Twitch-channel trigger conflict and inserts
+     * all assignment rows in one upsert.
+     * @param normalizedTriggerString The command's normalized trigger string, looked up fresh each attempt.
+     * @returns Resolves once all conflict checks and the batch insert succeed.
+     */
     async (normalizedTriggerString) => {
       const eligibilityByDiscordId = await getUserTwitchEligibilityBatch(connection, discordIds);
       await assertAllUsersAssignable(connection, commandId, discordIds, normalizedTriggerString, eligibilityByDiscordId);

--- a/src/db/commandConflicts.ts
+++ b/src/db/commandConflicts.ts
@@ -329,6 +329,67 @@ export async function insertUserCommandAssignment(
 }
 
 /**
+ * Runs `body` inside a transaction guarded by a named lock on `commandId`'s trigger string,
+ * retrying on deadlock up to `MAX_DEADLOCK_RETRIES` times. The named lock is session-scoped:
+ * acquired once (on the first attempt, after the trigger string is known) and released in the
+ * outer `finally`, so deadlock retries on the inner transaction still hold the lock between
+ * attempts. Factors out the retry/lock/transaction scaffolding shared by
+ * {@link assignUserToCommandWithinTransaction} and {@link assignUsersToCommandWithinTransaction},
+ * which differ only in the eligibility lookup, conflict checks, and insert `body` performs.
+ * @param connection Transaction-capable pool connection to run the work on.
+ * @param commandId Command id whose trigger string the named lock is scoped to.
+ * @param retryLogLabel Short name of the calling function, used in the deadlock-retry log message.
+ * @param retryLimitFnName Full name of the calling function, used in the retry-limit-reached error message.
+ * @param body Per-attempt work to run inside the transaction, given the command's normalized
+ *   trigger string. Must not itself begin/commit/rollback a transaction.
+ * @throws Whatever `body` throws (e.g. {@link CommandConflictError}), once retries are exhausted
+ *   or the error isn't a deadlock.
+ * @throws If the deadlock retry limit is reached.
+ */
+async function withDeadlockRetryAndTriggerLock(
+  connection: mysql.PoolConnection,
+  commandId: number,
+  retryLogLabel: string,
+  retryLimitFnName: string,
+  body: (normalizedTriggerString: string) => Promise<void>,
+): Promise<void> {
+  // The named lock is session-scoped: acquire it once and release it in the outer finally,
+  // so deadlock retries on the inner transaction still hold the lock between attempts.
+  let lockNameByTrigger: string | null = null;
+
+  try {
+    for (let attempt = 0; attempt < MAX_DEADLOCK_RETRIES; attempt++) {
+      await connection.beginTransaction();
+      try {
+        const normalizedTriggerString = await getCommandTriggerStringById(connection, commandId);
+
+        if (!lockNameByTrigger) {
+          lockNameByTrigger = getCommandWriteLockName(normalizedTriggerString);
+          await acquireNamedLock(connection, lockNameByTrigger);
+        }
+
+        await body(normalizedTriggerString);
+        await connection.commit();
+        return;
+      } catch (error) {
+        await connection.rollback();
+        if (isDeadlockError(error) && attempt < MAX_DEADLOCK_RETRIES - 1) {
+          log.warn(`Deadlock in ${retryLogLabel}, retrying (attempt ${attempt + 1}/${MAX_DEADLOCK_RETRIES}).`);
+          continue;
+        }
+        throw error;
+      }
+    }
+
+    throw new Error(`[DB] Deadlock retry limit reached in ${retryLimitFnName}.`);
+  } finally {
+    if (lockNameByTrigger) {
+      try { await releaseNamedLock(connection, lockNameByTrigger); } catch (err) { log.warn('Failed to release named lock:', err); }
+    }
+  }
+}
+
+/**
  * Assigns a Discord user to a custom command for single-Twitch triggering, running the conflict
  * check and insert inside a transaction guarded by a named lock on the command's trigger string.
  * Retries on deadlock up to `MAX_DEADLOCK_RETRIES` times, re-acquiring the transaction each attempt
@@ -344,50 +405,26 @@ export async function assignUserToCommandWithinTransaction(
   commandId: number,
   discordId: string,
 ): Promise<void> {
-  // The named lock is session-scoped: acquire it once and release it in the outer finally,
-  // so deadlock retries on the inner transaction still hold the lock between attempts.
-  let lockNameByTrigger: string | null = null;
+  await withDeadlockRetryAndTriggerLock(
+    connection,
+    commandId,
+    'assignUserToCommand',
+    'assignUserToCommandWithinTransaction',
+    async (normalizedTriggerString) => {
+      const userEligibility = await getUserTwitchEligibility(connection, discordId);
 
-  try {
-    for (let attempt = 0; attempt < MAX_DEADLOCK_RETRIES; attempt++) {
-      await connection.beginTransaction();
-      try {
-        const normalizedTriggerString = await getCommandTriggerStringById(connection, commandId);
-        const userEligibility = await getUserTwitchEligibility(connection, discordId);
-
-        if (!lockNameByTrigger) {
-          lockNameByTrigger = getCommandWriteLockName(normalizedTriggerString);
-          await acquireNamedLock(connection, lockNameByTrigger);
-        }
-
-        if (userEligibility.normalizedTwitchName && userEligibility.isTwitchBotEnabled) {
-          await assertNoTwitchChannelTriggerConflict(
-            connection,
-            commandId,
-            normalizedTriggerString,
-            userEligibility.normalizedTwitchName,
-          );
-        }
-
-        await insertUserCommandAssignment(connection, commandId, discordId);
-        await connection.commit();
-        return;
-      } catch (error) {
-        await connection.rollback();
-        if (isDeadlockError(error) && attempt < MAX_DEADLOCK_RETRIES - 1) {
-          log.warn(`Deadlock in assignUserToCommand, retrying (attempt ${attempt + 1}/${MAX_DEADLOCK_RETRIES}).`);
-          continue;
-        }
-        throw error;
+      if (userEligibility.normalizedTwitchName && userEligibility.isTwitchBotEnabled) {
+        await assertNoTwitchChannelTriggerConflict(
+          connection,
+          commandId,
+          normalizedTriggerString,
+          userEligibility.normalizedTwitchName,
+        );
       }
-    }
 
-    throw new Error('[DB] Deadlock retry limit reached in assignUserToCommandWithinTransaction.');
-  } finally {
-    if (lockNameByTrigger) {
-      try { await releaseNamedLock(connection, lockNameByTrigger); } catch (err) { log.warn('Failed to release named lock:', err); }
-    }
-  }
+      await insertUserCommandAssignment(connection, commandId, discordId);
+    },
+  );
 }
 
 /**
@@ -487,38 +524,15 @@ export async function assignUsersToCommandWithinTransaction(
 ): Promise<void> {
   if (discordIds.length === 0) return;
 
-  let lockNameByTrigger: string | null = null;
-
-  try {
-    for (let attempt = 0; attempt < MAX_DEADLOCK_RETRIES; attempt++) {
-      await connection.beginTransaction();
-      try {
-        const normalizedTriggerString = await getCommandTriggerStringById(connection, commandId);
-        const eligibilityByDiscordId = await getUserTwitchEligibilityBatch(connection, discordIds);
-
-        if (!lockNameByTrigger) {
-          lockNameByTrigger = getCommandWriteLockName(normalizedTriggerString);
-          await acquireNamedLock(connection, lockNameByTrigger);
-        }
-
-        await assertAllUsersAssignable(connection, commandId, discordIds, normalizedTriggerString, eligibilityByDiscordId);
-        await insertUserCommandAssignments(connection, commandId, discordIds);
-        await connection.commit();
-        return;
-      } catch (error) {
-        await connection.rollback();
-        if (isDeadlockError(error) && attempt < MAX_DEADLOCK_RETRIES - 1) {
-          log.warn(`Deadlock in assignUsersToCommand, retrying (attempt ${attempt + 1}/${MAX_DEADLOCK_RETRIES}).`);
-          continue;
-        }
-        throw error;
-      }
-    }
-
-    throw new Error('[DB] Deadlock retry limit reached in assignUsersToCommandWithinTransaction.');
-  } finally {
-    if (lockNameByTrigger) {
-      try { await releaseNamedLock(connection, lockNameByTrigger); } catch (err) { log.warn('Failed to release named lock:', err); }
-    }
-  }
+  await withDeadlockRetryAndTriggerLock(
+    connection,
+    commandId,
+    'assignUsersToCommand',
+    'assignUsersToCommandWithinTransaction',
+    async (normalizedTriggerString) => {
+      const eligibilityByDiscordId = await getUserTwitchEligibilityBatch(connection, discordIds);
+      await assertAllUsersAssignable(connection, commandId, discordIds, normalizedTriggerString, eligibilityByDiscordId);
+      await insertUserCommandAssignments(connection, commandId, discordIds);
+    },
+  );
 }

--- a/src/db/commandConflicts.ts
+++ b/src/db/commandConflicts.ts
@@ -342,9 +342,8 @@ export async function insertUserCommandAssignment(
  * @param retryLimitFnName Full name of the calling function, used in the retry-limit-reached error message.
  * @param body Per-attempt work to run inside the transaction, given the command's normalized
  *   trigger string. Must not itself begin/commit/rollback a transaction.
- * @throws Whatever `body` throws (e.g. {@link CommandConflictError}), once retries are exhausted
- *   or the error isn't a deadlock.
- * @throws If the deadlock retry limit is reached.
+ * @throws Whatever `body` throws (e.g. {@link CommandConflictError}), when that error isn't a deadlock.
+ * @throws If a deadlock persists through all `MAX_DEADLOCK_RETRIES` attempts.
  */
 async function withDeadlockRetryAndTriggerLock(
   connection: mysql.PoolConnection,
@@ -373,9 +372,12 @@ async function withDeadlockRetryAndTriggerLock(
         return;
       } catch (error) {
         await connection.rollback();
-        if (isDeadlockError(error) && attempt < MAX_DEADLOCK_RETRIES - 1) {
-          log.warn(`Deadlock in ${retryLogLabel}, retrying (attempt ${attempt + 1}/${MAX_DEADLOCK_RETRIES}).`);
-          continue;
+        if (isDeadlockError(error)) {
+          if (attempt < MAX_DEADLOCK_RETRIES - 1) {
+            log.warn(`Deadlock in ${retryLogLabel}, retrying (attempt ${attempt + 1}/${MAX_DEADLOCK_RETRIES}).`);
+            continue;
+          }
+          break;
         }
         throw error;
       }


### PR DESCRIPTION
## Summary
- `assignUserToCommandWithinTransaction` and `assignUsersToCommandWithinTransaction` in `src/db/commandConflicts.ts` each hand-rolled the same ~30 lines of scaffolding: a deadlock-retry loop up to `MAX_DEADLOCK_RETRIES`, `beginTransaction`/`commit`/`rollback`, and acquiring/releasing a named lock on the command's trigger string — differing only in the eligibility lookup, conflict check(s), and insert performed per attempt.
- Extracted `withDeadlockRetryAndTriggerLock(connection, commandId, retryLogLabel, retryLimitFnName, body)` and had both functions call it with their per-attempt work as `body`.
- Added JSDoc to the two inline `body` callbacks (CodeRabbit review comment) and to the new helper itself.

## Follow-up fix (from CodeRabbit review)
CodeRabbit flagged that the `[DB] Deadlock retry limit reached in ...` error was unreachable dead code — on the final retry attempt, the `attempt < MAX_DEADLOCK_RETRIES - 1` guard is always false, so the raw driver error was rethrown instead of the documented wrapped error, regardless of whether it was actually a deadlock. This bug predates this refactor (same logic existed in the original code), but since the dedup now centralizes the retry loop in one place, I fixed it here too: a deadlock now `break`s out of the loop on the final attempt instead of immediately rethrowing, so the wrapped stable error is correctly thrown when a deadlock persists through every attempt. Added a test for this case (`throws the stable retry-limit error, not the raw driver error, when a deadlock persists through every attempt`), alongside the existing test covering a non-deadlock error on the final attempt (unaffected, still passes).

## Test plan
- [x] `npx tsc --noEmit` — passes
- [x] `npm test` — 147 test files / 2737 tests pass, including `commandConflicts.test.ts`'s 45 tests (44 original + 1 new) covering both functions' conflict/deadlock/lock-release paths
- [x] `npm run lint` — no new warnings (pre-existing unrelated warning in `twitchBot.ts` only)
