### PR TITLE
Parse SFX upload trigger_id as bigint, matching sfxTriggerMutations.ts

### DIFF
--- a/src/web/routes/sfxFileUpload.ts
+++ b/src/web/routes/sfxFileUpload.ts
@@ -8,7 +8,7 @@ import { csrfProtection } from '../csrf';
 import { requireMod } from '../middleware';
 import { SFX_FOLDER, SFX_MAX_FILE_MB } from '../../shared/config';
 import { safeResolve } from '../../shared/pathUtils';
-import { parsePositiveIntId, createMulterErrorRedirectHandler, makeUploadMiddleware, parseCheckboxField } from './shared';
+import { parsePositiveIntId, parsePositiveBigIntId, createMulterErrorRedirectHandler, makeUploadMiddleware, parseCheckboxField } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
@@ -156,20 +156,20 @@ async function storeUploadedSound(
  * Persist an already-stored sound file's DB row. On failure, rolls back the
  * on-disk file (guarding the cleanup itself so a failed `rm()` can't escape
  * this function and turn the caller's intended redirect into a 500).
- * @param triggerId Owning trigger id.
+ * @param triggerId Owning trigger id (bigint — `sfxtrigger.id` is a BIGINT column).
  * @param storedName Relative filename already written under SFX_FOLDER.
  * @param weight Weighted-random selection weight.
  * @param hidden Whether the file is hidden from the public listing.
  * @returns true on success, false if the DB insert failed (and was rolled back).
  */
 async function persistUploadedSound(
-  triggerId: number,
+  triggerId: bigint,
   storedName: string,
   weight: number,
   hidden: boolean,
 ): Promise<boolean> {
   try {
-    await addSfxFile(BigInt(triggerId), storedName, weight, hidden);
+    await addSfxFile(triggerId, storedName, weight, hidden);
     return true;
   } catch (err) {
     const fullPath = safeResolve(SFX_FOLDER, storedName);
@@ -211,7 +211,7 @@ const uploadSound = makeUploadMiddleware(upload, 'sound', handleUploadError);
  * @param res Express response; always issues a redirect.
  */
 router.post('/sfx/file/upload', requireMod, csrfProtection, uploadSound, async (req, res) => {
-  const triggerId = parsePositiveIntId(req.body.trigger_id);
+  const triggerId = parsePositiveBigIntId(req.body.trigger_id);
   if (triggerId === null) return res.redirect('/sfx?error=invalid_id');
   if (!req.file) return res.redirect('/sfx?error=invalid_file');
 


### PR DESCRIPTION
## Summary

Small consistency fix from a code review. `sfxtrigger.id` is a BIGINT column, and the project's documented invariant is that BIGINT values must flow as `bigint`/strings, never coerced through `Number`, to avoid precision loss above `Number.MAX_SAFE_INTEGER`.

`src/web/routes/sfxFileUpload.ts`'s `POST /sfx/file/upload` handler was the one outlier mutation route on this column still using `parsePositiveIntId` (returns `number`) instead of `parsePositiveBigIntId` (returns `bigint`), requiring a redundant `Number` → `BigInt` round-trip at the `addSfxFile` call site. Every sibling mutation on the same column — `src/web/routes/sfxTriggerMutations.ts`'s `POST /sfx/trigger/add` and `POST /sfx/trigger/update` — already uses `parsePositiveBigIntId` correctly.

This is harmless today only because SFX trigger ids are small auto-increment values well under 2^53 — it was an inconsistent, undocumented exception to the stated convention rather than an active bug.

## Changes

- `sfxFileUpload.ts`: parse `trigger_id` with `parsePositiveBigIntId` instead of `parsePositiveIntId`.
- `persistUploadedSound`'s `triggerId` parameter changed from `number` to `bigint`; dropped the now-redundant `BigInt(triggerId)` coercion at the `addSfxFile(...)` call site.
- Updated the function's JSDoc `@param triggerId` line to reflect the `bigint` type.

`weight` parsing is unchanged (`parsePositiveIntId`), since `weight` is not a BIGINT column.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` — all 154 test files / 2866 tests pass
- [x] Reviewed `src/web/routes/sfxFileUpload.test.ts` — it only exercises the pure helpers (`detectAudioType`, `buildStoredName`, `handleUploadError`), not `trigger_id` parsing or `persistUploadedSound`/`addSfxFile` directly, so no test changes were needed; observable HTTP behavior (accepts numeric-string ids, rejects non-numeric/negative/array `trigger_id`) is unchanged since `parsePositiveBigIntId` has the same string-shape validation as `parsePositiveIntId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPTsSjNQC2YRRNkKzmxYba

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPTsSjNQC2YRRNkKzmxYba)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sound effect file uploads by correctly handling large trigger IDs.
  * Ensured uploaded sound effects are associated with the intended trigger.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->