### PR TITLE
Fix 5 open code-review findings (#475, #478, #479, #480, #481)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,12 @@ SFX_MAX_FILE_MB=10
 # OVERLAY_MAX_SSE_PER_CHANNEL=10
 # Optional: maximum concurrent SSE connections per channel-points streamer
 # CHANNEL_POINTS_MAX_SSE_PER_STREAMER=5
+# Optional: maximum concurrent SSE connections per dashboard events stream, per streamer
+# DASHBOARD_EVENTS_MAX_SSE_PER_STREAMER=5
+# Optional: maximum concurrent SSE connections per dashboard status stream, per guild
+# DASHBOARD_STATUS_MAX_SSE_PER_GUILD=10
+# Optional: maximum total concurrent SSE connections across the whole server
+# SSE_MAX_TOTAL_CONNECTIONS=500
 # Optional: path to the folder containing alerts-overlay image/sound uploads
 # ALERT_ASSETS_FOLDER=./alert-assets
 # Optional: maximum size (in MB) for an alert image/GIF upload via the web panel

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -18,7 +18,6 @@ vi.mock('./db/users', () => ({
   updateDiscordName: vi.fn(),
   getTwitchEnabledChannels: vi.fn(),
   getAllTwitchLinkedUsers: vi.fn(),
-  updateAccessLevel: vi.fn(),
 }));
 
 vi.mock('./db/customCommandCache', () => ({

--- a/src/db.ts
+++ b/src/db.ts
@@ -73,7 +73,7 @@ export async function removeOverride(guildId: string, commandId: number): Promis
 export {
   AccessLevel, ACCESS_LEVEL_LABELS,
   findUser, findUsersByIds, findUserByTwitchName, getAllUsers, getGuildMemberUsers,
-  updateDiscordName, getTwitchEnabledChannels, getAllTwitchLinkedUsers, updateAccessLevel,
+  updateDiscordName, getTwitchEnabledChannels, getAllTwitchLinkedUsers,
 } from './db/users';
 export type { AccessLevelValue, DbUser, TwitchLinkedUser } from './db/users';
 

--- a/src/db/users.test.ts
+++ b/src/db/users.test.ts
@@ -21,7 +21,6 @@ import {
   getTwitchEnabledChannels,
   getAllTwitchLinkedUsers,
   setTwitchBotEnabledRecord,
-  updateAccessLevel,
   AccessLevel,
 } from './users';
 import { normalizeTwitchChannelName } from '../twitch/twitchChannelName';
@@ -398,22 +397,6 @@ describe('getAllTwitchLinkedUsers', () => {
     vi.mocked(getPool).mockReturnValue(makePool([rows]) as any);
     const result = await getAllTwitchLinkedUsers();
     expect(result).toEqual([{ twitchName: 'alice', discordId: '1' }]);
-  });
-});
-
-// ─── updateAccessLevel ────────────────────────────────────────────────────────
-
-describe('updateAccessLevel', () => {
-  it('throws for an invalid access level', async () => {
-    vi.mocked(getPool).mockReturnValue(makePool() as any);
-    await expect(updateAccessLevel('1', 5)).rejects.toThrow('Invalid accessLevel: 5');
-  });
-
-  it('accepts all valid access levels', async () => {
-    for (const level of Object.values(AccessLevel)) {
-      vi.mocked(getPool).mockReturnValue(makePool() as any);
-      await expect(updateAccessLevel('1', level)).resolves.not.toThrow();
-    }
   });
 });
 

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -284,20 +284,3 @@ export async function setTwitchBotEnabledRecord(discordId: string, enabled: bool
     [enabled ? 1 : 0, discordId],
   ));
 }
-
-/**
- * Updates a user's legacy global access level.
- * @param discordId - Discord snowflake as a string.
- * @param accessLevel - New access level; must be one of `AccessLevel`'s values.
- * @returns Resolves once the update completes.
- * @throws If `accessLevel` is not a valid `AccessLevel` value.
- */
-export async function updateAccessLevel(discordId: string, accessLevel: number): Promise<void> {
-  if (!(Object.values(AccessLevel) as number[]).includes(accessLevel)) {
-    throw new Error(`Invalid accessLevel: ${accessLevel}`);
-  }
-  await withShortLockTimeout((conn) => conn.execute(
-    'UPDATE `user` SET access_level = ? WHERE discord_id = ?',
-    [accessLevel, discordId],
-  ));
-}

--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mockLogger } from '../test-utils/loggerMock';
 import { ACCESS_LEVEL_MOCK } from '../test-utils/accessLevelMock';
 import { flushMicrotasks } from '../test-utils/flushMicrotasks';
+import { deferred } from '../test-utils/deferredPromise';
 
 vi.mock('../shared/config', () => ({
   DISCORD_TOKEN: 'mock-token',
@@ -278,6 +279,43 @@ describe('startDiscordBot — guildCreate handler', () => {
 
     expect(vi.mocked(guilds.setMemberAccessLevel)).not.toHaveBeenCalled();
     expect(vi.mocked(registry.reloadGuildRegistry)).not.toHaveBeenCalled();
+  });
+
+  it('serializes provisioning across concurrent guildCreate events for the same owner via userMutationQueue', async () => {
+    const guilds = await import('../db.js');
+    const order: string[] = [];
+    const { promise: gate, resolve: openGate } = deferred();
+
+    vi.mocked(guilds.findUser)
+      .mockImplementationOnce(async () => {
+        order.push('a-findUser-start');
+        await gate;
+        order.push('a-findUser-end');
+        return null;
+      })
+      .mockImplementationOnce(async () => {
+        order.push('b-findUser');
+        return null;
+      });
+
+    const guildA = { ...makeNewGuild('same-owner'), id: 'guild-a' };
+    const guildB = { ...makeNewGuild('same-owner'), id: 'guild-b' };
+    const cb = getGuildCreateCb();
+
+    cb(guildA);
+    await flushMicrotasks();
+    cb(guildB);
+    await flushMicrotasks();
+
+    // guild B's provisioning must not start until guild A's finishes, since they share an owner
+    // and are serialised through userMutationQueue.
+    expect(order).toEqual(['a-findUser-start']);
+
+    openGate();
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(order).toEqual(['a-findUser-start', 'a-findUser-end', 'b-findUser']);
   });
 });
 

--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -294,9 +294,16 @@ describe('startDiscordBot — guildCreate handler', () => {
         return null;
       })
       .mockImplementationOnce(async () => {
+        // Guild A's owner row now exists, so guild B's provisioning skips upsertUser and only
+        // grants guild access — matching provisionGuildOwner's "don't overwrite an existing
+        // user" behavior.
         order.push('b-findUser');
-        return null;
+        return { discord_id: 'same-owner', discord_name: 'OwnerName', access_level: 0 } as any;
       });
+    vi.mocked(guilds.upsertUser).mockImplementation(async () => { order.push('a-upsertUser'); });
+    vi.mocked(guilds.setMemberAccessLevel).mockImplementation(async (guildId: string) => {
+      order.push(`${guildId === 'guild-a' ? 'a' : 'b'}-setMemberAccessLevel`);
+    });
 
     const guildA = { ...makeNewGuild('same-owner'), id: 'guild-a' };
     const guildB = { ...makeNewGuild('same-owner'), id: 'guild-b' };
@@ -307,15 +314,21 @@ describe('startDiscordBot — guildCreate handler', () => {
     cb(guildB);
     await flushMicrotasks();
 
-    // guild B's provisioning must not start until guild A's finishes, since they share an owner
-    // and are serialised through userMutationQueue.
+    // guild B's provisioning must not start — not even its findUser lookup — until guild A's
+    // entire queued sequence (upsertUser, then setMemberAccessLevel) has finished, since they
+    // share an owner and are serialised through userMutationQueue. If either write were moved
+    // outside the queue, it would show up here before 'a-findUser-end'.
     expect(order).toEqual(['a-findUser-start']);
 
     openGate();
     await new Promise((resolve) => setImmediate(resolve));
     await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
 
-    expect(order).toEqual(['a-findUser-start', 'a-findUser-end', 'b-findUser']);
+    expect(order).toEqual([
+      'a-findUser-start', 'a-findUser-end', 'a-upsertUser', 'a-setMemberAccessLevel',
+      'b-findUser', 'b-setMemberAccessLevel',
+    ]);
   });
 });
 

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -9,6 +9,7 @@ import { forgetGuild as forgetGuildVoiceState } from '../audio/audioPlayer';
 import { forgetGuildRefreshState } from './guildRefreshState';
 import { isRegisteredGuild, reloadGuildRegistry } from './guildRegistry';
 import { upsertGuild, getGuildById, findUser, upsertUser, setMemberAccessLevel, AccessLevel } from '../db';
