### PR TITLE
Fix three open security-review findings (#474, #476, #477)

### DIFF
--- a/src/commands/cooldownGate.ts
+++ b/src/commands/cooldownGate.ts
@@ -1,0 +1,36 @@
+import { GLOBAL_COOLDOWN_MS } from '../shared/config';
+
+/** A per-key cooldown gate: `tryClaim` throttles, `forget` drops a key's recorded claim time. */
+export interface CooldownGate {
+  tryClaim(key: string): boolean;
+  forget(key: string): void;
+}
+
+/**
+ * Creates an independent per-key cooldown gate backed by `GLOBAL_COOLDOWN_MS`. Used to
+ * throttle the custom-command and counter-trigger chat handlers per guild/channel, mirroring
+ * the per-guild cooldown `commandRouter.ts` already applies to SFX triggers — without it, any
+ * unprivileged chat member can spam a matching message as fast as they can send it.
+ */
+export function createCooldownGate(): CooldownGate {
+  const lastClaimedAt = new Map<string, number>();
+
+  return {
+    /**
+     * Returns true and records `now` for `key` if it is off cooldown; returns false — leaving
+     * the recorded time untouched — if a previous claim for `key` is still within the window.
+     */
+    tryClaim(key: string): boolean {
+      const now = Date.now();
+      const last = lastClaimedAt.get(key) ?? 0;
+      if (now - last < GLOBAL_COOLDOWN_MS) return false;
+      lastClaimedAt.set(key, now);
+      return true;
+    },
+
+    /** Forgets `key`'s recorded claim time. Safe to call for a key with no state (no-op). */
+    forget(key: string): void {
+      lastClaimedAt.delete(key);
+    },
+  };
+}

--- a/src/commands/counterHandler.test.ts
+++ b/src/commands/counterHandler.test.ts
@@ -3,6 +3,8 @@ import { mockLogger } from '../test-utils/loggerMock';
 
 vi.mock('../shared/logger', () => ({ createLogger: mockLogger }));
 
+vi.mock('../shared/config', () => ({ GLOBAL_COOLDOWN_MS: 3_000 }));
+
 vi.mock('../db', () => ({
   findCounterByCommand: vi.fn(),
   incrementCounter: vi.fn(),
@@ -16,6 +18,7 @@ import {
   executeCounterCommandForDiscord,
   executeCounterCommandForTwitch,
   registerCounterTwitchRuntime,
+  forgetGuildCounterCooldown,
 } from './counterHandler';
 import { findCounterByCommand, incrementCounter } from '../db';
 
@@ -43,18 +46,29 @@ const CHECK_COUNTER: MockCounter = {
   message: 'Current count: %d',
 };
 
-function makeMockMessage(content: string) {
+function makeMockMessage(content: string, overrides: Partial<{ guildId: string | null; channelId: string }> = {}) {
   return {
     id: 'msg-1',
     content,
+    guildId: 'guild-1',
+    channelId: 'channel-1',
     reply: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
   };
 }
 
 const mockTwitchRuntime = { send: vi.fn().mockResolvedValue(undefined) };
 
+// Base time far in the future so `Date.now() - 0` always exceeds GLOBAL_COOLDOWN_MS
+// at the start of each test. Each beforeEach adds enough to expire any previous claim,
+// matching the pattern in commandRouter.test.ts.
+const COOLDOWN_MS = 3_000;
+let mockNow = 1_000_000_000_000;
+
 beforeEach(() => {
+  mockNow += COOLDOWN_MS + 1_000;
   vi.clearAllMocks();
+  vi.spyOn(Date, 'now').mockReturnValue(mockNow);
   registerCounterTwitchRuntime(mockTwitchRuntime);
 });
 
@@ -141,5 +155,76 @@ describe('executeCounterCommandForTwitch', () => {
     await executeCounterCommandForTwitch('#chan', '!hits', null);
 
     expect(mockTwitchRuntime.send).not.toHaveBeenCalled();
+  });
+});
+
+describe('counter cooldown', () => {
+  it('blocks a second Discord counter command in the same guild within the cooldown window, without incrementing again', async () => {
+    vi.mocked(findCounterByCommand).mockResolvedValue(TRIGGER_COUNTER as any);
+    vi.mocked(incrementCounter).mockResolvedValue(5);
+
+    const msg1 = makeMockMessage('!hits');
+    await executeCounterCommandForDiscord(msg1 as any);
+    expect(msg1.reply).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(incrementCounter)).toHaveBeenCalledTimes(1);
+
+    // Same timestamp — cooldown has not elapsed
+    const msg2 = makeMockMessage('!hits');
+    await executeCounterCommandForDiscord(msg2 as any);
+    expect(msg2.reply).not.toHaveBeenCalled();
+    expect(vi.mocked(incrementCounter)).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not apply one Discord guild's cooldown to another guild", async () => {
+    vi.mocked(findCounterByCommand).mockResolvedValue(CHECK_COUNTER as any);
+
+    const msg1 = makeMockMessage('!count');
+    await executeCounterCommandForDiscord(msg1 as any);
+    expect(msg1.reply).toHaveBeenCalledTimes(1);
+
+    const msg2 = makeMockMessage('!count', { guildId: 'guild-2' });
+    await executeCounterCommandForDiscord(msg2 as any);
+    expect(msg2.reply).toHaveBeenCalledTimes(1);
+  });
+
+  it("forgetGuildCounterCooldown resets a guild's cooldown so a subsequent command fires immediately", async () => {
+    vi.mocked(findCounterByCommand).mockResolvedValue(CHECK_COUNTER as any);
+
+    const msg1 = makeMockMessage('!count');
+    await executeCounterCommandForDiscord(msg1 as any);
+    expect(msg1.reply).toHaveBeenCalledTimes(1);
+
+    forgetGuildCounterCooldown('guild-1');
+
+    const msg2 = makeMockMessage('!count');
+    await executeCounterCommandForDiscord(msg2 as any);
+    expect(msg2.reply).toHaveBeenCalledTimes(1);
+  });
+
+  it('forgetGuildCounterCooldown is a no-op for a guild with no state', () => {
+    expect(() => forgetGuildCounterCooldown('never-seen')).not.toThrow();
+  });
+
+  it('blocks a second Twitch counter command in the same channel within the cooldown window, without incrementing again', async () => {
+    vi.mocked(findCounterByCommand).mockResolvedValue(TRIGGER_COUNTER as any);
+    vi.mocked(incrementCounter).mockResolvedValue(5);
+
+    await executeCounterCommandForTwitch('#chan', '!hits', null);
+    expect(mockTwitchRuntime.send).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(incrementCounter)).toHaveBeenCalledTimes(1);
+
+    await executeCounterCommandForTwitch('#chan', '!hits', null);
+    expect(mockTwitchRuntime.send).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(incrementCounter)).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not apply one Twitch channel's cooldown to another channel", async () => {
+    vi.mocked(findCounterByCommand).mockResolvedValue(CHECK_COUNTER as any);
+
+    await executeCounterCommandForTwitch('#chan-a', '!count', null);
+    expect(mockTwitchRuntime.send).toHaveBeenCalledTimes(1);
+
+    await executeCounterCommandForTwitch('#chan-b', '!count', null);
+    expect(mockTwitchRuntime.send).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/commands/counterHandler.ts
+++ b/src/commands/counterHandler.ts
@@ -6,6 +6,36 @@ const log = createLogger('Counter');
 import { extractCommand } from './commandUtils';
 import { isDiscordNotFoundError } from '../discord/discordUtils';
 import { createRuntimeRegistry, type TwitchSendRuntime } from './twitchRuntime';
+import { createCooldownGate } from './cooldownGate';
+
+// ─── Cooldown ─────────────────────────────────────────────────────────────────
+//
+// Counter commands otherwise have no throttle: any chat member (no permission needed) can
+// spam a matching message as fast as they can send it — griefing a publicly displayed trigger
+// counter with unlimited DB-write increments, or flooding the channel with check replies.
+// Gated per guild (Discord) / channel (Twitch), mirroring the per-guild cooldown
+// commandRouter.ts already applies to SFX triggers.
+
+const counterCooldown = createCooldownGate();
+
+/**
+ * Resolves the cooldown key for a Discord message: guild-scoped when sent in a guild
+ * channel, falling back to a per-DM-channel key for the rare case of a DM invocation.
+ */
+function discordCooldownKey(message: Message): string {
+  return message.guildId ? `discord:${message.guildId}` : `discord:dm:${message.channelId}`;
+}
+
+/**
+ * Forgets a guild's counter cooldown so it stops occupying memory once the bot is no longer
+ * in that guild. Safe to call for a guild with no state (no-op). Called from the
+ * `guildDelete` handler; a guild the bot rejoins later starts fresh.
+ *
+ * @param guildId - Guild to forget.
+ */
+export function forgetGuildCounterCooldown(guildId: string): void {
+  counterCooldown.forget(`discord:${guildId}`);
+}
 
 // ─── Twitch runtime (registered from index.ts before startTwitchBot) ─────────
 //
@@ -37,16 +67,27 @@ interface CounterResult {
  * and formats the resulting response message. Shared by the Discord and Twitch
  * counter handlers so the lookup/increment/format logic isn't duplicated.
  *
+ * A match is throttled via `cooldownKey` (`GLOBAL_COOLDOWN_MS` per guild/channel) — a match
+ * found while that key's cooldown is active is treated the same as no match, before any
+ * increment or reply happens.
+ *
  * @param command - The full command string (e.g. `!clap`) used to find the counter.
  * @param errorPrefix - Log-line prefix identifying the calling platform (e.g. `[Discord]`).
- * @returns The response text, display label, and whether it's safe to send it; null if no counter matches `command`.
+ * @param cooldownKey - Cooldown-gate key for the invoking guild/channel.
+ * @returns The response text, display label, and whether it's safe to send it; null if no counter matches `command`, or if the match is on cooldown.
  */
 async function _buildCounterResponse(
   command: string,
   errorPrefix: string,
+  cooldownKey: string,
 ): Promise<CounterResult | null> {
   const counter = await findCounterByCommand(command);
   if (!counter) return null;
+
+  if (!counterCooldown.tryClaim(cooldownKey)) {
+    log.info(`[${errorPrefix}] Cooldown active, ignoring counter command '${command}'`);
+    return null;
+  }
 
   const isTrigger = counter.matchType === 'trigger';
   const label = isTrigger ? 'counter command' : 'counter check';
@@ -80,7 +121,7 @@ async function _buildCounterResponse(
 /**
  * Handles a Discord message that may be a counter command or check: extracts the
  * command, builds the counter response, and replies in-channel if the counter
- * was safely resolved.
+ * was safely resolved. Throttled per guild by `GLOBAL_COOLDOWN_MS`.
  *
  * @param message - The Discord message to check for a counter command.
  * @param username - Display name of the sender (unused; kept for call-site symmetry with the Twitch handler).
@@ -93,7 +134,7 @@ export async function executeCounterCommandForDiscord(
   const command = extractCommand(message.content);
   if (!command) return;
 
-  const result = await _buildCounterResponse(command, '[Discord]');
+  const result = await _buildCounterResponse(command, '[Discord]', discordCooldownKey(message));
   if (!result) return;
 
   if (!result.canReply) return;
@@ -111,7 +152,8 @@ export async function executeCounterCommandForDiscord(
 /**
  * Handles a Twitch chat message that may be a counter command or check: extracts
  * the command, builds the counter response, and sends it to the channel via the
- * registered Twitch runtime if safely resolved.
+ * registered Twitch runtime if safely resolved. Throttled per channel by
+ * `GLOBAL_COOLDOWN_MS`.
  *
  * @param channel - Twitch channel the message was sent in (also the send target).
  * @param rawMessage - Raw chat message text.
@@ -126,7 +168,7 @@ export async function executeCounterCommandForTwitch(
   const command = extractCommand(rawMessage);
   if (!command) return;
 
-  const result = await _buildCounterResponse(command, `[Twitch:${channel}]`);
+  const result = await _buildCounterResponse(command, `[Twitch:${channel}]`, `twitch:${channel}`);
   if (!result) return;
 
   if (!result.canReply) return;

--- a/src/commands/counterHandler.ts
+++ b/src/commands/counterHandler.ts
@@ -84,10 +84,10 @@ async function _buildCounterResponse(
   const counter = await findCounterByCommand(command);
   if (!counter) return null;
 
-  if (!counterCooldown.tryClaim(cooldownKey)) {
-    log.info(`[${errorPrefix}] Cooldown active, ignoring counter command '${command}'`);
-    return null;
-  }
+  // No log here: a spammed matching command would otherwise emit one log line per rejected
+  // message for as long as the sender keeps sending, unbounded — same silent-skip treatment
+  // as an unmatched command above.
+  if (!counterCooldown.tryClaim(cooldownKey)) return null;
 
   const isTrigger = counter.matchType === 'trigger';
   const label = isTrigger ? 'counter command' : 'counter check';

--- a/src/commands/customCommandHandler.test.ts
+++ b/src/commands/customCommandHandler.test.ts
@@ -3,6 +3,8 @@ import { mockLogger } from '../test-utils/loggerMock';
 
 vi.mock('../shared/logger', () => ({ createLogger: mockLogger }));
 
+vi.mock('../shared/config', () => ({ GLOBAL_COOLDOWN_MS: 3_000 }));
+
 vi.mock('../db', () => ({
   getCustomCommandForDiscord: vi.fn(),
   getCustomCommandForTwitchChannel: vi.fn(),
@@ -27,6 +29,7 @@ import {
   purgeExpiredSessionCache,
   resolveSharedChatSessionId,
   sessionCache,
+  forgetGuildCustomCommandCooldown,
 } from './customCommandHandler';
 import { getCustomCommandForDiscord, getCustomCommandForTwitchChannel } from '../db';
 import { isDiscordNotFoundError } from '../discord/discordUtils';
@@ -48,8 +51,16 @@ const mockRuntime = {
   getLoginUserIds: vi.fn<() => ReadonlyMap<string, string>>().mockReturnValue(new Map()),
 };
 
+// Base time far in the future so `Date.now() - 0` always exceeds GLOBAL_COOLDOWN_MS
+// at the start of each test. Each beforeEach adds enough to expire any previous claim,
+// matching the pattern in commandRouter.test.ts.
+const COOLDOWN_MS = 3_000;
+let mockNow = 1_000_000_000_000;
+
 beforeEach(() => {
+  mockNow += COOLDOWN_MS + 1_000;
   vi.clearAllMocks();
+  vi.spyOn(Date, 'now').mockReturnValue(mockNow);
   mockRuntime.send.mockResolvedValue(undefined);
   mockRuntime.getActiveChannels.mockReturnValue(new Set());
   mockRuntime.getLoginUserIds.mockReturnValue(new Map());
@@ -292,6 +303,73 @@ describe('executeCustomCommandForTwitch', () => {
     const expected = 'viewer1 said hello there';
     expect(mockRuntime.send).toHaveBeenCalledWith('#a', expected);
     expect(mockRuntime.send).toHaveBeenCalledWith('#b', expected);
+  });
+});
+
+// ─── Cooldown ─────────────────────────────────────────────────────────────────
+
+describe('custom-command cooldown', () => {
+  it('blocks a second Discord custom command in the same guild within the cooldown window', async () => {
+    vi.mocked(getCustomCommandForDiscord).mockResolvedValue({ output: 'Hi!', is_multi_twitch: false } as any);
+
+    const msg1 = mockMsg('!hello');
+    await executeCustomCommandForDiscord(msg1 as any, 'viewer1');
+    expect(msg1.reply).toHaveBeenCalledTimes(1);
+
+    // Same timestamp — cooldown has not elapsed
+    const msg2 = mockMsg('!hello');
+    await executeCustomCommandForDiscord(msg2 as any, 'viewer1');
+    expect(msg2.reply).not.toHaveBeenCalled();
+  });
+
+  it("does not apply one Discord guild's cooldown to another guild", async () => {
+    vi.mocked(getCustomCommandForDiscord).mockResolvedValue({ output: 'Hi!', is_multi_twitch: false } as any);
+
+    const msg1 = mockMsg('!hello');
+    await executeCustomCommandForDiscord(msg1 as any, 'viewer1');
+    expect(msg1.reply).toHaveBeenCalledTimes(1);
+
+    const msg2 = { ...mockMsg('!hello'), guildId: 'guild-2' };
+    await executeCustomCommandForDiscord(msg2 as any, 'viewer1');
+    expect(msg2.reply).toHaveBeenCalledTimes(1);
+  });
+
+  it("forgetGuildCustomCommandCooldown resets a guild's cooldown so a subsequent command fires immediately", async () => {
+    vi.mocked(getCustomCommandForDiscord).mockResolvedValue({ output: 'Hi!', is_multi_twitch: false } as any);
+
+    const msg1 = mockMsg('!hello');
+    await executeCustomCommandForDiscord(msg1 as any, 'viewer1');
+    expect(msg1.reply).toHaveBeenCalledTimes(1);
+
+    forgetGuildCustomCommandCooldown('guild-1');
+
+    const msg2 = mockMsg('!hello');
+    await executeCustomCommandForDiscord(msg2 as any, 'viewer1');
+    expect(msg2.reply).toHaveBeenCalledTimes(1);
+  });
+
+  it('forgetGuildCustomCommandCooldown is a no-op for a guild with no state', () => {
+    expect(() => forgetGuildCustomCommandCooldown('never-seen')).not.toThrow();
+  });
+
+  it('blocks a second Twitch custom command in the same channel within the cooldown window', async () => {
+    vi.mocked(getCustomCommandForTwitchChannel).mockResolvedValue({ output: 'Hey!', is_multi_twitch: false } as any);
+
+    await executeCustomCommandForTwitch('#chan', '!hey', 'viewer1');
+    expect(mockRuntime.send).toHaveBeenCalledTimes(1);
+
+    await executeCustomCommandForTwitch('#chan', '!hey', 'viewer1');
+    expect(mockRuntime.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not apply one Twitch channel's cooldown to another channel", async () => {
+    vi.mocked(getCustomCommandForTwitchChannel).mockResolvedValue({ output: 'Hey!', is_multi_twitch: false } as any);
+
+    await executeCustomCommandForTwitch('#chan-a', '!hey', 'viewer1');
+    expect(mockRuntime.send).toHaveBeenCalledTimes(1);
+
+    await executeCustomCommandForTwitch('#chan-b', '!hey', 'viewer1');
+    expect(mockRuntime.send).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/commands/customCommandHandler.ts
+++ b/src/commands/customCommandHandler.ts
@@ -10,6 +10,27 @@ import { getMultiTwitchDataForChannel } from '../twitch/monitor/twitchMonitor';
 import { fillTemplate } from '../shared/textTemplate';
 import { sendDedupedBySession } from './twitchBroadcast';
 import { createRuntimeRegistry, type TwitchBroadcastRuntime } from './twitchRuntime';
+import { createCooldownGate } from './cooldownGate';
+
+// ─── Cooldown ─────────────────────────────────────────────────────────────────
+//
+// Custom text-commands otherwise have no throttle: any chat member can spam a matching
+// message as fast as they can send it, flooding the channel (and, on Twitch, monopolizing
+// the shared send-queue budget across every connected channel). Gated per guild/channel,
+// mirroring the per-guild cooldown commandRouter.ts already applies to SFX triggers.
+
+const customCommandCooldown = createCooldownGate();
+
+/**
+ * Forgets a guild's custom-command cooldown so it stops occupying memory once the bot is no
+ * longer in that guild. Safe to call for a guild with no state (no-op). Called from the
+ * `guildDelete` handler; a guild the bot rejoins later starts fresh.
+ *
+ * @param guildId - Guild to forget.
+ */
+export function forgetGuildCustomCommandCooldown(guildId: string): void {
+  customCommandCooldown.forget(`discord:${guildId}`);
+}
 
 // ─── Twitch runtime (registered from index.ts before startTwitchBot) ─────────
 //
@@ -168,6 +189,9 @@ async function broadcastToActiveChannels(sourceChannel: string, command: string,
  * are skipped; output overrides replace the catalog text). Discord not-found errors
  * (e.g. message deleted before the reply lands) are silently swallowed.
  *
+ * A matched command is throttled per guild by `GLOBAL_COOLDOWN_MS` — a match found while
+ * that guild's cooldown is active is silently ignored, same as an unmatched command.
+ *
  * Before sending, the matched response is run through {@link fillTemplate} with
  * `{user}` (the invoking username), `{args}` (the raw text after the command token),
  * and `{arg}` (the first whitespace-delimited word of `{args}`) substituted in —
@@ -194,6 +218,11 @@ export async function executeCustomCommandForDiscord(
   const result = await lookupCommand(command, (cmd) => getCustomCommandForDiscord(cmd, resolvedGuildId));
   if (!result) return;
 
+  if (!customCommandCooldown.tryClaim(`discord:${resolvedGuildId}`)) {
+    log.info(`[Discord] Cooldown active for guild ${resolvedGuildId}, ignoring custom command '${command}'`);
+    return;
+  }
+
   const filledResponse = buildFilledResponse(result.response, message.content, username);
 
   try {
@@ -217,6 +246,9 @@ export async function executeCustomCommandForDiscord(
  * unknown placeholders resolve to an empty string; for multi-twitch broadcasts the
  * same filled string is reused for every target channel (no per-channel re-fill).
  *
+ * A matched command is throttled per channel by `GLOBAL_COOLDOWN_MS` — a match found while
+ * that channel's cooldown is active is silently ignored, same as an unmatched command.
+ *
  * @param channel - Twitch channel login the message was received on.
  * @param rawMessage - Raw chat message text.
  * @param username - Display name for `{user}` substitution; null or omitted if unknown.
@@ -232,6 +264,11 @@ export async function executeCustomCommandForTwitch(
 
   const result = await lookupCommand(command, (cmd) => getCustomCommandForTwitchChannel(channel, cmd));
   if (!result) return;
+
+  if (!customCommandCooldown.tryClaim(`twitch:${channel}`)) {
+    log.info(`[Twitch] Cooldown active for channel ${channel}, ignoring custom command '${command}'`);
+    return;
+  }
 
   const filledResponse = buildFilledResponse(result.response, rawMessage, username);
 

--- a/src/commands/customCommandHandler.ts
+++ b/src/commands/customCommandHandler.ts
@@ -218,10 +218,10 @@ export async function executeCustomCommandForDiscord(
   const result = await lookupCommand(command, (cmd) => getCustomCommandForDiscord(cmd, resolvedGuildId));
   if (!result) return;
 
-  if (!customCommandCooldown.tryClaim(`discord:${resolvedGuildId}`)) {
-    log.info(`[Discord] Cooldown active for guild ${resolvedGuildId}, ignoring custom command '${command}'`);
-    return;
-  }
+  // No log here: a spammed matching command would otherwise emit one log line per rejected
+  // message for as long as the sender keeps sending, unbounded — same silent-skip treatment
+  // as an unmatched command above.
+  if (!customCommandCooldown.tryClaim(`discord:${resolvedGuildId}`)) return;
 
   const filledResponse = buildFilledResponse(result.response, message.content, username);
 
@@ -265,10 +265,10 @@ export async function executeCustomCommandForTwitch(
   const result = await lookupCommand(command, (cmd) => getCustomCommandForTwitchChannel(channel, cmd));
   if (!result) return;
 
-  if (!customCommandCooldown.tryClaim(`twitch:${channel}`)) {
-    log.info(`[Twitch] Cooldown active for channel ${channel}, ignoring custom command '${command}'`);
-    return;
-  }
+  // No log here: a spammed matching command would otherwise emit one log line per rejected
+  // message for as long as the sender keeps sending, unbounded — same silent-skip treatment
+  // as an unmatched command above.
+  if (!customCommandCooldown.tryClaim(`twitch:${channel}`)) return;
 
   const filledResponse = buildFilledResponse(result.response, rawMessage, username);
 

--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -14,8 +14,14 @@ vi.mock('../commands/commandRouter', () => ({
   handleCommand: vi.fn().mockResolvedValue(undefined),
   forgetGuildCommandState: vi.fn(),
 }));
-vi.mock('../commands/customCommandHandler', () => ({ executeCustomCommandForDiscord: vi.fn().mockResolvedValue(undefined) }));
-vi.mock('../commands/counterHandler', () => ({ executeCounterCommandForDiscord: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../commands/customCommandHandler', () => ({
+  executeCustomCommandForDiscord: vi.fn().mockResolvedValue(undefined),
+  forgetGuildCustomCommandCooldown: vi.fn(),
+}));
+vi.mock('../commands/counterHandler', () => ({
+  executeCounterCommandForDiscord: vi.fn().mockResolvedValue(undefined),
+  forgetGuildCounterCooldown: vi.fn(),
+}));
 vi.mock('../shared/statusStore', () => ({ setDiscordReady: vi.fn(), clearVoiceStatus: vi.fn() }));
 vi.mock('../audio/audioPlayer', () => ({ forgetGuild: vi.fn() }));
 vi.mock('../web/routes/adminRefresh', () => ({ forgetGuildRefreshState: vi.fn() }));
@@ -283,16 +289,19 @@ describe('startDiscordBot — guildDelete handler', () => {
     return mockInstance.on.mock.calls.find(([event]: string[]) => event === 'guildDelete')?.[1] as (...args: any[]) => unknown;
   }
 
-  it('forgets the departed guild\'s in-memory voice, command, status, and refresh state', async () => {
+  it('forgets the departed guild\'s in-memory voice, command, cooldown, status, and refresh state', async () => {
     const audioPlayer = await import('../audio/audioPlayer.js');
     const status = await import('../shared/statusStore.js');
     const adminRefresh = await import('../web/routes/adminRefresh.js');
+    const counterHandler = await import('../commands/counterHandler.js');
     const cb = getGuildDeleteCb();
 
     cb({ id: 'departed-guild', name: 'Departed Server' });
 
     expect(vi.mocked(audioPlayer.forgetGuild)).toHaveBeenCalledWith('departed-guild');
     expect(vi.mocked(commands.forgetGuildCommandState)).toHaveBeenCalledWith('departed-guild');
+    expect(vi.mocked(customCmds.forgetGuildCustomCommandCooldown)).toHaveBeenCalledWith('departed-guild');
+    expect(vi.mocked(counterHandler.forgetGuildCounterCooldown)).toHaveBeenCalledWith('departed-guild');
     expect(vi.mocked(status.clearVoiceStatus)).toHaveBeenCalledWith('departed-guild');
     expect(vi.mocked(adminRefresh.forgetGuildRefreshState)).toHaveBeenCalledWith('departed-guild');
   });

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -2,8 +2,8 @@ import { Client, GatewayIntentBits, Guild } from 'discord.js';
 import { DISCORD_TOKEN } from '../shared/config';
 import { handleCommand, forgetGuildCommandState } from '../commands/commandRouter';
 import { fireAndForget } from '../commands/commandUtils';
-import { executeCustomCommandForDiscord } from '../commands/customCommandHandler';
-import { executeCounterCommandForDiscord } from '../commands/counterHandler';
+import { executeCustomCommandForDiscord, forgetGuildCustomCommandCooldown } from '../commands/customCommandHandler';
+import { executeCounterCommandForDiscord, forgetGuildCounterCooldown } from '../commands/counterHandler';
 import { setDiscordReady, clearVoiceStatus } from '../shared/statusStore';
 import { forgetGuild as forgetGuildVoiceState } from '../audio/audioPlayer';
 import { forgetGuildRefreshState } from '../web/routes/adminRefresh';
@@ -161,6 +161,8 @@ export function startDiscordBot(): void {
   localClient.on('guildDelete', (guild) => {
     forgetGuildVoiceState(guild.id);
     forgetGuildCommandState(guild.id);
+    forgetGuildCustomCommandCooldown(guild.id);
+    forgetGuildCounterCooldown(guild.id);
     clearVoiceStatus(guild.id);
     forgetGuildRefreshState(guild.id);
     log.info(`Forgot in-memory state for guild '${guild.name}' (${guild.id}) — bot removed.`);

--- a/src/shared/config.test.ts
+++ b/src/shared/config.test.ts
@@ -269,6 +269,18 @@ describe('config — Twitch EventSub / encryption settings', () => {
     const config = await loadConfig({ EVENTSUB_TOKEN_SECRET: 'f'.repeat(64) });
     expect(config.EVENTSUB_TOKEN_SECRET).toBe('f'.repeat(64));
   });
+
+  it('throws at startup when EVENTSUB_TOKEN_SECRET is the wrong length', async () => {
+    await expect(loadConfig({ EVENTSUB_TOKEN_SECRET: 'f'.repeat(63) })).rejects.toThrow(
+      'EVENTSUB_TOKEN_SECRET must be exactly 64 hex characters (32 bytes)',
+    );
+  });
+
+  it('throws at startup when EVENTSUB_TOKEN_SECRET contains non-hex characters', async () => {
+    await expect(loadConfig({ EVENTSUB_TOKEN_SECRET: 'z'.repeat(64) })).rejects.toThrow(
+      'EVENTSUB_TOKEN_SECRET must be exactly 64 hex characters (32 bytes)',
+    );
+  });
 });
 
 describe('config — SFX/OVERLAY folder defaults', () => {

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -74,6 +74,12 @@ export const TWITCH_EVENTSUB_REDIRECT_URI = process.env.TWITCH_EVENTSUB_REDIRECT
 // Must be exactly 64 hex characters (32 bytes). Generate with: openssl rand -hex 32
 // Required to use the Twitch OAuth connect flow for follow/sub notifications.
 export const EVENTSUB_TOKEN_SECRET = process.env.EVENTSUB_TOKEN_SECRET ?? '';
+// Validated eagerly (like SESSION_SECRET above) instead of leaving it to the first
+// encryptToken/decryptToken call — otherwise a malformed value boots cleanly and only
+// surfaces as a generic error the first time a streamer connects EventSub.
+if (EVENTSUB_TOKEN_SECRET !== '' && !/^[0-9a-fA-F]{64}$/.test(EVENTSUB_TOKEN_SECRET)) {
+  throw new Error('EVENTSUB_TOKEN_SECRET must be exactly 64 hex characters (32 bytes)');
+}
 
 // OpenAI API key, used only for the owner-only "Suggest description" SFX feature.
 // Leave unset to keep that feature disabled — everything else works without it.

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -263,16 +263,40 @@ describe('csrfErrorHandler', () => {
  * Because these are the exact singleton objects `server.ts` calls `app.use()` with, a
  * copy/paste mistake swapping which keyGenerator/skip pair is attached to which limiter
  * (see #477) shows up here as a limiter that fails to block, or blocks when it shouldn't.
+ *
+ * @param limiter - The `generalLimiter` or `sessionLimiter` instance under test.
+ * @param sessionUser - Value to stub as `req.session.user` on every request (undefined for unauthenticated).
+ * @returns A minimal Express app: session stub → `limiter` → a 200-returning probe route.
  */
-function buildLimiterTestApp(limiter: express.RequestHandler, sessionUser: unknown) {
+function buildLimiterTestApp(limiter: express.RequestHandler, sessionUser: unknown): express.Express {
   const testApp = express();
+  /** Stubs `req.session.user` to `sessionUser` so the limiter's keyGenerator/skip can be exercised without real login. */
   testApp.use((req, _res, next) => {
     (req as unknown as { session: { user: unknown } }).session = { user: sessionUser };
     next();
   });
   testApp.use(limiter);
+  /** Probe route: returns 200 unless a limiter ahead of it in the chain has already rejected the request. */
   testApp.get('/__limiter_probe', (_req, res) => res.json({ ok: true }));
   return testApp;
+}
+
+/**
+ * Sends `limit` requests through `testApp` and asserts every one succeeds (200), then sends
+ * one more and asserts it's rejected (429) — pinning the exact threshold instead of merely
+ * observing that a 429 eventually appears somewhere in a longer, looser loop.
+ *
+ * @param testApp - App built by {@link buildLimiterTestApp}.
+ * @param limit - The limiter's configured request cap for the window.
+ * @returns Resolves once all `limit` + 1 requests have completed and been asserted.
+ */
+async function expectExactThreshold(testApp: express.Express, limit: number): Promise<void> {
+  for (let i = 0; i < limit; i++) {
+    const res = await request(testApp).get('/__limiter_probe');
+    expect(res.status).toBe(200);
+  }
+  const res = await request(testApp).get('/__limiter_probe');
+  expect(res.status).toBe(429);
 }
 
 describe('generalLimiter wiring (server.ts)', () => {
@@ -284,17 +308,9 @@ describe('generalLimiter wiring (server.ts)', () => {
     await generalLimiter.resetKey('::1');
   });
 
-  it('blocks an unauthenticated caller after exceeding the 100/15min per-IP limit', async () => {
+  it('allows exactly 100 requests then blocks the 101st for an unauthenticated caller', async () => {
     const testApp = buildLimiterTestApp(generalLimiter, undefined);
-    let sawRateLimited = false;
-    for (let i = 0; i < 105; i++) {
-      const res = await request(testApp).get('/__limiter_probe');
-      if (res.status === 429) {
-        sawRateLimited = true;
-        break;
-      }
-    }
-    expect(sawRateLimited).toBe(true);
+    await expectExactThreshold(testApp, 100);
   });
 
   it('skips an authenticated caller (per-account throttling is sessionLimiter’s job)', async () => {
@@ -315,16 +331,8 @@ describe('sessionLimiter wiring (server.ts)', () => {
     }
   });
 
-  it('blocks an authenticated account after exceeding the 600/15min per-account limit', async () => {
+  it('allows exactly 600 requests then blocks the 601st for an authenticated account', async () => {
     const testApp = buildLimiterTestApp(sessionLimiter, { discordId: 'session-limiter-block-test' });
-    let sawRateLimited = false;
-    for (let i = 0; i < 605; i++) {
-      const res = await request(testApp).get('/__limiter_probe');
-      if (res.status === 429) {
-        sawRateLimited = true;
-        break;
-      }
-    }
-    expect(sawRateLimited).toBe(true);
+    await expectExactThreshold(testApp, 600);
   });
 });

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { Router } from 'express';
+import express, { Router } from 'express';
 import request from 'supertest';
 import { EventEmitter } from 'events';
 import { mockLogger } from '../test-utils/loggerMock';
@@ -113,7 +113,7 @@ vi.mock('./routes/companionRewards', () => ({ default: emptyRouter() }));
 vi.mock('./routes/companionKeys', () => ({ default: emptyRouter() }));
 vi.mock('./routes/serviceWorker', () => ({ default: emptyRouter() }));
 
-import { app } from './server';
+import { app, generalLimiter, sessionLimiter } from './server';
 import { requireAuth, requireGuildContext } from './middleware';
 
 describe('server route wiring', () => {
@@ -253,5 +253,78 @@ describe('csrfErrorHandler', () => {
     const res = await request(app).get('/__trigger_error');
     expect(res.status).toBe(500);
     expect(res.text).toContain('An unexpected error occurred.');
+  });
+});
+
+/**
+ * Mounts the real `generalLimiter`/`sessionLimiter` instances exported from server.ts behind
+ * a stub session middleware, so a request loop can drive them past their threshold directly —
+ * without needing hundreds of requests through the full mocked app to reach 100/600 hits.
+ * Because these are the exact singleton objects `server.ts` calls `app.use()` with, a
+ * copy/paste mistake swapping which keyGenerator/skip pair is attached to which limiter
+ * (see #477) shows up here as a limiter that fails to block, or blocks when it shouldn't.
+ */
+function buildLimiterTestApp(limiter: express.RequestHandler, sessionUser: unknown) {
+  const testApp = express();
+  testApp.use((req, _res, next) => {
+    (req as unknown as { session: { user: unknown } }).session = { user: sessionUser };
+    next();
+  });
+  testApp.use(limiter);
+  testApp.get('/__limiter_probe', (_req, res) => res.json({ ok: true }));
+  return testApp;
+}
+
+describe('generalLimiter wiring (server.ts)', () => {
+  beforeEach(async () => {
+    // Reset the per-IP bucket so earlier tests' requests through the shared `app`
+    // (same singleton limiter) don't make this test's threshold non-deterministic.
+    await generalLimiter.resetKey('::ffff:127.0.0.1');
+    await generalLimiter.resetKey('127.0.0.1');
+    await generalLimiter.resetKey('::1');
+  });
+
+  it('blocks an unauthenticated caller after exceeding the 100/15min per-IP limit', async () => {
+    const testApp = buildLimiterTestApp(generalLimiter, undefined);
+    let sawRateLimited = false;
+    for (let i = 0; i < 105; i++) {
+      const res = await request(testApp).get('/__limiter_probe');
+      if (res.status === 429) {
+        sawRateLimited = true;
+        break;
+      }
+    }
+    expect(sawRateLimited).toBe(true);
+  });
+
+  it('skips an authenticated caller (per-account throttling is sessionLimiter’s job)', async () => {
+    const testApp = buildLimiterTestApp(generalLimiter, { discordId: 'general-limiter-skip-test' });
+    for (let i = 0; i < 105; i++) {
+      const res = await request(testApp).get('/__limiter_probe');
+      expect(res.status).toBe(200);
+    }
+  });
+});
+
+describe('sessionLimiter wiring (server.ts)', () => {
+  it('skips an unauthenticated caller (per-IP throttling is generalLimiter’s job)', async () => {
+    const testApp = buildLimiterTestApp(sessionLimiter, undefined);
+    for (let i = 0; i < 105; i++) {
+      const res = await request(testApp).get('/__limiter_probe');
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it('blocks an authenticated account after exceeding the 600/15min per-account limit', async () => {
+    const testApp = buildLimiterTestApp(sessionLimiter, { discordId: 'session-limiter-block-test' });
+    let sawRateLimited = false;
+    for (let i = 0; i < 605; i++) {
+      const res = await request(testApp).get('/__limiter_probe');
+      if (res.status === 429) {
+        sawRateLimited = true;
+        break;
+      }
+    }
+    expect(sawRateLimited).toBe(true);
   });
 });

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -312,6 +312,12 @@ app.use((err: unknown, req: express.Request, res: express.Response, _next: expre
 // without spinning up a listening socket.
 export { app };
 
+// Exported so server.test.ts can exercise these exact instances directly — confirming both
+// that each got paired with the correct keyGenerator/skip function and that hitting the
+// threshold actually enforces a 429 — without looping enough real requests through the
+// entire app to reach the 100/600 thresholds via every other mounted route.
+export { generalLimiter, sessionLimiter };
+
 export function startWebPanel(): void {
   app.listen(WEB_PORT, () => {
     log.info(`Panel available at http://localhost:${WEB_PORT}`);


### PR DESCRIPTION
## Summary

Closes the three currently-open issues labeled `security` in this repo.

- **#476 — `EVENTSUB_TOKEN_SECRET` format isn't validated at startup.** `src/shared/config.ts` now validates the value against `/^[0-9a-fA-F]{64}$/` eagerly (mirroring the existing `SESSION_SECRET` check) instead of only inside `crypto.ts`'s `parseKey` at first use. A malformed value now fails fast at boot instead of surfacing as a generic `eventsub_config_failed` redirect the first time a streamer connects EventSub.
- **#474 — Custom text-commands and counter-trigger commands have no cooldown/rate limiting.** Added a shared `createCooldownGate()` helper (`src/commands/cooldownGate.ts`) and wired it into `customCommandHandler.ts` and `counterHandler.ts`, gated per Discord guild / Twitch channel using the existing `GLOBAL_COOLDOWN_MS` setting — mirroring the per-guild cooldown `commandRouter.ts` already applies to SFX triggers. This closes the gap where any unprivileged chat member could spam a matching message to grief a counter's DB-backed value, flood a Discord channel, or (on Twitch) monopolize the shared 20-msg/30s send-queue budget across every connected channel. Cooldown state is forgotten on `guildDelete`, matching the existing SFX-cooldown cleanup pattern.
- **#477 — `generalLimiter`/`sessionLimiter` lack an end-to-end enforcement test.** `generalLimiter` and `sessionLimiter` are now exported from `src/web/server.ts`, and `server.test.ts` drives the real instances through requests past their 100/15min and 600/15min thresholds and asserts a 429 — catching a copy/paste mistake that swaps which `keyGenerator`/`skip` pair is attached to which limiter (which the existing unit tests of the standalone helper functions alone would not catch).

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (2980 tests passing)
- [x] New/updated tests: `src/shared/config.test.ts`, `src/commands/customCommandHandler.test.ts`, `src/commands/counterHandler.test.ts`, `src/discord/discordBot.test.ts`, `src/web/server.test.ts`

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVNK4sanEvfeHXoQ8TAxKA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cooldown protection for counter and custom commands.
  * Discord cooldowns are scoped by guild, with DM fallback; Twitch cooldowns are scoped by channel.
  * Repeated commands during cooldowns are ignored.
  * Cooldown state is cleared when the bot leaves a Discord guild.

* **Bug Fixes**
  * Invalid event subscription secrets are now rejected during configuration loading.
  * Web request rate limiting now better protects unauthenticated and authenticated endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->