### PR TITLE
Add requireOwnerJson guard for the suggest-description JSON route

### DIFF
--- a/src/web/middleware.test.ts
+++ b/src/web/middleware.test.ts
@@ -15,7 +15,7 @@ vi.mock('./csrf', () => ({
 }));
 
 import { createHash } from 'crypto';
-import { requireAuth, requireManager, requireMod, requireAdmin, requireOwner, requireApiKey, requireCompanionKey, requireGuildContext } from './middleware';
+import { requireAuth, requireManager, requireMod, requireAdmin, requireOwner, requireOwnerJson, requireApiKey, requireCompanionKey, requireGuildContext } from './middleware';
 import { findKeyByHash, findDiscordIdByTokenHash, getEffectiveAccessLevelForUser, findUser, getAllGuilds, getGuildsForMember, AccessLevel } from '../db';
 
 function makeReq(overrides: object = {}): any {
@@ -212,6 +212,43 @@ describe('requireOwner', () => {
     requireOwner(req, res, next);
     const [, data] = res.render.mock.calls[0];
     expect(data.message).toContain('Owner');
+  });
+});
+
+// ─── requireOwnerJson ─────────────────────────────────────────────────────────
+
+describe('requireOwnerJson', () => {
+  it('calls next() when isOwner is true, regardless of accessLevel', () => {
+    const req = makeReq({ session: { user: { accessLevel: AccessLevel.USER, isOwner: true } } });
+    requireOwnerJson(req, makeRes(), next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('returns a JSON 403 for an Admin who is not the owner', () => {
+    const req = makeReq({ session: { user: { accessLevel: AccessLevel.ADMIN, isOwner: false } } });
+    const res = makeRes();
+    requireOwnerJson(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: 'forbidden' });
+    expect(res.render).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns a JSON 403 when isOwner is absent', () => {
+    const req = makeReq({ session: { user: { accessLevel: AccessLevel.ADMIN } } });
+    const res = makeRes();
+    requireOwnerJson(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: 'forbidden' });
+  });
+
+  it('returns a JSON 403 when no session user', () => {
+    const req = makeReq({ session: {} });
+    const res = makeRes();
+    requireOwnerJson(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: 'forbidden' });
+    expect(next).not.toHaveBeenCalled();
   });
 });
 

--- a/src/web/middleware.ts
+++ b/src/web/middleware.ts
@@ -194,3 +194,24 @@ export function requireOwner(req: Request, res: Response, next: NextFunction): v
     });
   }
 }
+
+/**
+ * Same check as {@link requireOwner}, for JSON-only routes: responds
+ * `403 { error: 'forbidden' }` instead of rendering an HTML error page, so a
+ * denied `fetch` call gets a real error payload instead of falling back to a
+ * generic parse-failure message. See issue #451 — this is intentionally a
+ * one-off next to `requireOwner` rather than a generic render-vs-json option
+ * on `requireAccessLevel`; extract a shared factory once a second JSON-over-session
+ * guard is needed.
+ * @param req - Express request; checked for `req.session.user?.isOwner`.
+ * @param res - Express response; used to send a 403 JSON body when denied.
+ * @param next - Called when the session user is the owner.
+ * @returns Nothing; either calls `next()` or sends a 403 JSON response.
+ */
+export function requireOwnerJson(req: Request, res: Response, next: NextFunction): void {
+  if (req.session.user?.isOwner) {
+    next();
+  } else {
+    res.status(403).json({ error: 'forbidden' });
+  }
+}

