### PR TITLE
Add per-streamer Twitch timer commands

### DIFF
--- a/DATABASE-SCHEMA.md
+++ b/DATABASE-SCHEMA.md
@@ -315,6 +315,23 @@ Expected constraints:
 - `UNIQUE KEY uq_alert_config (streamer_id, event_type)` — one row per streamer per event type.
 - Independent of `streamer_event_config` (Twitch chat messages) and `overlay_reward`/`overlay_video` (channel-point video overlay) — a streamer may enable an alert for an event type without enabling the corresponding chat message, or vice versa.
 
+## `timer_command`
+
+Per-streamer, Twitch-only auto-posted chat messages ("timer commands" — one message per row; a rotation is achieved by creating several timers). Config-only: the scheduler's live-status/chat-activity firing state lives in memory (`timerCommandScheduler.ts`), not in this table, so a restart just restarts each timer's countdown rather than replaying fires missed while the bot was down. Created by `migrations/timer_commands.sql`.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | `INT` PK, auto-increment | |
+| `streamer_id` | `INT` | FK to `streamer.id` ON DELETE CASCADE |
+| `name` | `VARCHAR(255)` | Admin-facing label only, never posted to chat |
+| `message` | `VARCHAR(500)` | The chat message posted on each fire |
+| `interval_seconds` | `INT` | Minimum time between fires; `CHECK (interval_seconds >= 60)` |
+| `min_messages` | `INT` | Minimum chat lines seen since the timer's last fire, in addition to the interval; `0` disables this gate; `CHECK (min_messages >= 0)` |
+| `require_live` | `TINYINT(1)` | When `1`, the timer only fires while the streamer's channel is live |
+| `enabled` | `TINYINT(1)` | Whether the scheduler considers this timer at all |
+
+Firing logic (see `timerCommandScheduler.ts`): on a 15s tick, a timer fires once its interval has elapsed **and** (if `require_live`) the channel is live **and** at least `min_messages` chat lines have been seen since its last fire. A newly-seen timer (first tick after creation or bot restart) seeds its clock and chat-line baseline without firing, so restarts don't cause a burst of immediate posts.
+
 ## `streamdeck_api_keys`
 
 Per-user Streamdeck API keys. Defined in `schema.sql`. For existing deployments where this table was created externally (before the multi-guild migration), `migrations/multi_guild.sql` conditionally adds the `guild_id` column.

--- a/migrations/timer_commands.sql
+++ b/migrations/timer_commands.sql
@@ -1,0 +1,15 @@
+-- Per-streamer, Twitch-only auto-posted chat messages (timer commands). Config-only —
+-- the scheduler's live/message-count firing state is kept in memory, not persisted here.
+CREATE TABLE timer_command (
+  id               INT          AUTO_INCREMENT PRIMARY KEY,
+  streamer_id      INT          NOT NULL,
+  name             VARCHAR(255) NOT NULL,
+  message          VARCHAR(500) NOT NULL,
+  interval_seconds INT          NOT NULL,
+  min_messages     INT          NOT NULL DEFAULT 0,
+  require_live     TINYINT(1)   NOT NULL DEFAULT 1,
+  enabled          TINYINT(1)   NOT NULL DEFAULT 1,
+  FOREIGN KEY (streamer_id) REFERENCES streamer(id) ON DELETE CASCADE,
+  CONSTRAINT chk_timer_command_interval CHECK (interval_seconds >= 60),
+  CONSTRAINT chk_timer_command_min_messages CHECK (min_messages >= 0)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/public/timers.js
+++ b/public/timers.js
@@ -1,0 +1,12 @@
+registerToggleEditHandler('btn-toggle-timer-edit', 'data-timer-id', 'timer-edit-');
+
+document.addEventListener('submit', function (event) {
+  var target = event.target;
+  if (!(target instanceof HTMLFormElement)) return;
+  if (!target.classList.contains('js-confirm-remove-timer')) return;
+
+  var timerName = target.dataset.timerName || 'this timer';
+  if (!window.confirm('Remove timer ' + timerName + '?')) {
+    event.preventDefault();
+  }
+});

--- a/schema.sql
+++ b/schema.sql
@@ -151,6 +151,28 @@ CREATE TABLE IF NOT EXISTS streamer_event_config (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ---------------------------------------------------------------------------
+-- timer_command
+-- Per-streamer, Twitch-only auto-posted chat messages. Config-only — the
+-- scheduler's live/message-count firing state is kept in memory (see
+-- timerCommandScheduler.ts), not persisted here, so a restart simply
+-- restarts each timer's countdown rather than replaying missed fires.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS timer_command (
+  id               INT          NOT NULL AUTO_INCREMENT,
+  streamer_id      INT          NOT NULL,
+  name             VARCHAR(255) NOT NULL,
+  message          VARCHAR(500) NOT NULL,
+  interval_seconds INT          NOT NULL,
+  min_messages     INT          NOT NULL DEFAULT 0,
+  require_live     TINYINT(1)   NOT NULL DEFAULT 1,
+  enabled          TINYINT(1)   NOT NULL DEFAULT 1,
+  PRIMARY KEY (id),
+  FOREIGN KEY (streamer_id) REFERENCES streamer(id) ON DELETE CASCADE,
+  CONSTRAINT chk_timer_command_interval CHECK (interval_seconds >= 60),
+  CONSTRAINT chk_timer_command_min_messages CHECK (min_messages >= 0)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ---------------------------------------------------------------------------
 -- custom_command
 -- trigger_string is NOT globally unique — the same trigger can exist on
 -- different Twitch channels. See DATABASE-SCHEMA.md for details.

--- a/src/db.ts
+++ b/src/db.ts
@@ -217,6 +217,15 @@ export {
 export type { RewardPricingHistoryPoint } from './db/rewardPricingHistory';
 export { recordPricingHistory, getPricingHistoryForRewards } from './db/rewardPricingHistory';
 
+// ─── Timer commands ─────────────────────────────────────────────────────────
+
+export type { DbTimerCommand, TimerCommandInput, TimerCommandForScheduler } from './db/timerCommands';
+export {
+  TimerCommandNotFoundError,
+  getTimerCommandsForStreamer, addTimerCommand, updateTimerCommand, removeTimerCommand,
+  setTimerCommandEnabled, getAllEnabledTimerCommandsWithChannel,
+} from './db/timerCommands';
+
 // ─── Streamdeck API keys ─────────────────────────────────────────────────────
 
 export type { StreamdeckKeyGuildStatusRow } from './db/streamdeckKeys';

--- a/src/db/timerCommands.test.ts
+++ b/src/db/timerCommands.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./pool', () => ({ getPool: vi.fn() }));
+vi.mock('mysql2/promise', () => ({ default: {} }));
+
+import { getPool } from './pool';
+import {
+  getTimerCommandsForStreamer,
+  addTimerCommand,
+  updateTimerCommand,
+  removeTimerCommand,
+  setTimerCommandEnabled,
+  getAllEnabledTimerCommandsWithChannel,
+  TimerCommandNotFoundError,
+  type TimerCommandInput,
+} from './timerCommands';
+import { makeMockPool } from '../test-utils/mockMysqlPool';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const sampleRow = {
+  id: 1,
+  streamer_id: 7,
+  name: 'Discord plug',
+  message: 'Join our Discord!',
+  interval_seconds: 600,
+  min_messages: 5,
+  require_live: 1,
+  enabled: 1,
+};
+
+const sampleInput: TimerCommandInput = {
+  name: 'Discord plug',
+  message: 'Join our Discord!',
+  intervalSeconds: 600,
+  minMessages: 5,
+  requireLive: true,
+  enabled: true,
+};
+
+describe('getTimerCommandsForStreamer', () => {
+  it('maps rows, converting BIT columns to booleans', async () => {
+    vi.mocked(getPool).mockReturnValue(makeMockPool({ rows: [sampleRow] }) as any);
+    const rows = await getTimerCommandsForStreamer(7);
+    expect(rows).toEqual([{
+      id: 1,
+      streamer_id: 7,
+      name: 'Discord plug',
+      message: 'Join our Discord!',
+      interval_seconds: 600,
+      min_messages: 5,
+      require_live: true,
+      enabled: true,
+    }]);
+  });
+
+  it('queries scoped to the streamer id', async () => {
+    const pool = makeMockPool({ rows: [] });
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await getTimerCommandsForStreamer(7);
+    expect(pool.execute.mock.calls[0][1]).toEqual([7]);
+  });
+});
+
+describe('addTimerCommand', () => {
+  it('inserts and returns the new insertId', async () => {
+    const pool = makeMockPool({ executeResult: [{ insertId: 42 }] });
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const id = await addTimerCommand(7, sampleInput);
+    expect(id).toBe(42);
+    expect(pool.execute.mock.calls[0][1]).toEqual([7, 'Discord plug', 'Join our Discord!', 600, 5, 1, 1]);
+  });
+});
+
+describe('updateTimerCommand', () => {
+  it('updates when a row matched', async () => {
+    const pool = makeMockPool({ executeResult: [{ affectedRows: 1 }] });
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(updateTimerCommand(1, 7, sampleInput)).resolves.toBeUndefined();
+    expect(pool.execute.mock.calls[0][1]).toEqual(['Discord plug', 'Join our Discord!', 600, 5, 1, 1, 1, 7]);
+  });
+
+  it('throws TimerCommandNotFoundError when no row matched (wrong id or wrong streamer)', async () => {
+    const pool = makeMockPool({ executeResult: [{ affectedRows: 0 }] });
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(updateTimerCommand(1, 999, sampleInput)).rejects.toThrow(TimerCommandNotFoundError);
+  });
+});
+
+describe('removeTimerCommand', () => {
+  it('deletes scoped to id and streamer id', async () => {
+    const pool = makeMockPool({ executeResult: [{ affectedRows: 1 }] });
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await removeTimerCommand(1, 7);
+    expect(pool.execute.mock.calls[0][1]).toEqual([1, 7]);
+  });
+
+  it('no-ops without throwing when nothing matched', async () => {
+    const pool = makeMockPool({ executeResult: [{ affectedRows: 0 }] });
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(removeTimerCommand(1, 999)).resolves.toBeUndefined();
+  });
+});
+
+describe('setTimerCommandEnabled', () => {
+  it('updates the enabled flag when a row matched', async () => {
+    const pool = makeMockPool({ executeResult: [{ affectedRows: 1 }] });
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await setTimerCommandEnabled(1, 7, false);
+    expect(pool.execute.mock.calls[0][1]).toEqual([0, 1, 7]);
+  });
+
+  it('throws TimerCommandNotFoundError when no row matched', async () => {
+    const pool = makeMockPool({ executeResult: [{ affectedRows: 0 }] });
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(setTimerCommandEnabled(1, 999, true)).rejects.toThrow(TimerCommandNotFoundError);
+  });
+});
+
+describe('getAllEnabledTimerCommandsWithChannel', () => {
+  it('maps joined rows to scheduler shape', async () => {
+    const joinedRow = {
+      id: 1,
+      channel: 'somestreamer',
+      message: 'Join our Discord!',
+      interval_seconds: 600,
+      min_messages: 5,
+      require_live: 1,
+    };
+    vi.mocked(getPool).mockReturnValue(makeMockPool({ rows: [joinedRow] }) as any);
+    const rows = await getAllEnabledTimerCommandsWithChannel();
+    expect(rows).toEqual([{
+      id: 1,
+      channel: 'somestreamer',
+      message: 'Join our Discord!',
+      interval_seconds: 600,
+      min_messages: 5,
+      require_live: true,
+    }]);
+  });
+
+  it('queries with no parameters (filtering happens in SQL)', async () => {
+    const pool = makeMockPool({ rows: [] });
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await getAllEnabledTimerCommandsWithChannel();
+    expect(pool.execute.mock.calls[0][1]).toBeUndefined();
+  });
+});

--- a/src/db/timerCommands.test.ts
+++ b/src/db/timerCommands.test.ts
@@ -80,10 +80,24 @@ describe('updateTimerCommand', () => {
     vi.mocked(getPool).mockReturnValue(pool as any);
     await expect(updateTimerCommand(1, 7, sampleInput)).resolves.toBeUndefined();
     expect(pool.execute.mock.calls[0][1]).toEqual(['Discord plug', 'Join our Discord!', 600, 5, 1, 1, 1, 7]);
+    // affectedRows > 0 already proves the row exists — no need for a follow-up existence check.
+    expect(pool.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when affectedRows is 0 but the row exists unchanged (a resubmitted, identical edit)', async () => {
+    const pool = makeMockPool();
+    pool.execute
+      .mockResolvedValueOnce([{ affectedRows: 0 }]) // the UPDATE itself: no-op, every value already equal
+      .mockResolvedValueOnce([[{ 1: 1 }]]); // the existence check: row is still there
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(updateTimerCommand(1, 7, sampleInput)).resolves.toBeUndefined();
   });
 
   it('throws TimerCommandNotFoundError when no row matched (wrong id or wrong streamer)', async () => {
-    const pool = makeMockPool({ executeResult: [{ affectedRows: 0 }] });
+    const pool = makeMockPool();
+    pool.execute
+      .mockResolvedValueOnce([{ affectedRows: 0 }]) // the UPDATE itself: nothing matched
+      .mockResolvedValueOnce([[]]); // the existence check: confirms the row is genuinely absent
     vi.mocked(getPool).mockReturnValue(pool as any);
     await expect(updateTimerCommand(1, 999, sampleInput)).rejects.toThrow(TimerCommandNotFoundError);
   });
@@ -112,8 +126,20 @@ describe('setTimerCommandEnabled', () => {
     expect(pool.execute.mock.calls[0][1]).toEqual([0, 1, 7]);
   });
 
+  it('does not throw when affectedRows is 0 but the row exists already in the requested state', async () => {
+    const pool = makeMockPool();
+    pool.execute
+      .mockResolvedValueOnce([{ affectedRows: 0 }]) // the UPDATE itself: no-op, already in that state
+      .mockResolvedValueOnce([[{ 1: 1 }]]); // the existence check: row is still there
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(setTimerCommandEnabled(1, 7, true)).resolves.toBeUndefined();
+  });
+
   it('throws TimerCommandNotFoundError when no row matched', async () => {
-    const pool = makeMockPool({ executeResult: [{ affectedRows: 0 }] });
+    const pool = makeMockPool();
+    pool.execute
+      .mockResolvedValueOnce([{ affectedRows: 0 }]) // the UPDATE itself: nothing matched
+      .mockResolvedValueOnce([[]]); // the existence check: confirms the row is genuinely absent
     vi.mocked(getPool).mockReturnValue(pool as any);
     await expect(setTimerCommandEnabled(1, 999, true)).rejects.toThrow(TimerCommandNotFoundError);
   });

--- a/src/db/timerCommands.ts
+++ b/src/db/timerCommands.ts
@@ -1,0 +1,163 @@
+import mysql from 'mysql2/promise';
+import { getPool } from './pool';
+import { fromBit } from './utils';
+
+/** A per-streamer, Twitch-only auto-posted timer command. */
+export interface DbTimerCommand {
+  id: number;
+  streamer_id: number;
+  name: string;
+  message: string;
+  interval_seconds: number;
+  min_messages: number;
+  require_live: boolean;
+  enabled: boolean;
+}
+
+/** Fields a streamer can edit for one timer via the admin UI. */
+export interface TimerCommandInput {
+  name: string;
+  message: string;
+  intervalSeconds: number;
+  minMessages: number;
+  requireLive: boolean;
+  enabled: boolean;
+}
+
+/** One enabled timer joined with its owning streamer's Twitch channel, for the scheduler's per-tick read. */
+export interface TimerCommandForScheduler {
+  id: number;
+  channel: string;
+  message: string;
+  interval_seconds: number;
+  min_messages: number;
+  require_live: boolean;
+}
+
+/** Thrown when a timer lookup/mutation scoped to a streamer matches no row — either the id doesn't exist or belongs to a different streamer. */
+export class TimerCommandNotFoundError extends Error {
+  constructor(id: number) {
+    super(`Timer command not found: ${id}`);
+    this.name = 'TimerCommandNotFoundError';
+  }
+}
+
+function mapRow(r: mysql.RowDataPacket): DbTimerCommand {
+  return {
+    id: r.id,
+    streamer_id: r.streamer_id,
+    name: r.name,
+    message: r.message,
+    interval_seconds: r.interval_seconds,
+    min_messages: r.min_messages,
+    require_live: fromBit(r.require_live),
+    enabled: fromBit(r.enabled),
+  };
+}
+
+const TIMER_COMMAND_SELECT = `
+  id, streamer_id, name, message, interval_seconds, min_messages, require_live, enabled`;
+
+/**
+ * Lists every timer command belonging to a streamer, for the self-service admin page.
+ * @param streamerId - DB row ID of the streamer.
+ */
+export async function getTimerCommandsForStreamer(streamerId: number): Promise<DbTimerCommand[]> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT ${TIMER_COMMAND_SELECT} FROM timer_command WHERE streamer_id = ? ORDER BY id`,
+    [streamerId],
+  );
+  return rows.map(mapRow);
+}
+
+/**
+ * Creates a new timer command for a streamer.
+ * @param streamerId - DB row ID of the owning streamer.
+ * @param input - The timer's fields.
+ * @returns The new timer's primary key.
+ */
+export async function addTimerCommand(streamerId: number, input: TimerCommandInput): Promise<number> {
+  const [result] = await getPool().execute<mysql.ResultSetHeader>(
+    `INSERT INTO timer_command (streamer_id, name, message, interval_seconds, min_messages, require_live, enabled)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    [
+      streamerId, input.name, input.message, input.intervalSeconds, input.minMessages,
+      input.requireLive ? 1 : 0, input.enabled ? 1 : 0,
+    ],
+  );
+  return result.insertId;
+}
+
+/**
+ * Updates an existing timer command, scoped to the owning streamer so one streamer can never
+ * edit another's timer by guessing an id.
+ * @param id - Primary key of the `timer_command` row.
+ * @param streamerId - DB row ID of the owning streamer.
+ * @param input - The timer's new fields.
+ * @throws {TimerCommandNotFoundError} If no row matches both `id` and `streamerId`.
+ */
+export async function updateTimerCommand(id: number, streamerId: number, input: TimerCommandInput): Promise<void> {
+  const [result] = await getPool().execute<mysql.ResultSetHeader>(
+    `UPDATE timer_command
+     SET name = ?, message = ?, interval_seconds = ?, min_messages = ?, require_live = ?, enabled = ?
+     WHERE id = ? AND streamer_id = ?`,
+    [
+      input.name, input.message, input.intervalSeconds, input.minMessages,
+      input.requireLive ? 1 : 0, input.enabled ? 1 : 0, id, streamerId,
+    ],
+  );
+  if (result.affectedRows === 0) throw new TimerCommandNotFoundError(id);
+}
+
+/**
+ * Deletes a timer command, scoped to the owning streamer. No-ops if the id doesn't exist or
+ * belongs to a different streamer.
+ * @param id - Primary key of the `timer_command` row.
+ * @param streamerId - DB row ID of the owning streamer.
+ */
+export async function removeTimerCommand(id: number, streamerId: number): Promise<void> {
+  await getPool().execute(
+    `DELETE FROM timer_command WHERE id = ? AND streamer_id = ?`,
+    [id, streamerId],
+  );
+}
+
+/**
+ * Toggles a timer command's `enabled` flag, scoped to the owning streamer.
+ * @param id - Primary key of the `timer_command` row.
+ * @param streamerId - DB row ID of the owning streamer.
+ * @param enabled - The new enabled state.
+ * @throws {TimerCommandNotFoundError} If no row matches both `id` and `streamerId`.
+ */
+export async function setTimerCommandEnabled(id: number, streamerId: number, enabled: boolean): Promise<void> {
+  const [result] = await getPool().execute<mysql.ResultSetHeader>(
+    `UPDATE timer_command SET enabled = ? WHERE id = ? AND streamer_id = ?`,
+    [enabled ? 1 : 0, id, streamerId],
+  );
+  if (result.affectedRows === 0) throw new TimerCommandNotFoundError(id);
+}
+
+/**
+ * Lists every enabled timer command across all streamers, joined with its owning streamer's
+ * linked Twitch channel name. Streamers with no linked Twitch name are excluded — there's no
+ * channel to post to. Queried fresh every scheduler tick rather than cached, mirroring
+ * `getAllEnabledPricingRows()`.
+ */
+export async function getAllEnabledTimerCommandsWithChannel(): Promise<TimerCommandForScheduler[]> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT tc.id, u.twitch_name AS channel, tc.message, tc.interval_seconds, tc.min_messages, tc.require_live
+     FROM timer_command tc
+     JOIN streamer s ON s.id = tc.streamer_id
+     JOIN \`user\` u ON u.discord_id = s.discord_id
+     WHERE tc.enabled = 1 AND u.twitch_name IS NOT NULL
+     ORDER BY tc.streamer_id`,
+  );
+  return rows.map((r) => ({
+    id: r.id,
+    channel: r.channel,
+    message: r.message,
+    interval_seconds: r.interval_seconds,
+    min_messages: r.min_messages,
+    require_live: fromBit(r.require_live),
+  }));
+}

