### PR TITLE
Add owner-only SFX description suggestions via OpenAI audio analysis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,9 @@ SFX_MAX_FILE_MB=10
 # ALERT_MAX_SOUND_MB=5
 # Optional: maximum concurrent SSE connections per alerts-overlay channel
 # ALERT_MAX_SSE_PER_CHANNEL=10
+# Optional: OpenAI API key for the owner-only "Suggest description" SFX feature
+# (analyses an uploaded sound and suggests a description). Leave unset to disable it.
+# OPENAI_API_KEY=your_openai_api_key_here
 
 # Web panel
 # Random secret string for signing session cookies — MUST be changed to a long random value

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "mediaplex": "^1.0.0",
         "multer": "^2.2.0",
         "mysql2": "^3.23.1",
+        "openai": "^6.48.0",
         "tmi.js": "^1.8.5",
         "winston": "^3.19.0",
         "winston-daily-rotate-file": "^5.0.0"
@@ -4625,6 +4626,36 @@
       "license": "MIT",
       "dependencies": {
         "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.48.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.48.0.tgz",
+      "integrity": "sha512-KhVp+FyV50QrXNextvL9hIU5l6ox5HYuKQjGVk7lIqprgJol90+dQXWONV6S1lRWsKA1bXjrow8RsUT14M1hNA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "mediaplex": "^1.0.0",
     "multer": "^2.2.0",
     "mysql2": "^3.23.1",
+    "openai": "^6.48.0",
     "tmi.js": "^1.8.5",
     "winston": "^3.19.0",
     "winston-daily-rotate-file": "^5.0.0"

--- a/public/sfx-suggest-description.js
+++ b/public/sfx-suggest-description.js
@@ -54,15 +54,34 @@ document.addEventListener('click', (event) => {
     headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': token },
     body: JSON.stringify({ trigger_id: triggerId, trigger_command: triggerCommand }),
   })
+    /**
+     * Pairs the response's ok flag with its parsed JSON body, since `res.ok` isn't
+     * available anymore once `.json()`'s promise resolves.
+     * @param {Response} res The fetch response.
+     * @returns {Promise<{ok: boolean, data: unknown}>} The paired ok flag and parsed body.
+     */
     .then((res) => res.json().then((data) => ({ ok: res.ok, data })))
+    /**
+     * Applies the suggestion on success, or shows a generic failure message.
+     * @param {{ok: boolean, data: unknown}} result The paired ok flag and parsed body.
+     * @returns {void}
+     */
     .then(({ ok, data }) => {
       if (!ok || !applySuggestedDescription(descriptionInput, statusEl, data)) {
         if (statusEl) statusEl.textContent = 'Could not generate a suggestion. Try again.';
       }
     })
+    /**
+     * Shows a generic failure message on a network error or unparseable response.
+     * @returns {void}
+     */
     .catch(() => {
       if (statusEl) statusEl.textContent = 'Could not generate a suggestion. Try again.';
     })
+    /**
+     * Re-enables the button regardless of outcome.
+     * @returns {void}
+     */
     .finally(() => {
       delete button.dataset.submitting;
       button.disabled = false;

--- a/public/sfx-suggest-description.js
+++ b/public/sfx-suggest-description.js
@@ -1,0 +1,70 @@
+/* ── Suggest description (owner-only, needs OPENAI_API_KEY) ─── */
+
+// Split out from sfx.js so this feature's request/response handling doesn't add to
+// that file's complexity — the button/status markup only exists in the DOM at all
+// when canSuggestDescriptions is true (views/sfx.ejs), so this is a safe no-op
+// listener to load unconditionally otherwise.
+
+/**
+ * Applies a successful suggestion response to the description input and status text.
+ * @param {HTMLElement | null} descriptionInput The trigger's description `<input>`, if found.
+ * @param {Element | null} statusEl The status `<span>` next to the Suggest button, if found.
+ * @param {unknown} data Parsed JSON response body.
+ * @returns {boolean} Whether the response contained a usable description.
+ */
+function applySuggestedDescription(descriptionInput, statusEl, data) {
+  if (!data || typeof data.description !== 'string') return false;
+  if (descriptionInput instanceof HTMLInputElement) descriptionInput.value = data.description;
+  if (statusEl) statusEl.textContent = 'Suggestion applied — review and Save Changes.';
+  return true;
+}
+
+// Unlike the upload form in sfx.js, this endpoint returns JSON (not a redirect)
+// since it just fills in a field rather than mutating a page — the mod still has
+// to click "Save Changes" to persist whatever ends up in the description input.
+/**
+ * Handle a click on a `.js-suggest-description` button: POST the trigger id (and
+ * its current command, sent as context only) to the suggest-description endpoint,
+ * and fill the sibling description input with the result.
+ * @param {Event} event The delegated click event.
+ * @returns {void}
+ */
+document.addEventListener('click', (event) => {
+  const target = event.target;
+  if (!(target instanceof Element)) return;
+  const button = target.closest('.js-suggest-description');
+  if (!(button instanceof HTMLElement)) return;
+  if (button.dataset.submitting === 'true') return;
+
+  const triggerId = button.getAttribute('data-trigger-id');
+  if (!triggerId) return;
+  const descriptionInput = document.getElementById('description_' + triggerId);
+  const statusEl = document.querySelector('.js-suggest-status[data-status-for="' + triggerId + '"]');
+  const commandInput = document.getElementById('trigger_command_' + triggerId);
+  const triggerCommand = commandInput instanceof HTMLInputElement ? commandInput.value : '';
+
+  button.dataset.submitting = 'true';
+  button.disabled = true;
+  if (statusEl) statusEl.textContent = 'Thinking…';
+
+  const token = (document.body && document.body.dataset.csrfToken) || '';
+
+  fetch('/sfx/trigger/suggest-description', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': token },
+    body: JSON.stringify({ trigger_id: triggerId, trigger_command: triggerCommand }),
+  })
+    .then((res) => res.json().then((data) => ({ ok: res.ok, data })))
+    .then(({ ok, data }) => {
+      if (!ok || !applySuggestedDescription(descriptionInput, statusEl, data)) {
+        if (statusEl) statusEl.textContent = 'Could not generate a suggestion. Try again.';
+      }
+    })
+    .catch(() => {
+      if (statusEl) statusEl.textContent = 'Could not generate a suggestion. Try again.';
+    })
+    .finally(() => {
+      delete button.dataset.submitting;
+      button.disabled = false;
+    });
+});

--- a/public/sfx.js
+++ b/public/sfx.js
@@ -130,61 +130,6 @@ document.addEventListener('submit', (event) => {
     });
 });
 
