### PR TITLE
Add shared Twitch chat rate limiter and per-streamer timer cap

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -222,8 +222,8 @@ export { recordPricingHistory, getPricingHistoryForRewards } from './db/rewardPr
 export type { DbTimerCommand, TimerCommandInput, TimerCommandForScheduler } from './db/timerCommands';
 export {
   TimerCommandNotFoundError,
-  getTimerCommandsForStreamer, addTimerCommand, updateTimerCommand, removeTimerCommand,
-  setTimerCommandEnabled, getAllEnabledTimerCommandsWithChannel,
+  getTimerCommandsForStreamer, countTimerCommandsForStreamer, addTimerCommand, updateTimerCommand,
+  removeTimerCommand, setTimerCommandEnabled, getAllEnabledTimerCommandsWithChannel,
 } from './db/timerCommands';
 
 // ─── Streamdeck API keys ─────────────────────────────────────────────────────

--- a/src/db/timerCommands.test.ts
+++ b/src/db/timerCommands.test.ts
@@ -6,6 +6,7 @@ vi.mock('mysql2/promise', () => ({ default: {} }));
 import { getPool } from './pool';
 import {
   getTimerCommandsForStreamer,
+  countTimerCommandsForStreamer,
   addTimerCommand,
   updateTimerCommand,
   removeTimerCommand,
@@ -60,6 +61,21 @@ describe('getTimerCommandsForStreamer', () => {
     const pool = makeMockPool({ rows: [] });
     vi.mocked(getPool).mockReturnValue(pool as any);
     await getTimerCommandsForStreamer(7);
+    expect(pool.execute.mock.calls[0][1]).toEqual([7]);
+  });
+});
+
+describe('countTimerCommandsForStreamer', () => {
+  it('parses the BIGINT-string COUNT(*) result back to a number', async () => {
+    const pool = makeMockPool({ executeResult: [[{ count: '3' }], []] });
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    expect(await countTimerCommandsForStreamer(7)).toBe(3);
+  });
+
+  it('queries scoped to the streamer id', async () => {
+    const pool = makeMockPool({ executeResult: [[{ count: '0' }], []] });
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await countTimerCommandsForStreamer(7);
     expect(pool.execute.mock.calls[0][1]).toEqual([7]);
   });
 });

--- a/src/db/timerCommands.ts
+++ b/src/db/timerCommands.ts
@@ -80,6 +80,23 @@ export async function getTimerCommandsForStreamer(streamerId: number): Promise<D
 }
 
 /**
+ * Counts how many timer commands a streamer currently has, so the `/timers/add` route can
+ * enforce a per-streamer cap before inserting a new row.
+ * @param streamerId - DB row ID of the streamer.
+ * @returns The row count. `COUNT(*)` is protocol-typed BIGINT, so `bigNumberStrings` stringifies
+ *   it — but this value is bounded by the cap enforced at insert time (see
+ *   `MAX_TIMER_COMMANDS_PER_STREAMER` in `timersMutations.ts`), never large enough to approach
+ *   `Number.MAX_SAFE_INTEGER`, so parsing it back to a number here is safe and deliberate.
+ */
+export async function countTimerCommandsForStreamer(streamerId: number): Promise<number> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT COUNT(*) AS count FROM timer_command WHERE streamer_id = ?`,
+    [streamerId],
+  );
+  return Number.parseInt(rows[0].count, 10);
+}
+
+/**
  * Creates a new timer command for a streamer.
  * @param streamerId - DB row ID of the owning streamer.
  * @param input - The timer's fields.

--- a/src/twitch/twitchBot.test.ts
+++ b/src/twitch/twitchBot.test.ts
@@ -13,9 +13,8 @@ const { mockClient, registeredHandlers } = vi.hoisted(() => {
     join: vi.fn(),
     part: vi.fn(),
     say: vi.fn(),
-    isMod: vi.fn(),
-    getUsername: vi.fn(),
     channels: [] as string[],
+    userstate: {} as Record<string, { badges?: Record<string, string> | null }>,
   };
   return { mockClient: client, registeredHandlers: handlers };
 });
@@ -134,8 +133,7 @@ function resetMockClient(): void {
   mockClient.join.mockResolvedValue(undefined);
   mockClient.part.mockResolvedValue(undefined);
   mockClient.say.mockResolvedValue(undefined);
-  mockClient.isMod.mockReturnValue(false);
-  mockClient.getUsername.mockReturnValue('testbot');
+  mockClient.userstate = {};
 }
 
 /** Start the bot with an empty channel list and simulate a successful connection. */
@@ -585,17 +583,11 @@ describe('sayInChannel', () => {
     expect(mockClient.say).toHaveBeenCalledWith('streamer', 'hello!');
   });
 
-  it('checks mod status against the normalized channel and the bot\'s own username', async () => {
-    await connectBot();
-    await sayInChannel('#STREAMER', 'hi');
-    expect(mockClient.isMod).toHaveBeenCalledWith('streamer', 'testbot');
-  });
-
   // Twitch's rate-limit window and per-channel floor are exercised exhaustively in
   // twitchSendQueue.test.ts — these just confirm sayInChannel wires channel + the live
-  // mod-status check into that shared limiter.
+  // privilege check (read from tmi.js's internal per-channel userstate badges) into it.
 
-  it('throttles a second non-privileged send to the same channel to at least 1s apart', async () => {
+  it('treats the channel as non-privileged when there is no userstate entry for it yet', async () => {
     await connectBot();
     await sayInChannel('#streamer', 'first');
     const second = sayInChannel('#streamer', 'second');
@@ -608,11 +600,29 @@ describe('sayInChannel', () => {
     expect(mockClient.say).toHaveBeenCalledTimes(2);
   });
 
-  it('exempts a privileged channel from the per-channel floor', async () => {
+  it.each([
+    ['moderator', { moderator: '1' }],
+    ['vip', { vip: '1' }],
+    ['broadcaster', { broadcaster: '1' }],
+  ])('exempts a channel from the per-channel floor when the badges show %s status', async (_label, badges) => {
     await connectBot();
-    mockClient.isMod.mockReturnValue(true);
+    mockClient.userstate = { streamer: { badges } };
     await sayInChannel('#streamer', 'first');
     await sayInChannel('#streamer', 'second');
+    expect(mockClient.say).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not treat a channel as privileged from another channel\'s badges', async () => {
+    await connectBot();
+    mockClient.userstate = { 'other-channel': { badges: { moderator: '1' } } };
+    await sayInChannel('#streamer', 'first');
+    const second = sayInChannel('#streamer', 'second');
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(mockClient.say).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await second;
     expect(mockClient.say).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/twitch/twitchBot.test.ts
+++ b/src/twitch/twitchBot.test.ts
@@ -591,33 +591,29 @@ describe('sayInChannel', () => {
     expect(mockClient.isMod).toHaveBeenCalledWith('streamer', 'testbot');
   });
 
-  // Twitch's rate-limit buckets are exercised exhaustively in twitchSendQueue.test.ts — these
-  // two just confirm sayInChannel wires the live mod-status check into that shared limiter.
+  // Twitch's rate-limit window and per-channel floor are exercised exhaustively in
+  // twitchSendQueue.test.ts — these just confirm sayInChannel wires channel + the live
+  // mod-status check into that shared limiter.
 
-  it('lets sends past the non-privileged bucket capacity through without delay when the bot is privileged', async () => {
+  it('throttles a second non-privileged send to the same channel to at least 1s apart', async () => {
     await connectBot();
-    mockClient.isMod.mockReturnValue(true);
+    await sayInChannel('#streamer', 'first');
+    const second = sayInChannel('#streamer', 'second');
 
-    for (let i = 0; i < 25; i++) {
-      await sayInChannel('#streamer', `message ${i}`);
-    }
-    expect(mockClient.say).toHaveBeenCalledTimes(25);
-  });
-
-  it('throttles a non-privileged channel once the shared rate-limit bucket is exhausted', async () => {
-    await connectBot();
-    for (let i = 0; i < 20; i++) {
-      await sayInChannel('#streamer', `message ${i}`);
-    }
-    expect(mockClient.say).toHaveBeenCalledTimes(20);
-
-    const next = sayInChannel('#streamer', 'one too many');
-    await vi.advanceTimersByTimeAsync(29_999);
-    expect(mockClient.say).toHaveBeenCalledTimes(20);
+    await vi.advanceTimersByTimeAsync(999);
+    expect(mockClient.say).toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(1);
-    await next;
-    expect(mockClient.say).toHaveBeenCalledTimes(21);
+    await second;
+    expect(mockClient.say).toHaveBeenCalledTimes(2);
+  });
+
+  it('exempts a privileged channel from the per-channel floor', async () => {
+    await connectBot();
+    mockClient.isMod.mockReturnValue(true);
+    await sayInChannel('#streamer', 'first');
+    await sayInChannel('#streamer', 'second');
+    expect(mockClient.say).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/twitch/twitchBot.test.ts
+++ b/src/twitch/twitchBot.test.ts
@@ -97,6 +97,7 @@ import {
   sayInChannel,
   __resetTwitchChannelDiscordIdCacheForTests,
 } from './twitchBot';
+import { __resetTwitchSendQueueForTests } from './twitchSendQueue';
 import {
   joinTwitchChannel,
   partTwitchChannel,
@@ -155,6 +156,7 @@ beforeEach(() => {
   resetMockClient();
   for (const key of Object.keys(registeredHandlers)) delete registeredHandlers[key];
   vi.useFakeTimers();
+  __resetTwitchSendQueueForTests();
 });
 
 afterEach(async () => {
@@ -577,6 +579,29 @@ describe('sayInChannel', () => {
     await connectBot();
     await sayInChannel('#STREAMER', 'hello!');
     expect(mockClient.say).toHaveBeenCalledWith('streamer', 'hello!');
+  });
+
+  it('throttles back-to-back sends to the same channel', async () => {
+    await connectBot();
+    await sayInChannel('#streamer', 'first');
+    expect(mockClient.say).toHaveBeenCalledTimes(1);
+
+    const second = sayInChannel('#streamer', 'second');
+    await vi.advanceTimersByTimeAsync(0);
+    // Still queued — spacing hasn't elapsed yet.
+    expect(mockClient.say).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1_500);
+    await second;
+    expect(mockClient.say).toHaveBeenCalledTimes(2);
+    expect(mockClient.say).toHaveBeenLastCalledWith('streamer', 'second');
+  });
+
+  it('does not delay sends to different channels', async () => {
+    await connectBot();
+    await sayInChannel('#streamer', 'first');
+    await sayInChannel('#otherstreamer', 'second');
+    expect(mockClient.say).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/twitch/twitchBot.test.ts
+++ b/src/twitch/twitchBot.test.ts
@@ -606,7 +606,10 @@ describe('sayInChannel', () => {
     ['broadcaster', { broadcaster: '1' }],
   ])('exempts a channel from the per-channel floor when the badges show %s status', async (_label, badges) => {
     await connectBot();
-    mockClient.userstate = { streamer: { badges } };
+    // tmi.js keys its internal userstate map by the IRC channel form ('#streamer'), not the
+    // bare normalized name — this must match that real shape, or a lookup-key regression
+    // (e.g. accidentally dropping the '#') would pass here despite never matching in production.
+    mockClient.userstate = { '#streamer': { badges } };
     await sayInChannel('#streamer', 'first');
     await sayInChannel('#streamer', 'second');
     expect(mockClient.say).toHaveBeenCalledTimes(2);
@@ -614,7 +617,7 @@ describe('sayInChannel', () => {
 
   it('does not treat a channel as privileged from another channel\'s badges', async () => {
     await connectBot();
-    mockClient.userstate = { 'other-channel': { badges: { moderator: '1' } } };
+    mockClient.userstate = { '#other-channel': { badges: { moderator: '1' } } };
     await sayInChannel('#streamer', 'first');
     const second = sayInChannel('#streamer', 'second');
 

--- a/src/twitch/twitchBot.test.ts
+++ b/src/twitch/twitchBot.test.ts
@@ -585,48 +585,39 @@ describe('sayInChannel', () => {
     expect(mockClient.say).toHaveBeenCalledWith('streamer', 'hello!');
   });
 
-  it('throttles back-to-back sends to the same channel', async () => {
-    await connectBot();
-    await sayInChannel('#streamer', 'first');
-    expect(mockClient.say).toHaveBeenCalledTimes(1);
-
-    const second = sayInChannel('#streamer', 'second');
-    await vi.advanceTimersByTimeAsync(0);
-    // Still queued — spacing hasn't elapsed yet.
-    expect(mockClient.say).toHaveBeenCalledTimes(1);
-
-    await vi.advanceTimersByTimeAsync(1_500);
-    await second;
-    expect(mockClient.say).toHaveBeenCalledTimes(2);
-    expect(mockClient.say).toHaveBeenLastCalledWith('streamer', 'second');
-  });
-
-  it('does not delay sends to different channels', async () => {
-    await connectBot();
-    await sayInChannel('#streamer', 'first');
-    await sayInChannel('#otherstreamer', 'second');
-    expect(mockClient.say).toHaveBeenCalledTimes(2);
-  });
-
-  it('uses the shorter moderator spacing when the bot is a mod in the channel', async () => {
-    await connectBot();
-    mockClient.isMod.mockReturnValue(true);
-
-    await sayInChannel('#streamer', 'first');
-    const second = sayInChannel('#streamer', 'second');
-
-    await vi.advanceTimersByTimeAsync(299);
-    expect(mockClient.say).toHaveBeenCalledTimes(1);
-
-    await vi.advanceTimersByTimeAsync(1);
-    await second;
-    expect(mockClient.say).toHaveBeenCalledTimes(2);
-  });
-
   it('checks mod status against the normalized channel and the bot\'s own username', async () => {
     await connectBot();
     await sayInChannel('#STREAMER', 'hi');
     expect(mockClient.isMod).toHaveBeenCalledWith('streamer', 'testbot');
+  });
+
+  // Twitch's rate-limit buckets are exercised exhaustively in twitchSendQueue.test.ts — these
+  // two just confirm sayInChannel wires the live mod-status check into that shared limiter.
+
+  it('lets sends past the non-privileged bucket capacity through without delay when the bot is privileged', async () => {
+    await connectBot();
+    mockClient.isMod.mockReturnValue(true);
+
+    for (let i = 0; i < 25; i++) {
+      await sayInChannel('#streamer', `message ${i}`);
+    }
+    expect(mockClient.say).toHaveBeenCalledTimes(25);
+  });
+
+  it('throttles a non-privileged channel once the shared rate-limit bucket is exhausted', async () => {
+    await connectBot();
+    for (let i = 0; i < 20; i++) {
+      await sayInChannel('#streamer', `message ${i}`);
+    }
+    expect(mockClient.say).toHaveBeenCalledTimes(20);
+
+    const next = sayInChannel('#streamer', 'one too many');
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(mockClient.say).toHaveBeenCalledTimes(20);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await next;
+    expect(mockClient.say).toHaveBeenCalledTimes(21);
   });
 });
 

--- a/src/twitch/twitchBot.test.ts
+++ b/src/twitch/twitchBot.test.ts
@@ -13,6 +13,8 @@ const { mockClient, registeredHandlers } = vi.hoisted(() => {
     join: vi.fn(),
     part: vi.fn(),
     say: vi.fn(),
+    isMod: vi.fn(),
+    getUsername: vi.fn(),
     channels: [] as string[],
   };
   return { mockClient: client, registeredHandlers: handlers };
@@ -132,6 +134,8 @@ function resetMockClient(): void {
   mockClient.join.mockResolvedValue(undefined);
   mockClient.part.mockResolvedValue(undefined);
   mockClient.say.mockResolvedValue(undefined);
+  mockClient.isMod.mockReturnValue(false);
+  mockClient.getUsername.mockReturnValue('testbot');
 }
 
 /** Start the bot with an empty channel list and simulate a successful connection. */
@@ -602,6 +606,27 @@ describe('sayInChannel', () => {
     await sayInChannel('#streamer', 'first');
     await sayInChannel('#otherstreamer', 'second');
     expect(mockClient.say).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses the shorter moderator spacing when the bot is a mod in the channel', async () => {
+    await connectBot();
+    mockClient.isMod.mockReturnValue(true);
+
+    await sayInChannel('#streamer', 'first');
+    const second = sayInChannel('#streamer', 'second');
+
+    await vi.advanceTimersByTimeAsync(299);
+    expect(mockClient.say).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await second;
+    expect(mockClient.say).toHaveBeenCalledTimes(2);
+  });
+
+  it('checks mod status against the normalized channel and the bot\'s own username', async () => {
+    await connectBot();
+    await sayInChannel('#STREAMER', 'hi');
+    expect(mockClient.isMod).toHaveBeenCalledWith('streamer', 'testbot');
   });
 });
 

--- a/src/twitch/twitchBot.ts
+++ b/src/twitch/twitchBot.ts
@@ -10,7 +10,7 @@ import { fireAndForget } from '../commands/commandUtils';
 import { recordChatMessage } from './twitchChatActivity';
 import { setTwitchChannel } from '../shared/statusStore';
 import { normalizeTwitchChannelName } from './twitchChannelName';
-import { throttledChannelSend, NON_MOD_MIN_SEND_INTERVAL_MS, MOD_MIN_SEND_INTERVAL_MS } from './twitchSendQueue';
+import { throttledTwitchSend } from './twitchSendQueue';
 import { createLogger } from '../shared/logger';
 import {
   createManagedLookupCache,
@@ -224,31 +224,30 @@ export async function startTwitchBot(): Promise<void> {
 }
 
 /**
- * Sends `message` to a Twitch channel via the connected tmi.js client, throttled per channel
- * (see {@link throttledChannelSend}) so this shared entry point — used by every auto-posting
- * feature (custom commands, counters, timers, shoutouts, EventSub, etc.) — can never burst a
- * channel past Twitch's chat rate limit, regardless of how many features fire at once. Uses the
- * higher moderator rate limit for channels where the bot currently holds mod (tmi.js tracks this
- * per channel from the IRC USERSTATE tags sent on join and on every send), so being a mod in a
- * channel isn't throttled down to the stricter non-mod rate.
+ * Sends `message` to a Twitch channel via the connected tmi.js client, throttled against
+ * Twitch's global per-account rate-limit buckets (see {@link throttledTwitchSend}) so this
+ * shared entry point — used by every auto-posting feature (custom commands, counters, timers,
+ * shoutouts, EventSub, etc.) — can never burst past them, regardless of how many features fire
+ * at once or which channels they target. Whether the bot is currently privileged
+ * (moderator/VIP/broadcaster) in the target channel is checked live via tmi.js (which tracks it
+ * per channel from the IRC USERSTATE tags sent on join and on every send), so gaining or losing
+ * that status takes effect from the next send.
  * @param channel - Twitch channel to send to (normalized before sending).
  * @param message - Message text to send.
  * @returns Resolves once the message has actually been sent.
  * @throws If `channel` doesn't normalize to a valid channel name, or the client isn't connected
  *   (checked both before queueing and again when the send actually runs, since the connection
- *   can drop while this send is waiting behind others for the same channel).
+ *   can drop while this send is waiting behind others in the global queue).
  */
 export async function sayInChannel(channel: string, message: string): Promise<void> {
   const normalized = normalizeTwitchChannelName(channel);
   if (!normalized) throw new Error(`[Twitch] Invalid channel name: ${channel}`);
   if (!client || !connected) throw new Error(`[Twitch] Cannot send message — not connected`);
-  const minIntervalMs = client.isMod(normalized, client.getUsername())
-    ? MOD_MIN_SEND_INTERVAL_MS
-    : NON_MOD_MIN_SEND_INTERVAL_MS;
-  await throttledChannelSend(normalized, async () => {
+  const isPrivileged = client.isMod(normalized, client.getUsername());
+  await throttledTwitchSend(isPrivileged, async () => {
     if (!client || !connected) throw new Error(`[Twitch] Cannot send message — not connected`);
     await client.say(normalized, message);
-  }, minIntervalMs);
+  });
 }
 
 /**

--- a/src/twitch/twitchBot.ts
+++ b/src/twitch/twitchBot.ts
@@ -229,13 +229,15 @@ export async function startTwitchBot(): Promise<void> {
  * and on every send — the same source `client.isMod()` reads, but `isMod()` only reflects the
  * `user-type` tag, which is never set for VIP or broadcaster status). `userstate` isn't part of
  * tmi.js's public type surface, the same tradeoff as `channels` in {@link onDisconnected}, but is
- * real internal state. Under-detecting privilege here only makes a send unnecessarily conservative
+ * real internal state — keyed by the IRC channel form (`#channel`, via tmi.js's internal
+ * `_.channel()`), not the bare name {@link normalizeTwitchChannelName} returns, so the `#` has to
+ * be added back here. Under-detecting privilege here only makes a send unnecessarily conservative
  * (throttled at the stricter non-privileged rate) rather than unsafe, so a missing/malformed
  * userstate entry — e.g. before the bot has joined `channel` — safely resolves to false.
