### PR TITLE
Add safety comments to BIGINT epoch-ms coercions

### DIFF
--- a/src/twitch/eventsub/twitchApiEventSub.ts
+++ b/src/twitch/eventsub/twitchApiEventSub.ts
@@ -9,6 +9,7 @@ const TOKEN_BUFFER_MS = 5 * 60 * 1000;
 
 export async function getValidToken(streamer: DbStreamerEventSub): Promise<string | null> {
   if (!streamer.eventsub_access_token) return null;
+  // eventsub_token_expiry is BIGINT epoch ms — safe to coerce, won't exceed MAX_SAFE_INTEGER until year 275760.
   const needsRefresh = streamer.eventsub_token_expiry != null
     && Date.now() > Number(streamer.eventsub_token_expiry) - TOKEN_BUFFER_MS;
   if (!needsRefresh) return streamer.eventsub_access_token;

--- a/src/twitch/pricing/rewardPricingService.ts
+++ b/src/twitch/pricing/rewardPricingService.ts
@@ -160,6 +160,7 @@ async function syncRewardPrice(
 
   const settings = settingsHint ?? await getPricingSettingsForStreamer(streamerId);
   const now = Date.now();
+  // demand_updated_at is BIGINT epoch ms — safe to coerce, won't exceed MAX_SAFE_INTEGER until year 275760.
   const elapsedSeconds = Math.max(0, (now - Number(row.demand_updated_at)) / 1000);
   const newDemand = applyIncrement
     ? applyRedemption(

--- a/src/web/routes/channelPointsAdmin.ts
+++ b/src/web/routes/channelPointsAdmin.ts
@@ -150,6 +150,7 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
 
     function buildHistoryChart(config: RewardPricingRow): string {
       const points = historyByRewardId.get(config.id) ?? [];
+      // recorded_at is BIGINT epoch ms — safe to coerce, won't exceed MAX_SAFE_INTEGER until year 275760.
       return renderPriceHistoryChart(points.map((p) => ({ t: Number(p.recorded_at), cost: p.cost })), rangeStartMs, rangeEndMs);
     }
 


### PR DESCRIPTION
## Summary
- Part of a codebase cleanup audit (split into several small PRs).
- Three `Number()` coercions of BIGINT epoch-ms columns (`demand_updated_at`, `eventsub_token_expiry`, `recorded_at`) had no comment justifying why they're safe, which per the project's BIGINT rule should read like a blind coercion unless annotated.
- Adds a one-line comment at each call site explaining the value is bounded (epoch ms, safe until year 275760). No behavior change.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 152 test files, 2829 tests, all passing


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mrb1bcWuEQdFUQ2PzK54fA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarifying comments about timestamp handling and numeric conversion safety.
  * No user-facing behavior or runtime functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->