### PR TITLE
Dedupe redundant try/catch around mutationQueue's previous await

### DIFF
--- a/src/shared/mutationQueue.test.ts
+++ b/src/shared/mutationQueue.test.ts
@@ -70,6 +70,25 @@ describe('createMutationQueue', () => {
     expect(order).toEqual(['second']);
   });
 
+  // ─── Timing: first call on a key starts promptly ──────────────────────────
+
+  it('starts operation() for a fresh key within a single microtask tick', async () => {
+    const queue = createMutationQueue();
+    let started = false;
+
+    // A fresh key has no `previous` to wait on (it defaults to an
+    // already-resolved promise), so operation() must begin executing after
+    // exactly one microtask tick. Any extra internal indirection between the
+    // gate and `previous` (e.g. deriving a shared "settled" promise via
+    // .then/.catch instead of awaiting `previous` directly) adds a tick here
+    // and is an observable regression — real callers key their own timing
+    // off exactly this.
+    void queue.run('k', async () => { started = true; });
+
+    await Promise.resolve();
+    expect(started).toBe(true);
+  });
+
   // ─── Queue-map cleanup ────────────────────────────────────────────────────
 
   it('removes the key from the internal map after the last operation completes', async () => {

--- a/src/shared/mutationQueue.ts
+++ b/src/shared/mutationQueue.ts
@@ -20,21 +20,21 @@ export function createMutationQueue<K = string>(): {
       const current = new Promise<void>((resolve) => {
         release = resolve;
       });
+      // `previous` can never reject: it's either `Promise.resolve()` (first
+      // call for this key) or a prior call's `queued` value, which is always
+      // wrapped in `.catch(() => {})` below before being stored. So both the
+      // externally-visible chain and this call's own execution gate can await
+      // it directly — no try/catch needed to swallow a failure that can't
+      // structurally occur, and no shared derived promise is introduced
+      // (which would add a microtask tick relative to awaiting `previous`
+      // itself, shifting when downstream operations observably start).
       const queued = (async () => {
-        try {
-          await previous;
-        } catch {
-          // Ignore earlier failures so later operations still run.
-        }
+        await previous;
         await current;
       })().catch(() => {});
       queues.set(key, queued);
 
-      try {
-        await previous;
-      } catch {
-        // Ignore earlier failures so later operations still run.
-      }
+      await previous;
 
       try {
         return await operation();


### PR DESCRIPTION
## Summary

Small internal dedup/refactor in `src/shared/mutationQueue.ts` — no behavior change. Follows up on a code review flagging that `run()` awaited the same `previous` promise twice, wrapped in an identical `try { await previous } catch { /* ignore */ }` block at both call sites.

## What changed and why

`previous` can never actually reject: it's either `Promise.resolve()` (first call for a key) or a prior call's `queued` value, which is *always* stored after being wrapped in `.catch(() => {})`. So the try/catch at both await sites was dead code, duplicated in two places. Replaced both with a plain `await previous` plus one comment documenting the invariant.

**Deliberately did not** go with the "single shared `previous.catch(() => {})` promise" approach that was originally suggested for this cleanup — I implemented and tested it first, and it looks equivalent but isn't: a freshly-chained `.then`/`.catch` promise starts pending and only settles one microtask tick after the promise it wraps, so awaiting it (from either call site) resumes one tick later than awaiting `previous` directly. That's not just a theoretical nit — it broke a real, previously-passing test (`twitchBot.test.ts`'s `reconcileJoinedChannels > marks a channel online...` case), because `mutationQueue` consumers key their own ordering off exactly when `previous`/`queued` settle. Reverted that approach and went with removing the dead try/catch instead, which is timing-neutral by construction (no new promise is introduced).

Added a regression test (`starts operation() for a fresh key within a single microtask tick`) that fails against the shared-promise approach, to guard against reintroducing this specific regression.

## Verification

- `npx tsc --noEmit && npm test` — all 2867 tests pass (2866 existing + 1 new), zero existing tests modified.
- Specifically re-ran `mutationQueue.test.ts`, `twitchBot.test.ts`, `twitchChannelMembership.test.ts`, `rewardPricingService.test.ts`, and `adminUserMutations.test.ts` (the mutationQueue call sites named as important in project conventions).
- Confirmed the new regression test and the real `twitchBot.test.ts` test both fail against the alternative (shared-derived-promise) implementation, and both pass against this one.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 154 files / 2867 tests passing)
- [ ] Human review of the reasoning above, since the actual fix diverges from the originally suggested approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPTsSjNQC2YRRNkKzmxYba

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPTsSjNQC2YRRNkKzmxYba)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved queued operation timing so new operations begin promptly.
  * Preserved reliable execution of subsequent operations when an earlier operation fails.

* **Tests**
  * Added coverage to verify that newly queued operations start within the expected timing window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->