- * @param channel - Normalized Twitch channel name.
+ * @param channel - Normalized Twitch channel name (without a leading `#`).
  */
 function isPrivilegedInChannel(channel: string): boolean {
-  const badges = (client as any)?.userstate?.[channel]?.badges as Record<string, string> | null | undefined;
+  const badges = (client as any)?.userstate?.[`#${channel}`]?.badges as Record<string, string> | null | undefined;
   return !!badges?.moderator || !!badges?.vip || !!badges?.broadcaster;
 }
 

--- a/src/twitch/twitchBot.ts
+++ b/src/twitch/twitchBot.ts
@@ -256,8 +256,10 @@ function isPrivilegedInChannel(channel: string): boolean {
  * shared entry point — used by every auto-posting feature (custom commands, counters, timers,
  * shoutouts, EventSub, etc.) — can never burst past them, regardless of how many features fire
  * at once or which channels they target. Whether the bot is currently privileged
- * (moderator/VIP/broadcaster) in the target channel is checked live (see
- * {@link isPrivilegedInChannel}), so gaining or losing that status takes effect from the next send.
+ * (moderator/VIP/broadcaster) in the target channel is re-checked live (see
+ * {@link isPrivilegedInChannel}) right before the send actually runs, not when it's queued, since
+ * this call may sit behind others for a while — the same reason the connection itself is
+ * rechecked below rather than trusted from before queueing.
  * @param channel - Twitch channel to send to (normalized before sending).
  * @param message - Message text to send.
  * @returns Resolves once the message has actually been sent.
@@ -269,8 +271,7 @@ export async function sayInChannel(channel: string, message: string): Promise<vo
   const normalized = normalizeTwitchChannelName(channel);
   if (!normalized) throw new Error(`[Twitch] Invalid channel name: ${channel}`);
   if (!client || !connected) throw new Error(`[Twitch] Cannot send message — not connected`);
-  const isPrivileged = isPrivilegedInChannel(normalized);
-  await throttledTwitchSend(normalized, isPrivileged, async () => {
+  await throttledTwitchSend(normalized, () => isPrivilegedInChannel(normalized), async () => {
     if (!client || !connected) throw new Error(`[Twitch] Cannot send message — not connected`);
     await client.say(normalized, message);
   });

--- a/src/twitch/twitchBot.ts
+++ b/src/twitch/twitchBot.ts
@@ -10,6 +10,7 @@ import { fireAndForget } from '../commands/commandUtils';
 import { recordChatMessage } from './twitchChatActivity';
 import { setTwitchChannel } from '../shared/statusStore';
 import { normalizeTwitchChannelName } from './twitchChannelName';
+import { throttledChannelSend } from './twitchSendQueue';
 import { createLogger } from '../shared/logger';
 import {
   createManagedLookupCache,
@@ -223,17 +224,25 @@ export async function startTwitchBot(): Promise<void> {
 }
 
 /**
- * Sends `message` to a Twitch channel via the connected tmi.js client.
+ * Sends `message` to a Twitch channel via the connected tmi.js client, throttled per channel
+ * (see {@link throttledChannelSend}) so this shared entry point — used by every auto-posting
+ * feature (custom commands, counters, timers, shoutouts, EventSub, etc.) — can never burst a
+ * channel past Twitch's chat rate limit, regardless of how many features fire at once.
  * @param channel - Twitch channel to send to (normalized before sending).
  * @param message - Message text to send.
- * @returns Resolves once the message has been sent.
- * @throws If `channel` doesn't normalize to a valid channel name, or the client isn't connected.
+ * @returns Resolves once the message has actually been sent.
+ * @throws If `channel` doesn't normalize to a valid channel name, or the client isn't connected
+ *   (checked both before queueing and again when the send actually runs, since the connection
+ *   can drop while this send is waiting behind others for the same channel).
  */
 export async function sayInChannel(channel: string, message: string): Promise<void> {
   const normalized = normalizeTwitchChannelName(channel);
   if (!normalized) throw new Error(`[Twitch] Invalid channel name: ${channel}`);
   if (!client || !connected) throw new Error(`[Twitch] Cannot send message — not connected`);
-  await client.say(normalized, message);
+  await throttledChannelSend(normalized, async () => {
+    if (!client || !connected) throw new Error(`[Twitch] Cannot send message — not connected`);
+    await client.say(normalized, message);
+  });
 }
 
 /**

--- a/src/twitch/twitchBot.ts
+++ b/src/twitch/twitchBot.ts
@@ -244,7 +244,7 @@ export async function sayInChannel(channel: string, message: string): Promise<vo
   if (!normalized) throw new Error(`[Twitch] Invalid channel name: ${channel}`);
   if (!client || !connected) throw new Error(`[Twitch] Cannot send message — not connected`);
   const isPrivileged = client.isMod(normalized, client.getUsername());
-  await throttledTwitchSend(isPrivileged, async () => {
+  await throttledTwitchSend(normalized, isPrivileged, async () => {
     if (!client || !connected) throw new Error(`[Twitch] Cannot send message — not connected`);
     await client.say(normalized, message);
   });

--- a/src/twitch/twitchBot.ts
+++ b/src/twitch/twitchBot.ts
@@ -224,14 +224,29 @@ export async function startTwitchBot(): Promise<void> {
 }
 
 /**
+ * Resolves whether the bot currently holds moderator/VIP/broadcaster status in `channel`, from
+ * tmi.js's internal per-channel `userstate` (populated from the IRC USERSTATE tags sent on join
+ * and on every send — the same source `client.isMod()` reads, but `isMod()` only reflects the
+ * `user-type` tag, which is never set for VIP or broadcaster status). `userstate` isn't part of
+ * tmi.js's public type surface, the same tradeoff as `channels` in {@link onDisconnected}, but is
+ * real internal state. Under-detecting privilege here only makes a send unnecessarily conservative
+ * (throttled at the stricter non-privileged rate) rather than unsafe, so a missing/malformed
+ * userstate entry — e.g. before the bot has joined `channel` — safely resolves to false.
+ * @param channel - Normalized Twitch channel name.
+ */
+function isPrivilegedInChannel(channel: string): boolean {
+  const badges = (client as any)?.userstate?.[channel]?.badges as Record<string, string> | null | undefined;
+  return !!badges?.moderator || !!badges?.vip || !!badges?.broadcaster;
+}
+
+/**
  * Sends `message` to a Twitch channel via the connected tmi.js client, throttled against
  * Twitch's global per-account rate-limit buckets (see {@link throttledTwitchSend}) so this
  * shared entry point — used by every auto-posting feature (custom commands, counters, timers,
  * shoutouts, EventSub, etc.) — can never burst past them, regardless of how many features fire
  * at once or which channels they target. Whether the bot is currently privileged
- * (moderator/VIP/broadcaster) in the target channel is checked live via tmi.js (which tracks it
- * per channel from the IRC USERSTATE tags sent on join and on every send), so gaining or losing
- * that status takes effect from the next send.
+ * (moderator/VIP/broadcaster) in the target channel is checked live (see
+ * {@link isPrivilegedInChannel}), so gaining or losing that status takes effect from the next send.
  * @param channel - Twitch channel to send to (normalized before sending).
  * @param message - Message text to send.
  * @returns Resolves once the message has actually been sent.
@@ -243,7 +258,7 @@ export async function sayInChannel(channel: string, message: string): Promise<vo
   const normalized = normalizeTwitchChannelName(channel);
   if (!normalized) throw new Error(`[Twitch] Invalid channel name: ${channel}`);
   if (!client || !connected) throw new Error(`[Twitch] Cannot send message — not connected`);
-  const isPrivileged = client.isMod(normalized, client.getUsername());
+  const isPrivileged = isPrivilegedInChannel(normalized);
   await throttledTwitchSend(normalized, isPrivileged, async () => {
     if (!client || !connected) throw new Error(`[Twitch] Cannot send message — not connected`);
     await client.say(normalized, message);

--- a/src/twitch/twitchBot.ts
+++ b/src/twitch/twitchBot.ts
@@ -10,7 +10,7 @@ import { fireAndForget } from '../commands/commandUtils';
 import { recordChatMessage } from './twitchChatActivity';
 import { setTwitchChannel } from '../shared/statusStore';
 import { normalizeTwitchChannelName } from './twitchChannelName';
-import { throttledChannelSend } from './twitchSendQueue';
+import { throttledChannelSend, NON_MOD_MIN_SEND_INTERVAL_MS, MOD_MIN_SEND_INTERVAL_MS } from './twitchSendQueue';
 import { createLogger } from '../shared/logger';
 import {
   createManagedLookupCache,
@@ -227,7 +227,10 @@ export async function startTwitchBot(): Promise<void> {
  * Sends `message` to a Twitch channel via the connected tmi.js client, throttled per channel
  * (see {@link throttledChannelSend}) so this shared entry point — used by every auto-posting
  * feature (custom commands, counters, timers, shoutouts, EventSub, etc.) — can never burst a
- * channel past Twitch's chat rate limit, regardless of how many features fire at once.
+ * channel past Twitch's chat rate limit, regardless of how many features fire at once. Uses the
+ * higher moderator rate limit for channels where the bot currently holds mod (tmi.js tracks this
+ * per channel from the IRC USERSTATE tags sent on join and on every send), so being a mod in a
+ * channel isn't throttled down to the stricter non-mod rate.
  * @param channel - Twitch channel to send to (normalized before sending).
  * @param message - Message text to send.
  * @returns Resolves once the message has actually been sent.
@@ -239,10 +242,13 @@ export async function sayInChannel(channel: string, message: string): Promise<vo
   const normalized = normalizeTwitchChannelName(channel);
   if (!normalized) throw new Error(`[Twitch] Invalid channel name: ${channel}`);
   if (!client || !connected) throw new Error(`[Twitch] Cannot send message — not connected`);
+  const minIntervalMs = client.isMod(normalized, client.getUsername())
+    ? MOD_MIN_SEND_INTERVAL_MS
+    : NON_MOD_MIN_SEND_INTERVAL_MS;
   await throttledChannelSend(normalized, async () => {
     if (!client || !connected) throw new Error(`[Twitch] Cannot send message — not connected`);
     await client.say(normalized, message);
-  });
+  }, minIntervalMs);
 }
 
 /**

--- a/src/twitch/twitchBot.ts
+++ b/src/twitch/twitchBot.ts
@@ -224,20 +224,29 @@ export async function startTwitchBot(): Promise<void> {
 }
 
 /**
+ * Shape of the subset of tmi.js's internal client state this file reaches into — not part of
+ * its public type surface (same tradeoff as the `channels` cast in {@link onDisconnected}), but
+ * narrowed to just what's read here rather than casting through `any`.
+ */
+interface TmiClientInternal {
+  userstate?: Record<string, { badges?: Record<string, string> | null } | undefined>;
+}
+
+/**
  * Resolves whether the bot currently holds moderator/VIP/broadcaster status in `channel`, from
  * tmi.js's internal per-channel `userstate` (populated from the IRC USERSTATE tags sent on join
  * and on every send — the same source `client.isMod()` reads, but `isMod()` only reflects the
- * `user-type` tag, which is never set for VIP or broadcaster status). `userstate` isn't part of
- * tmi.js's public type surface, the same tradeoff as `channels` in {@link onDisconnected}, but is
- * real internal state — keyed by the IRC channel form (`#channel`, via tmi.js's internal
- * `_.channel()`), not the bare name {@link normalizeTwitchChannelName} returns, so the `#` has to
- * be added back here. Under-detecting privilege here only makes a send unnecessarily conservative
- * (throttled at the stricter non-privileged rate) rather than unsafe, so a missing/malformed
- * userstate entry — e.g. before the bot has joined `channel` — safely resolves to false.
+ * `user-type` tag, which is never set for VIP or broadcaster status). `userstate` is keyed by the
+ * IRC channel form (`#channel`, via tmi.js's internal `_.channel()`), not the bare name
+ * {@link normalizeTwitchChannelName} returns, so the `#` has to be added back here.
+ * Under-detecting privilege here only makes a send unnecessarily conservative (throttled at the
+ * stricter non-privileged rate) rather than unsafe, so a missing/malformed userstate entry — e.g.
+ * before the bot has joined `channel` — safely resolves to false.
  * @param channel - Normalized Twitch channel name (without a leading `#`).
+ * @returns True if `channel`'s userstate badges show moderator, VIP, or broadcaster status.
  */
 function isPrivilegedInChannel(channel: string): boolean {
-  const badges = (client as any)?.userstate?.[`#${channel}`]?.badges as Record<string, string> | null | undefined;
+  const badges = (client as TmiClientInternal | null)?.userstate?.[`#${channel}`]?.badges;
   return !!badges?.moderator || !!badges?.vip || !!badges?.broadcaster;
 }
 

--- a/src/twitch/twitchSendQueue.test.ts
+++ b/src/twitch/twitchSendQueue.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { throttledChannelSend, __resetTwitchSendQueueForTests } from './twitchSendQueue';
 
+const INTERVAL_MS = 1_500;
+
 beforeEach(() => {
   vi.useFakeTimers();
   __resetTwitchSendQueueForTests();
@@ -13,15 +15,15 @@ afterEach(() => {
 describe('throttledChannelSend', () => {
   it('runs the first send for a channel immediately', async () => {
     const send = vi.fn().mockResolvedValue(undefined);
-    await throttledChannelSend('streamer', send);
+    await throttledChannelSend('streamer', send, INTERVAL_MS);
     expect(send).toHaveBeenCalledTimes(1);
   });
 
   it('delays a second send to the same channel until the spacing interval elapses', async () => {
     const send = vi.fn().mockResolvedValue(undefined);
-    await throttledChannelSend('streamer', send);
+    await throttledChannelSend('streamer', send, INTERVAL_MS);
 
-    const second = throttledChannelSend('streamer', send);
+    const second = throttledChannelSend('streamer', send, INTERVAL_MS);
     await vi.advanceTimersByTimeAsync(0);
     expect(send).toHaveBeenCalledTimes(1);
 
@@ -35,8 +37,8 @@ describe('throttledChannelSend', () => {
 
   it('does not delay sends to different channels', async () => {
     const send = vi.fn().mockResolvedValue(undefined);
-    await throttledChannelSend('streamer-a', send);
-    await throttledChannelSend('streamer-b', send);
+    await throttledChannelSend('streamer-a', send, INTERVAL_MS);
+    await throttledChannelSend('streamer-b', send, INTERVAL_MS);
     expect(send).toHaveBeenCalledTimes(2);
   });
 
@@ -44,9 +46,9 @@ describe('throttledChannelSend', () => {
     const order: string[] = [];
     const makeSend = (label: string) => vi.fn().mockImplementation(async () => { order.push(label); });
 
-    const p1 = throttledChannelSend('streamer', makeSend('a'));
-    const p2 = throttledChannelSend('streamer', makeSend('b'));
-    const p3 = throttledChannelSend('streamer', makeSend('c'));
+    const p1 = throttledChannelSend('streamer', makeSend('a'), INTERVAL_MS);
+    const p2 = throttledChannelSend('streamer', makeSend('b'), INTERVAL_MS);
+    const p3 = throttledChannelSend('streamer', makeSend('c'), INTERVAL_MS);
 
     await vi.advanceTimersByTimeAsync(3_000);
     await Promise.all([p1, p2, p3]);
@@ -58,8 +60,8 @@ describe('throttledChannelSend', () => {
     const failing = vi.fn().mockRejectedValue(new Error('boom'));
     const succeeding = vi.fn().mockResolvedValue(undefined);
 
-    const first = throttledChannelSend('streamer', failing);
-    const second = throttledChannelSend('streamer', succeeding);
+    const first = throttledChannelSend('streamer', failing, INTERVAL_MS);
+    const second = throttledChannelSend('streamer', succeeding, INTERVAL_MS);
 
     await expect(first).rejects.toThrow('boom');
 
@@ -69,5 +71,27 @@ describe('throttledChannelSend', () => {
     await vi.advanceTimersByTimeAsync(1);
     await second;
     expect(succeeding).toHaveBeenCalledTimes(1);
+  });
+
+  it('schedules the following send using the minIntervalMs passed to the current call, not a prior one', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    // First call schedules the next slot 1.5s out — a later call can't retroactively shrink
+    // the wait it's already queued behind, so the second send still waits the full interval.
+    await throttledChannelSend('streamer', send, INTERVAL_MS);
+
+    const second = throttledChannelSend('streamer', send, 300);
+    await vi.advanceTimersByTimeAsync(1_499);
+    expect(send).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    await second;
+    expect(send).toHaveBeenCalledTimes(2);
+
+    // The second call's 300ms interval now governs the wait before the third send.
+    const third = throttledChannelSend('streamer', send, 300);
+    await vi.advanceTimersByTimeAsync(299);
+    expect(send).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
+    await third;
+    expect(send).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/twitch/twitchSendQueue.test.ts
+++ b/src/twitch/twitchSendQueue.test.ts
@@ -1,7 +1,18 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { throttledChannelSend, __resetTwitchSendQueueForTests } from './twitchSendQueue';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import { throttledTwitchSend, __resetTwitchSendQueueForTests } from './twitchSendQueue';
 
-const INTERVAL_MS = 1_500;
+const WINDOW_MS = 30_000;
+const MODERATOR_CAPACITY = 100;
+const USER_CAPACITY = 20;
+
+/** Runs `count` sends of the given privilege against a single shared mock, resolving once they've all run. */
+async function fillBucket(isPrivileged: boolean, count: number): Promise<Mock> {
+  const send = vi.fn().mockResolvedValue(undefined);
+  for (let i = 0; i < count; i++) {
+    await throttledTwitchSend(isPrivileged, send);
+  }
+  return send;
+}
 
 beforeEach(() => {
   vi.useFakeTimers();
@@ -12,86 +23,85 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-describe('throttledChannelSend', () => {
-  it('runs the first send for a channel immediately', async () => {
+describe('throttledTwitchSend', () => {
+  it('runs a send immediately when both buckets have room', async () => {
     const send = vi.fn().mockResolvedValue(undefined);
-    await throttledChannelSend('streamer', send, INTERVAL_MS);
+    await throttledTwitchSend(false, send);
     expect(send).toHaveBeenCalledTimes(1);
   });
 
-  it('delays a second send to the same channel until the spacing interval elapses', async () => {
-    const send = vi.fn().mockResolvedValue(undefined);
-    await throttledChannelSend('streamer', send, INTERVAL_MS);
+  it('lets a non-privileged send run up to the user bucket capacity without delay', async () => {
+    const send = await fillBucket(false, USER_CAPACITY);
+    expect(send).toHaveBeenCalledTimes(USER_CAPACITY);
+  });
 
-    const second = throttledChannelSend('streamer', send, INTERVAL_MS);
-    await vi.advanceTimersByTimeAsync(0);
-    expect(send).toHaveBeenCalledTimes(1);
+  it('delays a non-privileged send past the user bucket capacity until the window rolls', async () => {
+    const send = await fillBucket(false, USER_CAPACITY);
 
-    await vi.advanceTimersByTimeAsync(1_499);
-    expect(send).toHaveBeenCalledTimes(1);
+    const next = throttledTwitchSend(false, send);
+    await vi.advanceTimersByTimeAsync(WINDOW_MS - 1);
+    expect(send).toHaveBeenCalledTimes(USER_CAPACITY);
 
     await vi.advanceTimersByTimeAsync(1);
-    await second;
-    expect(send).toHaveBeenCalledTimes(2);
+    await next;
+    expect(send).toHaveBeenCalledTimes(USER_CAPACITY + 1);
   });
 
-  it('does not delay sends to different channels', async () => {
+  it('lets a privileged send run well past the user bucket capacity, up to the moderator bucket capacity', async () => {
+    const send = await fillBucket(true, USER_CAPACITY + 5);
+    expect(send).toHaveBeenCalledTimes(USER_CAPACITY + 5);
+  });
+
+  it('delays a privileged send past the moderator bucket capacity until the window rolls', async () => {
+    const send = await fillBucket(true, MODERATOR_CAPACITY);
+
+    const next = throttledTwitchSend(true, send);
+    await vi.advanceTimersByTimeAsync(WINDOW_MS - 1);
+    expect(send).toHaveBeenCalledTimes(MODERATOR_CAPACITY);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await next;
+    expect(send).toHaveBeenCalledTimes(MODERATOR_CAPACITY + 1);
+  });
+
+  it('blocks a non-privileged send when a privileged burst has exhausted the shared moderator bucket, even though the user bucket is untouched', async () => {
+    // Fill the moderator bucket entirely with privileged sends — none of these touch the user bucket.
+    await fillBucket(true, MODERATOR_CAPACITY);
+
+    // User bucket is still completely empty (0/20), but the moderator bucket both kinds of
+    // send draw from is full, so this non-privileged send must still wait for it to roll.
     const send = vi.fn().mockResolvedValue(undefined);
-    await throttledChannelSend('streamer-a', send, INTERVAL_MS);
-    await throttledChannelSend('streamer-b', send, INTERVAL_MS);
-    expect(send).toHaveBeenCalledTimes(2);
+    const blocked = throttledTwitchSend(false, send);
+    await vi.advanceTimersByTimeAsync(WINDOW_MS - 1);
+    expect(send).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await blocked;
+    expect(send).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps queued sends for a channel in enqueue order', async () => {
+  it('keeps queued sends in enqueue order across mixed privileged/non-privileged calls', async () => {
     const order: string[] = [];
     const makeSend = (label: string) => vi.fn().mockImplementation(async () => { order.push(label); });
 
-    const p1 = throttledChannelSend('streamer', makeSend('a'), INTERVAL_MS);
-    const p2 = throttledChannelSend('streamer', makeSend('b'), INTERVAL_MS);
-    const p3 = throttledChannelSend('streamer', makeSend('c'), INTERVAL_MS);
+    const p1 = throttledTwitchSend(true, makeSend('a'));
+    const p2 = throttledTwitchSend(false, makeSend('b'));
+    const p3 = throttledTwitchSend(true, makeSend('c'));
 
-    await vi.advanceTimersByTimeAsync(3_000);
     await Promise.all([p1, p2, p3]);
-
     expect(order).toEqual(['a', 'b', 'c']);
   });
 
-  it('does not shrink the spacing of queued sends when an earlier send fails', async () => {
-    const failing = vi.fn().mockRejectedValue(new Error('boom'));
-    const succeeding = vi.fn().mockResolvedValue(undefined);
+  it('still consumes a bucket token when the send itself fails, so a failure cannot be used to dodge the limit', async () => {
+    await fillBucket(false, USER_CAPACITY - 1);
+    await expect(throttledTwitchSend(false, vi.fn().mockRejectedValue(new Error('boom')))).rejects.toThrow('boom');
 
-    const first = throttledChannelSend('streamer', failing, INTERVAL_MS);
-    const second = throttledChannelSend('streamer', succeeding, INTERVAL_MS);
-
-    await expect(first).rejects.toThrow('boom');
-
-    await vi.advanceTimersByTimeAsync(1_499);
-    expect(succeeding).not.toHaveBeenCalled();
-
-    await vi.advanceTimersByTimeAsync(1);
-    await second;
-    expect(succeeding).toHaveBeenCalledTimes(1);
-  });
-
-  it('schedules the following send using the minIntervalMs passed to the current call, not a prior one', async () => {
     const send = vi.fn().mockResolvedValue(undefined);
-    // First call schedules the next slot 1.5s out — a later call can't retroactively shrink
-    // the wait it's already queued behind, so the second send still waits the full interval.
-    await throttledChannelSend('streamer', send, INTERVAL_MS);
-
-    const second = throttledChannelSend('streamer', send, 300);
-    await vi.advanceTimersByTimeAsync(1_499);
+    const blocked = throttledTwitchSend(false, send);
+    await vi.advanceTimersByTimeAsync(WINDOW_MS - 1);
+    expect(send).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    await blocked;
     expect(send).toHaveBeenCalledTimes(1);
-    await vi.advanceTimersByTimeAsync(1);
-    await second;
-    expect(send).toHaveBeenCalledTimes(2);
-
-    // The second call's 300ms interval now governs the wait before the third send.
-    const third = throttledChannelSend('streamer', send, 300);
-    await vi.advanceTimersByTimeAsync(299);
-    expect(send).toHaveBeenCalledTimes(2);
-    await vi.advanceTimersByTimeAsync(1);
-    await third;
-    expect(send).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/twitch/twitchSendQueue.test.ts
+++ b/src/twitch/twitchSendQueue.test.ts
@@ -147,4 +147,32 @@ describe('throttledTwitchSend', () => {
     await blocked;
     expect(send).toHaveBeenCalledTimes(1);
   });
+
+  // ─── Send timeout ─────────────────────────────────────────────────────────
+
+  it('rejects and frees the queue when send() hangs past the timeout, instead of blocking later sends forever', async () => {
+    const hanging = vi.fn().mockImplementation(() => new Promise(() => {})); // never settles
+    // Attach the rejection assertion before advancing timers, so the promise has a handler
+    // already registered before it actually rejects (avoids a spurious unhandled-rejection
+    // warning from the gap between rejecting and a handler being attached).
+    const hungRejection = expect(throttledTwitchSend('streamer-a', false, hanging)).rejects.toThrow(/timed out/i);
+
+    const next = vi.fn().mockResolvedValue(undefined);
+    const nextCall = throttledTwitchSend('streamer-b', false, next);
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    await hungRejection;
+
+    await nextCall;
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not time out a send that resolves well within the timeout', async () => {
+    const send = vi.fn().mockImplementation(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5_000));
+    });
+    const call = throttledTwitchSend('streamer', false, send);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await expect(call).resolves.toBeUndefined();
+  });
 });

--- a/src/twitch/twitchSendQueue.test.ts
+++ b/src/twitch/twitchSendQueue.test.ts
@@ -47,6 +47,32 @@ describe('throttledTwitchSend', () => {
     expect(send).toHaveBeenCalledTimes(2);
   });
 
+  it('re-checks isPrivileged after a long wait, so a status change mid-wait is not left stale', async () => {
+    // Fill the moderator window entirely with privileged sends, then start a new privileged
+    // call that has to wait out the whole 30s window. Flip privileged to false while it waits.
+    await fillWindow('streamer', true, PRIVILEGED_LIMIT);
+    let privileged = true;
+    const first = vi.fn().mockResolvedValue(undefined);
+    const pending = throttledTwitchSend('streamer', () => privileged, first);
+    privileged = false;
+
+    await vi.advanceTimersByTimeAsync(WINDOW_MS);
+    await pending;
+    expect(first).toHaveBeenCalledTimes(1);
+
+    // If the send above had used the stale (privileged) classification instead of re-checking,
+    // it would never have recorded a non-privileged send for "streamer", and this next
+    // non-privileged send would go through immediately with no channel-floor wait at all.
+    const second = vi.fn().mockResolvedValue(undefined);
+    const blocked = throttledTwitchSend('streamer', () => false, second);
+    await vi.advanceTimersByTimeAsync(CHANNEL_FLOOR_MS - 1);
+    expect(second).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await blocked;
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
   // ─── Shared 30s window ──────────────────────────────────────────────────────
 
   it('lets a non-privileged send run up to the 20-message limit without delay (spread across channels to dodge the per-channel floor)', async () => {

--- a/src/twitch/twitchSendQueue.test.ts
+++ b/src/twitch/twitchSendQueue.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { throttledChannelSend, __resetTwitchSendQueueForTests } from './twitchSendQueue';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  __resetTwitchSendQueueForTests();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('throttledChannelSend', () => {
+  it('runs the first send for a channel immediately', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await throttledChannelSend('streamer', send);
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('delays a second send to the same channel until the spacing interval elapses', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await throttledChannelSend('streamer', send);
+
+    const second = throttledChannelSend('streamer', send);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(send).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1_499);
+    expect(send).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await second;
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not delay sends to different channels', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await throttledChannelSend('streamer-a', send);
+    await throttledChannelSend('streamer-b', send);
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps queued sends for a channel in enqueue order', async () => {
+    const order: string[] = [];
+    const makeSend = (label: string) => vi.fn().mockImplementation(async () => { order.push(label); });
+
+    const p1 = throttledChannelSend('streamer', makeSend('a'));
+    const p2 = throttledChannelSend('streamer', makeSend('b'));
+    const p3 = throttledChannelSend('streamer', makeSend('c'));
+
+    await vi.advanceTimersByTimeAsync(3_000);
+    await Promise.all([p1, p2, p3]);
+
+    expect(order).toEqual(['a', 'b', 'c']);
+  });
+
+  it('does not shrink the spacing of queued sends when an earlier send fails', async () => {
+    const failing = vi.fn().mockRejectedValue(new Error('boom'));
+    const succeeding = vi.fn().mockResolvedValue(undefined);
+
+    const first = throttledChannelSend('streamer', failing);
+    const second = throttledChannelSend('streamer', succeeding);
+
+    await expect(first).rejects.toThrow('boom');
+
+    await vi.advanceTimersByTimeAsync(1_499);
+    expect(succeeding).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await second;
+    expect(succeeding).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/twitch/twitchSendQueue.test.ts
+++ b/src/twitch/twitchSendQueue.test.ts
@@ -2,14 +2,15 @@ import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vite
 import { throttledTwitchSend, __resetTwitchSendQueueForTests } from './twitchSendQueue';
 
 const WINDOW_MS = 30_000;
-const MODERATOR_CAPACITY = 100;
-const USER_CAPACITY = 20;
+const PRIVILEGED_LIMIT = 100;
+const NON_PRIVILEGED_LIMIT = 20;
+const CHANNEL_FLOOR_MS = 1_000;
 
-/** Runs `count` sends of the given privilege against a single shared mock, resolving once they've all run. */
-async function fillBucket(isPrivileged: boolean, count: number): Promise<Mock> {
+/** Runs `count` sends of the given privilege to `channel` against a single shared mock. */
+async function fillWindow(channel: string, isPrivileged: boolean, count: number): Promise<Mock> {
   const send = vi.fn().mockResolvedValue(undefined);
   for (let i = 0; i < count; i++) {
-    await throttledTwitchSend(isPrivileged, send);
+    await throttledTwitchSend(channel, isPrivileged, send);
   }
   return send;
 }
@@ -24,54 +25,61 @@ afterEach(() => {
 });
 
 describe('throttledTwitchSend', () => {
-  it('runs a send immediately when both buckets have room', async () => {
+  it('runs a send immediately when the window has room and the channel floor is clear', async () => {
     const send = vi.fn().mockResolvedValue(undefined);
-    await throttledTwitchSend(false, send);
+    await throttledTwitchSend('streamer', false, send);
     expect(send).toHaveBeenCalledTimes(1);
   });
 
-  it('lets a non-privileged send run up to the user bucket capacity without delay', async () => {
-    const send = await fillBucket(false, USER_CAPACITY);
-    expect(send).toHaveBeenCalledTimes(USER_CAPACITY);
-  });
+  // ─── Shared 30s window ──────────────────────────────────────────────────────
 
-  it('delays a non-privileged send past the user bucket capacity until the window rolls', async () => {
-    const send = await fillBucket(false, USER_CAPACITY);
-
-    const next = throttledTwitchSend(false, send);
-    await vi.advanceTimersByTimeAsync(WINDOW_MS - 1);
-    expect(send).toHaveBeenCalledTimes(USER_CAPACITY);
-
-    await vi.advanceTimersByTimeAsync(1);
-    await next;
-    expect(send).toHaveBeenCalledTimes(USER_CAPACITY + 1);
-  });
-
-  it('lets a privileged send run well past the user bucket capacity, up to the moderator bucket capacity', async () => {
-    const send = await fillBucket(true, USER_CAPACITY + 5);
-    expect(send).toHaveBeenCalledTimes(USER_CAPACITY + 5);
-  });
-
-  it('delays a privileged send past the moderator bucket capacity until the window rolls', async () => {
-    const send = await fillBucket(true, MODERATOR_CAPACITY);
-
-    const next = throttledTwitchSend(true, send);
-    await vi.advanceTimersByTimeAsync(WINDOW_MS - 1);
-    expect(send).toHaveBeenCalledTimes(MODERATOR_CAPACITY);
-
-    await vi.advanceTimersByTimeAsync(1);
-    await next;
-    expect(send).toHaveBeenCalledTimes(MODERATOR_CAPACITY + 1);
-  });
-
-  it('blocks a non-privileged send when a privileged burst has exhausted the shared moderator bucket, even though the user bucket is untouched', async () => {
-    // Fill the moderator bucket entirely with privileged sends — none of these touch the user bucket.
-    await fillBucket(true, MODERATOR_CAPACITY);
-
-    // User bucket is still completely empty (0/20), but the moderator bucket both kinds of
-    // send draw from is full, so this non-privileged send must still wait for it to roll.
+  it('lets a non-privileged send run up to the 20-message limit without delay (spread across channels to dodge the per-channel floor)', async () => {
     const send = vi.fn().mockResolvedValue(undefined);
-    const blocked = throttledTwitchSend(false, send);
+    for (let i = 0; i < NON_PRIVILEGED_LIMIT; i++) {
+      await throttledTwitchSend(`streamer-${i}`, false, send);
+    }
+    expect(send).toHaveBeenCalledTimes(NON_PRIVILEGED_LIMIT);
+  });
+
+  it('delays a non-privileged send past the 20-message limit until the window rolls', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    for (let i = 0; i < NON_PRIVILEGED_LIMIT; i++) {
+      await throttledTwitchSend(`streamer-${i}`, false, send);
+    }
+
+    const next = throttledTwitchSend('streamer-overflow', false, send);
+    await vi.advanceTimersByTimeAsync(WINDOW_MS - 1);
+    expect(send).toHaveBeenCalledTimes(NON_PRIVILEGED_LIMIT);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await next;
+    expect(send).toHaveBeenCalledTimes(NON_PRIVILEGED_LIMIT + 1);
+  });
+
+  it('lets a privileged send keep going past the 20-message limit, up to the 100-message ceiling', async () => {
+    const send = await fillWindow('streamer', true, NON_PRIVILEGED_LIMIT + 5);
+    expect(send).toHaveBeenCalledTimes(NON_PRIVILEGED_LIMIT + 5);
+  });
+
+  it('delays a privileged send past the 100-message ceiling until the window rolls', async () => {
+    const send = await fillWindow('streamer', true, PRIVILEGED_LIMIT);
+
+    const next = throttledTwitchSend('streamer', true, send);
+    await vi.advanceTimersByTimeAsync(WINDOW_MS - 1);
+    expect(send).toHaveBeenCalledTimes(PRIVILEGED_LIMIT);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await next;
+    expect(send).toHaveBeenCalledTimes(PRIVILEGED_LIMIT + 1);
+  });
+
+  it('blocks a non-privileged send to one channel once a privileged burst on another channel has pushed the shared window past 20 — privileged sends still count toward it', async () => {
+    // 21 privileged sends push the shared window's count to 21, past the 20 threshold, even
+    // though none of them touched "streamer-b" at all.
+    await fillWindow('streamer-a', true, NON_PRIVILEGED_LIMIT + 1);
+
+    const send = vi.fn().mockResolvedValue(undefined);
+    const blocked = throttledTwitchSend('streamer-b', false, send);
     await vi.advanceTimersByTimeAsync(WINDOW_MS - 1);
     expect(send).not.toHaveBeenCalled();
 
@@ -80,24 +88,59 @@ describe('throttledTwitchSend', () => {
     expect(send).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps queued sends in enqueue order across mixed privileged/non-privileged calls', async () => {
+  // ─── Per-channel 1-message-per-second floor (non-privileged only) ───────────
+
+  it('delays a second non-privileged send to the same channel within 1s, even with the shared window nowhere near its limit', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await throttledTwitchSend('streamer', false, send);
+
+    const next = throttledTwitchSend('streamer', false, send);
+    await vi.advanceTimersByTimeAsync(CHANNEL_FLOOR_MS - 1);
+    expect(send).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await next;
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not apply the per-channel floor to different channels', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await throttledTwitchSend('streamer-a', false, send);
+    await throttledTwitchSend('streamer-b', false, send);
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it('exempts privileged sends from the per-channel floor', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await throttledTwitchSend('streamer', true, send);
+    await throttledTwitchSend('streamer', true, send);
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  // ─── Ordering & failure isolation ────────────────────────────────────────────
+
+  it('keeps queued sends in enqueue order across mixed privileged/non-privileged calls to different channels', async () => {
     const order: string[] = [];
     const makeSend = (label: string) => vi.fn().mockImplementation(async () => { order.push(label); });
 
-    const p1 = throttledTwitchSend(true, makeSend('a'));
-    const p2 = throttledTwitchSend(false, makeSend('b'));
-    const p3 = throttledTwitchSend(true, makeSend('c'));
+    const p1 = throttledTwitchSend('streamer-a', true, makeSend('a'));
+    const p2 = throttledTwitchSend('streamer-b', false, makeSend('b'));
+    const p3 = throttledTwitchSend('streamer-c', true, makeSend('c'));
 
     await Promise.all([p1, p2, p3]);
     expect(order).toEqual(['a', 'b', 'c']);
   });
 
-  it('still consumes a bucket token when the send itself fails, so a failure cannot be used to dodge the limit', async () => {
-    await fillBucket(false, USER_CAPACITY - 1);
-    await expect(throttledTwitchSend(false, vi.fn().mockRejectedValue(new Error('boom')))).rejects.toThrow('boom');
+  it('still consumes a window slot when the send itself fails, so a failure cannot be used to dodge the limit', async () => {
+    for (let i = 0; i < NON_PRIVILEGED_LIMIT - 1; i++) {
+      await throttledTwitchSend(`streamer-${i}`, false, vi.fn().mockResolvedValue(undefined));
+    }
+    await expect(
+      throttledTwitchSend('streamer-fail', false, vi.fn().mockRejectedValue(new Error('boom'))),
+    ).rejects.toThrow('boom');
 
     const send = vi.fn().mockResolvedValue(undefined);
-    const blocked = throttledTwitchSend(false, send);
+    const blocked = throttledTwitchSend('streamer-overflow', false, send);
     await vi.advanceTimersByTimeAsync(WINDOW_MS - 1);
     expect(send).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(1);

--- a/src/twitch/twitchSendQueue.test.ts
+++ b/src/twitch/twitchSendQueue.test.ts
@@ -10,7 +10,7 @@ const CHANNEL_FLOOR_MS = 1_000;
 async function fillWindow(channel: string, isPrivileged: boolean, count: number): Promise<Mock> {
   const send = vi.fn().mockResolvedValue(undefined);
   for (let i = 0; i < count; i++) {
-    await throttledTwitchSend(channel, isPrivileged, send);
+    await throttledTwitchSend(channel, () => isPrivileged, send);
   }
   return send;
 }
@@ -27,8 +27,24 @@ afterEach(() => {
 describe('throttledTwitchSend', () => {
   it('runs a send immediately when the window has room and the channel floor is clear', async () => {
     const send = vi.fn().mockResolvedValue(undefined);
-    await throttledTwitchSend('streamer', false, send);
+    await throttledTwitchSend('streamer', () => false, send);
     expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('evaluates isPrivileged when the send actually runs, not when it was enqueued', async () => {
+    // A call queued behind others reflects whatever isPrivileged() returns by the time it's
+    // its turn, not a snapshot taken at enqueue time — mirrors sayInChannel rechecking the
+    // connection itself for the same reason.
+    let privileged = false;
+    const send = vi.fn().mockResolvedValue(undefined);
+
+    await throttledTwitchSend('streamer', () => false, send); // occupies the channel floor
+    const second = throttledTwitchSend('streamer', () => privileged, send);
+    privileged = true; // flips before the queued call is actually evaluated
+
+    await vi.advanceTimersByTimeAsync(0);
+    await second; // no channel-floor wait, since it now runs as privileged
+    expect(send).toHaveBeenCalledTimes(2);
   });
 
   // ─── Shared 30s window ──────────────────────────────────────────────────────
@@ -36,7 +52,7 @@ describe('throttledTwitchSend', () => {
   it('lets a non-privileged send run up to the 20-message limit without delay (spread across channels to dodge the per-channel floor)', async () => {
     const send = vi.fn().mockResolvedValue(undefined);
     for (let i = 0; i < NON_PRIVILEGED_LIMIT; i++) {
-      await throttledTwitchSend(`streamer-${i}`, false, send);
+      await throttledTwitchSend(`streamer-${i}`, () => false, send);
     }
     expect(send).toHaveBeenCalledTimes(NON_PRIVILEGED_LIMIT);
   });
@@ -44,10 +60,10 @@ describe('throttledTwitchSend', () => {
   it('delays a non-privileged send past the 20-message limit until the window rolls', async () => {
     const send = vi.fn().mockResolvedValue(undefined);
     for (let i = 0; i < NON_PRIVILEGED_LIMIT; i++) {
-      await throttledTwitchSend(`streamer-${i}`, false, send);
+      await throttledTwitchSend(`streamer-${i}`, () => false, send);
     }
 
-    const next = throttledTwitchSend('streamer-overflow', false, send);
+    const next = throttledTwitchSend('streamer-overflow', () => false, send);
     await vi.advanceTimersByTimeAsync(WINDOW_MS - 1);
     expect(send).toHaveBeenCalledTimes(NON_PRIVILEGED_LIMIT);
 
@@ -64,7 +80,7 @@ describe('throttledTwitchSend', () => {
   it('delays a privileged send past the 100-message ceiling until the window rolls', async () => {
     const send = await fillWindow('streamer', true, PRIVILEGED_LIMIT);
 
-    const next = throttledTwitchSend('streamer', true, send);
+    const next = throttledTwitchSend('streamer', () => true, send);
     await vi.advanceTimersByTimeAsync(WINDOW_MS - 1);
     expect(send).toHaveBeenCalledTimes(PRIVILEGED_LIMIT);
 
@@ -79,7 +95,7 @@ describe('throttledTwitchSend', () => {
     await fillWindow('streamer-a', true, NON_PRIVILEGED_LIMIT + 1);
 
     const send = vi.fn().mockResolvedValue(undefined);
-    const blocked = throttledTwitchSend('streamer-b', false, send);
+    const blocked = throttledTwitchSend('streamer-b', () => false, send);
     await vi.advanceTimersByTimeAsync(WINDOW_MS - 1);
     expect(send).not.toHaveBeenCalled();
 
@@ -92,9 +108,9 @@ describe('throttledTwitchSend', () => {
 
   it('delays a second non-privileged send to the same channel within 1s, even with the shared window nowhere near its limit', async () => {
     const send = vi.fn().mockResolvedValue(undefined);
-    await throttledTwitchSend('streamer', false, send);
+    await throttledTwitchSend('streamer', () => false, send);
 
-    const next = throttledTwitchSend('streamer', false, send);
+    const next = throttledTwitchSend('streamer', () => false, send);
     await vi.advanceTimersByTimeAsync(CHANNEL_FLOOR_MS - 1);
     expect(send).toHaveBeenCalledTimes(1);
 
@@ -105,15 +121,15 @@ describe('throttledTwitchSend', () => {
 
   it('does not apply the per-channel floor to different channels', async () => {
     const send = vi.fn().mockResolvedValue(undefined);
-    await throttledTwitchSend('streamer-a', false, send);
-    await throttledTwitchSend('streamer-b', false, send);
+    await throttledTwitchSend('streamer-a', () => false, send);
+    await throttledTwitchSend('streamer-b', () => false, send);
     expect(send).toHaveBeenCalledTimes(2);
   });
 
   it('exempts privileged sends from the per-channel floor', async () => {
     const send = vi.fn().mockResolvedValue(undefined);
-    await throttledTwitchSend('streamer', true, send);
-    await throttledTwitchSend('streamer', true, send);
+    await throttledTwitchSend('streamer', () => true, send);
+    await throttledTwitchSend('streamer', () => true, send);
     expect(send).toHaveBeenCalledTimes(2);
   });
 
@@ -123,9 +139,9 @@ describe('throttledTwitchSend', () => {
     const order: string[] = [];
     const makeSend = (label: string) => vi.fn().mockImplementation(async () => { order.push(label); });
 
-    const p1 = throttledTwitchSend('streamer-a', true, makeSend('a'));
-    const p2 = throttledTwitchSend('streamer-b', false, makeSend('b'));
-    const p3 = throttledTwitchSend('streamer-c', true, makeSend('c'));
+    const p1 = throttledTwitchSend('streamer-a', () => true, makeSend('a'));
+    const p2 = throttledTwitchSend('streamer-b', () => false, makeSend('b'));
+    const p3 = throttledTwitchSend('streamer-c', () => true, makeSend('c'));
 
     await Promise.all([p1, p2, p3]);
     expect(order).toEqual(['a', 'b', 'c']);
@@ -133,14 +149,14 @@ describe('throttledTwitchSend', () => {
 
   it('still consumes a window slot when the send itself fails, so a failure cannot be used to dodge the limit', async () => {
     for (let i = 0; i < NON_PRIVILEGED_LIMIT - 1; i++) {
-      await throttledTwitchSend(`streamer-${i}`, false, vi.fn().mockResolvedValue(undefined));
+      await throttledTwitchSend(`streamer-${i}`, () => false, vi.fn().mockResolvedValue(undefined));
     }
     await expect(
-      throttledTwitchSend('streamer-fail', false, vi.fn().mockRejectedValue(new Error('boom'))),
+      throttledTwitchSend('streamer-fail', () => false, vi.fn().mockRejectedValue(new Error('boom'))),
     ).rejects.toThrow('boom');
 
     const send = vi.fn().mockResolvedValue(undefined);
-    const blocked = throttledTwitchSend('streamer-overflow', false, send);
+    const blocked = throttledTwitchSend('streamer-overflow', () => false, send);
     await vi.advanceTimersByTimeAsync(WINDOW_MS - 1);
     expect(send).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(1);
@@ -155,10 +171,10 @@ describe('throttledTwitchSend', () => {
     // Attach the rejection assertion before advancing timers, so the promise has a handler
     // already registered before it actually rejects (avoids a spurious unhandled-rejection
     // warning from the gap between rejecting and a handler being attached).
-    const hungRejection = expect(throttledTwitchSend('streamer-a', false, hanging)).rejects.toThrow(/timed out/i);
+    const hungRejection = expect(throttledTwitchSend('streamer-a', () => false, hanging)).rejects.toThrow(/timed out/i);
 
     const next = vi.fn().mockResolvedValue(undefined);
-    const nextCall = throttledTwitchSend('streamer-b', false, next);
+    const nextCall = throttledTwitchSend('streamer-b', () => false, next);
 
     await vi.advanceTimersByTimeAsync(10_000);
     await hungRejection;
@@ -171,7 +187,7 @@ describe('throttledTwitchSend', () => {
     const send = vi.fn().mockImplementation(async () => {
       await new Promise((resolve) => setTimeout(resolve, 5_000));
     });
-    const call = throttledTwitchSend('streamer', false, send);
+    const call = throttledTwitchSend('streamer', () => false, send);
     await vi.advanceTimersByTimeAsync(5_000);
     await expect(call).resolves.toBeUndefined();
   });

--- a/src/twitch/twitchSendQueue.ts
+++ b/src/twitch/twitchSendQueue.ts
@@ -1,0 +1,48 @@
+import { createMutationQueue } from '../shared/mutationQueue';
+
+/**
+ * Minimum spacing enforced between two outgoing chat sends to the same channel. Twitch's
+ * standard (non-moderator) chat rate limit is 20 messages per 30 seconds per channel — 1.5s
+ * spacing keeps every channel comfortably under that regardless of whether the bot happens to
+ * be a moderator there. Shared by every feature that posts to Twitch chat (custom commands,
+ * counters, shoutouts, timers, EventSub messages, etc.) via {@link sayInChannel} in `twitchBot.ts`,
+ * so a burst from one feature can't starve or rate-limit another posting to the same channel.
+ */
+const MIN_SEND_INTERVAL_MS = 1_500;
+
+// Per-channel FIFO ordering — sends to the same channel are serialized and spaced out; sends
+// to different channels run fully independently and are never delayed by each other.
+const channelQueue = createMutationQueue<string>();
+
+// Tracks the next scheduled send slot per channel, keyed off the schedule itself rather than
+// actual send completion time, so a slow/failed send doesn't shrink the spacing of the sends
+// queued behind it.
+const nextAllowedAt = new Map<string, number>();
+
+/** Resolves after `ms` milliseconds. */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => { setTimeout(resolve, ms); });
+}
+
+/**
+ * Runs `send` for `channel`, delaying it as needed so sends to the same channel never happen
+ * closer together than {@link MIN_SEND_INTERVAL_MS}. Queued per channel — a call returns only
+ * once it's actually run (send succeeded or threw), and calls for the same channel always run
+ * in the order they were enqueued.
+ * @param channel - Normalized Twitch channel name the send is targeting.
+ * @param send - Performs the actual send. Rejecting doesn't affect the timing of later queued sends.
+ */
+export async function throttledChannelSend(channel: string, send: () => Promise<void>): Promise<void> {
+  await channelQueue.run(channel, async () => {
+    const now = Date.now();
+    const scheduledAt = Math.max(now, nextAllowedAt.get(channel) ?? 0);
+    if (scheduledAt > now) await delay(scheduledAt - now);
+    nextAllowedAt.set(channel, scheduledAt + MIN_SEND_INTERVAL_MS);
+    await send();
+  });
+}
+
+/** Test-only: clears all per-channel send-timing state so each test starts from a clean slate. */
+export function __resetTwitchSendQueueForTests(): void {
+  nextAllowedAt.clear();
+}

--- a/src/twitch/twitchSendQueue.ts
+++ b/src/twitch/twitchSendQueue.ts
@@ -1,31 +1,43 @@
 import { createMutationQueue } from '../shared/mutationQueue';
 
 /**
- * Twitch enforces its chat message rate limits as two token buckets *per bot account*, shared
- * across every channel the bot posts to — not one bucket per channel. Every outgoing message
- * draws from the moderator bucket, whether or not the bot is privileged (moderator/VIP/
- * broadcaster) in the target channel. A message to a channel where the bot is *not* privileged
- * also draws from the smaller user bucket. That means a burst of privileged sends can leave too
- * few moderator-bucket tokens for a following non-privileged send, even though the user bucket
- * itself still has room — a per-channel spacing limiter can't express that shared contention,
- * so this models both buckets as rolling 30s windows shared globally instead.
+ * Twitch's chat message rate limits (dev.twitch.tv/docs/irc/#rate-limits), per bot account,
+ * shared across every channel the bot posts to — not one allowance per channel:
+ *
+ * - A single rolling 30s window counts every outgoing message, whether the bot is privileged
+ *   (moderator/VIP/broadcaster) in the target channel or not — privileged sends still add to
+ *   the same count non-privileged sends do.
+ * - A non-privileged send is blocked once that count reaches 20 in the window.
+ * - A privileged send is *not* blocked by that 20 threshold — it still adds to the same count,
+ *   but keeps being allowed until the count reaches the higher ceiling of 100.
+ * - Separately, a non-privileged send is capped at 1 message per second *per channel*
+ *   (privileged sends are exempt), regardless of how much room the 30s window has left.
+ *
+ * One consequence: a burst of privileged sends can push the shared 30s count past 20, which
+ * then blocks a *non*-privileged send to a completely different channel even though that
+ * channel's own per-second floor is untouched — the count is shared account-wide, not scoped
+ * to either channel.
  */
-const BUCKET_WINDOW_MS = 30_000;
+const WINDOW_MS = 30_000;
 
-/** Consumed by every send, privileged or not — Twitch's 100-messages-per-30s moderator/VIP/broadcaster limit. */
-const MODERATOR_BUCKET_CAPACITY = 100;
+/** Blocks a non-privileged send once the shared 30s count reaches this. */
+const NON_PRIVILEGED_LIMIT = 20;
 
-/** Consumed only by sends to a channel where the bot isn't privileged there — Twitch's 20-messages-per-30s limit. */
-const USER_BUCKET_CAPACITY = 20;
+/** Blocks a privileged send once the shared 30s count reaches this — privileged sends aren't blocked by {@link NON_PRIVILEGED_LIMIT}. */
+const PRIVILEGED_LIMIT = 100;
 
-/** Timestamps (epoch ms) of sends counted in the moderator bucket's current rolling window. */
-let moderatorBucketTimestamps: number[] = [];
-/** Timestamps (epoch ms) of sends counted in the user bucket's current rolling window. */
-let userBucketTimestamps: number[] = [];
+/** Minimum spacing between two non-privileged sends to the same channel, independent of the shared 30s count. */
+const NON_PRIVILEGED_CHANNEL_FLOOR_MS = 1_000;
 
-// Twitch's buckets are per-account, not per-channel, so every send — regardless of target
-// channel — contends for the same tokens. A single global queue serializes them; this also
-// guarantees sends are never reordered relative to each other, including across channels.
+/** Timestamps (epoch ms) of every send — privileged or not — counted in the current rolling window. */
+let sentTimestamps: number[] = [];
+
+/** Per-channel timestamp of the most recent non-privileged send, for {@link NON_PRIVILEGED_CHANNEL_FLOOR_MS}. */
+const lastNonPrivilegedSendAtByChannel = new Map<string, number>();
+
+// Twitch's rate limit is per-account, not per-channel, so every send — regardless of target
+// channel — contends for the same shared count. A single global queue serializes them; this
+// also guarantees sends are never reordered relative to each other, including across channels.
 const globalQueue = createMutationQueue<'global'>();
 
 /** Resolves after `ms` milliseconds. */
@@ -33,51 +45,58 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => { setTimeout(resolve, ms); });
 }
 
-/** Drops entries older than the rolling window from `timestamps` (mutated in place). */
-function pruneExpired(timestamps: number[], now: number): void {
-  while (timestamps.length > 0 && now - timestamps[0] >= BUCKET_WINDOW_MS) {
-    timestamps.shift();
+/** Drops entries older than the rolling window from {@link sentTimestamps} (mutated in place). */
+function pruneExpired(now: number): void {
+  while (sentTimestamps.length > 0 && now - sentTimestamps[0] >= WINDOW_MS) {
+    sentTimestamps.shift();
   }
 }
 
 /**
- * Waits until `timestamps` has room for one more entry under `capacity`, pruning expired
- * entries first and re-checking after however long the oldest remaining entry takes to age out
- * of the rolling window.
+ * Waits until the shared 30s window has room for one more send under `limit`, pruning expired
+ * entries first and re-checking after however long the oldest remaining entry takes to age out.
  */
-async function waitForBucketRoom(timestamps: number[], capacity: number): Promise<void> {
+async function waitForWindowRoom(limit: number): Promise<void> {
   for (;;) {
     const now = Date.now();
-    pruneExpired(timestamps, now);
-    if (timestamps.length < capacity) return;
-    await delay(BUCKET_WINDOW_MS - (now - timestamps[0]));
+    pruneExpired(now);
+    if (sentTimestamps.length < limit) return;
+    await delay(WINDOW_MS - (now - sentTimestamps[0]));
   }
 }
 
+/** Waits, if needed, so a non-privileged send to `channel` respects {@link NON_PRIVILEGED_CHANNEL_FLOOR_MS}. */
+async function waitForChannelFloor(channel: string): Promise<void> {
+  const last = lastNonPrivilegedSendAtByChannel.get(channel);
+  if (last === undefined) return;
+  const elapsed = Date.now() - last;
+  if (elapsed < NON_PRIVILEGED_CHANNEL_FLOOR_MS) await delay(NON_PRIVILEGED_CHANNEL_FLOOR_MS - elapsed);
+}
+
 /**
- * Runs `send`, waiting as needed for Twitch's global per-account rate-limit buckets to have
- * room first (see the module doc for how the two buckets interact). Every call draws from the
- * moderator bucket; a call for a channel where the bot isn't privileged there also draws from
- * the user bucket. Calls are serialized on a single global queue, so they always run in the
- * order they were enqueued, regardless of which channel each one targets.
- * @param isPrivileged - Whether the bot currently has moderator/VIP/broadcaster status in the channel being sent to.
+ * Runs `send` for `channel`, waiting as needed for Twitch's global per-account rate limit to
+ * have room first (see the module doc for exactly how the shared window and per-channel floor
+ * interact). Calls are serialized on a single global queue, so they always run in the order
+ * they were enqueued, regardless of which channel each one targets.
+ * @param channel - Normalized Twitch channel name the send is targeting.
+ * @param isPrivileged - Whether the bot currently has moderator/VIP/broadcaster status in `channel`.
  * @param send - Performs the actual send. Rejecting doesn't affect the timing of later queued sends.
  */
-export async function throttledTwitchSend(isPrivileged: boolean, send: () => Promise<void>): Promise<void> {
+export async function throttledTwitchSend(channel: string, isPrivileged: boolean, send: () => Promise<void>): Promise<void> {
   await globalQueue.run('global', async () => {
-    await waitForBucketRoom(moderatorBucketTimestamps, MODERATOR_BUCKET_CAPACITY);
-    if (!isPrivileged) await waitForBucketRoom(userBucketTimestamps, USER_BUCKET_CAPACITY);
+    await waitForWindowRoom(isPrivileged ? PRIVILEGED_LIMIT : NON_PRIVILEGED_LIMIT);
+    if (!isPrivileged) await waitForChannelFloor(channel);
 
     const sentAt = Date.now();
-    moderatorBucketTimestamps.push(sentAt);
-    if (!isPrivileged) userBucketTimestamps.push(sentAt);
+    sentTimestamps.push(sentAt);
+    if (!isPrivileged) lastNonPrivilegedSendAtByChannel.set(channel, sentAt);
 
     await send();
   });
 }
 
-/** Test-only: clears both rate-limit buckets so each test starts from a clean slate. */
+/** Test-only: clears all rate-limit state so each test starts from a clean slate. */
 export function __resetTwitchSendQueueForTests(): void {
-  moderatorBucketTimestamps = [];
-  userBucketTimestamps = [];
+  sentTimestamps = [];
+  lastNonPrivilegedSendAtByChannel.clear();
 }

--- a/src/twitch/twitchSendQueue.ts
+++ b/src/twitch/twitchSendQueue.ts
@@ -29,6 +29,14 @@ const PRIVILEGED_LIMIT = 100;
 /** Minimum spacing between two non-privileged sends to the same channel, independent of the shared 30s count. */
 const NON_PRIVILEGED_CHANNEL_FLOOR_MS = 1_000;
 
+/**
+ * Every send in this module runs behind a single global queue, so one stalled `send()` (tmi.js's
+ * `client.say()` has no built-in timeout and can hang indefinitely on a stalled socket) would
+ * otherwise wedge every later send, across every channel and feature, forever. Bounding it here
+ * guarantees the queue always frees up, even though the underlying send may still be stuck.
+ */
+const SEND_TIMEOUT_MS = 10_000;
+
 /** Timestamps (epoch ms) of every send — privileged or not — counted in the current rolling window. */
 let sentTimestamps: number[] = [];
 
@@ -74,13 +82,30 @@ async function waitForChannelFloor(channel: string): Promise<void> {
 }
 
 /**
+ * Races `promise` against a `ms`-millisecond timeout, rejecting with a timeout error if it
+ * doesn't settle in time. `promise` itself is left running — its eventual settlement is still
+ * observed (and silently ignored) so it can never surface as an unhandled rejection later.
+ */
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`Twitch send timed out after ${ms}ms`)), ms);
+    promise.then(
+      (value) => { clearTimeout(timer); resolve(value); },
+      (err) => { clearTimeout(timer); reject(err); },
+    );
+  });
+}
+
+/**
  * Runs `send` for `channel`, waiting as needed for Twitch's global per-account rate limit to
  * have room first (see the module doc for exactly how the shared window and per-channel floor
  * interact). Calls are serialized on a single global queue, so they always run in the order
  * they were enqueued, regardless of which channel each one targets.
  * @param channel - Normalized Twitch channel name the send is targeting.
  * @param isPrivileged - Whether the bot currently has moderator/VIP/broadcaster status in `channel`.
- * @param send - Performs the actual send. Rejecting doesn't affect the timing of later queued sends.
+ * @param send - Performs the actual send, bounded by {@link SEND_TIMEOUT_MS} so a stalled send
+ *   can't wedge the queue forever. Rejecting (including via that timeout) doesn't affect the
+ *   timing of later queued sends.
  */
 export async function throttledTwitchSend(channel: string, isPrivileged: boolean, send: () => Promise<void>): Promise<void> {
   await globalQueue.run('global', async () => {
@@ -91,7 +116,7 @@ export async function throttledTwitchSend(channel: string, isPrivileged: boolean
     sentTimestamps.push(sentAt);
     if (!isPrivileged) lastNonPrivilegedSendAtByChannel.set(channel, sentAt);
 
-    await send();
+    await withTimeout(send(), SEND_TIMEOUT_MS);
   });
 }
 

--- a/src/twitch/twitchSendQueue.ts
+++ b/src/twitch/twitchSendQueue.ts
@@ -109,7 +109,9 @@ function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
  * @param isPrivileged - Resolves whether the bot currently has moderator/VIP/broadcaster status
  *   in `channel`. Called right before the window/floor checks (not at enqueue time), since this
  *   call may have been waiting behind others — the same reason `send` rechecks the connection
- *   itself rather than trusting a snapshot taken before it was queued.
+ *   itself rather than trusting a snapshot taken before it was queued. Re-checked again after
+ *   each wait and the checks re-run under the refreshed status if it changed, since the wait
+ *   itself (up to the full 30s window) is another window for status to change again.
  * @param send - Performs the actual send, bounded by {@link SEND_TIMEOUT_MS} so a stalled send
  *   can't wedge the queue forever. Rejecting (including via that timeout) doesn't affect the
  *   timing of later queued sends.
@@ -118,9 +120,18 @@ function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
  */
 export async function throttledTwitchSend(channel: string, isPrivileged: () => boolean, send: () => Promise<void>): Promise<void> {
   await globalQueue.run('global', async () => {
-    const privileged = isPrivileged();
-    await waitForWindowRoom(privileged ? PRIVILEGED_LIMIT : NON_PRIVILEGED_LIMIT);
-    if (!privileged) await waitForChannelFloor(channel);
+    let privileged = isPrivileged();
+    for (;;) {
+      await waitForWindowRoom(privileged ? PRIVILEGED_LIMIT : NON_PRIVILEGED_LIMIT);
+      if (!privileged) await waitForChannelFloor(channel);
+
+      // The wait above can itself take a while (up to the full 30s window), so status may have
+      // changed again while waiting. Loop under the refreshed status until a pass finds it
+      // unchanged from what it started with — i.e. nothing to re-wait for.
+      const recheck = isPrivileged();
+      if (recheck === privileged) break;
+      privileged = recheck;
+    }
 
     const sentAt = Date.now();
     sentTimestamps.push(sentAt);

--- a/src/twitch/twitchSendQueue.ts
+++ b/src/twitch/twitchSendQueue.ts
@@ -1,14 +1,18 @@
 import { createMutationQueue } from '../shared/mutationQueue';
 
 /**
- * Minimum spacing enforced between two outgoing chat sends to the same channel. Twitch's
- * standard (non-moderator) chat rate limit is 20 messages per 30 seconds per channel — 1.5s
- * spacing keeps every channel comfortably under that regardless of whether the bot happens to
- * be a moderator there. Shared by every feature that posts to Twitch chat (custom commands,
- * counters, shoutouts, timers, EventSub messages, etc.) via {@link sayInChannel} in `twitchBot.ts`,
- * so a burst from one feature can't starve or rate-limit another posting to the same channel.
+ * Minimum spacing enforced between two outgoing chat sends to a channel where the bot is *not*
+ * a moderator. Twitch's standard chat rate limit there is 20 messages per 30 seconds per
+ * channel — 1.5s spacing keeps it comfortably under that.
  */
-const MIN_SEND_INTERVAL_MS = 1_500;
+export const NON_MOD_MIN_SEND_INTERVAL_MS = 1_500;
+
+/**
+ * Minimum spacing enforced between two outgoing chat sends to a channel where the bot *is* a
+ * moderator (or the broadcaster). Twitch's elevated chat rate limit there is 100 messages per
+ * 30 seconds per channel — 300ms spacing keeps it comfortably under that.
+ */
+export const MOD_MIN_SEND_INTERVAL_MS = 300;
 
 // Per-channel FIFO ordering — sends to the same channel are serialized and spaced out; sends
 // to different channels run fully independently and are never delayed by each other.
@@ -26,18 +30,21 @@ function delay(ms: number): Promise<void> {
 
 /**
  * Runs `send` for `channel`, delaying it as needed so sends to the same channel never happen
- * closer together than {@link MIN_SEND_INTERVAL_MS}. Queued per channel — a call returns only
- * once it's actually run (send succeeded or threw), and calls for the same channel always run
- * in the order they were enqueued.
+ * closer together than `minIntervalMs`. Queued per channel — a call returns only once it's
+ * actually run (send succeeded or threw), and calls for the same channel always run in the
+ * order they were enqueued. Callers pick `minIntervalMs` per call (e.g. based on the bot's
+ * current moderator status in that channel — see {@link NON_MOD_MIN_SEND_INTERVAL_MS} and
+ * {@link MOD_MIN_SEND_INTERVAL_MS}), so a status change takes effect from the next send onward.
  * @param channel - Normalized Twitch channel name the send is targeting.
  * @param send - Performs the actual send. Rejecting doesn't affect the timing of later queued sends.
+ * @param minIntervalMs - Minimum spacing to enforce after this send before the next one for `channel`.
  */
-export async function throttledChannelSend(channel: string, send: () => Promise<void>): Promise<void> {
+export async function throttledChannelSend(channel: string, send: () => Promise<void>, minIntervalMs: number): Promise<void> {
   await channelQueue.run(channel, async () => {
     const now = Date.now();
     const scheduledAt = Math.max(now, nextAllowedAt.get(channel) ?? 0);
     if (scheduledAt > now) await delay(scheduledAt - now);
-    nextAllowedAt.set(channel, scheduledAt + MIN_SEND_INTERVAL_MS);
+    nextAllowedAt.set(channel, scheduledAt + minIntervalMs);
     await send();
   });
 }

--- a/src/twitch/twitchSendQueue.ts
+++ b/src/twitch/twitchSendQueue.ts
@@ -106,21 +106,25 @@ function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
  * interact). Calls are serialized on a single global queue, so they always run in the order
  * they were enqueued, regardless of which channel each one targets.
  * @param channel - Normalized Twitch channel name the send is targeting.
- * @param isPrivileged - Whether the bot currently has moderator/VIP/broadcaster status in `channel`.
+ * @param isPrivileged - Resolves whether the bot currently has moderator/VIP/broadcaster status
+ *   in `channel`. Called right before the window/floor checks (not at enqueue time), since this
+ *   call may have been waiting behind others — the same reason `send` rechecks the connection
+ *   itself rather than trusting a snapshot taken before it was queued.
  * @param send - Performs the actual send, bounded by {@link SEND_TIMEOUT_MS} so a stalled send
  *   can't wedge the queue forever. Rejecting (including via that timeout) doesn't affect the
  *   timing of later queued sends.
  * @returns Resolves once `send` has actually run and settled (successfully or not); rejects with
  *   whatever `send` rejected with, including a timeout error if it didn't settle in time.
  */
-export async function throttledTwitchSend(channel: string, isPrivileged: boolean, send: () => Promise<void>): Promise<void> {
+export async function throttledTwitchSend(channel: string, isPrivileged: () => boolean, send: () => Promise<void>): Promise<void> {
   await globalQueue.run('global', async () => {
-    await waitForWindowRoom(isPrivileged ? PRIVILEGED_LIMIT : NON_PRIVILEGED_LIMIT);
-    if (!isPrivileged) await waitForChannelFloor(channel);
+    const privileged = isPrivileged();
+    await waitForWindowRoom(privileged ? PRIVILEGED_LIMIT : NON_PRIVILEGED_LIMIT);
+    if (!privileged) await waitForChannelFloor(channel);
 
     const sentAt = Date.now();
     sentTimestamps.push(sentAt);
-    if (!isPrivileged) lastNonPrivilegedSendAtByChannel.set(channel, sentAt);
+    if (!privileged) lastNonPrivilegedSendAtByChannel.set(channel, sentAt);
 
     await withTimeout(send(), SEND_TIMEOUT_MS);
   });

--- a/src/twitch/twitchSendQueue.ts
+++ b/src/twitch/twitchSendQueue.ts
@@ -1,55 +1,83 @@
 import { createMutationQueue } from '../shared/mutationQueue';
 
 /**
- * Minimum spacing enforced between two outgoing chat sends to a channel where the bot is *not*
- * a moderator. Twitch's standard chat rate limit there is 20 messages per 30 seconds per
- * channel — 1.5s spacing keeps it comfortably under that.
+ * Twitch enforces its chat message rate limits as two token buckets *per bot account*, shared
+ * across every channel the bot posts to — not one bucket per channel. Every outgoing message
+ * draws from the moderator bucket, whether or not the bot is privileged (moderator/VIP/
+ * broadcaster) in the target channel. A message to a channel where the bot is *not* privileged
+ * also draws from the smaller user bucket. That means a burst of privileged sends can leave too
+ * few moderator-bucket tokens for a following non-privileged send, even though the user bucket
+ * itself still has room — a per-channel spacing limiter can't express that shared contention,
+ * so this models both buckets as rolling 30s windows shared globally instead.
  */
-export const NON_MOD_MIN_SEND_INTERVAL_MS = 1_500;
+const BUCKET_WINDOW_MS = 30_000;
 
-/**
- * Minimum spacing enforced between two outgoing chat sends to a channel where the bot *is* a
- * moderator (or the broadcaster). Twitch's elevated chat rate limit there is 100 messages per
- * 30 seconds per channel — 300ms spacing keeps it comfortably under that.
- */
-export const MOD_MIN_SEND_INTERVAL_MS = 300;
+/** Consumed by every send, privileged or not — Twitch's 100-messages-per-30s moderator/VIP/broadcaster limit. */
+const MODERATOR_BUCKET_CAPACITY = 100;
 
-// Per-channel FIFO ordering — sends to the same channel are serialized and spaced out; sends
-// to different channels run fully independently and are never delayed by each other.
-const channelQueue = createMutationQueue<string>();
+/** Consumed only by sends to a channel where the bot isn't privileged there — Twitch's 20-messages-per-30s limit. */
+const USER_BUCKET_CAPACITY = 20;
 
-// Tracks the next scheduled send slot per channel, keyed off the schedule itself rather than
-// actual send completion time, so a slow/failed send doesn't shrink the spacing of the sends
-// queued behind it.
-const nextAllowedAt = new Map<string, number>();
+/** Timestamps (epoch ms) of sends counted in the moderator bucket's current rolling window. */
+let moderatorBucketTimestamps: number[] = [];
+/** Timestamps (epoch ms) of sends counted in the user bucket's current rolling window. */
+let userBucketTimestamps: number[] = [];
+
+// Twitch's buckets are per-account, not per-channel, so every send — regardless of target
+// channel — contends for the same tokens. A single global queue serializes them; this also
+// guarantees sends are never reordered relative to each other, including across channels.
+const globalQueue = createMutationQueue<'global'>();
 
 /** Resolves after `ms` milliseconds. */
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => { setTimeout(resolve, ms); });
 }
 
+/** Drops entries older than the rolling window from `timestamps` (mutated in place). */
+function pruneExpired(timestamps: number[], now: number): void {
+  while (timestamps.length > 0 && now - timestamps[0] >= BUCKET_WINDOW_MS) {
+    timestamps.shift();
+  }
+}
+
 /**
- * Runs `send` for `channel`, delaying it as needed so sends to the same channel never happen
- * closer together than `minIntervalMs`. Queued per channel — a call returns only once it's
- * actually run (send succeeded or threw), and calls for the same channel always run in the
- * order they were enqueued. Callers pick `minIntervalMs` per call (e.g. based on the bot's
- * current moderator status in that channel — see {@link NON_MOD_MIN_SEND_INTERVAL_MS} and
- * {@link MOD_MIN_SEND_INTERVAL_MS}), so a status change takes effect from the next send onward.
- * @param channel - Normalized Twitch channel name the send is targeting.
- * @param send - Performs the actual send. Rejecting doesn't affect the timing of later queued sends.
- * @param minIntervalMs - Minimum spacing to enforce after this send before the next one for `channel`.
+ * Waits until `timestamps` has room for one more entry under `capacity`, pruning expired
+ * entries first and re-checking after however long the oldest remaining entry takes to age out
+ * of the rolling window.
  */
-export async function throttledChannelSend(channel: string, send: () => Promise<void>, minIntervalMs: number): Promise<void> {
-  await channelQueue.run(channel, async () => {
+async function waitForBucketRoom(timestamps: number[], capacity: number): Promise<void> {
+  for (;;) {
     const now = Date.now();
-    const scheduledAt = Math.max(now, nextAllowedAt.get(channel) ?? 0);
-    if (scheduledAt > now) await delay(scheduledAt - now);
-    nextAllowedAt.set(channel, scheduledAt + minIntervalMs);
+    pruneExpired(timestamps, now);
+    if (timestamps.length < capacity) return;
+    await delay(BUCKET_WINDOW_MS - (now - timestamps[0]));
+  }
+}
+
+/**
+ * Runs `send`, waiting as needed for Twitch's global per-account rate-limit buckets to have
+ * room first (see the module doc for how the two buckets interact). Every call draws from the
+ * moderator bucket; a call for a channel where the bot isn't privileged there also draws from
+ * the user bucket. Calls are serialized on a single global queue, so they always run in the
+ * order they were enqueued, regardless of which channel each one targets.
+ * @param isPrivileged - Whether the bot currently has moderator/VIP/broadcaster status in the channel being sent to.
+ * @param send - Performs the actual send. Rejecting doesn't affect the timing of later queued sends.
+ */
+export async function throttledTwitchSend(isPrivileged: boolean, send: () => Promise<void>): Promise<void> {
+  await globalQueue.run('global', async () => {
+    await waitForBucketRoom(moderatorBucketTimestamps, MODERATOR_BUCKET_CAPACITY);
+    if (!isPrivileged) await waitForBucketRoom(userBucketTimestamps, USER_BUCKET_CAPACITY);
+
+    const sentAt = Date.now();
+    moderatorBucketTimestamps.push(sentAt);
+    if (!isPrivileged) userBucketTimestamps.push(sentAt);
+
     await send();
   });
 }
 
-/** Test-only: clears all per-channel send-timing state so each test starts from a clean slate. */
+/** Test-only: clears both rate-limit buckets so each test starts from a clean slate. */
 export function __resetTwitchSendQueueForTests(): void {
-  nextAllowedAt.clear();
+  moderatorBucketTimestamps = [];
+  userBucketTimestamps = [];
 }

--- a/src/twitch/twitchSendQueue.ts
+++ b/src/twitch/twitchSendQueue.ts
@@ -85,6 +85,10 @@ async function waitForChannelFloor(channel: string): Promise<void> {
  * Races `promise` against a `ms`-millisecond timeout, rejecting with a timeout error if it
  * doesn't settle in time. `promise` itself is left running — its eventual settlement is still
  * observed (and silently ignored) so it can never surface as an unhandled rejection later.
+ * @param promise - The promise to bound.
+ * @param ms - Milliseconds to wait before rejecting with a timeout error.
+ * @returns `promise`'s resolved value if it settles first; otherwise rejects with `promise`'s
+ *   own rejection reason, or a timeout error if neither happens within `ms`.
  */
 function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   return new Promise<T>((resolve, reject) => {
@@ -106,6 +110,8 @@ function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
  * @param send - Performs the actual send, bounded by {@link SEND_TIMEOUT_MS} so a stalled send
  *   can't wedge the queue forever. Rejecting (including via that timeout) doesn't affect the
  *   timing of later queued sends.
+ * @returns Resolves once `send` has actually run and settled (successfully or not); rejects with
+ *   whatever `send` rejected with, including a timeout error if it didn't settle in time.
  */
 export async function throttledTwitchSend(channel: string, isPrivileged: boolean, send: () => Promise<void>): Promise<void> {
   await globalQueue.run('global', async () => {

--- a/src/web/routes/timersMutations.test.ts
+++ b/src/web/routes/timersMutations.test.ts
@@ -6,6 +6,7 @@ vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
 vi.mock('../../db', () => ({
   getStreamerByDiscordId: vi.fn(),
   addTimerCommand: vi.fn(),
+  countTimerCommandsForStreamer: vi.fn(),
   updateTimerCommand: vi.fn(),
   removeTimerCommand: vi.fn(),
   setTimerCommandEnabled: vi.fn(),
@@ -26,8 +27,8 @@ vi.mock('../middleware', () => ({
 import supertest from 'supertest';
 import router from './timersMutations';
 import {
-  getStreamerByDiscordId, addTimerCommand, updateTimerCommand, removeTimerCommand,
-  setTimerCommandEnabled, TimerCommandNotFoundError,
+  getStreamerByDiscordId, addTimerCommand, countTimerCommandsForStreamer, updateTimerCommand,
+  removeTimerCommand, setTimerCommandEnabled, TimerCommandNotFoundError,
 } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 
@@ -52,6 +53,7 @@ function buildApp(sessionUser: SessionUser = USER) {
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
+  vi.mocked(countTimerCommandsForStreamer).mockResolvedValue(0);
 });
 
 describe('POST /add', () => {
@@ -99,6 +101,27 @@ describe('POST /add', () => {
 
     const res = await supertest(buildApp()).post('/add').type('form').send(VALID_TIMER_FORM);
     expect(res.headers.location).toBe('/timers?error=add_failed');
+  });
+
+  it('redirects with timer_limit_reached and skips the insert when the streamer is already at the cap', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(countTimerCommandsForStreamer).mockResolvedValue(20);
+
+    const res = await supertest(buildApp()).post('/add').type('form').send(VALID_TIMER_FORM);
+
+    expect(res.headers.location).toBe('/timers?error=timer_limit_reached');
+    expect(addTimerCommand).not.toHaveBeenCalled();
+  });
+
+  it('allows the insert when the streamer is one below the cap', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(countTimerCommandsForStreamer).mockResolvedValue(19);
+    vi.mocked(addTimerCommand).mockResolvedValue(1);
+
+    const res = await supertest(buildApp()).post('/add').type('form').send(VALID_TIMER_FORM);
+
+    expect(res.headers.location).toBe('/timers?success=timer_added');
+    expect(addTimerCommand).toHaveBeenCalled();
   });
 });
 

--- a/src/web/routes/timersMutations.test.ts
+++ b/src/web/routes/timersMutations.test.ts
@@ -123,6 +123,24 @@ describe('POST /add', () => {
     expect(res.headers.location).toBe('/timers?success=timer_added');
     expect(addTimerCommand).toHaveBeenCalled();
   });
+
+  it('serializes concurrent requests for the same streamer so a race cannot exceed the cap', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    // Simulates the real DB: the count reflects however many inserts have actually landed so far.
+    let insertedCount = 19;
+    vi.mocked(countTimerCommandsForStreamer).mockImplementation(async () => insertedCount);
+    vi.mocked(addTimerCommand).mockImplementation(async () => { insertedCount += 1; return 1; });
+
+    const app = buildApp();
+    const [res1, res2] = await Promise.all([
+      supertest(app).post('/add').type('form').send(VALID_TIMER_FORM),
+      supertest(app).post('/add').type('form').send(VALID_TIMER_FORM),
+    ]);
+
+    const locations = [res1.headers.location, res2.headers.location].sort();
+    expect(locations).toEqual(['/timers?error=timer_limit_reached', '/timers?success=timer_added']);
+    expect(addTimerCommand).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('POST /update', () => {

--- a/src/web/routes/timersMutations.test.ts
+++ b/src/web/routes/timersMutations.test.ts
@@ -103,6 +103,15 @@ describe('POST /add', () => {
     expect(res.headers.location).toBe('/timers?error=add_failed');
   });
 
+  it('redirects with add_failed when the count check throws', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
+    vi.mocked(countTimerCommandsForStreamer).mockRejectedValue(new Error('db down'));
+
+    const res = await supertest(buildApp()).post('/add').type('form').send(VALID_TIMER_FORM);
+    expect(res.headers.location).toBe('/timers?error=add_failed');
+    expect(addTimerCommand).not.toHaveBeenCalled();
+  });
+
   it('redirects with timer_limit_reached and skips the insert when the streamer is already at the cap', async () => {
     vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
     vi.mocked(countTimerCommandsForStreamer).mockResolvedValue(20);

--- a/src/web/routes/timersMutations.ts
+++ b/src/web/routes/timersMutations.ts
@@ -1,8 +1,8 @@
 import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import {
-  addTimerCommand, updateTimerCommand, removeTimerCommand, setTimerCommandEnabled,
-  TimerCommandNotFoundError,
+  addTimerCommand, countTimerCommandsForStreamer, updateTimerCommand, removeTimerCommand,
+  setTimerCommandEnabled, TimerCommandNotFoundError,
 } from '../../db';
 import type { TimerCommandInput } from '../../db';
 import { csrfProtection } from '../csrf';
@@ -21,6 +21,13 @@ const NOT_A_STREAMER_REDIRECT = '/timers?error=not_a_streamer';
 const MIN_INTERVAL_SECONDS = 60;
 /** MySQL `INT` (4-byte signed) max — both `interval_seconds` and `min_messages` are stored in `INT` columns. */
 const MAX_INT_COLUMN_VALUE = 2147483647;
+/**
+ * Per-streamer cap on the number of timer commands, enforced in `/timers/add`. Every enabled
+ * timer across every streamer is processed on every ~15s scheduler tick, so this bounds that
+ * per-tick work rather than letting one streamer's rows (accidental duplicates, or a scripted
+ * client) grow it unboundedly.
+ */
+const MAX_TIMER_COMMANDS_PER_STREAMER = 20;
 
 /**
  * Parses a required interval-seconds form field: an integer of at least
@@ -83,8 +90,9 @@ function parseTimerCommandFields(body: Record<string, string | string[] | undefi
  *   `require_live`, `enabled` from `req.body`.
  * @param res - Express response; redirects to `/timers?success=timer_added` on success, or to
  *   `/timers?error=<code>` if the requester isn't a streamer (`not_a_streamer`), a field is
- *   invalid (`missing_fields`, `invalid_interval`, `invalid_min_messages`), or the insert fails
- *   (`add_failed`).
+ *   invalid (`missing_fields`, `invalid_interval`, `invalid_min_messages`), the streamer has
+ *   already reached {@link MAX_TIMER_COMMANDS_PER_STREAMER} timers (`timer_limit_reached`), or
+ *   the insert fails (`add_failed`).
  */
 router.post('/add', requireAuth, csrfProtection, async (req, res) => {
   try {
@@ -94,6 +102,11 @@ router.post('/add', requireAuth, csrfProtection, async (req, res) => {
     const body = req.body as Record<string, string | string[] | undefined>;
     const result = parseTimerCommandFields(body);
     if (!result.ok) return res.redirect(`/timers?error=${result.errorCode}`);
+
+    const existingCount = await countTimerCommandsForStreamer(streamer.id);
+    if (existingCount >= MAX_TIMER_COMMANDS_PER_STREAMER) {
+      return res.redirect('/timers?error=timer_limit_reached');
+    }
 
     await addTimerCommand(streamer.id, result.input);
     res.redirect('/timers?success=timer_added');

--- a/src/web/routes/timersMutations.ts
+++ b/src/web/routes/timersMutations.ts
@@ -7,6 +7,7 @@ import {
 import type { TimerCommandInput } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
+import { createMutationQueue } from '../../shared/mutationQueue';
 import {
   logAndRedirectError, normalizeRequiredText, parseCheckboxField, parsePositiveIntId,
   requireStreamer,
@@ -14,6 +15,13 @@ import {
 
 const log = createLogger('Web');
 const router = Router();
+
+/**
+ * Serializes the per-streamer timer count check and insert in `POST /timers/add` (keyed by
+ * streamer id), so two concurrent requests for the same streamer can't both read a count under
+ * {@link MAX_TIMER_COMMANDS_PER_STREAMER} and each insert, letting the cap be exceeded.
+ */
+const timerAddQueue = createMutationQueue<number>();
 
 /** Redirect target used when the requester isn't a streamer, scoped to the timers admin page. */
 const NOT_A_STREAMER_REDIRECT = '/timers?error=not_a_streamer';
@@ -85,14 +93,16 @@ function parseTimerCommandFields(body: Record<string, string | string[] | undefi
 }
 
 /**
- * POST /timers/add — creates a new timer command for the requesting streamer.
+ * POST /timers/add — creates a new timer command for the requesting streamer. The count check
+ * and insert are serialized per streamer through {@link timerAddQueue} so two concurrent
+ * requests can't both observe a count under the cap and each insert, exceeding it.
  * @param req - Express request; reads `name`, `message`, `interval_seconds`, `min_messages`,
  *   `require_live`, `enabled` from `req.body`.
  * @param res - Express response; redirects to `/timers?success=timer_added` on success, or to
  *   `/timers?error=<code>` if the requester isn't a streamer (`not_a_streamer`), a field is
  *   invalid (`missing_fields`, `invalid_interval`, `invalid_min_messages`), the streamer has
  *   already reached {@link MAX_TIMER_COMMANDS_PER_STREAMER} timers (`timer_limit_reached`), or
- *   the insert fails (`add_failed`).
+ *   the count check or insert fails (`add_failed`).
  */
 router.post('/add', requireAuth, csrfProtection, async (req, res) => {
   try {
@@ -103,12 +113,13 @@ router.post('/add', requireAuth, csrfProtection, async (req, res) => {
     const result = parseTimerCommandFields(body);
     if (!result.ok) return res.redirect(`/timers?error=${result.errorCode}`);
 
-    const existingCount = await countTimerCommandsForStreamer(streamer.id);
-    if (existingCount >= MAX_TIMER_COMMANDS_PER_STREAMER) {
-      return res.redirect('/timers?error=timer_limit_reached');
-    }
-
-    await addTimerCommand(streamer.id, result.input);
+    const added = await timerAddQueue.run(streamer.id, async () => {
+      const existingCount = await countTimerCommandsForStreamer(streamer.id);
+      if (existingCount >= MAX_TIMER_COMMANDS_PER_STREAMER) return false;
+      await addTimerCommand(streamer.id, result.input);
+      return true;
+    });
+    if (!added) return res.redirect('/timers?error=timer_limit_reached');
     res.redirect('/timers?success=timer_added');
   } catch (err) {
     logAndRedirectError({ res, log, logLabel: 'Add timer command error:', err, basePath: '/timers', errorCode: 'add_failed' });

--- a/src/web/routes/timersMutations.ts
+++ b/src/web/routes/timersMutations.ts
@@ -38,28 +38,17 @@ const MAX_INT_COLUMN_VALUE = 2147483647;
 const MAX_TIMER_COMMANDS_PER_STREAMER = 20;
 
 /**
- * Parses a required interval-seconds form field: an integer of at least
- * {@link MIN_INTERVAL_SECONDS} and at most the DB column's `INT` range, matching the DB's
- * `chk_timer_command_interval` check — validated here so a bad value redirects with a clear
- * `invalid_interval` code instead of surfacing as an opaque DB constraint/range failure.
+ * Parses a required numeric form field: an integer within `[min, max]`. Shared by both
+ * `interval_seconds` (matching the DB's `chk_timer_command_interval` check, `min` =
+ * {@link MIN_INTERVAL_SECONDS}) and `min_messages` (matching `chk_timer_command_min_messages`,
+ * `min` = 0, since "no minimum" is valid) — validated here so a bad value redirects with a
+ * clear error code instead of surfacing as an opaque DB constraint/range failure.
  */
-function parseIntervalSecondsField(value: string | string[] | undefined): number | null {
+function parseIntFieldInRange(value: string | string[] | undefined, min: number, max: number): number | null {
   if (Array.isArray(value)) return null;
   if (typeof value !== 'string' || !/^\d+$/.test(value)) return null;
   const parsed = Number(value);
-  return Number.isSafeInteger(parsed) && parsed >= MIN_INTERVAL_SECONDS && parsed <= MAX_INT_COLUMN_VALUE ? parsed : null;
-}
-
-/**
- * Parses a required min-messages form field: a non-negative integer within the DB column's
- * `INT` range, matching the DB's `chk_timer_command_min_messages` check. `0` (the "no minimum"
- * value) is valid.
- */
-function parseMinMessagesField(value: string | string[] | undefined): number | null {
-  if (Array.isArray(value)) return null;
-  if (typeof value !== 'string' || !/^\d+$/.test(value)) return null;
-  const parsed = Number(value);
-  return Number.isSafeInteger(parsed) && parsed >= 0 && parsed <= MAX_INT_COLUMN_VALUE ? parsed : null;
+  return Number.isSafeInteger(parsed) && parsed >= min && parsed <= max ? parsed : null;
 }
 
 /** Result of validating the timer fields shared by the add and update forms — either the parsed input, or the specific error code to redirect with. */
@@ -73,10 +62,10 @@ function parseTimerCommandFields(body: Record<string, string | string[] | undefi
   const message = normalizeRequiredText(body.message as string | undefined);
   if (!name || !message) return { ok: false, errorCode: 'missing_fields' };
 
-  const intervalSeconds = parseIntervalSecondsField(body.interval_seconds);
+  const intervalSeconds = parseIntFieldInRange(body.interval_seconds, MIN_INTERVAL_SECONDS, MAX_INT_COLUMN_VALUE);
   if (intervalSeconds === null) return { ok: false, errorCode: 'invalid_interval' };
 
-  const minMessages = parseMinMessagesField(body.min_messages);
+  const minMessages = parseIntFieldInRange(body.min_messages, 0, MAX_INT_COLUMN_VALUE);
   if (minMessages === null) return { ok: false, errorCode: 'invalid_min_messages' };
 
   return {

--- a/views/timers.ejs
+++ b/views/timers.ejs
@@ -21,6 +21,7 @@
         missing_fields:      'Please provide a name, a message, and a valid interval/minimum-messages value.',
         invalid_interval:    'Interval must be a whole number of at least 60 seconds.',
         invalid_min_messages: 'Minimum messages must be zero or a positive whole number.',
+        timer_limit_reached: 'You have reached the maximum number of timers allowed.',
         invalid_id:          'Invalid timer ID.',
         timer_not_found:     'That timer no longer exists.',
         add_failed:          'Failed to add the timer.',


### PR DESCRIPTION
## Summary

Addresses the two highest-priority open issues (of #458, #457, #451):

- **#458 — No shared outgoing rate-limit for auto-posted Twitch chat messages.** Added `src/twitch/twitchSendQueue.ts`, throttling every outgoing Twitch chat send against Twitch's actual per-account rate-limit rules (dev.twitch.tv/docs/irc/#rate-limits): a single shared rolling 30s window count that every send (privileged or not) adds to — non-privileged (not mod/VIP/broadcaster in the target channel) sends are blocked once that count reaches 20, while privileged sends keep going until it reaches 100 — plus a separate 1-message-per-second-per-channel floor for non-privileged sends. The limit is global per bot account, not per channel, so a burst of privileged sends into mod channels can still block a non-privileged send to a completely different channel. `sayInChannel` in `src/twitch/twitchBot.ts` now routes every outgoing message through this limiter, checking the bot's live mod status per channel via tmi.js — since every auto-posting feature (custom commands, counters, multi, shoutouts, countdowns, EventSub, timers) already funnels through this single function, this closes the gap for all of them at once rather than patching the timer scheduler alone.
- **#457 — Add a per-streamer cap on the number of timer commands.** Added `countTimerCommandsForStreamer` in `src/db/timerCommands.ts` and wired it into the `POST /timers/add` route (`src/web/routes/timersMutations.ts`) to reject new timers past a cap of 20 per streamer, redirecting with `?error=timer_limit_reached` (message added to `views/timers.ejs`).

`#451` (JSON-aware auth guard) was left alone — its own issue text recommends deferring it until a second call site needs the pattern.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (2950 tests passing)
- [x] Added unit tests for `twitchSendQueue` covering: the shared 30s window's 20/100 thresholds, the per-channel 1s floor for non-privileged sends, cross-channel bucket contention (a privileged burst blocking an unrelated channel's non-privileged send), enqueue ordering, and bucket accounting on a failed send
- [x] Added/extended tests for `sayInChannel` (mod-status wiring, per-channel floor), `countTimerCommandsForStreamer`, and the `/timers/add` cap (at-cap rejection, one-below-cap success)

---

Co-Authored-By: Claude Sonnet 5

---
_Generated by [Claude Code](https://claude.ai/code/session_01SuN3Hi9PEbX3MdTBCsgvRk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced a per-streamer maximum of 20 timers, with a dedicated alert when the limit is reached.
  * Added streamer-scoped timer counting to support reliable concurrent additions.
  * Enhanced Twitch chat sending with privilege-aware throttling and serialized rate limiting across channels.
* **Bug Fixes**
  * Added timeouts for stalled queued Twitch sends so the queue cannot get stuck.
  * Improved handling of delayed sends when the bot disconnects.
  * Ensured channel-specific privileges do not affect throttling elsewhere.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->