### PR TITLE
Split runtime injection out of twitchEventSubHandler.ts

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -51,7 +51,7 @@ vi.mock('./commands/counterHandler', () => ({ registerCounterTwitchRuntime: vi.f
 vi.mock('./commands/multiCommandHandler', () => ({ registerMultiTwitchRuntime: vi.fn() }));
 vi.mock('./commands/shoutoutHandler', () => ({ registerShoutoutRuntime: vi.fn() }));
 vi.mock('./commands/countdownHandler', () => ({ registerCountdownTwitchRuntime: vi.fn() }));
-vi.mock('./twitch/eventsub/twitchEventSubHandler', () => ({
+vi.mock('./twitch/eventsub/twitchEventSubRuntime', () => ({
   registerEventSubOverlayRuntime: vi.fn(),
   registerEventSubTwitchRuntime: vi.fn(),
   registerEventSubCompanionRuntime: vi.fn(),
@@ -129,7 +129,7 @@ describe('startup — guild registry preload', () => {
   });
 
   it('registers the companion event runtime with pushCompanionEvent on a clean startup', async () => {
-    const { registerEventSubCompanionRuntime } = await import('./twitch/eventsub/twitchEventSubHandler.js');
+    const { registerEventSubCompanionRuntime } = await import('./twitch/eventsub/twitchEventSubRuntime.js');
     const { pushCompanionEvent } = await import('./web/routes/companionEvents.js');
 
     await runMain();
@@ -138,7 +138,7 @@ describe('startup — guild registry preload', () => {
   });
 
   it('registers the alerts overlay runtime with pushAlertEvent on a clean startup', async () => {
-    const { registerEventSubAlertRuntime } = await import('./twitch/eventsub/twitchEventSubHandler.js');
+    const { registerEventSubAlertRuntime } = await import('./twitch/eventsub/twitchEventSubRuntime.js');
     const { pushAlertEvent } = await import('./web/routes/alertsOverlaySource.js');
 
     await runMain();
@@ -156,7 +156,7 @@ describe('startup — guild registry preload', () => {
   });
 
   it('registers the dashboard events runtime with pushDashboardEvent on a clean startup', async () => {
-    const { registerEventSubDashboardRuntime } = await import('./twitch/eventsub/twitchEventSubHandler.js');
+    const { registerEventSubDashboardRuntime } = await import('./twitch/eventsub/twitchEventSubRuntime.js');
     const { pushDashboardEvent } = await import('./web/routes/dashboardEvents.js');
 
     await runMain();

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import { registerCountdownTwitchRuntime } from './commands/countdownHandler';
 import {
   registerEventSubOverlayRuntime, registerEventSubTwitchRuntime, registerEventSubCompanionRuntime,
   registerEventSubAlertRuntime, registerEventSubDashboardRuntime,
-} from './twitch/eventsub/twitchEventSubHandler';
+} from './twitch/eventsub/twitchEventSubRuntime';
 import { pushOverlayEvent } from './web/routes/overlaySource';
 import { pushCompanionEvent } from './web/routes/companionEvents';
 import { pushAlertEvent } from './web/routes/alertsOverlaySource';

--- a/src/twitch/eventsub/twitchEventSubHandler.test.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.test.ts
@@ -14,9 +14,11 @@ vi.mock('../pricing/rewardPricingService', () => ({ applyRedemptionPricing: vi.f
 import {
   handleFollow, handleSub, handleResub, handleGiftSub, handleRaid, handleRedemption,
   handleStreamOnline, handleStreamOffline, handleChannelUpdate,
+} from './twitchEventSubHandler';
+import {
   registerEventSubOverlayRuntime, registerEventSubTwitchRuntime, registerEventSubCompanionRuntime,
   registerEventSubAlertRuntime, registerEventSubDashboardRuntime,
-} from './twitchEventSubHandler';
+} from './twitchEventSubRuntime';
 import { getVideosForReward, getStreamerById, findCachedAlertConfig, recordStreamerEvent } from '../../db';
 import { pickWeightedRandom } from '../../commands/soundSelector';
 import { buildShoutoutMessage } from '../../commands/shoutoutHandler';

--- a/src/twitch/eventsub/twitchEventSubHandler.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.ts
@@ -1,4 +1,4 @@
-import type { EventSubConfig, AlertEventType, StreamerEventType, TextAnimation } from '../../db';
+import type { EventSubConfig, AlertEventType, StreamerEventType } from '../../db';
 import { getVideosForReward, getStreamerById, findCachedAlertConfig, recordStreamerEvent } from '../../db';
 import { pickWeightedRandom } from '../../commands/soundSelector';
 import { buildShoutoutMessage } from '../../commands/shoutoutHandler';
@@ -7,157 +7,15 @@ import { createLogger } from '../../shared/logger';
 import { triggerImmediateLiveCheck } from '../monitor/twitchMonitor';
 import { fillTemplate } from '../../shared/textTemplate';
 import { applyRedemptionPricing } from '../pricing/rewardPricingService';
-import { createRuntimeRegistry } from '../../commands/twitchRuntime';
+import {
+  overlayRuntimeRegistry,
+  companionRuntimeRegistry,
+  alertRuntimeRegistry,
+  dashboardEventRuntimeRegistry,
+  twitchRuntimeRegistry,
+} from './twitchEventSubRuntime';
 
 const log = createLogger('EventSubHandler');
-
-// Runtime injection for the overlay push function — avoids a direct import of the
-// web layer from core Twitch handler code.  registerEventSubOverlayRuntime is called
-// from index.ts before startWebPanel(), which is safe because pushOverlayEvent is
-// just a function reference and does not require the HTTP server to be running.
-/**
- * Public contract for the overlay runtime injection.
- * Passed to {@link registerEventSubOverlayRuntime} from index.ts.
- */
-interface EventSubOverlayRuntime {
-  /**
-   * Push an overlay event to the named channel's SSE stream.
-   * @param login - Broadcaster login name.
-   * @param videoPath - Server-relative path of the video to display.
-   */
-  pushOverlayEvent: (login: string, videoPath: string) => void;
-}
-
-const overlayRuntimeRegistry = createRuntimeRegistry<EventSubOverlayRuntime>();
-
-/**
- * Register the overlay push function. Called from index.ts after startWebPanel().
- * @param runtime - The {@link EventSubOverlayRuntime} to store.
- * @returns void
- */
-export function registerEventSubOverlayRuntime(runtime: EventSubOverlayRuntime): void {
-  overlayRuntimeRegistry.register(runtime);
-}
-
-// Runtime injection for the companion app push function — same rationale as
-// EventSubOverlayRuntime above. Registered from index.ts before startWebPanel(),
-// since pushCompanionEvent is just a function reference and doesn't require the
-// HTTP server to be running yet.
-/**
- * Public contract for the companion app runtime injection.
- * Passed to {@link registerEventSubCompanionRuntime} from index.ts.
- */
-interface EventSubCompanionRuntime {
-  /**
-   * Push a companion event to the named Discord user's SSE stream.
-   * @param discordId - Discord snowflake of the streamer who owns the redemption.
-   * @param event - The companion event payload to deliver.
-   */
-  pushCompanionEvent: (discordId: string, event: import('../../web/routes/companionEvents').CompanionEvent) => void;
-}
-
-const companionRuntimeRegistry = createRuntimeRegistry<EventSubCompanionRuntime>();
-
-/**
- * Register the companion app push function. Called from index.ts before startWebPanel().
- * @param runtime - The {@link EventSubCompanionRuntime} to store.
- * @returns void
- */
-export function registerEventSubCompanionRuntime(runtime: EventSubCompanionRuntime): void {
-  companionRuntimeRegistry.register(runtime);
-}
-
-// Runtime injection for the alerts overlay push function — same rationale as
-// EventSubOverlayRuntime above. Registered from index.ts before startWebPanel(),
-// since pushAlertEvent is just a function reference and doesn't require the HTTP
-// server to be running yet.
-/** A customisable alert (follow/sub/resub/giftsub/raid) pushed to a streamer's alerts browser source. */
-export interface AlertPayload {
-  /** Which event type this alert is for. */
-  type: AlertEventType;
-  /** On-screen text, already filled from the streamer's message template. */
-  message: string;
-  /** Server-relative URL of the configured image/GIF, or null if none is set. */
-  imageUrl: string | null;
-  /** Server-relative URL of the configured sound, or null if none is set. */
-  soundUrl: string | null;
-  /** How long (ms) the alert should stay on screen. */
-  durationMs: number;
-  /** On-screen text animation style to apply to `message`. */
-  textAnimation: TextAnimation;
-}
-
-/**
- * Public contract for the alerts overlay runtime injection.
- * Passed to {@link registerEventSubAlertRuntime} from index.ts.
- */
-interface EventSubAlertRuntime {
-  /**
-   * Push an alert to the named channel's alerts-overlay SSE stream.
-   * @param login - Broadcaster login name.
-   * @param alert - The alert payload to display.
-   */
-  pushAlertEvent: (login: string, alert: AlertPayload) => void;
-}
-
-const alertRuntimeRegistry = createRuntimeRegistry<EventSubAlertRuntime>();
-
-/**
- * Register the alerts overlay push function. Called from index.ts before startWebPanel().
- * @param runtime - The {@link EventSubAlertRuntime} to store.
- * @returns void
- */
-export function registerEventSubAlertRuntime(runtime: EventSubAlertRuntime): void {
-  alertRuntimeRegistry.register(runtime);
-}
-
-// Runtime injection for the dashboard "Recent Events" push function — same rationale as
-// EventSubOverlayRuntime above. Registered from index.ts before startWebPanel(), since
-// pushDashboardEvent is just a function reference and doesn't require the HTTP server to
-// be running yet.
-/**
- * Public contract for the dashboard events runtime injection.
- * Passed to {@link registerEventSubDashboardRuntime} from index.ts.
- */
-interface EventSubDashboardRuntime {
-  /**
-   * Push a streamer activity event to the dashboard's "Recent Events" SSE stream.
-   * @param streamerId - DB row ID of the streamer whose dashboard to push to.
-   * @param event - The dashboard event payload to display.
-   */
-  pushDashboardEvent: (streamerId: number, event: import('../../web/routes/dashboardEvents').DashboardEvent) => void;
-}
-
-const dashboardEventRuntimeRegistry = createRuntimeRegistry<EventSubDashboardRuntime>();
-
-/**
- * Register the dashboard events push function. Called from index.ts before startWebPanel().
- * @param runtime - The {@link EventSubDashboardRuntime} to store.
- * @returns void
- */
-export function registerEventSubDashboardRuntime(runtime: EventSubDashboardRuntime): void {
-  dashboardEventRuntimeRegistry.register(runtime);
-}
-
-// Runtime injection for the Twitch chat send function — avoids a direct import
-// of twitchBot from core EventSub handler code.  Registered from index.ts.
-interface EventSubTwitchRuntime {
-  send: (channel: string, message: string) => Promise<void>;
-}
-
-const twitchRuntimeRegistry = createRuntimeRegistry<EventSubTwitchRuntime>();
-
-/**
- * Register the Twitch chat send function. Called from index.ts during initialisation,
- * before startTwitchBot(), so the runtime is in place before the first event arrives.
- *
- * @param runtime - The {@link EventSubTwitchRuntime} to store; must supply a `send` function
- *   that delivers a chat message to the given channel.
- * @returns void
- */
-export function registerEventSubTwitchRuntime(runtime: EventSubTwitchRuntime): void {
-  twitchRuntimeRegistry.register(runtime);
-}
 
 export interface FollowEvent {
   user_login: string;

--- a/src/twitch/eventsub/twitchEventSubRuntime.test.ts
+++ b/src/twitch/eventsub/twitchEventSubRuntime.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  registerEventSubOverlayRuntime, overlayRuntimeRegistry,
+  registerEventSubCompanionRuntime, companionRuntimeRegistry,
+  registerEventSubAlertRuntime, alertRuntimeRegistry,
+  registerEventSubDashboardRuntime, dashboardEventRuntimeRegistry,
+  registerEventSubTwitchRuntime, twitchRuntimeRegistry,
+} from './twitchEventSubRuntime';
+
+// createRuntimeRegistry's own register/get contract is covered by
+// commands/twitchRuntime.test.ts; these tests only confirm each
+// registerEventSub*Runtime function delegates to the right registry.
+
+describe('registerEventSubOverlayRuntime', () => {
+  it('stores the runtime on overlayRuntimeRegistry', () => {
+    const runtime = { pushOverlayEvent: vi.fn() };
+    registerEventSubOverlayRuntime(runtime);
+    expect(overlayRuntimeRegistry.get()).toBe(runtime);
+  });
+});
+
+describe('registerEventSubCompanionRuntime', () => {
+  it('stores the runtime on companionRuntimeRegistry', () => {
+    const runtime = { pushCompanionEvent: vi.fn() };
+    registerEventSubCompanionRuntime(runtime);
+    expect(companionRuntimeRegistry.get()).toBe(runtime);
+  });
+});
+
+describe('registerEventSubAlertRuntime', () => {
+  it('stores the runtime on alertRuntimeRegistry', () => {
+    const runtime = { pushAlertEvent: vi.fn() };
+    registerEventSubAlertRuntime(runtime);
+    expect(alertRuntimeRegistry.get()).toBe(runtime);
+  });
+});
+
+describe('registerEventSubDashboardRuntime', () => {
+  it('stores the runtime on dashboardEventRuntimeRegistry', () => {
+    const runtime = { pushDashboardEvent: vi.fn() };
+    registerEventSubDashboardRuntime(runtime);
+    expect(dashboardEventRuntimeRegistry.get()).toBe(runtime);
+  });
+});
+
+describe('registerEventSubTwitchRuntime', () => {
+  it('stores the runtime on twitchRuntimeRegistry', () => {
+    const runtime = { send: vi.fn().mockResolvedValue(undefined) };
+    registerEventSubTwitchRuntime(runtime);
+    expect(twitchRuntimeRegistry.get()).toBe(runtime);
+  });
+});

--- a/src/twitch/eventsub/twitchEventSubRuntime.ts
+++ b/src/twitch/eventsub/twitchEventSubRuntime.ts
@@ -1,0 +1,150 @@
+import type { AlertEventType, TextAnimation } from '../../db';
+import { createRuntimeRegistry } from '../../commands/twitchRuntime';
+
+// Runtime injection for the overlay push function — avoids a direct import of the
+// web layer from core Twitch handler code.  registerEventSubOverlayRuntime is called
+// from index.ts before startWebPanel(), which is safe because pushOverlayEvent is
+// just a function reference and does not require the HTTP server to be running.
+/**
+ * Public contract for the overlay runtime injection.
+ * Passed to {@link registerEventSubOverlayRuntime} from index.ts.
+ */
+interface EventSubOverlayRuntime {
+  /**
+   * Push an overlay event to the named channel's SSE stream.
+   * @param login - Broadcaster login name.
+   * @param videoPath - Server-relative path of the video to display.
+   */
+  pushOverlayEvent: (login: string, videoPath: string) => void;
+}
+
+export const overlayRuntimeRegistry = createRuntimeRegistry<EventSubOverlayRuntime>();
+
+/**
+ * Register the overlay push function. Called from index.ts after startWebPanel().
+ * @param runtime - The {@link EventSubOverlayRuntime} to store.
+ * @returns void
+ */
+export function registerEventSubOverlayRuntime(runtime: EventSubOverlayRuntime): void {
+  overlayRuntimeRegistry.register(runtime);
+}
+
+// Runtime injection for the companion app push function — same rationale as
+// EventSubOverlayRuntime above. Registered from index.ts before startWebPanel(),
+// since pushCompanionEvent is just a function reference and doesn't require the
+// HTTP server to be running yet.
+/**
+ * Public contract for the companion app runtime injection.
+ * Passed to {@link registerEventSubCompanionRuntime} from index.ts.
+ */
+interface EventSubCompanionRuntime {
+  /**
+   * Push a companion event to the named Discord user's SSE stream.
+   * @param discordId - Discord snowflake of the streamer who owns the redemption.
+   * @param event - The companion event payload to deliver.
+   */
+  pushCompanionEvent: (discordId: string, event: import('../../web/routes/companionEvents').CompanionEvent) => void;
+}
+
+export const companionRuntimeRegistry = createRuntimeRegistry<EventSubCompanionRuntime>();
+
+/**
+ * Register the companion app push function. Called from index.ts before startWebPanel().
+ * @param runtime - The {@link EventSubCompanionRuntime} to store.
+ * @returns void
+ */
+export function registerEventSubCompanionRuntime(runtime: EventSubCompanionRuntime): void {
+  companionRuntimeRegistry.register(runtime);
+}
+
+// Runtime injection for the alerts overlay push function — same rationale as
+// EventSubOverlayRuntime above. Registered from index.ts before startWebPanel(),
+// since pushAlertEvent is just a function reference and doesn't require the HTTP
+// server to be running yet.
+/** A customisable alert (follow/sub/resub/giftsub/raid) pushed to a streamer's alerts browser source. */
+export interface AlertPayload {
+  /** Which event type this alert is for. */
+  type: AlertEventType;
+  /** On-screen text, already filled from the streamer's message template. */
+  message: string;
+  /** Server-relative URL of the configured image/GIF, or null if none is set. */
+  imageUrl: string | null;
+  /** Server-relative URL of the configured sound, or null if none is set. */
+  soundUrl: string | null;
+  /** How long (ms) the alert should stay on screen. */
+  durationMs: number;
+  /** On-screen text animation style to apply to `message`. */
+  textAnimation: TextAnimation;
+}
+
+/**
+ * Public contract for the alerts overlay runtime injection.
+ * Passed to {@link registerEventSubAlertRuntime} from index.ts.
+ */
+interface EventSubAlertRuntime {
+  /**
+   * Push an alert to the named channel's alerts-overlay SSE stream.
+   * @param login - Broadcaster login name.
+   * @param alert - The alert payload to display.
+   */
+  pushAlertEvent: (login: string, alert: AlertPayload) => void;
+}
+
+export const alertRuntimeRegistry = createRuntimeRegistry<EventSubAlertRuntime>();
+
+/**
+ * Register the alerts overlay push function. Called from index.ts before startWebPanel().
+ * @param runtime - The {@link EventSubAlertRuntime} to store.
+ * @returns void
+ */
+export function registerEventSubAlertRuntime(runtime: EventSubAlertRuntime): void {
+  alertRuntimeRegistry.register(runtime);
+}
+
+// Runtime injection for the dashboard "Recent Events" push function — same rationale as
+// EventSubOverlayRuntime above. Registered from index.ts before startWebPanel(), since
+// pushDashboardEvent is just a function reference and doesn't require the HTTP server to
+// be running yet.
+/**
+ * Public contract for the dashboard events runtime injection.
+ * Passed to {@link registerEventSubDashboardRuntime} from index.ts.
+ */
+interface EventSubDashboardRuntime {
+  /**
+   * Push a streamer activity event to the dashboard's "Recent Events" SSE stream.
+   * @param streamerId - DB row ID of the streamer whose dashboard to push to.
+   * @param event - The dashboard event payload to display.
+   */
+  pushDashboardEvent: (streamerId: number, event: import('../../web/routes/dashboardEvents').DashboardEvent) => void;
+}
+
+export const dashboardEventRuntimeRegistry = createRuntimeRegistry<EventSubDashboardRuntime>();
+
+/**
+ * Register the dashboard events push function. Called from index.ts before startWebPanel().
+ * @param runtime - The {@link EventSubDashboardRuntime} to store.
+ * @returns void
+ */
+export function registerEventSubDashboardRuntime(runtime: EventSubDashboardRuntime): void {
+  dashboardEventRuntimeRegistry.register(runtime);
+}
+
+// Runtime injection for the Twitch chat send function — avoids a direct import
+// of twitchBot from core EventSub handler code.  Registered from index.ts.
+interface EventSubTwitchRuntime {
+  send: (channel: string, message: string) => Promise<void>;
+}
+
+export const twitchRuntimeRegistry = createRuntimeRegistry<EventSubTwitchRuntime>();
+
+/**
+ * Register the Twitch chat send function. Called from index.ts during initialisation,
+ * before startTwitchBot(), so the runtime is in place before the first event arrives.
+ *
+ * @param runtime - The {@link EventSubTwitchRuntime} to store; must supply a `send` function
+ *   that delivers a chat message to the given channel.
+ * @returns void
+ */
+export function registerEventSubTwitchRuntime(runtime: EventSubTwitchRuntime): void {
+  twitchRuntimeRegistry.register(runtime);
+}

--- a/src/twitch/eventsub/twitchEventSubRuntime.ts
+++ b/src/twitch/eventsub/twitchEventSubRuntime.ts
@@ -21,7 +21,7 @@ interface EventSubOverlayRuntime {
 export const overlayRuntimeRegistry = createRuntimeRegistry<EventSubOverlayRuntime>();
 
 /**
- * Register the overlay push function. Called from index.ts after startWebPanel().
+ * Register the overlay push function. Called from index.ts before startWebPanel().
  * @param runtime - The {@link EventSubOverlayRuntime} to store.
  * @returns void
  */

--- a/src/web/routes/alertsOverlaySource.ts
+++ b/src/web/routes/alertsOverlaySource.ts
@@ -1,7 +1,7 @@
 import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import fs from 'fs';
-import type { AlertPayload } from '../../twitch/eventsub/twitchEventSubHandler';
+import type { AlertPayload } from '../../twitch/eventsub/twitchEventSubRuntime';
 import { ALERT_ASSETS_FOLDER, ALERT_MAX_SSE_PER_CHANNEL } from '../../shared/config';
 import { safeResolve } from '../../shared/pathUtils';
 import { renderView } from './shared';


### PR DESCRIPTION
## Summary

`src/twitch/eventsub/twitchEventSubHandler.ts` had grown to 578 lines mixing two unrelated concerns: runtime-injection plumbing (five separate registry/register-function pairs for overlay, companion, alerts, dashboard, and Twitch-chat push targets) and the actual EventSub event handlers (`handleFollow`, `handleSub`, `handleResub`, `handleGiftSub`, `handleRaid`, `handleRedemption`, `handleStreamOnline/Offline`, `handleChannelUpdate`).

This splits the file along that seam, mirroring the existing `commandMutations`/`commandAssignments` split pattern already used elsewhere in the codebase:

- **`src/twitch/eventsub/twitchEventSubRuntime.ts`** (new) — the five runtime registries, their `registerEventSub*Runtime` functions, the `AlertPayload` interface, and the runtime-contract interfaces.
- **`src/twitch/eventsub/twitchEventSubHandler.ts`** (trimmed, 578 → 436 lines) — keeps the event-payload interfaces, `tierName`, the shared side-effect helpers (`sendChatMessage`, `maybePushAlert`, `recordAndPushDashboardEvent`), and all `handle*` functions, now importing the registries from the new runtime module.

No behaviour change. Updated the handful of call sites that imported `register*Runtime`/`AlertPayload` from the old location (`src/index.ts`, `src/index.test.ts`, `src/web/routes/alertsOverlaySource.ts`) to point at the new file directly rather than leaving a re-export shim.

Added `twitchEventSubRuntime.test.ts` covering each `registerEventSub*Runtime` function's delegation to its registry (the underlying `createRuntimeRegistry` contract is already covered by `commands/twitchRuntime.test.ts`).

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` — all 2860 tests pass (154 test files)
- [x] Verified no other file still imports `register*Runtime`/`AlertPayload` from the old `twitchEventSubHandler` path (only `handle*` function/type imports remain there, which is correct)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RXwu6hM72Ci5bQknDU6Mht)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Centralized EventSub runtime registration and handling.
  - Preserved existing overlay, alert, dashboard, companion, and chat event behavior.

- **Tests**
  - Added coverage verifying runtime registrations are correctly connected.
  - Updated startup and handler tests to use the centralized runtime setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->