### PR TITLE
Remove dead code: removeUserMutation chain and stray unused re-exports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ npm test      # Vitest
 ## Critical Invariants
 
 - **`mediaplex` must be the first import in `src/index.ts`** — registers the Opus provider. Never reorder.
-- **Import DB functions from `src/db.ts` only**, never `src/db/*` directly. The facade wraps some functions with cache-invalidation side effects (`upsertUser`, `removeUser`, `updateTwitchBotEnabled`).
+- **Import DB functions from `src/db.ts` only**, never `src/db/*` directly. The facade wraps some functions with cache-invalidation side effects (`upsertUser`, `updateTwitchBotEnabled`).
 - **BIGINT columns are strings** (`bigNumberStrings: true` on the pool) — never coerce to `Number`. This protects against precision loss on values that can exceed `Number.MAX_SAFE_INTEGER`, like Discord snowflakes — it does not apply to a BIGINT result you can prove is bounded well within that range (e.g. `COUNT(*)` on a small admin table). If you do parse one of those back to a number, say so at the call site (why this particular value is bounded) — don't let it read like the same blind coercion the rule forbids elsewhere. See `getRowCount` in `src/db/utils.ts` for the pattern.
 - **Blank Twitch names → `NULL`** — `user.twitch_name` has a unique index; empty strings collide.
 - **`mutationQueue`** for concurrent-unsafe DB writes — user mutations serialise through it.

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -10,7 +10,6 @@ vi.mock('./db/pool', () => ({ getPool: vi.fn(), closePool: vi.fn() }));
 vi.mock('./db/users', () => ({
   upsertUserRecord: vi.fn(),
   setTwitchBotEnabledRecord: vi.fn(),
-  removeUserRecord: vi.fn(),
   AccessLevel: ACCESS_LEVEL_MOCK,
   ACCESS_LEVEL_LABELS: {},
   findUser: vi.fn(),
@@ -138,16 +137,15 @@ vi.mock('./db/lookupCache', () => ({
   DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS: 60_000,
 }));
 
-import { upsertUserRecord, setTwitchBotEnabledRecord, removeUserRecord } from './db/users';
+import { upsertUserRecord, setTwitchBotEnabledRecord } from './db/users';
 import { invalidateCustomCommandLookupCache } from './db/customCommandCache';
 import { upsertOverride as upsertOverrideRecord, removeOverride as removeOverrideRecord } from './db/guildCommandOverrides';
-import { upsertUser, updateTwitchBotEnabled, removeUser, upsertOverride, removeOverride } from './db';
+import { upsertUser, updateTwitchBotEnabled, upsertOverride, removeOverride } from './db';
 
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(upsertUserRecord).mockResolvedValue(false);
   vi.mocked(setTwitchBotEnabledRecord).mockResolvedValue(undefined);
-  vi.mocked(removeUserRecord).mockResolvedValue(undefined);
   vi.mocked(upsertOverrideRecord).mockResolvedValue(undefined);
   vi.mocked(removeOverrideRecord).mockResolvedValue(undefined);
 });
@@ -196,21 +194,6 @@ describe('updateTwitchBotEnabled', () => {
   it('propagates errors from setTwitchBotEnabledRecord', async () => {
     vi.mocked(setTwitchBotEnabledRecord).mockRejectedValue(new Error('DB error'));
     await expect(updateTwitchBotEnabled('1', true)).rejects.toThrow('DB error');
-    expect(invalidateCustomCommandLookupCache).not.toHaveBeenCalled();
-  });
-});
-
-// ─── removeUser ───────────────────────────────────────────────────────────────
-
-describe('removeUser', () => {
-  it('always calls invalidateCustomCommandLookupCache on success', async () => {
-    await removeUser('1');
-    expect(invalidateCustomCommandLookupCache).toHaveBeenCalledOnce();
-  });
-
-  it('propagates errors from removeUserRecord', async () => {
-    vi.mocked(removeUserRecord).mockRejectedValue(new Error('DB error'));
-    await expect(removeUser('1')).rejects.toThrow('DB error');
     expect(invalidateCustomCommandLookupCache).not.toHaveBeenCalled();
   });
 });

--- a/src/db.ts
+++ b/src/db.ts
@@ -77,7 +77,7 @@ export {
 } from './db/users';
 export type { AccessLevelValue, DbUser, TwitchLinkedUser } from './db/users';
 
-import { upsertUserRecord, setTwitchBotEnabledRecord, removeUserRecord } from './db/users';
+import { upsertUserRecord, setTwitchBotEnabledRecord } from './db/users';
 
 // Wrappers add cache invalidation — users.ts is a pure DB layer with no cache knowledge.
 
@@ -111,15 +111,6 @@ export async function upsertUser(
  */
 export async function updateTwitchBotEnabled(discordId: string, enabled: boolean): Promise<void> {
   await withInvalidation(() => setTwitchBotEnabledRecord(discordId, enabled));
-}
-
-/**
- * Deletes a user record and invalidates the custom-command lookup cache.
- * @param discordId - Discord snowflake as a string.
- * @returns Resolves once the deletion (and cache invalidation) completes.
- */
-export async function removeUser(discordId: string): Promise<void> {
-  await withInvalidation(() => removeUserRecord(discordId));
 }
 
 // ─── Custom commands ────────────────────────────────────────────────────────

--- a/src/db/commandLocks.ts
+++ b/src/db/commandLocks.ts
@@ -14,10 +14,6 @@ import { rowExists } from './utils';
 
 export type { SqlExecutor } from './commandStringUtils';
 export {
-  requireTrimmedString,
-  normalizeCommandList,
-  normalizeCommandInputs,
-  buildInClausePlaceholders,
   CommandNotFoundError,
   CommandConflictError,
   isMysqlDuplicateEntryError,

--- a/src/db/users.test.ts
+++ b/src/db/users.test.ts
@@ -22,7 +22,6 @@ import {
   getAllTwitchLinkedUsers,
   setTwitchBotEnabledRecord,
   updateAccessLevel,
-  removeUserRecord,
   AccessLevel,
 } from './users';
 import { normalizeTwitchChannelName } from '../twitch/twitchChannelName';
@@ -435,20 +434,6 @@ describe('setTwitchBotEnabledRecord', () => {
     await setTwitchBotEnabledRecord('1', false);
     const params = pool._conn.execute.mock.calls[1][1] as unknown[];
     expect(params[0]).toBe(0);
-  });
-});
-
-// ─── removeUserRecord ─────────────────────────────────────────────────────────
-
-describe('removeUserRecord', () => {
-  it('executes a DELETE with the discord_id', async () => {
-    const pool = makePool();
-    vi.mocked(getPool).mockReturnValue(pool as any);
-    await removeUserRecord('42');
-    const sql: string = pool._conn.execute.mock.calls[1][0] as string;
-    expect(sql).toContain('DELETE FROM');
-    const params = pool._conn.execute.mock.calls[1][1] as unknown[];
-    expect(params).toContain('42');
   });
 });
 

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -301,15 +301,3 @@ export async function updateAccessLevel(discordId: string, accessLevel: number):
     [accessLevel, discordId],
   ));
 }