-/* ── Suggest description (owner-only, needs OPENAI_API_KEY) ─── */
-
-// Unlike the upload form above, this endpoint returns JSON (not a redirect) since
-// it just fills in a field rather than mutating a page — the mod still has to click
-// "Save Changes" to persist whatever ends up in the description input.
-/**
- * Handle a click on a `.js-suggest-description` button: POST the trigger id (and
- * its current command, sent as context only) to the suggest-description endpoint,
- * and fill the sibling description input with the result.
- * @param {Event} event The delegated click event.
- * @returns {void}
- */
-document.addEventListener('click', (event) => {
-  const target = event.target;
-  if (!(target instanceof Element)) return;
-  const button = target.closest('.js-suggest-description');
-  if (!(button instanceof HTMLElement)) return;
-  if (button.dataset.submitting === 'true') return;
-
-  const triggerId = button.getAttribute('data-trigger-id');
-  if (!triggerId) return;
-  const descriptionInput = document.getElementById('description_' + triggerId);
-  const statusEl = document.querySelector('.js-suggest-status[data-status-for="' + triggerId + '"]');
-  const commandInput = document.getElementById('trigger_command_' + triggerId);
-  const triggerCommand = commandInput instanceof HTMLInputElement ? commandInput.value : '';
-
-  button.dataset.submitting = 'true';
-  button.disabled = true;
-  if (statusEl) statusEl.textContent = 'Thinking…';
-
-  const token = (document.body && document.body.dataset.csrfToken) || '';
-
-  fetch('/sfx/trigger/suggest-description', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': token },
-    body: JSON.stringify({ trigger_id: triggerId, trigger_command: triggerCommand }),
-  })
-    .then((res) => res.json().then((data) => ({ ok: res.ok, data })))
-    .then(({ ok, data }) => {
-      if (ok && data && typeof data.description === 'string') {
-        if (descriptionInput instanceof HTMLInputElement) descriptionInput.value = data.description;
-        if (statusEl) statusEl.textContent = 'Suggestion applied — review and Save Changes.';
-      } else {
-        if (statusEl) statusEl.textContent = 'Could not generate a suggestion. Try again.';
-      }
-    })
-    .catch(() => {
-      if (statusEl) statusEl.textContent = 'Could not generate a suggestion. Try again.';
-    })
-    .finally(() => {
-      delete button.dataset.submitting;
-      button.disabled = false;
-    });
-});
-
 /* ── Confirm destructive actions ───────────────────────────── */
 
 /**

--- a/public/sfx.js
+++ b/public/sfx.js
@@ -130,6 +130,61 @@ document.addEventListener('submit', (event) => {
     });
 });
 
+/* ── Suggest description (owner-only, needs OPENAI_API_KEY) ─── */
+
+// Unlike the upload form above, this endpoint returns JSON (not a redirect) since
+// it just fills in a field rather than mutating a page — the mod still has to click
+// "Save Changes" to persist whatever ends up in the description input.
+/**
+ * Handle a click on a `.js-suggest-description` button: POST the trigger id (and
+ * its current command, sent as context only) to the suggest-description endpoint,
+ * and fill the sibling description input with the result.
+ * @param {Event} event The delegated click event.
+ * @returns {void}
+ */
+document.addEventListener('click', (event) => {
+  const target = event.target;
+  if (!(target instanceof Element)) return;
+  const button = target.closest('.js-suggest-description');
+  if (!(button instanceof HTMLElement)) return;
+  if (button.dataset.submitting === 'true') return;
+
+  const triggerId = button.getAttribute('data-trigger-id');
+  if (!triggerId) return;
+  const descriptionInput = document.getElementById('description_' + triggerId);
+  const statusEl = document.querySelector('.js-suggest-status[data-status-for="' + triggerId + '"]');
+  const commandInput = document.getElementById('trigger_command_' + triggerId);
+  const triggerCommand = commandInput instanceof HTMLInputElement ? commandInput.value : '';
+
+  button.dataset.submitting = 'true';
+  button.disabled = true;
+  if (statusEl) statusEl.textContent = 'Thinking…';
+
+  const token = (document.body && document.body.dataset.csrfToken) || '';
+
+  fetch('/sfx/trigger/suggest-description', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': token },
+    body: JSON.stringify({ trigger_id: triggerId, trigger_command: triggerCommand }),
+  })
+    .then((res) => res.json().then((data) => ({ ok: res.ok, data })))
+    .then(({ ok, data }) => {
+      if (ok && data && typeof data.description === 'string') {
+        if (descriptionInput instanceof HTMLInputElement) descriptionInput.value = data.description;
+        if (statusEl) statusEl.textContent = 'Suggestion applied — review and Save Changes.';
+      } else {
+        if (statusEl) statusEl.textContent = 'Could not generate a suggestion. Try again.';
+      }
+    })
+    .catch(() => {
+      if (statusEl) statusEl.textContent = 'Could not generate a suggestion. Try again.';
+    })
+    .finally(() => {
+      delete button.dataset.submitting;
+      button.disabled = false;
+    });
+});
+
 /* ── Confirm destructive actions ───────────────────────────── */
 
 /**

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -74,3 +74,7 @@ export const TWITCH_EVENTSUB_REDIRECT_URI = process.env.TWITCH_EVENTSUB_REDIRECT
 // Must be exactly 64 hex characters (32 bytes). Generate with: openssl rand -hex 32
 // Required to use the Twitch OAuth connect flow for follow/sub notifications.
 export const EVENTSUB_TOKEN_SECRET = process.env.EVENTSUB_TOKEN_SECRET ?? '';
+
+// OpenAI API key, used only for the owner-only "Suggest description" SFX feature.
+// Leave unset to keep that feature disabled — everything else works without it.
+export const OPENAI_API_KEY = process.env.OPENAI_API_KEY ?? '';

--- a/src/web/middleware.test.ts
+++ b/src/web/middleware.test.ts
@@ -15,7 +15,7 @@ vi.mock('./csrf', () => ({
 }));
 
 import { createHash } from 'crypto';
-import { requireAuth, requireManager, requireMod, requireAdmin, requireApiKey, requireCompanionKey, requireGuildContext } from './middleware';
+import { requireAuth, requireManager, requireMod, requireAdmin, requireOwner, requireApiKey, requireCompanionKey, requireGuildContext } from './middleware';
 import { findKeyByHash, findDiscordIdByTokenHash, getEffectiveAccessLevelForUser, findUser, getAllGuilds, getGuildsForMember, AccessLevel } from '../db';
 
 function makeReq(overrides: object = {}): any {
@@ -172,6 +172,46 @@ describe('requireAdmin', () => {
     requireAdmin(req, res, next);
     const [, data] = res.render.mock.calls[0];
     expect(data.message).toContain('Admin');
+  });
+});
+
+// ─── requireOwner ─────────────────────────────────────────────────────────────
+
+describe('requireOwner', () => {
+  it('calls next() when isOwner is true, regardless of accessLevel', () => {
+    const req = makeReq({ session: { user: { accessLevel: AccessLevel.USER, isOwner: true } } });
+    requireOwner(req, makeRes(), next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('returns 403 for an Admin who is not the owner', () => {
+    const req = makeReq({ session: { user: { accessLevel: AccessLevel.ADMIN, isOwner: false } } });
+    const res = makeRes();
+    requireOwner(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when isOwner is absent', () => {
+    const req = makeReq({ session: { user: { accessLevel: AccessLevel.ADMIN } } });
+    const res = makeRes();
+    requireOwner(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('returns 403 when no session user', () => {
+    const req = makeReq({ session: {} });
+    const res = makeRes();
+    requireOwner(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('renders error template with an Owner-required message', () => {
+    const req = makeReq({ session: { user: { accessLevel: AccessLevel.ADMIN, isOwner: false } } });
+    const res = makeRes();
+    requireOwner(req, res, next);
+    const [, data] = res.render.mock.calls[0];
+    expect(data.message).toContain('Owner');
   });
 });
 

--- a/src/web/middleware.ts
+++ b/src/web/middleware.ts
@@ -177,6 +177,10 @@ export const requireAdmin = requireAccessLevel(AccessLevel.ADMIN, 'Admin');
  * manually in the DB (see `user.is_owner` in schema.sql), not a per-guild `AccessLevel`
  * — an Admin in a given guild is not necessarily the owner. Used to gate features
  * still being trialled to the single most-trusted account before a wider rollout.
+ * @param req - Express request; checked for `req.session.user?.isOwner`.
+ * @param res - Express response; used to render a 403 error page when denied.
+ * @param next - Called when the session user is the owner.
+ * @returns Nothing; either calls `next()` or renders the error view with a 403 status.
  */
 export function requireOwner(req: Request, res: Response, next: NextFunction): void {
   if (req.session.user?.isOwner) {

--- a/src/web/middleware.ts
+++ b/src/web/middleware.ts
@@ -170,3 +170,23 @@ export const requireCompanionKey = authenticateBearerToken(
 
 /** Ensures the current-guild access level is Admin, otherwise renders a 403. */
 export const requireAdmin = requireAccessLevel(AccessLevel.ADMIN, 'Admin');
+
+/**
+ * Ensures the session user is the bot owner (`user.is_owner`), otherwise renders a
+ * 403. Distinct from {@link requireAdmin}: `isOwner` is a global super-admin flag set
+ * manually in the DB (see `user.is_owner` in schema.sql), not a per-guild `AccessLevel`
+ * — an Admin in a given guild is not necessarily the owner. Used to gate features
+ * still being trialled to the single most-trusted account before a wider rollout.
+ */
+export function requireOwner(req: Request, res: Response, next: NextFunction): void {
+  if (req.session.user?.isOwner) {
+    next();
+  } else {
+    res.status(403);
+    renderView(res, 'error', {
+      message: 'Access denied — Owner required.',
+      user: req.session.user ?? null,
+      csrfToken: req.session?.user ? ensureSessionCsrfToken(req) : '',
+    });
+  }
+}

--- a/src/web/routes/sfx.test.ts
+++ b/src/web/routes/sfx.test.ts
@@ -14,7 +14,7 @@ vi.mock('../../db', () => ({
 }));
 /** Mocks the shared logger so route handlers don't write real log output during tests. */
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
-vi.mock('../../shared/config', () => ({ SFX_MAX_FILE_MB: 10 }));
+vi.mock('../../shared/config', () => ({ SFX_MAX_FILE_MB: 10, OPENAI_API_KEY: 'test-openai-key' }));
 vi.mock('../csrf', () => ({
   csrfProtection: (req: any, _res: any, next: any) => {
     req.csrfToken = () => 'test-csrf-token';
@@ -65,6 +65,22 @@ describe('GET /sfx', () => {
     expect((res.body as any).locals.canManage).toBe(true);
   });
 
+  it('sets canSuggestDescriptions=true for the owner when OPENAI_API_KEY is set', async () => {
+    const res = await buildApp({ discordId: '1', accessLevel: AccessLevel.USER, isOwner: true });
+    expect((res.body as any).locals.canSuggestDescriptions).toBe(true);
+  });
+
+  it('sets canSuggestDescriptions=false for a non-owner Admin, even though canManage is true', async () => {
+    const res = await buildApp({ discordId: '1', accessLevel: AccessLevel.ADMIN, isOwner: false });
+    expect((res.body as any).locals.canManage).toBe(true);
+    expect((res.body as any).locals.canSuggestDescriptions).toBe(false);
+  });
+
+  it('sets canSuggestDescriptions=false when isOwner is absent from the session', async () => {
+    const res = await buildApp({ discordId: '1', accessLevel: AccessLevel.USER });
+    expect((res.body as any).locals.canSuggestDescriptions).toBe(false);
+  });
+
   it('passes through a known error query param and ignores unknown ones', async () => {
     const known = await buildApp({ discordId: '1', accessLevel: AccessLevel.MOD }, '?error=command_taken');
     expect((known.body as any).locals.error).toBe('command_taken');
@@ -82,5 +98,33 @@ describe('GET /sfx', () => {
     const res = await buildApp();
     expect(res.status).toBe(500);
     expect((res.body as any).view).toBe('error');
+  });
+
+  it('sets canSuggestDescriptions=false for the owner when OPENAI_API_KEY is unset', async () => {
+    vi.resetModules();
+    vi.doMock('../../db', () => ({
+      getAllSfxTriggers: vi.fn().mockResolvedValue([]),
+      getAllCategories: vi.fn().mockResolvedValue([]),
+      AccessLevel: ACCESS_LEVEL_MOCK,
+    }));
+    vi.doMock('../../shared/logger', () => ({ createLogger: mockLogger }));
+    vi.doMock('../../shared/config', () => ({ SFX_MAX_FILE_MB: 10, OPENAI_API_KEY: '' }));
+    vi.doMock('../csrf', () => ({
+      csrfProtection: (req: any, _res: any, next: any) => {
+        req.csrfToken = () => 'test-csrf-token';
+        next();
+      },
+    }));
+
+    const freshRouter: any = (await import('./sfx.js')).default;
+    const freshBuildTestApp = (await import('../../test-utils/expressTestApp.js')).buildTestApp;
+    const app = freshBuildTestApp({
+      router: freshRouter,
+      sessionUser: { discordId: '1', accessLevel: AccessLevel.USER, isOwner: true },
+      mockRender: 'nested',
+    });
+
+    const res = await supertest(app).get('/sfx');
+    expect((res.body as any).locals.canSuggestDescriptions).toBe(false);
   });
 });

--- a/src/web/routes/sfx.ts
+++ b/src/web/routes/sfx.ts
@@ -2,7 +2,7 @@ import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import { getAllSfxTriggers, getAllCategories, AccessLevel } from '../../db';
 import { csrfProtection } from '../csrf';
-import { SFX_MAX_FILE_MB } from '../../shared/config';
+import { SFX_MAX_FILE_MB, OPENAI_API_KEY } from '../../shared/config';
 import { filterQueryParam, renderError, renderView } from './shared';
 
 const log = createLogger('Web');
@@ -37,17 +37,22 @@ const KNOWN_SUCCESS = new Set([
 /**
  * Render the SFX page with all triggers and categories. Visible to any logged-in
  * user; management controls are only rendered for Mod+ (canManage), matching the
- * server-side requireMod guard on every mutation route.
+ * server-side requireMod guard on every mutation route. The "Suggest description"
+ * button (canSuggestDescriptions) is further restricted to the bot owner while that
+ * feature is being trialled, and hidden entirely when OPENAI_API_KEY isn't set,
+ * matching the server-side requireOwner guard on its route.
  */
 router.get('/sfx', csrfProtection, async (req, res) => {
   try {
     const [triggers, categories] = await Promise.all([getAllSfxTriggers(), getAllCategories()]);
     const canManage = (req.session.user?.accessLevel ?? 0) >= AccessLevel.MOD;
+    const canSuggestDescriptions = !!req.session.user?.isOwner && OPENAI_API_KEY !== '';
     renderView(res, 'sfx', {
       user: req.session.user,
       triggers,
       categories,
       canManage,
+      canSuggestDescriptions,
       maxUploadMb: SFX_MAX_FILE_MB,
       csrfToken: req.csrfToken(),
       error: filterQueryParam(req.query.error, KNOWN_ERRORS),

--- a/src/web/routes/sfxMutations.test.ts
+++ b/src/web/routes/sfxMutations.test.ts
@@ -14,6 +14,10 @@ vi.mock('../../db', () => ({
   createCategory: vi.fn(),
   renameCategory: vi.fn(),
   deleteCategory: vi.fn(),
+  // Unused by any test in this file (no test hits POST /sfx/trigger/suggest-description
+  // here — see sfxSuggestDescription.test.ts) but required so the aggregator router
+  // can be constructed: sfxSuggestDescription.ts imports it at module load.
+  findSoundFiles: vi.fn(),
   isMysqlDuplicateEntryError: (err: unknown) =>
     !!err && typeof err === 'object' && (err as { code?: string }).code === 'ER_DUP_ENTRY',
 }));
@@ -27,6 +31,9 @@ vi.mock('../csrf', () => ({
 
 vi.mock('../middleware', () => ({
   requireMod: vi.fn((_req: any, _res: any, next: any) => next()),
+  // Unused here for the same reason as findSoundFiles above — required only so
+  // the suggest-description sub-router can be mounted.
+  requireOwner: vi.fn((_req: any, _res: any, next: any) => next()),
 }));
 
 vi.mock('../../shared/config', () => ({
@@ -34,6 +41,8 @@ vi.mock('../../shared/config', () => ({
   // 1 MB so the oversized-upload test can trigger Multer's LIMIT_FILE_SIZE with a
   // just-over-1 MB buffer. Every other upload test uses a few-byte buffer.
   SFX_MAX_FILE_MB: 1,
+  // Unused here — suggest-description isn't exercised by this file's tests.
+  OPENAI_API_KEY: '',
 }));
 
 vi.mock('fs', () => ({

--- a/src/web/routes/sfxMutations.ts
+++ b/src/web/routes/sfxMutations.ts
@@ -3,16 +3,20 @@ import sfxTriggerMutationsRouter from './sfxTriggerMutations';
 import sfxFileMutationsRouter from './sfxFileMutations';
 import sfxFileUploadRouter from './sfxFileUpload';
 import sfxCategoryMutationsRouter from './sfxCategoryMutations';
+import sfxSuggestDescriptionRouter from './sfxSuggestDescription';
 
 // Aggregator for the SFX management endpoints. The handlers are split by domain
 // (triggers / sound files / categories) across sibling routers, mirroring the
 // commandMutations / commandAssignments split, then mounted together here.
 // Sound-file upload has its own router (multer + magic-byte detection) separate
 // from the lighter update/remove mutations, to keep per-file complexity down.
+// suggest-description is also split out — it responds with JSON instead of a
+// redirect, and is owner-gated rather than mod-gated, unlike its siblings here.
 const router = Router();
 router.use(sfxTriggerMutationsRouter);
 router.use(sfxFileMutationsRouter);
 router.use(sfxFileUploadRouter);
 router.use(sfxCategoryMutationsRouter);
+router.use(sfxSuggestDescriptionRouter);
 
 export default router;

--- a/src/web/routes/sfxSuggestDescription.test.ts
+++ b/src/web/routes/sfxSuggestDescription.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+import { mockLogger } from '../../test-utils/loggerMock';
+import type { SfxFile } from '../../db';
+
+const mockCreate = vi.fn();
+
+vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
+vi.mock('../../shared/config', () => ({ OPENAI_API_KEY: 'test-key', SFX_FOLDER: '/app/sfx' }));
+vi.mock('../csrf', () => ({ csrfProtection: (_req: any, _res: any, next: any) => next() }));
+vi.mock('../middleware', () => ({ requireOwner: (_req: any, _res: any, next: any) => next() }));
+vi.mock('../../db', () => ({ findSoundFiles: vi.fn() }));
+vi.mock('fs', () => ({
+  default: {
+    promises: {
+      readFile: vi.fn(),
+    },
+  },
+}));
+vi.mock('child_process', () => ({ spawn: vi.fn() }));
+vi.mock('ffmpeg-static', () => ({ default: '/usr/bin/ffmpeg' }));
+vi.mock('openai', () => ({
+  default: vi.fn().mockImplementation(function OpenAI() {
+    return { chat: { completions: { create: mockCreate } } };
+  }),
+}));
+
+import supertest from 'supertest';
+import { spawn } from 'child_process';
+import fs from 'fs';
+import { findSoundFiles } from '../../db';
+import { buildTestApp } from '../../test-utils/expressTestApp';
+import router, { sampleFilesForSuggestion, transcodeToMp3, requestDescriptionSuggestion } from './sfxSuggestDescription';
+
+/** Builds a minimal SfxFile fixture. */
+function makeFile(id: number, weight: number, file = `sound-${id}.mp3`, hidden = false): SfxFile {
+  return { id, trigger_id: 1n, file, trigger_command: null, weight, hidden, category_id: null };
+}
+
+/** Fake ChildProcess-like EventEmitter for mocking `spawn` in transcodeToMp3 tests. */
+function makeFakeProcess() {
+  const proc = new EventEmitter() as any;
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.stdin = { write: vi.fn(), end: vi.fn() };
+  return proc;
+}
+
+function buildApp() {
+  return buildTestApp({ router, bodyParser: 'json' });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── sampleFilesForSuggestion ───────────────────────────────────────────────────
+
+describe('sampleFilesForSuggestion', () => {
+  it('returns all files sorted by weight when count is within maxSample', () => {
+    const files = [makeFile(1, 3), makeFile(2, 1), makeFile(3, 2)];
+    expect(sampleFilesForSuggestion(files, 5).map((f) => f.id)).toEqual([2, 3, 1]);
+  });
+
+  it('breaks weight ties by id', () => {
+    const files = [makeFile(2, 1), makeFile(1, 1)];
+    expect(sampleFilesForSuggestion(files, 5).map((f) => f.id)).toEqual([1, 2]);
+  });
+
+  it('always includes the rarest and most common file when sub-sampling', () => {
+    const files = Array.from({ length: 10 }, (_, i) => makeFile(i + 1, i + 1));
+    const sample = sampleFilesForSuggestion(files, 5);
+    const weights = sample.map((f) => f.weight);
+    expect(weights[0]).toBe(1);
+    expect(weights[weights.length - 1]).toBe(10);
+    expect(sample).toHaveLength(5);
+  });
+
+  it('spaces the remaining picks evenly across the weight-sorted list', () => {
+    const files = Array.from({ length: 10 }, (_, i) => makeFile(i + 1, i + 1));
+    // Sorted weights are 1..10 (indices 0..9). Endpoints {0,9} plus 3 evenly spaced
+    // inner picks at indices {2,5,7} → weights {1,3,6,8,10}.
+    expect(sampleFilesForSuggestion(files, 5).map((f) => f.weight)).toEqual([1, 3, 6, 8, 10]);
+  });
+
+  it('respects a smaller maxSample', () => {
+    const files = Array.from({ length: 10 }, (_, i) => makeFile(i + 1, i + 1));
+    // Endpoints {0,9} plus 1 inner pick at index round(9/2)=5 → weights {1,6,10}.
+    expect(sampleFilesForSuggestion(files, 3).map((f) => f.weight)).toEqual([1, 6, 10]);
+  });
+
+  it('still returns both endpoints even when maxSample is below 2', () => {
+    const files = [makeFile(1, 1), makeFile(2, 2), makeFile(3, 3)];
+    expect(sampleFilesForSuggestion(files, 1).map((f) => f.weight)).toEqual([1, 3]);
+  });
+
+  it('includes hidden files — hidden only affects the public listing, not playback', () => {
+    const files = [makeFile(1, 1, 'a.mp3', true)];
+    expect(sampleFilesForSuggestion(files, 5)).toHaveLength(1);
+  });
+
+  it('handles a single file', () => {
+    const files = [makeFile(1, 1)];
+    expect(sampleFilesForSuggestion(files, 5).map((f) => f.id)).toEqual([1]);
+  });
+});
+
+// ── transcodeToMp3 ──────────────────────────────────────────────────────────────
+
+describe('transcodeToMp3', () => {
+  it('resolves with the concatenated stdout on a clean exit', async () => {
+    const proc = makeFakeProcess();
+    vi.mocked(spawn).mockReturnValue(proc);
+    const promise = transcodeToMp3(Buffer.from('input'));
+    proc.stdout.emit('data', Buffer.from('mp3-'));
+    proc.stdout.emit('data', Buffer.from('bytes'));
+    proc.emit('close', 0);
+    await expect(promise).resolves.toEqual(Buffer.from('mp3-bytes'));
+  });
+
+  it('rejects with stderr context on a non-zero exit code', async () => {
+    const proc = makeFakeProcess();
+    vi.mocked(spawn).mockReturnValue(proc);
+    const promise = transcodeToMp3(Buffer.from('input'));
+    proc.stderr.emit('data', Buffer.from('bad input'));
+    proc.emit('close', 1);
+    await expect(promise).rejects.toThrow(/ffmpeg exited with code 1.*bad input/s);
+  });
+
+  it('rejects when the spawned process errors', async () => {
+    const proc = makeFakeProcess();
+    vi.mocked(spawn).mockReturnValue(proc);
+    const promise = transcodeToMp3(Buffer.from('input'));
+    proc.emit('error', new Error('spawn failed'));
+    await expect(promise).rejects.toThrow('spawn failed');
+  });
+});
+
+// ── requestDescriptionSuggestion ─────────────────────────────────────────────────
+
+describe('requestDescriptionSuggestion', () => {
+  it('sends one input_audio block per clip and returns the trimmed description', async () => {
+    mockCreate.mockResolvedValue({ choices: [{ message: { content: '  A loud air horn blast.  ' } }] });
+    const clips = [{ buffer: Buffer.from('a'), format: 'mp3' as const }, { buffer: Buffer.from('b'), format: 'wav' as const }];
+
+    const result = await requestDescriptionSuggestion(clips, '!airhorn', 2);
+
+    expect(result).toBe('A loud air horn blast.');
+    const call = mockCreate.mock.calls[0][0];
+    expect(call.model).toBe('gpt-audio-mini');
+    const content = call.messages[0].content;
+    expect(content[0].type).toBe('text');
+    expect(content.filter((c: any) => c.type === 'input_audio')).toHaveLength(2);
+    expect(content[1].input_audio).toEqual({ data: Buffer.from('a').toString('base64'), format: 'mp3' });
+  });
+
+  it('mentions the sample size in the prompt when clips are a subset of the total files', async () => {
+    mockCreate.mockResolvedValue({ choices: [{ message: { content: 'desc' } }] });
+    await requestDescriptionSuggestion([{ buffer: Buffer.from('a'), format: 'mp3' }], '!meme', 8);
+    expect(mockCreate.mock.calls[0][0].messages[0].content[0].text).toMatch(/sample of 1 of them/);
+  });
+
+  it('omits sample language when all files were analysed', async () => {
+    mockCreate.mockResolvedValue({ choices: [{ message: { content: 'desc' } }] });
+    await requestDescriptionSuggestion([{ buffer: Buffer.from('a'), format: 'mp3' }], '!clap', 1);
+    expect(mockCreate.mock.calls[0][0].messages[0].content[0].text).not.toMatch(/sample of/);
+  });
+
+  it('truncates a description longer than the VARCHAR(255) column', async () => {
+    mockCreate.mockResolvedValue({ choices: [{ message: { content: 'x'.repeat(300) } }] });
+    const result = await requestDescriptionSuggestion([{ buffer: Buffer.from('a'), format: 'mp3' }], '!clap', 1);
+    expect(result).toHaveLength(255);
+  });
+
+  it('throws when OpenAI returns no content', async () => {
+    mockCreate.mockResolvedValue({ choices: [{ message: { content: null } }] });
+    await expect(requestDescriptionSuggestion([{ buffer: Buffer.from('a'), format: 'mp3' }], '!clap', 1)).rejects.toThrow('empty description');
+  });
+});
+
+// ── POST /sfx/trigger/suggest-description ────────────────────────────────────────
+
+describe('POST /sfx/trigger/suggest-description', () => {
+  beforeEach(() => {
+    vi.mocked(fs.promises.readFile).mockResolvedValue(Buffer.from('audio-bytes'));
+    mockCreate.mockResolvedValue({ choices: [{ message: { content: 'A cheerful clap.' } }] });
+  });
+
+  it('rejects a missing/invalid trigger id', async () => {
+    const res = await supertest(buildApp()).post('/sfx/trigger/suggest-description').send({ trigger_id: 'not-a-number' });
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'invalid_id' });
+    expect(vi.mocked(findSoundFiles)).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the trigger has no sound files', async () => {
+    vi.mocked(findSoundFiles).mockResolvedValue([]);
+    const res = await supertest(buildApp()).post('/sfx/trigger/suggest-description').send({ trigger_id: '5' });
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'no_file' });
+  });
+
+  it('returns 502 when loading the trigger files throws', async () => {
+    vi.mocked(findSoundFiles).mockRejectedValue(new Error('db down'));
+    const res = await supertest(buildApp()).post('/sfx/trigger/suggest-description').send({ trigger_id: '5' });
+    expect(res.status).toBe(502);
+    expect(res.body).toEqual({ error: 'suggestion_failed' });
+  });
+
+  it('returns 502 when the OpenAI call fails', async () => {
+    vi.mocked(findSoundFiles).mockResolvedValue([makeFile(1, 1)]);
+    mockCreate.mockRejectedValue(new Error('rate limited'));
+    const res = await supertest(buildApp()).post('/sfx/trigger/suggest-description').send({ trigger_id: '5' });
+    expect(res.status).toBe(502);
+    expect(res.body).toEqual({ error: 'suggestion_failed' });
+  });
+
+  it('succeeds with a single file, passing the trigger command as context', async () => {
+    vi.mocked(findSoundFiles).mockResolvedValue([makeFile(1, 1, 'clap.wav')]);
+    const res = await supertest(buildApp())
+      .post('/sfx/trigger/suggest-description')
+      .send({ trigger_id: '5', trigger_command: '!clap' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ description: 'A cheerful clap.' });
+    expect(fs.promises.readFile).toHaveBeenCalledWith('/app/sfx/clap.wav');
+    expect(mockCreate.mock.calls[0][0].messages[0].content[0].text).toMatch(/!clap/);
+  });
+
+  it('samples down to MAX_SAMPLE files and transcodes ogg clips before sending', async () => {
+    const files = [
+      makeFile(1, 1, 'rare.ogg'),
+      makeFile(2, 5, 'a.mp3'),
+      makeFile(3, 10, 'common.wav'),
+      makeFile(4, 15, 'b.mp3'),
+      makeFile(5, 20, 'c.wav'),
+      makeFile(6, 25, 'd.mp3'),
+    ];
+    vi.mocked(findSoundFiles).mockResolvedValue(files);
+
+    const proc = makeFakeProcess();
+    vi.mocked(spawn).mockReturnValue(proc);
+    // Use .end() (not await) so the request is dispatched immediately — a supertest
+    // Test object is otherwise inert until awaited/`.then()`d, and we need it sent
+    // before we can wait for the transcode's ffmpeg mock to be invoked.
+    const createPromise = new Promise<any>((resolve, reject) => {
+      supertest(buildApp())
+        .post('/sfx/trigger/suggest-description')
+        .send({ trigger_id: '5' })
+        .end((err, res) => (err ? reject(err) : resolve(res)));
+    });
+    await vi.waitFor(() => expect(spawn).toHaveBeenCalled());
+    proc.stdout.emit('data', Buffer.from('transcoded'));
+    proc.emit('close', 0);
+
+    const res = await createPromise;
+    expect(res.status).toBe(200);
+    const content = mockCreate.mock.calls[0][0].messages[0].content;
+    expect(content.filter((c: any) => c.type === 'input_audio')).toHaveLength(5);
+    expect(mockCreate.mock.calls[0][0].messages[0].content[0].text).toMatch(/sample of 5 of them/);
+  });
+
+  it('returns 502 when a file has an unrecognised stored extension', async () => {
+    vi.mocked(findSoundFiles).mockResolvedValue([makeFile(1, 1, 'weird.xyz')]);
+    const res = await supertest(buildApp()).post('/sfx/trigger/suggest-description').send({ trigger_id: '5' });
+    expect(res.status).toBe(502);
+    expect(res.body).toEqual({ error: 'suggestion_failed' });
+  });
+});
+
+describe('POST /sfx/trigger/suggest-description (OPENAI_API_KEY unset)', () => {
+  it('responds 503 without touching the database', async () => {
+    vi.resetModules();
+    vi.doMock('../../shared/logger', () => ({ createLogger: mockLogger }));
+    vi.doMock('../../shared/config', () => ({ OPENAI_API_KEY: '', SFX_FOLDER: '/app/sfx' }));
+    vi.doMock('../csrf', () => ({ csrfProtection: (_req: any, _res: any, next: any) => next() }));
+    vi.doMock('../middleware', () => ({ requireOwner: (_req: any, _res: any, next: any) => next() }));
+    const findSoundFilesSpy = vi.fn();
+    vi.doMock('../../db', () => ({ findSoundFiles: findSoundFilesSpy }));
+
+    const freshRouter: any = (await import('./sfxSuggestDescription.js')).default;
+    const freshBuildTestApp = (await import('../../test-utils/expressTestApp.js')).buildTestApp;
+    const app = freshBuildTestApp({ router: freshRouter, bodyParser: 'json' });
+
+    const res = await supertest(app).post('/sfx/trigger/suggest-description').send({ trigger_id: '5' });
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ error: 'not_configured' });
+    expect(findSoundFilesSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/web/routes/sfxSuggestDescription.test.ts
+++ b/src/web/routes/sfxSuggestDescription.test.ts
@@ -42,7 +42,11 @@ function makeFakeProcess() {
   const proc = new EventEmitter() as any;
   proc.stdout = new EventEmitter();
   proc.stderr = new EventEmitter();
-  proc.stdin = { write: vi.fn(), end: vi.fn() };
+  const stdin = new EventEmitter() as any;
+  stdin.write = vi.fn();
+  stdin.end = vi.fn();
+  proc.stdin = stdin;
+  proc.kill = vi.fn();
   return proc;
 }
 
@@ -133,6 +137,32 @@ describe('transcodeToMp3', () => {
     const promise = transcodeToMp3(Buffer.from('input'));
     proc.emit('error', new Error('spawn failed'));
     await expect(promise).rejects.toThrow('spawn failed');
+  });
+
+  it('does not crash on an EPIPE from stdin when ffmpeg exits early', async () => {
+    const proc = makeFakeProcess();
+    vi.mocked(spawn).mockReturnValue(proc);
+    const promise = transcodeToMp3(Buffer.from('input'));
+    // Simulate ffmpeg exiting before consuming all of stdin: emitting 'error' on
+    // the stdin stream must not throw an unhandled error and crash the process.
+    expect(() => proc.stdin.emit('error', new Error('EPIPE'))).not.toThrow();
+    proc.emit('close', 1);
+    await expect(promise).rejects.toThrow(/ffmpeg exited with code 1/);
+  });
+
+  it('kills the process and rejects if it does not close within the timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const proc = makeFakeProcess();
+      vi.mocked(spawn).mockReturnValue(proc);
+      const promise = transcodeToMp3(Buffer.from('input'));
+      const assertion = expect(promise).rejects.toThrow(/timed out/);
+      await vi.advanceTimersByTimeAsync(10_000);
+      await assertion;
+      expect(proc.kill).toHaveBeenCalledWith('SIGKILL');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/src/web/routes/sfxSuggestDescription.ts
+++ b/src/web/routes/sfxSuggestDescription.ts
@@ -72,10 +72,14 @@ function formatFromFilename(filename: string): 'wav' | 'mp3' | 'ogg' | null {
   return ext === 'wav' || ext === 'mp3' || ext === 'ogg' ? ext : null;
 }
 
+/** Kills the ffmpeg process and rejects if a transcode hasn't finished within this long. */
+const TRANSCODE_TIMEOUT_MS = 10_000;
+
 /**
  * Transcodes an in-memory audio buffer to MP3 via `ffmpeg-static`, entirely in memory
  * (stdin/stdout pipes) — used for `ogg` clips, since OpenAI's audio-input models only
- * accept `wav`/`mp3`.
+ * accept `wav`/`mp3`. Kills the process and rejects if it hasn't finished within
+ * `TRANSCODE_TIMEOUT_MS`, so a hung/corrupt input can't block the request indefinitely.
  * @param buffer Raw bytes of the source audio file.
  * @returns The transcoded MP3 bytes.
  */
@@ -88,10 +92,24 @@ export function transcodeToMp3(buffer: Buffer): Promise<Buffer> {
     const proc = spawn(ffmpegPath, ['-i', 'pipe:0', '-f', 'mp3', 'pipe:1']);
     const stdout: Buffer[] = [];
     const stderr: Buffer[] = [];
+    const timeout = setTimeout(() => {
+      proc.kill('SIGKILL');
+      reject(new Error(`ffmpeg transcode timed out after ${TRANSCODE_TIMEOUT_MS}ms`));
+    }, TRANSCODE_TIMEOUT_MS);
     proc.stdout.on('data', (chunk: Buffer) => stdout.push(chunk));
     proc.stderr.on('data', (chunk: Buffer) => stderr.push(chunk));
-    proc.on('error', reject);
+    proc.on('error', (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+    // If ffmpeg exits before consuming all of stdin (e.g. a corrupt/truncated
+    // file), writing/ending the pipe emits an 'error' (EPIPE) on the stdin stream
+    // itself. Without a listener here, Node treats that as an unhandled 'error'
+    // event and throws — crashing the whole process, not just this request. The
+    // actual failure is already surfaced via the 'close' handler below.
+    proc.stdin.on('error', () => {});
     proc.on('close', (code) => {
+      clearTimeout(timeout);
       if (code === 0) {
         resolve(Buffer.concat(stdout));
       } else {

--- a/src/web/routes/sfxSuggestDescription.ts
+++ b/src/web/routes/sfxSuggestDescription.ts
@@ -1,0 +1,217 @@
+import { createLogger } from '../../shared/logger';
+import { Router } from 'express';
+import fs from 'fs';
+import path from 'path';
+import { spawn } from 'child_process';
+import ffmpegPath from 'ffmpeg-static';
+import OpenAI from 'openai';
+import type { SfxFile } from '../../db';
+import { findSoundFiles } from '../../db';
+import { csrfProtection } from '../csrf';
+import { requireOwner } from '../middleware';
+import { OPENAI_API_KEY, SFX_FOLDER } from '../../shared/config';
+import { safeResolve } from '../../shared/pathUtils';
+import { parsePositiveBigIntId, normalizeRequiredText } from './shared';
+
+const log = createLogger('Web');
+const router = Router();
+
+/** Audio-capable chat model used for description suggestions — the "mini" variant keeps this cheap for a trial feature. */
+const SUGGESTION_MODEL = 'gpt-audio-mini';
+/** Matches `sfxtrigger.description`'s `VARCHAR(255)` column (schema.sql). */
+const MAX_DESCRIPTION_LENGTH = 255;
+/** Caps how many sound files are sent to the model per suggestion, bounding both request size and cost. */
+const MAX_SAMPLE = 5;
+/** Caps the trigger-command context text sent to the model, since it's client-supplied and only used for prompt context. */
+const MAX_TRIGGER_COMMAND_LENGTH = 100;
+
+let openaiClient: OpenAI | null = null;
+
+/** Lazily constructs (and caches) the OpenAI client, so importing this module never requires `OPENAI_API_KEY` to be set. */
+function getOpenAiClient(): OpenAI {
+  if (!openaiClient) openaiClient = new OpenAI({ apiKey: OPENAI_API_KEY });
+  return openaiClient;
+}
+
+/**
+ * Picks which of a trigger's sound files to analyse when there's more than `maxSample`.
+ * Sorts by `weight` (ties broken by `id` for determinism), always keeps the rarest
+ * (lowest weight) and most common (highest weight) file so the suggestion sees both
+ * ends of the trigger's variety, then fills the remaining budget with files evenly
+ * spaced across the sorted list. Includes hidden files — `hidden` only affects the
+ * public listing, not playback, so a hidden file still contributes to what the
+ * trigger actually sounds like.
+ * @param files All sound files belonging to the trigger.
+ * @param maxSample Maximum number of files to return (default `MAX_SAMPLE`).
+ * @returns Up to `maxSample` files, sorted by weight ascending.
+ */
+export function sampleFilesForSuggestion(files: SfxFile[], maxSample: number = MAX_SAMPLE): SfxFile[] {
+  const sorted = [...files].sort((a, b) => a.weight - b.weight || a.id - b.id);
+  if (sorted.length <= maxSample) return sorted;
+
+  const lastIndex = sorted.length - 1;
+  const selected = new Set<number>([0, lastIndex]);
+  const remaining = maxSample - selected.size;
+  const innerCount = lastIndex - 1; // indices 1..lastIndex-1 are available for spacing
+  for (let i = 1; i <= remaining && innerCount > 0; i++) {
+    const idx = Math.round((i * (innerCount + 1)) / (remaining + 1));
+    selected.add(Math.min(Math.max(idx, 1), innerCount));
+  }
+  return Array.from(selected).sort((a, b) => a - b).map((i) => sorted[i]);
+}
+
+/**
+ * Determines the audio format from a stored SFX filename's extension. Storage always
+ * writes the magic-byte-detected extension (`buildStoredName` in `sfxFileUpload.ts`),
+ * so the extension is trustworthy without re-sniffing the file's bytes.
+ * @param filename Stored relative filename (within `SFX_FOLDER`).
+ * @returns The detected format, or null if the extension isn't one of the supported types.
+ */
+function formatFromFilename(filename: string): 'wav' | 'mp3' | 'ogg' | null {
+  const ext = path.extname(filename).slice(1).toLowerCase();
+  return ext === 'wav' || ext === 'mp3' || ext === 'ogg' ? ext : null;
+}
+
+/**
+ * Transcodes an in-memory audio buffer to MP3 via `ffmpeg-static`, entirely in memory
+ * (stdin/stdout pipes) — used for `ogg` clips, since OpenAI's audio-input models only
+ * accept `wav`/`mp3`.
+ * @param buffer Raw bytes of the source audio file.
+ * @returns The transcoded MP3 bytes.
+ */
+export function transcodeToMp3(buffer: Buffer): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    if (!ffmpegPath) {
+      reject(new Error('ffmpeg-static returned no path'));
+      return;
+    }
+    const proc = spawn(ffmpegPath, ['-i', 'pipe:0', '-f', 'mp3', 'pipe:1']);
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    proc.stdout.on('data', (chunk: Buffer) => stdout.push(chunk));
+    proc.stderr.on('data', (chunk: Buffer) => stderr.push(chunk));
+    proc.on('error', reject);
+    proc.on('close', (code) => {
+      if (code === 0) {
+        resolve(Buffer.concat(stdout));
+      } else {
+        reject(new Error(`ffmpeg exited with code ${code}: ${Buffer.concat(stderr).toString('utf8').slice(-500)}`));
+      }
+    });
+    proc.stdin.write(buffer);
+    proc.stdin.end();
+  });
+}
+
+/** A single audio clip ready to send to OpenAI, alongside its accepted format. */
+export interface AudioClip {
+  buffer: Buffer;
+  format: 'wav' | 'mp3';
+}
+
+/**
+ * Asks OpenAI to describe the given audio clip(s) for use as a public SFX description.
+ * @param clips One or more sampled clips (see {@link sampleFilesForSuggestion}) — more
+ *   than one when the trigger's files were sub-sampled, so the model can describe the
+ *   general theme rather than a single arbitrary clip.
+ * @param triggerCommand The trigger's command string, given as context only (client-supplied, not persisted).
+ * @param totalFileCount Total number of sound files the trigger actually has, so the
+ *   prompt can tell the model when `clips` is a sample rather than the full set.
+ * @returns A suggested description, trimmed to fit `sfxtrigger.description`'s column width.
+ */
+export async function requestDescriptionSuggestion(
+  clips: AudioClip[],
+  triggerCommand: string,
+  totalFileCount: number,
+): Promise<string> {
+  const context = triggerCommand ? ` for the trigger "${triggerCommand}"` : '';
+  const instruction = totalFileCount > clips.length
+    ? `This Discord soundboard trigger${context} has ${totalFileCount} different sound files; you're hearing a sample of ${clips.length} of them. Write one concise public-facing description (under 12 words) covering the general theme or variety of the sounds. Describe what's actually audible — don't just restate the trigger name.`
+    : `This is a Discord soundboard sound${context}. Write one concise public-facing description (under 12 words) of what's audible. Describe what's actually audible — don't just restate the trigger name.`;
+
+  const completion = await getOpenAiClient().chat.completions.create({
+    model: SUGGESTION_MODEL,
+    modalities: ['text'],
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: instruction },
+          ...clips.map((clip) => ({
+            type: 'input_audio' as const,
+            input_audio: { data: clip.buffer.toString('base64'), format: clip.format },
+          })),
+        ],
+      },
+    ],
+  });
+
+  const text = completion.choices[0]?.message?.content?.trim();
+  if (!text) throw new Error('OpenAI returned an empty description');
+  return text.length > MAX_DESCRIPTION_LENGTH ? text.slice(0, MAX_DESCRIPTION_LENGTH) : text;
+}
+
+/**
+ * Reads a sampled sound file from disk and converts it to a format OpenAI's
+ * audio-input models accept, transcoding `ogg` to `mp3` via {@link transcodeToMp3}.
+ * @param file The sfx row to load (its `file` column is the stored relative filename).
+ * @returns The loaded/converted clip, ready for {@link requestDescriptionSuggestion}.
+ * @throws If the filename's extension isn't a recognised format, or the resolved path escapes `SFX_FOLDER`.
+ */
+async function loadClip(file: SfxFile): Promise<AudioClip> {
+  const format = formatFromFilename(file.file);
+  if (!format) throw new Error(`Unrecognised stored extension for SFX file ${file.file}`);
+  const fullPath = safeResolve(SFX_FOLDER, file.file);
+  if (!fullPath) throw new Error(`Unsafe stored path for SFX file ${file.file}`);
+  const buffer = await fs.promises.readFile(fullPath);
+  return format === 'ogg' ? { buffer: await transcodeToMp3(buffer), format: 'mp3' } : { buffer, format };
+}
+
+// This route responds with JSON rather than a redirect — unlike the rest of the SFX
+// mutation routes — because it's an AJAX-triggered "fill in a field" action (sfx.js
+// populates the description input from the response) rather than a page mutation.
+/**
+ * POST /sfx/trigger/suggest-description — analyses a sample of a trigger's sound
+ * files with OpenAI and returns a suggested public description. Owner-only while
+ * this feature is being trialled for cost/effectiveness (see `requireOwner`).
+ * @param req Express request; reads `trigger_id` and optional `trigger_command` (context only) from a JSON body.
+ * @param res Express response; always responds with JSON.
+ */
+router.post('/sfx/trigger/suggest-description', requireOwner, csrfProtection, async (req, res) => {
+  if (!OPENAI_API_KEY) {
+    res.status(503).json({ error: 'not_configured' });
+    return;
+  }
+
+  const triggerId = parsePositiveBigIntId(req.body?.trigger_id);
+  if (triggerId === null) {
+    res.status(400).json({ error: 'invalid_id' });
+    return;
+  }
+  const triggerCommand = normalizeRequiredText(req.body?.trigger_command)?.slice(0, MAX_TRIGGER_COMMAND_LENGTH) ?? '';
+
+  let files: SfxFile[];
+  try {
+    files = await findSoundFiles(triggerId);
+  } catch (err) {
+    log.error('Suggest SFX description error (load files):', err);
+    res.status(502).json({ error: 'suggestion_failed' });
+    return;
+  }
+  if (files.length === 0) {
+    res.status(404).json({ error: 'no_file' });
+    return;
+  }
+
+  try {
+    const sample = sampleFilesForSuggestion(files);
+    const clips = await Promise.all(sample.map(loadClip));
+    const description = await requestDescriptionSuggestion(clips, triggerCommand, files.length);
+    res.status(200).json({ description });
+  } catch (err) {
+    log.error('Suggest SFX description error:', err);
+    res.status(502).json({ error: 'suggestion_failed' });
+  }
+});
+
+export default router;

--- a/views/sfx.ejs
+++ b/views/sfx.ejs
@@ -243,7 +243,7 @@
                         <% } %>
                       </div>
                       <% if (canSuggestDescriptions) { %>
-                      <span class="hint hint-compact js-suggest-status" data-status-for="<%= t.triggerId %>"></span>
+                      <span class="hint hint-compact js-suggest-status" role="status" aria-live="polite" data-status-for="<%= t.triggerId %>"></span>
                       <% } %>
                     </div>
                     <div class="button-row-wrap">

--- a/views/sfx.ejs
+++ b/views/sfx.ejs
@@ -321,5 +321,6 @@
   <%- include('partials/footer') %>
   <script src="/utils.js"></script>
   <script src="/sfx.js"></script>
+  <script src="/sfx-suggest-description.js"></script>
 </body>
 </html>

--- a/views/sfx.ejs
+++ b/views/sfx.ejs
@@ -236,7 +236,15 @@
                     </div>
                     <div class="form-section-gap">
                       <label for="description_<%= t.triggerId %>" class="form-label">Description <span class="muted">(optional)</span></label>
-                      <input id="description_<%= t.triggerId %>" class="input full-width" type="text" name="description" value="<%= t.description || '' %>">
+                      <div class="form-row-wrap items-end gap-05">
+                        <input id="description_<%= t.triggerId %>" class="input full-width" type="text" name="description" value="<%= t.description || '' %>">
+                        <% if (canSuggestDescriptions) { %>
+                        <button type="button" class="btn btn-sm btn-ghost js-suggest-description" data-trigger-id="<%= t.triggerId %>">✨ Suggest</button>
+                        <% } %>
+                      </div>
+                      <% if (canSuggestDescriptions) { %>
+                      <span class="hint hint-compact js-suggest-status" data-status-for="<%= t.triggerId %>"></span>
+                      <% } %>
                     </div>
                     <div class="button-row-wrap">
                       <button type="submit" class="btn">Save Changes</button>


### PR DESCRIPTION
## Summary

- Adds a "✨ Suggest" button next to each trigger's description field in the SFX admin panel (`views/sfx.ejs`). Clicking it analyses a sample of the trigger's sound files with OpenAI and fills the description input for the mod to review/edit before clicking Save — nothing is auto-saved.
- Sampling (`sampleFilesForSuggestion` in `src/web/routes/sfxSuggestDescription.ts`) picks up to 5 of the trigger's files: always the rarest and most common by `weight`, plus the rest spread evenly across the weight-sorted list, so a trigger with many varied sounds gets a suggestion covering that variety rather than one arbitrary clip.
- `ogg` files are transcoded to `mp3` in-memory via `ffmpeg-static` before being sent, since OpenAI's audio-input models only accept `wav`/`mp3`.
- **Owner-only for now**: gated behind a new `requireOwner` middleware (`src/web/middleware.ts`), built on the existing `user.is_owner` global super-admin flag — distinct from the per-guild `AccessLevel` enum. This keeps the feature restricted to the single most-trusted account while its cost/effectiveness is trialled, before a wider rollout (a one-line change to swap the guard later).
- Entirely disabled (button hidden, route returns `503`) when `OPENAI_API_KEY` is unset — no new required configuration for existing deployments.
- New dependency: `openai` (official SDK).

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 153 files / 2862 tests passing)
- [x] `npm run lint` (no new warnings/errors)
- [ ] Manual check in a running instance: as the owner with `OPENAI_API_KEY` set, expand a trigger's Edit panel, click Suggest, confirm the description fills in and Save Changes still works; confirm the button is absent for non-owners and when the key is unset; confirm a trigger with several `ogg` files of differing weights works (exercises the transcode + sampling paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AZpPy5F3Gm78JhcULTT2Ls)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an owner-only “Suggest” option to generate SFX descriptions from uploaded audio.
  * The suggestion UI shows real-time status (“Thinking…”) and applies the returned description to the form.
  * Suggestions are disabled when no OpenAI API key is configured.
* **Access Control**
  * Enforced owner-only access for the suggestion endpoint via a dedicated protection layer.
* **Documentation**
  * Updated `.env.example` with an optional `OPENAI_API_KEY` setting to enable the feature.
* **Tests**
  * Expanded coverage for owner gating and the suggestion workflow (success and failure cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->