### PR TITLE
Fix IDOR: guild-scope admin Twitch disconnect (streamer token wipe)

### DIFF
--- a/src/db/eventSub.test.ts
+++ b/src/db/eventSub.test.ts
@@ -238,13 +238,34 @@ describe('saveStreamerToken', () => {
 // ─── clearStreamerToken ───────────────────────────────────────────────────────
 
 describe('clearStreamerToken', () => {
-  it('executes UPDATE NULLing token fields for the given streamerId', async () => {
-    const pool = makePool();
+  it('executes an unscoped UPDATE NULLing token fields when guildId is omitted', async () => {
+    const pool = { execute: vi.fn().mockResolvedValue([{ affectedRows: 1 }, []]) };
     vi.mocked(getPool).mockReturnValue(pool as any);
-    await clearStreamerToken(5);
+    const result = await clearStreamerToken(5);
     const [sql, params] = pool.execute.mock.calls[0] as [string, unknown[]];
     expect(sql.toLowerCase()).toContain('update');
-    expect(params).toContain(5);
+    expect(sql).not.toContain('g.guild_id');
+    expect(params).toEqual([5]);
+    expect(result).toBe(true);
+  });
+
+  it('scopes the update via the joined stream_group when guildId is given, returning true when a row was updated', async () => {
+    const pool = { execute: vi.fn().mockResolvedValue([{ affectedRows: 1 }, []]) };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await clearStreamerToken(5, 'guild-1');
+    const [sql, params] = pool.execute.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('g.guild_id = ?');
+    expect(params).toEqual([5, 'guild-1']);
+    expect(result).toBe(true);
+  });
+
+  it('returns false without updating when the streamer\'s group belongs to a different guild', async () => {
+    const pool = { execute: vi.fn().mockResolvedValue([{ affectedRows: 0 }, []]) };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await clearStreamerToken(5, 'other-guild');
+    const [, params] = pool.execute.mock.calls[0] as [string, unknown[]];
+    expect(params).toEqual([5, 'other-guild']);
+    expect(result).toBe(false);
   });
 });
 

--- a/src/db/eventSub.ts
+++ b/src/db/eventSub.ts
@@ -156,17 +156,40 @@ export async function saveStreamerToken(
 }
 
 /**
- * Null out all OAuth token fields for a streamer (used on logout or token revocation).
+ * Null out all OAuth token fields for a streamer (used on logout, token revocation, or an
+ * admin-forced disconnect).
  *
  * @param streamerId - DB row ID of the streamer whose tokens should be cleared.
+ * @param guildId - Optional guild to scope the update to, joining through the streamer's
+ *   `stream_group` the same way {@link removeStreamer} in `streamMonitor.ts` scopes deletes.
+ *   A no-op if the streamer's group doesn't belong to `guildId`, preventing one guild's
+ *   admin from clearing another guild's streamer token. Pass this whenever `streamerId`
+ *   comes from a cross-guild-untrusted caller (e.g. an admin HTTP route). Omit it for
+ *   internal/system callers that already own the record by construction (a user clearing
+ *   their own token via their session, or Twitch-initiated revocation/refresh-failure
+ *   handling keyed off a broadcaster ID we resolved ourselves) — for those the update
+ *   remains unscoped, matching the pre-existing behavior.
+ * @returns True if a row was actually updated; false if `guildId` was given and the
+ *   streamer's group didn't belong to it (or `streamerId` doesn't exist).
  */
-export async function clearStreamerToken(streamerId: number): Promise<void> {
-  await getPool().execute(
+export async function clearStreamerToken(streamerId: number, guildId?: string): Promise<boolean> {
+  if (guildId !== undefined) {
+    const [result] = await getPool().execute<mysql.ResultSetHeader>(
+      `UPDATE streamer s
+       JOIN stream_group g ON s.group_id = g.id
+       SET s.twitch_user_id=NULL, s.eventsub_access_token=NULL, s.eventsub_refresh_token=NULL, s.eventsub_token_expiry=NULL
+       WHERE s.id = ? AND g.guild_id = ?`,
+      [streamerId, guildId],
+    );
+    return result.affectedRows > 0;
+  }
+  const [result] = await getPool().execute<mysql.ResultSetHeader>(
     `UPDATE streamer
      SET twitch_user_id=NULL, eventsub_access_token=NULL, eventsub_refresh_token=NULL, eventsub_token_expiry=NULL
      WHERE id=?`,
     [streamerId],
   );
+  return result.affectedRows > 0;
 }
 
 /** Extracts the 9 event-config column values (everything but `streamer_id`) from a config, in SQL parameter order, coercing booleans to 0/1 for BIT(1) columns. */

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
@@ -761,7 +761,7 @@ describe('handleRevocation', () => {
     vi.mocked(getActiveChannels).mockReturnValue(new Set(['revokedstreamer']));
     vi.mocked(createEventSubSubscription).mockResolvedValue('sub-id');
     vi.mocked(listEventSubSubscriptions).mockResolvedValue([]);
-    vi.mocked(clearStreamerToken).mockResolvedValue(undefined);
+    vi.mocked(clearStreamerToken).mockResolvedValue(true);
     await subscribeForStreamer('sess-revoke', {
       uid: 'uid-revoke',
       token: 'tok-revoke',

--- a/src/web/routes/eventsubAdmin.test.ts
+++ b/src/web/routes/eventsubAdmin.test.ts
@@ -35,15 +35,16 @@ import { buildTestApp } from '../../test-utils/expressTestApp';
 /**
  * Builds a minimal Express app with the eventsub admin router mounted, a stubbed session, and res.render captured as JSON.
  * @param accessLevel - The access level to assign to the session user (defaults to Admin).
+ * @param currentGuildId - The session user's currently-selected guild (defaults to `'guild-1'`).
  * @returns The configured Express app, ready to be driven with supertest.
  */
-function buildApp(accessLevel = 3) {
-  return buildTestApp({ router, sessionUser: { discordId: '1', accessLevel }, mockRender: 'spread' });
+function buildApp(accessLevel = 3, currentGuildId = 'guild-1') {
+  return buildTestApp({ router, sessionUser: { discordId: '1', accessLevel, currentGuildId }, mockRender: 'spread' });
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(clearStreamerToken).mockResolvedValue(undefined);
+  vi.mocked(clearStreamerToken).mockResolvedValue(true);
 });
 
 describe('POST /streams/twitch-disconnect/:streamerId', () => {
@@ -66,12 +67,21 @@ describe('POST /streams/twitch-disconnect/:streamerId', () => {
     expect(res.headers.location).toBe('/admin/streams?error=invalid_id');
   });
 
-  it('clears the token and triggers a reload on success', async () => {
+  it('clears the token, scoped to the caller\'s current guild, and triggers a reload on success', async () => {
     const res = await supertest(buildApp()).post('/streams/twitch-disconnect/42');
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/admin/streams');
-    expect(clearStreamerToken).toHaveBeenCalledWith(42);
+    expect(clearStreamerToken).toHaveBeenCalledWith(42, 'guild-1');
     expect(reloadEventSubSubscriptions).toHaveBeenCalledTimes(1);
+  });
+
+  it('redirects with invalid_id and does not reload when the streamer belongs to a different guild', async () => {
+    vi.mocked(clearStreamerToken).mockResolvedValue(false);
+    const res = await supertest(buildApp()).post('/streams/twitch-disconnect/42');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/admin/streams?error=invalid_id');
+    expect(clearStreamerToken).toHaveBeenCalledWith(42, 'guild-1');
+    expect(reloadEventSubSubscriptions).not.toHaveBeenCalled();
   });
 
   it('redirects with eventsub_disconnect_failed when clearStreamerToken throws', async () => {

--- a/src/web/routes/eventsubAdmin.ts
+++ b/src/web/routes/eventsubAdmin.ts
@@ -3,6 +3,7 @@ import { Router } from 'express';
 import { clearStreamerToken } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireAdmin } from '../middleware';
+import { getSessionUser } from '../session';
 import { reloadEventSubSubscriptions } from '../../twitch/eventsub/twitchEventSub';
 import { parsePositiveIntId } from './shared';
 import { redirectStreamsInvalid, redirectStreamsFailure } from './streamsErrors';
@@ -16,18 +17,22 @@ const router = Router();
 /**
  * POST /admin/streams/twitch-disconnect/:streamerId — admin-only forced disconnect of
  * a streamer's Twitch OAuth token, e.g. if it has been compromised. Clears the stored
- * token and reloads EventSub subscriptions.
- * @param req - Express request; reads the `streamerId` route param.
+ * token, scoped to the admin's currently-selected guild so an admin cannot force-disconnect
+ * a streamer belonging to a different guild, and reloads EventSub subscriptions.
+ * @param req - Express request; reads the `streamerId` route param and the caller's
+ *   `currentGuildId` from the session.
  * @param res - Express response; redirects to `/admin/streams` on success, or to
- *   `/admin/streams?error=<code>` if `streamerId` is not a valid positive integer
- *   (`error=invalid_id`) or the disconnect fails (`error=eventsub_disconnect_failed`).
+ *   `/admin/streams?error=<code>` if `streamerId` is not a valid positive integer or
+ *   doesn't belong to the caller's current guild (`error=invalid_id`), or the disconnect
+ *   fails (`error=eventsub_disconnect_failed`).
  */
 router.post('/streams/twitch-disconnect/:streamerId', requireAdmin, csrfProtection, async (req, res) => {
   const streamerId = parsePositiveIntId(req.params.streamerId);
   if (streamerId === null) return redirectStreamsInvalid(res, 'invalid_id');
 
   try {
-    await clearStreamerToken(streamerId);
+    const cleared = await clearStreamerToken(streamerId, getSessionUser(req).currentGuildId!);
+    if (!cleared) return redirectStreamsInvalid(res, 'invalid_id');
     reloadEventSubSubscriptions();
   } catch (err) {
     return redirectStreamsFailure(res, log, 'EventSub admin disconnect error:', err, 'eventsub_disconnect_failed');

--- a/src/web/routes/userSettings.test.ts
+++ b/src/web/routes/userSettings.test.ts
@@ -242,7 +242,7 @@ describe('POST /twitch-disconnect', () => {
 
   it('clears the token, reloads EventSub subscriptions, and redirects on success', async () => {
     vi.mocked(getStreamerByDiscordId).mockResolvedValue({ id: 7, twitch_name: 'streamer' } as any);
-    vi.mocked(clearStreamerToken).mockResolvedValue(undefined);
+    vi.mocked(clearStreamerToken).mockResolvedValue(true);
 
     const res = await supertest(buildApp()).post('/twitch-disconnect');
     expect(res.status).toBe(302);


### PR DESCRIPTION
## Security fix: IDOR / broken access control

`POST /admin/streams/twitch-disconnect/:streamerId` in `src/web/routes/eventsubAdmin.ts` only checked `requireAdmin` — that the caller is an Admin *in their currently-selected guild* — but never verified that the target `streamerId` actually belonged to that guild.

Because `streamer` rows are guild-scoped only indirectly (via `streamer.group_id -> stream_group.guild_id`), an Admin in Guild A could pass an arbitrary `streamerId` belonging to Guild B and force-disconnect (wipe the stored Twitch OAuth token of) a streamer they have no authority over — a cross-tenant privilege escalation. Every sibling mutation on `streamer` (e.g. `removeStreamer`) is already guild-scoped via the same `JOIN stream_group` pattern; this route was the exception.

### Fix

- `clearStreamerToken` (`src/db/eventSub.ts`) now takes an **optional** `guildId` parameter. When provided, the `UPDATE` is scoped via `JOIN stream_group g ON s.group_id = g.id AND g.guild_id = ?`, mirroring `removeStreamer`'s pattern exactly. Return type changed to `Promise<boolean>` (`affectedRows > 0`), also mirroring `removeStreamer`.
- The admin route (`src/web/routes/eventsubAdmin.ts`) now passes `getSessionUser(req).currentGuildId!` and redirects to `?error=invalid_id` if the update reports no row changed (streamer not found, or belongs to a different guild) instead of silently succeeding.

**Design note:** `guildId` is optional rather than required, because `clearStreamerToken` has three other pre-existing callers (self-service disconnect in `userSettings.ts`, Twitch-initiated revocation handling and token-refresh-failure handling in `twitchEventSubSubscriptions.ts`/`twitchApiEventSub.ts`) that resolve `streamerId` via trusted, non-cross-guild paths (the caller's own session, or a broadcaster ID we resolved ourselves) — not attacker-supplied cross-tenant input. None of those call sites have a guild readily available (the self-disconnect route isn't guild-scoped at all; the Twitch-webhook-driven paths have no session/guild context), and threading one through would require unrelated plumbing (adding guild info to `StreamerInfo`/`DbStreamerEventSub`) with real risk of silently leaving compromised tokens uncleared if a lookup mismatched. Those three callers are left untouched, calling the unscoped single-argument form exactly as before. Only the vulnerable admin route, which is the sole caller taking attacker-controlled `streamerId` input, now passes `guildId`.

### Testing

- `src/db/eventSub.test.ts`: new cases for `clearStreamerToken` — unscoped call (no `guildId`), scoped call matching the caller's guild (returns `true`, row updated), and scoped call for a different guild (returns `false`, asserts the `g.guild_id = ?` clause and params).
- `src/web/routes/eventsubAdmin.test.ts`: new case simulating a cross-guild `streamerId` (mocked `clearStreamerToken` resolving `false`) and asserting a redirect to `?error=invalid_id` with no EventSub reload triggered, plus updated assertions on the existing success case to include the guild argument.
- Updated two unrelated pre-existing tests (`userSettings.test.ts`, `twitchEventSubSubscriptions.test.ts`) whose mocks resolved `clearStreamerToken` to `undefined`, now `true`, to match the new `Promise<boolean>` return type — no behavior change.

`npx tsc --noEmit && npm test` passes (154 files / 2869 tests).

### Verification

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — all 2869 tests pass
- [x] Grepped all callers of `clearStreamerToken` (`grep -rn clearStreamerToken src/`) — confirmed only the admin route needed the new `guildId` argument; the 3 other callers are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPTsSjNQC2YRRNkKzmxYba

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPTsSjNQC2YRRNkKzmxYba)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Twitch stream disconnections are now limited to the currently selected guild.
  * Disconnect attempts for streams outside the selected guild are rejected as invalid.
  * Subscription updates are triggered only after a token is successfully cleared.
  * Improved handling and feedback for unsuccessful Twitch disconnect requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->