-
-/**
- * Deletes a user record.
- * @param discordId - Discord snowflake as a string.
- * @returns Resolves once the deletion completes.
- */
-export async function removeUserRecord(discordId: string): Promise<void> {
-  await withShortLockTimeout((conn) => conn.execute(
-    'DELETE FROM `user` WHERE discord_id = ?',
-    [discordId],
-  ));
-}

--- a/src/web/middleware.ts
+++ b/src/web/middleware.ts
@@ -12,11 +12,6 @@ import {
 } from '../db';
 import { renderView } from './routes/shared';
 
-// Re-exported so existing `import { ..., getSessionUser } from '../middleware'` call sites
-// work; defined in ./session (not here) because ./routes/shared imports from this file, and
-// routes/shared.ts itself needs getSessionUser — defining it here would be circular.
-export { getSessionUser } from './session';
-
 /**
  * Ensures the request has a logged-in session user, redirecting to login otherwise.
  * @param req - Express request; checked for `req.session.user`.

--- a/src/web/routes/admin.test.ts
+++ b/src/web/routes/admin.test.ts
@@ -52,7 +52,6 @@ vi.mock('./adminUserMutations', () => {
     isDuplicateTwitchNameDbError: vi.fn().mockReturnValue(false),
     isLockWaitTimeoutDbError: vi.fn().mockReturnValue(false),
     addOrUpdateUserMutation: vi.fn().mockResolvedValue(undefined),
-    removeUserMutation: vi.fn().mockResolvedValue(undefined),
     toggleTwitchMutation: vi.fn().mockResolvedValue(undefined),
   };
 });

--- a/src/web/routes/adminUserMutations.test.ts
+++ b/src/web/routes/adminUserMutations.test.ts
@@ -5,7 +5,6 @@ vi.mock('../../db', () => ({
   findUser: vi.fn(),
   findUserByTwitchName: vi.fn(),
   upsertUser: vi.fn(),
-  removeUser: vi.fn(),
   updateTwitchBotEnabled: vi.fn(),
   getTwitchEnabledChannels: vi.fn(),
 }));
@@ -23,7 +22,6 @@ vi.mock('../../db/users', () => ({ AccessLevel: ACCESS_LEVEL_MOCK }));
 
 import {
   addOrUpdateUserMutation,
-  removeUserMutation,
   toggleTwitchMutation,
   DuplicateTwitchNameError,
   isLockWaitTimeoutDbError,
@@ -33,7 +31,6 @@ import {
   findUser,
   findUserByTwitchName,
   upsertUser,
-  removeUser,
   updateTwitchBotEnabled,
   getTwitchEnabledChannels,
 } from '../../db';
@@ -61,7 +58,6 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(upsertUser).mockResolvedValue(undefined);
   vi.mocked(updateTwitchBotEnabled).mockResolvedValue(undefined);
-  vi.mocked(removeUser).mockResolvedValue(undefined);
   vi.mocked(joinTwitchChannel).mockResolvedValue(undefined);
   vi.mocked(partTwitchChannel).mockResolvedValue(undefined);
   vi.mocked(getTwitchEnabledChannels).mockResolvedValue([]);
@@ -152,103 +148,6 @@ describe('addOrUpdateUserMutation — handleChangeTwitchChannel rollback', () =>
     const rollbackCall = upsertCalls[upsertCalls.length - 1];
     // previousChannel was null — rollback must use null, not ''
     expect(rollbackCall[3]).toBeNull();
-  });
-});
-
-describe('removeUserMutation — rollback on partTwitchChannel failure', () => {
-  it('re-inserts the user when partTwitchChannel throws during removal', async () => {
-    const existingUser: MockDbUser = {
-      ...BASE_USER,
-      twitch_name: 'streamerchan',
-      is_twitch_bot_enabled: true,
-    };
-
-    vi.mocked(findUser).mockResolvedValue(existingUser as any);
-    vi.mocked(partTwitchChannel).mockRejectedValue(new Error('Part failed'));
-
-    await expect(removeUserMutation('111')).rejects.toThrow('Part failed');
-
-    expect(vi.mocked(upsertUser)).toHaveBeenCalledWith(
-      existingUser.discord_id,
-      existingUser.discord_name,
-      existingUser.access_level,
-      existingUser.twitch_name,
-    );
-    expect(vi.mocked(updateTwitchBotEnabled)).toHaveBeenCalledWith(
-      existingUser.discord_id,
-      existingUser.is_twitch_bot_enabled,
-    );
-  });
-});
-
-describe('removeUserMutation — early exits', () => {
-  it('returns after removeUser when the user had the Twitch bot disabled', async () => {
-    const existingUser: MockDbUser = {
-      ...BASE_USER,
-      twitch_name: 'streamerchan',
-      is_twitch_bot_enabled: false,
-    };
-    vi.mocked(findUser).mockResolvedValue(existingUser as any);
-
-    await expect(removeUserMutation('111')).resolves.toBeUndefined();
-
-    expect(vi.mocked(removeUser)).toHaveBeenCalledWith('111');
-    expect(vi.mocked(getTwitchEnabledChannels)).not.toHaveBeenCalled();
-    expect(vi.mocked(partTwitchChannel)).not.toHaveBeenCalled();
-  });
-
-  it('returns after removeUser when the user has no Twitch name', async () => {
-    vi.mocked(findUser).mockResolvedValue({ ...BASE_USER, twitch_name: null, is_twitch_bot_enabled: true } as any);
-
-    await expect(removeUserMutation('111')).resolves.toBeUndefined();
-
-    expect(vi.mocked(partTwitchChannel)).not.toHaveBeenCalled();
-  });
-
-  it('throws when the stored Twitch channel normalizes to an invalid value', async () => {
-    const existingUser: MockDbUser = {
-      ...BASE_USER,
-      twitch_name: 'bad chan!!',
-      is_twitch_bot_enabled: true,
-    };
-    vi.mocked(findUser).mockResolvedValue(existingUser as any);
-    vi.mocked(normalizeTwitchChannelName).mockReturnValueOnce(null);
-
-    await expect(removeUserMutation('111')).rejects.toThrow('Removed user has an invalid Twitch channel');
-
-    expect(vi.mocked(partTwitchChannel)).not.toHaveBeenCalled();
-  });
-
-  it('returns without parting when the channel is still enabled for another user', async () => {
-    const existingUser: MockDbUser = {
-      ...BASE_USER,
-      twitch_name: 'streamerchan',
-      is_twitch_bot_enabled: true,
-    };
-    vi.mocked(findUser).mockResolvedValue(existingUser as any);
-    vi.mocked(getTwitchEnabledChannels).mockResolvedValue(['streamerchan']);
-
-    await expect(removeUserMutation('111')).resolves.toBeUndefined();
-
-    expect(vi.mocked(partTwitchChannel)).not.toHaveBeenCalled();
-  });
-});
-
-describe('removeUserMutation — rollback itself fails', () => {
-  it('logs when the rollback upsertUser call also fails, and still rethrows the original error', async () => {
-    const existingUser: MockDbUser = {
-      ...BASE_USER,
-      twitch_name: 'streamerchan',
-      is_twitch_bot_enabled: true,
-    };
-
-    vi.mocked(findUser).mockResolvedValue(existingUser as any);
-    vi.mocked(partTwitchChannel).mockRejectedValue(new Error('Part failed'));
-    vi.mocked(upsertUser).mockRejectedValue(new Error('Rollback upsert failed'));
-
-    await expect(removeUserMutation('111')).rejects.toThrow('Part failed');
-
-    expect(vi.mocked(upsertUser)).toHaveBeenCalled();
   });
 });
 

--- a/src/web/routes/adminUserMutations.ts
+++ b/src/web/routes/adminUserMutations.ts
@@ -4,7 +4,6 @@ import {
   findUser,
   findUserByTwitchName,
   upsertUser,
-  removeUser,
   updateTwitchBotEnabled,
   AccessLevelValue,
 } from '../../db';
@@ -161,42 +160,6 @@ export async function addOrUpdateUserMutation({
   }
 
   await handleChangeTwitchChannel({ discordId, discordName, level, previousChannel, committedChannel, wasBotEnabled: existingUser?.is_twitch_bot_enabled ?? false });
-}
-
-export async function removeUserMutation(discordId: string): Promise<void> {
-  const existingUser = await findUser(discordId);
-  await removeUser(discordId);
-
-  if (!existingUser?.is_twitch_bot_enabled || !existingUser.twitch_name) {
-    return;
-  }
-
-  const normalizedChannel = normalizeTwitchChannelName(existingUser.twitch_name);
-  if (!normalizedChannel) {
-    throw new Error('Removed user has an invalid Twitch channel');
-  }
-
-  const enabledChannels = await getTwitchEnabledChannels();
-  if (enabledChannels.includes(normalizedChannel)) {
-    return;
-  }
-
-  try {
-    await partTwitchChannel(normalizedChannel);
-  } catch (partErr) {
-    try {
-      await upsertUser(
-        existingUser.discord_id,
-        existingUser.discord_name?.trim() ?? '',
-        existingUser.access_level as AccessLevelValue,
-        existingUser.twitch_name ?? null,
-      );
-      await updateTwitchBotEnabled(existingUser.discord_id, existingUser.is_twitch_bot_enabled);
-    } catch (rollbackErr) {
-      log.error(`Failed to restore user after Twitch part failed during removal: ${discordId}`, rollbackErr);
-    }
-    throw partErr;
-  }
 }
 
 export async function toggleTwitchMutation(discordId: string, nextEnabled: boolean): Promise<void> {

--- a/src/web/routes/alertsAdminMutations.ts
+++ b/src/web/routes/alertsAdminMutations.ts
@@ -105,5 +105,3 @@ router.post('/settings/:eventType/test', requireAuth, csrfProtection, async (req
     logAndRedirectError({ res, log, logLabel: 'Alert test-send error:', err, basePath: '/alerts/settings', errorCode: 'save_failed' });
   }
 });
-
-export default router;

--- a/src/web/routes/alertsAssetMutations.ts
+++ b/src/web/routes/alertsAssetMutations.ts
@@ -252,5 +252,3 @@ router.post('/settings/:eventType/image/delete', requireAuth, csrfProtection, ma
  *   delete route above.
  */
 router.post('/settings/:eventType/sound/delete', requireAuth, csrfProtection, makeDeleteHandler(setAlertSound, 'sound'));