--- a/src/db/timerCommands.ts
+++ b/src/db/timerCommands.ts
@@ -1,6 +1,6 @@
 import mysql from 'mysql2/promise';
 import { getPool } from './pool';
-import { fromBit } from './utils';
+import { fromBit, affectedOrExists } from './utils';
 
 /** A per-streamer, Twitch-only auto-posted timer command. */
 export interface DbTimerCommand {
@@ -58,6 +58,15 @@ function mapRow(r: mysql.RowDataPacket): DbTimerCommand {
 const TIMER_COMMAND_SELECT = `
   id, streamer_id, name, message, interval_seconds, min_messages, require_live, enabled`;
 
+/** Whether a timer command exists for `id` scoped to `streamerId` — same ownership scope as the UPDATE statements below. */
+async function timerCommandExists(id: number, streamerId: number): Promise<boolean> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT 1 FROM timer_command WHERE id = ? AND streamer_id = ? LIMIT 1`,
+    [id, streamerId],
+  );
+  return rows.length > 0;
+}
+
 /**
  * Lists every timer command belonging to a streamer, for the self-service admin page.
  * @param streamerId - DB row ID of the streamer.
@@ -106,7 +115,12 @@ export async function updateTimerCommand(id: number, streamerId: number, input: 
       input.requireLive ? 1 : 0, input.enabled ? 1 : 0, id, streamerId,
     ],
   );
-  if (result.affectedRows === 0) throw new TimerCommandNotFoundError(id);
+  // affectedRows is 0 both when no row matched and when the row matched but every value was
+  // already equal (MySQL's default UPDATE semantics count only rows actually changed) — a
+  // resubmitted, unchanged edit must not be mistaken for a missing/foreign timer.
+  if (!(await affectedOrExists(result.affectedRows, () => timerCommandExists(id, streamerId)))) {
+    throw new TimerCommandNotFoundError(id);
+  }
 }
 
 /**
@@ -134,7 +148,12 @@ export async function setTimerCommandEnabled(id: number, streamerId: number, ena
     `UPDATE timer_command SET enabled = ? WHERE id = ? AND streamer_id = ?`,
     [enabled ? 1 : 0, id, streamerId],
   );
-  if (result.affectedRows === 0) throw new TimerCommandNotFoundError(id);
+  // See updateTimerCommand: affectedRows is 0 both for a missing row and a no-op toggle
+  // (already in the requested state), so a re-click of an already-toggled timer must not
+  // be mistaken for a missing/foreign one.
+  if (!(await affectedOrExists(result.affectedRows, () => timerCommandExists(id, streamerId)))) {
+    throw new TimerCommandNotFoundError(id);
+  }
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { pushDashboardEvent } from './web/routes/dashboardEvents';
 import { startCounterScheduler, stopCounterScheduler } from './commands/counterScheduler';
 import { startRewardPricingScheduler, stopRewardPricingScheduler } from './twitch/pricing/rewardPricingScheduler';
 import { registerRewardPricingRuntime } from './twitch/pricing/rewardPricingService';
+import { startTimerCommandScheduler, stopTimerCommandScheduler, registerTimerCommandsRuntime } from './twitch/timers/timerCommandScheduler';
 import { createLogger } from './shared/logger';
 
 const log = createLogger('Bot');
@@ -37,6 +38,7 @@ async function shutdown(signal: string): Promise<void> {
   log.info(`${signal} received — disconnecting from voice and shutting down.`);
   stopCounterScheduler();
   await stopRewardPricingScheduler();
+  await stopTimerCommandScheduler();
   stopEventSub();
   await stopTwitchMonitor();
   await stopTwitchBot();
@@ -81,6 +83,7 @@ async function main(): Promise<void> {
   registerEventSubDashboardRuntime({ pushDashboardEvent });
   registerEventSubTwitchRuntime({ send: sayInChannel });
   registerRewardPricingRuntime({ pushPricingUpdate });
+  registerTimerCommandsRuntime({ send: sayInChannel });
 
   // Load the guild registry before the Discord client connects so the
   // messageCreate gate recognises registered guilds from the first message.
@@ -97,6 +100,7 @@ async function main(): Promise<void> {
   startWebPanel();
   startCounterScheduler();
   startRewardPricingScheduler();
+  startTimerCommandScheduler();
 
   startTwitchMonitor().catch((err) => log.error('TwitchMonitor startup error:', err));
   startEventSub();

--- a/src/twitch/monitor/twitchMonitor.test.ts
+++ b/src/twitch/monitor/twitchMonitor.test.ts
@@ -26,7 +26,7 @@ vi.mock('./twitchMonitorStartup', () => ({ performStartupLiveCheck: vi.fn().mock
 
 import {
   startTwitchMonitor, stopTwitchMonitor, triggerImmediateLiveCheck, getLiveStates,
-  shutdownTwitchMonitor, restartTwitchMonitor, getMultiTwitchDataForChannel,
+  shutdownTwitchMonitor, restartTwitchMonitor, getMultiTwitchDataForChannel, isChannelLive,
 } from './twitchMonitor';
 import { getAllStreamersWithGroups, clearStreamerLive } from '../../db';
 import { getUsers, getStreams } from '../twitchApi';
@@ -396,6 +396,25 @@ describe('shutdown, restart, multitwitch lookup, and live-state ordering', () =>
     expect(result).not.toBeNull();
     expect(result!.url).toBe('https://www.multitwitch.tv/alpha/zeta');
     expect(result!.participants).toEqual(['alpha', 'zeta']);
+  });
+
+  it('isChannelLive returns false for a login with no live state', async () => {
+    vi.mocked(getAllStreamersWithGroups).mockResolvedValue([makeStreamer()] as any);
+    vi.mocked(getUsers).mockResolvedValue([{ login: 'teststreamer', id: 'uid-5' }]);
+    await startTwitchMonitor();
+
+    expect(isChannelLive('teststreamer')).toBe(false);
+  });
+
+  it('isChannelLive returns true once the streamer is tracked as live, case-insensitively', async () => {
+    vi.mocked(getAllStreamersWithGroups).mockResolvedValue([makeStreamer()] as any);
+    vi.mocked(getUsers).mockResolvedValue([{ login: 'teststreamer', id: 'uid-5' }]);
+    await startTwitchMonitor();
+
+    vi.mocked(getStreams).mockResolvedValueOnce([makeStream()] as any);
+    await triggerImmediateLiveCheck('teststreamer');
+
+    expect(isChannelLive('TestStreamer')).toBe(true);
   });
 
   it('getLiveStates sorts by group name, then by login within a group', async () => {

--- a/src/twitch/monitor/twitchMonitor.ts
+++ b/src/twitch/monitor/twitchMonitor.ts
@@ -180,6 +180,15 @@ export async function restartTwitchMonitor(): Promise<void> {
   await startTwitchMonitor();
 }
 
+/**
+ * Returns whether `login`'s stream is currently tracked as live by the monitor. Used by timer
+ * commands' `require_live` gate.
+ * @param login - Twitch login name to check.
+ */
+export function isChannelLive(login: string): boolean {
+  return liveStates.getByLogin(login.toLowerCase()) !== undefined;
+}
+
 // ─── Multi-twitch URL query (for !multi command) ─────────────────────────────
 
 /**

--- a/src/twitch/timers/timerCommandScheduler.test.ts
+++ b/src/twitch/timers/timerCommandScheduler.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+
+/** Hoisted so the `vi.mock('../../shared/logger', ...)` factory below can safely reference it. */
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
+vi.mock('../../db', () => ({ getAllEnabledTimerCommandsWithChannel: vi.fn() }));
+vi.mock('../twitchChatActivity', () => ({ getMessageCount: vi.fn() }));
+vi.mock('../monitor/twitchMonitor', () => ({ isChannelLive: vi.fn() }));
+
+import { getAllEnabledTimerCommandsWithChannel } from '../../db';
+import { getMessageCount } from '../twitchChatActivity';
+import { isChannelLive } from '../monitor/twitchMonitor';
+import {
+  runTimerCommandTick, startTimerCommandScheduler, stopTimerCommandScheduler, registerTimerCommandsRuntime,
+} from './timerCommandScheduler';
+
+interface TestRow {
+  id: number;
+  channel: string;
+  message: string;
+  interval_seconds: number;
+  min_messages: number;
+  require_live: boolean;
+}
+
+function timerRow(overrides: Partial<TestRow> = {}): TestRow {
+  return {
+    id: 1,
+    channel: 'somestreamer',
+    message: 'hello',
+    interval_seconds: 600,
+    min_messages: 0,
+    require_live: true,
+    ...overrides,
+  };
+}
+
+let send: Mock<(channel: string, message: string) => Promise<void>>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(2025, 0, 1));
+  send = vi.fn().mockResolvedValue(undefined);
+  registerTimerCommandsRuntime({ send });
+  vi.mocked(isChannelLive).mockReturnValue(true);
+  vi.mocked(getMessageCount).mockReturnValue(0);
+});
+
+afterEach(async () => {
+  await stopTimerCommandScheduler();
+  vi.useRealTimers();
+});
+
+describe('runTimerCommandTick', () => {
+  it('seeds state on first sight without firing', async () => {
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([timerRow()] as any);
+    await runTimerCommandTick();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('fires once the interval has elapsed and the channel is live', async () => {
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([timerRow({ interval_seconds: 600 })] as any);
+    await runTimerCommandTick(); // seed
+    await vi.advanceTimersByTimeAsync(600_000);
+    await runTimerCommandTick();
+    expect(send).toHaveBeenCalledWith('somestreamer', 'hello');
+  });
+
+  it('does not fire before the interval elapses', async () => {
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([timerRow({ interval_seconds: 600 })] as any);
+    await runTimerCommandTick(); // seed
+    await vi.advanceTimersByTimeAsync(300_000);
+    await runTimerCommandTick();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('does not fire while offline when require_live is set', async () => {
+    vi.mocked(isChannelLive).mockReturnValue(false);
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue(
+      [timerRow({ interval_seconds: 600, require_live: true })] as any,
+    );
+    await runTimerCommandTick(); // seed
+    await vi.advanceTimersByTimeAsync(600_000);
+    await runTimerCommandTick();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('does not fire below the min_messages threshold', async () => {
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue(
+      [timerRow({ interval_seconds: 600, min_messages: 5 })] as any,
+    );
+    await runTimerCommandTick(); // seeds messagesAtLastFire at the current count (0)
+    await vi.advanceTimersByTimeAsync(600_000);
+    vi.mocked(getMessageCount).mockReturnValue(3); // below the 5-message threshold
+    await runTimerCommandTick();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('fires once the min_messages threshold is met', async () => {
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue(
+      [timerRow({ interval_seconds: 600, min_messages: 5 })] as any,
+    );
+    await runTimerCommandTick(); // seeds messagesAtLastFire at the current count (0)
+    await vi.advanceTimersByTimeAsync(600_000);
+    vi.mocked(getMessageCount).mockReturnValue(5);
+    await runTimerCommandTick();
+    expect(send).toHaveBeenCalledWith('somestreamer', 'hello');
+  });
+
+  it('prunes in-memory state once a timer disappears from the enabled-rows query', async () => {
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValueOnce([timerRow()] as any);
+    await runTimerCommandTick(); // seeded
+
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValueOnce([]);
+    await runTimerCommandTick(); // pruned — the timer's old state is gone
+
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValueOnce([timerRow()] as any);
+    await vi.advanceTimersByTimeAsync(600_000);
+    await runTimerCommandTick(); // re-seen: seeds fresh state again instead of firing on stale state
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("one channel's send failure does not block another's", async () => {
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([
+      timerRow({ id: 1, channel: 'streamer-a' }),
+      timerRow({ id: 2, channel: 'streamer-b' }),
+    ] as any);
+    await runTimerCommandTick(); // seed both
+    await vi.advanceTimersByTimeAsync(600_000);
+
+    send.mockImplementation(async (channel: string) => {
+      if (channel === 'streamer-a') throw new Error('boom');
+    });
+
+    await expect(runTimerCommandTick()).resolves.toBeUndefined();
+    expect(send).toHaveBeenCalledWith('streamer-a', 'hello');
+    expect(send).toHaveBeenCalledWith('streamer-b', 'hello');
+  });
+
+  it('does not throw when loading rows fails', async () => {
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockRejectedValue(new Error('db down'));
+    await expect(runTimerCommandTick()).resolves.toBeUndefined();
+  });
+
+  it('a reentrancy guard prevents overlapping ticks', async () => {
+    let resolveFirst!: () => void;
+    const gate = new Promise<void>((resolve) => { resolveFirst = resolve; });
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockImplementation(async () => {
+      await gate;
+      return [];
+    });
+
+    const first = runTimerCommandTick();
+    const second = runTimerCommandTick(); // should not trigger a second fetch
+
+    resolveFirst();
+    await Promise.all([first, second]);
+
+    expect(getAllEnabledTimerCommandsWithChannel).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('startTimerCommandScheduler / stopTimerCommandScheduler', () => {
+  it('fires runTimerCommandTick on the configured interval', async () => {
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([]);
+    startTimerCommandScheduler();
+
+    expect(getAllEnabledTimerCommandsWithChannel).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(getAllEnabledTimerCommandsWithChannel).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(getAllEnabledTimerCommandsWithChannel).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not leak the interval when started twice without stopping', async () => {
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([]);
+    startTimerCommandScheduler();
+    startTimerCommandScheduler(); // second call should no-op, not replace the tracked handle
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(getAllEnabledTimerCommandsWithChannel).toHaveBeenCalledTimes(1);
+
+    await stopTimerCommandScheduler();
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(getAllEnabledTimerCommandsWithChannel).toHaveBeenCalledTimes(1);
+  });
+
+  it('stop prevents further ticks', async () => {
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([]);
+    startTimerCommandScheduler();
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(getAllEnabledTimerCommandsWithChannel).toHaveBeenCalledTimes(1);
+
+    await stopTimerCommandScheduler();
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(getAllEnabledTimerCommandsWithChannel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/twitch/timers/timerCommandScheduler.ts
+++ b/src/twitch/timers/timerCommandScheduler.ts
@@ -1,0 +1,120 @@
+import { createLogger } from '../../shared/logger';
+import { getAllEnabledTimerCommandsWithChannel } from '../../db';
+import { getMessageCount } from '../twitchChatActivity';
+import { isChannelLive } from '../monitor/twitchMonitor';
+import { createRuntimeRegistry, type TwitchSendRuntime } from '../../commands/twitchRuntime';
+
+const log = createLogger('TimerCommandScheduler');
+
+// ─── Twitch runtime (registered from index.ts before startTwitchBot) ────────
+//
+// Same pattern as counterHandler.ts/shoutoutHandler.ts to avoid a circular
+// import between twitchBot.ts and this scheduler.
+
+const timerCommandsRuntime = createRuntimeRegistry<TwitchSendRuntime>();
+
+/** Stores the Twitch chat runtime used to post timer messages. Call once from index.ts after the Twitch bot is ready. */
+export function registerTimerCommandsRuntime(runtime: TwitchSendRuntime): void {
+  timerCommandsRuntime.register(runtime);
+}
+
+const TICK_INTERVAL_MS = 15_000;
+
+/** A timer's in-memory firing state — never persisted, so a restart simply restarts the countdown. */
+interface TimerRuntimeState {
+  lastFiredAt: number;
+  messagesAtLastFire: number;
+}
+
+const timerState = new Map<number, TimerRuntimeState>();
+
+let tickTimer: ReturnType<typeof setInterval> | null = null;
+let tickRunning = false;
+let currentTickPromise: Promise<void> = Promise.resolve();
+
+/**
+ * Decides whether a timer should fire right now, given its config and current in-memory state.
+ * @param row - The timer's config, joined with its Twitch channel.
+ * @param state - The timer's current in-memory firing state.
+ * @param now - Current time in epoch ms.
+ */
+function shouldFire(
+  row: { interval_seconds: number; min_messages: number; require_live: boolean; channel: string },
+  state: TimerRuntimeState,
+  now: number,
+): boolean {
+  if (row.require_live && !isChannelLive(row.channel)) return false;
+  if (now - state.lastFiredAt < row.interval_seconds * 1000) return false;
+  if (row.min_messages > 0 && getMessageCount(row.channel) - state.messagesAtLastFire < row.min_messages) return false;
+  return true;
+}
+
+/**
+ * Runs one scheduler tick: fetches every enabled timer, prunes in-memory state for timers that
+ * no longer exist/are disabled, seeds state for newly-seen timers (without firing them — a
+ * restart or brand-new timer waits one full interval before its first post), and fires any
+ * timer whose interval/live/min-messages conditions are all satisfied. Rows are processed
+ * concurrently via `Promise.allSettled` so one channel's send failure can't block another's.
+ * No-ops (re-uses the in-flight promise) if a tick is already running.
+ */
+export async function runTimerCommandTick(): Promise<void> {
+  if (tickRunning) return currentTickPromise;
+  tickRunning = true;
+  currentTickPromise = (async () => {
+    try {
+      const rows = await getAllEnabledTimerCommandsWithChannel();
+      const now = Date.now();
+
+      const liveIds = new Set(rows.map((row) => row.id));
+      for (const id of timerState.keys()) {
+        if (!liveIds.has(id)) timerState.delete(id);
+      }
+
+      await Promise.allSettled(rows.map(async (row) => {
+        let state = timerState.get(row.id);
+        if (!state) {
+          state = { lastFiredAt: now, messagesAtLastFire: getMessageCount(row.channel) };
+          timerState.set(row.id, state);
+          return;
+        }
+
+        if (!shouldFire(row, state, now)) return;
+
+        const runtime = timerCommandsRuntime.get();
+        if (!runtime) return;
+
+        try {
+          await runtime.send(row.channel, row.message);
+          state.lastFiredAt = now;
+          state.messagesAtLastFire = getMessageCount(row.channel);
+        } catch (err) {
+          log.error(`Failed to post timer command ${row.id} to ${row.channel}:`, err);
+        }
+      }));
+    } catch (err) {
+      log.error('Failed to load enabled timer commands:', err);
+    } finally {
+      tickRunning = false;
+    }
+  })();
+  return currentTickPromise;
+}
+
+/**
+ * Starts the periodic timer-command tick. Call once at bot startup.
+ * No-ops if already started, so a second call can't leak the original interval handle.
+ */
+export function startTimerCommandScheduler(): void {
+  if (tickTimer) return;
+  tickTimer = setInterval(() => {
+    runTimerCommandTick().catch((err) => log.error('Timer command tick error:', err));
+  }, TICK_INTERVAL_MS);
+  log.info(`Started — timer command tick every ${TICK_INTERVAL_MS / 1000}s`);
+}
+
+/** Stops the periodic timer-command tick and awaits any in-flight tick before returning. */
+export async function stopTimerCommandScheduler(): Promise<void> {
+  if (tickTimer) { clearInterval(tickTimer); tickTimer = null; }
+  await currentTickPromise;
+  timerState.clear();
+}

--- a/src/twitch/timers/timerCommandScheduler.ts
+++ b/src/twitch/timers/timerCommandScheduler.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '../../shared/logger';
-import { getAllEnabledTimerCommandsWithChannel } from '../../db';
+import { getAllEnabledTimerCommandsWithChannel, type TimerCommandForScheduler } from '../../db';
 import { getMessageCount } from '../twitchChatActivity';
 import { isChannelLive } from '../monitor/twitchMonitor';
 import { createRuntimeRegistry, type TwitchSendRuntime } from '../../commands/twitchRuntime';
@@ -49,13 +49,46 @@ function shouldFire(
   return true;
 }
 
+/** Removes in-memory state for any timer id no longer present in the latest enabled-rows fetch. */
+function pruneStaleTimerState(currentIds: ReadonlySet<number>): void {
+  for (const id of timerState.keys()) {
+    if (!currentIds.has(id)) timerState.delete(id);
+  }
+}
+
+/**
+ * Seeds in-memory state for a newly-seen timer without firing it (a restart or brand-new timer
+ * waits one full interval before its first post), otherwise fires it via the registered runtime
+ * if its conditions are satisfied. Never throws — a send failure is logged and swallowed so it
+ * can't block other rows in the same tick.
+ * @param row - The timer's config, joined with its Twitch channel.
+ * @param now - Current time in epoch ms, shared across the whole tick.
+ */
+async function processTimerRow(row: TimerCommandForScheduler, now: number): Promise<void> {
+  const state = timerState.get(row.id);
+  if (!state) {
+    timerState.set(row.id, { lastFiredAt: now, messagesAtLastFire: getMessageCount(row.channel) });
+    return;
+  }
+  if (!shouldFire(row, state, now)) return;
+
+  const runtime = timerCommandsRuntime.get();
+  if (!runtime) return;
+
+  try {
+    await runtime.send(row.channel, row.message);
+    state.lastFiredAt = now;
+    state.messagesAtLastFire = getMessageCount(row.channel);
+  } catch (err) {
+    log.error(`Failed to post timer command ${row.id} to ${row.channel}:`, err);
+  }
+}
+
 /**
  * Runs one scheduler tick: fetches every enabled timer, prunes in-memory state for timers that
- * no longer exist/are disabled, seeds state for newly-seen timers (without firing them — a
- * restart or brand-new timer waits one full interval before its first post), and fires any
- * timer whose interval/live/min-messages conditions are all satisfied. Rows are processed
- * concurrently via `Promise.allSettled` so one channel's send failure can't block another's.
- * No-ops (re-uses the in-flight promise) if a tick is already running.
+ * no longer exist/are disabled, then processes each row (see {@link processTimerRow}) concurrently
+ * via `Promise.allSettled` so one channel's send failure can't block another's. No-ops (re-uses
+ * the in-flight promise) if a tick is already running.
  */
 export async function runTimerCommandTick(): Promise<void> {
   if (tickRunning) return currentTickPromise;
@@ -63,34 +96,10 @@ export async function runTimerCommandTick(): Promise<void> {
   currentTickPromise = (async () => {
     try {
       const rows = await getAllEnabledTimerCommandsWithChannel();
+      pruneStaleTimerState(new Set(rows.map((row) => row.id)));
+
       const now = Date.now();
-
-      const liveIds = new Set(rows.map((row) => row.id));
-      for (const id of timerState.keys()) {
-        if (!liveIds.has(id)) timerState.delete(id);
-      }
-
-      await Promise.allSettled(rows.map(async (row) => {
-        let state = timerState.get(row.id);
-        if (!state) {
-          state = { lastFiredAt: now, messagesAtLastFire: getMessageCount(row.channel) };
-          timerState.set(row.id, state);
-          return;
-        }
-
-        if (!shouldFire(row, state, now)) return;
-
-        const runtime = timerCommandsRuntime.get();
-        if (!runtime) return;
-
-        try {
-          await runtime.send(row.channel, row.message);
-          state.lastFiredAt = now;
-          state.messagesAtLastFire = getMessageCount(row.channel);
-        } catch (err) {
-          log.error(`Failed to post timer command ${row.id} to ${row.channel}:`, err);
-        }
-      }));
+      await Promise.allSettled(rows.map((row) => processTimerRow(row, now)));
     } catch (err) {
       log.error('Failed to load enabled timer commands:', err);
     } finally {

--- a/src/twitch/twitchBot.test.ts
+++ b/src/twitch/twitchBot.test.ts
@@ -85,6 +85,10 @@ vi.mock('../commands/countdownHandler', () => ({
   executeCountdownForTwitch: vi.fn(),
 }));
 
+vi.mock('./twitchChatActivity', () => ({
+  recordChatMessage: vi.fn(),
+}));
+
 // ─── Imports (after mocks) ────────────────────────────────────────────────────
 
 import {
@@ -110,6 +114,7 @@ import { executeMultiCommandForTwitch } from '../commands/multiCommandHandler';
 import { executeShoutoutForTwitch } from '../commands/shoutoutHandler';
 import { handleCommand } from '../commands/commandRouter';
 import { executeCountdownForTwitch } from '../commands/countdownHandler';
+import { recordChatMessage } from './twitchChatActivity';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -185,27 +190,37 @@ describe('handleTwitchMessage', () => {
   it('ignores self-messages', () => {
     sendMessage('#streamer', makeTags(), 'hello', true);
     expect(executeCustomCommandForTwitch).not.toHaveBeenCalled();
+    expect(recordChatMessage).not.toHaveBeenCalled();
   });
 
   it('ignores messages for an invalid channel name', () => {
     sendMessage('!!bad', makeTags(), 'hello');
     expect(executeCustomCommandForTwitch).not.toHaveBeenCalled();
+    expect(recordChatMessage).not.toHaveBeenCalled();
   });
 
   it('ignores messages for channels not in activeChannels', () => {
     sendMessage('#otherchan', makeTags(), 'hello');
     expect(executeCustomCommandForTwitch).not.toHaveBeenCalled();
+    expect(recordChatMessage).not.toHaveBeenCalled();
   });
 
   it('ignores shared-chat messages that originated in a different channel', () => {
     sendMessage('#streamer', makeTags({ 'room-id': '111', 'source-room-id': '999' }), 'hello');
     expect(executeCustomCommandForTwitch).not.toHaveBeenCalled();
+    expect(recordChatMessage).not.toHaveBeenCalled();
   });
 
   it('processes messages when source-room-id matches room-id', () => {
     vi.mocked(executeCustomCommandForTwitch).mockResolvedValue(undefined);
     sendMessage('#streamer', makeTags({ 'room-id': '111', 'source-room-id': '111' }), 'hello');
     expect(executeCustomCommandForTwitch).toHaveBeenCalledWith('streamer', 'hello', null);
+    expect(recordChatMessage).toHaveBeenCalledWith('streamer');
+  });
+
+  it('records chat activity for a normal message', () => {
+    sendMessage('#streamer', makeTags(), 'hello');
+    expect(recordChatMessage).toHaveBeenCalledWith('streamer');
   });
 
   it('dispatches all six executors for a normal message', async () => {

--- a/src/twitch/twitchBot.ts
+++ b/src/twitch/twitchBot.ts
@@ -7,6 +7,7 @@ import { executeMultiCommandForTwitch } from '../commands/multiCommandHandler';
 import { executeShoutoutForTwitch } from '../commands/shoutoutHandler';
 import { executeCountdownForTwitch } from '../commands/countdownHandler';
 import { fireAndForget } from '../commands/commandUtils';
+import { recordChatMessage } from './twitchChatActivity';
 import { setTwitchChannel } from '../shared/statusStore';
 import { normalizeTwitchChannelName } from './twitchChannelName';
 import { createLogger } from '../shared/logger';
@@ -90,12 +91,13 @@ async function resolveGuildIdForTwitchCommand(normalizedChannel: string): Promis
 }
 
 /**
- * tmi.js `message` event handler: dispatches an incoming Twitch chat message to
+ * tmi.js `message` event handler: records the message for timer commands'
+ * `min_messages` gate (see `twitchChatActivity.ts`), then dispatches it to
  * every command handler (custom commands, counters, `!multi`, `!so`, the shared
  * command router, countdowns) in parallel via {@link fireAndForget}. Ignores the
  * bot's own messages, messages from channels not in the active set, and messages
  * shared into this channel from a partner channel in a Twitch shared-chat session
- * (so each message is only handled once, in its source channel).
+ * (so each message is only recorded/handled once, in its source channel).
  * @param channel - Twitch channel the message was received in (as `#channel`).
  * @param tags - tmi.js chat user state (badges, mod status, display name, etc.) for the sender.
  * @param message - Raw chat message text.
@@ -118,6 +120,8 @@ function handleTwitchMessage(
     // (including SFX command handling) so each message is only processed once, in
     // its source channel.
     if (tags['source-room-id'] && tags['source-room-id'] !== tags['room-id']) return;
+
+    recordChatMessage(normalizedChannel);
 
     const displayName = tags['display-name'] ?? tags.username ?? null;
     const isMod = tags.mod === true || !!(tags.badges as Record<string, string> | null | undefined)?.broadcaster;

--- a/src/twitch/twitchChatActivity.test.ts
+++ b/src/twitch/twitchChatActivity.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { recordChatMessage, getMessageCount, clearChatActivity } from './twitchChatActivity';
+
+beforeEach(() => {
+  clearChatActivity();
+});
+
+describe('twitchChatActivity', () => {
+  it('returns 0 for a channel with no recorded messages', () => {
+    expect(getMessageCount('somestreamer')).toBe(0);
+  });
+
+  it('increments the count for a channel on each recorded message', () => {
+    recordChatMessage('somestreamer');
+    recordChatMessage('somestreamer');
+    recordChatMessage('somestreamer');
+    expect(getMessageCount('somestreamer')).toBe(3);
+  });
+
+  it('tracks counts independently per channel', () => {
+    recordChatMessage('streamer-a');
+    recordChatMessage('streamer-a');
+    recordChatMessage('streamer-b');
+    expect(getMessageCount('streamer-a')).toBe(2);
+    expect(getMessageCount('streamer-b')).toBe(1);
+  });
+
+  it('clearChatActivity resets every channel to 0', () => {
+    recordChatMessage('somestreamer');
+    clearChatActivity();
+    expect(getMessageCount('somestreamer')).toBe(0);
+  });
+});

--- a/src/twitch/twitchChatActivity.ts
+++ b/src/twitch/twitchChatActivity.ts
@@ -1,0 +1,22 @@
+/**
+ * In-memory per-channel Twitch chat message counter. Used by timer commands' `min_messages`
+ * gate to tell how much chat activity has happened since a timer's last fire. Deliberately
+ * ephemeral (not DB-persisted) — like `twitchMonitor.ts`'s live-state map, a bot restart just
+ * resets the baseline rather than replaying history.
+ */
+const messageCounts = new Map<string, number>();
+
+/** Records one chat message seen in `channel`, incrementing its running total. */
+export function recordChatMessage(channel: string): void {
+  messageCounts.set(channel, (messageCounts.get(channel) ?? 0) + 1);
+}
+
+/** Returns the running chat message count for `channel`, or 0 if none have been recorded yet. */
+export function getMessageCount(channel: string): number {
+  return messageCounts.get(channel) ?? 0;
+}
+
+/** Clears all recorded chat activity. Test-only. */
+export function clearChatActivity(): void {
+  messageCounts.clear();
+}

--- a/src/web/routes/timers.test.ts
+++ b/src/web/routes/timers.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mockLogger } from '../../test-utils/loggerMock';
+
+vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
+
+vi.mock('../../db', () => ({
+  getStreamerByDiscordId: vi.fn(),
+  getTimerCommandsForStreamer: vi.fn(),
+}));
+
+vi.mock('../csrf', () => ({
+  csrfProtection: (req: any, _res: any, next: any) => {
+    req.csrfToken = () => 'test-csrf-token';
+    next();
+  },
+}));
+
+vi.mock('../middleware', () => ({
+  requireAuth: (_req: any, _res: any, next: any) => next(),
+}));
+
+// This module composes timersMutations's router too; stub it out so this file only
+// exercises the GET route defined directly in timers.ts.
+vi.mock('./timersMutations', async () => {
+  const { Router } = await import('express');
+  return { default: Router() };
+});
+
+import supertest from 'supertest';
+import router from './timers';
+import { getStreamerByDiscordId, getTimerCommandsForStreamer } from '../../db';
+import { buildTestApp } from '../../test-utils/expressTestApp';
+
+type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3; isOwner: boolean };
+const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: 0, isOwner: false };
+
+const MOCK_STREAMER = { id: 123, discord_id: USER.discordId };
+
+function buildApp() {
+  return buildTestApp({ router, bodyParser: 'urlencoded', sessionUser: USER, mockRender: 'spread' });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
+  vi.mocked(getTimerCommandsForStreamer).mockResolvedValue([]);
+});
+
+describe('GET /', () => {
+  it('renders with isStreamer false and no timers when the session user has no streamer record', async () => {
+    const res = await supertest(buildApp()).get('/');
+    expect(res.status).toBe(200);
+    expect(res.body.view).toBe('timers');
+    expect(res.body.isStreamer).toBe(false);
+    expect(res.body.timers).toEqual([]);
+    expect(getTimerCommandsForStreamer).not.toHaveBeenCalled();
+  });
+
+  it("renders the requesting streamer's own timers", async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const timers = [{ id: 1, streamer_id: 123, name: 'Plug', message: 'hi', interval_seconds: 600, min_messages: 0, require_live: true, enabled: true }];
+    vi.mocked(getTimerCommandsForStreamer).mockResolvedValue(timers as any);
+
+    const res = await supertest(buildApp()).get('/');
+
+    expect(res.body.isStreamer).toBe(true);
+    expect(res.body.timers).toEqual(timers);
+    expect(getTimerCommandsForStreamer).toHaveBeenCalledWith(123);
+  });
+
+  it('returns a 500 error page when loading timers fails', async () => {
+    vi.mocked(getStreamerByDiscordId).mockRejectedValue(new Error('db down'));
+    const res = await supertest(buildApp()).get('/');
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/web/routes/timers.ts
+++ b/src/web/routes/timers.ts
@@ -12,7 +12,7 @@ const log = createLogger('Timers');
 const router = Router();
 
 const KNOWN_ERRORS = new Set([
-  'missing_fields', 'invalid_interval', 'invalid_min_messages',
+  'not_a_streamer', 'missing_fields', 'invalid_interval', 'invalid_min_messages',
   'invalid_id', 'timer_not_found', 'add_failed', 'update_failed', 'remove_failed', 'toggle_failed',
 ]);
 const KNOWN_SUCCESSES = new Set(['timer_added', 'timer_updated', 'timer_removed']);

--- a/src/web/routes/timers.ts
+++ b/src/web/routes/timers.ts
@@ -1,0 +1,50 @@
+import { createLogger } from '../../shared/logger';
+import { Router } from 'express';
+import { csrfProtection } from '../csrf';
+import { requireAuth } from '../middleware';
+import { getSessionUser } from '../session';
+import { getStreamerByDiscordId, getTimerCommandsForStreamer } from '../../db';
+import type { DbTimerCommand } from '../../db';
+import { renderError, renderView, filterQueryParam } from './shared';
+import timersMutationsRouter from './timersMutations';
+
+const log = createLogger('Timers');
+const router = Router();
+
+const KNOWN_ERRORS = new Set([
+  'missing_fields', 'invalid_interval', 'invalid_min_messages',
+  'invalid_id', 'timer_not_found', 'add_failed', 'update_failed', 'remove_failed', 'toggle_failed',
+]);
+const KNOWN_SUCCESSES = new Set(['timer_added', 'timer_updated', 'timer_removed']);
+
+/**
+ * GET /timers — renders the self-service timer-commands page for the logged-in streamer:
+ * their own timers (name, message, interval, min-messages, live requirement, enabled state)
+ * plus an add form. Shows a "link your Twitch account" prompt instead of the timer list when
+ * the session user has no linked `streamer` record, mirroring `/channel-points`'s handling of
+ * the same case — no redirect loop, since a non-streamer viewing this page isn't an error.
+ * @param req - Express request; reads `req.session.user`, `error`, and `success` query params.
+ * @param res - Express response; renders the `timers` view, or a 500 error page on failure.
+ */
+router.get('/', requireAuth, csrfProtection, async (req, res) => {
+  try {
+    const streamer = await getStreamerByDiscordId(getSessionUser(req).discordId);
+    const timers: DbTimerCommand[] = streamer ? await getTimerCommandsForStreamer(streamer.id) : [];
+
+    renderView(res, 'timers', {
+      user: req.session.user,
+      isStreamer: !!streamer,
+      timers,
+      csrfToken: req.csrfToken(),
+      error: filterQueryParam(req.query.error, KNOWN_ERRORS),
+      success: filterQueryParam(req.query.success, KNOWN_SUCCESSES),
+    });
+  } catch (err) {
+    log.error('Timers page error:', err);
+    renderError(res, 500, 'Failed to load timers page.', req.session.user);
+  }
+});
+
+router.use(timersMutationsRouter);
+
+export default router;

--- a/src/web/routes/timersMutations.test.ts
+++ b/src/web/routes/timersMutations.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mockLogger } from '../../test-utils/loggerMock';
+
+vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
+
+vi.mock('../../db', () => ({
+  getStreamerByDiscordId: vi.fn(),
+  addTimerCommand: vi.fn(),
+  updateTimerCommand: vi.fn(),
+  removeTimerCommand: vi.fn(),
+  setTimerCommandEnabled: vi.fn(),
+  TimerCommandNotFoundError: class TimerCommandNotFoundError extends Error {},
+}));
+
+vi.mock('../csrf', () => ({
+  csrfProtection: (req: any, _res: any, next: any) => {
+    req.csrfToken = () => 'test-csrf-token';
+    next();
+  },
+}));
+
+vi.mock('../middleware', () => ({
+  requireAuth: (_req: any, _res: any, next: any) => next(),
+}));
+
+import supertest from 'supertest';
+import router from './timersMutations';
+import {
+  getStreamerByDiscordId, addTimerCommand, updateTimerCommand, removeTimerCommand,
+  setTimerCommandEnabled, TimerCommandNotFoundError,
+} from '../../db';
+import { buildTestApp } from '../../test-utils/expressTestApp';
+
+type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3; isOwner: boolean };
+const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: 0, isOwner: false };
+
+const MOCK_STREAMER = { id: 123, discord_id: USER.discordId };
+
+const VALID_TIMER_FORM = {
+  name: 'Discord plug',
+  message: 'Join our Discord!',
+  interval_seconds: '600',
+  min_messages: '0',
+  require_live: 'on',
+  enabled: 'on',
+};
+
+function buildApp(sessionUser: SessionUser = USER) {
+  return buildTestApp({ router, bodyParser: 'urlencoded', sessionUser });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
+});
+
+describe('POST /add', () => {
+  it('redirects with error when user is not a streamer', async () => {
+    const res = await supertest(buildApp()).post('/add').type('form').send(VALID_TIMER_FORM);
+    expect(res.headers.location).toBe('/timers?error=not_a_streamer');
+    expect(addTimerCommand).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['missing name', { name: '' }],
+    ['missing message', { message: '' }],
+    ['interval below the 60s floor', { interval_seconds: '59' }],
+    ['non-numeric interval', { interval_seconds: 'abc' }],
+    ['negative min_messages', { min_messages: '-1' }],
+  ])('redirects with missing_fields when %s', async (_label, override) => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp()).post('/add').type('form').send({ ...VALID_TIMER_FORM, ...override });
+    expect(res.headers.location).toBe('/timers?error=missing_fields');
+    expect(addTimerCommand).not.toHaveBeenCalled();
+  });
+
+  it('creates the timer and redirects to success', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(addTimerCommand).mockResolvedValue(1);
+
+    const res = await supertest(buildApp()).post('/add').type('form').send(VALID_TIMER_FORM);
+
+    expect(res.headers.location).toBe('/timers?success=timer_added');
+    expect(addTimerCommand).toHaveBeenCalledWith(123, {
+      name: 'Discord plug',
+      message: 'Join our Discord!',
+      intervalSeconds: 600,
+      minMessages: 0,
+      requireLive: true,
+      enabled: true,
+    });
+  });
+
+  it('redirects with add_failed when the insert throws', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(addTimerCommand).mockRejectedValue(new Error('db down'));
+
+    const res = await supertest(buildApp()).post('/add').type('form').send(VALID_TIMER_FORM);
+    expect(res.headers.location).toBe('/timers?error=add_failed');
+  });
+});
+
+describe('POST /update', () => {
+  it('redirects with invalid_id when id is malformed', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp()).post('/update').type('form').send({ ...VALID_TIMER_FORM, id: 'abc' });
+    expect(res.headers.location).toBe('/timers?error=invalid_id');
+    expect(updateTimerCommand).not.toHaveBeenCalled();
+  });
+
+  it('updates and redirects to success, scoped to the requesting streamer', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+
+    const res = await supertest(buildApp()).post('/update').type('form').send({ ...VALID_TIMER_FORM, id: '5' });
+
+    expect(res.headers.location).toBe('/timers?success=timer_updated');
+    expect(updateTimerCommand).toHaveBeenCalledWith(5, 123, {
+      name: 'Discord plug',
+      message: 'Join our Discord!',
+      intervalSeconds: 600,
+      minMessages: 0,
+      requireLive: true,
+      enabled: true,
+    });
+  });
+
+  it('redirects with timer_not_found when the id belongs to another streamer', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(updateTimerCommand).mockRejectedValue(new TimerCommandNotFoundError(5));
+
+    const res = await supertest(buildApp()).post('/update').type('form').send({ ...VALID_TIMER_FORM, id: '5' });
+    expect(res.headers.location).toBe('/timers?error=timer_not_found');
+  });
+});
+
+describe('POST /remove', () => {
+  it('redirects with invalid_id when id is malformed', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp()).post('/remove').type('form').send({ id: 'abc' });
+    expect(res.headers.location).toBe('/timers?error=invalid_id');
+    expect(removeTimerCommand).not.toHaveBeenCalled();
+  });
+
+  it('removes and redirects to success, scoped to the requesting streamer', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp()).post('/remove').type('form').send({ id: '5' });
+    expect(res.headers.location).toBe('/timers?success=timer_removed');
+    expect(removeTimerCommand).toHaveBeenCalledWith(5, 123);
+  });
+});
+
+describe('POST /toggle', () => {
+  it('redirects with invalid_id when id is malformed', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp()).post('/toggle').type('form').send({ id: 'abc', enabled: 'true' });
+    expect(res.headers.location).toBe('/timers?error=invalid_id');
+    expect(setTimerCommandEnabled).not.toHaveBeenCalled();
+  });
+
+  it('toggles and redirects, scoped to the requesting streamer', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    const res = await supertest(buildApp()).post('/toggle').type('form').send({ id: '5', enabled: 'false' });
+    expect(res.headers.location).toBe('/timers');
+    expect(setTimerCommandEnabled).toHaveBeenCalledWith(5, 123, false);
+  });
+
+  it('redirects with timer_not_found when the id belongs to another streamer', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(setTimerCommandEnabled).mockRejectedValue(new TimerCommandNotFoundError(5));
+    const res = await supertest(buildApp()).post('/toggle').type('form').send({ id: '5', enabled: 'true' });
+    expect(res.headers.location).toBe('/timers?error=timer_not_found');
+  });
+});

