### PR TITLE
Fix stale CSS on first page load after a deploy

### DIFF
--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -177,6 +177,14 @@ describe('server route wiring', () => {
   });
 });
 
+describe('static assets', () => {
+  it('sends Cache-Control: no-cache so browsers always revalidate against the server', async () => {
+    const res = await request(app).get('/style.css');
+    expect(res.status).toBe(200);
+    expect(res.headers['cache-control']).toBe('no-cache');
+  });
+});
+
 describe('CSP header', () => {
   it('restricts font-src to self, without falling back to helmet defaults', async () => {
     const res = await request(app).get('/__marker_dashboard');

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -92,8 +92,18 @@ app.set('views', path.join(__dirname, '../../views'));
 // serviceWorker.ts) takes effect instead of the raw, unsubstituted file on disk.
 app.use(serviceWorkerRouter);
 
-// Static assets
-app.use(express.static(path.join(__dirname, '../../public')));
+// Static assets. `Cache-Control: no-cache` forces revalidation (via the ETag express.static
+// already sends) on every request rather than letting browsers serve a stale copy from
+// heuristic HTTP caching — without it, a deploy's new CSS/JS can be masked both for plain
+// page loads and for the service worker's own cache-busting fetches in install (see
+// serviceWorker.ts), since those fetches would otherwise also read from the stale HTTP cache.
+app.use(
+  express.static(path.join(__dirname, '../../public'), {
+    setHeaders: (res) => {
+      res.setHeader('Cache-Control', 'no-cache');
+    },
+  }),
+);
 
 // Rate limiting — applied after static assets so file downloads aren't counted
 const generalLimiter = rateLimit({

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -99,6 +99,7 @@ app.use(serviceWorkerRouter);
 // serviceWorker.ts), since those fetches would otherwise also read from the stale HTTP cache.
 app.use(
   express.static(path.join(__dirname, '../../public'), {
+    /** Forces revalidation on every static asset response instead of allowing heuristic HTTP caching. */
     setHeaders: (res) => {
       res.setHeader('Cache-Control', 'no-cache');
     },


### PR DESCRIPTION
## Summary

Users reported that the first time a page loads on a device after an update, it renders with the old CSS until manually refreshed.

Root cause: `express.static` (`src/web/server.ts`) sent no explicit `Cache-Control` header, so browsers could serve `/style.css` from their HTTP disk cache via heuristic freshness without ever asking the server. This also poisoned the service worker's own cache-busting: `public/service-worker.js` hashes `public/` at startup to pick a fresh cache name on deploy, but its `install` handler's `cache.addAll` fetches were subject to the same stale HTTP cache, so the new service-worker cache could still get seeded with old CSS bytes.

## Change

- `src/web/server.ts`: pass `setHeaders` to `express.static` to send `Cache-Control: no-cache` on every static asset, forcing revalidation (via the existing ETag) on every request instead of allowing heuristic caching. This mirrors the pattern already used for `/service-worker.js` in `serviceWorker.ts`.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 2857 tests passing)
- [x] Added `src/web/server.test.ts` coverage asserting `/style.css` responds with `Cache-Control: no-cache`


---
_Generated by [Claude Code](https://claude.ai/code/session_013cEhy5uu9BeFKza45UMvHy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated static asset delivery to ensure browsers revalidate files and receive the latest versions.
  * Reduced the likelihood of outdated styles or other public assets being displayed after updates.

* **Tests**
  * Added coverage verifying that static assets are served with the appropriate cache-control behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->