### PR TITLE
Rename local not-found sentinel classes to carry the Error suffix

### DIFF
--- a/src/db/companionOAuthCodes.ts
+++ b/src/db/companionOAuthCodes.ts
@@ -78,7 +78,7 @@ export async function consumeCode(code: string): Promise<string | null> {
  */
 export async function exchangeCodeForToken(code: string): Promise<string | null> {
   const hash = createHash('sha256').update(code).digest('hex');
-  class CodeNotFound extends Error {}
+  class CodeNotFoundError extends Error {}
   try {
     return await withTransaction(async (conn) => {
       const discordId = await consumeCodeOnConnection(conn, hash);
@@ -86,11 +86,11 @@ export async function exchangeCodeForToken(code: string): Promise<string | null>
       // consumeCodeOnConnection above, so an invalid/expired/already-used code — or the
       // edge case where the row vanishes between the UPDATE and the follow-up SELECT —
       // doesn't permanently burn the code with no token to show for it.
-      if (!discordId) throw new CodeNotFound();
+      if (!discordId) throw new CodeNotFoundError();
       return issueTokenOnConnection(conn, discordId);
     });
   } catch (err) {
-    if (err instanceof CodeNotFound) return null;
+    if (err instanceof CodeNotFoundError) return null;
     throw err;
   }
 }

--- a/src/db/overlayVideos.ts
+++ b/src/db/overlayVideos.ts
@@ -89,7 +89,7 @@ export async function getVideoById(videoId: number, streamerId: number): Promise
  * @returns The deleted row's filename (for filesystem cleanup), or null if no matching row existed.
  */
 export async function deleteVideo(videoId: number, streamerId: number): Promise<string | null> {
-  class VideoNotFound extends Error {}
+  class VideoNotFoundError extends Error {}
   try {
     return await withTransaction(async (conn) => {
       const [rows] = await conn.execute<mysql.RowDataPacket[]>(
@@ -97,19 +97,19 @@ export async function deleteVideo(videoId: number, streamerId: number): Promise<
         [videoId, streamerId],
       );
       if (rows.length === 0) {
-        throw new VideoNotFound();
+        throw new VideoNotFoundError();
       }
       const filename: string = rows[0].filename;
       const [del] = await conn.execute<mysql.ResultSetHeader>(
         `DELETE FROM overlay_video WHERE id = ? AND streamer_id = ?`, [videoId, streamerId],
       );
       if (del.affectedRows === 0) {
-        throw new VideoNotFound();
+        throw new VideoNotFoundError();
       }
       return filename;
     });
   } catch (err) {
-    if (err instanceof VideoNotFound) return null;
+    if (err instanceof VideoNotFoundError) return null;
     throw err;
   }
 }
@@ -182,7 +182,7 @@ export async function setRewardVideos(
   streamerId: number,
   videos: Array<{ videoId: number; weight: number }>,
 ): Promise<void> {
-  class RewardNotFound extends Error {}
+  class RewardNotFoundError extends Error {}
   try {
     await withTransaction(async (conn) => {
       // Verify reward belongs to this streamer
@@ -191,7 +191,7 @@ export async function setRewardVideos(
         [rewardId, streamerId],
       );
       if (check.length === 0) {
-        throw new RewardNotFound();
+        throw new RewardNotFoundError();
       }
       await conn.execute(`DELETE FROM overlay_reward_video WHERE reward_id = ?`, [rewardId]);
       if (videos.length === 0) return;
@@ -214,7 +214,7 @@ export async function setRewardVideos(
       );
     });
   } catch (err) {
-    if (err instanceof RewardNotFound) return;
+    if (err instanceof RewardNotFoundError) return;
     throw err;
   }
 }

--- a/src/db/sfx.ts
+++ b/src/db/sfx.ts
@@ -228,7 +228,7 @@ export async function updateSfxTrigger(
  * @param id Trigger id.
  */
 export async function deleteSfxTrigger(id: bigint): Promise<{ files: string[] } | null> {
-  class TriggerNotFound extends Error {}
+  class TriggerNotFoundError extends Error {}
   try {
     const result = await withTransaction(async (conn) => {
       const [triggerRows] = await conn.execute<mysql.RowDataPacket[]>(
@@ -236,7 +236,7 @@ export async function deleteSfxTrigger(id: bigint): Promise<{ files: string[] } 
         [id.toString()],
       );
       if (triggerRows.length === 0) {
-        throw new TriggerNotFound();
+        throw new TriggerNotFoundError();
       }
       const [rows] = await conn.execute<mysql.RowDataPacket[]>(
         `SELECT file FROM sfx WHERE trigger_id = ? FOR UPDATE`,
@@ -250,7 +250,7 @@ export async function deleteSfxTrigger(id: bigint): Promise<{ files: string[] } 
     invalidateSfxLookupCache();
     return result;
   } catch (err) {
-    if (err instanceof TriggerNotFound) return null;
+    if (err instanceof TriggerNotFoundError) return null;
     throw err;
   }
 }
@@ -308,7 +308,7 @@ export async function updateSfxFile(id: number, weight: number, hidden: boolean)
  * @param id sfx row id.
  */
 export async function deleteSfxFile(id: number): Promise<string | null> {
-  class FileNotFound extends Error {}
+  class FileNotFoundError extends Error {}
   try {
     const file = await withTransaction(async (conn) => {
       const [rows] = await conn.execute<mysql.RowDataPacket[]>(
@@ -316,19 +316,19 @@ export async function deleteSfxFile(id: number): Promise<string | null> {
         [id],
       );
       if (rows.length === 0) {
-        throw new FileNotFound();
+        throw new FileNotFoundError();
       }
       const file: string = rows[0].file;
       const [result] = await conn.execute<mysql.ResultSetHeader>(`DELETE FROM sfx WHERE id = ?`, [id]);
       if (result.affectedRows === 0) {
-        throw new FileNotFound();
+        throw new FileNotFoundError();
       }
       return file;
     });
     invalidateSfxLookupCache();
     return file;
   } catch (err) {
-    if (err instanceof FileNotFound) return null;
+    if (err instanceof FileNotFoundError) return null;
     throw err;
   }
 }


### PR DESCRIPTION
## Summary
- Part of a codebase cleanup audit (split into several small PRs).
- `VideoNotFound`, `RewardNotFound` (`src/db/overlayVideos.ts`), `TriggerNotFound`, `FileNotFound` (`src/db/sfx.ts`), and `CodeNotFound` (`src/db/companionOAuthCodes.ts`) are all local, unexported control-flow sentinel classes used to break out of a `withTransaction` callback and get caught in the same function — they never cross a module boundary, unlike the exported `*Error` classes (`CommandNotFoundError`, `CounterNotFoundError`, `ReservedCommandError`, `CommandConflictError`) that are part of the public error contract thrown to route handlers.
- Renamed the 5 local classes to add the `Error` suffix for naming consistency with the exported ones. Purely cosmetic — no exports added, no behavior change (they're still local to their function, still caught in the same `catch` block).

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 152 test files, 2829 tests, all passing
- [x] Grepped for the 5 old class names repo-wide to confirm no stray references remain


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mrb1bcWuEQdFUQ2PzK54fA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when handling missing or unavailable videos, sound effects, triggers, and authorization codes.
  * Preserved existing behavior for invalid, expired, already-used, or missing records, including safe transaction rollback and null responses where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->