--- a/src/web/routes/timersMutations.test.ts
+++ b/src/web/routes/timersMutations.test.ts
@@ -62,15 +62,17 @@ describe('POST /add', () => {
   });
 
   it.each([
-    ['missing name', { name: '' }],
-    ['missing message', { message: '' }],
-    ['interval below the 60s floor', { interval_seconds: '59' }],
-    ['non-numeric interval', { interval_seconds: 'abc' }],
-    ['negative min_messages', { min_messages: '-1' }],
-  ])('redirects with missing_fields when %s', async (_label, override) => {
+    ['missing name', { name: '' }, 'missing_fields'],
+    ['missing message', { message: '' }, 'missing_fields'],
+    ['interval below the 60s floor', { interval_seconds: '59' }, 'invalid_interval'],
+    ['non-numeric interval', { interval_seconds: 'abc' }, 'invalid_interval'],
+    ['interval beyond the INT column range', { interval_seconds: '99999999999' }, 'invalid_interval'],
+    ['negative min_messages', { min_messages: '-1' }, 'invalid_min_messages'],
+    ['min_messages beyond the INT column range', { min_messages: '99999999999' }, 'invalid_min_messages'],
+  ])('redirects with the specific error code when %s', async (_label, override, expectedErrorCode) => {
     vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
     const res = await supertest(buildApp()).post('/add').type('form').send({ ...VALID_TIMER_FORM, ...override });
-    expect(res.headers.location).toBe('/timers?error=missing_fields');
+    expect(res.headers.location).toBe(`/timers?error=${expectedErrorCode}`);
     expect(addTimerCommand).not.toHaveBeenCalled();
   });
 

