### PR TITLE
Cache-bust Twitch thumbnail URLs to fix stale Discord images

### DIFF
--- a/src/twitch/monitor/twitchMonitorEmbed.test.ts
+++ b/src/twitch/monitor/twitchMonitorEmbed.test.ts
@@ -48,7 +48,17 @@ describe('getStreamUrl', () => {
 describe('getThumbnailUrl', () => {
   it('replaces {width} and {height} placeholders', () => {
     const stream = makeStream({ thumbnail_url: 'https://thumb.tv/{width}x{height}.jpg' });
-    expect(getThumbnailUrl(stream)).toBe('https://thumb.tv/640x360.jpg');
+    expect(getThumbnailUrl(stream)).toMatch(/^https:\/\/thumb\.tv\/640x360\.jpg\?cb=\d+$/);
+  });
+
+  it('appends a different cache-busting value on each call', () => {
+    const stream = makeStream({ thumbnail_url: 'https://thumb.tv/{width}x{height}.jpg' });
+    const first = getThumbnailUrl(stream);
+    vi.useFakeTimers();
+    vi.advanceTimersByTime(1000);
+    const second = getThumbnailUrl(stream);
+    vi.useRealTimers();
+    expect(second).not.toBe(first);
   });
 });
 
@@ -86,7 +96,7 @@ describe('buildEmbedPreview', () => {
     expect(preview.title).toBe('Playing Minecraft');
     expect(preview.url).toBe('https://www.twitch.tv/streamer1');
     expect(preview.color).toBe('#9146FF');
-    expect(preview.imageUrl).toBe('https://thumb.tv/640x360.jpg');
+    expect(preview.imageUrl).toMatch(/^https:\/\/thumb\.tv\/640x360\.jpg\?cb=\d+$/);
   });
 
   it('includes a Game field', () => {

--- a/src/twitch/monitor/twitchMonitorEmbed.test.ts
+++ b/src/twitch/monitor/twitchMonitorEmbed.test.ts
@@ -53,8 +53,8 @@ describe('getThumbnailUrl', () => {
 
   it('appends a different cache-busting value on each call', () => {
     const stream = makeStream({ thumbnail_url: 'https://thumb.tv/{width}x{height}.jpg' });
-    const first = getThumbnailUrl(stream);
     vi.useFakeTimers();
+    const first = getThumbnailUrl(stream);
     vi.advanceTimersByTime(1000);
     const second = getThumbnailUrl(stream);
     vi.useRealTimers();

--- a/src/twitch/monitor/twitchMonitorEmbed.ts
+++ b/src/twitch/monitor/twitchMonitorEmbed.ts
@@ -30,14 +30,19 @@ export function getStreamUrl(login: string): string {
 }
 
 /**
- * Resolves `stream`'s thumbnail template URL to a concrete 640x360 image URL.
+ * Resolves `stream`'s thumbnail template URL to a concrete 640x360 image URL, with a
+ * cache-busting query param appended. Twitch's thumbnail URL is stable for a given login
+ * (no timestamp of its own), so without a cache-buster Discord's media proxy — which caches
+ * images by URL — keeps serving whatever snapshot it first fetched for that login, even
+ * across unrelated stream sessions weeks apart.
  * @param stream - Twitch stream whose thumbnail URL should be resolved.
- * @returns The thumbnail URL with `{width}`/`{height}` placeholders filled in.
+ * @returns The thumbnail URL with `{width}`/`{height}` placeholders filled in and a fresh `cb` param.
  */
 export function getThumbnailUrl(stream: TwitchStream): string {
-  return stream.thumbnail_url
+  const resolved = stream.thumbnail_url
     .replace('{width}', '640')
     .replace('{height}', '360');
+  return `${resolved}?cb=${Date.now()}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Stream thumbnails posted to Discord could show a stale screenshot from a completely unrelated stream session weeks earlier — even on a brand-new "went live" announcement.
- Root cause: Twitch's `thumbnail_url` is a stable per-login URL (only `{width}`/`{height}` vary, no timestamp). Discord's media proxy caches images by URL, so once it had fetched a login's thumbnail once, every later post/edit that reused the same URL just served the cached copy instead of re-fetching Twitch's current frame.
- Fix: `getThumbnailUrl` in `src/twitch/monitor/twitchMonitorEmbed.ts` now appends a `?cb=<timestamp>` cache-busting query param, so each post/edit forces Discord to refetch the current thumbnail.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (all 2856 tests pass)
- [x] Updated `twitchMonitorEmbed.test.ts` assertions to match the new cache-busted URL format, and added a test confirming the cache-buster changes between calls.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QKVe6iuXFjfCy3iKFf3ga9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Twitch stream thumbnail refreshing by adding cache-busting parameters to thumbnail URLs.
  * Ensured embedded previews display the latest available thumbnail instead of a cached image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->