### PR TITLE
Fix Windows CI flake in sfxMutations upload-ordering test

### DIFF
--- a/src/web/routes/sfxMutations.test.ts
+++ b/src/web/routes/sfxMutations.test.ts
@@ -525,7 +525,15 @@ describe('access control', () => {
   });
 
   it('uploads run csrfProtection before Multer buffers the file', async () => {
-    vi.mocked(csrfProtection).mockImplementationOnce((_req: any, res: any) => res.status(403).send('bad csrf'));
+    vi.mocked(csrfProtection).mockImplementationOnce((req: any, res: any) => {
+      // Drain the still-arriving upload body before responding. csrfProtection short-circuits
+      // ahead of Multer, so nothing else reads this request — if the 403 lands (and the socket
+      // closes) while the client is still writing the multipart body, the client sees a
+      // connection reset instead of the response. That race is timing-dependent and was flaky
+      // on Windows CI (ECONNRESET); consuming the body first lets the write finish cleanly.
+      req.resume();
+      req.on('end', () => res.status(403).send('bad csrf'));
+    });
     // Oversized so the assertion actually distinguishes ordering: if Multer ran first,
     // it would reject with LIMIT_FILE_SIZE (a different status) instead of csrfProtection's 403.
     const oversized = Buffer.alloc(1024 * 1024 + 1024, 1);


### PR DESCRIPTION
## Summary

- `sfxMutations.test.ts > access control > uploads run csrfProtection before Multer buffers the file` occasionally failed on Windows CI with `Error: read ECONNRESET`.
- Root cause: the mocked `csrfProtection` short-circuits the request before Multer (or anything else) reads the body, so the ~1 MB multipart payload used to distinguish middleware ordering was left completely unread. Sending the 403 response — and closing the socket — while the client was still writing that body raced with the write; occasionally the connection got reset instead of the response being delivered. This is timing-dependent and was more likely to hit on Windows CI runners.
- Fix: the mock now drains (`req.resume()`) the incoming request stream and only responds with 403 once the body has fully arrived (`req.on('end', ...)`), so the client's write always completes cleanly before the socket closes. This is a test-only change — no production code paths are affected.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx vitest run src/web/routes/sfxMutations.test.ts` (53 passed)
- [x] `npm test` (154 files / 2869 tests passed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QqyTDNMh6MZMNZHdoP3gdV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of the file upload security test by properly handling streamed request data before returning an authorization error.
  * Preserved all existing test coverage and assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->