### PR TITLE
Route sfx.ts's AccessLevel import through the db facade

### DIFF
--- a/src/web/routes/sfx.test.ts
+++ b/src/web/routes/sfx.test.ts
@@ -6,9 +6,11 @@ const { mockLogger, ACCESS_LEVEL_MOCK } = vi.hoisted(() => ({
   ACCESS_LEVEL_MOCK: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
 }));
 
+/** Mocks the `db` facade so `AccessLevel` resolves to the shared hoisted mock instead of hitting the real module. */
 vi.mock('../../db', () => ({
   getAllSfxTriggers: vi.fn().mockResolvedValue([]),
   getAllCategories: vi.fn().mockResolvedValue([]),
+  AccessLevel: ACCESS_LEVEL_MOCK,
 }));
 /** Mocks the shared logger so route handlers don't write real log output during tests. */
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
@@ -19,15 +21,10 @@ vi.mock('../csrf', () => ({
     next();
   },
 }));
-/** Mocks `db/users` so `AccessLevel` resolves to the shared hoisted mock instead of hitting the real module. */
-vi.mock('../../db/users', () => ({
-  AccessLevel: ACCESS_LEVEL_MOCK,
-}));
 
 import supertest from 'supertest';
 import router from './sfx';
-import { getAllSfxTriggers, getAllCategories } from '../../db';
-import { AccessLevel } from '../../db/users';
+import { getAllSfxTriggers, getAllCategories, AccessLevel } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 
 /**

--- a/src/web/routes/sfx.ts
+++ b/src/web/routes/sfx.ts
@@ -1,9 +1,8 @@
 import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
-import { getAllSfxTriggers, getAllCategories } from '../../db';
+import { getAllSfxTriggers, getAllCategories, AccessLevel } from '../../db';
 import { csrfProtection } from '../csrf';
 import { SFX_MAX_FILE_MB } from '../../shared/config';
-import { AccessLevel } from '../../db/users';
 import { filterQueryParam, renderError, renderView } from './shared';
 
 const log = createLogger('Web');


### PR DESCRIPTION
## Summary
- `src/web/routes/sfx.ts` imported `AccessLevel` directly from `../../db/users`, the one place in `src/web/routes/*.ts` that reached into `db/users.ts` directly instead of going through the `db.ts` facade documented in `CLAUDE.md` ("Import DB functions from `src/db.ts` only, never `src/db/*` directly").
- `AccessLevel` is a plain constant with no cache-invalidation side effects, so this isn't a functional bug — it's a small consistency fix bringing `sfx.ts` in line with every other route file.
- Moved `AccessLevel` into the existing `../../db` import and removed the now-empty `../../db/users` import.
- Updated `sfx.test.ts`'s mocks accordingly (moved the mocked `AccessLevel` value onto the `../../db` mock instead of a separate `../../db/users` mock).

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — all 154 test files / 2866 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPTsSjNQC2YRRNkKzmxYba

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPTsSjNQC2YRRNkKzmxYba)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access-level handling for sound effect routes.
  * Ensured route behavior and automated checks use the same access-level source for more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->