### PR TITLE
Fix LiveStateMap evicting sibling entries for multi-group streamers

### DIFF
--- a/src/twitch/monitor/twitchMonitorTypes.test.ts
+++ b/src/twitch/monitor/twitchMonitorTypes.test.ts
@@ -153,29 +153,37 @@ describe('LiveStateMap', () => {
     expect(map.has('10')).toBe(false);
   });
 
-  it('set() evicts a stale entry under a different key when the same login moves without delete()', () => {
-    // A login moving from key "10" to key "11" (a streamer re-registering under a new DB
-    // row id) without an intervening delete("10") must not leave two Map entries for the
-    // same login.
+  it('set() for the same login under two different keys leaves both entries coexisting', () => {
+    // The same Twitch login can be registered as a streamer in more than one Discord stream
+    // group at once, so each group's DB row id (map key) must keep its own independent
+    // LiveState — a second set() for the same login must NOT evict the first key's entry.
     const map = new LiveStateMap();
     const first = makeState({ login: 'alice' });
     const second = makeState({ login: 'alice' });
     map.set('10', first);
     map.set('11', second);
 
+    expect(map.has('10')).toBe(true);
+    expect(map.has('11')).toBe(true);
+    expect(map.get('10')).toBe(first);
+    expect(map.get('11')).toBe(second);
+    expect(map.size).toBe(2);
+
+    const byLogin = map.getByLogin('alice');
+    expect([first, second]).toContain(byLogin);
+  });
+
+  it('delete on one key of a shared login leaves the other key untouched', () => {
+    const map = new LiveStateMap();
+    const first = makeState({ login: 'alice' });
+    const second = makeState({ login: 'alice' });
+    map.set('10', first);
+    map.set('11', second);
+    map.delete('10');
+
     expect(map.has('10')).toBe(false);
     expect(map.get('11')).toBe(second);
     expect(map.getByLogin('alice')).toBe(second);
-    expect(map.size).toBe(1);
-  });
-
-  it('delete on a key already evicted by a later set() is a harmless no-op', () => {
-    const map = new LiveStateMap();
-    map.set('10', makeState({ login: 'alice' }));
-    map.set('11', makeState({ login: 'alice' })); // evicts key "10" already
-    map.delete('10');
-
-    expect(map.getByLogin('alice')).toBe(map.get('11'));
     expect(map.size).toBe(1);
   });
 
@@ -186,5 +194,21 @@ describe('LiveStateMap', () => {
 
     expect(map.size).toBe(0);
     expect(map.getByLogin('alice')).toBeUndefined();
+  });
+
+  it('regression: a streamer going live in two Discord groups in the same poll tick keeps both group entries independently', () => {
+    // Simulates dispatchStreamerPolls() processing two group-rows for the same Twitch login
+    // within one poll tick: the first group's set() must not be evicted when the second
+    // group's set() runs, and vice versa.
+    const map = new LiveStateMap();
+    const groupOneState = makeState({ login: 'alice', streamerId: 10, groupId: 1 });
+    const groupTwoState = makeState({ login: 'alice', streamerId: 11, groupId: 2 });
+
+    map.set('10', groupOneState);
+    map.set('11', groupTwoState);
+
+    expect(map.get('10')).toBe(groupOneState);
+    expect(map.get('11')).toBe(groupTwoState);
+    expect(map.size).toBe(2);
   });
 });

