### PR TITLE
Scope dashboard bot status to the viewer's own guild

### DIFF
--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -26,7 +26,6 @@ vi.mock('./guildRegistry', () => ({
 }));
 vi.mock('../db', () => ({
   upsertGuild: vi.fn().mockResolvedValue(undefined),
-  getAllGuilds: vi.fn().mockResolvedValue([{ guild_id: 'guild-id', name: 'TestGuild', voice_channel_id: null }]),
   getGuildById: vi.fn().mockResolvedValue(null),
   findUser: vi.fn().mockResolvedValue(null),
   upsertUser: vi.fn().mockResolvedValue(undefined),
@@ -308,23 +307,15 @@ describe('startDiscordBot — guildDelete handler', () => {
   });
 });
 
-// ─── startDiscordBot — clientReady error path ─────────────────────────────────
+// ─── startDiscordBot — clientReady ready state ─────────────────────────────────
 
-describe('startDiscordBot — clientReady error path', () => {
-  it('catches getAllGuilds errors without crashing', async () => {
-    const db = await import('../db.js');
-    vi.mocked(db.getAllGuilds).mockRejectedValueOnce(new Error('guild unavailable'));
-    mod.startDiscordBot();
-    const readyCb = mockInstance.once.mock.calls.find(([event]: string[]) => event === 'clientReady')?.[1];
-    await expect(readyCb(mockInstance)).resolves.toBeUndefined();
-  });
-
-  it('sets ready state with DB guild names on clientReady success', async () => {
+describe('startDiscordBot — clientReady ready state', () => {
+  it('sets ready state with the bot tag on clientReady success', async () => {
     const status = await import('../shared/statusStore.js');
     mod.startDiscordBot();
     const readyCb = mockInstance.once.mock.calls.find(([event]: string[]) => event === 'clientReady')?.[1];
     await readyCb(mockInstance);
-    expect(vi.mocked(status.setDiscordReady)).toHaveBeenCalledWith('Bot#1234', 'TestGuild');
+    expect(vi.mocked(status.setDiscordReady)).toHaveBeenCalledWith('Bot#1234');
   });
 });
 

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -8,7 +8,7 @@ import { setDiscordReady, clearVoiceStatus } from '../shared/statusStore';
 import { forgetGuild as forgetGuildVoiceState } from '../audio/audioPlayer';
 import { forgetGuildRefreshState } from '../web/routes/adminRefresh';
 import { isRegisteredGuild, reloadGuildRegistry } from './guildRegistry';
-import { upsertGuild, getAllGuilds, getGuildById, findUser, upsertUser, setMemberAccessLevel, AccessLevel } from '../db';
+import { upsertGuild, getGuildById, findUser, upsertUser, setMemberAccessLevel, AccessLevel } from '../db';
 import { createLogger } from '../shared/logger';
 
 const log = createLogger('Discord');
@@ -175,13 +175,7 @@ export function startDiscordBot(): void {
     bootingClient = null;
     client = c;
     log.info(`Logged in as ${c.user.tag}`);
-    try {
-      const registeredGuilds = await getAllGuilds();
-      const names = registeredGuilds.map((g) => g.name).join(', ') || 'Unknown';
-      setDiscordReady(c.user.tag, names);
-    } catch (err) {
-      log.error('Failed to initialise:', err);
-    }
+    setDiscordReady(c.user.tag);
   });
 
   localClient.on('error', (err) => {

--- a/src/shared/statusStore.test.ts
+++ b/src/shared/statusStore.test.ts
@@ -12,12 +12,11 @@ describe('Discord status', () => {
     expect(mod.getStatus(null).discord.ready).toBe(false);
   });
 
-  it('setDiscordReady marks ready with tag and guildName', () => {
-    mod.setDiscordReady('Bot#1234', 'MyGuild');
+  it('setDiscordReady marks ready with tag', () => {
+    mod.setDiscordReady('Bot#1234');
     const { discord } = mod.getStatus(null);
     expect(discord.ready).toBe(true);
     expect(discord.tag).toBe('Bot#1234');
-    expect(discord.guildName).toBe('MyGuild');
   });
 });
 
@@ -171,7 +170,7 @@ describe('onStatusChanged', () => {
   it('setDiscordReady notifies with null (not scoped to one guild)', () => {
     const listener = vi.fn();
     mod.onStatusChanged(listener);
-    mod.setDiscordReady('Bot#1234', 'MyGuild');
+    mod.setDiscordReady('Bot#1234');
     expect(listener).toHaveBeenCalledWith(null);
   });
 
@@ -244,7 +243,7 @@ describe('onStatusChanged', () => {
     const second = vi.fn();
     mod.onStatusChanged(first);
     mod.onStatusChanged(second);
-    mod.setDiscordReady('Bot#1234', 'MyGuild');
+    mod.setDiscordReady('Bot#1234');
     expect(first).toHaveBeenCalledWith(null);
     expect(second).toHaveBeenCalledWith(null);
   });
@@ -253,14 +252,14 @@ describe('onStatusChanged', () => {
     const listener = vi.fn();
     mod.onStatusChanged(listener);
     mod.onStatusChanged(listener);
-    mod.setDiscordReady('Bot#1234', 'MyGuild');
+    mod.setDiscordReady('Bot#1234');
     expect(listener).toHaveBeenCalledOnce();
   });
 });
 
 describe('getStatus returns shallow copies', () => {
   it('mutating returned discord object does not affect internal state', () => {
-    mod.setDiscordReady('Bot#1234', 'MyGuild');
+    mod.setDiscordReady('Bot#1234');
     const snapshot = mod.getStatus(null);
     (snapshot.discord as Record<string, unknown>).tag = 'mutated';
     expect(mod.getStatus(null).discord.tag).toBe('Bot#1234');

--- a/src/shared/statusStore.ts
+++ b/src/shared/statusStore.ts
@@ -61,7 +61,6 @@ const state = {
   discord: {
     ready: false,
     tag: null as string | null,
-    guildName: null as string | null,
   },
   voice: new Map<string, VoiceStatus>(),
   twitch: new Map<string, ChannelStatus>(),
@@ -84,14 +83,12 @@ export function clearVoiceStatus(guildId: string): void {
 }
 
 /**
- * Marks the Discord bot as ready with its tag and guild name. Notifies the registered
- * status-change listener (see {@link onStatusChanged}) with `null` since this isn't scoped
- * to one guild.
+ * Marks the Discord bot as ready with its tag. Notifies the registered status-change
+ * listener (see {@link onStatusChanged}) with `null` since this isn't scoped to one guild.
  */
-export function setDiscordReady(tag: string, guildName: string): void {
+export function setDiscordReady(tag: string): void {
   state.discord.ready = true;
   state.discord.tag = tag;
-  state.discord.guildName = guildName;
   notifyStatusChanged(null);
 }
 
@@ -208,11 +205,13 @@ export function setTwitchChannelLive(login: string, isLive: boolean): void {
 }
 
 /**
- * Returns a snapshot of the current bot status (Discord, voice for the given
- * guild, Twitch channels, TikTok channels). Voice status is scoped to a
- * single guild so a viewer of one guild's dashboard never sees another
- * guild's now-playing info; a null guildId (no guild selected yet) reports a
- * default disconnected/idle voice status.
+ * Returns a raw, unscoped snapshot of the current bot status (Discord ready/tag, voice for
+ * the given guild, every tracked Twitch channel, every tracked TikTok channel). Voice status
+ * is the only field scoped here — to a single guild, so a viewer of one guild's dashboard
+ * never sees another guild's now-playing info; a null guildId (no guild selected yet) reports
+ * a default disconnected/idle voice status. The Discord server name and per-guild Twitch
+ * channel filtering happen one layer up, in `src/web/guildScopedStatus.ts`, since that needs
+ * DB lookups this in-memory store deliberately stays free of.
  *
  * @param guildId - Guild to read voice status for, or null if none is selected.
  */

--- a/src/web/guildScopedStatus.test.ts
+++ b/src/web/guildScopedStatus.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../shared/statusStore', () => ({
+  getStatus: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  getGuildById: vi.fn(),
+  getGuildMemberUsers: vi.fn(),
+}));
+
+vi.mock('../twitch/twitchChannelName', () => ({
+  normalizeTwitchChannelName: vi.fn((s: string) => (s ? s.toLowerCase() : null)),
+}));
+
+import { getGuildScopedStatus } from './guildScopedStatus';
+import { getStatus } from '../shared/statusStore';
+import { getGuildById, getGuildMemberUsers } from '../db';
+
+const BASE_STATUS = {
+  discord: { ready: true, tag: 'Bot#1234' },
+  voice: { connected: false, channelName: null, playing: false, currentFile: null, lastCommand: null, lastSource: null, lastPlayedAt: null },
+  twitch: {
+    ourstreamer: { connected: true, lastConnectedAt: null, lastDisconnectedAt: null, isLive: false },
+    otherguildstreamer: { connected: true, lastConnectedAt: null, lastDisconnectedAt: null, isLive: true },
+  },
+  tiktok: {
+    someone: { connected: true, lastConnectedAt: null, lastDisconnectedAt: null, isLive: false },
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getStatus).mockReturnValue(BASE_STATUS as any);
+  vi.mocked(getGuildById).mockResolvedValue({ guild_id: 'guild-A', name: 'Our Guild', voice_channel_id: null });
+  vi.mocked(getGuildMemberUsers).mockResolvedValue([
+    { discord_id: '1', discord_name: 'Streamer', is_twitch_bot_enabled: true, twitch_name: 'ourstreamer', access_level: 2, is_owner: false },
+  ]);
+});
+
+describe('getGuildScopedStatus — null guildId', () => {
+  it('returns an empty-scoped snapshot without any DB lookup', async () => {
+    const result = await getGuildScopedStatus(null);
+    expect(result.discord.guildName).toBeNull();
+    expect(result.twitch).toEqual({});
+    expect(result.tiktok).toEqual({});
+    expect(getGuildById).not.toHaveBeenCalled();
+    expect(getGuildMemberUsers).not.toHaveBeenCalled();
+  });
+
+  it('still passes null through to the underlying statusStore lookup', async () => {
+    await getGuildScopedStatus(null);
+    expect(getStatus).toHaveBeenCalledWith(null);
+  });
+});
+
+describe('getGuildScopedStatus — discord.guildName', () => {
+  it('resolves to the requested guild\'s own name, not a joined list of every guild', async () => {
+    const result = await getGuildScopedStatus('guild-A');
+    expect(result.discord.guildName).toBe('Our Guild');
+    expect(getGuildById).toHaveBeenCalledWith('guild-A');
+  });
+
+  it('is null when the guild is not found in the DB, without throwing', async () => {
+    vi.mocked(getGuildById).mockResolvedValue(null);
+    const result = await getGuildScopedStatus('guild-A');
+    expect(result.discord.guildName).toBeNull();
+  });
+});
+
+describe('getGuildScopedStatus — twitch scoping', () => {
+  it('includes only channels owned by this guild\'s twitch-bot-enabled members', async () => {
+    const result = await getGuildScopedStatus('guild-A');
+    expect(Object.keys(result.twitch)).toEqual(['ourstreamer']);
+    expect(result.twitch.otherguildstreamer).toBeUndefined();
+  });
+
+  it('excludes a member\'s twitch channel when is_twitch_bot_enabled is false', async () => {
+    vi.mocked(getGuildMemberUsers).mockResolvedValue([
+      { discord_id: '1', discord_name: 'Streamer', is_twitch_bot_enabled: false, twitch_name: 'ourstreamer', access_level: 2, is_owner: false },
+    ]);
+    const result = await getGuildScopedStatus('guild-A');
+    expect(result.twitch).toEqual({});
+  });
+
+  it('excludes a member with no twitch_name set', async () => {
+    vi.mocked(getGuildMemberUsers).mockResolvedValue([
+      { discord_id: '1', discord_name: 'Streamer', is_twitch_bot_enabled: true, twitch_name: null, access_level: 2, is_owner: false },
+    ]);
+    const result = await getGuildScopedStatus('guild-A');
+    expect(result.twitch).toEqual({});
+  });
+
+  it('returns no twitch channels when the guild has no members', async () => {
+    vi.mocked(getGuildMemberUsers).mockResolvedValue([]);
+    const result = await getGuildScopedStatus('guild-A');
+    expect(result.twitch).toEqual({});
+  });
+});
+
+describe('getGuildScopedStatus — tiktok', () => {
+  it('is always empty, regardless of what the global store tracks', async () => {
+    const result = await getGuildScopedStatus('guild-A');
+    expect(result.tiktok).toEqual({});
+  });
+});
+
+describe('getGuildScopedStatus — voice', () => {
+  it('passes through the already guild-scoped voice status unchanged', async () => {
+    const result = await getGuildScopedStatus('guild-A');
+    expect(result.voice).toEqual(BASE_STATUS.voice);
+  });
+});

--- a/src/web/guildScopedStatus.ts
+++ b/src/web/guildScopedStatus.ts
@@ -1,0 +1,56 @@
+import { getStatus, type ChannelStatus } from '../shared/statusStore';
+import { getGuildById, getGuildMemberUsers } from '../db';
+import { normalizeTwitchChannelName } from '../twitch/twitchChannelName';
+
+/** Bot status scoped to a single guild — safe to send to that guild's dashboard viewers. */
+export interface GuildScopedStatus {
+  discord: { ready: boolean; tag: string | null; guildName: string | null };
+  voice: ReturnType<typeof getStatus>['voice'];
+  twitch: Record<string, ChannelStatus>;
+  tiktok: Record<string, ChannelStatus>;
+}
+
+/**
+ * Returns the bot status for `guildId`'s dashboard: the guild's own name (never another
+ * guild's), voice status for the guild (already scoped by `statusStore.getStatus`), and
+ * Twitch channels filtered to just this guild's members. TikTok channels come only from a
+ * global env-configured list with no guild association anywhere in the schema, so they're
+ * always omitted here rather than guessed or leaked to every guild.
+ *
+ * @param guildId - Guild to scope the snapshot to, or null if no guild is selected (e.g. an
+ *   anonymous dashboard visitor) — returns a snapshot with no guild name and no Twitch/TikTok
+ *   channels, without any DB lookup.
+ */
+export async function getGuildScopedStatus(guildId: string | null): Promise<GuildScopedStatus> {
+  const status = getStatus(guildId);
+
+  if (!guildId) {
+    return {
+      discord: { ...status.discord, guildName: null },
+      voice: status.voice,
+      twitch: {},
+      tiktok: {},
+    };
+  }
+
+  const [guild, members] = await Promise.all([
+    getGuildById(guildId),
+    getGuildMemberUsers(guildId),
+  ]);
+
+  const allowedTwitchChannels = new Set(
+    members
+      .filter((m) => m.is_twitch_bot_enabled && m.twitch_name)
+      .map((m) => normalizeTwitchChannelName(m.twitch_name as string))
+      .filter((v): v is string => v !== null),
+  );
+
+  return {
+    discord: { ...status.discord, guildName: guild?.name ?? null },
+    voice: status.voice,
+    twitch: Object.fromEntries(
+      Object.entries(status.twitch).filter(([channel]) => allowedTwitchChannels.has(channel)),
+    ),
+    tiktok: {},
+  };
+}

--- a/src/web/routes/api.test.ts
+++ b/src/web/routes/api.test.ts
@@ -76,6 +76,12 @@ describe('GET /status', () => {
     expect(res.body).toEqual({ ok: false, error: 'No guild selected' });
     expect(vi.mocked(getGuildScopedStatus)).not.toHaveBeenCalled();
   });
+
+  it('returns 500 when the status lookup fails', async () => {
+    vi.mocked(getGuildScopedStatus).mockRejectedValue(new Error('DB down'));
+    const res = await supertest(buildApp()).get('/status').expect(500);
+    expect(res.body).toEqual({ ok: false, error: 'Failed to fetch status' });
+  });
 });
 
 describe('GET /voice/channels', () => {

--- a/src/web/routes/api.test.ts
+++ b/src/web/routes/api.test.ts
@@ -10,8 +10,8 @@ vi.mock('../csrf', () => ({
   csrfProtection: (_req: any, _res: any, next: any) => next(),
 }));
 
-vi.mock('../../shared/statusStore', () => ({
-  getStatus: vi.fn(),
+vi.mock('../guildScopedStatus', () => ({
+  getGuildScopedStatus: vi.fn(),
 }));
 
 vi.mock('../../audio/audioPlayer', () => ({
@@ -40,7 +40,7 @@ vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
 
 import supertest from 'supertest';
 import router from './api';
-import { getStatus } from '../../shared/statusStore';
+import { getGuildScopedStatus } from '../guildScopedStatus';
 import { connect, disconnect, getCurrentChannelId } from '../../audio/audioPlayer';
 import { getDiscordClient } from '../../discord/discordBot';
 import { getAvailableVoiceChannels } from '../../discord/discordUtils';
@@ -56,7 +56,7 @@ function buildApp(currentGuildId: string | null = GUILD_ID) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(getStatus).mockReturnValue({ discord: {}, voice: {}, twitch: {}, tiktok: {} } as never);
+  vi.mocked(getGuildScopedStatus).mockResolvedValue({ discord: {}, voice: {}, twitch: {}, tiktok: {} } as never);
   vi.mocked(getDiscordClient).mockReturnValue({} as never);
   vi.mocked(connect).mockResolvedValue(undefined);
   vi.mocked(getCurrentChannelId).mockReturnValue('current-vc');
@@ -68,13 +68,13 @@ describe('GET /status', () => {
   it('returns the status snapshot for the session guild', async () => {
     const res = await supertest(buildApp()).get('/status').expect(200);
     expect(res.body).toEqual({ discord: {}, voice: {}, twitch: {}, tiktok: {} });
-    expect(vi.mocked(getStatus)).toHaveBeenCalledWith(GUILD_ID);
+    expect(vi.mocked(getGuildScopedStatus)).toHaveBeenCalledWith(GUILD_ID);
   });
 
   it('returns 400 when no guild is selected', async () => {
     const res = await supertest(buildApp(null)).get('/status').expect(400);
     expect(res.body).toEqual({ ok: false, error: 'No guild selected' });
-    expect(vi.mocked(getStatus)).not.toHaveBeenCalled();
+    expect(vi.mocked(getGuildScopedStatus)).not.toHaveBeenCalled();
   });
 });
 

--- a/src/web/routes/api.ts
+++ b/src/web/routes/api.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '../../shared/logger';
 import { Router, type Request, type Response } from 'express';
-import { getStatus } from '../../shared/statusStore';
+import { getGuildScopedStatus } from '../guildScopedStatus';
 import { requireAuth, requireMod } from '../middleware';
 import { connect, disconnect, getCurrentChannelId } from '../../audio/audioPlayer';
 import { csrfProtection } from '../csrf';
@@ -31,16 +31,19 @@ function getSessionGuildId(req: Request, res: Response): string | null {
 
 /**
  * GET /status — live bot status JSON, polled by the dashboard frontend every
- * few seconds. Voice status is scoped to the viewer's current guild so a
- * Manager on guild B's dashboard never sees guild A's now-playing info.
+ * few seconds. Voice status, the Discord "Server" name, and Twitch channels
+ * are all scoped to the viewer's current guild so a Manager on guild B's
+ * dashboard never sees guild A's now-playing info, server name, or Twitch
+ * channels; TikTok channels are always omitted since they have no guild
+ * association in the data model.
  * @param req - Express request; guild is taken from the session.
- * @param res - Express response; returns `getStatus(guildId)`, or 400 if no
- *   guild is selected.
+ * @param res - Express response; returns `getGuildScopedStatus(guildId)`, or
+ *   400 if no guild is selected.
  */
-router.get('/status', requireAuth, (req, res) => {
+router.get('/status', requireAuth, async (req, res) => {
   const guildId = getSessionGuildId(req, res);
   if (!guildId) return;
-  res.json(getStatus(guildId));
+  res.json(await getGuildScopedStatus(guildId));
 });
 
 /**

--- a/src/web/routes/api.ts
+++ b/src/web/routes/api.ts
@@ -37,13 +37,18 @@ function getSessionGuildId(req: Request, res: Response): string | null {
  * channels; TikTok channels are always omitted since they have no guild
  * association in the data model.
  * @param req - Express request; guild is taken from the session.
- * @param res - Express response; returns `getGuildScopedStatus(guildId)`, or
- *   400 if no guild is selected.
+ * @param res - Express response; returns `getGuildScopedStatus(guildId)`, 400
+ *   if no guild is selected, or 500 if the lookup fails.
  */
 router.get('/status', requireAuth, async (req, res) => {
   const guildId = getSessionGuildId(req, res);
   if (!guildId) return;
-  res.json(await getGuildScopedStatus(guildId));
+  try {
+    res.json(await getGuildScopedStatus(guildId));
+  } catch (err) {
+    log.error('Failed to fetch status:', err);
+    res.status(500).json({ ok: false, error: 'Failed to fetch status' });
+  }
 });
 
 /**

--- a/src/web/routes/dashboard.test.ts
+++ b/src/web/routes/dashboard.test.ts
@@ -4,8 +4,8 @@ import { mockLogger } from '../../test-utils/loggerMock';
 /** Mocks the shared logger so route handlers don't write real log output during tests. */
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
 
-vi.mock('../../shared/statusStore', () => ({
-  getStatus: vi.fn(),
+vi.mock('../guildScopedStatus', () => ({
+  getGuildScopedStatus: vi.fn(),
 }));
 
 vi.mock('../../db', () => ({
@@ -33,7 +33,7 @@ vi.mock('./dashboardEvents', () => ({
 
 import supertest from 'supertest';
 import router from './dashboard';
-import { getStatus } from '../../shared/statusStore';
+import { getGuildScopedStatus } from '../guildScopedStatus';
 import {
   getStreamerByDiscordId, getSfxTriggerCount, getCustomCommandCount, getCounterCount, getRecentStreamerEvents,
 } from '../../db';
@@ -53,7 +53,7 @@ function buildApp(sessionUser: unknown = undefined) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(getStatus).mockReturnValue(STATUS as any);
+  vi.mocked(getGuildScopedStatus).mockResolvedValue(STATUS as any);
   vi.mocked(getSfxTriggerCount).mockResolvedValue(3);
   vi.mocked(getCustomCommandCount).mockResolvedValue(5);
   vi.mocked(getCounterCount).mockResolvedValue(2);
@@ -71,7 +71,7 @@ describe('GET /', () => {
     expect(res.body.recentEvents).toEqual([]);
     expect(getStreamerByDiscordId).not.toHaveBeenCalled();
     expect(getRecentStreamerEvents).not.toHaveBeenCalled();
-    expect(getStatus).toHaveBeenCalledWith(null);
+    expect(getGuildScopedStatus).toHaveBeenCalledWith(null);
   });
 
   it('includes usage-stat counts from the db layer', async () => {
@@ -81,7 +81,7 @@ describe('GET /', () => {
 
   it('scopes status to the session\'s current guild', async () => {
     await supertest(buildApp({ discordId: '100', currentGuildId: 'guild-A' })).get('/');
-    expect(getStatus).toHaveBeenCalledWith('guild-A');
+    expect(getGuildScopedStatus).toHaveBeenCalledWith('guild-A');
   });
 
   it('sets needsReconnect true when the streamer has auth-failed subs', async () => {

--- a/src/web/routes/dashboard.ts
+++ b/src/web/routes/dashboard.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
-import { getStatus } from '../../shared/statusStore';
+import { getGuildScopedStatus } from '../guildScopedStatus';
 import { csrfProtection } from '../csrf';
 import { getStreamerByDiscordId, getSfxTriggerCount, getCustomCommandCount, getCounterCount, getRecentStreamerEvents } from '../../db';
 import { hasAuthFailedSubs } from '../../twitch/eventsub/twitchEventSubSubscriptions';
@@ -21,7 +21,7 @@ const router = Router();
  */
 router.get('/', csrfProtection, async (req, res) => {
   try {
-    const status = getStatus(req.session.user?.currentGuildId ?? null);
+    const status = await getGuildScopedStatus(req.session.user?.currentGuildId ?? null);
     const [sfxCount, commandCount, counterCount, streamer] = await Promise.all([
       getSfxTriggerCount(), getCustomCommandCount(), getCounterCount(),
       req.session.user ? getStreamerByDiscordId(req.session.user.discordId) : Promise.resolve(null),

--- a/src/web/routes/dashboardStatusEvents.test.ts
+++ b/src/web/routes/dashboardStatusEvents.test.ts
@@ -6,19 +6,25 @@ vi.mock('../../shared/config', () => ({
 }));
 
 vi.mock('../../shared/statusStore', () => ({
-  getStatus: vi.fn(),
   onStatusChanged: vi.fn(),
 }));
 
+vi.mock('../guildScopedStatus', () => ({
+  getGuildScopedStatus: vi.fn(),
+}));
+
+vi.mock('../../shared/logger', () => ({ createLogger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn() }) }));
+
 import supertest from 'supertest';
 import router, { MAX_SSE_CONNECTIONS_PER_GUILD, connections } from './dashboardStatusEvents';
-import { getStatus, onStatusChanged } from '../../shared/statusStore';
+import { onStatusChanged } from '../../shared/statusStore';
+import { getGuildScopedStatus } from '../guildScopedStatus';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 
 // Captured immediately after import, before any beforeEach's clearAllMocks() erases the
 // one-time module-load call — dashboardStatusEvents.ts registers this listener as a
 // top-level side effect, not per-request, so it's only ever recorded once.
-const registeredListener = vi.mocked(onStatusChanged).mock.calls[0]?.[0] as (guildId: string | null) => void;
+const registeredListener = vi.mocked(onStatusChanged).mock.calls[0]?.[0] as (guildId: string | null) => Promise<void>;
 
 /** Finds a route's handler function directly from the router's internal stack, bypassing HTTP entirely — needed to control the request's 'close' event deterministically. */
 function getRouteHandler(routePath: string): (req: any, res: any, next: any) => void {
@@ -137,38 +143,54 @@ describe('status-change push (registered via onStatusChanged)', () => {
     expect(typeof registeredListener).toBe('function');
   });
 
-  it('pushes a guild-scoped snapshot to only that guild when guildId is given', () => {
+  it('pushes a guild-scoped snapshot to only that guild when guildId is given', async () => {
     const resA = { write: vi.fn() };
     const resB = { write: vi.fn() };
     connections.set('guild-A', new Set([resA] as any));
     connections.set('guild-B', new Set([resB] as any));
-    vi.mocked(getStatus).mockImplementation((guildId) => ({ guildId }) as any);
+    vi.mocked(getGuildScopedStatus).mockImplementation(async (guildId) => ({ guildId }) as any);
 
-    registeredListener('guild-A');
+    await registeredListener('guild-A');
 
-    expect(getStatus).toHaveBeenCalledWith('guild-A');
-    expect(getStatus).not.toHaveBeenCalledWith('guild-B');
+    expect(getGuildScopedStatus).toHaveBeenCalledWith('guild-A');
+    expect(getGuildScopedStatus).not.toHaveBeenCalledWith('guild-B');
     expect(resA.write).toHaveBeenCalledWith(`data: ${JSON.stringify({ guildId: 'guild-A' })}\n\n`);
     expect(resB.write).not.toHaveBeenCalled();
   });
 
-  it('pushes an individually-scoped snapshot to every connected guild when guildId is null', () => {
+  it('pushes an individually-scoped snapshot to every connected guild when guildId is null', async () => {
     const resA = { write: vi.fn() };
     const resB = { write: vi.fn() };
     connections.set('guild-A', new Set([resA] as any));
     connections.set('guild-B', new Set([resB] as any));
-    vi.mocked(getStatus).mockImplementation((guildId) => ({ guildId }) as any);
+    vi.mocked(getGuildScopedStatus).mockImplementation(async (guildId) => ({ guildId }) as any);
 
-    registeredListener(null);
+    await registeredListener(null);
 
-    expect(getStatus).toHaveBeenCalledWith('guild-A');
-    expect(getStatus).toHaveBeenCalledWith('guild-B');
+    expect(getGuildScopedStatus).toHaveBeenCalledWith('guild-A');
+    expect(getGuildScopedStatus).toHaveBeenCalledWith('guild-B');
     expect(resA.write).toHaveBeenCalledWith(`data: ${JSON.stringify({ guildId: 'guild-A' })}\n\n`);
     expect(resB.write).toHaveBeenCalledWith(`data: ${JSON.stringify({ guildId: 'guild-B' })}\n\n`);
   });
 
-  it('does nothing when guildId is null and there are no connected guilds', () => {
-    registeredListener(null);
-    expect(getStatus).not.toHaveBeenCalled();
+  it('does nothing when guildId is null and there are no connected guilds', async () => {
+    await registeredListener(null);
+    expect(getGuildScopedStatus).not.toHaveBeenCalled();
+  });
+
+  it('a rejected lookup for one guild does not stop the broadcast to other connected guilds', async () => {
+    const resA = { write: vi.fn() };
+    const resB = { write: vi.fn() };
+    connections.set('guild-A', new Set([resA] as any));
+    connections.set('guild-B', new Set([resB] as any));
+    vi.mocked(getGuildScopedStatus).mockImplementation(async (guildId) => {
+      if (guildId === 'guild-A') throw new Error('DB down');
+      return { guildId } as any;
+    });
+
+    await registeredListener(null);
+
+    expect(resA.write).not.toHaveBeenCalled();
+    expect(resB.write).toHaveBeenCalledWith(`data: ${JSON.stringify({ guildId: 'guild-B' })}\n\n`);
   });
 });

--- a/src/web/routes/dashboardStatusEvents.test.ts
+++ b/src/web/routes/dashboardStatusEvents.test.ts
@@ -193,4 +193,66 @@ describe('status-change push (registered via onStatusChanged)', () => {
     expect(resA.write).not.toHaveBeenCalled();
     expect(resB.write).toHaveBeenCalledWith(`data: ${JSON.stringify({ guildId: 'guild-B' })}\n\n`);
   });
+
+  it('serializes same-guild pushes so a slow first lookup cannot resolve after (and clobber) a later one', async () => {
+    const resA = { write: vi.fn() };
+    connections.set('guild-A', new Set([resA] as any));
+
+    let resolveFirstLookup!: () => void;
+    const firstLookupGate = new Promise<void>((resolve) => { resolveFirstLookup = resolve; });
+    let lookupsStarted = 0;
+    vi.mocked(getGuildScopedStatus).mockImplementation(async () => {
+      lookupsStarted += 1;
+      if (lookupsStarted === 1) {
+        await firstLookupGate;
+        return { value: 'first' } as any;
+      }
+      return { value: 'second' } as any;
+    });
+
+    const firstPush = registeredListener('guild-A');
+    const secondPush = registeredListener('guild-A');
+
+    // The second push's lookup must not start until the first one (still gated) finishes —
+    // otherwise a faster second DB round-trip could broadcast before the first, leaving the
+    // client stuck on stale data.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(lookupsStarted).toBe(1);
+
+    resolveFirstLookup();
+    await Promise.all([firstPush, secondPush]);
+
+    expect(resA.write).toHaveBeenNthCalledWith(1, `data: ${JSON.stringify({ value: 'first' })}\n\n`);
+    expect(resA.write).toHaveBeenNthCalledWith(2, `data: ${JSON.stringify({ value: 'second' })}\n\n`);
+  });
+
+  it('does not serialize pushes for different guilds against each other', async () => {
+    const resA = { write: vi.fn() };
+    const resB = { write: vi.fn() };
+    connections.set('guild-A', new Set([resA] as any));
+    connections.set('guild-B', new Set([resB] as any));
+
+    let resolveGuildALookup!: () => void;
+    const guildALookupGate = new Promise<void>((resolve) => { resolveGuildALookup = resolve; });
+    vi.mocked(getGuildScopedStatus).mockImplementation(async (guildId) => {
+      if (guildId === 'guild-A') {
+        await guildALookupGate;
+        return { guildId } as any;
+      }
+      return { guildId } as any;
+    });
+
+    const guildAPush = registeredListener('guild-A');
+    const guildBPush = registeredListener('guild-B');
+
+    // guild-B's push must complete even while guild-A's is still gated — they don't share a queue.
+    await guildBPush;
+    expect(resB.write).toHaveBeenCalledWith(`data: ${JSON.stringify({ guildId: 'guild-B' })}\n\n`);
+    expect(resA.write).not.toHaveBeenCalled();
+
+    resolveGuildALookup();
+    await guildAPush;
+    expect(resA.write).toHaveBeenCalledWith(`data: ${JSON.stringify({ guildId: 'guild-A' })}\n\n`);
+  });
 });

--- a/src/web/routes/dashboardStatusEvents.ts
+++ b/src/web/routes/dashboardStatusEvents.ts
@@ -4,6 +4,7 @@ import { onStatusChanged } from '../../shared/statusStore';
 import { getGuildScopedStatus } from '../guildScopedStatus';
 import { attachSseConnection, broadcastToChannel } from './sseChannel';
 import { createLogger } from '../../shared/logger';
+import { createMutationQueue } from '../../shared/mutationQueue';
 
 const log = createLogger('Web');
 const router = Router();
@@ -13,24 +14,32 @@ export const connections = new Map<string, Set<import('express').Response>>();
 
 export const MAX_SSE_CONNECTIONS_PER_GUILD = DASHBOARD_STATUS_MAX_SSE_PER_GUILD;
 
+// Serializes each guild's own status pushes so a slower DB round-trip for an older change can
+// never resolve after — and clobber the client with stale data behind — a newer one for the same
+// guild. Unrelated guilds stay independent, same as the DB-mutation queues this pattern is shared
+// with (see src/twitch/twitchChannelMembership.ts).
+const statusPushQueue = createMutationQueue<string>();
+
 /**
  * Pushes a fresh status snapshot to every dashboard connected for `guildId`, or — when
  * `guildId` is null (a change not scoped to one guild, e.g. Discord ready state or a
  * Twitch/TikTok channel connecting) — to every currently connected guild, each with its own
  * guild-scoped snapshot. Registered once as the {@link onStatusChanged} listener below, so it
  * fires after every `statusStore` mutation. Each guild's snapshot is resolved and broadcast
- * independently, so one guild's lookup failing doesn't stop the others from receiving theirs.
+ * independently — one guild's lookup failing doesn't stop the others from receiving theirs —
+ * and serialized per guild via {@link statusPushQueue} so same-guild updates always broadcast
+ * in the order they were triggered, even if their DB lookups resolve out of order.
  * @param guildId - The guild whose voice status changed, or null for a global change.
  */
 async function pushStatusUpdate(guildId: string | null): Promise<void> {
   const keys = guildId !== null ? [guildId] : Array.from(connections.keys());
-  await Promise.all(keys.map(async (key) => {
+  await Promise.all(keys.map((key) => statusPushQueue.run(key, async () => {
     try {
       broadcastToChannel(connections, key, await getGuildScopedStatus(key));
     } catch (err) {
       log.error(`Failed to push status update for guild ${key}:`, err);
     }
-  }));
+  })));
 }
 
 onStatusChanged(pushStatusUpdate);

--- a/src/web/routes/dashboardStatusEvents.ts
+++ b/src/web/routes/dashboardStatusEvents.ts
@@ -1,8 +1,11 @@
 import { Router } from 'express';
 import { DASHBOARD_STATUS_MAX_SSE_PER_GUILD } from '../../shared/config';
-import { getStatus, onStatusChanged } from '../../shared/statusStore';
+import { onStatusChanged } from '../../shared/statusStore';
+import { getGuildScopedStatus } from '../guildScopedStatus';
 import { attachSseConnection, broadcastToChannel } from './sseChannel';
+import { createLogger } from '../../shared/logger';
 
+const log = createLogger('Web');
 const router = Router();
 
 // In-memory map of active SSE connections keyed by guild ID.
@@ -15,22 +18,27 @@ export const MAX_SSE_CONNECTIONS_PER_GUILD = DASHBOARD_STATUS_MAX_SSE_PER_GUILD;
  * `guildId` is null (a change not scoped to one guild, e.g. Discord ready state or a
  * Twitch/TikTok channel connecting) — to every currently connected guild, each with its own
  * guild-scoped snapshot. Registered once as the {@link onStatusChanged} listener below, so it
- * fires after every `statusStore` mutation.
+ * fires after every `statusStore` mutation. Each guild's snapshot is resolved and broadcast
+ * independently, so one guild's lookup failing doesn't stop the others from receiving theirs.
  * @param guildId - The guild whose voice status changed, or null for a global change.
  */
-function pushStatusUpdate(guildId: string | null): void {
+async function pushStatusUpdate(guildId: string | null): Promise<void> {
   const keys = guildId !== null ? [guildId] : Array.from(connections.keys());
-  for (const key of keys) {
-    broadcastToChannel(connections, key, getStatus(key));
-  }
+  await Promise.all(keys.map(async (key) => {
+    try {
+      broadcastToChannel(connections, key, await getGuildScopedStatus(key));
+    } catch (err) {
+      log.error(`Failed to push status update for guild ${key}:`, err);
+    }
+  }));
 }
 
 onStatusChanged(pushStatusUpdate);
 
 /**
- * GET /dashboard/status/events — SSE endpoint streaming live `getStatus(guildId)` snapshots
- * for the viewer's current guild, so the dashboard's "Bot Status" cards can update without
- * polling. Mounted behind the parent router's `requireAuth`, so a session user is always
+ * GET /dashboard/status/events — SSE endpoint streaming live `getGuildScopedStatus(guildId)`
+ * snapshots for the viewer's current guild, so the dashboard's "Bot Status" cards can update
+ * without polling. Mounted behind the parent router's `requireAuth`, so a session user is always
  * present; the guild is taken from the session (never a request param), matching every other
  * guild-scoped route.
  * @param req - Express request; reads `req.session.user.currentGuildId`.


### PR DESCRIPTION
## Summary

The dashboard's bot status (`GET /`, `GET /api/status`, and the `GET /dashboard/status/events` SSE stream) previously leaked bot-wide data to every viewer, regardless of which guild's dashboard they were on:

- **Discord "Server" field** showed a comma-joined list of the names of *every* guild the bot serves, not just the viewer's own.
- **Twitch/TikTok channel lists** showed every channel the bot handles across all guilds, unfiltered.

Only `voice` status was actually guild-scoped before this change.

## Changes

- `src/shared/statusStore.ts`: dropped the bot-wide `guildName` field/param from `setDiscordReady`/`state.discord` — this in-memory store now only tracks Discord ready/tag, not any guild name.
- `src/discord/discordBot.ts`: simplified the `clientReady` handler to just `setDiscordReady(c.user.tag)`, removing the `getAllGuilds()` name-joining logic.
- New `src/web/guildScopedStatus.ts` — `getGuildScopedStatus(guildId)`: resolves the Discord server name to just the requested guild (via `getGuildById`), filters Twitch channels to that guild's own twitch-bot-enabled members (via the existing `getGuildMemberUsers`), and always omits TikTok channels since they come only from a global env var with no guild association anywhere in the schema.
- Updated the three status call sites (`dashboard.ts`, `api.ts`, `dashboardStatusEvents.ts`) to use `getGuildScopedStatus` instead of the raw `statusStore.getStatus`.
- Updated/added tests across all touched files.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (2861 tests passing, including new coverage in `guildScopedStatus.test.ts`)
- [ ] Manual check in a dev environment with ≥2 guilds registered: confirm each guild's dashboard only shows its own server name and its own Twitch streamer(s), and TikTok always shows "no channels configured".


---
_Generated by [Claude Code](https://claude.ai/code/session_01L2Mq2NZqKKCsWW55HfYozr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guild-scoped status snapshots for the dashboard and `/status`.
  * Dashboard status updates now stream guild-appropriate snapshots.
* **Bug Fixes**
  * Guild status update failures no longer block updates for other guilds.
  * Discord readiness now reports only the bot tag (no persisted guild-name dependency).
* **Tests**
  * Updated and added coverage for guild scoping, `/status` behavior, and per-guild SSE update ordering/error isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->