--- a/src/web/routes/sfx.ts
+++ b/src/web/routes/sfx.ts
@@ -42,7 +42,7 @@ const KNOWN_SUCCESS = new Set([
  * server-side requireMod guard on every mutation route. The "Suggest description"
  * button (canSuggestDescriptions) is further restricted to the bot owner while that
  * feature is being trialled, and hidden entirely when OPENAI_API_KEY isn't set,
- * matching the server-side requireOwner guard on its route.
+ * matching the server-side requireOwnerJson guard on its route.
  */
 router.get('/sfx', csrfProtection, async (req, res) => {
   try {

--- a/src/web/routes/sfxMutations.test.ts
+++ b/src/web/routes/sfxMutations.test.ts
@@ -33,7 +33,7 @@ vi.mock('../middleware', () => ({
   requireMod: vi.fn((_req: any, _res: any, next: any) => next()),
   // Unused here for the same reason as findSoundFiles above — required only so
   // the suggest-description sub-router can be mounted.
-  requireOwner: vi.fn((_req: any, _res: any, next: any) => next()),
+  requireOwnerJson: vi.fn((_req: any, _res: any, next: any) => next()),
 }));
 
 vi.mock('../../shared/config', () => ({

--- a/src/web/routes/sfxSuggestDescription.test.ts
+++ b/src/web/routes/sfxSuggestDescription.test.ts
@@ -8,7 +8,7 @@ const mockCreate = vi.fn();
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
 vi.mock('../../shared/config', () => ({ OPENAI_API_KEY: 'test-key', SFX_FOLDER: '/app/sfx' }));
 vi.mock('../csrf', () => ({ csrfProtection: (_req: any, _res: any, next: any) => next() }));
-vi.mock('../middleware', () => ({ requireOwner: (_req: any, _res: any, next: any) => next() }));
+vi.mock('../middleware', () => ({ requireOwnerJson: (_req: any, _res: any, next: any) => next() }));
 vi.mock('../../db', () => ({ findSoundFiles: vi.fn() }));
 vi.mock('fs', () => ({
   default: {
@@ -322,7 +322,7 @@ describe('POST /sfx/trigger/suggest-description (OPENAI_API_KEY unset)', () => {
     vi.doMock('../../shared/logger', () => ({ createLogger: mockLogger }));
     vi.doMock('../../shared/config', () => ({ OPENAI_API_KEY: '', SFX_FOLDER: '/app/sfx' }));
     vi.doMock('../csrf', () => ({ csrfProtection: (_req: any, _res: any, next: any) => next() }));
-    vi.doMock('../middleware', () => ({ requireOwner: (_req: any, _res: any, next: any) => next() }));
+    vi.doMock('../middleware', () => ({ requireOwnerJson: (_req: any, _res: any, next: any) => next() }));
     const findSoundFilesSpy = vi.fn();
     vi.doMock('../../db', () => ({ findSoundFiles: findSoundFilesSpy }));
 

--- a/src/web/routes/sfxSuggestDescription.ts
+++ b/src/web/routes/sfxSuggestDescription.ts
@@ -8,7 +8,7 @@ import OpenAI from 'openai';
 import type { SfxFile } from '../../db';
 import { findSoundFiles } from '../../db';
 import { csrfProtection } from '../csrf';
-import { requireOwner } from '../middleware';
+import { requireOwnerJson } from '../middleware';
 import { OPENAI_API_KEY, SFX_FOLDER } from '../../shared/config';
 import { safeResolve } from '../../shared/pathUtils';
 import { parsePositiveBigIntId, normalizeRequiredText } from './shared';
@@ -195,11 +195,12 @@ async function loadClip(file: SfxFile): Promise<AudioClip> {
 /**
  * POST /sfx/trigger/suggest-description — analyses a sample of a trigger's sound
  * files with OpenAI and returns a suggested public description. Owner-only while
- * this feature is being trialled for cost/effectiveness (see `requireOwner`).
+ * this feature is being trialled for cost/effectiveness (see `requireOwnerJson`,
+ * which sends a JSON 403 on denial to match this route's all-JSON response contract).
  * @param req Express request; reads `trigger_id` and optional `trigger_command` (context only) from a JSON body.
  * @param res Express response; always responds with JSON.
  */
-router.post('/sfx/trigger/suggest-description', requireOwner, csrfProtection, async (req, res) => {
+router.post('/sfx/trigger/suggest-description', requireOwnerJson, csrfProtection, async (req, res) => {
   if (!OPENAI_API_KEY) {
     res.status(503).json({ error: 'not_configured' });
     return;


### PR DESCRIPTION
## Summary

Closes #451 for its actual one-off call site.

`POST /sfx/trigger/suggest-description` is a `fetch`-driven, JSON-in/JSON-out route, but it was gated by `requireOwner`, which renders an HTML 403 error page on denial — a content-type mismatch that forces the client-side `fetch` code into a generic parse-failure fallback instead of reading a real error payload.

- Added `requireOwnerJson` in `src/web/middleware.ts`, a sibling to `requireOwner` with the same `isOwner` check, but responding `403 { error: 'forbidden' }` instead of rendering HTML.
- Wired it into `POST /sfx/trigger/suggest-description` in place of `requireOwner`.
- Updated the doc comment in `src/web/routes/sfx.ts` that referenced the old guard name.

**Scope note:** the issue's own "why not now" explicitly argues against building a generic render-vs-json option on the shared `requireAccessLevel` factory yet, since only one call site needs it today — extracting a shared abstraction from a single call site would be guessing its shape. This PR only adds the narrow one-off `requireOwnerJson`, matching that guidance and the project's stance against speculative abstractions. Revisit generalizing once a second/third JSON-over-session route shows up.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 2962 tests passing)
- [x] Added `requireOwnerJson` unit tests in `src/web/middleware.test.ts` (next(), 403 JSON for non-owner, missing `isOwner`, no session user)
- [x] Updated existing mocks in `sfxSuggestDescription.test.ts` and `sfxMutations.test.ts` (aggregator router) to match the renamed import

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3GHT4er8thM9ek9JjtEAk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added owner-only access control for description suggestions, returning a JSON `403 Forbidden` response when authorization fails.
* **Bug Fixes**
  * Prevented unauthorized requests from receiving HTML error pages or continuing to route handlers.
* **Tests**
  * Added coverage for authorized access, missing owners, unauthorized requests, and JSON error responses.
* **Documentation**
  * Updated route documentation to describe the JSON authorization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->