### PR TITLE
Add in-browser playback for SFX sound files

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -437,6 +437,8 @@ details[open] > .disclosure-toggle::before { transform: rotate(90deg); }
 .p-0    { padding: 0; }
 .pt-0   { padding-top: 0; }
 
+.sfx-preview { height: 2rem; max-width: 14rem; }
+
 .w-auto  { width: auto; }
 .w-5rem  { width: 5rem; }
 .w-6rem  { width: 6rem; }

--- a/src/db.ts
+++ b/src/db.ts
@@ -190,7 +190,7 @@ export {
   findTrigger, findSoundFiles, getAllSfxTriggers, getSfxTriggerCount, getPublicSfxTriggers,
   getAllCategories, createCategory, renameCategory, deleteCategory,
   createSfxTrigger, updateSfxTrigger, deleteSfxTrigger,
-  addSfxFile, updateSfxFile, deleteSfxFile,
+  addSfxFile, updateSfxFile, deleteSfxFile, getSfxFileById,
 } from './db/sfx';
 export type { SfxLookupResult } from './db/sfxCache';
 export { findCachedSfxTrigger } from './db/sfxCache';

--- a/src/db/sfx.test.ts
+++ b/src/db/sfx.test.ts
@@ -34,7 +34,7 @@ import {
   findTrigger, findSoundFiles, getPublicSfxTriggers, getAllSfxTriggers, getSfxTriggerCount,
   getAllCategories, createCategory, renameCategory, deleteCategory,
   createSfxTrigger, updateSfxTrigger, deleteSfxTrigger,
-  addSfxFile, updateSfxFile, deleteSfxFile,
+  addSfxFile, updateSfxFile, deleteSfxFile, getSfxFileById,
 } from './sfx';
 import { invalidateSfxLookupCache } from './sfxCache';
 import { makeMockPool } from '../test-utils/mockMysqlPool';