--- a/src/twitch/monitor/twitchMonitorTypes.ts
+++ b/src/twitch/monitor/twitchMonitorTypes.ts
@@ -36,49 +36,66 @@ export function makeLiveState(
 
 /**
  * A `Map<string, LiveState>` keyed by streamer DB row id, that also maintains a private
- * `login -> key` index so a state can be looked up by its (lowercased) Twitch login in O(1)
- * instead of a linear scan over every entry. Structurally compatible with plain
- * `Map<string, LiveState>` — every other module's `.get`/`.has`/`.values()`/`.entries()` calls
- * keep working unchanged; only `getByLogin` is new.
+ * `login -> key set` index so a state can be looked up by its (lowercased) Twitch login in O(1)
+ * instead of a linear scan over every entry. The same Twitch login can legitimately back more
+ * than one map entry at once — a streamer can be registered as a streamer in multiple Discord
+ * stream groups simultaneously, each with its own DB row id / map key — so the index maps a
+ * login to the set of *all* keys currently holding it, not a single key. Structurally
+ * compatible with plain `Map<string, LiveState>` — every other module's
+ * `.get`/`.has`/`.values()`/`.entries()` calls keep working unchanged; only `getByLogin` is new.
  */
 export class LiveStateMap extends Map<string, LiveState> {
-  private readonly loginIndex = new Map<string, string>();
+  private readonly loginIndex = new Map<string, Set<string>>();
 
   /**
-   * Sets the entry for `key`, keeping the login index in sync: cleans up `key`'s previous
-   * login (if any), and evicts any stale entry under a *different* key that previously held
-   * `value.login` — so a login can never resolve to two `Map` entries, even if the caller
-   * moves a login to a new key without an intervening `delete()`.
+   * Sets the entry for `key`, keeping the login index in sync: if `key` previously held a
+   * *different* login, removes `key` from that old login's key set (pruning the set entirely
+   * if it becomes empty), then adds `key` to `value.login`'s key set. Does NOT remove any other
+   * key already registered under `value.login` — multiple keys legitimately sharing a login
+   * (one per Discord stream group the streamer is registered in) must coexist.
    * @param key Streamer DB row id.
-   * @param value Live state to store; `value.login` becomes the login index's target for `key`.
+   * @param value Live state to store; `value.login` gains `key` as one of its index targets.
    * @returns This map, per the standard `Map.set` contract.
    */
   override set(key: string, value: LiveState): this {
     const existingAtKey = this.get(key);
-    if (existingAtKey && existingAtKey.login !== value.login && this.loginIndex.get(existingAtKey.login) === key) {
-      this.loginIndex.delete(existingAtKey.login);
+    if (existingAtKey && existingAtKey.login !== value.login) {
+      const oldLoginKeys = this.loginIndex.get(existingAtKey.login);
+      if (oldLoginKeys) {
+        oldLoginKeys.delete(key);
+        if (oldLoginKeys.size === 0) {
+          this.loginIndex.delete(existingAtKey.login);
+        }
+      }
     }
 
-    const previousKeyForLogin = this.loginIndex.get(value.login);
-    if (previousKeyForLogin !== undefined && previousKeyForLogin !== key) {
-      super.delete(previousKeyForLogin);
+    let loginKeys = this.loginIndex.get(value.login);
+    if (!loginKeys) {
+      loginKeys = new Set<string>();
+      this.loginIndex.set(value.login, loginKeys);
     }
+    loginKeys.add(key);
 
     super.set(key, value);
-    this.loginIndex.set(value.login, key);
     return this;
   }
 
   /**
-   * Deletes the entry for `key`, removing its login index entry if the index still points at
-   * `key` (it may not, if a later `set()` already moved that login to a different key).
+   * Deletes the entry for `key`, removing it from its login's key set (pruning the set entirely
+   * if it becomes empty as a result).
    * @param key Streamer DB row id to remove.
    * @returns True if an entry for `key` existed and was removed, per the standard `Map.delete` contract.
    */
   override delete(key: string): boolean {
     const existing = this.get(key);
-    if (existing && this.loginIndex.get(existing.login) === key) {
-      this.loginIndex.delete(existing.login);
+    if (existing) {
+      const loginKeys = this.loginIndex.get(existing.login);
+      if (loginKeys) {
+        loginKeys.delete(key);
+        if (loginKeys.size === 0) {
+          this.loginIndex.delete(existing.login);
+        }
+      }
     }
     return super.delete(key);
   }
@@ -89,9 +106,20 @@ export class LiveStateMap extends Map<string, LiveState> {
     this.loginIndex.clear();
   }
 
-  /** Looks up the live state for a (lowercased) Twitch login in O(1), or undefined if not live. */
+  /**
+   * Looks up a live state for a (lowercased) Twitch login in O(1), or undefined if not live.
+   * A login may back multiple map entries at once (one per Discord stream group the streamer is
+   * registered in); this returns an arbitrary one of them without disambiguating by group —
+   * callers needing a specific group's state should look it up by key (DB row id) instead.
+   * @param login Lowercased Twitch login to look up.
+   * @returns Any one `LiveState` currently registered under `login`, or undefined if none.
+   */
   getByLogin(login: string): LiveState | undefined {
-    const key = this.loginIndex.get(login);
-    return key === undefined ? undefined : this.get(key);
+    const keys = this.loginIndex.get(login);
+    if (!keys) {
+      return undefined;
+    }
+    const firstKey = keys.values().next().value;
+    return firstKey === undefined ? undefined : this.get(firstKey);
   }
 }


### PR DESCRIPTION
## Bug

`LiveStateMap` (`src/twitch/monitor/twitchMonitorTypes.ts`) maintained a private `loginIndex: Map<login, key>` assuming a Twitch login maps to at most one map key (streamer DB row id) at a time. Its `set()` explicitly evicted any *other* map entry sharing the new entry's `login`:

```ts
const previousKeyForLogin = this.loginIndex.get(value.login);
if (previousKeyForLogin !== undefined && previousKeyForLogin !== key) {
  super.delete(previousKeyForLogin);   // evicts a sibling group's live-state entry
}
```

That assumption is false: `addStreamer()` (`src/db/streamMonitor.ts`) allows the same Twitch account to be registered as a streamer in more than one Discord stream group simultaneously, and the rest of the monitor is explicitly built around that:

- `postAnnouncement()` (`src/twitch/monitor/twitchMonitorAnnouncements.ts`) keys live-state "by DB row id so each streamer×group pair has independent state".
- `handleStreamOffline()` / `cancelOfflineTimersForLogin()` (`src/twitch/monitor/twitchMonitorOffline.ts`) both iterate "all state entries for this login (one per group)".
- `dispatchStreamerPolls()` (`src/twitch/monitor/twitchMonitorPoll.ts`) processes every group-row for a given login sequentially within one poll tick.

Net effect: the moment a multi-group streamer went live, processing the second group's row called `liveStates.set(secondGroupKey, ...)`, which silently deleted the first group's map entry. On the next poll tick, the first group's `handleLiveStreamer()` saw `isNew = !liveStates.has(stateKey) === true` again and reposted a duplicate "now live" Discord announcement — repeating every tick indefinitely — while the original announcement message for that group was never edited or cleaned up when the streamer eventually went offline (an orphaned message).

## Fix

Changed `loginIndex` from a one-to-one `Map<string, string>` (login → single key) to a one-to-many `Map<string, Set<string>>` (login → set of keys), in `src/twitch/monitor/twitchMonitorTypes.ts`:

- `set(key, value)`: if `key` previously held a *different* login, still cleans up that old login→key association (pruning the login's set if it becomes empty) — that part of the original logic was correct and preserved (a single key legitimately changing which login it represents should still clean up after itself). It then adds `key` to `value.login`'s key set, **without removing any other key already registered under that login**.
- `delete(key)`: removes `key` from its login's key set (pruning the set if now empty).
- `clear()`: unchanged in spirit — clears both the map and the index.
- `getByLogin(login)`: signature and return type (`LiveState | undefined`) unchanged. Its only caller, `getMultiTwitchDataForChannel()` in `src/twitch/monitor/twitchMonitor.ts`, doesn't disambiguate by group and just needs *a* live state for the login — it now returns an arbitrary one of the set's entries. This PR is scoped to stopping the eviction bug, not redesigning that function's per-group semantics.

## Tests

`src/twitch/monitor/twitchMonitorTypes.test.ts`:
- Rewrote the two tests that asserted the old (buggy) eviction behavior to instead assert coexistence: setting two different keys under the same login now leaves both entries present (`size` 2), and `getByLogin` returns one of them.
- Added an explicit regression test simulating the real-world scenario: the same streamer going live in two Discord groups within one poll tick (two `set()` calls, same login, different keys) — asserts both entries remain independently retrievable via `get()` afterward.
- Kept all other existing `LiveStateMap` tests passing unchanged (`getByLogin` unknown login, normal `Map` behavior, `delete` removing the login index entry, `clear` emptying both, and the single-key-changes-login case).

## Verification

- `npx tsc --noEmit && npm test` — both pass; full suite is 154 test files / 2867 tests, all green.
- `grep -rn "loginIndex\|LiveStateMap" src/` confirms no other file reaches into `loginIndex` internals — `src/twitch/monitor/twitchMonitor.ts` only uses the public `getByLogin()` API, which keeps its signature.

No PR template exists in this repo, so this description follows the standard format.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KPTsSjNQC2YRRNkKzmxYba)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed live-state tracking so the same Twitch login can appear across multiple entries without one replacing another.
  * Deleting one entry now preserves other entries associated with the same login.
  * Improved handling of multiple group updates for the same Twitch login during a single polling cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->