### PR TITLE
Remove CSRF token acceptance via query string

### DIFF
--- a/src/web/csrf.test.ts
+++ b/src/web/csrf.test.ts
@@ -109,13 +109,19 @@ describe('csrfProtection — X-CSRF-Token falls back to X-XSRF-Token when empty'
   });
 });
 
-describe('csrfProtection — query takes priority over body and header', () => {
-  it('uses query token when query, body, and header tokens are all present', async () => {
+describe('csrfProtection — query string token is ignored', () => {
+  it('uses body token and ignores a wrong query token when both are present', async () => {
     const res = await supertest(buildApp())
-      .post(`/test?_csrf=${SESSION_TOKEN}`)
-      .send('_csrf=wrong-body-token')
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .set('X-CSRF-Token', 'wrong-header-token');
+      .post('/test?_csrf=wrong-query-token')
+      .send(`_csrf=${SESSION_TOKEN}`)
+      .set('Content-Type', 'application/x-www-form-urlencoded');
     expect(res.status).toBe(200);
+  });
+
+  it('rejects a request with only a (even correct) query token and no body/header token', async () => {
+    const res = await supertest(buildApp())
+      .post(`/test?_csrf=${SESSION_TOKEN}`);
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('EBADCSRFTOKEN');
   });
 });

--- a/src/web/csrf.ts
+++ b/src/web/csrf.ts
@@ -24,8 +24,6 @@ export function ensureSessionCsrfToken(req: Parameters<RequestHandler>[0]): stri
 }
 
 function getSubmittedCsrfToken(req: Parameters<RequestHandler>[0]): string | null {
-  // Query param checked first — available before multipart body parsing (Multer).
-  if (typeof req.query?._csrf === 'string') return req.query._csrf;
   if (typeof req.body?._csrf === 'string') return req.body._csrf;
   const xcsrf = req.headers['x-csrf-token'];
   const header = (typeof xcsrf === 'string' && xcsrf.trim() !== '') ? xcsrf : req.headers['x-xsrf-token'];
@@ -38,10 +36,13 @@ function getSubmittedCsrfToken(req: Parameters<RequestHandler>[0]): string | nul
  * Safe methods (GET, HEAD, OPTIONS) pass through unconditionally.
  *
  * For unsafe methods the submitted token is resolved in this priority order:
- * 1. Query parameter `_csrf`
- * 2. Form/JSON body field `_csrf`
- * 3. `X-CSRF-Token` header (ignored when empty)
- * 4. `X-XSRF-Token` header
+ * 1. Form/JSON body field `_csrf`
+ * 2. `X-CSRF-Token` header (ignored when empty)
+ * 3. `X-XSRF-Token` header
+ *
+ * The query string is deliberately not checked — a CSRF token placed in a URL
+ * can leak via server access logs, browser history, and the `Referer` header
+ * sent to third-party resources the page subsequently loads.
  *
  * The submitted token must match the session's `csrfToken` via constant-time
  * comparison. Mismatches call `next` with an error bearing `code: 'EBADCSRFTOKEN'`.


### PR DESCRIPTION
## Summary

`getSubmittedCsrfToken` in `src/web/csrf.ts` checked `req.query._csrf` before the request body or headers, for every unsafe HTTP method. This is a CSRF-token-leakage hardening fix that removes that path.

- The query-string acceptance path was **dead code from every real client's perspective** — every actual upload/form flow in the app deliberately avoids the query string and sends the token via the request body (hidden `_csrf` form field) or an `X-CSRF-Token` header instead, specifically to keep the secret out of the URL. This is already documented in several places in the codebase:
  - `views/overlayAdmin.ejs` (video-upload form)
  - `public/sfx.js` (sound upload)
  - `public/utils.js`
  - `src/web/routes/sfxFileUpload.ts`
- Accepting `_csrf` via the query string was also a live foot-gun: a CSRF token embedded in a URL can leak via server access logs, browser history, and the `Referer` header sent to any third-party resource the page subsequently loads — directly contradicting the app's own stated design goal in the comments above.

## Changes

- Removed the `req.query._csrf` branch from `getSubmittedCsrfToken`. It now falls through to body, then `X-CSRF-Token` header, then `X-XSRF-Token` header.
- Updated the `csrfProtection` JSDoc to reflect the new 3-step priority order and documented the reasoning for excluding the query string.
- Rewrote the `csrf.test.ts` test that previously asserted "query takes priority over body and header" to instead assert the query token is **ignored**:
  - a request with a wrong/garbage `_csrf` query param but a valid token in the body now succeeds (body token is used).
  - a request with only a (even valid-looking) query param and no body/header token is now rejected.

## Verification

- `npx tsc --noEmit` — passes.
- `npm test` — all 154 test files / 2867 tests pass, including the full `csrf.test.ts` suite (12 tests).
- Grepped the repo for `_csrf` across `.ejs`/`.js`/`.ts` files (excluding `node_modules`) to confirm no client code relies on the query string for the CSRF token. Every occurrence is either a hidden form field (submitted in the request body) or a header/JSON-body usage — none use `?_csrf=`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPTsSjNQC2YRRNkKzmxYba)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CSRF validation now ignores tokens supplied in query strings.
  * Requests use tokens from the form or JSON body, followed by supported request headers.
  * Requests with only a query-string token are rejected, while valid body tokens continue to work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->