### PR TITLE
Fix five high-priority issues from the repo code review (#469-#473)

### DIFF
--- a/src/commands/customCommandHandler.test.ts
+++ b/src/commands/customCommandHandler.test.ts
@@ -18,10 +18,6 @@ vi.mock('../discord/discordUtils', () => ({
   isDiscordNotFoundError: vi.fn().mockReturnValue(false),
 }));
 
-vi.mock('../twitch/monitor/twitchMonitor', () => ({
-  getMultiTwitchDataForChannel: vi.fn().mockReturnValue(null),
-}));
-
 import {
   executeCustomCommandForDiscord,
   executeCustomCommandForTwitch,
@@ -33,7 +29,6 @@ import {
 } from './customCommandHandler';
 import { getCustomCommandForDiscord, getCustomCommandForTwitchChannel } from '../db';
 import { isDiscordNotFoundError } from '../discord/discordUtils';
-import { getMultiTwitchDataForChannel } from '../twitch/monitor/twitchMonitor';
 import { getSharedChatSession } from '../twitch/twitchApi';
 
 function mockMsg(content: string) {
@@ -49,6 +44,7 @@ const mockRuntime = {
   send: vi.fn().mockResolvedValue(undefined),
   getActiveChannels: vi.fn<() => ReadonlySet<string>>().mockReturnValue(new Set()),
   getLoginUserIds: vi.fn<() => ReadonlyMap<string, string>>().mockReturnValue(new Map()),
+  getMultiTwitchDataForChannel: vi.fn().mockReturnValue(null),
 };
 
 // Base time far in the future so `Date.now() - 0` always exceeds GLOBAL_COOLDOWN_MS
@@ -64,6 +60,7 @@ beforeEach(() => {
   mockRuntime.send.mockResolvedValue(undefined);
   mockRuntime.getActiveChannels.mockReturnValue(new Set());
   mockRuntime.getLoginUserIds.mockReturnValue(new Map());
+  mockRuntime.getMultiTwitchDataForChannel.mockReturnValue(null);
   registerTwitchChatRuntime(mockRuntime);
 });
 
@@ -203,7 +200,7 @@ describe('executeCustomCommandForTwitch', () => {
       output: 'Multi!',
       is_multi_twitch: true,
     } as any);
-    vi.mocked(getMultiTwitchDataForChannel).mockReturnValue({
+    mockRuntime.getMultiTwitchDataForChannel.mockReturnValue({
       url: 'multitwitch.tv/a/b',
       participants: ['#a', '#b'],
     } as any);
@@ -220,7 +217,7 @@ describe('executeCustomCommandForTwitch', () => {
       output: 'Hi!',
       is_multi_twitch: true,
     } as any);
-    vi.mocked(getMultiTwitchDataForChannel).mockReturnValue(null); // not in a group
+    mockRuntime.getMultiTwitchDataForChannel.mockReturnValue(null); // not in a group
     mockRuntime.getActiveChannels.mockReturnValue(new Set(['#a', '#b']));
 
     await executeCustomCommandForTwitch('#a', '!hi', null);
@@ -270,7 +267,7 @@ describe('executeCustomCommandForTwitch', () => {
       output: 'Multi!',
       is_multi_twitch: true,
     } as any);
-    vi.mocked(getMultiTwitchDataForChannel).mockReturnValue({
+    mockRuntime.getMultiTwitchDataForChannel.mockReturnValue({
       url: 'multitwitch.tv/a/b',
       participants: ['#a', '#b'],
     } as any);
@@ -292,7 +289,7 @@ describe('executeCustomCommandForTwitch', () => {
       output: '{user} said {args}',
       is_multi_twitch: true,
     } as any);
-    vi.mocked(getMultiTwitchDataForChannel).mockReturnValue({
+    mockRuntime.getMultiTwitchDataForChannel.mockReturnValue({
       url: 'multitwitch.tv/a/b',
       participants: ['#a', '#b'],
     } as any);

--- a/src/commands/customCommandHandler.ts
+++ b/src/commands/customCommandHandler.ts
@@ -6,7 +6,7 @@ const log = createLogger('CustomCmd');
 import { getSharedChatSession } from '../twitch/twitchApi';
 import { extractCommand, extractArgs } from './commandUtils';
 import { isDiscordNotFoundError } from '../discord/discordUtils';
-import { getMultiTwitchDataForChannel } from '../twitch/monitor/twitchMonitor';
+import type { MultiTwitchGroupInfo } from '../twitch/monitor/twitchMonitorTypes';
 import { fillTemplate } from '../shared/textTemplate';
 import { sendDedupedBySession } from './twitchBroadcast';
 import { createRuntimeRegistry, type TwitchBroadcastRuntime } from './twitchRuntime';
@@ -34,10 +34,15 @@ export function forgetGuildCustomCommandCooldown(guildId: string): void {
 
 // ─── Twitch runtime (registered from index.ts before startTwitchBot) ─────────
 //
-// Avoids a circular import: twitchBot.ts → customCommandHandler.ts → twitchBot.ts.
-// index.ts wires the concrete implementations once both modules are loaded.
+// Avoids two circular imports: twitchBot.ts → customCommandHandler.ts → twitchBot.ts, and
+// discordBot.ts → customCommandHandler.ts → twitch/monitor/twitchMonitor.ts → discordBot.ts (the
+// monitor modules import getDiscordClient). index.ts wires the concrete implementations once
+// every module involved is loaded.
 
-type TwitchChatRuntime = TwitchBroadcastRuntime;
+interface TwitchChatRuntime extends TwitchBroadcastRuntime {
+  /** Delegates to `twitchMonitor.ts`'s `getMultiTwitchDataForChannel`, injected to avoid importing that module directly. */
+  getMultiTwitchDataForChannel: (login: string) => MultiTwitchGroupInfo | null;
+}
 
 const twitchChatRuntime = createRuntimeRegistry<TwitchChatRuntime>();
 
@@ -154,7 +159,7 @@ async function broadcastToActiveChannels(sourceChannel: string, command: string,
   const runtime = twitchChatRuntime.get();
   if (!runtime) return false;
 
-  const { send, getActiveChannels, getLoginUserIds } = runtime;
+  const { send, getActiveChannels, getLoginUserIds, getMultiTwitchDataForChannel } = runtime;
   const activeChannels = getActiveChannels();
   const loginUserIds = getLoginUserIds();
 

--- a/src/commands/customCommandHandler.ts
+++ b/src/commands/customCommandHandler.ts
@@ -40,7 +40,13 @@ export function forgetGuildCustomCommandCooldown(guildId: string): void {
 // every module involved is loaded.
 
 interface TwitchChatRuntime extends TwitchBroadcastRuntime {
-  /** Delegates to `twitchMonitor.ts`'s `getMultiTwitchDataForChannel`, injected to avoid importing that module directly. */
+  /**
+   * Delegates to `twitchMonitor.ts`'s `getMultiTwitchDataForChannel`, injected to avoid
+   * importing that module directly.
+   * @param login - Twitch channel login to look up.
+   * @returns The channel's current MultiTwitch group info, or null if it isn't in an active
+   *   multi-twitch group.
+   */
   getMultiTwitchDataForChannel: (login: string) => MultiTwitchGroupInfo | null;
 }
 

--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -24,7 +24,7 @@ vi.mock('../commands/counterHandler', () => ({
 }));
 vi.mock('../shared/statusStore', () => ({ setDiscordReady: vi.fn(), clearVoiceStatus: vi.fn() }));
 vi.mock('../audio/audioPlayer', () => ({ forgetGuild: vi.fn() }));
-vi.mock('../web/routes/adminRefresh', () => ({ forgetGuildRefreshState: vi.fn() }));
+vi.mock('./guildRefreshState', () => ({ forgetGuildRefreshState: vi.fn() }));
 vi.mock('./guildRegistry', () => ({
   // Only the legacy configured guild is registered in these tests.
   isRegisteredGuild: vi.fn((id: string) => id === 'guild-id'),
@@ -292,7 +292,7 @@ describe('startDiscordBot — guildDelete handler', () => {
   it('forgets the departed guild\'s in-memory voice, command, cooldown, status, and refresh state', async () => {
     const audioPlayer = await import('../audio/audioPlayer.js');
     const status = await import('../shared/statusStore.js');
-    const adminRefresh = await import('../web/routes/adminRefresh.js');
+    const guildRefreshState = await import('./guildRefreshState.js');
     const counterHandler = await import('../commands/counterHandler.js');
     const cb = getGuildDeleteCb();
 
@@ -303,7 +303,7 @@ describe('startDiscordBot — guildDelete handler', () => {
     expect(vi.mocked(customCmds.forgetGuildCustomCommandCooldown)).toHaveBeenCalledWith('departed-guild');
     expect(vi.mocked(counterHandler.forgetGuildCounterCooldown)).toHaveBeenCalledWith('departed-guild');
     expect(vi.mocked(status.clearVoiceStatus)).toHaveBeenCalledWith('departed-guild');
-    expect(vi.mocked(adminRefresh.forgetGuildRefreshState)).toHaveBeenCalledWith('departed-guild');
+    expect(vi.mocked(guildRefreshState.forgetGuildRefreshState)).toHaveBeenCalledWith('departed-guild');
   });
 
   it('does not touch the guild DB row', async () => {

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -6,7 +6,7 @@ import { executeCustomCommandForDiscord, forgetGuildCustomCommandCooldown } from
 import { executeCounterCommandForDiscord, forgetGuildCounterCooldown } from '../commands/counterHandler';
 import { setDiscordReady, clearVoiceStatus } from '../shared/statusStore';
 import { forgetGuild as forgetGuildVoiceState } from '../audio/audioPlayer';
-import { forgetGuildRefreshState } from '../web/routes/adminRefresh';
+import { forgetGuildRefreshState } from './guildRefreshState';
 import { isRegisteredGuild, reloadGuildRegistry } from './guildRegistry';
 import { upsertGuild, getGuildById, findUser, upsertUser, setMemberAccessLevel, AccessLevel } from '../db';
 import { createLogger } from '../shared/logger';

--- a/src/discord/guildRefreshState.test.ts
+++ b/src/discord/guildRefreshState.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { refreshStates, getRefreshState, forgetGuildRefreshState } from './guildRefreshState';
+
+const GUILD_ID = '900000000000000001';
+
+beforeEach(() => {
+  refreshStates.clear();
+});
+
+describe('getRefreshState', () => {
+  it('returns idle defaults for a guild with no recorded refresh', () => {
+    expect(getRefreshState(GUILD_ID)).toEqual({
+      outcome: 'idle',
+      updatedCount: 0,
+      failureCount: 0,
+      startedAt: null,
+      finishedAt: null,
+    });
+  });
+
+  it('returns the recorded state for a guild with one', () => {
+    refreshStates.set(GUILD_ID, { outcome: 'success', updatedCount: 3, failureCount: 0, startedAt: 1, finishedAt: 2 });
+    expect(getRefreshState(GUILD_ID)).toEqual({ outcome: 'success', updatedCount: 3, failureCount: 0, startedAt: 1, finishedAt: 2 });
+  });
+});
+
+describe('forgetGuildRefreshState', () => {
+  it("removes a guild's recorded refresh state, resetting it to idle on next read", () => {
+    refreshStates.set(GUILD_ID, { outcome: 'success', updatedCount: 3, failureCount: 0, startedAt: 1, finishedAt: 2 });
+
+    forgetGuildRefreshState(GUILD_ID);
+
+    expect(getRefreshState(GUILD_ID)).toEqual({
+      outcome: 'idle',
+      updatedCount: 0,
+      failureCount: 0,
+      startedAt: null,
+      finishedAt: null,
+    });
+  });
+
+  it('is a no-op for a guild with no recorded state', () => {
+    expect(() => forgetGuildRefreshState('never-seen')).not.toThrow();
+  });
+});

--- a/src/discord/guildRefreshState.ts
+++ b/src/discord/guildRefreshState.ts
@@ -1,0 +1,46 @@
+/**
+ * Per-guild progress state for the Discord-name-refresh job, shared between the Discord bot
+ * (which forgets a guild's state on `guildDelete`) and the admin web panel (which drives and
+ * polls the job). Lives in its own module — rather than in `web/routes/adminRefresh.ts`, which
+ * the Discord bot would otherwise have to import from directly — so `discord/discordBot.ts` and
+ * `web/routes/adminRefresh.ts` can both depend on this without importing from each other.
+ */
+
+/** Lifecycle state of a guild's Discord-name-refresh job. */
+export type RefreshOutcome = 'idle' | 'running' | 'success' | 'partial' | 'noop' | 'error';
+
+/** Progress/result of a guild's most recent (or in-progress) Discord-name-refresh job. */
+export interface RefreshState {
+  outcome: RefreshOutcome;
+  updatedCount: number;
+  failureCount: number;
+  startedAt: number | null;
+  finishedAt: number | null;
+}
+
+/** Returns a fresh idle `RefreshState`, used as the default for a guild with no recorded refresh. */
+function idleRefreshState(): RefreshState {
+  return { outcome: 'idle', updatedCount: 0, failureCount: 0, startedAt: null, finishedAt: null };
+}
+
+// Per-guild progress state, intentionally in-process because the web panel runs as
+// a single bot instance today. If the panel is ever scaled horizontally, move this
+// state into shared storage before relying on /users/refresh-status.
+export const refreshStates = new Map<string, RefreshState>();
+
+/** Returns the Discord-name-refresh progress for a guild, defaulting to idle when no refresh has run yet. */
+export function getRefreshState(guildId: string): RefreshState {
+  return refreshStates.get(guildId) ?? idleRefreshState();
+}
+
+/**
+ * Forgets a guild's Discord-name-refresh progress state so it stops occupying
+ * memory once the bot is no longer in that guild. Safe to call for a guild
+ * with no state (no-op). Called from the `guildDelete` handler; a guild the
+ * bot rejoins later starts fresh via {@link getRefreshState}'s idle default.
+ *
+ * @param guildId - Guild to forget.
+ */
+export function forgetGuildRefreshState(guildId: string): void {
+  refreshStates.delete(guildId);
+}

--- a/src/discord/guildRefreshState.ts
+++ b/src/discord/guildRefreshState.ts
@@ -28,7 +28,11 @@ function idleRefreshState(): RefreshState {
 // state into shared storage before relying on /users/refresh-status.
 export const refreshStates = new Map<string, RefreshState>();
 
-/** Returns the Discord-name-refresh progress for a guild, defaulting to idle when no refresh has run yet. */
+/**
+ * Returns the Discord-name-refresh progress for a guild, defaulting to idle when no refresh has run yet.
+ * @param guildId - Guild to look up.
+ * @returns The guild's recorded `RefreshState`, or a fresh idle one if none has been recorded.
+ */
 export function getRefreshState(guildId: string): RefreshState {
   return refreshStates.get(guildId) ?? idleRefreshState();
 }
@@ -40,6 +44,7 @@ export function getRefreshState(guildId: string): RefreshState {
  * bot rejoins later starts fresh via {@link getRefreshState}'s idle default.
  *
  * @param guildId - Guild to forget.
+ * @returns Nothing.
  */
 export function forgetGuildRefreshState(guildId: string): void {
   refreshStates.delete(guildId);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -71,7 +71,17 @@ vi.mock('./twitch/pricing/rewardPricingScheduler', () => ({
 vi.mock('./twitch/pricing/rewardPricingService', () => ({
   registerRewardPricingRuntime: vi.fn(),
 }));
-vi.mock('./shared/logger', () => ({ createLogger: mockLogger }));
+// Captures the 'Bot'-named logger instance each createLogger('Bot') call produces, so tests can
+// assert on log.error calls in addition to process.exit — mockLogger() returns a fresh vi.fn()
+// set per call, so the instance used inside index.ts isn't otherwise reachable from the test.
+let lastBotLogger: ReturnType<typeof mockLogger> | undefined;
+vi.mock('./shared/logger', () => ({
+  createLogger: (name: string) => {
+    const logger = mockLogger();
+    if (name === 'Bot') lastBotLogger = logger;
+    return logger;
+  },
+}));
 
 let exitSpy: ReturnType<typeof vi.spyOn>;
 
@@ -221,23 +231,27 @@ describe('shutdown', () => {
 // ─── Global unhandled error handlers ──────────────────────────────────────────
 
 describe('global error handlers', () => {
-  it('exits the process on an unhandled promise rejection', async () => {
+  it('logs and exits the process on an unhandled promise rejection', async () => {
     await runMain();
+    const reason = new Error('boom');
 
     expect(() => {
-      process.emit('unhandledRejection', new Error('boom'), Promise.reject(new Error('boom')).catch(() => {}));
+      process.emit('unhandledRejection', reason, Promise.reject(reason).catch(() => {}));
     }).toThrow('process.exit');
 
     expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(lastBotLogger?.error).toHaveBeenCalledWith('Unhandled promise rejection:', reason);
   });
 
-  it('exits the process on an uncaught exception', async () => {
+  it('logs and exits the process on an uncaught exception', async () => {
     await runMain();
+    const err = new Error('boom');
 
     expect(() => {
-      process.emit('uncaughtException', new Error('boom'));
+      process.emit('uncaughtException', err);
     }).toThrow('process.exit');
 
     expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(lastBotLogger?.error).toHaveBeenCalledWith('Uncaught exception:', err);
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -34,6 +34,7 @@ vi.mock('./twitch/twitchChannelMembership', () => ({
 vi.mock('./twitch/monitor/twitchMonitor', () => ({
   startTwitchMonitor: vi.fn().mockResolvedValue(undefined),
   stopTwitchMonitor: vi.fn().mockResolvedValue(undefined),
+  getMultiTwitchDataForChannel: vi.fn(),
 }));
 vi.mock('./twitch/eventsub/twitchEventSub', () => ({
   startEventSub: vi.fn(),
@@ -80,11 +81,14 @@ beforeEach(() => {
   // module cache but does not reset call counts. clearAllMocks() resets counts to 0
   // so failure-path assertions on mocks like startDiscordBot start from a clean slate.
   vi.clearAllMocks();
-  // Each import('./index.js') registers fresh SIGINT/SIGTERM listeners on the real
-  // process object; resetModules doesn't remove the old ones. Clear them so a test
-  // that emits a signal only triggers its own run's shutdown() closure.
+  // Each import('./index.js') registers fresh SIGINT/SIGTERM/unhandledRejection/
+  // uncaughtException listeners on the real process object; resetModules doesn't
+  // remove the old ones. Clear them so a test that emits a signal or error only
+  // triggers its own run's handler.
   process.removeAllListeners('SIGINT');
   process.removeAllListeners('SIGTERM');
+  process.removeAllListeners('unhandledRejection');
+  process.removeAllListeners('uncaughtException');
   // Throw on the first call so main() stops executing after a catch block calls
   // process.exit(1). Revert to a no-op on subsequent calls so the outer
   // main().catch() path — which also calls process.exit(1) after the inner throw
@@ -99,6 +103,8 @@ afterEach(() => {
   exitSpy.mockRestore();
   process.removeAllListeners('SIGINT');
   process.removeAllListeners('SIGTERM');
+  process.removeAllListeners('unhandledRejection');
+  process.removeAllListeners('uncaughtException');
 });
 
 /** Imports index.ts (which fires main() immediately) and waits for it to settle. */
@@ -209,5 +215,29 @@ describe('shutdown', () => {
     await new Promise<void>((resolve) => setImmediate(resolve));
 
     expect(vi.mocked(stopRewardPricingScheduler)).toHaveBeenCalledOnce();
+  });
+});
+
+// ─── Global unhandled error handlers ──────────────────────────────────────────
+
+describe('global error handlers', () => {
+  it('exits the process on an unhandled promise rejection', async () => {
+    await runMain();
+
+    expect(() => {
+      process.emit('unhandledRejection', new Error('boom'), Promise.reject(new Error('boom')).catch(() => {}));
+    }).toThrow('process.exit');
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('exits the process on an uncaught exception', async () => {
+    await runMain();
+
+    expect(() => {
+      process.emit('uncaughtException', new Error('boom'));
+    }).toThrow('process.exit');
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,10 +55,24 @@ process.on('SIGTERM', () => { shutdown('SIGTERM').catch((err) => { log.error('Sh
 // internals (discord.js, tmi.js, mysql2, ws) rather than the app's own promise chains would go
 // fully unhandled and silently kill the process — there's no supervisor (pm2/systemd) to restart
 // it, so we log loudly and exit deliberately instead, making the failure visible and diagnosable.
+
+/**
+ * Logs an unhandled promise rejection and exits, rather than letting Node's default
+ * (process termination without a clean log line) or silently continuing.
+ * @param reason - The rejection reason (typically an `Error`, but not guaranteed to be).
+ * @returns Never returns — always calls `process.exit(1)`.
+ */
 process.on('unhandledRejection', (reason) => {
   log.error('Unhandled promise rejection:', reason);
   process.exit(1);
 });
+
+/**
+ * Logs an uncaught synchronous exception and exits — continuing after `uncaughtException` risks
+ * running with corrupted state, so this deliberately does not attempt to recover.
+ * @param err - The uncaught error.
+ * @returns Never returns — always calls `process.exit(1)`.
+ */
 process.on('uncaughtException', (err) => {
   log.error('Uncaught exception:', err);
   process.exit(1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { startTwitchBot, stopTwitchBot, sayInChannel } from './twitch/twitchBot'
 import { getActiveChannels, getActiveChannelUserIds, setChannelJoinedHook } from './twitch/twitchChannelMembership';
 import { startDiscordBot, stopDiscordBot } from './discord/discordBot';
 import { reloadGuildRegistry } from './discord/guildRegistry';
-import { startTwitchMonitor, stopTwitchMonitor } from './twitch/monitor/twitchMonitor';
+import { startTwitchMonitor, stopTwitchMonitor, getMultiTwitchDataForChannel } from './twitch/monitor/twitchMonitor';
 import { startEventSub, stopEventSub, reloadEventSubSubscriptions } from './twitch/eventsub/twitchEventSub';
 import { startWebPanel } from './web/server';
 import { disconnect } from './audio/audioPlayer';
@@ -51,6 +51,19 @@ async function shutdown(signal: string): Promise<void> {
 process.on('SIGINT',  () => { shutdown('SIGINT').catch((err)  => { log.error('Shutdown error:', err); process.exit(1); }); });
 process.on('SIGTERM', () => { shutdown('SIGTERM').catch((err) => { log.error('Shutdown error:', err); process.exit(1); }); });
 
+// Without these, a rejection or throw originating from inside a third-party library's own
+// internals (discord.js, tmi.js, mysql2, ws) rather than the app's own promise chains would go
+// fully unhandled and silently kill the process — there's no supervisor (pm2/systemd) to restart
+// it, so we log loudly and exit deliberately instead, making the failure visible and diagnosable.
+process.on('unhandledRejection', (reason) => {
+  log.error('Unhandled promise rejection:', reason);
+  process.exit(1);
+});
+process.on('uncaughtException', (err) => {
+  log.error('Uncaught exception:', err);
+  process.exit(1);
+});
+
 async function main(): Promise<void> {
   log.info('Starting BCUK Bot 4...');
 
@@ -72,6 +85,7 @@ async function main(): Promise<void> {
     send: sayInChannel,
     getActiveChannels,
     getLoginUserIds: getActiveChannelUserIds,
+    getMultiTwitchDataForChannel,
   });
   registerCounterTwitchRuntime({ send: sayInChannel });
   registerMultiTwitchRuntime({ send: sayInChannel, getActiveChannels, getLoginUserIds: getActiveChannelUserIds });

--- a/src/twitch/monitor/twitchMonitorMultitwitch.ts
+++ b/src/twitch/monitor/twitchMonitorMultitwitch.ts
@@ -4,7 +4,9 @@ import { getDiscordClient } from '../../discord/discordBot';
 const log = createLogger('TwitchMonitor');
 import { tryEditDiscordMessage } from '../../discord/discordUtils';
 import { buildEmbed } from './twitchMonitorEmbed';
-import { LiveState } from './twitchMonitorTypes';
+import { LiveState, MultiTwitchGroupInfo } from './twitchMonitorTypes';
+
+export type { MultiTwitchGroupInfo };
 
 // ─── Public types ─────────────────────────────────────────────────────────────
 
@@ -13,11 +15,6 @@ export interface MultiTwitchPreview {
   applicable: boolean;
   participants: string[];
   url: string | null;
-}
-
-export interface MultiTwitchGroupInfo {
-  url: string;
-  participants: string[];
 }
 
 // ─── Internal types ───────────────────────────────────────────────────────────

--- a/src/twitch/monitor/twitchMonitorTypes.ts
+++ b/src/twitch/monitor/twitchMonitorTypes.ts
@@ -1,6 +1,17 @@
 import { DbStreamGroup, DbStreamerFull } from '../../db';
 import { TwitchStream } from '../twitchApi';
 
+/**
+ * A group's current MultiTwitch link: the URL and the participant logins it covers. Lives here
+ * (rather than in `twitchMonitorMultitwitch.ts`, which imports Discord bot internals) so it can
+ * be depended on — e.g. by `commands/customCommandHandler.ts`'s injected runtime — without
+ * pulling in that import chain.
+ */
+export interface MultiTwitchGroupInfo {
+  url: string;
+  participants: string[];
+}
+
 export interface LiveState {
   streamerId: number;
   groupId: number;

--- a/src/twitch/twitchApi.test.ts
+++ b/src/twitch/twitchApi.test.ts
@@ -9,7 +9,7 @@ vi.mock('../shared/config', () => ({
 
 import {
   getUsers, getStreams, getChannelInfo, getSharedChatSession, getAppToken,
-  updateRewardCost, createCustomReward, updateCustomReward, deleteCustomReward,
+  getCustomRewards, updateRewardCost, createCustomReward, updateCustomReward, deleteCustomReward,
   TwitchRewardUnsupportedError, TwitchRewardAuthError,
 } from './twitchApi';
 
@@ -154,6 +154,35 @@ describe('getSharedChatSession', () => {
     vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(200, TOKEN_RESPONSE));
     await getAppToken();
     expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('getCustomRewards', () => {
+  it('sends a GET with the broadcaster_id query param, returning the reward list', async () => {
+    const rewards = [{ id: 'rwd1', title: 'Cool Reward', cost: 500 }];
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(200, { data: rewards }));
+
+    const result = await getCustomRewards('bc1', 'user-token');
+
+    const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+    expect(String(url)).toContain('broadcaster_id=bc1');
+    expect(init?.method).toBeUndefined(); // defaults to GET
+    expect(result).toEqual(rewards);
+  });
+
+  it('throws with the response status on a 401 response', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(401, {}));
+    await expect(getCustomRewards('bc1', 'user-token')).rejects.toThrow('getCustomRewards failed: 401');
+  });
+
+  it('returns an empty array on a 403 response, rather than throwing', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(403, {}));
+    expect(await getCustomRewards('bc1', 'user-token')).toEqual([]);
+  });
+
+  it('throws a generic error for other non-OK statuses', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(500, {}));
+    await expect(getCustomRewards('bc1', 'user-token')).rejects.toThrow('getCustomRewards failed: 500');
   });
 });
 

--- a/src/twitch/twitchApi.ts
+++ b/src/twitch/twitchApi.ts
@@ -249,7 +249,7 @@ function customRewardUrl(broadcasterId: string, rewardId?: string): string {
 
 /**
  * Lists a broadcaster's custom rewards via Helix. Unlike its create/update/delete siblings, a
- * 403 (channel points unavailable, or the app lacks visibility into this broadcaster's rewards)
+ * 403 (the broadcaster is not a Twitch Partner or Affiliate, so channel points aren't available)
  * is treated as "no rewards" rather than a typed error, since listing is read-only and callers
  * generally just want to render whatever's available.
  * @param broadcasterId - Twitch user ID whose custom rewards to list.

--- a/src/twitch/twitchApi.ts
+++ b/src/twitch/twitchApi.ts
@@ -247,6 +247,16 @@ function customRewardUrl(broadcasterId: string, rewardId?: string): string {
   return rewardId ? `${base}&id=${encodeURIComponent(rewardId)}` : base;
 }
 
+/**
+ * Lists a broadcaster's custom rewards via Helix. Unlike its create/update/delete siblings, a
+ * 403 (channel points unavailable, or the app lacks visibility into this broadcaster's rewards)
+ * is treated as "no rewards" rather than a typed error, since listing is read-only and callers
+ * generally just want to render whatever's available.
+ * @param broadcasterId - Twitch user ID whose custom rewards to list.
+ * @param userToken - Broadcaster OAuth user token with the channel:manage:redemptions scope.
+ * @returns The broadcaster's custom rewards, or `[]` on a 403.
+ * @throws If Twitch returns a non-OK, non-403 status.
+ */
 export async function getCustomRewards(broadcasterId: string, userToken: string): Promise<TwitchCustomReward[]> {
   const res = await twitchFetch(customRewardUrl(broadcasterId), { headers: authHeaders(userToken) });
   if (res.status === 403) return [];

--- a/src/twitch/twitchBot.test.ts
+++ b/src/twitch/twitchBot.test.ts
@@ -745,6 +745,13 @@ describe('stopTwitchBot', () => {
 
     expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('streamer', false);
     expect(getActiveChannels().size).toBe(0);
+
+    // Client reference was cleared despite the hang: a second stop is a no-op
+    // (mirrors the "no-op when never started" case) rather than awaiting the
+    // still-hanging disconnect() again.
+    mockClient.disconnect.mockClear();
+    await stopTwitchBot();
+    expect(mockClient.disconnect).not.toHaveBeenCalled();
   });
 });
 

--- a/src/twitch/twitchBot.test.ts
+++ b/src/twitch/twitchBot.test.ts
@@ -106,6 +106,7 @@ import {
   getActiveChannelUserIds,
   setChannelJoinedHook,
 } from './twitchChannelMembership';
+import * as twitchChannelMembership from './twitchChannelMembership';
 import { getTwitchEnabledChannels, getAllTwitchLinkedUsers, findUserByTwitchName } from '../db';
 import { resolveGuildIdForDiscordId } from '../discord/voicePresence';
 import { getUsers } from './twitchApi';
@@ -738,6 +739,7 @@ describe('stopTwitchBot', () => {
     await joinTwitchChannel('streamer');
     mockClient.disconnect.mockImplementation(() => new Promise(() => {})); // never resolves/rejects
     vi.mocked(setTwitchChannel).mockClear();
+    const setTmiClientSpy = vi.spyOn(twitchChannelMembership, 'setTmiClient');
 
     const stopped = stopTwitchBot();
     await vi.advanceTimersByTimeAsync(5_000);
@@ -745,6 +747,8 @@ describe('stopTwitchBot', () => {
 
     expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('streamer', false);
     expect(getActiveChannels().size).toBe(0);
+    expect(setTmiClientSpy).toHaveBeenCalledWith(null);
+    setTmiClientSpy.mockRestore();
 
     // Client reference was cleared despite the hang: a second stop is a no-op
     // (mirrors the "no-op when never started" case) rather than awaiting the

--- a/src/twitch/twitchBot.test.ts
+++ b/src/twitch/twitchBot.test.ts
@@ -731,6 +731,21 @@ describe('stopTwitchBot', () => {
     expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('streamer', false);
     expect(getActiveChannels().size).toBe(0);
   });
+
+  it('does not hang forever when client.disconnect() never settles', async () => {
+    await connectBot();
+    vi.mocked(getUsers).mockResolvedValue([]);
+    await joinTwitchChannel('streamer');
+    mockClient.disconnect.mockImplementation(() => new Promise(() => {})); // never resolves/rejects
+    vi.mocked(setTwitchChannel).mockClear();
+
+    const stopped = stopTwitchBot();
+    await vi.advanceTimersByTimeAsync(5_000);
+    await stopped;
+
+    expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('streamer', false);
+    expect(getActiveChannels().size).toBe(0);
+  });
 });
 
 // ─── reconcileJoinedChannels (via onConnected) ────────────────────────────────

--- a/src/twitch/twitchBot.ts
+++ b/src/twitch/twitchBot.ts
@@ -10,7 +10,7 @@ import { fireAndForget } from '../commands/commandUtils';
 import { recordChatMessage } from './twitchChatActivity';
 import { setTwitchChannel } from '../shared/statusStore';
 import { normalizeTwitchChannelName } from './twitchChannelName';
-import { throttledTwitchSend } from './twitchSendQueue';
+import { throttledTwitchSend, withTimeout } from './twitchSendQueue';
 import { createLogger } from '../shared/logger';
 import {
   createManagedLookupCache,
@@ -35,6 +35,14 @@ const log = createLogger('Twitch');
 let client: tmi.Client | null = null;
 let connected = false;
 const TWITCH_CHAT_MESSAGE_PATTERN = /^\[#[^\]]+\] <[^>]+>: /;
+
+/**
+ * Upper bound on how long {@link stopTwitchBot} waits for `client.disconnect()`. tmi.js only
+ * resolves that promise once the underlying WebSocket fires a `close` event, which may never
+ * happen if the socket is already half-open at the network level — bounding it here guarantees
+ * shutdown always proceeds instead of hanging indefinitely.
+ */
+const DISCONNECT_TIMEOUT_MS = 5_000;
 
 // Bulk-loads every twitch_name → discord_id mapping in one query (like
 // getTwitchEnabledChannels()) instead of a lazy per-channel lookup, so a
@@ -279,8 +287,9 @@ export async function sayInChannel(channel: string, message: string): Promise<vo
 
 /**
  * Stops the Twitch bot: disconnects the tmi.js client (marking channels
- * disconnected if the disconnect itself fails), tears down the client
- * reference, and clears channel-membership state.
+ * disconnected if the disconnect itself fails or doesn't settle within
+ * {@link DISCONNECT_TIMEOUT_MS}), tears down the client reference, and
+ * clears channel-membership state.
  * @returns Resolves once shutdown is complete.
  */
 export async function stopTwitchBot(): Promise<void> {
@@ -288,7 +297,7 @@ export async function stopTwitchBot(): Promise<void> {
   setConnected(false);
   if (client) {
     try {
-      await client.disconnect();
+      await withTimeout(client.disconnect(), DISCONNECT_TIMEOUT_MS, 'Twitch disconnect');
     } catch (err) {
       log.warn('Error during disconnect:', err);
       getActiveChannels().forEach((ch) => { setTwitchChannel(ch, false); });

--- a/src/twitch/twitchSendQueue.test.ts
+++ b/src/twitch/twitchSendQueue.test.ts
@@ -226,8 +226,9 @@ describe('withTimeout', () => {
   });
 
   it('rejects with the wrapped promise\'s own rejection reason when it settles before the timeout', async () => {
-    const result = withTimeout(Promise.reject(new Error('boom')), 1_000, 'test op');
-    await expect(result).rejects.toThrow('boom');
+    const reason = new Error('boom');
+    const result = withTimeout(Promise.reject(reason), 1_000, 'test op');
+    await expect(result).rejects.toBe(reason);
   });
 
   it('rejects with a labeled timeout error when the wrapped promise never settles', async () => {

--- a/src/twitch/twitchSendQueue.test.ts
+++ b/src/twitch/twitchSendQueue.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
-import { throttledTwitchSend, __resetTwitchSendQueueForTests } from './twitchSendQueue';
+import { throttledTwitchSend, withTimeout, __resetTwitchSendQueueForTests } from './twitchSendQueue';
 
 const WINDOW_MS = 30_000;
 const PRIVILEGED_LIMIT = 100;
@@ -216,5 +216,24 @@ describe('throttledTwitchSend', () => {
     const call = throttledTwitchSend('streamer', () => false, send);
     await vi.advanceTimersByTimeAsync(5_000);
     await expect(call).resolves.toBeUndefined();
+  });
+});
+
+describe('withTimeout', () => {
+  it('resolves with the wrapped promise\'s value when it settles before the timeout', async () => {
+    const result = withTimeout(Promise.resolve('done'), 1_000, 'test op');
+    await expect(result).resolves.toBe('done');
+  });
+
+  it('rejects with the wrapped promise\'s own rejection reason when it settles before the timeout', async () => {
+    const result = withTimeout(Promise.reject(new Error('boom')), 1_000, 'test op');
+    await expect(result).rejects.toThrow('boom');
+  });
+
+  it('rejects with a labeled timeout error when the wrapped promise never settles', async () => {
+    const result = withTimeout(new Promise(() => {}), 1_000, 'test op');
+    const assertion = expect(result).rejects.toThrow('test op timed out after 1000ms');
+    await vi.advanceTimersByTimeAsync(1_000);
+    await assertion;
   });
 });

--- a/src/twitch/twitchSendQueue.ts
+++ b/src/twitch/twitchSendQueue.ts
@@ -87,12 +87,13 @@ async function waitForChannelFloor(channel: string): Promise<void> {
  * observed (and silently ignored) so it can never surface as an unhandled rejection later.
  * @param promise - The promise to bound.
  * @param ms - Milliseconds to wait before rejecting with a timeout error.
+ * @param label - Describes what timed out, used in the rejection message (e.g. `'Twitch send'`).
  * @returns `promise`'s resolved value if it settles first; otherwise rejects with `promise`'s
  *   own rejection reason, or a timeout error if neither happens within `ms`.
  */
-function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+export function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
   return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error(`Twitch send timed out after ${ms}ms`)), ms);
+    const timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
     promise.then(
       (value) => { clearTimeout(timer); resolve(value); },
       (err) => { clearTimeout(timer); reject(err); },
@@ -137,7 +138,7 @@ export async function throttledTwitchSend(channel: string, isPrivileged: () => b
     sentTimestamps.push(sentAt);
     if (!privileged) lastNonPrivilegedSendAtByChannel.set(channel, sentAt);
 
-    await withTimeout(send(), SEND_TIMEOUT_MS);
+    await withTimeout(send(), SEND_TIMEOUT_MS, 'Twitch send');
   });
 }
 

--- a/src/web/routes/adminRefresh.test.ts
+++ b/src/web/routes/adminRefresh.test.ts
@@ -24,7 +24,7 @@ import supertest from 'supertest';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 
 // Import module last so mocks are in place before module-level code runs
-import router, { refreshStates, getRefreshState, forgetGuildRefreshState } from './adminRefresh';
+import router, { refreshStates, getRefreshState } from './adminRefresh';
 
 const GUILD_ID = '900000000000000001';
 const OTHER_GUILD_ID = '900000000000000002';
@@ -62,41 +62,8 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-// ─── getRefreshState defaults ────────────────────────────────────────────────
-
-describe('getRefreshState', () => {
-  it('returns idle defaults for a guild with no recorded refresh', () => {
-    expect(getRefreshState(GUILD_ID)).toEqual({
-      outcome: 'idle',
-      updatedCount: 0,
-      failureCount: 0,
-      startedAt: null,
-      finishedAt: null,
-    });
-  });
-});
-
-// ─── forgetGuildRefreshState ────────────────────────────────────────────────
-
-describe('forgetGuildRefreshState', () => {
-  it('removes a guild\'s recorded refresh state, resetting it to idle on next read', () => {
-    refreshStates.set(GUILD_ID, { outcome: 'success', updatedCount: 3, failureCount: 0, startedAt: 1, finishedAt: 2 });
-
-    forgetGuildRefreshState(GUILD_ID);
-
-    expect(getRefreshState(GUILD_ID)).toEqual({
-      outcome: 'idle',
-      updatedCount: 0,
-      failureCount: 0,
-      startedAt: null,
-      finishedAt: null,
-    });
-  });
-
-  it('is a no-op for a guild with no recorded state', () => {
-    expect(() => forgetGuildRefreshState('never-seen')).not.toThrow();
-  });
-});
+// getRefreshState/forgetGuildRefreshState's own behavior is covered by
+// src/discord/guildRefreshState.test.ts, which now owns that state.
 
 // ─── GET /users/refresh-status ────────────────────────────────────────────────
 

--- a/src/web/routes/adminRefresh.ts
+++ b/src/web/routes/adminRefresh.ts
@@ -6,44 +6,12 @@ import { requireManager } from '../middleware';
 import { getSessionUser } from '../session';
 import { getDiscordClient, fetchMemberDisplayName } from '../../discord/discordBot';
 import { userMutationQueue } from './adminUserMutationQueue';
+import {
+  type RefreshOutcome, type RefreshState, refreshStates, getRefreshState, forgetGuildRefreshState,
+} from '../../discord/guildRefreshState';
 
-/** Lifecycle state of a guild's Discord-name-refresh job. */
-export type RefreshOutcome = 'idle' | 'running' | 'success' | 'partial' | 'noop' | 'error';
-
-/** Progress/result of a guild's most recent (or in-progress) Discord-name-refresh job. */
-export interface RefreshState {
-  outcome: RefreshOutcome;
-  updatedCount: number;
-  failureCount: number;
-  startedAt: number | null;
-  finishedAt: number | null;
-}
-
-function idleRefreshState(): RefreshState {
-  return { outcome: 'idle', updatedCount: 0, failureCount: 0, startedAt: null, finishedAt: null };
-}
-
-// Per-guild progress state, intentionally in-process because the web panel runs as
-// a single bot instance today. If the panel is ever scaled horizontally, move this
-// state into shared storage before relying on /users/refresh-status.
-export const refreshStates = new Map<string, RefreshState>();
-
-/** Returns the Discord-name-refresh progress for a guild, defaulting to idle when no refresh has run yet. */
-export function getRefreshState(guildId: string): RefreshState {
-  return refreshStates.get(guildId) ?? idleRefreshState();
-}
-
-/**
- * Forgets a guild's Discord-name-refresh progress state so it stops occupying
- * memory once the bot is no longer in that guild. Safe to call for a guild
- * with no state (no-op). Called from the `guildDelete` handler; a guild the
- * bot rejoins later starts fresh via {@link getRefreshState}'s idle default.
- *
- * @param guildId - Guild to forget.
- */
-export function forgetGuildRefreshState(guildId: string): void {
-  refreshStates.delete(guildId);
-}
+export type { RefreshOutcome, RefreshState };
+export { refreshStates, getRefreshState, forgetGuildRefreshState };
 
 const log = createLogger('Web');
 


### PR DESCRIPTION
## Summary

Fixes the five open `severity:high` issues filed as part of the full repository code review.

- **#469** — `stopTwitchBot()` awaited `client.disconnect()` unconditionally; if the underlying WebSocket never fires `close` (half-open socket), shutdown hung forever. Now bounded with a 5s timeout via `withTimeout` (promoted from `twitchSendQueue.ts`, which already used the same pattern for sends), and the client reference is always cleared regardless of outcome.
- **#470** — No `process.on('unhandledRejection'/'uncaughtException')` handlers existed, so a rejection from inside a third-party lib (discord.js, tmi.js, mysql2, ws) would silently kill the whole process with no supervisor to restart it. Added handlers in `src/index.ts` that log loudly and exit(1).
- **#471** — `discordBot.ts → customCommandHandler.ts → twitch/monitor/twitchMonitor.ts → {twitchMonitorAnnouncements,twitchMonitorMultitwitch,twitchMonitorStartup}.ts → discordBot.ts` formed a real circular import (7 distinct madge-reported cycle paths). `customCommandHandler.ts` no longer imports `getMultiTwitchDataForChannel` directly — it's now injected via the existing Twitch chat runtime (`registerTwitchChatRuntime`), the same `registerXRuntime` pattern the file already uses to avoid the sibling `twitchBot.ts` cycle. The `MultiTwitchGroupInfo` type also moved to `twitchMonitorTypes.ts` (no Discord-bot dependency) so even the type-only reference doesn't reintroduce the cycle.
- **#472** — `discordBot.ts` and `web/routes/adminRefresh.ts` imported directly from each other. Moved the shared guild-refresh state (`refreshStates`/`getRefreshState`/`forgetGuildRefreshState`) into a new `src/discord/guildRefreshState.ts` module that both sides depend on without a cycle; `adminRefresh.ts` re-exports them for backward compatibility.
- **#473** — `getCustomRewards()`'s `403 → []` and `!res.ok → throw` branches had no direct test coverage (its only consumers mock it outright). Added a `describe('getCustomRewards')` block to `twitchApi.test.ts` mirroring the sibling reward functions' status-branch tests.

Verified with `madge --circular` that the targeted cycles are gone (16 → 9 remaining, all pre-existing and unrelated to these issues — e.g. `db/*Cache.ts` pairs, `audioPlayer.ts`/`discordUtils.ts`/`commandRouter.ts`).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (2988 tests passing)
- [x] `npx madge --circular` confirms the #471/#472 cycles are eliminated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKvSGL1adRzqT2rPqWFtwo

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKvSGL1adRzqT2rPqWFtwo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared Discord refresh-status tracking with progress outcomes and cleanup when a guild is removed.
  * Added Twitch custom-reward retrieval with clearer handling for unavailable permissions.

* **Bug Fixes**
  * Improved Twitch shutdown reliability when disconnection hangs or fails.
  * Improved Twitch chat handling for multi-channel broadcasts.

* **Reliability**
  * Added clearer timeout reporting and safer handling of unexpected process errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->