### PR TITLE
Remove 8 dead re-exports from db.ts facade

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -9,13 +9,13 @@ export { getPool, closePool } from './db/pool';
 // ─── Guilds ──────────────────────────────────────────────────────────────────
 
 export {
-  getAllGuilds, getProvisionedGuilds, getGuildById, getGuildsForMember, upsertGuild, setGuildVoiceChannel,
+  getAllGuilds, getProvisionedGuilds, getGuildById, getGuildsForMember, upsertGuild,
 } from './db/guilds';
 export type { DbGuild } from './db/guilds';
 
 export {
-  getGuildMembers, getMemberAccessLevel, setMemberAccessLevel,
-  removeGuildMember, getEffectiveAccessLevel, getEffectiveAccessLevelForUser,
+  getMemberAccessLevel, setMemberAccessLevel,
+  removeGuildMember, getEffectiveAccessLevelForUser,
 } from './db/guildMembers';
 export type { DbGuildMember } from './db/guildMembers';
 
@@ -72,7 +72,7 @@ export async function removeOverride(guildId: string, commandId: number): Promis
 
 export {
   AccessLevel, ACCESS_LEVEL_LABELS,
-  findUser, findUsersByIds, findUserByTwitchName, findOwnerUser, getAllUsers, getGuildMemberUsers,
+  findUser, findUsersByIds, findUserByTwitchName, getAllUsers, getGuildMemberUsers,
   updateDiscordName, getTwitchEnabledChannels, getAllTwitchLinkedUsers, updateAccessLevel,
 } from './db/users';
 export type { AccessLevelValue, DbUser, TwitchLinkedUser } from './db/users';
@@ -193,7 +193,7 @@ export {
   addSfxFile, updateSfxFile, deleteSfxFile,
 } from './db/sfx';
 export type { SfxLookupResult } from './db/sfxCache';
-export { findCachedSfxTrigger, invalidateSfxLookupCache } from './db/sfxCache';
+export { findCachedSfxTrigger } from './db/sfxCache';
 
 // ─── Overlay videos ─────────────────────────────────────────────────────────
 
@@ -208,14 +208,14 @@ export {
 
 export type { RewardPricingRow, RewardPricingInput, StreamerPricingSettings } from './db/rewardPricing';
 export {
-  getPricingForReward, getPricingConfigById, getPricingConfigsForStreamer, getAllEnabledPricingRows,
+  getPricingForReward, getPricingConfigsForStreamer, getAllEnabledPricingRows,
   upsertPricingConfig, recordPricingUpdate, deletePricingConfig, markPricingUnsupported,
   updatePricingCooldownForReward, getPricingSettingsForStreamer, savePricingSettingsForStreamer,
   DEFAULT_PRICING_COOLDOWN_SECONDS,
 } from './db/rewardPricing';
 
 export type { RewardPricingHistoryPoint } from './db/rewardPricingHistory';
-export { recordPricingHistory, getPricingHistory, getPricingHistoryForRewards } from './db/rewardPricingHistory';
+export { recordPricingHistory, getPricingHistoryForRewards } from './db/rewardPricingHistory';
 
 // ─── Streamdeck API keys ─────────────────────────────────────────────────────
 
@@ -245,4 +245,4 @@ export {
   getTokenStatus,
   revokeToken,
 } from './db/companionTokens';
-export { createCode, consumeCode, exchangeCodeForToken } from './db/companionOAuthCodes';
+export { createCode, exchangeCodeForToken } from './db/companionOAuthCodes';


### PR DESCRIPTION
## Summary
- Part of a codebase cleanup audit (split into several small PRs).
- Removes 8 re-exports from `src/db.ts` that are never imported anywhere outside their own defining module and its test file: `setGuildVoiceChannel`, `getGuildMembers`, `getEffectiveAccessLevel`, `findOwnerUser`, `invalidateSfxLookupCache`, `getPricingConfigById`, `getPricingHistory`, `consumeCode`.
- The underlying implementations in `src/db/*.ts` are untouched — only the facade re-export lines are removed, since some are still used internally within `src/db/*`.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 152 test files, 2829 tests, all passing


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mrb1bcWuEQdFUQ2PzK54fA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom-command cache updates during user profile changes.
  * Custom-command data now refreshes when a Twitch name is added or changed, while avoiding unnecessary cache refreshes for unrelated updates.
  * This helps keep command behavior current while improving update efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->