### PR TITLE
Fix high severity npm audit vulnerability in brace-expansion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2108,16 +2108,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer-from": {


### PR DESCRIPTION
## Summary
- `npm audit` reported one high severity vulnerability: `brace-expansion` <=5.0.7 is vulnerable to a DoS via unbounded expansion length ([GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg))
- Ran `npm audit fix`, which bumps the transitive dev dependency `brace-expansion` from 5.0.7 to 5.0.8 in `package-lock.json`
- No source code changes required; `npm audit` now reports 0 vulnerabilities

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 158 test files / 2932 tests pass
- [x] `npm audit` — 0 vulnerabilities


---
_Generated by [Claude Code](https://claude.ai/code/session_01MuRajbiaZp4kxyUCS2p1YP)_