### PR TITLE
Group overlay nav links under "Overlays", split out controller page

### DIFF
--- a/src/web/routes/overlayAdmin.test.ts
+++ b/src/web/routes/overlayAdmin.test.ts
@@ -101,6 +101,14 @@ describe('GET /settings — query param filtering', () => {
   });
 });
 
+describe('GET /controller/settings', () => {
+  it('renders the controller admin view with the base URL', async () => {
+    const res = await supertest(buildApp()).get('/controller/settings');
+    expect(res.status).toBe(200);
+    expect(res.body.baseUrl).toBe('http://localhost:3000');
+  });
+});
+
 // fetchTwitchRewards isn't exported, so it's exercised indirectly through GET /settings —
 // twitchRewards in the rendered locals is its return value.
 describe('GET /settings — fetchTwitchRewards', () => {

--- a/src/web/routes/overlayAdmin.ts
+++ b/src/web/routes/overlayAdmin.ts
@@ -75,6 +75,20 @@ router.get('/settings', requireAuth, csrfProtection, async (req, res) => {
   }
 });
 
+/**
+ * GET /overlay/controller/settings — renders the controller overlay info page
+ * (the OBS browser-source URL and setup notes for the gamepad overlay).
+ * @param req - Express request; reads `req.session.user`.
+ * @param res - Express response; renders the `controllerAdmin` view.
+ */
+router.get('/controller/settings', requireAuth, csrfProtection, (req, res) => {
+  renderView(res, 'controllerAdmin', {
+    user: req.session.user,
+    csrfToken: req.csrfToken(),
+    baseUrl: PUBLIC_URL,
+  });
+});
+
 router.use(mutationsRouter);
 router.use(rewardMutationsRouter);
 

--- a/views/controllerAdmin.ejs
+++ b/views/controllerAdmin.ejs
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BCUK Bot — Controller</title>
+  <link rel="stylesheet" href="/style.css">
+  <%- include('partials/pwa-head') %>
+</head>
+<body data-csrf-token="<%= csrfToken %>">
+  <%- include('partials/nav') %>
+
+  <main class="container">
+
+    <!-- ── Controller Overlay ────────────────────────────────────── -->
+    <section class="section">
+      <h2 class="section-title">Controller Overlay</h2>
+      <div class="card">
+        <div class="card-body">
+          <p class="hint hint-compact">Add this URL as a Browser Source in OBS to display a gamepad input visualiser (throttle, brake, steering, handbrake):</p>
+          <code class="mono overlay-url-display"><%= baseUrl %>/overlay/controller</code>
+          <p class="hint mt-05">Works with any Xbox / PlayStation / generic controller. Transparent background — native size is <strong>332&times;212px</strong> (set the OBS browser source to these dimensions, then scale to taste).</p>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <%- include('partials/pwa-register') %>
+  <%- include('partials/footer') %>
+  <script src="/utils.js"></script>
+</body>
+</html>

--- a/views/overlayAdmin.ejs
+++ b/views/overlayAdmin.ejs
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>BCUK Bot — Overlay</title>
+  <title>BCUK Bot — Video Overlay</title>
   <link rel="stylesheet" href="/style.css">
   <%- include('partials/pwa-head') %>
 </head>
@@ -60,18 +60,6 @@
           <% const login = streamer.twitch_name ? streamer.twitch_name.toLowerCase() : ''; %>
           <code class="mono overlay-url-display"><%= baseUrl %>/overlay/<%= login %></code>
           <p class="hint mt-05">In OBS: Sources → Add → Browser → check "Local file" OFF, paste the URL above.</p>
-        </div>
-      </div>
-    </section>
-
-    <!-- ── Controller Overlay ────────────────────────────────────── -->
-    <section class="section">
-      <h2 class="section-title">Controller Overlay</h2>
-      <div class="card">
-        <div class="card-body">
-          <p class="hint hint-compact">Add this URL as a Browser Source in OBS to display a gamepad input visualiser (throttle, brake, steering, handbrake):</p>
-          <code class="mono overlay-url-display"><%= baseUrl %>/overlay/controller</code>
-          <p class="hint mt-05">Works with any Xbox / PlayStation / generic controller. Transparent background — native size is <strong>332&times;212px</strong> (set the OBS browser source to these dimensions, then scale to taste).</p>
         </div>
       </div>
     </section>

--- a/views/partials/nav.ejs
+++ b/views/partials/nav.ejs
@@ -35,8 +35,14 @@
       </div>
       <% } %>
       <% if (user) { %>
-      <a href="/overlay/settings" class="nav-item">Overlay</a>
-      <a href="/alerts/settings" class="nav-item">Alerts</a>
+      <div class="nav-group">
+        <button class="nav-group-label" aria-haspopup="true" aria-expanded="false">Overlays <span class="nav-caret">▾</span></button>
+        <div class="nav-group-items">
+          <a href="/overlay/settings" class="nav-item">Video</a>
+          <a href="/alerts/settings" class="nav-item">Alerts</a>
+          <a href="/overlay/controller/settings" class="nav-item">Controller</a>
+        </div>
+      </div>
       <a href="/channel-points" class="nav-item">Channel Points</a>
       <a href="/user/settings" class="nav-item">Settings</a>
       <% } %>


### PR DESCRIPTION
## Summary
- Video overlay, alerts, and the controller (gamepad) overlay are all "overlay" features, but the nav previously had a lone "Overlay" item, a lone "Alerts" item, and the controller info bolted onto the video overlay settings page. Added an "Overlays" nav group (`Video`, `Alerts`, `Controller`) matching the style of the existing `Bot Commands`/`Devices`/`Admin` groups.
- Split the "Controller Overlay" info card (OBS browser-source URL/instructions) out of `overlayAdmin.ejs` into its own view (`controllerAdmin.ejs`), served from a new `GET /overlay/controller/settings` route.
- Renamed the video overlay page `<title>` from "Overlay" to "Video Overlay" for clarity.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (all 153 files / 2855 tests pass, including a new test for `GET /controller/settings`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Axd52FsuzKDEHUx4JkafVn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Controller Overlay administration page with OBS Browser Source setup instructions.
  * Added Controller Overlay access to the Overlays navigation menu.
  * Included CSRF protection and the configured application URL on the new page.

* **Improvements**
  * Grouped Video, Alerts, and Controller settings under a single Overlays menu.
  * Simplified the Video Overlay administration page by moving Controller instructions to its own page.

* **Tests**
  * Added coverage confirming the Controller settings page loads with the expected application URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->