### PR TITLE
Fix controller overlay OBS scrollbars

### DIFF
--- a/public/controllerOverlay.css
+++ b/public/controllerOverlay.css
@@ -1,6 +1,6 @@
 * { box-sizing: border-box; margin: 0; padding: 0; }
 html, body { background: transparent; }
-#root { position: relative; display: inline-block; vertical-align: bottom; padding: 6px; font-family: 'Segoe UI', sans-serif; }
+#root { position: relative; display: inline-block; vertical-align: bottom; padding: 8px; font-family: 'Segoe UI', sans-serif; }
 #status { position: absolute; z-index: 10; top: 50%; left: 50%; transform: translate(-50%, -50%); white-space: nowrap; text-align: center; font-size: 16px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: #ffffff; background: rgba(0,0,0,0.85); border: 1px solid rgba(255,255,255,0.15); padding: 10px 20px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.5); }
 #status.connected { visibility: hidden; }
 #ctrl { display: block; }

--- a/public/controllerOverlay.css
+++ b/public/controllerOverlay.css
@@ -1,6 +1,6 @@
 * { box-sizing: border-box; margin: 0; padding: 0; }
 html, body { background: transparent; }
-#root { position: relative; display: inline-block; padding: 6px; font-family: 'Segoe UI', sans-serif; }
+#root { position: relative; display: inline-block; vertical-align: bottom; padding: 6px; font-family: 'Segoe UI', sans-serif; }
 #status { position: absolute; z-index: 10; top: 50%; left: 50%; transform: translate(-50%, -50%); white-space: nowrap; text-align: center; font-size: 16px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; color: #ffffff; background: rgba(0,0,0,0.85); border: 1px solid rgba(255,255,255,0.15); padding: 10px 20px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.5); }
 #status.connected { visibility: hidden; }
 #ctrl { display: block; }

--- a/views/controllerAdmin.ejs
+++ b/views/controllerAdmin.ejs
@@ -19,7 +19,7 @@
         <div class="card-body">
           <p class="hint hint-compact">Add this URL as a Browser Source in OBS to display a gamepad input visualiser (throttle, brake, steering, handbrake):</p>
           <code class="mono overlay-url-display"><%= baseUrl %>/overlay/controller</code>
-          <p class="hint mt-05">Works with any Xbox / PlayStation / generic controller. Transparent background — native size is <strong>332&times;212px</strong> (set the OBS browser source to these dimensions, then scale to taste).</p>
+          <p class="hint mt-05">Works with any Xbox / PlayStation / generic controller. Transparent background — native size is <strong>336&times;216px</strong> (set the OBS browser source to these dimensions, then scale to taste).</p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- The controller overlay's documented size (332×212px) was correct for the visible artwork, but the page actually rendered 216px tall — 4px too tall — because `#root` is `display: inline-block` with no `vertical-align` set, which reserves descender space below it in `body`'s inline formatting context (the classic "phantom gap under inline-block" bug).
- Fixed by adding `vertical-align: bottom` to `#root`. Headless-browser measurement confirmed this alone brings `html`/`body` from 332×216 down to exactly 332×212.
- However, real-world testing in OBS (reported by the user) showed that setting the browser source to exactly 332×212 still produced scrollbars — OBS's CEF renderer substitutes different font metrics than the browser used for measurement, which can reintroduce a few px of descender gap even with `vertical-align: bottom`. The user confirmed empirically that padding the source out by 4px in each dimension (336×216) eliminates the scrollbars reliably.
- To make that margin part of the contract instead of relying on users manually padding their OBS source, `#root`'s padding was bumped 6px→8px, making the *documented* native size 336×216 — an exact, reproducible value with a built-in safety margin against font-substitution differences, rather than the previous value that only held under one specific renderer's metrics.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (2861 tests pass)
- [x] Measured rendered `html`/`body` dimensions in a headless Chromium page before/after each change to confirm the target dimensions are hit exactly (332×212, then 336×216)
- [x] User confirmed in real OBS that 336×216 removes the scrollbars that 332×212 still showed


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gacc9pCbXLJVooGm9bkqBC)_