### PR TITLE
Move Timers link into Bot Commands nav dropdown

### DIFF
--- a/views/partials/nav.ejs
+++ b/views/partials/nav.ejs
@@ -8,6 +8,7 @@
         <button class="nav-group-label" aria-haspopup="true" aria-expanded="false">Bot Commands <span class="nav-caret">▾</span></button>
         <div class="nav-group-items">
           <a href="/sfx" class="nav-item">SFX</a>
+          <a href="/timers" class="nav-item">Timers</a>
           <% if (user && user.accessLevel >= 2) { %>
           <a href="/commands" class="nav-item">Commands</a>
           <a href="/counters" class="nav-item">Counters</a>
@@ -43,7 +44,6 @@
         </div>
       </div>
       <a href="/channel-points" class="nav-item">Channel Points</a>
-      <a href="/timers" class="nav-item">Timers</a>
       <a href="/user/settings" class="nav-item">Settings</a>
       <% } %>
     </div>


### PR DESCRIPTION
## Summary
- Moved the "Timers" nav link out of the top-level menu and into the "Bot Commands" dropdown, alongside SFX/Commands/Counters.

## Test plan
- [x] `npx tsc --noEmit`
- [x] Markup-only change; no test suite changes needed

---
_Generated by [Claude Code](https://claude.ai/code/session_016JC7pwYyPfFgUiqA6Lx9vw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Navigation**
  * Moved the **Timers** link into the **Bot Commands** section for improved organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->