### PR TITLE
Ask for verbatim spoken quotes in SFX description suggestions

### DIFF
--- a/src/web/routes/sfxSuggestDescription.test.ts
+++ b/src/web/routes/sfxSuggestDescription.test.ts
@@ -196,6 +196,24 @@ describe('requestDescriptionSuggestion', () => {
     expect(mockCreate.mock.calls[0][0].messages[0].content[0].text).not.toMatch(/sample of/);
   });
 
+  it('single-clip prompt asks for a verbatim quote gated on recognizability, with a no-speech fallback', async () => {
+    mockCreate.mockResolvedValue({ choices: [{ message: { content: 'desc' } }] });
+    await requestDescriptionSuggestion([{ buffer: Buffer.from('a'), format: 'mp3' }], '!clap', 1);
+    const text = mockCreate.mock.calls[0][0].messages[0].content[0].text;
+    expect(text).toMatch(/recognizable spoken words/);
+    expect(text).toMatch(/transcribe them verbatim/);
+    expect(text).toMatch(/Otherwise describe what's audible/);
+  });
+
+  it('sampled prompt asks for a verbatim quote gated on recognizability, with a general-theme fallback', async () => {
+    mockCreate.mockResolvedValue({ choices: [{ message: { content: 'desc' } }] });
+    await requestDescriptionSuggestion([{ buffer: Buffer.from('a'), format: 'mp3' }], '!meme', 8);
+    const text = mockCreate.mock.calls[0][0].messages[0].content[0].text;
+    expect(text).toMatch(/recognizable spoken words/);
+    expect(text).toMatch(/include a representative quote verbatim/);
+    expect(text).toMatch(/Otherwise describe the general theme or variety/);
+  });
+
   it('truncates a description longer than the VARCHAR(255) column', async () => {
     mockCreate.mockResolvedValue({ choices: [{ message: { content: 'x'.repeat(300) } }] });
     const result = await requestDescriptionSuggestion([{ buffer: Buffer.from('a'), format: 'mp3' }], '!clap', 1);

--- a/src/web/routes/sfxSuggestDescription.ts
+++ b/src/web/routes/sfxSuggestDescription.ts
@@ -143,9 +143,13 @@ export async function requestDescriptionSuggestion(
   totalFileCount: number,
 ): Promise<string> {
   const context = triggerCommand ? ` for the trigger "${triggerCommand}"` : '';
+  // Explicitly ask for a verbatim quote when someone's speaking: without this, the
+  // model tends to paraphrase recognizable lines/catchphrases away into a vague
+  // paraphrase (e.g. a mumbled "mmm, bacon" becomes "a man making a sound"), even
+  // though the actual words are usually the most useful description for a soundboard.
   const instruction = totalFileCount > clips.length
-    ? `This Discord soundboard trigger${context} has ${totalFileCount} different sound files; you're hearing a sample of ${clips.length} of them. Write one concise public-facing description (under 12 words) covering the general theme or variety of the sounds. Describe what's actually audible — don't just restate the trigger name.`
-    : `This is a Discord soundboard sound${context}. Write one concise public-facing description (under 12 words) of what's audible. Describe what's actually audible — don't just restate the trigger name.`;
+    ? `This Discord soundboard trigger${context} has ${totalFileCount} different sound files; you're hearing a sample of ${clips.length} of them. If any clip has recognizable spoken words, include a representative quote verbatim (in quotes) rather than paraphrasing it. Otherwise describe the general theme or variety of the sounds. Write one concise public-facing description, under 12 words, and don't just restate the trigger name.`
+    : `This is a Discord soundboard sound${context}. If someone is speaking, transcribe the actual words verbatim (in quotes) rather than paraphrasing — that's usually the most useful description for a soundboard entry. Otherwise describe what's audible. Write one concise public-facing description, under 12 words, and don't just restate the trigger name.`;
 
   const completion = await getOpenAiClient().chat.completions.create({
     model: SUGGESTION_MODEL,

--- a/src/web/routes/sfxSuggestDescription.ts
+++ b/src/web/routes/sfxSuggestDescription.ts
@@ -149,7 +149,7 @@ export async function requestDescriptionSuggestion(
   // though the actual words are usually the most useful description for a soundboard.
   const instruction = totalFileCount > clips.length
     ? `This Discord soundboard trigger${context} has ${totalFileCount} different sound files; you're hearing a sample of ${clips.length} of them. If any clip has recognizable spoken words, include a representative quote verbatim (in quotes) rather than paraphrasing it. Otherwise describe the general theme or variety of the sounds. Write one concise public-facing description, under 12 words, and don't just restate the trigger name.`
-    : `This is a Discord soundboard sound${context}. If someone is speaking, transcribe the actual words verbatim (in quotes) rather than paraphrasing — that's usually the most useful description for a soundboard entry. Otherwise describe what's audible. Write one concise public-facing description, under 12 words, and don't just restate the trigger name.`;
+    : `This is a Discord soundboard sound${context}. If it has recognizable spoken words, transcribe them verbatim (in quotes) rather than paraphrasing — that's usually the most useful description for a soundboard entry. Otherwise describe what's audible. Write one concise public-facing description, under 12 words, and don't just restate the trigger name.`;
 
   const completion = await getOpenAiClient().chat.completions.create({
     model: SUGGESTION_MODEL,


### PR DESCRIPTION
## Summary

Follow-up to #450. Reported gap: a clip of Homer Simpson saying "mmm, bacon" wasn't reflected in the suggested description.

- The suggestion prompt (`requestDescriptionSuggestion` in `src/web/routes/sfxSuggestDescription.ts`) previously only asked for a general description of what's audible. For clips with recognizable/mumbled speech, that led the model to paraphrase the actual line away (e.g. into something like "a man making a sound") instead of transcribing it — even though the real quote is usually the most useful description for a soundboard entry.
- Both prompt variants (single clip, and the multi-clip sampled case) now explicitly ask the model to include a verbatim quote when speech is audible, falling back to a general description otherwise.
- No behavioral/API changes beyond the prompt text — existing tests that assert on the `"sample of N of them"` phrasing still hold since that wording is unchanged.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 153 files / 2864 tests passing)
- [x] `npm run lint` (no new warnings/errors)
- [ ] Manual re-test against the reported clip once deployed, to confirm the quote now comes through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AZpPy5F3Gm78JhcULTT2Ls)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced sound-effect description suggestions to include recognizable spoken words as representative quotes.
  * Improved guidance for distinguishing audible content from broader themes and variety when generating descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->