### PR TITLE
Migrate remaining log+redirect catch blocks onto logAndRedirectError

### DIFF
--- a/src/web/routes/commandAssignments.ts
+++ b/src/web/routes/commandAssignments.ts
@@ -9,7 +9,7 @@ import {
 } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireMod } from '../middleware';
-import { parsePositiveIntId, normalizeDiscordId } from './shared';
+import { parsePositiveIntId, normalizeDiscordId, logAndRedirectError } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
@@ -48,8 +48,9 @@ router.post('/commands/assign', requireMod, csrfProtection, async (req, res) => 
       return res.redirect('/commands?error=command_taken');
     }
 
-    log.error('Assign user to command error:', err);
-    return res.redirect('/commands?error=assign_failed');
+    return logAndRedirectError({
+      res, log, logLabel: 'Assign user to command error:', err, basePath: '/commands', errorCode: 'assign_failed',
+    });
   }
 
   res.redirect('/commands');
@@ -78,8 +79,9 @@ router.post('/commands/unassign', requireMod, csrfProtection, async (req, res) =
   try {
     await unassignUserFromCommand(parsedCommandId, normalizedDiscordId);
   } catch (err) {
-    log.error('Unassign user from command error:', err);
-    return res.redirect('/commands?error=unassign_failed');
+    return logAndRedirectError({
+      res, log, logLabel: 'Unassign user from command error:', err, basePath: '/commands', errorCode: 'unassign_failed',
+    });
   }
 
   res.redirect('/commands');

--- a/src/web/routes/eventsubCallback.ts
+++ b/src/web/routes/eventsubCallback.ts
@@ -5,6 +5,7 @@ import { exchangeCode, getUserFromToken } from '../../twitch/eventsub/twitchApiE
 import { TWITCH_EVENTSUB_REDIRECT_URI } from '../../shared/config';
 import { reloadEventSubSubscriptions } from '../../twitch/eventsub/twitchEventSub';
 import { clearAuthFailedSubs } from '../../twitch/eventsub/twitchEventSubSubscriptions';
+import { logAndRedirectError } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
@@ -89,8 +90,9 @@ router.get('/twitch/eventsub/callback', async (req, res) => {
     log.info(`EventSub OAuth connected for ${streamer.twitch_name}`);
     res.redirect('/user/settings?success=twitch_connected');
   } catch (err) {
-    log.error('EventSub OAuth callback error:', err);
-    res.redirect('/user/settings?error=eventsub_config_failed');
+    logAndRedirectError({
+      res, log, logLabel: 'EventSub OAuth callback error:', err, basePath: '/user/settings', errorCode: 'eventsub_config_failed',
+    });
   }
 });
 


### PR DESCRIPTION
## Summary
- Part of a codebase cleanup audit (split into several small PRs).
- `src/web/routes/shared.ts`'s `logAndRedirectError` helper standardizes the `catch (err) { log.error(...); res.redirect(base + '?error=code'); }` tail, and 19 files already use it, but a few call sites still repeated the pattern manually.
- Reviewed all 59 `log.error(` call sites across the 37 files in `src/web/routes/` that don't already use the helper everywhere. Migrated the 3 that are a genuine 1:1 match:
  - `commandAssignments.ts` `/commands/assign` — the generic fallback branch (kept the `CommandConflictError`-specific branch as-is).
  - `commandAssignments.ts` `/commands/unassign` — the whole catch block.
  - `eventsubCallback.ts`'s OAuth callback catch block.
- Left everything else alone — the remaining sites are GET handlers using `renderError`/`renderView` (the correct helper for GET, per this repo's error-handling convention), JSON API responses, fire-and-forget/cleanup logging with no redirect at all, or purpose-built helpers with extra branching (e.g. `adminUserValidation.ts`'s `handleDbError`, which distinguishes DB lock-timeout errors from other failures) — none of those are equivalent 1:1 replacements for the shared helper.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 152 test files, 2829 tests, all passing (including `commandAssignments.test.ts` and `eventsubCallback.test.ts` specifically)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mrb1bcWuEQdFUQ2PzK54fA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for command assignment and unassignment actions.
  * Improved error handling during EventSub OAuth configuration.
  * Error logging and redirects are now handled more consistently when these operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->