+import { userMutationQueue } from '../web/routes/adminUserMutationQueue';
 import { createLogger } from '../shared/logger';
 
 const log = createLogger('Discord');
@@ -76,6 +77,11 @@ export async function fetchMemberDisplayName(
  * @param guild - The discord.js Guild that was just joined for the first time.
  * @returns Resolves once the owner's access is granted, or once an owner-fetch
  *   failure has been logged. Rejects if granting DB access fails.
+ *
+ * The user-row read/upsert/access-grant sequence is serialised through {@link userMutationQueue}
+ * on `owner.id`, matching every other write path that touches a user row by `discord_id` (e.g.
+ * the webpanel's admin routes) — a user can belong to multiple guilds, so an unqueued sequence
+ * here could otherwise race against a concurrent webpanel edit of the same user.
  */
 async function provisionGuildOwner(guild: Guild): Promise<void> {
   let owner;
@@ -85,11 +91,13 @@ async function provisionGuildOwner(guild: Guild): Promise<void> {
     log.error(`Failed to fetch owner for guild ${guild.id}:`, err);
     return;
   }
-  const existingUser = await findUser(owner.id);
-  if (!existingUser) {
-    await upsertUser(owner.id, owner.user.username, AccessLevel.USER);
-  }
-  await setMemberAccessLevel(guild.id, owner.id, AccessLevel.ADMIN);
+  await userMutationQueue.run(owner.id, async () => {
+    const existingUser = await findUser(owner.id);
+    if (!existingUser) {
+      await upsertUser(owner.id, owner.user.username, AccessLevel.USER);
+    }
+    await setMemberAccessLevel(guild.id, owner.id, AccessLevel.ADMIN);
+  });
   log.info(`Granted Admin access to server owner ${owner.user.tag} (${owner.id}) for guild '${guild.name}' (${guild.id}).`);
 }
 

--- a/src/test-utils/fixtures.test.ts
+++ b/src/test-utils/fixtures.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
 
-// `fixtures.ts` imports `AccessLevel` from `../db/users` at runtime, which transitively pulls in
+// `fixtures.ts` imports `AccessLevel` from `../db` at runtime, which transitively pulls in
 // `../db/pool` (and its required env vars). Mock it out, matching the convention used across
-// `src/web/routes/*.test.ts` (e.g. `rateLimits.test.ts`, `shared.test.ts`).
-vi.mock('../db/users', () => ({ AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 } }));
+// `src/web/routes/*.test.ts` (e.g. `shared.test.ts`).
+vi.mock('../db', () => ({ AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 } }));
 
 import { makeSessionUser, makeDbGuild } from './fixtures';
