### PR TITLE
Add shared-chat group cooldown to prevent timer flooding

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -111,7 +111,7 @@ async function main(): Promise<void> {
   registerEventSubDashboardRuntime({ pushDashboardEvent });
   registerEventSubTwitchRuntime({ send: sayInChannel });
   registerRewardPricingRuntime({ pushPricingUpdate });
-  registerTimerCommandsRuntime({ send: sayInChannel });
+  registerTimerCommandsRuntime({ send: sayInChannel, getLoginUserIds: getActiveChannelUserIds });
 
   // Load the guild registry before the Discord client connects so the
   // messageCreate gate recognises registered guilds from the first message.

--- a/src/twitch/timers/timerCommandScheduler.test.ts
+++ b/src/twitch/timers/timerCommandScheduler.test.ts
@@ -9,10 +9,12 @@ vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
 vi.mock('../../db', () => ({ getAllEnabledTimerCommandsWithChannel: vi.fn() }));
 vi.mock('../twitchChatActivity', () => ({ getMessageCount: vi.fn() }));
 vi.mock('../monitor/twitchMonitor', () => ({ isChannelLive: vi.fn() }));
+vi.mock('../../commands/customCommandHandler', () => ({ resolveSharedChatSessionId: vi.fn() }));
 
 import { getAllEnabledTimerCommandsWithChannel } from '../../db';
 import { getMessageCount } from '../twitchChatActivity';
 import { isChannelLive } from '../monitor/twitchMonitor';
+import { resolveSharedChatSessionId } from '../../commands/customCommandHandler';
 import {
   runTimerCommandTick, startTimerCommandScheduler, stopTimerCommandScheduler, registerTimerCommandsRuntime,
 } from './timerCommandScheduler';
@@ -39,15 +41,18 @@ function timerRow(overrides: Partial<TestRow> = {}): TestRow {
 }
 
 let send: Mock<(channel: string, message: string) => Promise<void>>;
+let getLoginUserIds: Mock<() => ReadonlyMap<string, string>>;
 
 beforeEach(() => {
   vi.clearAllMocks();
   vi.useFakeTimers();
   vi.setSystemTime(new Date(2025, 0, 1));
   send = vi.fn().mockResolvedValue(undefined);
-  registerTimerCommandsRuntime({ send });
+  getLoginUserIds = vi.fn().mockReturnValue(new Map());
+  registerTimerCommandsRuntime({ send, getLoginUserIds });
   vi.mocked(isChannelLive).mockReturnValue(true);
   vi.mocked(getMessageCount).mockReturnValue(0);
+  vi.mocked(resolveSharedChatSessionId).mockResolvedValue(null);
 });
 
 afterEach(async () => {
@@ -161,6 +166,94 @@ describe('runTimerCommandTick', () => {
     await Promise.all([first, second]);
 
     expect(getAllEnabledTimerCommandsWithChannel).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Shared Chat group cooldown', () => {
+  /** Routes `resolveSharedChatSessionId` to a fixed session id per Twitch user id. */
+  function stubSessions(sessionIdByUserId: Record<string, string>): void {
+    vi.mocked(resolveSharedChatSessionId).mockImplementation(async (userId: string) => sessionIdByUserId[userId] ?? null);
+  }
+
+  it('suppresses a second ready timer sharing the same session, then fires it once the group cooldown elapses', async () => {
+    getLoginUserIds.mockReturnValue(new Map([['streamer-a', 'uid-a'], ['streamer-b', 'uid-b']]));
+    stubSessions({ 'uid-a': 'session-1', 'uid-b': 'session-1' });
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([
+      timerRow({ id: 1, channel: 'streamer-a', message: 'msg-a', interval_seconds: 60 }),
+      timerRow({ id: 2, channel: 'streamer-b', message: 'msg-b', interval_seconds: 60 }),
+    ] as any);
+
+    await runTimerCommandTick(); // seed both
+    await vi.advanceTimersByTimeAsync(60_000);
+    await runTimerCommandTick(); // both ready, same session off cooldown -> only the oldest (streamer-a) fires
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith('streamer-a', 'msg-a');
+
+    send.mockClear();
+    await vi.advanceTimersByTimeAsync(60_000); // both ready again, but group cooldown (120s) not yet elapsed
+    await runTimerCommandTick();
+    expect(send).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(60_000); // group cooldown now elapsed (120s since streamer-a fired)
+    await runTimerCommandTick();
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith('streamer-b', 'msg-b');
+  });
+
+  it('rotates fairly among three timers sharing a session instead of favoring the same one', async () => {
+    getLoginUserIds.mockReturnValue(new Map([
+      ['streamer-a', 'uid-a'], ['streamer-b', 'uid-b'], ['streamer-c', 'uid-c'],
+    ]));
+    stubSessions({ 'uid-a': 'session-1', 'uid-b': 'session-1', 'uid-c': 'session-1' });
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([
+      timerRow({ id: 1, channel: 'streamer-a', message: 'msg-a', interval_seconds: 60 }),
+      timerRow({ id: 2, channel: 'streamer-b', message: 'msg-b', interval_seconds: 60 }),
+      timerRow({ id: 3, channel: 'streamer-c', message: 'msg-c', interval_seconds: 60 }),
+    ] as any);
+
+    await runTimerCommandTick(); // seed all three
+
+    const fired: string[] = [];
+    for (let window = 0; window < 3; window++) {
+      await vi.advanceTimersByTimeAsync(120_000); // clears both each timer's own interval and the group cooldown
+      await runTimerCommandTick();
+      expect(send).toHaveBeenCalledTimes(1);
+      fired.push(send.mock.calls[0][1]);
+      send.mockClear();
+    }
+
+    // Each of the three distinct messages gets a turn — none is skipped in favor of another.
+    expect(new Set(fired)).toEqual(new Set(['msg-a', 'msg-b', 'msg-c']));
+  });
+
+  it('fires independently when timers resolve to different sessions', async () => {
+    getLoginUserIds.mockReturnValue(new Map([['streamer-a', 'uid-a'], ['streamer-b', 'uid-b']]));
+    stubSessions({ 'uid-a': 'session-1', 'uid-b': 'session-2' });
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([
+      timerRow({ id: 1, channel: 'streamer-a', message: 'msg-a', interval_seconds: 60 }),
+      timerRow({ id: 2, channel: 'streamer-b', message: 'msg-b', interval_seconds: 60 }),
+    ] as any);
+
+    await runTimerCommandTick(); // seed both
+    await vi.advanceTimersByTimeAsync(60_000);
+    await runTimerCommandTick();
+
+    expect(send).toHaveBeenCalledWith('streamer-a', 'msg-a');
+    expect(send).toHaveBeenCalledWith('streamer-b', 'msg-b');
+  });
+
+  it('fires normally when the session lookup fails (treated as not in Shared Chat)', async () => {
+    getLoginUserIds.mockReturnValue(new Map([['streamer-a', 'uid-a']]));
+    vi.mocked(resolveSharedChatSessionId).mockRejectedValue(new Error('helix down'));
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([
+      timerRow({ id: 1, channel: 'streamer-a', message: 'msg-a', interval_seconds: 60 }),
+    ] as any);
+
+    await runTimerCommandTick(); // seed
+    await vi.advanceTimersByTimeAsync(60_000);
+    await runTimerCommandTick();
+
+    expect(send).toHaveBeenCalledWith('streamer-a', 'msg-a');
   });
 });
 

--- a/src/twitch/timers/timerCommandScheduler.test.ts
+++ b/src/twitch/timers/timerCommandScheduler.test.ts
@@ -242,6 +242,30 @@ describe('Shared Chat group cooldown', () => {
     expect(send).toHaveBeenCalledWith('streamer-b', 'msg-b');
   });
 
+  it('releases the group cooldown reservation when the picked row fails to send', async () => {
+    getLoginUserIds.mockReturnValue(new Map([['streamer-a', 'uid-a'], ['streamer-b', 'uid-b']]));
+    stubSessions({ 'uid-a': 'session-1', 'uid-b': 'session-1' });
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([
+      timerRow({ id: 1, channel: 'streamer-a', message: 'msg-a', interval_seconds: 60 }),
+      timerRow({ id: 2, channel: 'streamer-b', message: 'msg-b', interval_seconds: 60 }),
+    ] as any);
+
+    await runTimerCommandTick(); // seed both
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    send.mockRejectedValueOnce(new Error('helix down')); // fails for whichever row is picked (streamer-a, being oldest)
+    await runTimerCommandTick();
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith('streamer-a', 'msg-a');
+
+    // The failed send released the reservation, so the session can be retried on the very next
+    // tick instead of being blocked for the full 120s group cooldown.
+    send.mockClear();
+    await runTimerCommandTick();
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith('streamer-a', 'msg-a');
+  });
+
   it('fires normally when the session lookup fails (treated as not in Shared Chat)', async () => {
     getLoginUserIds.mockReturnValue(new Map([['streamer-a', 'uid-a']]));
     vi.mocked(resolveSharedChatSessionId).mockRejectedValue(new Error('helix down'));

--- a/src/twitch/timers/timerCommandScheduler.ts
+++ b/src/twitch/timers/timerCommandScheduler.ts
@@ -2,6 +2,7 @@ import { createLogger } from '../../shared/logger';
 import { getAllEnabledTimerCommandsWithChannel, type TimerCommandForScheduler } from '../../db';
 import { getMessageCount } from '../twitchChatActivity';
 import { isChannelLive } from '../monitor/twitchMonitor';
+import { resolveSharedChatSessionId } from '../../commands/customCommandHandler';
 import { createRuntimeRegistry, type TwitchSendRuntime } from '../../commands/twitchRuntime';
 
 const log = createLogger('TimerCommandScheduler');
@@ -11,10 +12,15 @@ const log = createLogger('TimerCommandScheduler');
 // Same pattern as counterHandler.ts/shoutoutHandler.ts to avoid a circular
 // import between twitchBot.ts and this scheduler.
 
-const timerCommandsRuntime = createRuntimeRegistry<TwitchSendRuntime>();
+/** Adds a channel → Twitch-user-id lookup to the bare send runtime, needed to resolve Shared Chat sessions for the group cooldown below. */
+interface TimerCommandsRuntime extends TwitchSendRuntime {
+  getLoginUserIds: () => ReadonlyMap<string, string>;
+}
+
+const timerCommandsRuntime = createRuntimeRegistry<TimerCommandsRuntime>();
 
 /** Stores the Twitch chat runtime used to post timer messages. Call once from index.ts after the Twitch bot is ready. */
-export function registerTimerCommandsRuntime(runtime: TwitchSendRuntime): void {
+export function registerTimerCommandsRuntime(runtime: TimerCommandsRuntime): void {
   timerCommandsRuntime.register(runtime);
 }
 
@@ -28,12 +34,33 @@ interface TimerRuntimeState {
 
 const timerState = new Map<number, TimerRuntimeState>();
 
+// ─── Shared Chat group cooldown ──────────────────────────────────────────────
+//
+// When several streamers' channels are merged into one Twitch Shared Chat session
+// (multitwitch), each streamer's timer otherwise keeps firing on its own independent
+// schedule — and since Shared Chat shows every participating channel's messages in
+// one merged view, that stacks up and floods it. This caps how often ANY timer may
+// post into a given session, and rotates fairly among the timers sharing it (see
+// `pickRowsToFire`) so distinct messages take turns instead of one dominating.
+
+const SHARED_SESSION_COOLDOWN_MS = 120_000;
+const sessionLastFiredAt = new Map<string, number>();
+const SESSION_COOLDOWN_ENTRY_MAX_AGE_MS = 10 * SHARED_SESSION_COOLDOWN_MS;
+
+/** Drops session-cooldown entries older than {@link SESSION_COOLDOWN_ENTRY_MAX_AGE_MS} so the map doesn't grow unbounded as Shared Chat sessions come and go over long uptimes. */
+function pruneStaleSessionCooldowns(now: number): void {
+  for (const [sessionId, firedAt] of sessionLastFiredAt) {
+    if (now - firedAt > SESSION_COOLDOWN_ENTRY_MAX_AGE_MS) sessionLastFiredAt.delete(sessionId);
+  }
+}
+
 let tickTimer: ReturnType<typeof setInterval> | null = null;
 let tickRunning = false;
 let currentTickPromise: Promise<void> = Promise.resolve();
 
 /**
  * Decides whether a timer should fire right now, given its config and current in-memory state.
+ * Does not account for the Shared Chat group cooldown — see {@link pickRowsToFire}.
  * @param row - The timer's config, joined with its Twitch channel.
  * @param state - The timer's current in-memory firing state.
  * @param now - Current time in epoch ms.
@@ -57,24 +84,89 @@ function pruneStaleTimerState(currentIds: ReadonlySet<number>): void {
 }
 
 /**
+ * Resolves each of `channels`' current Twitch Shared Chat session id, in parallel, deduplicating
+ * by underlying Twitch user id so a channel is only looked up once regardless of how many rows
+ * reference it. A channel with no known user id, or whose session lookup fails/returns null, maps
+ * to `null` (treated as "not currently in Shared Chat" by callers).
+ * @param channels - Twitch channel logins to resolve.
+ * @param loginUserIds - Map from channel login to Twitch user id.
+ */
+async function resolveSessionIdsByChannel(
+  channels: readonly string[],
+  loginUserIds: ReadonlyMap<string, string>,
+): Promise<Map<string, string | null>> {
+  const uniqueUserIds = [...new Set(channels.map((ch) => loginUserIds.get(ch)).filter((id): id is string => id !== undefined))];
+  const resolved = await Promise.all(uniqueUserIds.map((uid) => resolveSharedChatSessionId(uid).catch(() => null)));
+  const sessionIdByUserId = new Map(uniqueUserIds.map((uid, i) => [uid, resolved[i]]));
+
+  const sessionIdByChannel = new Map<string, string | null>();
+  for (const channel of channels) {
+    const userId = loginUserIds.get(channel);
+    sessionIdByChannel.set(channel, userId ? (sessionIdByUserId.get(userId) ?? null) : null);
+  }
+  return sessionIdByChannel;
+}
+
+/**
+ * From the rows that already passed their own {@link shouldFire} check, decides which ones
+ * actually get to fire this tick, applying the Shared Chat group cooldown: rows with no resolved
+ * session always fire (unaffected — this is the fully-independent, outside-of-multitwitch case).
+ * For rows sharing a session that's currently off cooldown, only the single row that has gone
+ * longest without firing (oldest `lastFiredAt`) is picked, and the session is immediately reserved
+ * — this rotates fairly among the timers sharing a session (instead of one perpetually winning) and
+ * prevents two rows in the same session both firing in one tick. Rows in a session still on
+ * cooldown, and rows not picked from an eligible session, are left untouched so they're
+ * reconsidered on a later tick.
+ * @param eligibleRows - Rows that already passed their own per-timer `shouldFire` check.
+ * @param sessionIdByChannel - Each row's channel's resolved Shared Chat session id (or null).
+ * @param now - Current time in epoch ms, shared across the whole tick.
+ */
+function pickRowsToFire(
+  eligibleRows: readonly TimerCommandForScheduler[],
+  sessionIdByChannel: ReadonlyMap<string, string | null>,
+  now: number,
+): TimerCommandForScheduler[] {
+  const toFire: TimerCommandForScheduler[] = [];
+  const bySession = new Map<string, TimerCommandForScheduler[]>();
+
+  for (const row of eligibleRows) {
+    const sessionId = sessionIdByChannel.get(row.channel) ?? null;
+    if (!sessionId) {
+      toFire.push(row);
+      continue;
+    }
+    const group = bySession.get(sessionId);
+    if (group) group.push(row); else bySession.set(sessionId, [row]);
+  }
+
+  for (const [sessionId, rows] of bySession) {
+    const lastFired = sessionLastFiredAt.get(sessionId) ?? 0;
+    if (now - lastFired < SHARED_SESSION_COOLDOWN_MS) continue;
+
+    const picked = rows.reduce((oldest, row) => {
+      const oldestState = timerState.get(oldest.id)!;
+      const rowState = timerState.get(row.id)!;
+      return rowState.lastFiredAt < oldestState.lastFiredAt ? row : oldest;
+    });
+    sessionLastFiredAt.set(sessionId, now);
+    toFire.push(picked);
+  }
+
+  return toFire;
+}
+
+/**
  * Seeds in-memory state for a newly-seen timer without firing it (a restart or brand-new timer
- * waits one full interval before its first post), otherwise fires it via the registered runtime
- * if its conditions are satisfied. Never throws — a send failure is logged and swallowed so it
- * can't block other rows in the same tick.
+ * waits one full interval before its first post). Never throws — a send failure is logged and
+ * swallowed so it can't block other rows in the same tick.
  * @param row - The timer's config, joined with its Twitch channel.
  * @param now - Current time in epoch ms, shared across the whole tick.
  */
-async function processTimerRow(row: TimerCommandForScheduler, now: number): Promise<void> {
-  const state = timerState.get(row.id);
-  if (!state) {
-    timerState.set(row.id, { lastFiredAt: now, messagesAtLastFire: getMessageCount(row.channel) });
-    return;
-  }
-  if (!shouldFire(row, state, now)) return;
-
+async function sendTimerRow(row: TimerCommandForScheduler, now: number): Promise<void> {
   const runtime = timerCommandsRuntime.get();
   if (!runtime) return;
 
+  const state = timerState.get(row.id)!;
   try {
     await runtime.send(row.channel, row.message);
     state.lastFiredAt = now;
@@ -85,10 +177,13 @@ async function processTimerRow(row: TimerCommandForScheduler, now: number): Prom
 }
 
 /**
- * Runs one scheduler tick: fetches every enabled timer, prunes in-memory state for timers that
- * no longer exist/are disabled, then processes each row (see {@link processTimerRow}) concurrently
- * via `Promise.allSettled` so one channel's send failure can't block another's. No-ops (re-uses
- * the in-flight promise) if a tick is already running.
+ * Runs one scheduler tick: fetches every enabled timer, prunes in-memory state for timers that no
+ * longer exist/are disabled, seeds any newly-seen timer without firing it, then for the rest:
+ * evaluates each row's own fire condition, resolves Shared Chat sessions for the ones that are
+ * ready, picks which of those actually get to fire this tick (applying the group cooldown — see
+ * {@link pickRowsToFire}), and sends the picked rows concurrently via `Promise.allSettled` so one
+ * channel's send failure can't block another's. No-ops (re-uses the in-flight promise) if a tick
+ * is already running.
  */
 export async function runTimerCommandTick(): Promise<void> {
   if (tickRunning) return currentTickPromise;
@@ -99,7 +194,23 @@ export async function runTimerCommandTick(): Promise<void> {
       pruneStaleTimerState(new Set(rows.map((row) => row.id)));
 
       const now = Date.now();
-      await Promise.allSettled(rows.map((row) => processTimerRow(row, now)));
+      pruneStaleSessionCooldowns(now);
+
+      const eligibleRows: TimerCommandForScheduler[] = [];
+      for (const row of rows) {
+        const state = timerState.get(row.id);
+        if (!state) {
+          timerState.set(row.id, { lastFiredAt: now, messagesAtLastFire: getMessageCount(row.channel) });
+          continue;
+        }
+        if (shouldFire(row, state, now)) eligibleRows.push(row);
+      }
+
+      const loginUserIds = timerCommandsRuntime.get()?.getLoginUserIds() ?? new Map<string, string>();
+      const sessionIdByChannel = await resolveSessionIdsByChannel(eligibleRows.map((row) => row.channel), loginUserIds);
+      const toFire = pickRowsToFire(eligibleRows, sessionIdByChannel, now);
+
+      await Promise.allSettled(toFire.map((row) => sendTimerRow(row, now)));
     } catch (err) {
       log.error('Failed to load enabled timer commands:', err);
     } finally {
@@ -126,4 +237,5 @@ export async function stopTimerCommandScheduler(): Promise<void> {
   if (tickTimer) { clearInterval(tickTimer); tickTimer = null; }
   await currentTickPromise;
   timerState.clear();
+  sessionLastFiredAt.clear();
 }

--- a/src/twitch/timers/timerCommandScheduler.ts
+++ b/src/twitch/timers/timerCommandScheduler.ts
@@ -107,14 +107,22 @@ async function resolveSessionIdsByChannel(
   return sessionIdByChannel;
 }
 
+/** A row picked to fire this tick, paired with the Shared Chat session (if any) it was picked for. */
+interface PickedRow {
+  row: TimerCommandForScheduler;
+  sessionId: string | null;
+}
+
 /**
  * From the rows that already passed their own {@link shouldFire} check, decides which ones
  * actually get to fire this tick, applying the Shared Chat group cooldown: rows with no resolved
  * session always fire (unaffected — this is the fully-independent, outside-of-multitwitch case).
  * For rows sharing a session that's currently off cooldown, only the single row that has gone
- * longest without firing (oldest `lastFiredAt`) is picked, and the session is immediately reserved
+ * longest without firing (oldest `lastFiredAt`) is picked, and the session is tentatively reserved
  * — this rotates fairly among the timers sharing a session (instead of one perpetually winning) and
- * prevents two rows in the same session both firing in one tick. Rows in a session still on
+ * prevents two rows in the same session both firing in one tick. The reservation is only
+ * provisional: {@link sendTimerRow} releases it if the send doesn't actually succeed, so a failed
+ * send can't silence the whole group for the full cooldown window. Rows in a session still on
  * cooldown, and rows not picked from an eligible session, are left untouched so they're
  * reconsidered on a later tick.
  * @param eligibleRows - Rows that already passed their own per-timer `shouldFire` check.
@@ -125,14 +133,14 @@ function pickRowsToFire(
   eligibleRows: readonly TimerCommandForScheduler[],
   sessionIdByChannel: ReadonlyMap<string, string | null>,
   now: number,
-): TimerCommandForScheduler[] {
-  const toFire: TimerCommandForScheduler[] = [];
+): PickedRow[] {
+  const toFire: PickedRow[] = [];
   const bySession = new Map<string, TimerCommandForScheduler[]>();
 
   for (const row of eligibleRows) {
     const sessionId = sessionIdByChannel.get(row.channel) ?? null;
     if (!sessionId) {
-      toFire.push(row);
+      toFire.push({ row, sessionId: null });
       continue;
     }
     const group = bySession.get(sessionId);
@@ -148,23 +156,30 @@ function pickRowsToFire(
       const rowState = timerState.get(row.id)!;
       return rowState.lastFiredAt < oldestState.lastFiredAt ? row : oldest;
     });
-    sessionLastFiredAt.set(sessionId, now);
-    toFire.push(picked);
+    sessionLastFiredAt.set(sessionId, now); // provisional — released by sendTimerRow on failure
+    toFire.push({ row: picked, sessionId });
   }
 
   return toFire;
 }
 
 /**
- * Seeds in-memory state for a newly-seen timer without firing it (a restart or brand-new timer
- * waits one full interval before its first post). Never throws — a send failure is logged and
- * swallowed so it can't block other rows in the same tick.
+ * Posts one selected timer row to its channel and records the fire in the in-memory state.
+ * No-ops if no runtime is registered. Never throws — a send failure is logged and swallowed so it
+ * can't block other rows in the same tick. If `sessionId` is set and the send doesn't succeed (no
+ * runtime, or `runtime.send` throws), releases that session's cooldown reservation made by
+ * {@link pickRowsToFire} — guarded by a timestamp match so it can't clobber a newer reservation
+ * made by another row in the same session on a later tick.
  * @param row - The timer's config, joined with its Twitch channel.
  * @param now - Current time in epoch ms, shared across the whole tick.
+ * @param sessionId - The Shared Chat session this row was provisionally reserved for, or null.
  */
-async function sendTimerRow(row: TimerCommandForScheduler, now: number): Promise<void> {
+async function sendTimerRow(row: TimerCommandForScheduler, now: number, sessionId: string | null): Promise<void> {
   const runtime = timerCommandsRuntime.get();
-  if (!runtime) return;
+  if (!runtime) {
+    if (sessionId && sessionLastFiredAt.get(sessionId) === now) sessionLastFiredAt.delete(sessionId);
+    return;
+  }
 
   const state = timerState.get(row.id)!;
   try {
@@ -172,6 +187,7 @@ async function sendTimerRow(row: TimerCommandForScheduler, now: number): Promise
     state.lastFiredAt = now;
     state.messagesAtLastFire = getMessageCount(row.channel);
   } catch (err) {
+    if (sessionId && sessionLastFiredAt.get(sessionId) === now) sessionLastFiredAt.delete(sessionId);
     log.error(`Failed to post timer command ${row.id} to ${row.channel}:`, err);
   }
 }
@@ -210,7 +226,7 @@ export async function runTimerCommandTick(): Promise<void> {
       const sessionIdByChannel = await resolveSessionIdsByChannel(eligibleRows.map((row) => row.channel), loginUserIds);
       const toFire = pickRowsToFire(eligibleRows, sessionIdByChannel, now);
 
-      await Promise.allSettled(toFire.map((row) => sendTimerRow(row, now)));
+      await Promise.allSettled(toFire.map(({ row, sessionId }) => sendTimerRow(row, now, sessionId)));
     } catch (err) {
       log.error('Failed to load enabled timer commands:', err);
     } finally {


### PR DESCRIPTION
## Summary
- When several streamers' channels are merged into one Twitch Shared Chat session (multitwitch), each streamer's timer previously kept firing on its own independent schedule, stacking up messages in the merged chat view.
- Timers now share a cooldown per Shared Chat session (`SHARED_SESSION_COOLDOWN_MS`, 2 minutes) and rotate fairly among the timers sharing that session — whichever timer has gone longest without firing gets the next turn — so distinct messages take turns instead of one dominating.
- Timers outside of Shared Chat are unaffected: they keep firing fully independently, exactly as before.
- Reuses the existing `resolveSharedChatSessionId` (Twitch Shared Chat session lookup + caching) already used by `customCommandHandler.ts`/`multiCommandHandler.ts` for the same purpose.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 2995 tests passing)
- [x] Added new cases to `src/twitch/timers/timerCommandScheduler.test.ts`: session-shared suppression + resume after cooldown, 3-timer fair rotation, independent firing across different sessions, and graceful fallback when session lookup fails

---
_Generated by [Claude Code](https://claude.ai/code/session_016JC7pwYyPfFgUiqA6Lx9vw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timer command scheduling for Twitch Shared Chat sessions.
  * Prevented repeated timer messages from firing within the same shared session during the cooldown period.
  * Ensured timers rotate fairly so eligible channels receive opportunities in turn.
  * Kept timer activity independent across separate sessions.
  * Preserved normal timer behavior when session information is unavailable.
  * Improved cleanup of expired scheduling state during shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->