### PR TITLE
Dedupe row-mapping in rewardPricingHistory.ts

### DIFF
--- a/src/db/rewardPricingHistory.ts
+++ b/src/db/rewardPricingHistory.ts
@@ -15,7 +15,11 @@ export interface RewardPricingHistoryPoint {
 // window the last prune ran.
 const RETENTION_MS = 25 * 60 * 60 * 1000;
 
-/** Maps a `reward_pricing_history` row to a {@link RewardPricingHistoryPoint}. */
+/**
+ * Maps a `reward_pricing_history` row to a {@link RewardPricingHistoryPoint}.
+ * @param r - Row containing `recorded_at`, `cost`, and `demand` columns.
+ * @returns The point, with `recorded_at` coerced to a string and `demand` to a number.
+ */
 function mapRow(r: mysql.RowDataPacket): RewardPricingHistoryPoint {
   return { recorded_at: String(r.recorded_at), cost: r.cost, demand: Number(r.demand) };
 }

--- a/src/db/rewardPricingHistory.ts
+++ b/src/db/rewardPricingHistory.ts
@@ -15,6 +15,11 @@ export interface RewardPricingHistoryPoint {
 // window the last prune ran.
 const RETENTION_MS = 25 * 60 * 60 * 1000;
 
+/** Maps a `reward_pricing_history` row to a {@link RewardPricingHistoryPoint}. */
+function mapRow(r: mysql.RowDataPacket): RewardPricingHistoryPoint {
+  return { recorded_at: String(r.recorded_at), cost: r.cost, demand: Number(r.demand) };
+}
+
 /**
  * Records a price/demand point for a reward, then prunes points older than the
  * retention window for that same reward so the table stays bounded to roughly the
@@ -57,11 +62,7 @@ export async function getPricingHistory(rewardPricingId: number, sinceMs: number
      ORDER BY recorded_at ASC`,
     [rewardPricingId, sinceMs],
   );
-  return rows.map((r) => ({
-    recorded_at: String(r.recorded_at),
-    cost: r.cost,
-    demand: Number(r.demand),
-  }));
+  return rows.map(mapRow);
 }
 
 /**
@@ -90,7 +91,7 @@ export async function getPricingHistoryForRewards(
 
   for (const r of rows) {
     const rewardPricingId = r.reward_pricing_id as number;
-    const point: RewardPricingHistoryPoint = { recorded_at: String(r.recorded_at), cost: r.cost, demand: Number(r.demand) };
+    const point = mapRow(r);
     const existing = byRewardId.get(rewardPricingId);
     if (existing) existing.push(point);
     else byRewardId.set(rewardPricingId, [point]);


### PR DESCRIPTION
## Summary
- Part of a codebase cleanup audit (split into several small PRs).
- `getPricingHistory` and `getPricingHistoryForRewards` in `src/db/rewardPricingHistory.ts` both inlined the identical `{ recorded_at: String(r.recorded_at), cost: r.cost, demand: Number(r.demand) }` row mapping.
- Extracted a shared `mapRow` helper, matching the existing pattern in `src/db/rewardPricing.ts`. No behavior change.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 152 test files, 2829 tests, all passing


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mrb1bcWuEQdFUQ2PzK54fA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency when processing reward pricing history data.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->