@@ -464,6 +464,21 @@ describe('updateSfxFile', () => {
     vi.mocked(getPool).mockReturnValue(pool as any);
     await updateSfxFile(11, 3, true);
     expect(invalidateSfxLookupCache).toHaveBeenCalledOnce();
+  });
+});
+
+describe('getSfxFileById', () => {
+  it('returns the stored file path when the row exists', async () => {
+    const pool = makePool([{ file: 'clap.mp3' }]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    expect(await getSfxFileById(11)).toEqual({ file: 'clap.mp3' });
+    expect(pool.execute.mock.calls[0][1]).toEqual([11]);
+  });
+
+  it('returns null when no row matches', async () => {
+    const pool = makePool([]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    expect(await getSfxFileById(999)).toBeNull();
   });
 });
 

--- a/src/db/sfx.ts
+++ b/src/db/sfx.ts
@@ -277,6 +277,20 @@ export async function addSfxFile(
 }
 
 /**
+ * Look up a sound file's stored relative path by its `sfx` row id, for streaming
+ * playback. Returns null if no such row exists.
+ * @param id sfx row id.
+ */
+export async function getSfxFileById(id: number): Promise<{ file: string } | null> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT file FROM sfx WHERE id = ?`,
+    [id],
+  );
+  if (rows.length === 0) return null;
+  return { file: rows[0].file };
+}
+
+/**
  * Update a sound file's weight and hidden flag.
  * @param id sfx row id.
  * @param weight Weighted-random selection weight (>= 1).

--- a/src/web/routes/sfx.test.ts
+++ b/src/web/routes/sfx.test.ts
@@ -1,20 +1,25 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
 /** Hoisted so the `vi.mock` factories below can safely reference these — `vi.mock` factories are hoisted above imports, so plain imported bindings could throw `ReferenceError` depending on import order. */
-const { mockLogger, ACCESS_LEVEL_MOCK } = vi.hoisted(() => ({
+const { mockLogger, ACCESS_LEVEL_MOCK, SFX_FOLDER_MOCK } = vi.hoisted(() => ({
   mockLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
   ACCESS_LEVEL_MOCK: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
+  SFX_FOLDER_MOCK: require('fs').mkdtempSync(require('path').join(require('os').tmpdir(), 'sfx-test-')) as string,
 }));
 
 /** Mocks the `db` facade so `AccessLevel` resolves to the shared hoisted mock instead of hitting the real module. */
 vi.mock('../../db', () => ({
   getAllSfxTriggers: vi.fn().mockResolvedValue([]),
   getAllCategories: vi.fn().mockResolvedValue([]),
+  getSfxFileById: vi.fn().mockResolvedValue(null),
   AccessLevel: ACCESS_LEVEL_MOCK,
 }));
 /** Mocks the shared logger so route handlers don't write real log output during tests. */
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
-vi.mock('../../shared/config', () => ({ SFX_MAX_FILE_MB: 10, OPENAI_API_KEY: 'test-openai-key' }));
+vi.mock('../../shared/config', () => ({ SFX_MAX_FILE_MB: 10, OPENAI_API_KEY: 'test-openai-key', SFX_FOLDER: SFX_FOLDER_MOCK }));
 vi.mock('../csrf', () => ({
   csrfProtection: (req: any, _res: any, next: any) => {
     req.csrfToken = () => 'test-csrf-token';
@@ -24,7 +29,7 @@ vi.mock('../csrf', () => ({
 
 import supertest from 'supertest';
 import router from './sfx';
-import { getAllSfxTriggers, getAllCategories, AccessLevel } from '../../db';
+import { getAllSfxTriggers, getAllCategories, getSfxFileById, AccessLevel } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 
 /**
@@ -43,6 +48,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(getAllSfxTriggers).mockResolvedValue([]);
   vi.mocked(getAllCategories).mockResolvedValue([]);
+  vi.mocked(getSfxFileById).mockResolvedValue(null);
 });
 
 describe('GET /sfx', () => {
@@ -126,5 +132,49 @@ describe('GET /sfx', () => {
 
     const res = await supertest(app).get('/sfx');
     expect((res.body as any).locals.canSuggestDescriptions).toBe(false);
+  });
+});
+
+describe('GET /sfx/file/:id/audio', () => {
+  function buildAudioApp() {
+    return buildTestApp({ router, sessionUser: { discordId: '1', accessLevel: AccessLevel.USER } });
+  }
+
+  it('streams the file when the id resolves to a real file under SFX_FOLDER', async () => {
+    fs.writeFileSync(path.join(SFX_FOLDER_MOCK, 'clap.mp3'), 'fake-audio-bytes');
+    vi.mocked(getSfxFileById).mockResolvedValue({ file: 'clap.mp3' });
+
+    const res = await supertest(buildAudioApp()).get('/sfx/file/1/audio');
+    expect(res.status).toBe(200);
+    expect(Buffer.isBuffer(res.body) ? res.body.toString() : res.text).toBe('fake-audio-bytes');
+  });
+
+  it('returns 400 for a non-numeric id', async () => {
+    const res = await supertest(buildAudioApp()).get('/sfx/file/not-a-number/audio');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when no sfx row matches the id', async () => {
+    vi.mocked(getSfxFileById).mockResolvedValue(null);
+    const res = await supertest(buildAudioApp()).get('/sfx/file/999/audio');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when the stored path escapes SFX_FOLDER', async () => {
+    vi.mocked(getSfxFileById).mockResolvedValue({ file: '../../etc/passwd' });
+    const res = await supertest(buildAudioApp()).get('/sfx/file/1/audio');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when the DB row points at a file that no longer exists on disk', async () => {
+    vi.mocked(getSfxFileById).mockResolvedValue({ file: 'missing.mp3' });
+    const res = await supertest(buildAudioApp()).get('/sfx/file/1/audio');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 500 when the DB lookup throws', async () => {
+    vi.mocked(getSfxFileById).mockRejectedValue(new Error('DB down'));
+    const res = await supertest(buildAudioApp()).get('/sfx/file/1/audio');
+    expect(res.status).toBe(500);
   });
 });

--- a/src/web/routes/sfx.test.ts
+++ b/src/web/routes/sfx.test.ts
@@ -137,6 +137,7 @@ describe('GET /sfx', () => {
 });
 
 describe('GET /sfx/file/:id/audio', () => {
+  /** Builds a supertest-ready app for the audio route, with a stubbed level-0 user session. */
   function buildAudioApp() {
     return buildTestApp({ router, sessionUser: { discordId: '1', accessLevel: AccessLevel.USER } });
   }

--- a/src/web/routes/sfx.test.ts
+++ b/src/web/routes/sfx.test.ts
@@ -1,13 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
 
-/** Hoisted so the `vi.mock` factories below can safely reference these — `vi.mock` factories are hoisted above imports, so plain imported bindings could throw `ReferenceError` depending on import order. */
+/** Hoisted so the `vi.mock` factories below can safely reference these — `vi.mock` factories are hoisted above imports, so plain imported bindings could throw `ReferenceError` depending on import order. This is a plain string literal (no filesystem calls) precisely so it can be computed before any module import has run; the directory itself is created below, after the real `fs`/`os`/`path` imports are available. */
 const { mockLogger, ACCESS_LEVEL_MOCK, SFX_FOLDER_MOCK } = vi.hoisted(() => ({
   mockLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
   ACCESS_LEVEL_MOCK: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
-  SFX_FOLDER_MOCK: require('fs').mkdtempSync(require('path').join(require('os').tmpdir(), 'sfx-test-')) as string,
+  SFX_FOLDER_MOCK: '/tmp/bcuk-sfx-route-test-fixture',
 }));
 
 /** Mocks the `db` facade so `AccessLevel` resolves to the shared hoisted mock instead of hitting the real module. */
@@ -31,6 +30,8 @@ import supertest from 'supertest';
 import router from './sfx';
 import { getAllSfxTriggers, getAllCategories, getSfxFileById, AccessLevel } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
+
+fs.mkdirSync(SFX_FOLDER_MOCK, { recursive: true });
 
 /**
  * Build a supertest GET request against the SFX view router with a stubbed session

--- a/src/web/routes/sfx.ts
+++ b/src/web/routes/sfx.ts
@@ -1,9 +1,11 @@
 import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
-import { getAllSfxTriggers, getAllCategories, AccessLevel } from '../../db';
+import fs from 'fs';
+import { getAllSfxTriggers, getAllCategories, getSfxFileById, AccessLevel } from '../../db';
 import { csrfProtection } from '../csrf';
-import { SFX_MAX_FILE_MB, OPENAI_API_KEY } from '../../shared/config';
-import { filterQueryParam, renderError, renderView } from './shared';
+import { SFX_FOLDER, SFX_MAX_FILE_MB, OPENAI_API_KEY } from '../../shared/config';
+import { safeResolve } from '../../shared/pathUtils';
+import { filterQueryParam, parsePositiveIntId, renderError, renderView } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
@@ -62,6 +64,48 @@ router.get('/sfx', csrfProtection, async (req, res) => {
     log.error('SFX error:', err);
     renderError(res, 500, 'Failed to load SFX data.', req.session.user);
   }
+});
+
+/**
+ * GET /sfx/file/:id/audio — streams a sound file's audio bytes for in-browser
+ * playback on the SFX management page. Reachable by any logged-in user (this
+ * router is mounted behind `requireAuth`, matching the read-only visibility of
+ * the sounds table on the page itself). Resolves the DB row's stored filename
+ * against `SFX_FOLDER` via `safeResolve` before touching the filesystem, so a
+ * crafted id can't be used to read files outside that folder.
+ * @param req - Express request; reads the `id` route param (an `sfx` row id).
+ * @param res - Express response; streams the file with `Content-Disposition:
+ *   inline` on success, or replies 400/404 if the id is invalid or unresolved.
+ */
+router.get('/sfx/file/:id/audio', async (req, res) => {
+  const id = parsePositiveIntId(req.params.id);
+  if (id === null) { res.status(400).end(); return; }
+
+  let row;
+  try {
+    row = await getSfxFileById(id);
+  } catch (err) {
+    log.error('SFX audio lookup error:', err);
+    res.status(500).end();
+    return;
+  }
+  if (!row) { res.status(404).end(); return; }
+
+  const resolved = safeResolve(SFX_FOLDER, row.file);
+  if (!resolved) { res.status(404).end(); return; }
+
+  try {
+    await fs.promises.access(resolved);
+  } catch {
+    res.status(404).end();
+    return;
+  }
+
+  res.sendFile(resolved, { headers: { 'Content-Disposition': 'inline' } }, (err) => {
+    if (err && !res.headersSent) {
+      res.status(404).end();
+    }
+  });
 });
 
 export default router;

--- a/views/sfx.ejs
+++ b/views/sfx.ejs
@@ -139,16 +139,17 @@
               <td colspan="5">
                 <% if (t.files.length > 0) { %>
                 <table class="inner-table">
-                  <thead><tr><th scope="col">File</th><th scope="col">Weight</th><th scope="col">Status</th><% if (canManage) { %><th scope="col">Actions</th><% } %></tr></thead>
+                  <thead><tr><th scope="col">File</th><th scope="col">Listen</th><th scope="col">Weight</th><th scope="col">Status</th><% if (canManage) { %><th scope="col">Actions</th><% } %></tr></thead>
                   <tbody>
                     <% t.files.forEach(function(f) { %>
                     <tr>
                       <% if (canManage) { %>
-                      <td colspan="<%= canManage ? 4 : 3 %>">
+                      <td colspan="<%= canManage ? 5 : 4 %>">
                         <form method="POST" action="/sfx/file/update" class="form-row-wrap items-end gap-05">
                           <input type="hidden" name="_csrf" value="<%= csrfToken %>">
                           <input type="hidden" name="file_id" value="<%= f.id %>">
                           <span class="mono form-col-grow"><%= f.file %></span>
+                          <audio class="sfx-preview" controls preload="none" src="/sfx/file/<%= f.id %>/audio"></audio>
                           <label class="form-label">Weight
                             <input class="input w-6rem" type="number" name="weight" min="1" value="<%= f.weight %>">
                           </label>
@@ -160,13 +161,14 @@
                       </td>
                       <% } else { %>
                       <td class="mono"><%= f.file %></td>
+                      <td><audio class="sfx-preview" controls preload="none" src="/sfx/file/<%= f.id %>/audio"></audio></td>
                       <td><%= f.weight %></td>
                       <td><% if (f.hidden) { %><span class="badge badge-hidden">Hidden</span><% } else { %><span class="badge badge-active">Active</span><% } %></td>
                       <% } %>
                     </tr>
                     <% if (canManage) { %>
                     <tr>
-                      <td colspan="4" class="pt-0">
+                      <td colspan="5" class="pt-0">
                         <form method="POST" action="/sfx/file/remove" class="inline-form-sm js-confirm-remove-file" data-file-name="<%= f.file %>">
                           <input type="hidden" name="_csrf" value="<%= csrfToken %>">
                           <input type="hidden" name="file_id" value="<%= f.id %>">


### PR DESCRIPTION
## Summary
- Adds `GET /sfx/file/:id/audio`, which streams a sound file's bytes for in-browser playback. The DB row's stored filename is resolved against `SFX_FOLDER` via `safeResolve` before touching disk, so a crafted id can't read outside that folder.
- Adds an `<audio controls preload="none">` element per sound row on the SFX management page (`/sfx`), for both the Mod+ editable row and the read-only row, so anyone who can already see the sounds table can listen to a file without downloading it separately.
- New `getSfxFileById` DB helper (`src/db/sfx.ts`, re-exported from `src/db.ts`) backs the lookup.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 2874 tests)
- [x] New unit tests for `getSfxFileById` (`src/db/sfx.test.ts`) and the audio route — 200 streaming, 400 bad id, 404 missing row/missing file/path-traversal attempt, 500 on DB error (`src/web/routes/sfx.test.ts`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RjpJeXQAWYDbDPkE6etGs2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio previews to SFX file listings.
  * Added secure in-app playback for stored SFX audio files.
  * Added clear handling for invalid, missing, or unavailable audio files.
  * Improved preview sizing and table layout.

* **Tests**
  * Added coverage for successful playback and relevant error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->