### PR TITLE
Guard counterScheduler against double-start

### DIFF
--- a/src/commands/counterScheduler.test.ts
+++ b/src/commands/counterScheduler.test.ts
@@ -87,6 +87,28 @@ describe('counterScheduler', () => {
     expect(archiveAndResetYearlyCounters).toHaveBeenNthCalledWith(2, 2024);
   });
 
+  it('does not leak a duplicate tick chain when started twice without stopping', async () => {
+    vi.setSystemTime(new Date(2025, 0, 1)); // Jan 1, 2025
+    startCounterScheduler();
+    startCounterScheduler(); // second call should no-op, not kick off a second tick() chain
+    await flushAsync();
+
+    // If the second call had leaked a duplicate chain, this would be 2.
+    expect(archiveAndResetYearlyCounters).toHaveBeenCalledTimes(1);
+
+    // Advance an hour; only one timer chain should be pending, so only one more poll fires.
+    await vi.advanceTimersByTimeAsync(3_600_000);
+    await flushAsync();
+
+    // Still Jan 1, lastArchivedYear already set — no additional archive call either way,
+    // but a leaked second chain would have logged/scheduled independently. Confirm the
+    // scheduler can still be fully stopped with a single stopCounterScheduler() call.
+    stopCounterScheduler();
+    await vi.advanceTimersByTimeAsync(7_200_000);
+    await flushAsync();
+    expect(archiveAndResetYearlyCounters).toHaveBeenCalledTimes(1);
+  });
+
   it('stopCounterScheduler prevents further ticks', async () => {
     vi.setSystemTime(new Date(2025, 5, 15)); // June 15 — no archive expected
     startCounterScheduler();

--- a/src/commands/counterScheduler.ts
+++ b/src/commands/counterScheduler.ts
@@ -9,6 +9,11 @@ const POLL_INTERVAL_MS = 3_600_000;
 
 let schedulerTimer: ReturnType<typeof setTimeout> | null = null;
 let lastArchivedYear: number | null = null;
+// Set synchronously in startCounterScheduler(), before tick() does any async work.
+// schedulerTimer itself isn't assigned until tick()'s async work completes, so it can't be
+// used as the re-entrancy guard: two synchronous back-to-back start calls would both see it
+// as null and both kick off a tick() chain. This flag closes that gap.
+let started = false;
 
 async function tick(): Promise<void> {
   const now = new Date();
@@ -31,13 +36,22 @@ async function tick(): Promise<void> {
   );
 }
 
+/**
+ * Starts the hourly counter-archive poll. Call once at bot startup.
+ * No-ops if already started, so a second call can't leak a duplicate self-perpetuating
+ * `setTimeout` chain that `stopCounterScheduler()` wouldn't be able to fully cancel.
+ */
 export function startCounterScheduler(): void {
+  if (started) return;
+  started = true;
   tick().catch((err) => log.error('Startup error:', err));
   const hoursUntil = Math.round(msUntilNextJan1() / 3_600_000);
   log.info(`Started — polling hourly, next yearly archive in ~${hoursUntil}h.`);
 }
 
+/** Stops the hourly counter-archive poll, cancelling any pending timer. */
 export function stopCounterScheduler(): void {
+  started = false;
   if (schedulerTimer !== null) {
     clearTimeout(schedulerTimer);
     schedulerTimer = null;


### PR DESCRIPTION
## Summary
- `src/commands/counterScheduler.ts`'s `startCounterScheduler()` had no re-entrancy guard, unlike its sibling `rewardPricingScheduler.ts`'s `startRewardPricingScheduler()`.
- A second call would leak a duplicate self-perpetuating `tick()`/`setTimeout` chain that `stopCounterScheduler()` can't fully cancel, since it only tracks the single most-recently-assigned `schedulerTimer` handle.
- Only one call site exists today (`src/index.ts`), so this isn't exploitable currently — this is small defensive hardening to bring the scheduler in line with its sibling, flagged in code review.

## Details
`schedulerTimer` is only assigned inside `tick()` after its async work settles — not synchronously inside `startCounterScheduler()` — so a naive `if (schedulerTimer !== null) return;` guard wouldn't stop two synchronous back-to-back calls (both would see `schedulerTimer` as `null` and both would kick off a `tick()` chain). `rewardPricingScheduler.ts` avoids this because `setInterval` assigns its handle synchronously.

Added a separate `started` boolean, set synchronously before `tick()` runs, closing that race. `stopCounterScheduler()` resets it.

## Test plan
- [x] `npx tsc --noEmit` — passes
- [x] `npm test` — all 154 test files / 2867 tests pass
- [x] Added `does not leak a duplicate tick chain when started twice without stopping` to `counterScheduler.test.ts`, mirroring `rewardPricingScheduler.test.ts`'s equivalent double-start test — calls `startCounterScheduler()` twice synchronously and asserts `archiveAndResetYearlyCounters` is only invoked once, then confirms a single `stopCounterScheduler()` call still fully cancels the chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPTsSjNQC2YRRNkKzmxYba

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPTsSjNQC2YRRNkKzmxYba)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate scheduler runs when the counter scheduler is started multiple times.
  * Ensured stopping the scheduler fully cancels future polling.
  * Restored the ability to restart the scheduler cleanly after stopping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->