-
-export default router;


### PR DESCRIPTION
## Summary

Closes #427 by removing the dead code it flagged, plus three more instances of unused/unreachable exports found during the same sweep.

- **`removeUserMutation`** (`src/web/routes/adminUserMutations.ts`) and its dependency chain — `removeUser` (`src/db.ts` facade) and `removeUserRecord` (`src/db/users.ts`) — deleted. Verified this is dead by design, not an oversight: the one production admin-remove route (`admin.ts`'s `POST /admin/users/remove`) intentionally only calls guild-scoped `removeGuildMember`, since a user's global row/Twitch identity may still belong to other guilds. `removeUserMutation` did a full *global* delete, which predates multi-guild support and would be actively wrong to wire up now.
- **`getSessionUser` re-export** in `src/web/middleware.ts` — unused; every real call site already imports it from `./session` directly. Removed along with the stale comment claiming call sites depended on it.
- **`requireTrimmedString`/`normalizeCommandList`/`normalizeCommandInputs`/`buildInClausePlaceholders` re-exports** in `src/db/commandLocks.ts` — unused; real callers import these from `commandStringUtils` directly, and `commandLocks.ts` itself already imports them separately for internal use.
- **Stray `export default router`** in `alertsAdminMutations.ts` and `alertsAssetMutations.ts` — unused; unlike other route files (whose default export is the one mounted in `server.ts`), these two are sub-routers consumed only via the named `router` export.

Also updated the stale `CLAUDE.md` line that referenced `removeUser` as one of the facade's cache-invalidating exports.

Found via a full-repo `ts-prune` sweep (all unused exports) plus `eslint` (unused locals, clean) — confirmed no other dead code remains after this cleanup.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 154 files / 2866 tests pass
- [x] `npx eslint .` — no new warnings
- [x] Re-ran `ts-prune` after cleanup — no unused exports remain


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9jZGD9Uk534twoMLoYRkA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Administration**
  * Removed the ability to remove users through administrative workflows.
  * Existing user creation, updates, and Twitch bot setting controls remain available.

* **Reliability**
  * Improved consistency when updating user details and Twitch bot settings.

* **Maintenance**
  * Simplified internal route and database interfaces without changing alert asset management or authentication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->