-import { AccessLevel } from '../db/users';
+import { AccessLevel } from '../db';
 
 describe('makeSessionUser', () => {
   it('returns a default level-0 test user when called with no overrides', () => {

--- a/src/test-utils/fixtures.ts
+++ b/src/test-utils/fixtures.ts
@@ -1,4 +1,4 @@
-import { AccessLevel, type AccessLevelValue } from '../db/users';
+import { AccessLevel, type AccessLevelValue } from '../db';
 
 /** Shape of the `req.session.user` object used across `src/web/routes/*.test.ts` session stubs. */
 export interface SessionUserFixture {

--- a/src/twitch/twitchChannelMembership.test.ts
+++ b/src/twitch/twitchChannelMembership.test.ts
@@ -217,24 +217,49 @@ describe('membershipMutationQueue serialization', () => {
     expect(order).toEqual(['join-start', 'join-end', 'part']);
   });
 
-  it('runs operations on different channels independently', async () => {
-    const client = makeMockClient();
+  it('runs non-join operations on different channels independently', async () => {
+    // client.join() calls are globally throttled (see the throttledJoin describe block below),
+    // so this exercises the queue's per-channel independence using part instead.
+    const client = makeMockClient(['#alice', '#carol']);
     setTmiClient(client as any);
     setConnected(true);
     const order: string[] = [];
     const { promise: gate, resolve: openGate } = deferred();
-    client.join.mockImplementation(async (channel: string) => {
+    client.part.mockImplementation(async (channel: string) => {
       if (channel === 'alice') await gate;
       order.push(channel);
     });
 
-    const alicePromise = joinTwitchChannel('alice'); // blocks on gate
-    await joinTwitchChannel('carol'); // must resolve without waiting for alice's gate
+    const alicePromise = partTwitchChannel('alice'); // blocks on gate
+    await partTwitchChannel('carol'); // must resolve without waiting for alice's gate
     expect(order).toEqual(['carol']);
 
     openGate();
     await alicePromise;
     expect(order).toEqual(['carol', 'alice']);
+  });
+});
+
+// ─── joinTwitchChannel global JOIN throttle ────────────────────────────────
+
+describe('joinTwitchChannel global join throttle', () => {
+  it('spaces client.join() calls across different channels by JOIN_THROTTLE_MS, not just per-channel', async () => {
+    const client = makeMockClient();
+    setTmiClient(client as any);
+    setConnected(true);
+
+    const alicePromise = joinTwitchChannel('alice');
+    const carolPromise = joinTwitchChannel('carol'); // must not call client.join before alice's throttle window elapses
+
+    await flushMicrotasks();
+    expect(client.join).toHaveBeenCalledTimes(1);
+    expect(client.join).toHaveBeenCalledWith('alice');
+
+    await vi.runAllTimersAsync();
+    await Promise.all([alicePromise, carolPromise]);
+
+    expect(client.join).toHaveBeenNthCalledWith(1, 'alice');
+    expect(client.join).toHaveBeenNthCalledWith(2, 'carol');
   });
 });
 

--- a/src/twitch/twitchChannelMembership.test.ts
+++ b/src/twitch/twitchChannelMembership.test.ts
@@ -255,7 +255,12 @@ describe('joinTwitchChannel global join throttle', () => {
     expect(client.join).toHaveBeenCalledTimes(1);
     expect(client.join).toHaveBeenCalledWith('alice');
 
-    await vi.runAllTimersAsync();
+    // Assert the throttle actually holds for the full window, not just "eventually" — advancing
+    // one tick short of JOIN_THROTTLE_MS must not release carol's join yet.
+    await vi.advanceTimersByTimeAsync(599);
+    expect(client.join).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
     await Promise.all([alicePromise, carolPromise]);
 
     expect(client.join).toHaveBeenNthCalledWith(1, 'alice');

--- a/src/twitch/twitchChannelMembership.ts
+++ b/src/twitch/twitchChannelMembership.ts
@@ -18,6 +18,25 @@ const membershipMutationQueue = createMutationQueue();
 const JOIN_THROTTLE_MS = 600;
 let _onChannelJoined: ((channel: string) => void) | null = null;
 
+// A chain of promises gating client.join() calls so they're spaced JOIN_THROTTLE_MS apart
+// globally — across both the reconnect-reconciliation path and ad-hoc single joins (e.g. from
+// the admin panel) — since those are only serialised per-channel by membershipMutationQueue and
+// could otherwise collectively exceed Twitch's IRC JOIN rate limit.
+let joinGate: Promise<void> = Promise.resolve();
+
+/** Calls `client.join(channel)`, globally throttled to JOIN_THROTTLE_MS between joins across all channels. */
+async function throttledJoin(client: tmi.Client, channel: string): Promise<void> {
+  const previousGate = joinGate;
+  let releaseGate!: () => void;
+  joinGate = new Promise((resolve) => { releaseGate = resolve; });
+  await previousGate;
+  try {
+    await client.join(channel);
+  } finally {
+    setTimeout(releaseGate, JOIN_THROTTLE_MS);
+  }
+}
+
 /** Sets the active tmi.js client instance (called from twitchBot after connect). */
 export function setTmiClient(c: tmi.Client | null): void {
   _client = c;
@@ -74,8 +93,7 @@ async function joinMissingChannel(channel: string): Promise<void> {
     cacheChannelUserId(channel);
     return;
   }
-  await _client.join(channel);
-  await new Promise<void>((resolve) => { setTimeout(resolve, JOIN_THROTTLE_MS); });
+  await throttledJoin(_client, channel);
   setTwitchChannel(channel, true);
   cacheChannelUserId(channel);
   fireChannelJoinedHook(channel);
@@ -168,7 +186,7 @@ export async function joinTwitchChannel(channel: string): Promise<void> {
     activeChannels.add(normalized);
     setTwitchChannel(normalized, false);
     try {
-      await _client.join(normalized);
+      await throttledJoin(_client, normalized);
       setTwitchChannel(normalized, true);
       cacheChannelUserId(normalized);
     } catch (err) {
@@ -225,8 +243,9 @@ export function getActiveChannelUserIds(): ReadonlyMap<string, string> {
   return activeChannelUserIds;
 }
 
-/** Clears all active channel and user ID state (used in tests). */
+/** Clears all active channel and user ID state, and resets the join throttle gate (used in tests). */
 export function clearMembershipState(): void {
   activeChannels.clear();
   activeChannelUserIds.clear();
+  joinGate = Promise.resolve();
 }

--- a/src/twitch/twitchChannelMembership.ts
+++ b/src/twitch/twitchChannelMembership.ts
@@ -24,7 +24,14 @@ let _onChannelJoined: ((channel: string) => void) | null = null;
 // could otherwise collectively exceed Twitch's IRC JOIN rate limit.
 let joinGate: Promise<void> = Promise.resolve();
 
-/** Calls `client.join(channel)`, globally throttled to JOIN_THROTTLE_MS between joins across all channels. */
+/**
+ * Calls `client.join(channel)`, globally throttled to JOIN_THROTTLE_MS between joins across all
+ * channels.
+ * @param client - The connected tmi.js client to join with.
+ * @param channel - The already-normalized channel name to join.
+ * @returns Resolves once the join call itself has completed (not once the throttle window has
+ *   elapsed — the throttle only delays the *next* queued join).
+ */
 async function throttledJoin(client: tmi.Client, channel: string): Promise<void> {
   const previousGate = joinGate;
   let releaseGate!: () => void;

--- a/src/web/routes/admin.test.ts
+++ b/src/web/routes/admin.test.ts
@@ -64,13 +64,11 @@ vi.mock('../../shared/logger', () => ({
   createLogger: () => mockLog,
 }));
 
-vi.mock('../../db/users', () => ({ AccessLevel: ACCESS_LEVEL_MOCK }));
-
 import supertest from 'supertest';
 import router from './admin';
 import { findUser, getMemberAccessLevel, getGuildMemberUsers, setMemberAccessLevel, removeGuildMember } from '../../db';
 import { reloadGuildRegistry } from '../../discord/guildRegistry';
-import { AccessLevel } from '../../db/users';
+import { AccessLevel } from '../../db';
 import { normalizeTwitchChannelName } from '../../twitch/twitchChannelName';
 import {
   DuplicateTwitchNameError,

--- a/src/web/routes/adminUserMutations.test.ts
+++ b/src/web/routes/adminUserMutations.test.ts
@@ -7,6 +7,7 @@ vi.mock('../../db', () => ({
   upsertUser: vi.fn(),
   updateTwitchBotEnabled: vi.fn(),
   getTwitchEnabledChannels: vi.fn(),
+  AccessLevel: ACCESS_LEVEL_MOCK,
 }));
 
 vi.mock('../../twitch/twitchChannelMembership', () => ({
@@ -17,8 +18,6 @@ vi.mock('../../twitch/twitchChannelMembership', () => ({
 vi.mock('../../twitch/twitchChannelName', () => ({
   normalizeTwitchChannelName: vi.fn((name: string | null) => name?.toLowerCase() ?? null),
 }));
-
-vi.mock('../../db/users', () => ({ AccessLevel: ACCESS_LEVEL_MOCK }));
 
 import {
   addOrUpdateUserMutation,
@@ -36,7 +35,7 @@ import {
 } from '../../db';
 import { joinTwitchChannel, partTwitchChannel } from '../../twitch/twitchChannelMembership';
 import { normalizeTwitchChannelName } from '../../twitch/twitchChannelName';
-import { AccessLevel } from '../../db/users';
+import { AccessLevel } from '../../db';
 
 type MockDbUser = {
   discord_id: string;

--- a/src/web/routes/adminUserValidation.test.ts
+++ b/src/web/routes/adminUserValidation.test.ts
@@ -2,9 +2,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mockLogger } from '../../test-utils/loggerMock';
 import { ACCESS_LEVEL_MOCK } from '../../test-utils/accessLevelMock';
 
-vi.mock('../../db/users', () => ({
-  AccessLevel: ACCESS_LEVEL_MOCK,
-}));
 vi.mock('../../db', () => ({
   findUser: vi.fn(),
   getMemberAccessLevel: vi.fn(),
@@ -23,7 +20,7 @@ vi.mock('./adminUserMutations', () => ({
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
 
 import { findUser, getMemberAccessLevel } from '../../db';
-import { AccessLevel } from '../../db/users';
+import { AccessLevel } from '../../db';
 import { isLockWaitTimeoutDbError } from './adminUserMutations';
 import { normalizeTwitchChannelName } from '../../twitch/twitchChannelName';
 import {

--- a/src/web/routes/alertAnimationSync.test.ts
+++ b/src/web/routes/alertAnimationSync.test.ts
@@ -2,11 +2,30 @@ import { describe, it, expect, vi } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 
-// The '../../db' facade pulls in '../../shared/config' (which requires real env vars) at module
-// scope, so mock it here — the test only needs the plain ALERT_TEXT_ANIMATIONS array.
-vi.mock('../../db', () => ({
-  ALERT_TEXT_ANIMATIONS: ['none', 'wave', 'pulse', 'glitch', 'shake', 'rainbow', 'flicker', 'tilt', 'bounce-in', 'typewriter'],
+// The '../../db' facade transitively pulls in '../../shared/config' (which requires real env
+// vars) and '../../db/pool' / '../../db/alertConfigCache' (which need a live DB connection) at
+// module scope. Stub all three with safe dummy values so the *real* ALERT_TEXT_ANIMATIONS from
+// db/alertConfig.ts loads through the facade — keeping this test pinned to the authoritative
+// list instead of a hand-copied duplicate that could silently drift from it.
+vi.mock('../../shared/config', () => ({
+  DISCORD_TOKEN: 'mock-token',
+  TWITCH_USERNAME: 'mock-user',
+  TWITCH_OAUTH_TOKEN: 'oauth:mock',
+  TWITCH_CLIENT_ID: 'mock-client-id',
+  TWITCH_CLIENT_SECRET: 'mock-client-secret',
+  DB_HOST: 'localhost',
+  DB_PORT: 3306,
+  DB_USER: 'mock-user',
+  DB_PASSWORD: 'mock-password',
+  DB_NAME: 'mock-db',
+  SESSION_SECRET: 'mock-session-secret-that-is-long-enough',
+  DISCORD_CLIENT_ID: 'mock-discord-client-id',
+  DISCORD_CLIENT_SECRET: 'mock-discord-client-secret',
+  DISCORD_CALLBACK_URL: 'http://localhost:3000/auth/discord/callback',
+  PUBLIC_URL: 'http://localhost:3000',
 }));
+vi.mock('../../db/pool', () => ({ getPool: vi.fn(), withTransaction: vi.fn() }));
+vi.mock('../../db/alertConfigCache', () => ({ invalidateAlertConfigLookupCache: vi.fn(), findCachedAlertConfig: vi.fn() }));
 
 import { ALERT_TEXT_ANIMATIONS } from '../../db';
 

--- a/src/web/routes/alertAnimationSync.test.ts
+++ b/src/web/routes/alertAnimationSync.test.ts
@@ -2,14 +2,13 @@ import { describe, it, expect, vi } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 
-// alertConfig.ts pulls in pool.ts (reads real DB env vars at module scope) and
-// alertConfigCache.ts (builds a managed lookup cache at module scope) — mock both so importing
-// the plain ALERT_TEXT_ANIMATIONS array here doesn't require a real DB connection, mirroring
-// src/db/alertConfig.test.ts's own mocks.
-vi.mock('../../db/pool', () => ({ getPool: vi.fn(), withTransaction: vi.fn() }));
-vi.mock('../../db/alertConfigCache', () => ({ invalidateAlertConfigLookupCache: vi.fn(), findCachedAlertConfig: vi.fn() }));
+// The '../../db' facade pulls in '../../shared/config' (which requires real env vars) at module
+// scope, so mock it here — the test only needs the plain ALERT_TEXT_ANIMATIONS array.
+vi.mock('../../db', () => ({
+  ALERT_TEXT_ANIMATIONS: ['none', 'wave', 'pulse', 'glitch', 'shake', 'rainbow', 'flicker', 'tilt', 'bounce-in', 'typewriter'],
+}));
 
-import { ALERT_TEXT_ANIMATIONS } from '../../db/alertConfig';
+import { ALERT_TEXT_ANIMATIONS } from '../../db';
 
 const REPO_ROOT = path.join(__dirname, '..', '..', '..');
 

--- a/src/web/routes/alertsAdmin.test.ts
+++ b/src/web/routes/alertsAdmin.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ACCESS_LEVEL_MOCK } from '../../test-utils/accessLevelMock';
 
 vi.mock('../../db', () => ({
   ALERT_EVENT_TYPES: ['follow', 'sub', 'resub', 'giftsub', 'raid'],
   ALERT_TEXT_ANIMATIONS: ['none', 'wave', 'pulse', 'glitch', 'shake', 'rainbow', 'flicker', 'tilt', 'bounce-in', 'typewriter'],
   getStreamerByDiscordId: vi.fn(),
   getAlertConfigsForStreamer: vi.fn(),
-  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
+  AccessLevel: ACCESS_LEVEL_MOCK,
 }));
 
 vi.mock('../csrf', () => ({

--- a/src/web/routes/alertsAdmin.test.ts
+++ b/src/web/routes/alertsAdmin.test.ts
@@ -5,6 +5,7 @@ vi.mock('../../db', () => ({
   ALERT_TEXT_ANIMATIONS: ['none', 'wave', 'pulse', 'glitch', 'shake', 'rainbow', 'flicker', 'tilt', 'bounce-in', 'typewriter'],
   getStreamerByDiscordId: vi.fn(),
   getAlertConfigsForStreamer: vi.fn(),
+  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
 }));
 
 vi.mock('../csrf', () => ({
@@ -42,7 +43,7 @@ vi.mock('./alertsAssetMutations', async () => {
 import supertest from 'supertest';
 import router from './alertsAdmin';
 import { getStreamerByDiscordId, getAlertConfigsForStreamer } from '../../db';
-import { AccessLevel } from '../../db/users';
+import { AccessLevel } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 import { makeSessionUser, type SessionUserFixture } from '../../test-utils/fixtures';
 

--- a/src/web/routes/alertsAdminMutations.test.ts
+++ b/src/web/routes/alertsAdminMutations.test.ts
@@ -10,6 +10,7 @@ vi.mock('../../db', () => ({
   getStreamerByDiscordId: vi.fn(),
   saveAlertConfig: vi.fn(),
   getAlertConfig: vi.fn(),
+  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
 }));
 
 vi.mock('../csrf', () => ({
@@ -38,7 +39,7 @@ vi.mock('../../shared/config', () => ({}));
 import supertest from 'supertest';
 import { router } from './alertsAdminMutations';
 import { getStreamerByDiscordId, saveAlertConfig, getAlertConfig } from '../../db';
-import { AccessLevel } from '../../db/users';
+import { AccessLevel } from '../../db';
 import { pushAlertEvent } from './alertsOverlaySource';
 import { reloadEventSubSubscriptions } from '../../twitch/eventsub/twitchEventSub';
 import { buildTestApp } from '../../test-utils/expressTestApp';

--- a/src/web/routes/alertsAdminMutations.test.ts
+++ b/src/web/routes/alertsAdminMutations.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mockLogger } from '../../test-utils/loggerMock';
+import { ACCESS_LEVEL_MOCK } from '../../test-utils/accessLevelMock';
 
 /** Mocks the shared logger so route handlers don't write real log output during tests. */
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
@@ -10,7 +11,7 @@ vi.mock('../../db', () => ({
   getStreamerByDiscordId: vi.fn(),
   saveAlertConfig: vi.fn(),
   getAlertConfig: vi.fn(),
-  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
+  AccessLevel: ACCESS_LEVEL_MOCK,
 }));
 
 vi.mock('../csrf', () => ({

--- a/src/web/routes/alertsAssetMutations.test.ts
+++ b/src/web/routes/alertsAssetMutations.test.ts
@@ -11,6 +11,7 @@ vi.mock('../../db', () => ({
   setAlertSound: vi.fn(),
   // Pulled in transitively via sfxFileUpload.ts (source of the shared detectAudioType).
   addSfxFile: vi.fn(),
+  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
 }));
 
 vi.mock('../csrf', () => ({
@@ -49,7 +50,7 @@ vi.mock('fs', () => ({
 import supertest from 'supertest';
 import { router, detectImageType } from './alertsAssetMutations';
 import { getStreamerByDiscordId, setAlertImage, setAlertSound } from '../../db';
-import { AccessLevel } from '../../db/users';
+import { AccessLevel } from '../../db';
 import fs from 'fs';
 import { csrfProtection } from '../csrf';
 import { buildTestApp } from '../../test-utils/expressTestApp';

--- a/src/web/routes/alertsAssetMutations.test.ts
+++ b/src/web/routes/alertsAssetMutations.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mockLogger } from '../../test-utils/loggerMock';
+import { ACCESS_LEVEL_MOCK } from '../../test-utils/accessLevelMock';
 
 /** Mocks the shared logger so route handlers don't write real log output during tests. */
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
@@ -11,7 +12,7 @@ vi.mock('../../db', () => ({
   setAlertSound: vi.fn(),
   // Pulled in transitively via sfxFileUpload.ts (source of the shared detectAudioType).
   addSfxFile: vi.fn(),
-  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
+  AccessLevel: ACCESS_LEVEL_MOCK,
 }));
 
 vi.mock('../csrf', () => ({

--- a/src/web/routes/channelPointsAdmin.test.ts
+++ b/src/web/routes/channelPointsAdmin.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mockLogger } from '../../test-utils/loggerMock';
+import { ACCESS_LEVEL_MOCK } from '../../test-utils/accessLevelMock';
 
 vi.mock('../../db', () => ({
   getStreamerByDiscordId: vi.fn(),
   getPricingConfigsForStreamer: vi.fn(),
   getPricingSettingsForStreamer: vi.fn(),
   getPricingHistoryForRewards: vi.fn(),
-  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
+  AccessLevel: ACCESS_LEVEL_MOCK,
 }));
 
 vi.mock('../csrf', () => ({

--- a/src/web/routes/channelPointsAdmin.test.ts
+++ b/src/web/routes/channelPointsAdmin.test.ts
@@ -6,6 +6,7 @@ vi.mock('../../db', () => ({
   getPricingConfigsForStreamer: vi.fn(),
   getPricingSettingsForStreamer: vi.fn(),
   getPricingHistoryForRewards: vi.fn(),
+  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
 }));
 
 vi.mock('../csrf', () => ({
@@ -18,11 +19,6 @@ vi.mock('../csrf', () => ({
 vi.mock('../middleware', () => ({
   requireAuth: (_req: any, _res: any, next: any) => next(),
 }));
-
-// `makeSessionUser` (from `test-utils/fixtures`) imports `AccessLevel` from `../../db/users` at
-// runtime, which transitively pulls in `../../db/pool` and its required env vars. Mock it out,
-// matching the convention used elsewhere (e.g. `streamGroups.test.ts`).
-vi.mock('../../db/users', () => ({ AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 } }));
 
 vi.mock('../../twitch/twitchApi', () => ({
   getCustomRewards: vi.fn(),

--- a/src/web/routes/commandAssignments.test.ts
+++ b/src/web/routes/commandAssignments.test.ts
@@ -10,6 +10,7 @@ vi.mock('../../db', () => {
     findUser: vi.fn().mockResolvedValue(null),
     CommandConflictError,
     isMysqlDuplicateEntryError: vi.fn().mockReturnValue(false),
+    AccessLevel: ACCESS_LEVEL_MOCK,
   };
 });
 vi.mock('../csrf', () => ({
@@ -19,14 +20,11 @@ vi.mock('../middleware', () => ({
   requireMod: (_req: any, _res: any, next: any) => next(),
 }));
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
-vi.mock('../../db/users', () => ({
-  AccessLevel: ACCESS_LEVEL_MOCK,
-}));
 
 import supertest from 'supertest';
 import router from './commandAssignments';
 import { assignUserToCommand, unassignUserFromCommand, findUser, CommandConflictError, isMysqlDuplicateEntryError } from '../../db';
-import { AccessLevel } from '../../db/users';
+import { AccessLevel } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 
 /** Builds a supertest-ready app: the command assignments router with a urlencoded body parser (no session or render stub needed). */

--- a/src/web/routes/commandMutations.test.ts
+++ b/src/web/routes/commandMutations.test.ts
@@ -16,11 +16,9 @@ vi.mock('../../db', () => {
     CommandNotFoundError,
     ReservedCommandError,
     isMysqlDuplicateEntryError: vi.fn().mockReturnValue(false),
+    AccessLevel: ACCESS_LEVEL_MOCK,
   };
 });
-vi.mock('../../db/users', () => ({
-  AccessLevel: ACCESS_LEVEL_MOCK,
-}));
 vi.mock('../csrf', () => ({ csrfProtection: (_req: any, _res: any, next: any) => next() }));
 vi.mock('../middleware', () => ({ requireMod: (_req: any, _res: any, next: any) => next() }));
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
@@ -33,7 +31,7 @@ import {
   CommandConflictError, CommandNotFoundError, ReservedCommandError,
   isMysqlDuplicateEntryError,
 } from '../../db';
-import { AccessLevel } from '../../db/users';
+import { AccessLevel } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 
 /** Builds a supertest-ready app: the command mutations router with a urlencoded body parser (no session or render stub needed). */

--- a/src/web/routes/commands.test.ts
+++ b/src/web/routes/commands.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-/** Hoisted so the `vi.mock('../../db/users', ...)` factory below can safely reference it — `vi.mock` factories are hoisted above imports, so a plain imported binding could throw `ReferenceError` depending on import order. */
+/** Hoisted so the `vi.mock('../../db', ...)` factory below can safely reference it — `vi.mock` factories are hoisted above imports, so a plain imported binding could throw `ReferenceError` depending on import order. */
 const { ACCESS_LEVEL_MOCK } = vi.hoisted(() => ({
   ACCESS_LEVEL_MOCK: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
 }));
@@ -27,6 +27,7 @@ vi.mock('../../db', () => {
     CommandNotFoundError,
     ReservedCommandError,
     isMysqlDuplicateEntryError: vi.fn().mockReturnValue(false),
+    AccessLevel: ACCESS_LEVEL_MOCK,
   };
 });
 
@@ -48,9 +49,6 @@ vi.mock('../../logger', () => ({
   createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
 }));
 
-/** Mocks `db/users` so `AccessLevel` resolves to the shared hoisted mock instead of hitting the real module. */
-vi.mock('../../db/users', () => ({ AccessLevel: ACCESS_LEVEL_MOCK }));
-
 import express from 'express';
 import supertest from 'supertest';
 import router from './commands';
@@ -71,7 +69,7 @@ import {
   CommandNotFoundError,
   ReservedCommandError,
 } from '../../db';
-import { AccessLevel } from '../../db/users';
+import { AccessLevel } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 
 /** Builds a supertest-ready app: the commands router with a stubbed session and a render mock that sends `rendered:<view>` (locals ignored). */

--- a/src/web/routes/companionKeys.test.ts
+++ b/src/web/routes/companionKeys.test.ts
@@ -5,6 +5,7 @@ vi.mock('../../db', () => ({
   issueToken: vi.fn(),
   getTokenStatus: vi.fn(),
   revokeToken: vi.fn(),
+  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
 }));
 vi.mock('../csrf', () => ({
   csrfProtection: (req: any, _res: any, next: any) => {
@@ -19,7 +20,7 @@ import express from 'express';
 import supertest from 'supertest';
 import router from './companionKeys';
 import { issueToken, getTokenStatus, revokeToken } from '../../db';
-import { AccessLevel } from '../../db/users';
+import { AccessLevel } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 
 const GUILD_ID = '900000000000000001';

--- a/src/web/routes/companionKeys.test.ts
+++ b/src/web/routes/companionKeys.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mockLogger } from '../../test-utils/loggerMock';
+import { ACCESS_LEVEL_MOCK } from '../../test-utils/accessLevelMock';
 
 vi.mock('../../db', () => ({
   issueToken: vi.fn(),
   getTokenStatus: vi.fn(),
   revokeToken: vi.fn(),
-  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
+  AccessLevel: ACCESS_LEVEL_MOCK,
 }));
 vi.mock('../csrf', () => ({
   csrfProtection: (req: any, _res: any, next: any) => {

--- a/src/web/routes/counterHistory.test.ts
+++ b/src/web/routes/counterHistory.test.ts
@@ -8,6 +8,7 @@ const { mockLogger, ACCESS_LEVEL_MOCK } = vi.hoisted(() => ({
 
 vi.mock('../../db', () => ({
   getCounterHistory: vi.fn().mockResolvedValue(null),
+  AccessLevel: ACCESS_LEVEL_MOCK,
 }));
 
 vi.mock('../csrf', () => ({
@@ -24,13 +25,10 @@ vi.mock('../middleware', () => ({
 /** Mocks the shared logger so route handlers don't write real log output during tests. */
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
 
-/** Mocks `db/users` so `AccessLevel` resolves to the shared hoisted mock instead of hitting the real module. */
-vi.mock('../../db/users', () => ({ AccessLevel: ACCESS_LEVEL_MOCK }));
-
 import supertest from 'supertest';
 import router from './counterHistory';
 import { getCounterHistory } from '../../db';
-import { AccessLevel } from '../../db/users';
+import { AccessLevel } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 
 /** Builds a supertest-ready app: the counter history router with a stubbed session and a render mock that sends `rendered:<view>` (locals ignored). */

--- a/src/web/routes/counters.test.ts
+++ b/src/web/routes/counters.test.ts
@@ -16,6 +16,7 @@ vi.mock('../../db', () => {
     CounterNotFoundError,
     ReservedCommandError,
     isMysqlDuplicateEntryError: vi.fn().mockReturnValue(false),
+    AccessLevel: ACCESS_LEVEL_MOCK,
   };
 });
 
@@ -36,8 +37,6 @@ vi.mock('../../logger', () => ({
   createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }),
 }));
 
-vi.mock('../../db/users', () => ({ AccessLevel: ACCESS_LEVEL_MOCK }));
-
 import supertest from 'supertest';
 import router from './counters';
 import {
@@ -52,7 +51,7 @@ import {
   CounterNotFoundError,
   ReservedCommandError,
 } from '../../db';
-import { AccessLevel } from '../../db/users';
+import { AccessLevel } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 
 /** Builds a supertest-ready app: the counters router with a stubbed session and a render mock that sends `rendered:<view>` (locals ignored). */

--- a/src/web/routes/eventsubCallback.test.ts
+++ b/src/web/routes/eventsubCallback.test.ts
@@ -9,6 +9,7 @@ vi.mock('../../db', () => ({
   saveStreamerToken: vi.fn(),
   initEventConfig: vi.fn(),
   initAlertConfigs: vi.fn(),
+  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
 }));
 
 vi.mock('../../twitch/eventsub/twitchApiEventSub', () => ({
@@ -33,7 +34,7 @@ import supertest from 'supertest';
 import router from './eventsubCallback';
 import { getStreamerById, saveStreamerToken, initEventConfig, initAlertConfigs } from '../../db';
 import { exchangeCode, getUserFromToken } from '../../twitch/eventsub/twitchApiEventSub';
-import { AccessLevel } from '../../db/users';
+import { AccessLevel } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 import { makeSessionUser, type SessionUserFixture } from '../../test-utils/fixtures';
 

--- a/src/web/routes/eventsubCallback.test.ts
+++ b/src/web/routes/eventsubCallback.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mockLogger } from '../../test-utils/loggerMock';
+import { ACCESS_LEVEL_MOCK } from '../../test-utils/accessLevelMock';
 
 /** Mocks the shared logger so route handlers don't write real log output during tests. */
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
@@ -9,7 +10,7 @@ vi.mock('../../db', () => ({
   saveStreamerToken: vi.fn(),
   initEventConfig: vi.fn(),
   initAlertConfigs: vi.fn(),
-  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
+  AccessLevel: ACCESS_LEVEL_MOCK,
 }));
 
 vi.mock('../../twitch/eventsub/twitchApiEventSub', () => ({

--- a/src/web/routes/guild.test.ts
+++ b/src/web/routes/guild.test.ts
@@ -7,8 +7,6 @@ vi.mock('../../db', () => ({
   getAllGuilds: vi.fn(),
   getGuildsForMember: vi.fn(),
   findUser: vi.fn(),
-}));
-vi.mock('../../db/users', () => ({
   AccessLevel: ACCESS_LEVEL_MOCK,
 }));
 vi.mock('../csrf', () => ({
@@ -23,7 +21,7 @@ import express from 'express';
 import supertest from 'supertest';
 import router from './guild';
 import { findUser, getAllGuilds, getEffectiveAccessLevelForUser, getGuildsForMember } from '../../db';
-import { AccessLevel } from '../../db/users';
+import { AccessLevel } from '../../db';
 
 const TWO_GUILDS = [
   { guildId: '100000000000000001', name: 'Alpha' },

--- a/src/web/routes/overlayAdmin.test.ts
+++ b/src/web/routes/overlayAdmin.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ACCESS_LEVEL_MOCK } from '../../test-utils/accessLevelMock';
 
 vi.mock('../../db', () => ({
   getStreamerByDiscordId: vi.fn(),
   getVideosForStreamer: vi.fn(),
   getRewardsForStreamer: vi.fn(),
-  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
+  AccessLevel: ACCESS_LEVEL_MOCK,
 }));
 
 vi.mock('../csrf', () => ({

--- a/src/web/routes/overlayAdmin.test.ts
+++ b/src/web/routes/overlayAdmin.test.ts
@@ -4,6 +4,7 @@ vi.mock('../../db', () => ({
   getStreamerByDiscordId: vi.fn(),
   getVideosForStreamer: vi.fn(),
   getRewardsForStreamer: vi.fn(),
+  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
 }));
 
 vi.mock('../csrf', () => ({
@@ -46,7 +47,7 @@ import router from './overlayAdmin';
 import { getStreamerByDiscordId, getVideosForStreamer, getRewardsForStreamer } from '../../db';
 import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
 import { getCustomRewards } from '../../twitch/twitchApi';
-import { AccessLevel } from '../../db/users';
+import { AccessLevel } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 import { makeSessionUser, type SessionUserFixture } from '../../test-utils/fixtures';
 

--- a/src/web/routes/overlayAdminMutations.test.ts
+++ b/src/web/routes/overlayAdminMutations.test.ts
@@ -11,6 +11,7 @@ vi.mock('../../db', () => ({
   upsertReward: vi.fn(),
   setRewardVideos: vi.fn(),
   deleteReward: vi.fn(),
+  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
 }));
 
 vi.mock('../csrf', () => ({
@@ -44,7 +45,7 @@ import supertest from 'supertest';
 import multer from 'multer';
 import { router, detectVideoType, handleUploadError } from './overlayAdminMutations';
 import { getStreamerByDiscordId, addVideo, deleteVideo } from '../../db';
-import { AccessLevel } from '../../db/users';
+import { AccessLevel } from '../../db';
 import fs from 'fs';
 import { csrfProtection } from '../csrf';
 import { buildTestApp } from '../../test-utils/expressTestApp';

--- a/src/web/routes/overlayAdminMutations.test.ts
+++ b/src/web/routes/overlayAdminMutations.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mockLogger } from '../../test-utils/loggerMock';
+import { ACCESS_LEVEL_MOCK } from '../../test-utils/accessLevelMock';
 
 /** Mocks the shared logger so route handlers don't write real log output during tests. */
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
@@ -11,7 +12,7 @@ vi.mock('../../db', () => ({
   upsertReward: vi.fn(),
   setRewardVideos: vi.fn(),
   deleteReward: vi.fn(),
-  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
+  AccessLevel: ACCESS_LEVEL_MOCK,
 }));
 
 vi.mock('../csrf', () => ({

--- a/src/web/routes/overlayAdminRewardMutations.test.ts
+++ b/src/web/routes/overlayAdminRewardMutations.test.ts
@@ -10,6 +10,7 @@ vi.mock('../../db', () => ({
   upsertReward: vi.fn(),
   setRewardVideos: vi.fn(),
   deleteReward: vi.fn(),
+  AccessLevel: ACCESS_LEVEL_MOCK,
 }));
 
 vi.mock('../csrf', () => ({
@@ -28,12 +29,10 @@ vi.mock('../../config', () => ({
   PUBLIC_URL: 'https://example.com',
 }));
 
-vi.mock('../../db/users', () => ({ AccessLevel: ACCESS_LEVEL_MOCK }));
-
 import supertest from 'supertest';
 import { router } from './overlayAdminRewardMutations';
 import { getStreamerByDiscordId, upsertReward, setRewardVideos, deleteReward } from '../../db';
-import { AccessLevel } from '../../db/users';
+import { AccessLevel } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 
 type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3 };

--- a/src/web/routes/sfxPublic.test.ts
+++ b/src/web/routes/sfxPublic.test.ts
@@ -4,18 +4,15 @@ import { ACCESS_LEVEL_MOCK } from '../../test-utils/accessLevelMock';
 
 vi.mock('../../db', () => ({
   getPublicSfxTriggers: vi.fn().mockResolvedValue([]),
+  AccessLevel: ACCESS_LEVEL_MOCK,
 }));
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
 vi.mock('../middleware', () => ({
   requireAuth: (_req: any, _res: any, next: any) => next(),
 }));
-vi.mock('../../db/users', () => ({
-  AccessLevel: ACCESS_LEVEL_MOCK,
-}));
-
 import supertest from 'supertest';
 import { getPublicSfxTriggers } from '../../db';
-import { AccessLevel } from '../../db/users';
+import { AccessLevel } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 
 let router: any;

--- a/src/web/routes/shared.test.ts
+++ b/src/web/routes/shared.test.ts
@@ -4,8 +4,6 @@ import type { Response } from 'express';
 import type { SessionUser } from '../../types/express';
 import { ACCESS_LEVEL_MOCK } from '../../test-utils/accessLevelMock';
 
-vi.mock('../../db/users', () => ({ AccessLevel: ACCESS_LEVEL_MOCK }));
-
 vi.mock('../../db', () => {
   class ReservedCommandError extends Error {}
   class CommandConflictError extends Error {}
@@ -14,10 +12,11 @@ vi.mock('../../db', () => {
     ReservedCommandError,
     CommandConflictError,
     isMysqlDuplicateEntryError: vi.fn().mockReturnValue(false),
+    AccessLevel: ACCESS_LEVEL_MOCK,
   };
 });
 
-import { AccessLevel } from '../../db/users';
+import { AccessLevel } from '../../db';
 import {
   getStreamerByDiscordId,
   ReservedCommandError,

--- a/src/web/routes/streamGroups.test.ts
+++ b/src/web/routes/streamGroups.test.ts
@@ -6,6 +6,7 @@ vi.mock('../../db', () => ({
   addStreamGroup: vi.fn(),
   updateStreamGroup: vi.fn(),
   removeStreamGroupAndStreamers: vi.fn(),
+  AccessLevel: ACCESS_LEVEL_MOCK,
 }));
 
 vi.mock('../csrf', () => ({
@@ -25,13 +26,11 @@ vi.mock('../../twitch/monitor/twitchMonitor', () => ({
 
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
 
-vi.mock('../../db/users', () => ({ AccessLevel: ACCESS_LEVEL_MOCK }));
-
 import supertest from 'supertest';
 import router from './streamGroups';
 import { addStreamGroup, updateStreamGroup, removeStreamGroupAndStreamers } from '../../db';
 import { restartTwitchMonitor } from '../../twitch/monitor/twitchMonitor';
-import { AccessLevel } from '../../db/users';
+import { AccessLevel } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 import { makeSessionUser, type SessionUserFixture } from '../../test-utils/fixtures';
 

--- a/src/web/routes/streamStreamers.test.ts
+++ b/src/web/routes/streamStreamers.test.ts
@@ -6,6 +6,7 @@ vi.mock('../../db', () => ({
   addStreamer: vi.fn(),
   removeStreamer: vi.fn(),
   findUser: vi.fn(),
+  AccessLevel: ACCESS_LEVEL_MOCK,
 }));
 
 vi.mock('../csrf', () => ({
@@ -25,13 +26,11 @@ vi.mock('../../twitch/monitor/twitchMonitor', () => ({
 
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
 
-vi.mock('../../db/users', () => ({ AccessLevel: ACCESS_LEVEL_MOCK }));
-
 import supertest from 'supertest';
 import router from './streamStreamers';
 import { addStreamer, removeStreamer, findUser } from '../../db';
 import { restartTwitchMonitor } from '../../twitch/monitor/twitchMonitor';
-import { AccessLevel, AccessLevelValue } from '../../db/users';
+import { AccessLevel, AccessLevelValue } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 
 const GUILD_ID = '900000000000000001';

--- a/src/web/routes/streamdeckKeys.test.ts
+++ b/src/web/routes/streamdeckKeys.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mockLogger } from '../../test-utils/loggerMock';
+import { ACCESS_LEVEL_MOCK } from '../../test-utils/accessLevelMock';
 
 vi.mock('../../db', () => ({
   hasApiKey: vi.fn().mockResolvedValue(false),
@@ -12,7 +13,7 @@ vi.mock('../../db', () => ({
   denyApiKey: vi.fn().mockResolvedValue(undefined),
   getAllApiKeys: vi.fn().mockResolvedValue([]),
   getPendingRequests: vi.fn().mockResolvedValue([]),
-  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
+  AccessLevel: ACCESS_LEVEL_MOCK,
 }));
 vi.mock('../csrf', () => ({
   csrfProtection: (req: any, _res: any, next: any) => {

--- a/src/web/routes/streamdeckKeys.test.ts
+++ b/src/web/routes/streamdeckKeys.test.ts
@@ -12,6 +12,7 @@ vi.mock('../../db', () => ({
   denyApiKey: vi.fn().mockResolvedValue(undefined),
   getAllApiKeys: vi.fn().mockResolvedValue([]),
   getPendingRequests: vi.fn().mockResolvedValue([]),
+  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
 }));
 vi.mock('../csrf', () => ({
   csrfProtection: (req: any, _res: any, next: any) => {
@@ -33,7 +34,7 @@ import {
   getGuildStatusForKey, revokeApiKey,
   approveApiKey, denyApiKey, getAllApiKeys, getPendingRequests,
 } from '../../db';
-import { AccessLevel } from '../../db/users';
+import { AccessLevel } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 
 const GUILD_ID = '900000000000000001';

--- a/src/web/routes/streams.test.ts
+++ b/src/web/routes/streams.test.ts
@@ -34,8 +34,6 @@ vi.mock('../../twitch/monitor/twitchMonitor', () => ({
 
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
 
-vi.mock('../../db/users', () => ({ AccessLevel: ACCESS_LEVEL_MOCK }));
-
 import express from 'express';
 import supertest from 'supertest';
 import router from './streams';
@@ -44,7 +42,7 @@ import {
   addStreamGroup, addStreamer, findUser,
 } from '../../db';
 import { getLiveStates } from '../../twitch/monitor/twitchMonitor';
-import { AccessLevel, AccessLevelValue } from '../../db/users';
+import { AccessLevel, AccessLevelValue } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 
 const GUILD_ID = '900000000000000001';

--- a/src/web/routes/userSettings.test.ts
+++ b/src/web/routes/userSettings.test.ts
@@ -6,6 +6,7 @@ vi.mock('../../db', () => ({
   getStreamerByDiscordId: vi.fn(),
   saveEventConfig: vi.fn(),
   clearStreamerToken: vi.fn(),
+  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
 }));
 
 vi.mock('../csrf', () => ({
@@ -40,7 +41,7 @@ import supertest from 'supertest';
 import router from './userSettings';
 import { findUser, getStreamerByDiscordId, saveEventConfig, clearStreamerToken } from '../../db';
 import { reloadEventSubSubscriptions } from '../../twitch/eventsub/twitchEventSub';
-import { AccessLevel } from '../../db/users';
+import { AccessLevel } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 import { makeSessionUser, type SessionUserFixture } from '../../test-utils/fixtures';
 

--- a/src/web/routes/userSettings.test.ts
+++ b/src/web/routes/userSettings.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mockLogger } from '../../test-utils/loggerMock';
+import { ACCESS_LEVEL_MOCK } from '../../test-utils/accessLevelMock';
 
 vi.mock('../../db', () => ({
   findUser: vi.fn(),
   getStreamerByDiscordId: vi.fn(),
   saveEventConfig: vi.fn(),
   clearStreamerToken: vi.fn(),
-  AccessLevel: { USER: 0, MOD: 1, MANAGER: 2, ADMIN: 3 },
+  AccessLevel: ACCESS_LEVEL_MOCK,
 }));
 
 vi.mock('../csrf', () => ({


### PR DESCRIPTION
## Summary

Fixes the 6 open issues filed from the repository code review. Five required code changes; the sixth (#476) turned out to already be fixed by a prior PR (#482), so it's just being closed here with a note.

- **#481** (Low): Documents `DASHBOARD_EVENTS_MAX_SSE_PER_STREAMER`, `DASHBOARD_STATUS_MAX_SSE_PER_GUILD`, and `SSE_MAX_TOTAL_CONNECTIONS` in `.env.example`.
- **#480** (Low): Routes ~29 test files (and `test-utils/fixtures.ts`) through the `src/db.ts` facade for `AccessLevel`/`AccessLevelValue`/`ALERT_TEXT_ANIMATIONS` instead of importing from `src/db/*` directly, per CLAUDE.md's facade rule. `rateLimits.test.ts` keeps its direct `db/users` import since it `vi.mock`s that exact path.
- **#479** (Low): Removes the unused legacy `updateAccessLevel()` (global access-level column) from `src/db/users.ts` — the per-guild `setMemberAccessLevel()` fully supersedes it — plus its `db.ts` re-export and tests.
- **#478** (Low): `joinTwitchChannel()` (the ad-hoc admin-panel join path) now goes through a shared global join-throttle gate with `joinMissingChannel()` (the reconnect-reconciliation path), so a burst of individual admin joins can't collectively exceed Twitch's IRC JOIN rate limit (20/10s). Previously only the reconciliation path was throttled.
- **#475** (Medium): `provisionGuildOwner`'s user-row read → conditional upsert → access-grant sequence is now serialized through `userMutationQueue` on `owner.id`, matching every other write path in the codebase that touches a user row by `discord_id` (webpanel admin routes). Previously it was the one unqueued write path, able to race a concurrent webpanel edit of the same user.
- **#476** (Medium, already fixed): `EVENTSUB_TOKEN_SECRET` startup validation was already added in #482 with full test coverage — no changes needed here.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` — all 2991 tests pass (160 files)
- [x] Added a new test in `discordBot.test.ts` verifying `provisionGuildOwner` serializes across concurrent `guildCreate` events for the same owner
- [x] Updated `twitchChannelMembership.test.ts` to cover the new global join throttle (replaced a test that asserted the now-intentionally-changed cross-channel-unthrottled join behavior, added a test asserting joins across channels are now globally spaced)

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HqqW8Q7oZR5PR83vFxSoKV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional limits for concurrent SSE connections per streamer, per guild, and server-wide.

* **Bug Fixes**
  * Improved guild setup reliability when multiple provisioning events occur simultaneously.
  * Standardized Twitch channel joining to prevent bursts and maintain consistent spacing across channels.

* **Refactor**
  * Consolidated access-level handling through the shared database interface.
  * Removed support for legacy global access-level updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->