### PR TITLE
Clean up rowExists identifier-validation fix (tests + dedupe)

### DIFF
--- a/src/db/utils.test.ts
+++ b/src/db/utils.test.ts
@@ -80,6 +80,23 @@ describe('rowExists', () => {
     expect(result).toBe(true);
     expect(executor.execute.mock.calls[0][1]).toEqual(['123456789012345']);
   });
+
+  it('rejects a table name containing non-identifier characters without querying', async () => {
+    const executor = { execute: vi.fn() };
+    await expect(rowExists(executor as any, 'counter; DROP TABLE user', 'id', 5)).rejects.toThrow('Invalid input');
+    expect(executor.execute).not.toHaveBeenCalled();
+  });
+
+  it('rejects a column name containing non-identifier characters without querying', async () => {
+    const executor = { execute: vi.fn() };
+    await expect(rowExists(executor as any, 'counter', 'id = 1 OR 1=1 -- ', 5)).rejects.toThrow('Invalid input');
+    expect(executor.execute).not.toHaveBeenCalled();
+  });
+
+  it('accepts a table/column made only of letters, digits, and underscores', async () => {
+    const executor = { execute: vi.fn().mockResolvedValue([[], []]) };
+    await expect(rowExists(executor as any, 'custom_command_2', 'command_id_2', 1)).resolves.toBe(false);
+  });
 });
 
 describe('hashesMatch', () => {

--- a/src/db/utils.ts
+++ b/src/db/utils.ts
@@ -8,13 +8,17 @@ export function fromBit(value: unknown): boolean {
   return value == 1;
 }
 
+const IDENTIFIER_PATTERN = /^[a-zA-Z0-9_]+$/;
+
 /**
  * Checks whether a row exists in `table` where `column` equals `value`.
  * @param executor Pool or transaction connection to query with.
  * @param table Table name — must be a fixed, trusted identifier, never derived from user input.
- * @param column Column name — same trust requirement as `table`.
+ *   Validated against an allowlist pattern as defence-in-depth before being interpolated into SQL.
+ * @param column Column name — same trust requirement and validation as `table`.
  * @param value Value to match against `column`.
  * @returns True if a matching row exists.
+ * @throws If `table` or `column` isn't a plain alphanumeric/underscore identifier.
  */
 export async function rowExists(
   executor: SqlExecutor,
@@ -22,10 +26,7 @@ export async function rowExists(
   column: string,
   value: string | number,
 ): Promise<boolean> {
-  if (!/^[a-zA-Z0-9_]+$/.test(table)) {
-    throw new Error('Invalid input');
-  }
-  if (!/^[a-zA-Z0-9_]+$/.test(column)) {
+  if (!IDENTIFIER_PATTERN.test(table) || !IDENTIFIER_PATTERN.test(column)) {
     throw new Error('Invalid input');
   }
   const [rows] = await executor.execute<mysql.RowDataPacket[]>(


### PR DESCRIPTION
## Summary
Follow-up on #409 (Aikido's autofix adding allowlist validation for the `table`/`column` identifiers interpolated into `rowExists`'s SQL string). All current call sites pass hardcoded literals, so this isn't an active vulnerability today, but it's reasonable defence-in-depth against future callers.

This PR closes two gaps in that autofix, per project convention (every behaviour change needs a test):
- Added Vitest cases in `src/db/utils.test.ts` covering: a rejected table name, a rejected column name (asserting the query is never executed), and a valid alphanumeric/underscore identifier still working.
- Collapsed the two duplicated `if (!/^[a-zA-Z0-9_]+$/.test(...))` checks into a single shared `IDENTIFIER_PATTERN` regex and one combined condition.
- Updated the `rowExists` JSDoc to document the validation and the new `@throws`.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (2739 tests passed)

https://claude.ai/code/session_017QcfnLuVx3X1pKYsYjUihH


---
_Generated by [Claude Code](https://claude.ai/code/session_017QcfnLuVx3X1pKYsYjUihH)_