--- a/src/web/routes/timersMutations.test.ts
+++ b/src/web/routes/timersMutations.test.ts
@@ -133,6 +133,14 @@ describe('POST /update', () => {
     const res = await supertest(buildApp()).post('/update').type('form').send({ ...VALID_TIMER_FORM, id: '5' });
     expect(res.headers.location).toBe('/timers?error=timer_not_found');
   });
+
+  it('redirects with update_failed when the update throws a non-NotFound error', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(updateTimerCommand).mockRejectedValue(new Error('db down'));
+
+    const res = await supertest(buildApp()).post('/update').type('form').send({ ...VALID_TIMER_FORM, id: '5' });
+    expect(res.headers.location).toBe('/timers?error=update_failed');
+  });
 });
 
 describe('POST /remove', () => {
@@ -148,6 +156,14 @@ describe('POST /remove', () => {
     const res = await supertest(buildApp()).post('/remove').type('form').send({ id: '5' });
     expect(res.headers.location).toBe('/timers?success=timer_removed');
     expect(removeTimerCommand).toHaveBeenCalledWith(5, 123);
+  });
+
+  it('redirects with remove_failed when the delete throws', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(removeTimerCommand).mockRejectedValue(new Error('db down'));
+
+    const res = await supertest(buildApp()).post('/remove').type('form').send({ id: '5' });
+    expect(res.headers.location).toBe('/timers?error=remove_failed');
   });
 });
 
@@ -171,5 +187,12 @@ describe('POST /toggle', () => {
     vi.mocked(setTimerCommandEnabled).mockRejectedValue(new TimerCommandNotFoundError(5));
     const res = await supertest(buildApp()).post('/toggle').type('form').send({ id: '5', enabled: 'true' });
     expect(res.headers.location).toBe('/timers?error=timer_not_found');
+  });
+
+  it('redirects with toggle_failed when the update throws a non-NotFound error', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(setTimerCommandEnabled).mockRejectedValue(new Error('db down'));
+    const res = await supertest(buildApp()).post('/toggle').type('form').send({ id: '5', enabled: 'true' });
+    expect(res.headers.location).toBe('/timers?error=toggle_failed');
   });
 });

--- a/src/web/routes/timersMutations.ts
+++ b/src/web/routes/timersMutations.ts
@@ -19,50 +19,61 @@ const router = Router();
 const NOT_A_STREAMER_REDIRECT = '/timers?error=not_a_streamer';
 
 const MIN_INTERVAL_SECONDS = 60;
+/** MySQL `INT` (4-byte signed) max — both `interval_seconds` and `min_messages` are stored in `INT` columns. */
+const MAX_INT_COLUMN_VALUE = 2147483647;
 
 /**
  * Parses a required interval-seconds form field: an integer of at least
- * {@link MIN_INTERVAL_SECONDS}, matching the DB's `chk_timer_command_interval` check —
- * validated here so a bad value redirects with a clear `invalid_interval` code instead of
- * surfacing as an opaque DB constraint failure.
+ * {@link MIN_INTERVAL_SECONDS} and at most the DB column's `INT` range, matching the DB's
+ * `chk_timer_command_interval` check — validated here so a bad value redirects with a clear
+ * `invalid_interval` code instead of surfacing as an opaque DB constraint/range failure.
  */
 function parseIntervalSecondsField(value: string | string[] | undefined): number | null {
   if (Array.isArray(value)) return null;
   if (typeof value !== 'string' || !/^\d+$/.test(value)) return null;
   const parsed = Number(value);
-  return Number.isSafeInteger(parsed) && parsed >= MIN_INTERVAL_SECONDS ? parsed : null;
+  return Number.isSafeInteger(parsed) && parsed >= MIN_INTERVAL_SECONDS && parsed <= MAX_INT_COLUMN_VALUE ? parsed : null;
 }
 
 /**
- * Parses a required min-messages form field: a non-negative integer, matching the DB's
- * `chk_timer_command_min_messages` check. `0` (the "no minimum" value) is valid.
+ * Parses a required min-messages form field: a non-negative integer within the DB column's
+ * `INT` range, matching the DB's `chk_timer_command_min_messages` check. `0` (the "no minimum"
+ * value) is valid.
  */
 function parseMinMessagesField(value: string | string[] | undefined): number | null {
   if (Array.isArray(value)) return null;
   if (typeof value !== 'string' || !/^\d+$/.test(value)) return null;
   const parsed = Number(value);
-  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+  return Number.isSafeInteger(parsed) && parsed >= 0 && parsed <= MAX_INT_COLUMN_VALUE ? parsed : null;
 }
 
-/** Parses and validates the timer fields shared by the add and update forms. Returns `null` if any field is invalid. */
-function parseTimerCommandFields(body: Record<string, string | string[] | undefined>): TimerCommandInput | null {
+/** Result of validating the timer fields shared by the add and update forms — either the parsed input, or the specific error code to redirect with. */
+type TimerFieldsResult =
+  | { ok: true; input: TimerCommandInput }
+  | { ok: false; errorCode: 'missing_fields' | 'invalid_interval' | 'invalid_min_messages' };
+
+/** Parses and validates the timer fields shared by the add and update forms, reporting which field failed. */
+function parseTimerCommandFields(body: Record<string, string | string[] | undefined>): TimerFieldsResult {
   const name = normalizeRequiredText(body.name as string | undefined);
   const message = normalizeRequiredText(body.message as string | undefined);
-  if (!name || !message) return null;
+  if (!name || !message) return { ok: false, errorCode: 'missing_fields' };
 
   const intervalSeconds = parseIntervalSecondsField(body.interval_seconds);
-  if (intervalSeconds === null) return null;
+  if (intervalSeconds === null) return { ok: false, errorCode: 'invalid_interval' };
 
   const minMessages = parseMinMessagesField(body.min_messages);
-  if (minMessages === null) return null;
+  if (minMessages === null) return { ok: false, errorCode: 'invalid_min_messages' };
 
   return {
-    name,
-    message,
-    intervalSeconds,
-    minMessages,
-    requireLive: parseCheckboxField(body.require_live),
-    enabled: parseCheckboxField(body.enabled),
+    ok: true,
+    input: {
+      name,
+      message,
+      intervalSeconds,
+      minMessages,
+      requireLive: parseCheckboxField(body.require_live),
+      enabled: parseCheckboxField(body.enabled),
+    },
   };
 }
 
@@ -81,10 +92,10 @@ router.post('/add', requireAuth, csrfProtection, async (req, res) => {
     if (!streamer) return;
 
     const body = req.body as Record<string, string | string[] | undefined>;
-    const input = parseTimerCommandFields(body);
-    if (!input) return res.redirect('/timers?error=missing_fields');
+    const result = parseTimerCommandFields(body);
+    if (!result.ok) return res.redirect(`/timers?error=${result.errorCode}`);
 
-    await addTimerCommand(streamer.id, input);
+    await addTimerCommand(streamer.id, result.input);
     res.redirect('/timers?success=timer_added');
   } catch (err) {
     logAndRedirectError({ res, log, logLabel: 'Add timer command error:', err, basePath: '/timers', errorCode: 'add_failed' });
@@ -96,8 +107,9 @@ router.post('/add', requireAuth, csrfProtection, async (req, res) => {
  * @param req - Express request; reads `id`, plus the same fields as `/timers/add`, from `req.body`.
  * @param res - Express response; redirects to `/timers?success=timer_updated` on success, or to
  *   `/timers?error=<code>` if the requester isn't a streamer (`not_a_streamer`), `id` is
- *   malformed (`invalid_id`), a field is invalid (`missing_fields`), the timer doesn't exist or
- *   belongs to another streamer (`timer_not_found`), or the update fails (`update_failed`).
+ *   malformed (`invalid_id`), a field is invalid (`missing_fields`, `invalid_interval`,
+ *   `invalid_min_messages`), the timer doesn't exist or belongs to another streamer
+ *   (`timer_not_found`), or the update fails (`update_failed`).
  */
 router.post('/update', requireAuth, csrfProtection, async (req, res) => {
   try {
@@ -108,10 +120,10 @@ router.post('/update', requireAuth, csrfProtection, async (req, res) => {
     const id = parsePositiveIntId(body.id);
     if (id === null) return res.redirect('/timers?error=invalid_id');
 
-    const input = parseTimerCommandFields(body);
-    if (!input) return res.redirect('/timers?error=missing_fields');
+    const result = parseTimerCommandFields(body);
+    if (!result.ok) return res.redirect(`/timers?error=${result.errorCode}`);
 
-    await updateTimerCommand(id, streamer.id, input);
+    await updateTimerCommand(id, streamer.id, result.input);
     res.redirect('/timers?success=timer_updated');
   } catch (err) {
     if (err instanceof TimerCommandNotFoundError) {

--- a/src/web/routes/timersMutations.ts
+++ b/src/web/routes/timersMutations.ts
@@ -1,0 +1,175 @@
+import { createLogger } from '../../shared/logger';
+import { Router } from 'express';
+import {
+  addTimerCommand, updateTimerCommand, removeTimerCommand, setTimerCommandEnabled,
+  TimerCommandNotFoundError,
+} from '../../db';
+import type { TimerCommandInput } from '../../db';
+import { csrfProtection } from '../csrf';
+import { requireAuth } from '../middleware';
+import {
+  logAndRedirectError, normalizeRequiredText, parseCheckboxField, parsePositiveIntId,
+  requireStreamer,
+} from './shared';
+
+const log = createLogger('Web');
+const router = Router();
+
+/** Redirect target used when the requester isn't a streamer, scoped to the timers admin page. */
+const NOT_A_STREAMER_REDIRECT = '/timers?error=not_a_streamer';
+
+const MIN_INTERVAL_SECONDS = 60;
+
+/**
+ * Parses a required interval-seconds form field: an integer of at least
+ * {@link MIN_INTERVAL_SECONDS}, matching the DB's `chk_timer_command_interval` check —
+ * validated here so a bad value redirects with a clear `invalid_interval` code instead of
+ * surfacing as an opaque DB constraint failure.
+ */
+function parseIntervalSecondsField(value: string | string[] | undefined): number | null {
+  if (Array.isArray(value)) return null;
+  if (typeof value !== 'string' || !/^\d+$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= MIN_INTERVAL_SECONDS ? parsed : null;
+}
+
+/**
+ * Parses a required min-messages form field: a non-negative integer, matching the DB's
+ * `chk_timer_command_min_messages` check. `0` (the "no minimum" value) is valid.
+ */
+function parseMinMessagesField(value: string | string[] | undefined): number | null {
+  if (Array.isArray(value)) return null;
+  if (typeof value !== 'string' || !/^\d+$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
+/** Parses and validates the timer fields shared by the add and update forms. Returns `null` if any field is invalid. */
+function parseTimerCommandFields(body: Record<string, string | string[] | undefined>): TimerCommandInput | null {
+  const name = normalizeRequiredText(body.name as string | undefined);
+  const message = normalizeRequiredText(body.message as string | undefined);
+  if (!name || !message) return null;
+
+  const intervalSeconds = parseIntervalSecondsField(body.interval_seconds);
+  if (intervalSeconds === null) return null;
+
+  const minMessages = parseMinMessagesField(body.min_messages);
+  if (minMessages === null) return null;
+
+  return {
+    name,
+    message,
+    intervalSeconds,
+    minMessages,
+    requireLive: parseCheckboxField(body.require_live),
+    enabled: parseCheckboxField(body.enabled),
+  };
+}
+
+/**
+ * POST /timers/add — creates a new timer command for the requesting streamer.
+ * @param req - Express request; reads `name`, `message`, `interval_seconds`, `min_messages`,
+ *   `require_live`, `enabled` from `req.body`.
+ * @param res - Express response; redirects to `/timers?success=timer_added` on success, or to
+ *   `/timers?error=<code>` if the requester isn't a streamer (`not_a_streamer`), a field is
+ *   invalid (`missing_fields`, `invalid_interval`, `invalid_min_messages`), or the insert fails
+ *   (`add_failed`).
+ */
+router.post('/add', requireAuth, csrfProtection, async (req, res) => {
+  try {
+    const streamer = await requireStreamer(req, res, NOT_A_STREAMER_REDIRECT);
+    if (!streamer) return;
+
+    const body = req.body as Record<string, string | string[] | undefined>;
+    const input = parseTimerCommandFields(body);
+    if (!input) return res.redirect('/timers?error=missing_fields');
+
+    await addTimerCommand(streamer.id, input);
+    res.redirect('/timers?success=timer_added');
+  } catch (err) {
+    logAndRedirectError({ res, log, logLabel: 'Add timer command error:', err, basePath: '/timers', errorCode: 'add_failed' });
+  }
+});
+
+/**
+ * POST /timers/update — updates an existing timer command belonging to the requesting streamer.
+ * @param req - Express request; reads `id`, plus the same fields as `/timers/add`, from `req.body`.
+ * @param res - Express response; redirects to `/timers?success=timer_updated` on success, or to
+ *   `/timers?error=<code>` if the requester isn't a streamer (`not_a_streamer`), `id` is
+ *   malformed (`invalid_id`), a field is invalid (`missing_fields`), the timer doesn't exist or
+ *   belongs to another streamer (`timer_not_found`), or the update fails (`update_failed`).
+ */
+router.post('/update', requireAuth, csrfProtection, async (req, res) => {
+  try {
+    const streamer = await requireStreamer(req, res, NOT_A_STREAMER_REDIRECT);
+    if (!streamer) return;
+
+    const body = req.body as Record<string, string | string[] | undefined>;
+    const id = parsePositiveIntId(body.id);
+    if (id === null) return res.redirect('/timers?error=invalid_id');
+
+    const input = parseTimerCommandFields(body);
+    if (!input) return res.redirect('/timers?error=missing_fields');
+
+    await updateTimerCommand(id, streamer.id, input);
+    res.redirect('/timers?success=timer_updated');
+  } catch (err) {
+    if (err instanceof TimerCommandNotFoundError) {
+      return res.redirect('/timers?error=timer_not_found');
+    }
+    logAndRedirectError({ res, log, logLabel: 'Update timer command error:', err, basePath: '/timers', errorCode: 'update_failed' });
+  }
+});
+
+/**
+ * POST /timers/remove — deletes a timer command belonging to the requesting streamer.
+ * No-ops (still redirects to success) if the id doesn't exist or belongs to another streamer.
+ * @param req - Express request; reads `id` from `req.body`.
+ * @param res - Express response; redirects to `/timers?success=timer_removed` on success, or to
+ *   `/timers?error=<code>` if the requester isn't a streamer (`not_a_streamer`), `id` is
+ *   malformed (`invalid_id`), or the delete fails (`remove_failed`).
+ */
+router.post('/remove', requireAuth, csrfProtection, async (req, res) => {
+  try {
+    const streamer = await requireStreamer(req, res, NOT_A_STREAMER_REDIRECT);
+    if (!streamer) return;
+
+    const id = parsePositiveIntId((req.body as Record<string, string | string[] | undefined>).id);
+    if (id === null) return res.redirect('/timers?error=invalid_id');
+
+    await removeTimerCommand(id, streamer.id);
+    res.redirect('/timers?success=timer_removed');
+  } catch (err) {
+    logAndRedirectError({ res, log, logLabel: 'Remove timer command error:', err, basePath: '/timers', errorCode: 'remove_failed' });
+  }
+});
+
+/**
+ * POST /timers/toggle — flips a timer command's `enabled` flag, for a one-click
+ * enable/disable control in the timer list without opening the full edit form.
+ * @param req - Express request; reads `id` and `enabled` (`'true'`/`'false'`) from `req.body`.
+ * @param res - Express response; redirects to `/timers` on success, or to `/timers?error=<code>`
+ *   if the requester isn't a streamer (`not_a_streamer`), `id` is malformed (`invalid_id`), the
+ *   timer doesn't exist or belongs to another streamer (`timer_not_found`), or the update fails
+ *   (`toggle_failed`).
+ */
+router.post('/toggle', requireAuth, csrfProtection, async (req, res) => {
+  try {
+    const streamer = await requireStreamer(req, res, NOT_A_STREAMER_REDIRECT);
+    if (!streamer) return;
+
+    const body = req.body as Record<string, string | string[] | undefined>;
+    const id = parsePositiveIntId(body.id);
+    if (id === null) return res.redirect('/timers?error=invalid_id');
+
+    await setTimerCommandEnabled(id, streamer.id, body.enabled === 'true');
+    res.redirect('/timers');
+  } catch (err) {
+    if (err instanceof TimerCommandNotFoundError) {
+      return res.redirect('/timers?error=timer_not_found');
+    }
+    logAndRedirectError({ res, log, logLabel: 'Toggle timer command error:', err, basePath: '/timers', errorCode: 'toggle_failed' });
+  }
+});
+
+export default router;

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -104,6 +104,7 @@ vi.mock('./routes/overlayAdmin', () => ({ default: emptyRouter() }));
 vi.mock('./routes/alertsOverlaySource', () => ({ default: emptyRouter() }));
 vi.mock('./routes/alertsAdmin', () => ({ default: emptyRouter() }));
 vi.mock('./routes/channelPointsAdmin', () => ({ default: emptyRouter() }));
+vi.mock('./routes/timers', () => ({ default: emptyRouter() }));
 vi.mock('./routes/dashboardEvents', () => ({ default: emptyRouter() }));
 vi.mock('./routes/dashboardStatusEvents', () => ({ default: emptyRouter() }));
 vi.mock('./routes/companionAuth', () => ({ default: emptyRouter() }));

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -39,6 +39,7 @@ import overlayAdminRouter from './routes/overlayAdmin';
 import alertsOverlaySourceRouter from './routes/alertsOverlaySource';
 import alertsAdminRouter from './routes/alertsAdmin';
 import channelPointsAdminRouter from './routes/channelPointsAdmin';
+import timersRouter from './routes/timers';
 import privacyRouter from './routes/privacy';
 import tosRouter from './routes/tos';
 import serviceWorkerRouter from './routes/serviceWorker';
@@ -232,6 +233,7 @@ app.use('/user/settings', requireAuth, userSettingsRouter);
 app.use('/overlay', requireAuth, overlayAdminRouter);
 app.use('/alerts', requireAuth, alertsAdminRouter);
 app.use('/channel-points', requireAuth, channelPointsAdminRouter);
+app.use('/timers', requireAuth, timersRouter);
 app.use('/dashboard', requireAuth, dashboardEventsRouter);
 app.use('/dashboard', requireAuth, dashboardStatusEventsRouter);
 

--- a/views/partials/nav.ejs
+++ b/views/partials/nav.ejs
@@ -43,6 +43,7 @@
         </div>
       </div>
       <a href="/channel-points" class="nav-item">Channel Points</a>
+      <a href="/timers" class="nav-item">Timers</a>
       <a href="/user/settings" class="nav-item">Settings</a>
       <% } %>
     </div>

--- a/views/timers.ejs
+++ b/views/timers.ejs
@@ -34,7 +34,7 @@
       <% } %>
 
       <% if (success) { %>
-      <div class="card card-alert-success">
+      <div class="card card-alert-success" role="status" aria-live="polite">
         <% const successMessages = {
           timer_added:   'Timer added.',
           timer_updated: 'Timer updated.',

--- a/views/timers.ejs
+++ b/views/timers.ejs
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BCUK Bot — Timers</title>
+  <link rel="stylesheet" href="/style.css">
+  <%- include('partials/pwa-head') %>
+</head>
+<body data-csrf-token="<%= csrfToken %>">
+  <%- include('partials/nav') %>
+
+  <main class="container">
+    <section class="section">
+      <h2 class="section-title">Timer Commands</h2>
+      <p class="hint mb-075">Auto-posts a message into your own Twitch chat on a repeating schedule.</p>
+
+      <% if (error) { %>
+      <% const errorMessages = {
+        not_a_streamer:      'You are not configured as a monitored streamer.',
+        missing_fields:      'Please provide a name, a message, and a valid interval/minimum-messages value.',
+        invalid_interval:    'Interval must be a whole number of at least 60 seconds.',
+        invalid_min_messages: 'Minimum messages must be zero or a positive whole number.',
+        invalid_id:          'Invalid timer ID.',
+        timer_not_found:     'That timer no longer exists.',
+        add_failed:          'Failed to add the timer.',
+        update_failed:       'Failed to update the timer.',
+        remove_failed:       'Failed to remove the timer.',
+        toggle_failed:       'Failed to update the timer.',
+      }; %>
+      <div class="card card-alert-danger" role="alert" aria-live="assertive" aria-atomic="true">
+        <span class="text-danger">&#9888; <%= errorMessages[error] || `Operation failed: ${error.replace(/_/g, ' ')}` %></span>
+      </div>
+      <% } %>
+
+      <% if (success) { %>
+      <div class="card card-alert-success">
+        <% const successMessages = {
+          timer_added:   'Timer added.',
+          timer_updated: 'Timer updated.',
+          timer_removed: 'Timer removed.',
+        }; %>
+        <%= successMessages[success] ?? 'Done.' %>
+      </div>
+      <% } %>
+
+      <% if (!isStreamer) { %>
+      <div class="card">
+        <div class="card-body">
+          <p class="hint">You are not configured as a monitored streamer. Contact a Manager or Admin.</p>
+        </div>
+      </div>
+      <% } else { %>
+
+      <div class="card card-spaced">
+        <div class="card-header"><span class="card-icon">➕</span><span class="card-label">Add Timer</span></div>
+        <div class="card-body">
+          <form method="POST" action="/timers/add">
+            <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+            <div class="form-row-wrap form-section-gap">
+              <div class="form-col-grow">
+                <label for="name" class="form-label">Name</label>
+                <input id="name" class="input full-width" type="text" name="name" placeholder="e.g. Discord plug" required>
+              </div>
+              <div>
+                <label for="interval_seconds" class="form-label">Interval (seconds)</label>
+                <input id="interval_seconds" class="input" type="number" min="60" step="1" name="interval_seconds" value="600" required>
+              </div>
+              <div>
+                <label for="min_messages" class="form-label">Min. chat messages</label>
+                <input id="min_messages" class="input" type="number" min="0" step="1" name="min_messages" value="0" required>
+              </div>
+              <label class="input checkbox-input-label">
+                <input type="checkbox" name="require_live" checked> Only while live
+              </label>
+              <label class="input checkbox-input-label">
+                <input type="checkbox" name="enabled" checked> Enabled
+              </label>
+            </div>
+            <div class="form-section-gap">
+              <label for="message" class="form-label">Message</label>
+              <textarea id="message" class="input stream-textarea" name="message" rows="2" placeholder="Join our Discord at ..." required></textarea>
+            </div>
+            <button type="submit" class="btn">Add Timer</button>
+          </form>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="table-scroll">
+          <table class="table" aria-label="Timer commands">
+            <thead>
+              <tr>
+                <th scope="col">Name</th>
+                <th scope="col">Message</th>
+                <th scope="col">Interval</th>
+                <th scope="col">Min. Messages</th>
+                <th scope="col">Live Only</th>
+                <th scope="col">Status</th>
+                <th scope="col">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% timers.forEach(function(timer) { %>
+              <tr>
+                <td><strong><%= timer.name %></strong></td>
+                <td class="command-output-cell"><%= timer.message %></td>
+                <td><%= timer.interval_seconds %>s</td>
+                <td><%= timer.min_messages %></td>
+                <td><span class="badge <%= timer.require_live ? 'badge-active' : 'badge-offline' %>"><%= timer.require_live ? 'Yes' : 'No' %></span></td>
+                <td>
+                  <form method="POST" action="/timers/toggle" class="inline-form-sm">
+                    <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                    <input type="hidden" name="id" value="<%= timer.id %>">
+                    <input type="hidden" name="enabled" value="<%= timer.enabled ? 'false' : 'true' %>">
+                    <button type="submit" class="btn btn-sm <%= timer.enabled ? 'btn-ghost' : '' %>">
+                      <span class="badge <%= timer.enabled ? 'badge-active' : 'badge-offline' %>"><%= timer.enabled ? 'Enabled' : 'Off' %></span>
+                    </button>
+                  </form>
+                </td>
+                <td>
+                  <div class="actions">
+                    <button type="button" class="btn btn-sm btn-ghost btn-toggle-timer-edit" data-timer-id="<%= timer.id %>" aria-controls="timer-edit-<%= timer.id %>" aria-expanded="false">✏️ Edit</button>
+                    <form method="POST" action="/timers/remove" class="inline-form-sm js-confirm-remove-timer" data-timer-name="<%= timer.name %>">
+                      <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                      <input type="hidden" name="id" value="<%= timer.id %>">
+                      <button type="submit" class="btn btn-danger btn-sm">Remove</button>
+                    </form>
+                  </div>
+                </td>
+              </tr>
+              <tr class="files-row is-hidden" id="timer-edit-<%= timer.id %>">
+                <td colspan="7">
+                  <div class="command-edit-panel">
+                    <form method="POST" action="/timers/update" class="stack-gap-md">
+                      <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                      <input type="hidden" name="id" value="<%= timer.id %>">
+                      <div class="form-row-wrap form-section-gap">
+                        <div class="form-col-grow">
+                          <label for="name_<%= timer.id %>" class="form-label">Name</label>
+                          <input id="name_<%= timer.id %>" class="input full-width" type="text" name="name" value="<%= timer.name %>" required>
+                        </div>
+                        <div>
+                          <label for="interval_seconds_<%= timer.id %>" class="form-label">Interval (seconds)</label>
+                          <input id="interval_seconds_<%= timer.id %>" class="input" type="number" min="60" step="1" name="interval_seconds" value="<%= timer.interval_seconds %>" required>
+                        </div>
+                        <div>
+                          <label for="min_messages_<%= timer.id %>" class="form-label">Min. chat messages</label>
+                          <input id="min_messages_<%= timer.id %>" class="input" type="number" min="0" step="1" name="min_messages" value="<%= timer.min_messages %>" required>
+                        </div>
+                        <label class="input checkbox-input-label">
+                          <input type="checkbox" name="require_live" <%= timer.require_live ? 'checked' : '' %>> Only while live
+                        </label>
+                        <label class="input checkbox-input-label">
+                          <input type="checkbox" name="enabled" <%= timer.enabled ? 'checked' : '' %>> Enabled
+                        </label>
+                      </div>
+                      <div class="form-section-gap">
+                        <label for="message_<%= timer.id %>" class="form-label">Message</label>
+                        <textarea id="message_<%= timer.id %>" class="input stream-textarea" name="message" rows="2" required><%= timer.message %></textarea>
+                      </div>
+                      <div class="button-row-wrap">
+                        <button type="submit" class="btn">Save Changes</button>
+                        <button type="button" class="btn btn-ghost btn-toggle-timer-edit" data-timer-id="<%= timer.id %>">Cancel</button>
+                      </div>
+                    </form>
+                  </div>
+                </td>
+              </tr>
+              <% }) %>
+              <% if (timers.length === 0) { %>
+              <tr>
+                <td colspan="7" class="empty-msg">No timers configured yet.</td>
+              </tr>
+              <% } %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <% } %>
+    </section>
+  </main>
+
+  <%- include('partials/pwa-register') %>
+  <%- include('partials/footer') %>
+  <script src="/utils.js"></script>
+  <script src="/timers.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds per-streamer, Twitch-only "timer commands" — messages auto-posted into a streamer's own Twitch chat on a repeating schedule (Nightbot/StreamElements-style), without a viewer needing to trigger anything.
- A timer fires once its interval has elapsed **and** (optionally) the channel is currently live **and** at least N chat messages have been seen since its last fire.
- One message per timer row; a streamer creates multiple timers for a rotation effect.
- Managed on a new self-service `/timers` page, scoped to the logged-in streamer's own `streamer_id` (same ownership model as `/channel-points`).

## What's new

- **Schema**: new `timer_command` table (config-only — `schema.sql` + `migrations/timer_commands.sql` + `DATABASE-SCHEMA.md`). The scheduler's live/message-count firing state is deliberately kept in memory, not persisted, so a restart just restarts each timer's countdown.
- **DB layer**: `src/db/timerCommands.ts` — CRUD scoped by `streamer_id`, plus `getAllEnabledTimerCommandsWithChannel()` for the scheduler's per-tick read.
- **Chat activity tracking**: `src/twitch/twitchChatActivity.ts` — a small in-memory per-channel chat-message counter, fed from `twitchBot.ts`'s message handler, backing the `min_messages` gate.
- **Live status**: `twitchMonitor.ts` gains a small `isChannelLive(login)` export reusing its existing live-state map.
- **Scheduler**: `src/twitch/timers/timerCommandScheduler.ts` — a 15s-tick `setInterval` scheduler following the existing `rewardPricingScheduler.ts`/`counterScheduler.ts` pattern (re-entrancy guard, `Promise.allSettled` per row, start/stop lifecycle wired into `index.ts`), posting via a registered Twitch send runtime (`registerTimerCommandsRuntime`).
- **Web UI**: `/timers` self-service page (`src/web/routes/timers.ts` + `timersMutations.ts` + `views/timers.ejs` + `public/timers.js`), mounted in `server.ts`, linked from the nav.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (158 test files, 2925 tests, including new coverage for the DB layer, chat-activity counter, scheduler firing/gating/pruning/concurrency behavior, `isChannelLive`, and the web routes)
- [ ] Manually verify in a running instance: create a timer with a short interval, confirm it posts to Twitch chat after the interval elapses while live, and stays silent while offline (`require_live`) or below the `min_messages` threshold


---
_Generated by [Claude Code](https://claude.ai/code/session_01TVqztcMRYKAxf1v3CENJrz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Timers page (and navigation link) for managing automated Twitch chat timer commands.
  * Timer commands can be configured with message text, interval, minimum chat activity, and optional “channel must be live” gating.
  * Enabled timers now run automatically via a scheduler, posting to the appropriate Twitch channel.
* **Bug Fixes**
  * Timer sends are resilient: a failure for one channel won’t block others.
  * Added safer timer lifecycle handling (no duplicate ticks; missing/disabled timers are cleaned up).
* **UI Improvements**
  * Added confirmation prompts before removing timers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->