### PR TITLE
Move Timers to a Manager-only, multi-streamer assignment model

### DIFF
--- a/DATABASE-SCHEMA.md
+++ b/DATABASE-SCHEMA.md
@@ -317,20 +317,32 @@ Expected constraints:
 
 ## `timer_command`
 
-Per-streamer, Twitch-only auto-posted chat messages ("timer commands" — one message per row; a rotation is achieved by creating several timers). Config-only: the scheduler's live-status/chat-activity firing state lives in memory (`timerCommandScheduler.ts`), not in this table, so a restart just restarts each timer's countdown rather than replaying fires missed while the bot was down. Created by `migrations/timer_commands.sql`.
+Twitch-only auto-posted chat messages ("timer commands" — one message per row; a rotation is achieved by creating several timers), managed like `custom_command`: a global catalog assigned to Twitch-linked Discord users via `timer_command_streamer`, rather than owned by a single streamer. Config-only: the scheduler's live-status/chat-activity firing state lives in memory, keyed per (timer, assigned channel) pair (`timerCommandScheduler.ts`), not in this table, so a restart just restarts each one's countdown rather than replaying fires missed while the bot was down. Created by `migrations/timer_commands.sql`; moved to the assignment model by `migrations/timer_command_streamer_assignment.sql`.
 
 | Column | Type | Notes |
 | --- | --- | --- |
 | `id` | `INT` PK, auto-increment | |
-| `streamer_id` | `INT` | FK to `streamer.id` ON DELETE CASCADE |
 | `name` | `VARCHAR(255)` | Admin-facing label only, never posted to chat |
 | `message` | `VARCHAR(500)` | The chat message posted on each fire |
 | `interval_seconds` | `INT` | Minimum time between fires; `CHECK (interval_seconds >= 60)` |
 | `min_messages` | `INT` | Minimum chat lines seen since the timer's last fire, in addition to the interval; `0` disables this gate; `CHECK (min_messages >= 0)` |
-| `require_live` | `TINYINT(1)` | When `1`, the timer only fires while the streamer's channel is live |
+| `require_live` | `TINYINT(1)` | When `1`, the timer only fires while the assigned channel is live |
 | `enabled` | `TINYINT(1)` | Whether the scheduler considers this timer at all |
 
-Firing logic (see `timerCommandScheduler.ts`): on a 15s tick, a timer fires once its interval has elapsed **and** (if `require_live`) the channel is live **and** at least `min_messages` chat lines have been seen since its last fire. A newly-seen timer (first tick after creation or bot restart) seeds its clock and chat-line baseline without firing, so restarts don't cause a burst of immediate posts.
+Firing logic (see `timerCommandScheduler.ts`): on a 15s tick, each of a timer's assigned channels is evaluated independently — it fires once its own interval has elapsed **and** (if `require_live`) that channel is live **and** at least `min_messages` chat lines have been seen on that channel since its last fire. A newly-seen (timer, channel) pair (first tick after creation/assignment or bot restart) seeds its clock and chat-line baseline without firing, so restarts don't cause a burst of immediate posts. When several assigned channels are merged into one Twitch Shared Chat session, a shared cooldown across that session's timers prevents flooding the merged chat — see the "Shared Chat group cooldown" section of `timerCommandScheduler.ts`.
+
+## `timer_command_streamer`
+
+Join table mapping timer commands to the Discord users (Twitch streamers) they're assigned to. Mirrors `twitch_user_commands`. Added by `migrations/timer_command_streamer_assignment.sql`.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `timer_id` | `INT` | FK to `timer_command.id` ON DELETE CASCADE |
+| `discord_id` | `BIGINT` | FK to `user.discord_id` ON DELETE CASCADE |
+
+Expected constraints:
+
+- `PRIMARY KEY (timer_id, discord_id)` — a user can only be assigned to a given timer once.
 
 ## `streamdeck_api_keys`
 

--- a/migrations/timer_command_streamer_assignment.sql
+++ b/migrations/timer_command_streamer_assignment.sql
@@ -1,0 +1,49 @@
+-- Migration: timer commands become assignable to multiple streamers
+--
+-- timer_command was previously self-service, owned by exactly one streamer
+-- (streamer_id). Timers are now a Manager-only catalog, like custom_command:
+-- each timer is assigned to zero or more Twitch-linked Discord users via a
+-- new join table, timer_command_streamer, mirroring custom_command's
+-- twitch_user_commands. Existing single-owner rows are backfilled into the
+-- join table before the old column is dropped.
+
+CREATE TABLE IF NOT EXISTS timer_command_streamer (
+  timer_id   INT    NOT NULL,
+  discord_id BIGINT NOT NULL,
+  PRIMARY KEY (timer_id, discord_id),
+  FOREIGN KEY (timer_id)   REFERENCES timer_command(id) ON DELETE CASCADE,
+  FOREIGN KEY (discord_id) REFERENCES `user`(discord_id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Column may already be gone on a re-run — guard the backfill and drop below
+-- so this migration is safe to run more than once.
+SET @streamer_id_exists = (
+  SELECT COUNT(*) FROM information_schema.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'timer_command' AND COLUMN_NAME = 'streamer_id'
+);
+
+-- Backfill: each existing timer's sole owner becomes its first assignment.
+SET @sql = IF(@streamer_id_exists = 0,
+  'SELECT ''nothing to backfill''',
+  'INSERT IGNORE INTO timer_command_streamer (timer_id, discord_id)
+   SELECT tc.id, s.discord_id FROM timer_command tc JOIN streamer s ON s.id = tc.streamer_id');
+PREPARE _s FROM @sql; EXECUTE _s; DEALLOCATE PREPARE _s;
+
+-- Drop the old single-owner column and its FK. It was never given an explicit
+-- name in schema.sql, so MySQL auto-generated one — look it up rather than
+-- guessing it, same approach as streamdeck_multi_guild.sql.
+SET @streamer_id_fk = (
+  SELECT CONSTRAINT_NAME FROM information_schema.KEY_COLUMN_USAGE
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'timer_command'
+    AND COLUMN_NAME = 'streamer_id' AND REFERENCED_TABLE_NAME IS NOT NULL
+  LIMIT 1
+);
+
+SET @sql = IF(@streamer_id_exists = 0,
+  'SELECT ''nothing to drop''',
+  CONCAT(
+    'ALTER TABLE timer_command ',
+    IF(@streamer_id_fk IS NOT NULL, CONCAT('DROP FOREIGN KEY `', @streamer_id_fk, '`, '), ''),
+    'DROP COLUMN streamer_id'
+  ));
+PREPARE _s FROM @sql; EXECUTE _s; DEALLOCATE PREPARE _s;

--- a/migrations/timer_command_streamer_assignment.sql
+++ b/migrations/timer_command_streamer_assignment.sql
@@ -22,11 +22,16 @@ SET @streamer_id_exists = (
   WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'timer_command' AND COLUMN_NAME = 'streamer_id'
 );
 
--- Backfill: each existing timer's sole owner becomes its first assignment.
+-- Backfill: each existing timer's sole owner becomes its first assignment. The NOT EXISTS guard
+-- (rather than INSERT IGNORE) makes a re-run idempotent without downgrading unrelated errors
+-- (a foreign-key violation, a truncated value) to a silently-ignored warning.
 SET @sql = IF(@streamer_id_exists = 0,
   'SELECT ''nothing to backfill''',
-  'INSERT IGNORE INTO timer_command_streamer (timer_id, discord_id)
-   SELECT tc.id, s.discord_id FROM timer_command tc JOIN streamer s ON s.id = tc.streamer_id');
+  'INSERT INTO timer_command_streamer (timer_id, discord_id)
+   SELECT tc.id, s.discord_id FROM timer_command tc JOIN streamer s ON s.id = tc.streamer_id
+   WHERE NOT EXISTS (
+     SELECT 1 FROM timer_command_streamer tcs WHERE tcs.timer_id = tc.id AND tcs.discord_id = s.discord_id
+   )');
 PREPARE _s FROM @sql; EXECUTE _s; DEALLOCATE PREPARE _s;
 
 -- Drop the old single-owner column and its FK. It was never given an explicit

--- a/public/commands.js
+++ b/public/commands.js
@@ -1,16 +1,5 @@
 registerToggleEditHandler('btn-toggle-command-edit', 'data-command-id', 'command-edit-');
-
-// Per-user badge color is a hash of the Discord ID, applied via the CSSOM (element.style)
-// rather than an inline style="" attribute, so it works under CSP style-src without 'unsafe-inline'.
-document.querySelectorAll('.badge-user-hue[data-user-hue]').forEach(function (el) {
-  var discordId = el.dataset.userHue;
-  var h = 5381;
-  for (var i = 0; i < discordId.length; i++) {
-    h = ((h << 5) + h) ^ discordId.charCodeAt(i);
-    h >>>= 0;
-  }
-  el.style.setProperty('--hue', h % 360);
-});
+registerUserHueBadges();
 
 document.addEventListener('submit', function (event) {
   var target = event.target;

--- a/public/timers.js
+++ b/public/timers.js
@@ -1,5 +1,17 @@
 registerToggleEditHandler('btn-toggle-timer-edit', 'data-timer-id', 'timer-edit-');
 
+// Per-user badge color is a hash of the Discord ID, applied via the CSSOM (element.style)
+// rather than an inline style="" attribute, so it works under CSP style-src without 'unsafe-inline'.
+document.querySelectorAll('.badge-user-hue[data-user-hue]').forEach(function (el) {
+  var discordId = el.dataset.userHue;
+  var h = 5381;
+  for (var i = 0; i < discordId.length; i++) {
+    h = ((h << 5) + h) ^ discordId.charCodeAt(i);
+    h >>>= 0;
+  }
+  el.style.setProperty('--hue', h % 360);
+});
+
 document.addEventListener('submit', function (event) {
   var target = event.target;
   if (!(target instanceof HTMLFormElement)) return;

--- a/public/timers.js
+++ b/public/timers.js
@@ -1,16 +1,5 @@
 registerToggleEditHandler('btn-toggle-timer-edit', 'data-timer-id', 'timer-edit-');
-
-// Per-user badge color is a hash of the Discord ID, applied via the CSSOM (element.style)
-// rather than an inline style="" attribute, so it works under CSP style-src without 'unsafe-inline'.
-document.querySelectorAll('.badge-user-hue[data-user-hue]').forEach(function (el) {
-  var discordId = el.dataset.userHue;
-  var h = 5381;
-  for (var i = 0; i < discordId.length; i++) {
-    h = ((h << 5) + h) ^ discordId.charCodeAt(i);
-    h >>>= 0;
-  }
-  el.style.setProperty('--hue', h % 360);
-});
+registerUserHueBadges();
 
 document.addEventListener('submit', function (event) {
   var target = event.target;

--- a/public/utils.js
+++ b/public/utils.js
@@ -77,22 +77,29 @@ function registerUploadFormHandler(formClassName, fallbackPath) {
 }
 
 /**
- * Colors every `.badge-user-hue[data-user-hue]` element on the page by hashing its Discord ID
- * into a hue, applied via the CSSOM (`element.style`) rather than an inline `style=""` attribute
- * so it works under CSP `style-src` without `'unsafe-inline'`. Shared by every page that lists
- * per-user assignment badges (Commands, Timers).
+ * Applies a deterministic hue (derived by hashing the element's Discord ID) to one user badge,
+ * via the CSSOM (`element.style`) rather than an inline `style=""` attribute so it works under
+ * CSP `style-src` without `'unsafe-inline'`.
+ * @param {HTMLElement} el - Badge element carrying a `data-user-hue` Discord ID.
+ * @returns {void}
+ */
+function applyUserHueBadge(el) {
+  var discordId = el.dataset.userHue;
+  var h = 5381;
+  for (var i = 0; i < discordId.length; i++) {
+    h = ((h << 5) + h) ^ discordId.charCodeAt(i);
+    h >>>= 0;
+  }
+  el.style.setProperty('--hue', h % 360);
+}
+
+/**
+ * Colors every `.badge-user-hue[data-user-hue]` element on the page — see {@link applyUserHueBadge}.
+ * Shared by every page that lists per-user assignment badges (Commands, Timers).
  * @returns {void}
  */
 function registerUserHueBadges() {
-  document.querySelectorAll('.badge-user-hue[data-user-hue]').forEach(function (el) {
-    var discordId = el.dataset.userHue;
-    var h = 5381;
-    for (var i = 0; i < discordId.length; i++) {
-      h = ((h << 5) + h) ^ discordId.charCodeAt(i);
-      h >>>= 0;
-    }
-    el.style.setProperty('--hue', h % 360);
-  });
+  document.querySelectorAll('.badge-user-hue[data-user-hue]').forEach(applyUserHueBadge);
 }
 
 function registerToggleEditHandler(buttonClass, idAttr, rowPrefix) {

--- a/public/utils.js
+++ b/public/utils.js
@@ -76,6 +76,25 @@ function registerUploadFormHandler(formClassName, fallbackPath) {
   });
 }
 
+/**
+ * Colors every `.badge-user-hue[data-user-hue]` element on the page by hashing its Discord ID
+ * into a hue, applied via the CSSOM (`element.style`) rather than an inline `style=""` attribute
+ * so it works under CSP `style-src` without `'unsafe-inline'`. Shared by every page that lists
+ * per-user assignment badges (Commands, Timers).
+ * @returns {void}
+ */
+function registerUserHueBadges() {
+  document.querySelectorAll('.badge-user-hue[data-user-hue]').forEach(function (el) {
+    var discordId = el.dataset.userHue;
+    var h = 5381;
+    for (var i = 0; i < discordId.length; i++) {
+      h = ((h << 5) + h) ^ discordId.charCodeAt(i);
+      h >>>= 0;
+    }
+    el.style.setProperty('--hue', h % 360);
+  });
+}
+
 function registerToggleEditHandler(buttonClass, idAttr, rowPrefix) {
   document.addEventListener('click', function (event) {
     var target = event.target;

--- a/schema.sql
+++ b/schema.sql
@@ -152,14 +152,15 @@ CREATE TABLE IF NOT EXISTS streamer_event_config (
 
 -- ---------------------------------------------------------------------------
 -- timer_command
--- Per-streamer, Twitch-only auto-posted chat messages. Config-only — the
--- scheduler's live/message-count firing state is kept in memory (see
--- timerCommandScheduler.ts), not persisted here, so a restart simply
--- restarts each timer's countdown rather than replaying missed fires.
+-- Twitch-only auto-posted chat messages, managed like custom_command: a global
+-- catalog assigned to Twitch-linked Discord users via timer_command_streamer.
+-- Each assigned channel fires independently (the scheduler's live/message-count
+-- firing state is kept in memory per (timer, channel) pair — see
+-- timerCommandScheduler.ts — not persisted here, so a restart simply restarts
+-- each one's countdown rather than replaying missed fires).
 -- ---------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS timer_command (
   id               INT          NOT NULL AUTO_INCREMENT,
-  streamer_id      INT          NOT NULL,
   name             VARCHAR(255) NOT NULL,
   message          VARCHAR(500) NOT NULL,
   interval_seconds INT          NOT NULL,
@@ -167,9 +168,21 @@ CREATE TABLE IF NOT EXISTS timer_command (
   require_live     TINYINT(1)   NOT NULL DEFAULT 1,
   enabled          TINYINT(1)   NOT NULL DEFAULT 1,
   PRIMARY KEY (id),
-  FOREIGN KEY (streamer_id) REFERENCES streamer(id) ON DELETE CASCADE,
   CONSTRAINT chk_timer_command_interval CHECK (interval_seconds >= 60),
   CONSTRAINT chk_timer_command_min_messages CHECK (min_messages >= 0)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ---------------------------------------------------------------------------
+-- timer_command_streamer
+-- Maps timer commands to the Discord users (Twitch streamers) they belong to.
+-- Mirrors twitch_user_commands.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS timer_command_streamer (
+  timer_id   INT    NOT NULL,
+  discord_id BIGINT NOT NULL,
+  PRIMARY KEY (timer_id, discord_id),
+  FOREIGN KEY (timer_id)   REFERENCES timer_command(id) ON DELETE CASCADE,
+  FOREIGN KEY (discord_id) REFERENCES `user`(discord_id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- ---------------------------------------------------------------------------

--- a/src/db.ts
+++ b/src/db.ts
@@ -219,11 +219,15 @@ export { recordPricingHistory, getPricingHistoryForRewards } from './db/rewardPr
 
 // ─── Timer commands ─────────────────────────────────────────────────────────
 
-export type { DbTimerCommand, TimerCommandInput, TimerCommandForScheduler } from './db/timerCommands';
+export type {
+  DbTimerCommand, DbTimerCommandAssignedUser, DbTimerCommandWithAssignments,
+  TimerCommandInput, TimerCommandForScheduler,
+} from './db/timerCommands';
 export {
   TimerCommandNotFoundError,
-  getTimerCommandsForStreamer, countTimerCommandsForStreamer, addTimerCommand, updateTimerCommand,
+  getAllTimerCommandsWithAssignments, addTimerCommand, updateTimerCommand,
   removeTimerCommand, setTimerCommandEnabled, getAllEnabledTimerCommandsWithChannel,
+  assignUserToTimer, assignUsersToTimer, unassignUserFromTimer,
 } from './db/timerCommands';
 
 // ─── Streamdeck API keys ─────────────────────────────────────────────────────

--- a/src/db/timerCommands.test.ts
+++ b/src/db/timerCommands.test.ts
@@ -17,6 +17,7 @@ import {
   TimerCommandNotFoundError,
   type TimerCommandInput,
 } from './timerCommands';
+import { AccessLevel } from './users';
 import { makeMockPool } from '../test-utils/mockMysqlPool';
 
 beforeEach(() => {
@@ -97,16 +98,17 @@ describe('getAllTimerCommandsWithAssignments', () => {
     expect(result[1].enabled).toBe(false);
   });
 
-  it('marks user as orphaned when user_discord_id is null', async () => {
+  it('marks user as orphaned when user_discord_id is null, falling back access_level to USER', async () => {
     const row = {
       id: 1, name: 'Plug', message: 'Join!', interval_seconds: 600, min_messages: 0,
       require_live: 1, enabled: 1, assigned_discord_id: 'orphan1', user_discord_id: null,
-      discord_name: null, twitch_name: null, access_level: 0,
+      discord_name: null, twitch_name: null, access_level: null,
     };
     const pool = makeMockPool({ rows: [row] });
     vi.mocked(getPool).mockReturnValue(pool as any);
     const result = await getAllTimerCommandsWithAssignments();
     expect(result[0].assigned_users[0].is_orphaned_user).toBe(true);
+    expect(result[0].assigned_users[0].access_level).toBe(AccessLevel.USER);
   });
 
   it('marks user as not orphaned when user_discord_id matches', async () => {
@@ -224,6 +226,8 @@ describe('assignUsersToTimer', () => {
     const pool = makeMockPool();
     vi.mocked(getPool).mockReturnValue(pool as any);
     await assignUsersToTimer(1, ['u1', 'u2']);
+    expect(pool.execute).toHaveBeenCalledTimes(1);
+    expect(pool.execute.mock.calls[0][0]).toContain('VALUES (?, ?), (?, ?) AS new_row');
     expect(pool.execute.mock.calls[0][1]).toEqual([1, 'u1', 1, 'u2']);
   });
 });

--- a/src/db/timerCommands.test.ts
+++ b/src/db/timerCommands.test.ts
@@ -5,12 +5,14 @@ vi.mock('mysql2/promise', () => ({ default: {} }));
 
 import { getPool } from './pool';
 import {
-  getTimerCommandsForStreamer,
-  countTimerCommandsForStreamer,
+  getAllTimerCommandsWithAssignments,
   addTimerCommand,
   updateTimerCommand,
   removeTimerCommand,
   setTimerCommandEnabled,
+  assignUserToTimer,
+  assignUsersToTimer,
+  unassignUserFromTimer,
   getAllEnabledTimerCommandsWithChannel,
   TimerCommandNotFoundError,
   type TimerCommandInput,
@@ -21,17 +23,6 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-const sampleRow = {
-  id: 1,
-  streamer_id: 7,
-  name: 'Discord plug',
-  message: 'Join our Discord!',
-  interval_seconds: 600,
-  min_messages: 5,
-  require_live: 1,
-  enabled: 1,
-};
-
 const sampleInput: TimerCommandInput = {
   name: 'Discord plug',
   message: 'Join our Discord!',
@@ -41,42 +32,93 @@ const sampleInput: TimerCommandInput = {
   enabled: true,
 };
 
-describe('getTimerCommandsForStreamer', () => {
-  it('maps rows, converting BIT columns to booleans', async () => {
-    vi.mocked(getPool).mockReturnValue(makeMockPool({ rows: [sampleRow] }) as any);
-    const rows = await getTimerCommandsForStreamer(7);
-    expect(rows).toEqual([{
-      id: 1,
-      streamer_id: 7,
-      name: 'Discord plug',
-      message: 'Join our Discord!',
-      interval_seconds: 600,
-      min_messages: 5,
-      require_live: true,
-      enabled: true,
-    }]);
+describe('getAllTimerCommandsWithAssignments', () => {
+  it('returns empty array when no rows', async () => {
+    vi.mocked(getPool).mockReturnValue(makeMockPool() as any);
+    const result = await getAllTimerCommandsWithAssignments();
+    expect(result).toEqual([]);
   });
 
-  it('queries scoped to the streamer id', async () => {
-    const pool = makeMockPool({ rows: [] });
+  it('maps a timer row with no assigned users (null assigned_discord_id)', async () => {
+    const row = {
+      id: 1, name: 'Discord plug', message: 'Join!', interval_seconds: 600, min_messages: 0,
+      require_live: 1, enabled: 1, assigned_discord_id: null, user_discord_id: null,
+      discord_name: null, twitch_name: null, access_level: 0,
+    };
+    const pool = makeMockPool({ rows: [row] });
     vi.mocked(getPool).mockReturnValue(pool as any);
-    await getTimerCommandsForStreamer(7);
-    expect(pool.execute.mock.calls[0][1]).toEqual([7]);
+    const result = await getAllTimerCommandsWithAssignments();
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Discord plug');
+    expect(result[0].assigned_users).toHaveLength(0);
+    expect(result[0].require_live).toBe(true);
+    expect(result[0].enabled).toBe(true);
   });
-});
 
-describe('countTimerCommandsForStreamer', () => {
-  it('parses the BIGINT-string COUNT(*) result back to a number', async () => {
-    const pool = makeMockPool({ executeResult: [[{ count: '3' }], []] });
+  it('groups multiple rows for the same timer into one entry with multiple assigned users', async () => {
+    const rows = [
+      {
+        id: 1, name: 'Discord plug', message: 'Join!', interval_seconds: 600, min_messages: 0,
+        require_live: 1, enabled: 1, assigned_discord_id: 'u1', user_discord_id: 'u1',
+        discord_name: 'Alice', twitch_name: 'alice', access_level: 0,
+      },
+      {
+        id: 1, name: 'Discord plug', message: 'Join!', interval_seconds: 600, min_messages: 0,
+        require_live: 1, enabled: 1, assigned_discord_id: 'u2', user_discord_id: 'u2',
+        discord_name: 'Bob', twitch_name: 'bob', access_level: 1,
+      },
+    ];
+    const pool = makeMockPool({ rows });
     vi.mocked(getPool).mockReturnValue(pool as any);
-    expect(await countTimerCommandsForStreamer(7)).toBe(3);
+    const result = await getAllTimerCommandsWithAssignments();
+    expect(result).toHaveLength(1);
+    expect(result[0].assigned_users).toHaveLength(2);
+    expect(result[0].assigned_users[0].discord_id).toBe('u1');
+    expect(result[0].assigned_users[1].discord_id).toBe('u2');
   });
 
-  it('queries scoped to the streamer id', async () => {
-    const pool = makeMockPool({ executeResult: [[{ count: '0' }], []] });
+  it('handles multiple distinct timers', async () => {
+    const rows = [
+      {
+        id: 1, name: 'Plug', message: 'Join!', interval_seconds: 600, min_messages: 0,
+        require_live: 1, enabled: 1, assigned_discord_id: null, user_discord_id: null,
+        discord_name: null, twitch_name: null, access_level: 0,
+      },
+      {
+        id: 2, name: 'Reminder', message: 'Sub!', interval_seconds: 900, min_messages: 0,
+        require_live: 0, enabled: 0, assigned_discord_id: null, user_discord_id: null,
+        discord_name: null, twitch_name: null, access_level: 0,
+      },
+    ];
+    const pool = makeMockPool({ rows });
     vi.mocked(getPool).mockReturnValue(pool as any);
-    await countTimerCommandsForStreamer(7);
-    expect(pool.execute.mock.calls[0][1]).toEqual([7]);
+    const result = await getAllTimerCommandsWithAssignments();
+    expect(result).toHaveLength(2);
+    expect(result[1].enabled).toBe(false);
+  });
+
+  it('marks user as orphaned when user_discord_id is null', async () => {
+    const row = {
+      id: 1, name: 'Plug', message: 'Join!', interval_seconds: 600, min_messages: 0,
+      require_live: 1, enabled: 1, assigned_discord_id: 'orphan1', user_discord_id: null,
+      discord_name: null, twitch_name: null, access_level: 0,
+    };
+    const pool = makeMockPool({ rows: [row] });
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await getAllTimerCommandsWithAssignments();
+    expect(result[0].assigned_users[0].is_orphaned_user).toBe(true);
+  });
+
+  it('marks user as not orphaned when user_discord_id matches', async () => {
+    const row = {
+      id: 1, name: 'Plug', message: 'Join!', interval_seconds: 600, min_messages: 0,
+      require_live: 1, enabled: 1, assigned_discord_id: 'u1', user_discord_id: 'u1',
+      discord_name: 'Alice', twitch_name: 'alice', access_level: 0,
+    };
+    const pool = makeMockPool({ rows: [row] });
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await getAllTimerCommandsWithAssignments();
+    expect(result[0].assigned_users[0].is_orphaned_user).toBe(false);
   });
 });
 
@@ -84,9 +126,9 @@ describe('addTimerCommand', () => {
   it('inserts and returns the new insertId', async () => {
     const pool = makeMockPool({ executeResult: [{ insertId: 42 }] });
     vi.mocked(getPool).mockReturnValue(pool as any);
-    const id = await addTimerCommand(7, sampleInput);
+    const id = await addTimerCommand(sampleInput);
     expect(id).toBe(42);
-    expect(pool.execute.mock.calls[0][1]).toEqual([7, 'Discord plug', 'Join our Discord!', 600, 5, 1, 1]);
+    expect(pool.execute.mock.calls[0][1]).toEqual(['Discord plug', 'Join our Discord!', 600, 5, 1, 1]);
   });
 });
 
@@ -94,8 +136,8 @@ describe('updateTimerCommand', () => {
   it('updates when a row matched', async () => {
     const pool = makeMockPool({ executeResult: [{ affectedRows: 1 }] });
     vi.mocked(getPool).mockReturnValue(pool as any);
-    await expect(updateTimerCommand(1, 7, sampleInput)).resolves.toBeUndefined();
-    expect(pool.execute.mock.calls[0][1]).toEqual(['Discord plug', 'Join our Discord!', 600, 5, 1, 1, 1, 7]);
+    await expect(updateTimerCommand(1, sampleInput)).resolves.toBeUndefined();
+    expect(pool.execute.mock.calls[0][1]).toEqual(['Discord plug', 'Join our Discord!', 600, 5, 1, 1, 1]);
     // affectedRows > 0 already proves the row exists — no need for a follow-up existence check.
     expect(pool.execute).toHaveBeenCalledTimes(1);
   });
@@ -106,49 +148,7 @@ describe('updateTimerCommand', () => {
       .mockResolvedValueOnce([{ affectedRows: 0 }]) // the UPDATE itself: no-op, every value already equal
       .mockResolvedValueOnce([[{ 1: 1 }]]); // the existence check: row is still there
     vi.mocked(getPool).mockReturnValue(pool as any);
-    await expect(updateTimerCommand(1, 7, sampleInput)).resolves.toBeUndefined();
-  });
-
-  it('throws TimerCommandNotFoundError when no row matched (wrong id or wrong streamer)', async () => {
-    const pool = makeMockPool();
-    pool.execute
-      .mockResolvedValueOnce([{ affectedRows: 0 }]) // the UPDATE itself: nothing matched
-      .mockResolvedValueOnce([[]]); // the existence check: confirms the row is genuinely absent
-    vi.mocked(getPool).mockReturnValue(pool as any);
-    await expect(updateTimerCommand(1, 999, sampleInput)).rejects.toThrow(TimerCommandNotFoundError);
-  });
-});
-
-describe('removeTimerCommand', () => {
-  it('deletes scoped to id and streamer id', async () => {
-    const pool = makeMockPool({ executeResult: [{ affectedRows: 1 }] });
-    vi.mocked(getPool).mockReturnValue(pool as any);
-    await removeTimerCommand(1, 7);
-    expect(pool.execute.mock.calls[0][1]).toEqual([1, 7]);
-  });
-
-  it('no-ops without throwing when nothing matched', async () => {
-    const pool = makeMockPool({ executeResult: [{ affectedRows: 0 }] });
-    vi.mocked(getPool).mockReturnValue(pool as any);
-    await expect(removeTimerCommand(1, 999)).resolves.toBeUndefined();
-  });
-});
-
-describe('setTimerCommandEnabled', () => {
-  it('updates the enabled flag when a row matched', async () => {
-    const pool = makeMockPool({ executeResult: [{ affectedRows: 1 }] });
-    vi.mocked(getPool).mockReturnValue(pool as any);
-    await setTimerCommandEnabled(1, 7, false);
-    expect(pool.execute.mock.calls[0][1]).toEqual([0, 1, 7]);
-  });
-
-  it('does not throw when affectedRows is 0 but the row exists already in the requested state', async () => {
-    const pool = makeMockPool();
-    pool.execute
-      .mockResolvedValueOnce([{ affectedRows: 0 }]) // the UPDATE itself: no-op, already in that state
-      .mockResolvedValueOnce([[{ 1: 1 }]]); // the existence check: row is still there
-    vi.mocked(getPool).mockReturnValue(pool as any);
-    await expect(setTimerCommandEnabled(1, 7, true)).resolves.toBeUndefined();
+    await expect(updateTimerCommand(1, sampleInput)).resolves.toBeUndefined();
   });
 
   it('throws TimerCommandNotFoundError when no row matched', async () => {
@@ -157,7 +157,83 @@ describe('setTimerCommandEnabled', () => {
       .mockResolvedValueOnce([{ affectedRows: 0 }]) // the UPDATE itself: nothing matched
       .mockResolvedValueOnce([[]]); // the existence check: confirms the row is genuinely absent
     vi.mocked(getPool).mockReturnValue(pool as any);
-    await expect(setTimerCommandEnabled(1, 999, true)).rejects.toThrow(TimerCommandNotFoundError);
+    await expect(updateTimerCommand(999, sampleInput)).rejects.toThrow(TimerCommandNotFoundError);
+  });
+});
+
+describe('removeTimerCommand', () => {
+  it('deletes scoped to id', async () => {
+    const pool = makeMockPool({ executeResult: [{ affectedRows: 1 }] });
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await removeTimerCommand(1);
+    expect(pool.execute.mock.calls[0][1]).toEqual([1]);
+  });
+
+  it('no-ops without throwing when nothing matched', async () => {
+    const pool = makeMockPool({ executeResult: [{ affectedRows: 0 }] });
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(removeTimerCommand(999)).resolves.toBeUndefined();
+  });
+});
+
+describe('setTimerCommandEnabled', () => {
+  it('updates the enabled flag when a row matched', async () => {
+    const pool = makeMockPool({ executeResult: [{ affectedRows: 1 }] });
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await setTimerCommandEnabled(1, false);
+    expect(pool.execute.mock.calls[0][1]).toEqual([0, 1]);
+  });
+
+  it('does not throw when affectedRows is 0 but the row exists already in the requested state', async () => {
+    const pool = makeMockPool();
+    pool.execute
+      .mockResolvedValueOnce([{ affectedRows: 0 }]) // the UPDATE itself: no-op, already in that state
+      .mockResolvedValueOnce([[{ 1: 1 }]]); // the existence check: row is still there
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(setTimerCommandEnabled(1, true)).resolves.toBeUndefined();
+  });
+
+  it('throws TimerCommandNotFoundError when no row matched', async () => {
+    const pool = makeMockPool();
+    pool.execute
+      .mockResolvedValueOnce([{ affectedRows: 0 }]) // the UPDATE itself: nothing matched
+      .mockResolvedValueOnce([[]]); // the existence check: confirms the row is genuinely absent
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(setTimerCommandEnabled(999, true)).rejects.toThrow(TimerCommandNotFoundError);
+  });
+});
+
+describe('assignUserToTimer', () => {
+  it('inserts an assignment row, tolerating a duplicate via the no-op upsert', async () => {
+    const pool = makeMockPool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await assignUserToTimer(1, 'u1');
+    expect(pool.execute.mock.calls[0][1]).toEqual([1, 'u1']);
+  });
+});
+
+describe('assignUsersToTimer', () => {
+  it('is a no-op when discordIds is empty', async () => {
+    const pool = makeMockPool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await assignUsersToTimer(1, []);
+    expect(pool.execute).not.toHaveBeenCalled();
+  });
+
+  it('inserts one row per discord id in a single statement', async () => {
+    const pool = makeMockPool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await assignUsersToTimer(1, ['u1', 'u2']);
+    expect(pool.execute.mock.calls[0][1]).toEqual([1, 'u1', 1, 'u2']);
+  });
+});
+
+describe('unassignUserFromTimer', () => {
+  it('deletes scoped to timer id and discord id', async () => {
+    const pool = makeMockPool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await unassignUserFromTimer(1, 'u1');
+    expect(pool.execute.mock.calls[0][1]).toEqual([1, 'u1']);
   });
 });
 
@@ -181,6 +257,17 @@ describe('getAllEnabledTimerCommandsWithChannel', () => {
       min_messages: 5,
       require_live: true,
     }]);
+  });
+
+  it('returns one row per assigned channel when a timer has multiple assignments', async () => {
+    const rows = [
+      { id: 1, channel: 'streamer-a', message: 'hi', interval_seconds: 600, min_messages: 0, require_live: 1 },
+      { id: 1, channel: 'streamer-b', message: 'hi', interval_seconds: 600, min_messages: 0, require_live: 1 },
+    ];
+    vi.mocked(getPool).mockReturnValue(makeMockPool({ rows }) as any);
+    const result = await getAllEnabledTimerCommandsWithChannel();
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.channel)).toEqual(['streamer-a', 'streamer-b']);
   });
 
   it('queries with no parameters (filtering happens in SQL)', async () => {

--- a/src/db/timerCommands.ts
+++ b/src/db/timerCommands.ts
@@ -1,11 +1,12 @@
 import mysql from 'mysql2/promise';
 import { getPool } from './pool';
-import { fromBit, affectedOrExists } from './utils';
+import { fromBit, affectedOrExists, rowExists } from './utils';
+import { AccessLevel } from './users';
+import type { AccessLevelValue } from './users';
 
-/** A per-streamer, Twitch-only auto-posted timer command. */
+/** A timer command row from the database. */
 export interface DbTimerCommand {
   id: number;
-  streamer_id: number;
   name: string;
   message: string;
   interval_seconds: number;
@@ -14,7 +15,21 @@ export interface DbTimerCommand {
   enabled: boolean;
 }
 
-/** Fields a streamer can edit for one timer via the admin UI. */
+/** A user assigned to a timer command (may be orphaned if their account no longer exists). */
+export interface DbTimerCommandAssignedUser {
+  discord_id: string;
+  discord_name: string | null;
+  twitch_name: string | null;
+  access_level: AccessLevelValue;
+  is_orphaned_user: boolean;
+}
+
+/** A timer command with its full list of assigned users. */
+export interface DbTimerCommandWithAssignments extends DbTimerCommand {
+  assigned_users: DbTimerCommandAssignedUser[];
+}
+
+/** Fields a manager can edit for one timer via the admin UI. */
 export interface TimerCommandInput {
   name: string;
   message: string;
@@ -24,7 +39,7 @@ export interface TimerCommandInput {
   enabled: boolean;
 }
 
-/** One enabled timer joined with its owning streamer's Twitch channel, for the scheduler's per-tick read. */
+/** One enabled timer joined with one of its assigned users' Twitch channel, for the scheduler's per-tick read. A timer assigned to several channels appears once per channel, each firing independently. */
 export interface TimerCommandForScheduler {
   id: number;
   channel: string;
@@ -34,7 +49,7 @@ export interface TimerCommandForScheduler {
   require_live: boolean;
 }
 
-/** Thrown when a timer lookup/mutation scoped to a streamer matches no row — either the id doesn't exist or belongs to a different streamer. */
+/** Thrown when a timer lookup/mutation matches no row. */
 export class TimerCommandNotFoundError extends Error {
   constructor(id: number) {
     super(`Timer command not found: ${id}`);
@@ -45,7 +60,6 @@ export class TimerCommandNotFoundError extends Error {
 function mapRow(r: mysql.RowDataPacket): DbTimerCommand {
   return {
     id: r.id,
-    streamer_id: r.streamer_id,
     name: r.name,
     message: r.message,
     interval_seconds: r.interval_seconds,
@@ -55,59 +69,59 @@ function mapRow(r: mysql.RowDataPacket): DbTimerCommand {
   };
 }
 
-const TIMER_COMMAND_SELECT = `
-  id, streamer_id, name, message, interval_seconds, min_messages, require_live, enabled`;
+/** Whether a timer command exists for `id`. */
+async function timerCommandExists(id: number): Promise<boolean> {
+  return rowExists(getPool(), 'timer_command', 'id', id);
+}
 
-/** Whether a timer command exists for `id` scoped to `streamerId` — same ownership scope as the UPDATE statements below. */
-async function timerCommandExists(id: number, streamerId: number): Promise<boolean> {
+/** Return all timer commands, each with its full list of assigned users, for the manager admin page. */
+export async function getAllTimerCommandsWithAssignments(): Promise<DbTimerCommandWithAssignments[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    `SELECT 1 FROM timer_command WHERE id = ? AND streamer_id = ? LIMIT 1`,
-    [id, streamerId],
+    `SELECT tc.id, tc.name, tc.message, tc.interval_seconds, tc.min_messages, tc.require_live, tc.enabled,
+            tcs.discord_id AS assigned_discord_id,
+            u.discord_id AS user_discord_id,
+            u.discord_name, u.twitch_name, u.access_level
+     FROM timer_command tc
+     LEFT JOIN timer_command_streamer tcs ON tc.id = tcs.timer_id
+     LEFT JOIN \`user\` u ON tcs.discord_id = u.discord_id
+     ORDER BY tc.name, u.discord_name, tcs.discord_id`,
   );
-  return rows.length > 0;
+
+  const timerMap = new Map<number, DbTimerCommandWithAssignments>();
+
+  for (const row of rows) {
+    if (!timerMap.has(row.id)) {
+      timerMap.set(row.id, {
+        ...mapRow(row),
+        assigned_users: [],
+      });
+    }
+
+    if (row.assigned_discord_id !== null && row.assigned_discord_id !== undefined) {
+      timerMap.get(row.id)!.assigned_users.push({
+        discord_id: String(row.assigned_discord_id),
+        discord_name: row.discord_name ?? null,
+        twitch_name: row.twitch_name ?? null,
+        access_level: row.access_level ?? AccessLevel.USER,
+        is_orphaned_user: row.user_discord_id === null || row.user_discord_id === undefined,
+      });
+    }
+  }
+
+  return Array.from(timerMap.values());
 }
 
 /**
- * Lists every timer command belonging to a streamer, for the self-service admin page.
- * @param streamerId - DB row ID of the streamer.
- */
-export async function getTimerCommandsForStreamer(streamerId: number): Promise<DbTimerCommand[]> {
-  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    `SELECT ${TIMER_COMMAND_SELECT} FROM timer_command WHERE streamer_id = ? ORDER BY id`,
-    [streamerId],
-  );
-  return rows.map(mapRow);
-}
-
-/**
- * Counts how many timer commands a streamer currently has, so the `/timers/add` route can
- * enforce a per-streamer cap before inserting a new row.
- * @param streamerId - DB row ID of the streamer.
- * @returns The row count. `COUNT(*)` is protocol-typed BIGINT, so `bigNumberStrings` stringifies
- *   it — but this value is bounded by the cap enforced at insert time (see
- *   `MAX_TIMER_COMMANDS_PER_STREAMER` in `timersMutations.ts`), never large enough to approach
- *   `Number.MAX_SAFE_INTEGER`, so parsing it back to a number here is safe and deliberate.
- */
-export async function countTimerCommandsForStreamer(streamerId: number): Promise<number> {
-  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    `SELECT COUNT(*) AS count FROM timer_command WHERE streamer_id = ?`,
-    [streamerId],
-  );
-  return Number.parseInt(rows[0].count, 10);
-}
-
-/**
- * Creates a new timer command for a streamer.
- * @param streamerId - DB row ID of the owning streamer.
+ * Creates a new timer command.
  * @param input - The timer's fields.
  * @returns The new timer's primary key.
  */
-export async function addTimerCommand(streamerId: number, input: TimerCommandInput): Promise<number> {
+export async function addTimerCommand(input: TimerCommandInput): Promise<number> {
   const [result] = await getPool().execute<mysql.ResultSetHeader>(
-    `INSERT INTO timer_command (streamer_id, name, message, interval_seconds, min_messages, require_live, enabled)
-     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO timer_command (name, message, interval_seconds, min_messages, require_live, enabled)
+     VALUES (?, ?, ?, ?, ?, ?)`,
     [
-      streamerId, input.name, input.message, input.intervalSeconds, input.minMessages,
+      input.name, input.message, input.intervalSeconds, input.minMessages,
       input.requireLive ? 1 : 0, input.enabled ? 1 : 0,
     ],
   );
@@ -115,78 +129,120 @@ export async function addTimerCommand(streamerId: number, input: TimerCommandInp
 }
 
 /**
- * Updates an existing timer command, scoped to the owning streamer so one streamer can never
- * edit another's timer by guessing an id.
+ * Updates an existing timer command's fields.
  * @param id - Primary key of the `timer_command` row.
- * @param streamerId - DB row ID of the owning streamer.
  * @param input - The timer's new fields.
- * @throws {TimerCommandNotFoundError} If no row matches both `id` and `streamerId`.
+ * @throws {TimerCommandNotFoundError} If no row matches `id`.
  */
-export async function updateTimerCommand(id: number, streamerId: number, input: TimerCommandInput): Promise<void> {
+export async function updateTimerCommand(id: number, input: TimerCommandInput): Promise<void> {
   const [result] = await getPool().execute<mysql.ResultSetHeader>(
     `UPDATE timer_command
      SET name = ?, message = ?, interval_seconds = ?, min_messages = ?, require_live = ?, enabled = ?
-     WHERE id = ? AND streamer_id = ?`,
+     WHERE id = ?`,
     [
       input.name, input.message, input.intervalSeconds, input.minMessages,
-      input.requireLive ? 1 : 0, input.enabled ? 1 : 0, id, streamerId,
+      input.requireLive ? 1 : 0, input.enabled ? 1 : 0, id,
     ],
   );
   // affectedRows is 0 both when no row matched and when the row matched but every value was
   // already equal (MySQL's default UPDATE semantics count only rows actually changed) — a
-  // resubmitted, unchanged edit must not be mistaken for a missing/foreign timer.
-  if (!(await affectedOrExists(result.affectedRows, () => timerCommandExists(id, streamerId)))) {
+  // resubmitted, unchanged edit must not be mistaken for a missing timer.
+  if (!(await affectedOrExists(result.affectedRows, () => timerCommandExists(id)))) {
     throw new TimerCommandNotFoundError(id);
   }
 }
 
 /**
- * Deletes a timer command, scoped to the owning streamer. No-ops if the id doesn't exist or
- * belongs to a different streamer.
+ * Deletes a timer command and all its streamer assignments (cascaded by the FK).
  * @param id - Primary key of the `timer_command` row.
- * @param streamerId - DB row ID of the owning streamer.
  */
-export async function removeTimerCommand(id: number, streamerId: number): Promise<void> {
-  await getPool().execute(
-    `DELETE FROM timer_command WHERE id = ? AND streamer_id = ?`,
-    [id, streamerId],
-  );
+export async function removeTimerCommand(id: number): Promise<void> {
+  await getPool().execute(`DELETE FROM timer_command WHERE id = ?`, [id]);
 }
 
 /**
- * Toggles a timer command's `enabled` flag, scoped to the owning streamer.
+ * Toggles a timer command's `enabled` flag, for a one-click enable/disable control in the
+ * timer list without opening the full edit form.
  * @param id - Primary key of the `timer_command` row.
- * @param streamerId - DB row ID of the owning streamer.
  * @param enabled - The new enabled state.
- * @throws {TimerCommandNotFoundError} If no row matches both `id` and `streamerId`.
+ * @throws {TimerCommandNotFoundError} If no row matches `id`.
  */
-export async function setTimerCommandEnabled(id: number, streamerId: number, enabled: boolean): Promise<void> {
+export async function setTimerCommandEnabled(id: number, enabled: boolean): Promise<void> {
   const [result] = await getPool().execute<mysql.ResultSetHeader>(
-    `UPDATE timer_command SET enabled = ? WHERE id = ? AND streamer_id = ?`,
-    [enabled ? 1 : 0, id, streamerId],
+    `UPDATE timer_command SET enabled = ? WHERE id = ?`,
+    [enabled ? 1 : 0, id],
   );
   // See updateTimerCommand: affectedRows is 0 both for a missing row and a no-op toggle
   // (already in the requested state), so a re-click of an already-toggled timer must not
-  // be mistaken for a missing/foreign one.
-  if (!(await affectedOrExists(result.affectedRows, () => timerCommandExists(id, streamerId)))) {
+  // be mistaken for a missing one.
+  if (!(await affectedOrExists(result.affectedRows, () => timerCommandExists(id)))) {
     throw new TimerCommandNotFoundError(id);
   }
 }
 
 /**
- * Lists every enabled timer command across all streamers, joined with its owning streamer's
- * linked Twitch channel name. Streamers with no linked Twitch name are excluded — there's no
- * channel to post to. Queried fresh every scheduler tick rather than cached, mirroring
- * `getAllEnabledPricingRows()`.
+ * Assigns a Twitch-linked Discord user to a timer command's channel list.
+ * @param timerId - ID of the timer to assign the user to.
+ * @param discordId - Discord snowflake of the user to assign.
+ */
+export async function assignUserToTimer(timerId: number, discordId: string): Promise<void> {
+  await getPool().execute(
+    `INSERT INTO timer_command_streamer (timer_id, discord_id)
+     VALUES (?, ?) AS new_row
+     ON DUPLICATE KEY UPDATE
+       timer_id = new_row.timer_id`,
+    [timerId, discordId],
+  );
+}
+
+/**
+ * Assigns multiple Discord users to a timer command's channel list in one statement.
+ * A no-op (no query issued) when `discordIds` is empty.
+ * @param timerId - ID of the timer to assign the users to.
+ * @param discordIds - Discord snowflakes of the users to assign.
+ */
+export async function assignUsersToTimer(timerId: number, discordIds: string[]): Promise<void> {
+  if (discordIds.length === 0) return;
+
+  const placeholders = discordIds.map(() => '(?, ?)').join(', ');
+  const params = discordIds.flatMap((discordId) => [timerId, discordId]);
+
+  await getPool().execute(
+    `INSERT INTO timer_command_streamer (timer_id, discord_id)
+     VALUES ${placeholders} AS new_row
+     ON DUPLICATE KEY UPDATE
+       timer_id = new_row.timer_id`,
+    params,
+  );
+}
+
+/**
+ * Removes a Discord user's assignment from a timer command.
+ * @param timerId - ID of the timer to remove the assignment from.
+ * @param discordId - Discord snowflake of the user to unassign.
+ */
+export async function unassignUserFromTimer(timerId: number, discordId: string): Promise<void> {
+  await getPool().execute(
+    `DELETE FROM timer_command_streamer WHERE timer_id = ? AND discord_id = ?`,
+    [timerId, discordId],
+  );
+}
+
+/**
+ * Lists every enabled timer command joined with each of its assigned users' linked Twitch
+ * channel, for the scheduler's per-tick read. A timer assigned to several streamers appears
+ * once per assigned channel, each firing independently — assignees with no linked Twitch name
+ * are excluded, since there's no channel to post to. Queried fresh every scheduler tick rather
+ * than cached, mirroring `getAllEnabledPricingRows()`.
  */
 export async function getAllEnabledTimerCommandsWithChannel(): Promise<TimerCommandForScheduler[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
     `SELECT tc.id, u.twitch_name AS channel, tc.message, tc.interval_seconds, tc.min_messages, tc.require_live
      FROM timer_command tc
-     JOIN streamer s ON s.id = tc.streamer_id
-     JOIN \`user\` u ON u.discord_id = s.discord_id
+     JOIN timer_command_streamer tcs ON tcs.timer_id = tc.id
+     JOIN \`user\` u ON u.discord_id = tcs.discord_id
      WHERE tc.enabled = 1 AND u.twitch_name IS NOT NULL
-     ORDER BY tc.streamer_id`,
+     ORDER BY tc.id, u.discord_id`,
   );
   return rows.map((r) => ({
     id: r.id,

--- a/src/db/timerCommands.ts
+++ b/src/db/timerCommands.ts
@@ -241,7 +241,7 @@ export async function getAllEnabledTimerCommandsWithChannel(): Promise<TimerComm
      FROM timer_command tc
      JOIN timer_command_streamer tcs ON tcs.timer_id = tc.id
      JOIN \`user\` u ON u.discord_id = tcs.discord_id
-     WHERE tc.enabled = 1 AND u.twitch_name IS NOT NULL
+     WHERE tc.enabled = 1 AND u.twitch_name IS NOT NULL AND u.twitch_name <> ''
      ORDER BY tc.id, u.discord_id`,
   );
   return rows.map((r) => ({

--- a/src/twitch/timers/timerCommandScheduler.test.ts
+++ b/src/twitch/timers/timerCommandScheduler.test.ts
@@ -129,6 +129,24 @@ describe('runTimerCommandTick', () => {
     expect(send).not.toHaveBeenCalled();
   });
 
+  it('fires independently per channel when the same timer is assigned to multiple streamers', async () => {
+    // A timer can now be assigned to several streamers' channels — each appears as its own row
+    // sharing the same timer id, and each must fire on its own live/interval schedule rather
+    // than sharing one countdown.
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([
+      timerRow({ id: 1, channel: 'streamer-a', interval_seconds: 600 }),
+      timerRow({ id: 1, channel: 'streamer-b', interval_seconds: 600 }),
+    ] as any);
+    await runTimerCommandTick(); // seed both channels independently
+
+    vi.mocked(isChannelLive).mockImplementation((channel: string) => channel === 'streamer-a');
+    await vi.advanceTimersByTimeAsync(600_000);
+    await runTimerCommandTick();
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith('streamer-a', 'hello');
+  });
+
   it("one channel's send failure does not block another's", async () => {
     vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([
       timerRow({ id: 1, channel: 'streamer-a' }),

--- a/src/twitch/timers/timerCommandScheduler.test.ts
+++ b/src/twitch/timers/timerCommandScheduler.test.ts
@@ -147,6 +147,24 @@ describe('runTimerCommandTick', () => {
     expect(send).toHaveBeenCalledWith('streamer-a', 'hello');
   });
 
+  it("keeps firing state independent for the same timer id on different channels (a shared, id-only-keyed state would let one channel's fire reset the other's clock)", async () => {
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([
+      timerRow({ id: 2, channel: 'streamer-a', interval_seconds: 600 }),
+      timerRow({ id: 2, channel: 'streamer-b', interval_seconds: 300 }),
+    ] as any);
+    await runTimerCommandTick(); // seed both channels (both live by default per beforeEach)
+
+    await vi.advanceTimersByTimeAsync(300_000);
+    await runTimerCommandTick(); // only streamer-b's shorter interval has elapsed
+    expect(send).toHaveBeenCalledWith('streamer-b', 'hello');
+    expect(send).not.toHaveBeenCalledWith('streamer-a', 'hello');
+
+    send.mockClear();
+    await vi.advanceTimersByTimeAsync(300_000);
+    await runTimerCommandTick(); // streamer-a's own 600s interval has now elapsed since its seed
+    expect(send).toHaveBeenCalledWith('streamer-a', 'hello');
+  });
+
   it("one channel's send failure does not block another's", async () => {
     vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([
       timerRow({ id: 1, channel: 'streamer-a' }),

--- a/src/twitch/timers/timerCommandScheduler.ts
+++ b/src/twitch/timers/timerCommandScheduler.ts
@@ -38,6 +38,7 @@ interface TimerRuntimeState {
  * own live/interval/message-count schedule — the same timer definition posting into two different
  * channels must not share one countdown.
  * @param row - The timer's config, joined with the channel this row is for.
+ * @returns The composite `"{id}::{channel}"` key used as this row's `timerState` map key.
  */
 function rowKey(row: { id: number; channel: string }): string {
   return `${row.id}::${row.channel}`;
@@ -87,7 +88,12 @@ function shouldFire(
   return true;
 }
 
-/** Removes in-memory state for any (timer id, channel) pair no longer present in the latest enabled-rows fetch. */
+/**
+ * Removes in-memory state for any (timer id, channel) pair no longer present in the latest
+ * enabled-rows fetch.
+ * @param currentKeys - {@link rowKey} values for every row in the latest enabled-rows fetch.
+ * @returns Nothing — mutates the module-level `timerState` map in place.
+ */
 function pruneStaleTimerState(currentKeys: ReadonlySet<string>): void {
   for (const key of timerState.keys()) {
     if (!currentKeys.has(key)) timerState.delete(key);

--- a/src/twitch/timers/timerCommandScheduler.ts
+++ b/src/twitch/timers/timerCommandScheduler.ts
@@ -32,7 +32,18 @@ interface TimerRuntimeState {
   messagesAtLastFire: number;
 }
 
-const timerState = new Map<number, TimerRuntimeState>();
+/**
+ * Firing state is keyed by (timer id, channel) rather than timer id alone: a timer can now be
+ * assigned to several streamers' channels, and each assigned channel fires independently, on its
+ * own live/interval/message-count schedule — the same timer definition posting into two different
+ * channels must not share one countdown.
+ * @param row - The timer's config, joined with the channel this row is for.
+ */
+function rowKey(row: { id: number; channel: string }): string {
+  return `${row.id}::${row.channel}`;
+}
+
+const timerState = new Map<string, TimerRuntimeState>();
 
 // ─── Shared Chat group cooldown ──────────────────────────────────────────────
 //
@@ -76,10 +87,10 @@ function shouldFire(
   return true;
 }
 
-/** Removes in-memory state for any timer id no longer present in the latest enabled-rows fetch. */
-function pruneStaleTimerState(currentIds: ReadonlySet<number>): void {
-  for (const id of timerState.keys()) {
-    if (!currentIds.has(id)) timerState.delete(id);
+/** Removes in-memory state for any (timer id, channel) pair no longer present in the latest enabled-rows fetch. */
+function pruneStaleTimerState(currentKeys: ReadonlySet<string>): void {
+  for (const key of timerState.keys()) {
+    if (!currentKeys.has(key)) timerState.delete(key);
   }
 }
 
@@ -152,8 +163,8 @@ function pickRowsToFire(
     if (now - lastFired < SHARED_SESSION_COOLDOWN_MS) continue;
 
     const picked = rows.reduce((oldest, row) => {
-      const oldestState = timerState.get(oldest.id)!;
-      const rowState = timerState.get(row.id)!;
+      const oldestState = timerState.get(rowKey(oldest))!;
+      const rowState = timerState.get(rowKey(row))!;
       return rowState.lastFiredAt < oldestState.lastFiredAt ? row : oldest;
     });
     sessionLastFiredAt.set(sessionId, now); // provisional — released by sendTimerRow on failure
@@ -181,7 +192,7 @@ async function sendTimerRow(row: TimerCommandForScheduler, now: number, sessionI
     return;
   }
 
-  const state = timerState.get(row.id)!;
+  const state = timerState.get(rowKey(row))!;
   try {
     await runtime.send(row.channel, row.message);
     state.lastFiredAt = now;
@@ -207,16 +218,17 @@ export async function runTimerCommandTick(): Promise<void> {
   currentTickPromise = (async () => {
     try {
       const rows = await getAllEnabledTimerCommandsWithChannel();
-      pruneStaleTimerState(new Set(rows.map((row) => row.id)));
+      pruneStaleTimerState(new Set(rows.map(rowKey)));
 
       const now = Date.now();
       pruneStaleSessionCooldowns(now);
 
       const eligibleRows: TimerCommandForScheduler[] = [];
       for (const row of rows) {
-        const state = timerState.get(row.id);
+        const key = rowKey(row);
+        const state = timerState.get(key);
         if (!state) {
-          timerState.set(row.id, { lastFiredAt: now, messagesAtLastFire: getMessageCount(row.channel) });
+          timerState.set(key, { lastFiredAt: now, messagesAtLastFire: getMessageCount(row.channel) });
           continue;
         }
         if (shouldFire(row, state, now)) eligibleRows.push(row);

--- a/src/web/routes/assignmentRoutes.ts
+++ b/src/web/routes/assignmentRoutes.ts
@@ -1,0 +1,121 @@
+import { Router } from 'express';
+import type { Logger } from 'winston';
+import { findUser } from '../../db';
+import { csrfProtection } from '../csrf';
+import { requireMod } from '../middleware';
+import { normalizeDiscordId, logAndRedirectError } from './shared';
+
+/** Options for {@link createAssignmentRouter}. */
+export interface AssignmentRouterOptions<TId> {
+  /** Path the assign/unassign routes live under, and the redirect target on success/error (e.g. `/commands`, `/timers`). */
+  basePath: string;
+  /** Form field name carrying the entity id (e.g. `command_id`, `timer_id`). */
+  idField: string;
+  /** Parses/validates the raw id field into `TId`, or null if malformed. */
+  parseId: (raw: string) => TId | null;
+  /** Assigns `discordId` to the entity. May throw — see {@link mapAssignError}. */
+  assign: (id: TId, discordId: string) => Promise<void>;
+  /** Removes `discordId`'s assignment from the entity. */
+  unassign: (id: TId, discordId: string) => Promise<void>;
+  /**
+   * Maps an error thrown by `assign` to a specific error code, or null to fall through to the
+   * generic `assign_failed` redirect. Lets a caller special-case its own error types (e.g.
+   * Commands' trigger-conflict errors) without other callers carrying logic they don't need.
+   */
+  mapAssignError?: (err: unknown) => string | null;
+  /** Logger to record unexpected errors on. */
+  log: Logger;
+}
+
+/**
+ * Builds a `POST {basePath}/assign` / `POST {basePath}/unassign` router pair: assigns or removes
+ * a Twitch-linked Discord user's association with an entity (a custom command, a timer command,
+ * ...). Both routes are gated `requireMod` + `csrfProtection`. Shared by `commandAssignments.ts`
+ * and `timerAssignments.ts`, which previously duplicated this same shape end to end.
+ * @param options - See {@link AssignmentRouterOptions}.
+ */
+export function createAssignmentRouter<TId>(options: AssignmentRouterOptions<TId>): Router {
+  const { basePath, idField, parseId, assign, unassign, mapAssignError, log } = options;
+  const router = Router();
+
+  /**
+   * POST `{basePath}/assign` — assigns a Twitch-linked Discord user to the entity identified by
+   * `idField`.
+   * @param req - Express request; reads `idField` and `discord_id` from `req.body`.
+   * @param res - Express response; redirects to `basePath` on success, or to
+   *   `basePath?error=<code>` if fields are missing (`missing_fields`), IDs are malformed
+   *   (`invalid_id`), the user doesn't exist or has no linked Twitch name
+   *   (`invalid_assignment_user`), `mapAssignError` maps a thrown error to a specific code, or
+   *   the assignment write fails for any other reason (`assign_failed`).
+   */
+  router.post(`${basePath}/assign`, requireMod, csrfProtection, async (req, res) => {
+    const body = req.body as Record<string, string | undefined>;
+    const rawId = body[idField];
+    const discordId = body.discord_id;
+    if (!rawId || !discordId) {
+      return res.redirect(`${basePath}?error=missing_fields`);
+    }
+
+    const id = parseId(rawId);
+    const normalizedDiscordId = normalizeDiscordId(discordId);
+
+    if (id === null || normalizedDiscordId === null) {
+      return res.redirect(`${basePath}?error=invalid_id`);
+    }
+
+    try {
+      const user = await findUser(normalizedDiscordId);
+      if (!user || !user.twitch_name) {
+        return res.redirect(`${basePath}?error=invalid_assignment_user`);
+      }
+
+      await assign(id, normalizedDiscordId);
+    } catch (err) {
+      const mappedErrorCode = mapAssignError?.(err);
+      if (mappedErrorCode) {
+        return res.redirect(`${basePath}?error=${mappedErrorCode}`);
+      }
+
+      return logAndRedirectError({
+        res, log, logLabel: `Assign user error (${basePath}):`, err, basePath, errorCode: 'assign_failed',
+      });
+    }
+
+    res.redirect(basePath);
+  });
+
+  /**
+   * POST `{basePath}/unassign` — removes a user's assignment from the entity identified by `idField`.
+   * @param req - Express request; reads `idField` and `discord_id` from `req.body`.
+   * @param res - Express response; redirects to `basePath` on success, or to
+   *   `basePath?error=<code>` if fields are missing (`missing_fields`), IDs are malformed
+   *   (`invalid_id`), or the unassign write fails (`unassign_failed`).
+   */
+  router.post(`${basePath}/unassign`, requireMod, csrfProtection, async (req, res) => {
+    const body = req.body as Record<string, string | undefined>;
+    const rawId = body[idField];
+    const discordId = body.discord_id;
+    if (!rawId || !discordId) {
+      return res.redirect(`${basePath}?error=missing_fields`);
+    }
+
+    const id = parseId(rawId);
+    const normalizedDiscordId = normalizeDiscordId(discordId);
+
+    if (id === null || normalizedDiscordId === null) {
+      return res.redirect(`${basePath}?error=invalid_id`);
+    }
+
+    try {
+      await unassign(id, normalizedDiscordId);
+    } catch (err) {
+      return logAndRedirectError({
+        res, log, logLabel: `Unassign user error (${basePath}):`, err, basePath, errorCode: 'unassign_failed',
+      });
+    }
+
+    res.redirect(basePath);
+  });
+
+  return router;
+}

--- a/src/web/routes/assignmentRoutes.ts
+++ b/src/web/routes/assignmentRoutes.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, type Request, type Response } from 'express';
 import type { Logger } from 'winston';
 import { findUser } from '../../db';
 import { csrfProtection } from '../csrf';
@@ -13,7 +13,7 @@ export interface AssignmentRouterOptions<TId> {
   idField: string;
   /** Parses/validates the raw id field into `TId`, or null if malformed. */
   parseId: (raw: string) => TId | null;
-  /** Assigns `discordId` to the entity. May throw — see {@link mapAssignError}. */
+  /** Assigns `discordId` to the entity. May throw — see {@link AssignmentRouterOptions.mapAssignError}. */
   assign: (id: TId, discordId: string) => Promise<void>;
   /** Removes `discordId`'s assignment from the entity. */
   unassign: (id: TId, discordId: string) => Promise<void>;
@@ -27,6 +27,110 @@ export interface AssignmentRouterOptions<TId> {
   log: Logger;
 }
 
+/** The `idField`/`discord_id` pair read from an assign/unassign request body, once both are confirmed present. */
+interface AssignmentRequestFields {
+  rawId: string;
+  discordId: string;
+}
+
+/** Reads and presence-checks `idField`/`discord_id` from `req.body`, or null if either is missing. */
+function readAssignmentFields(req: Request, idField: string): AssignmentRequestFields | null {
+  const body = req.body as Record<string, string | undefined>;
+  const rawId = body[idField];
+  const discordId = body.discord_id;
+  return rawId && discordId ? { rawId, discordId } : null;
+}
+
+/**
+ * POST `{basePath}/assign` handler — assigns a Twitch-linked Discord user to the entity
+ * identified by `idField`.
+ * @param req - Express request; reads `idField` and `discord_id` from `req.body`.
+ * @param res - Express response; redirects to `basePath` on success, or to
+ *   `basePath?error=<code>` if fields are missing (`missing_fields`), IDs are malformed
+ *   (`invalid_id`), the user doesn't exist or has no linked Twitch name
+ *   (`invalid_assignment_user`), `mapAssignError` maps a thrown error to a specific code, or the
+ *   assignment write fails for any other reason (`assign_failed`).
+ * @param options - See {@link AssignmentRouterOptions}.
+ */
+async function handleAssign<TId>(req: Request, res: Response, options: AssignmentRouterOptions<TId>): Promise<void> {
+  const { basePath, idField, parseId, assign, mapAssignError, log } = options;
+
+  const fields = readAssignmentFields(req, idField);
+  if (!fields) {
+    res.redirect(`${basePath}?error=missing_fields`);
+    return;
+  }
+
+  const id = parseId(fields.rawId);
+  const normalizedDiscordId = normalizeDiscordId(fields.discordId);
+  if (id === null || normalizedDiscordId === null) {
+    res.redirect(`${basePath}?error=invalid_id`);
+    return;
+  }
+
+  try {
+    const user = await findUser(normalizedDiscordId);
+    if (!user || !user.twitch_name) {
+      res.redirect(`${basePath}?error=invalid_assignment_user`);
+      return;
+    }
+
+    await assign(id, normalizedDiscordId);
+  } catch (err) {
+    const mappedErrorCode = mapAssignError?.(err);
+    if (mappedErrorCode) {
+      // An expected, mapped condition (e.g. a trigger conflict) — not a bug, so it isn't logged
+      // as an error, matching the pre-refactor behavior for Commands' conflict redirects.
+      res.redirect(`${basePath}?error=${mappedErrorCode}`);
+      return;
+    }
+
+    logAndRedirectError({
+      res, log, logLabel: `Assign user error (${basePath}):`, err, basePath, errorCode: 'assign_failed',
+    });
+    return;
+  }
+
+  res.redirect(basePath);
+}
+
+/**
+ * POST `{basePath}/unassign` handler — removes a user's assignment from the entity identified by
+ * `idField`.
+ * @param req - Express request; reads `idField` and `discord_id` from `req.body`.
+ * @param res - Express response; redirects to `basePath` on success, or to
+ *   `basePath?error=<code>` if fields are missing (`missing_fields`), IDs are malformed
+ *   (`invalid_id`), or the unassign write fails (`unassign_failed`).
+ * @param options - See {@link AssignmentRouterOptions}.
+ */
+async function handleUnassign<TId>(req: Request, res: Response, options: AssignmentRouterOptions<TId>): Promise<void> {
+  const { basePath, idField, parseId, unassign, log } = options;
+
+  const fields = readAssignmentFields(req, idField);
+  if (!fields) {
+    res.redirect(`${basePath}?error=missing_fields`);
+    return;
+  }
+
+  const id = parseId(fields.rawId);
+  const normalizedDiscordId = normalizeDiscordId(fields.discordId);
+  if (id === null || normalizedDiscordId === null) {
+    res.redirect(`${basePath}?error=invalid_id`);
+    return;
+  }
+
+  try {
+    await unassign(id, normalizedDiscordId);
+  } catch (err) {
+    logAndRedirectError({
+      res, log, logLabel: `Unassign user error (${basePath}):`, err, basePath, errorCode: 'unassign_failed',
+    });
+    return;
+  }
+
+  res.redirect(basePath);
+}
+
 /**
  * Builds a `POST {basePath}/assign` / `POST {basePath}/unassign` router pair: assigns or removes
  * a Twitch-linked Discord user's association with an entity (a custom command, a timer command,
@@ -35,87 +139,8 @@ export interface AssignmentRouterOptions<TId> {
  * @param options - See {@link AssignmentRouterOptions}.
  */
 export function createAssignmentRouter<TId>(options: AssignmentRouterOptions<TId>): Router {
-  const { basePath, idField, parseId, assign, unassign, mapAssignError, log } = options;
   const router = Router();
-
-  /**
-   * POST `{basePath}/assign` — assigns a Twitch-linked Discord user to the entity identified by
-   * `idField`.
-   * @param req - Express request; reads `idField` and `discord_id` from `req.body`.
-   * @param res - Express response; redirects to `basePath` on success, or to
-   *   `basePath?error=<code>` if fields are missing (`missing_fields`), IDs are malformed
-   *   (`invalid_id`), the user doesn't exist or has no linked Twitch name
-   *   (`invalid_assignment_user`), `mapAssignError` maps a thrown error to a specific code, or
-   *   the assignment write fails for any other reason (`assign_failed`).
-   */
-  router.post(`${basePath}/assign`, requireMod, csrfProtection, async (req, res) => {
-    const body = req.body as Record<string, string | undefined>;
-    const rawId = body[idField];
-    const discordId = body.discord_id;
-    if (!rawId || !discordId) {
-      return res.redirect(`${basePath}?error=missing_fields`);
-    }
-
-    const id = parseId(rawId);
-    const normalizedDiscordId = normalizeDiscordId(discordId);
-
-    if (id === null || normalizedDiscordId === null) {
-      return res.redirect(`${basePath}?error=invalid_id`);
-    }
-
-    try {
-      const user = await findUser(normalizedDiscordId);
-      if (!user || !user.twitch_name) {
-        return res.redirect(`${basePath}?error=invalid_assignment_user`);
-      }
-
-      await assign(id, normalizedDiscordId);
-    } catch (err) {
-      const mappedErrorCode = mapAssignError?.(err);
-      if (mappedErrorCode) {
-        return res.redirect(`${basePath}?error=${mappedErrorCode}`);
-      }
-
-      return logAndRedirectError({
-        res, log, logLabel: `Assign user error (${basePath}):`, err, basePath, errorCode: 'assign_failed',
-      });
-    }
-
-    res.redirect(basePath);
-  });
-
-  /**
-   * POST `{basePath}/unassign` — removes a user's assignment from the entity identified by `idField`.
-   * @param req - Express request; reads `idField` and `discord_id` from `req.body`.
-   * @param res - Express response; redirects to `basePath` on success, or to
-   *   `basePath?error=<code>` if fields are missing (`missing_fields`), IDs are malformed
-   *   (`invalid_id`), or the unassign write fails (`unassign_failed`).
-   */
-  router.post(`${basePath}/unassign`, requireMod, csrfProtection, async (req, res) => {
-    const body = req.body as Record<string, string | undefined>;
-    const rawId = body[idField];
-    const discordId = body.discord_id;
-    if (!rawId || !discordId) {
-      return res.redirect(`${basePath}?error=missing_fields`);
-    }
-
-    const id = parseId(rawId);
-    const normalizedDiscordId = normalizeDiscordId(discordId);
-
-    if (id === null || normalizedDiscordId === null) {
-      return res.redirect(`${basePath}?error=invalid_id`);
-    }
-
-    try {
-      await unassign(id, normalizedDiscordId);
-    } catch (err) {
-      return logAndRedirectError({
-        res, log, logLabel: `Unassign user error (${basePath}):`, err, basePath, errorCode: 'unassign_failed',
-      });
-    }
-
-    res.redirect(basePath);
-  });
-
+  router.post(`${options.basePath}/assign`, requireMod, csrfProtection, (req, res) => handleAssign(req, res, options));
+  router.post(`${options.basePath}/unassign`, requireMod, csrfProtection, (req, res) => handleUnassign(req, res, options));
   return router;
 }

--- a/src/web/routes/commandAssignments.ts
+++ b/src/web/routes/commandAssignments.ts
@@ -1,90 +1,28 @@
 import { createLogger } from '../../shared/logger';
-import { Router } from 'express';
 import {
   assignUserToCommand,
   CommandConflictError,
   isMysqlDuplicateEntryError,
-  findUser,
   unassignUserFromCommand,
 } from '../../db';
-import { csrfProtection } from '../csrf';
-import { requireMod } from '../middleware';
-import { parsePositiveIntId, normalizeDiscordId, logAndRedirectError } from './shared';
-
-const log = createLogger('Web');
-const router = Router();
+import { parsePositiveIntId } from './shared';
+import { createAssignmentRouter } from './assignmentRoutes';
 
 /**
- * POST /commands/assign — assigns a Twitch-linked Discord user to a custom command.
- * @param req - Express request; reads `command_id` and `discord_id` from `req.body`.
- * @param res - Express response; redirects to `/commands` on success, or to
- *   `/commands?error=<code>` if fields are missing (`missing_fields`), IDs are
- *   malformed (`invalid_id`), the user doesn't exist or has no linked Twitch name
- *   (`invalid_assignment_user`), the command is already assigned (`command_taken`),
- *   or the assignment write fails (`assign_failed`).
+ * `POST /commands/assign` / `POST /commands/unassign` — assigns or removes a Twitch-linked
+ * Discord user's association with a custom command. See {@link createAssignmentRouter} for the
+ * shared route shape; a command assignment conflict (`CommandConflictError` or a raw MySQL
+ * duplicate-entry error) redirects to `?error=command_taken` instead of the generic
+ * `assign_failed`.
  */
-router.post('/commands/assign', requireMod, csrfProtection, async (req, res) => {
-  const { command_id, discord_id } = req.body as { command_id?: string; discord_id?: string };
-  if (!command_id || !discord_id) {
-    return res.redirect('/commands?error=missing_fields');
-  }
-
-  const parsedCommandId = parsePositiveIntId(command_id);
-  const normalizedDiscordId = normalizeDiscordId(discord_id);
-
-  if (parsedCommandId === null || normalizedDiscordId === null) {
-    return res.redirect('/commands?error=invalid_id');
-  }
-
-  try {
-    const user = await findUser(normalizedDiscordId);
-    if (!user || !user.twitch_name) {
-      return res.redirect('/commands?error=invalid_assignment_user');
-    }
-
-    await assignUserToCommand(parsedCommandId, normalizedDiscordId);
-  } catch (err) {
-    if (err instanceof CommandConflictError || isMysqlDuplicateEntryError(err)) {
-      return res.redirect('/commands?error=command_taken');
-    }
-
-    return logAndRedirectError({
-      res, log, logLabel: 'Assign user to command error:', err, basePath: '/commands', errorCode: 'assign_failed',
-    });
-  }
-
-  res.redirect('/commands');
+export default createAssignmentRouter({
+  basePath: '/commands',
+  idField: 'command_id',
+  parseId: parsePositiveIntId,
+  assign: assignUserToCommand,
+  unassign: unassignUserFromCommand,
+  mapAssignError: (err) => (
+    err instanceof CommandConflictError || isMysqlDuplicateEntryError(err) ? 'command_taken' : null
+  ),
+  log: createLogger('Web'),
 });
-
-/**
- * POST /commands/unassign — removes a user's assignment from a custom command.
- * @param req - Express request; reads `command_id` and `discord_id` from `req.body`.
- * @param res - Express response; redirects to `/commands` on success, or to
- *   `/commands?error=<code>` if fields are missing (`missing_fields`), IDs are
- *   malformed (`invalid_id`), or the unassign write fails (`unassign_failed`).
- */
-router.post('/commands/unassign', requireMod, csrfProtection, async (req, res) => {
-  const { command_id, discord_id } = req.body as { command_id?: string; discord_id?: string };
-  if (!command_id || !discord_id) {
-    return res.redirect('/commands?error=missing_fields');
-  }
-
-  const parsedCommandId = parsePositiveIntId(command_id);
-  const normalizedDiscordId = normalizeDiscordId(discord_id);
-
-  if (parsedCommandId === null || normalizedDiscordId === null) {
-    return res.redirect('/commands?error=invalid_id');
-  }
-
-  try {
-    await unassignUserFromCommand(parsedCommandId, normalizedDiscordId);
-  } catch (err) {
-    return logAndRedirectError({
-      res, log, logLabel: 'Unassign user from command error:', err, basePath: '/commands', errorCode: 'unassign_failed',
-    });
-  }
-
-  res.redirect('/commands');
-});
-
-export default router;

--- a/src/web/routes/timerAssignments.test.ts
+++ b/src/web/routes/timerAssignments.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mockLogger } from '../../test-utils/loggerMock';
+import { ACCESS_LEVEL_MOCK } from '../../test-utils/accessLevelMock';
+
+vi.mock('../../db', () => ({
+  assignUserToTimer: vi.fn().mockResolvedValue(undefined),
+  unassignUserFromTimer: vi.fn().mockResolvedValue(undefined),
+  findUser: vi.fn().mockResolvedValue(null),
+  AccessLevel: ACCESS_LEVEL_MOCK,
+}));
+vi.mock('../csrf', () => ({
+  csrfProtection: (_req: any, _res: any, next: any) => next(),
+}));
+vi.mock('../middleware', () => ({
+  requireMod: (_req: any, _res: any, next: any) => next(),
+}));
+vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
+
+import supertest from 'supertest';
+import router from './timerAssignments';
+import { assignUserToTimer, unassignUserFromTimer, findUser } from '../../db';
+import { AccessLevel } from '../../db';
+import { buildTestApp } from '../../test-utils/expressTestApp';
+
+/** Builds a supertest-ready app: the timer assignments router with a urlencoded body parser (no session or render stub needed). */
+function buildApp() {
+  return buildTestApp({ router, bodyParser: 'urlencoded' });
+}
+
+const VALID_TIMER_ID = '5';
+const VALID_DISCORD_ID = '123456789012345678'; // 18 digits
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(findUser).mockResolvedValue({ discord_id: VALID_DISCORD_ID, discord_name: 'Alice', twitch_name: 'alice', access_level: AccessLevel.USER } as any);
+  vi.mocked(assignUserToTimer).mockResolvedValue(undefined);
+  vi.mocked(unassignUserFromTimer).mockResolvedValue(undefined);
+});
+
+// ─── POST /timers/assign ──────────────────────────────────────────────────────
+
+describe('POST /timers/assign', () => {
+  it('redirects to /timers on success', async () => {
+    const res = await supertest(buildApp())
+      .post('/timers/assign')
+      .send(`timer_id=${VALID_TIMER_ID}&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/timers');
+    expect(vi.mocked(assignUserToTimer)).toHaveBeenCalledWith(5, VALID_DISCORD_ID);
+  });
+
+  it('redirects to ?error=missing_fields when fields are absent', async () => {
+    const res = await supertest(buildApp()).post('/timers/assign').send('');
+    expect(res.headers.location).toBe('/timers?error=missing_fields');
+  });
+
+  it('redirects to ?error=invalid_id for non-numeric timer_id', async () => {
+    const res = await supertest(buildApp())
+      .post('/timers/assign')
+      .send(`timer_id=abc&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/timers?error=invalid_id');
+  });
+
+  it('redirects to ?error=invalid_id for invalid discord_id', async () => {
+    const res = await supertest(buildApp())
+      .post('/timers/assign')
+      .send(`timer_id=${VALID_TIMER_ID}&discord_id=bad`);
+    expect(res.headers.location).toBe('/timers?error=invalid_id');
+  });
+
+  it('redirects to ?error=invalid_assignment_user when user not found', async () => {
+    vi.mocked(findUser).mockResolvedValue(null);
+    const res = await supertest(buildApp())
+      .post('/timers/assign')
+      .send(`timer_id=${VALID_TIMER_ID}&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/timers?error=invalid_assignment_user');
+  });
+
+  it('redirects to ?error=invalid_assignment_user when user has no twitch_name', async () => {
+    vi.mocked(findUser).mockResolvedValue({ discord_id: VALID_DISCORD_ID, discord_name: 'Alice', twitch_name: null, access_level: AccessLevel.USER } as any);
+    const res = await supertest(buildApp())
+      .post('/timers/assign')
+      .send(`timer_id=${VALID_TIMER_ID}&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/timers?error=invalid_assignment_user');
+  });
+
+  it('redirects to ?error=assign_failed on unexpected error', async () => {
+    vi.mocked(assignUserToTimer).mockRejectedValueOnce(new Error('unexpected'));
+    const res = await supertest(buildApp())
+      .post('/timers/assign')
+      .send(`timer_id=${VALID_TIMER_ID}&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/timers?error=assign_failed');
+  });
+});
+
+// ─── POST /timers/unassign ────────────────────────────────────────────────────
+
+describe('POST /timers/unassign', () => {
+  it('redirects to /timers on success', async () => {
+    const res = await supertest(buildApp())
+      .post('/timers/unassign')
+      .send(`timer_id=${VALID_TIMER_ID}&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/timers');
+    expect(vi.mocked(unassignUserFromTimer)).toHaveBeenCalledWith(5, VALID_DISCORD_ID);
+  });
+
+  it('redirects to ?error=missing_fields when fields are absent', async () => {
+    const res = await supertest(buildApp()).post('/timers/unassign').send('');
+    expect(res.headers.location).toBe('/timers?error=missing_fields');
+  });
+
+  it('redirects to ?error=invalid_id for non-numeric timer_id', async () => {
+    const res = await supertest(buildApp())
+      .post('/timers/unassign')
+      .send(`timer_id=abc&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/timers?error=invalid_id');
+  });
+
+  it('redirects to ?error=invalid_id for malformed discord_id', async () => {
+    const res = await supertest(buildApp())
+      .post('/timers/unassign')
+      .send(`timer_id=${VALID_TIMER_ID}&discord_id=bad`);
+    expect(res.headers.location).toBe('/timers?error=invalid_id');
+  });
+
+  it('redirects to ?error=unassign_failed on unexpected error', async () => {
+    vi.mocked(unassignUserFromTimer).mockRejectedValueOnce(new Error('db error'));
+    const res = await supertest(buildApp())
+      .post('/timers/unassign')
+      .send(`timer_id=${VALID_TIMER_ID}&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/timers?error=unassign_failed');
+  });
+});

--- a/src/web/routes/timerAssignments.ts
+++ b/src/web/routes/timerAssignments.ts
@@ -1,0 +1,79 @@
+import { createLogger } from '../../shared/logger';
+import { Router } from 'express';
+import { assignUserToTimer, findUser, unassignUserFromTimer } from '../../db';
+import { csrfProtection } from '../csrf';
+import { requireMod } from '../middleware';
+import { parsePositiveIntId, normalizeDiscordId, logAndRedirectError } from './shared';
+
+const log = createLogger('Web');
+const router = Router();
+
+/**
+ * POST /timers/assign — assigns a Twitch-linked Discord user to a timer command's channel list.
+ * @param req - Express request; reads `timer_id` and `discord_id` from `req.body`.
+ * @param res - Express response; redirects to `/timers` on success, or to
+ *   `/timers?error=<code>` if fields are missing (`missing_fields`), IDs are
+ *   malformed (`invalid_id`), the user doesn't exist or has no linked Twitch name
+ *   (`invalid_assignment_user`), or the assignment write fails (`assign_failed`).
+ */
+router.post('/timers/assign', requireMod, csrfProtection, async (req, res) => {
+  const { timer_id, discord_id } = req.body as { timer_id?: string; discord_id?: string };
+  if (!timer_id || !discord_id) {
+    return res.redirect('/timers?error=missing_fields');
+  }
+
+  const parsedTimerId = parsePositiveIntId(timer_id);
+  const normalizedDiscordId = normalizeDiscordId(discord_id);
+
+  if (parsedTimerId === null || normalizedDiscordId === null) {
+    return res.redirect('/timers?error=invalid_id');
+  }
+
+  try {
+    const user = await findUser(normalizedDiscordId);
+    if (!user || !user.twitch_name) {
+      return res.redirect('/timers?error=invalid_assignment_user');
+    }
+
+    await assignUserToTimer(parsedTimerId, normalizedDiscordId);
+  } catch (err) {
+    return logAndRedirectError({
+      res, log, logLabel: 'Assign user to timer error:', err, basePath: '/timers', errorCode: 'assign_failed',
+    });
+  }
+
+  res.redirect('/timers');
+});
+
+/**
+ * POST /timers/unassign — removes a user's assignment from a timer command.
+ * @param req - Express request; reads `timer_id` and `discord_id` from `req.body`.
+ * @param res - Express response; redirects to `/timers` on success, or to
+ *   `/timers?error=<code>` if fields are missing (`missing_fields`), IDs are
+ *   malformed (`invalid_id`), or the unassign write fails (`unassign_failed`).
+ */
+router.post('/timers/unassign', requireMod, csrfProtection, async (req, res) => {
+  const { timer_id, discord_id } = req.body as { timer_id?: string; discord_id?: string };
+  if (!timer_id || !discord_id) {
+    return res.redirect('/timers?error=missing_fields');
+  }
+
+  const parsedTimerId = parsePositiveIntId(timer_id);
+  const normalizedDiscordId = normalizeDiscordId(discord_id);
+
+  if (parsedTimerId === null || normalizedDiscordId === null) {
+    return res.redirect('/timers?error=invalid_id');
+  }
+
+  try {
+    await unassignUserFromTimer(parsedTimerId, normalizedDiscordId);
+  } catch (err) {
+    return logAndRedirectError({
+      res, log, logLabel: 'Unassign user from timer error:', err, basePath: '/timers', errorCode: 'unassign_failed',
+    });
+  }
+
+  res.redirect('/timers');
+});
+
+export default router;

--- a/src/web/routes/timerAssignments.ts
+++ b/src/web/routes/timerAssignments.ts
@@ -1,79 +1,19 @@
 import { createLogger } from '../../shared/logger';
-import { Router } from 'express';
-import { assignUserToTimer, findUser, unassignUserFromTimer } from '../../db';
-import { csrfProtection } from '../csrf';
-import { requireMod } from '../middleware';
-import { parsePositiveIntId, normalizeDiscordId, logAndRedirectError } from './shared';
-
-const log = createLogger('Web');
-const router = Router();
+import { assignUserToTimer, unassignUserFromTimer } from '../../db';
+import { parsePositiveIntId } from './shared';
+import { createAssignmentRouter } from './assignmentRoutes';
 
 /**
- * POST /timers/assign — assigns a Twitch-linked Discord user to a timer command's channel list.
- * @param req - Express request; reads `timer_id` and `discord_id` from `req.body`.
- * @param res - Express response; redirects to `/timers` on success, or to
- *   `/timers?error=<code>` if fields are missing (`missing_fields`), IDs are
- *   malformed (`invalid_id`), the user doesn't exist or has no linked Twitch name
- *   (`invalid_assignment_user`), or the assignment write fails (`assign_failed`).
+ * `POST /timers/assign` / `POST /timers/unassign` — assigns or removes a Twitch-linked Discord
+ * user's association with a timer command. See {@link createAssignmentRouter} for the shared
+ * route shape; timers have no conflict concept, so an assignment failure always falls through
+ * to the generic `assign_failed` redirect.
  */
-router.post('/timers/assign', requireMod, csrfProtection, async (req, res) => {
-  const { timer_id, discord_id } = req.body as { timer_id?: string; discord_id?: string };
-  if (!timer_id || !discord_id) {
-    return res.redirect('/timers?error=missing_fields');
-  }
-
-  const parsedTimerId = parsePositiveIntId(timer_id);
-  const normalizedDiscordId = normalizeDiscordId(discord_id);
-
-  if (parsedTimerId === null || normalizedDiscordId === null) {
-    return res.redirect('/timers?error=invalid_id');
-  }
-
-  try {
-    const user = await findUser(normalizedDiscordId);
-    if (!user || !user.twitch_name) {
-      return res.redirect('/timers?error=invalid_assignment_user');
-    }
-
-    await assignUserToTimer(parsedTimerId, normalizedDiscordId);
-  } catch (err) {
-    return logAndRedirectError({
-      res, log, logLabel: 'Assign user to timer error:', err, basePath: '/timers', errorCode: 'assign_failed',
-    });
-  }
-
-  res.redirect('/timers');
+export default createAssignmentRouter({
+  basePath: '/timers',
+  idField: 'timer_id',
+  parseId: parsePositiveIntId,
+  assign: assignUserToTimer,
+  unassign: unassignUserFromTimer,
+  log: createLogger('Web'),
 });
-
-/**
- * POST /timers/unassign — removes a user's assignment from a timer command.
- * @param req - Express request; reads `timer_id` and `discord_id` from `req.body`.
- * @param res - Express response; redirects to `/timers` on success, or to
- *   `/timers?error=<code>` if fields are missing (`missing_fields`), IDs are
- *   malformed (`invalid_id`), or the unassign write fails (`unassign_failed`).
- */
-router.post('/timers/unassign', requireMod, csrfProtection, async (req, res) => {
-  const { timer_id, discord_id } = req.body as { timer_id?: string; discord_id?: string };
-  if (!timer_id || !discord_id) {
-    return res.redirect('/timers?error=missing_fields');
-  }
-
-  const parsedTimerId = parsePositiveIntId(timer_id);
-  const normalizedDiscordId = normalizeDiscordId(discord_id);
-
-  if (parsedTimerId === null || normalizedDiscordId === null) {
-    return res.redirect('/timers?error=invalid_id');
-  }
-
-  try {
-    await unassignUserFromTimer(parsedTimerId, normalizedDiscordId);
-  } catch (err) {
-    return logAndRedirectError({
-      res, log, logLabel: 'Unassign user from timer error:', err, basePath: '/timers', errorCode: 'unassign_failed',
-    });
-  }
-
-  res.redirect('/timers');
-});
-
-export default router;

--- a/src/web/routes/timers.test.ts
+++ b/src/web/routes/timers.test.ts
@@ -18,7 +18,7 @@ vi.mock('../csrf', () => ({
 }));
 
 vi.mock('../middleware', () => ({
-  requireAuth: (_req: any, _res: any, next: any) => next(),
+  requireManager: (_req: any, _res: any, next: any) => next(),
 }));
 
 // This module composes timersMutations's and timerAssignments's routers too; stub them out so

--- a/src/web/routes/timers.test.ts
+++ b/src/web/routes/timers.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mockLogger } from '../../test-utils/loggerMock';
+import { ACCESS_LEVEL_MOCK } from '../../test-utils/accessLevelMock';
 
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
 
 vi.mock('../../db', () => ({
-  getStreamerByDiscordId: vi.fn(),
-  getTimerCommandsForStreamer: vi.fn(),
+  getAllTimerCommandsWithAssignments: vi.fn(),
+  getAllUsers: vi.fn(),
+  AccessLevel: ACCESS_LEVEL_MOCK,
 }));
 
 vi.mock('../csrf', () => ({
@@ -19,22 +21,24 @@ vi.mock('../middleware', () => ({
   requireAuth: (_req: any, _res: any, next: any) => next(),
 }));
 
-// This module composes timersMutations's router too; stub it out so this file only
-// exercises the GET route defined directly in timers.ts.
+// This module composes timersMutations's and timerAssignments's routers too; stub them out so
+// this file only exercises the GET route defined directly in timers.ts.
 vi.mock('./timersMutations', async () => {
+  const { Router } = await import('express');
+  return { default: Router() };
+});
+vi.mock('./timerAssignments', async () => {
   const { Router } = await import('express');
   return { default: Router() };
 });
 
 import supertest from 'supertest';
 import router from './timers';
-import { getStreamerByDiscordId, getTimerCommandsForStreamer } from '../../db';
+import { getAllTimerCommandsWithAssignments, getAllUsers } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 
 type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3; isOwner: boolean };
-const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: 0, isOwner: false };
-
-const MOCK_STREAMER = { id: 123, discord_id: USER.discordId };
+const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: 2, isOwner: false };
 
 function buildApp() {
   return buildTestApp({ router, bodyParser: 'urlencoded', sessionUser: USER, mockRender: 'spread' });
@@ -42,35 +46,54 @@ function buildApp() {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
-  vi.mocked(getTimerCommandsForStreamer).mockResolvedValue([]);
+  vi.mocked(getAllTimerCommandsWithAssignments).mockResolvedValue([]);
+  vi.mocked(getAllUsers).mockResolvedValue([]);
 });
 
-describe('GET /', () => {
-  it('renders with isStreamer false and no timers when the session user has no streamer record', async () => {
-    const res = await supertest(buildApp()).get('/');
+describe('GET /timers', () => {
+  it('renders the timers view with an empty list when there are no timers', async () => {
+    const res = await supertest(buildApp()).get('/timers');
     expect(res.status).toBe(200);
     expect(res.body.view).toBe('timers');
-    expect(res.body.isStreamer).toBe(false);
     expect(res.body.timers).toEqual([]);
-    expect(getTimerCommandsForStreamer).not.toHaveBeenCalled();
   });
 
-  it("renders the requesting streamer's own timers", async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    const timers = [{ id: 1, streamer_id: 123, name: 'Plug', message: 'hi', interval_seconds: 600, min_messages: 0, require_live: true, enabled: true }];
-    vi.mocked(getTimerCommandsForStreamer).mockResolvedValue(timers as any);
+  it("renders every timer with its assigned users and each timer's unassigned_users", async () => {
+    vi.mocked(getAllTimerCommandsWithAssignments).mockResolvedValue([
+      {
+        id: 1, name: 'Plug', message: 'Join!', interval_seconds: 600, min_messages: 0,
+        require_live: true, enabled: true,
+        assigned_users: [{ discord_id: '111', discord_name: 'Alice', twitch_name: 'alice', access_level: 0, is_orphaned_user: false }],
+      } as any,
+    ]);
+    vi.mocked(getAllUsers).mockResolvedValue([
+      { discord_id: '111', twitch_name: 'alice' } as any,
+      { discord_id: '222', twitch_name: 'bob' } as any,
+      { discord_id: '333', twitch_name: null } as any,
+    ]);
 
-    const res = await supertest(buildApp()).get('/');
+    const res = await supertest(buildApp()).get('/timers');
 
-    expect(res.body.isStreamer).toBe(true);
-    expect(res.body.timers).toEqual(timers);
-    expect(getTimerCommandsForStreamer).toHaveBeenCalledWith(123);
+    expect(res.body.timers).toHaveLength(1);
+    // only discord_id '222' (twitch_name present, not already assigned) should be unassigned
+    expect(res.body.timers[0].unassigned_users).toEqual([{ discord_id: '222', twitch_name: 'bob' }]);
+    // assignableUsers excludes the null-twitch_name entry
+    expect(res.body.assignableUsers).toHaveLength(2);
   });
 
   it('returns a 500 error page when loading timers fails', async () => {
-    vi.mocked(getStreamerByDiscordId).mockRejectedValue(new Error('db down'));
-    const res = await supertest(buildApp()).get('/');
+    vi.mocked(getAllTimerCommandsWithAssignments).mockRejectedValue(new Error('db down'));
+    const res = await supertest(buildApp()).get('/timers');
     expect(res.status).toBe(500);
+  });
+
+  it('passes a known error param to the view', async () => {
+    const res = await supertest(buildApp()).get('/timers?error=add_failed');
+    expect(res.body.error).toBe('add_failed');
+  });
+
+  it('passes null to the view for an unknown error param', async () => {
+    const res = await supertest(buildApp()).get('/timers?error=totally_unknown');
+    expect(res.body.error).toBeNull();
   });
 });

--- a/src/web/routes/timers.ts
+++ b/src/web/routes/timers.ts
@@ -2,7 +2,7 @@ import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import { DbTimerCommandWithAssignments, DbUser, getAllTimerCommandsWithAssignments, getAllUsers } from '../../db';
 import { csrfProtection } from '../csrf';
-import { requireAuth } from '../middleware';
+import { requireManager } from '../middleware';
 import { renderError, filterQueryParam, renderView } from './shared';
 import timersMutationsRouter from './timersMutations';
 import timerAssignmentsRouter from './timerAssignments';
@@ -22,10 +22,11 @@ interface TimerViewModel extends DbTimerCommandWithAssignments {
 
 /**
  * GET /timers — renders the Timers admin page: the global timer-command catalog, each with
- * its list of assigned Twitch-linked streamers, plus an add form. Manager-only in practice
- * (the nav link is hidden below Manager, and mutations require Mod+), mirroring `/commands`.
+ * its list of assigned Twitch-linked streamers, plus an add form. Gated at Manager — the page
+ * lists every Twitch-linked user's discord_id/discord_name/twitch_name plus every timer's
+ * assignments, so authentication alone isn't enough (mutations additionally require Mod+).
  */
-router.get('/timers', requireAuth, csrfProtection, async (req, res) => {
+router.get('/timers', requireManager, csrfProtection, async (req, res) => {
   try {
     const [timers, users] = await Promise.all([
       getAllTimerCommandsWithAssignments(),

--- a/src/web/routes/timers.ts
+++ b/src/web/routes/timers.ts
@@ -1,43 +1,51 @@
 import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
+import { DbTimerCommandWithAssignments, DbUser, getAllTimerCommandsWithAssignments, getAllUsers } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
-import { getSessionUser } from '../session';
-import { getStreamerByDiscordId, getTimerCommandsForStreamer } from '../../db';
-import type { DbTimerCommand } from '../../db';
-import { renderError, renderView, filterQueryParam } from './shared';
+import { renderError, filterQueryParam, renderView } from './shared';
 import timersMutationsRouter from './timersMutations';
+import timerAssignmentsRouter from './timerAssignments';
 
-const log = createLogger('Timers');
+const log = createLogger('Web');
 const router = Router();
 
 const KNOWN_ERRORS = new Set([
-  'not_a_streamer', 'missing_fields', 'invalid_interval', 'invalid_min_messages',
-  'invalid_id', 'timer_not_found', 'add_failed', 'update_failed', 'remove_failed', 'toggle_failed',
+  'missing_fields', 'invalid_interval', 'invalid_min_messages', 'invalid_id',
+  'timer_not_found', 'add_failed', 'update_failed', 'remove_failed', 'toggle_failed',
+  'assign_failed', 'unassign_failed', 'invalid_assignment_user',
 ]);
-const KNOWN_SUCCESSES = new Set(['timer_added', 'timer_updated', 'timer_removed']);
+
+interface TimerViewModel extends DbTimerCommandWithAssignments {
+  unassigned_users: DbUser[];
+}
 
 /**
- * GET /timers — renders the self-service timer-commands page for the logged-in streamer:
- * their own timers (name, message, interval, min-messages, live requirement, enabled state)
- * plus an add form. Shows a "link your Twitch account" prompt instead of the timer list when
- * the session user has no linked `streamer` record, mirroring `/channel-points`'s handling of
- * the same case — no redirect loop, since a non-streamer viewing this page isn't an error.
- * @param req - Express request; reads `req.session.user`, `error`, and `success` query params.
- * @param res - Express response; renders the `timers` view, or a 500 error page on failure.
+ * GET /timers — renders the Timers admin page: the global timer-command catalog, each with
+ * its list of assigned Twitch-linked streamers, plus an add form. Manager-only in practice
+ * (the nav link is hidden below Manager, and mutations require Mod+), mirroring `/commands`.
  */
-router.get('/', requireAuth, csrfProtection, async (req, res) => {
+router.get('/timers', requireAuth, csrfProtection, async (req, res) => {
   try {
-    const streamer = await getStreamerByDiscordId(getSessionUser(req).discordId);
-    const timers: DbTimerCommand[] = streamer ? await getTimerCommandsForStreamer(streamer.id) : [];
+    const [timers, users] = await Promise.all([
+      getAllTimerCommandsWithAssignments(),
+      getAllUsers(),
+    ]);
+    const assignableUsers = users.filter((entry) => entry.twitch_name);
+    const timersForView: TimerViewModel[] = timers.map((timer) => {
+      const assignedDiscordIds = new Set(timer.assigned_users.map((entry) => entry.discord_id));
+      return {
+        ...timer,
+        unassigned_users: assignableUsers.filter((entry) => !assignedDiscordIds.has(entry.discord_id)),
+      };
+    });
 
     renderView(res, 'timers', {
       user: req.session.user,
-      isStreamer: !!streamer,
-      timers,
+      timers: timersForView,
+      assignableUsers,
       csrfToken: req.csrfToken(),
       error: filterQueryParam(req.query.error, KNOWN_ERRORS),
-      success: filterQueryParam(req.query.success, KNOWN_SUCCESSES),
     });
   } catch (err) {
     log.error('Timers page error:', err);
@@ -46,5 +54,6 @@ router.get('/', requireAuth, csrfProtection, async (req, res) => {
 });
 
 router.use(timersMutationsRouter);
+router.use(timerAssignmentsRouter);
 
 export default router;

--- a/src/web/routes/timersMutations.test.ts
+++ b/src/web/routes/timersMutations.test.ts
@@ -1,248 +1,219 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mockLogger } from '../../test-utils/loggerMock';
+import { ACCESS_LEVEL_MOCK } from '../../test-utils/accessLevelMock';
 
+vi.mock('../../db', () => {
+  class TimerCommandNotFoundError extends Error {}
+  return {
+    addTimerCommand: vi.fn().mockResolvedValue(1),
+    updateTimerCommand: vi.fn().mockResolvedValue(undefined),
+    removeTimerCommand: vi.fn().mockResolvedValue(undefined),
+    setTimerCommandEnabled: vi.fn().mockResolvedValue(undefined),
+    assignUsersToTimer: vi.fn().mockResolvedValue(undefined),
+    findUsersByIds: vi.fn().mockResolvedValue(new Map()),
+    TimerCommandNotFoundError,
+    AccessLevel: ACCESS_LEVEL_MOCK,
+  };
+});
+vi.mock('../csrf', () => ({ csrfProtection: (_req: any, _res: any, next: any) => next() }));
+vi.mock('../middleware', () => ({ requireMod: (_req: any, _res: any, next: any) => next() }));
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
-
-vi.mock('../../db', () => ({
-  getStreamerByDiscordId: vi.fn(),
-  addTimerCommand: vi.fn(),
-  countTimerCommandsForStreamer: vi.fn(),
-  updateTimerCommand: vi.fn(),
-  removeTimerCommand: vi.fn(),
-  setTimerCommandEnabled: vi.fn(),
-  TimerCommandNotFoundError: class TimerCommandNotFoundError extends Error {},
-}));
-
-vi.mock('../csrf', () => ({
-  csrfProtection: (req: any, _res: any, next: any) => {
-    req.csrfToken = () => 'test-csrf-token';
-    next();
-  },
-}));
-
-vi.mock('../middleware', () => ({
-  requireAuth: (_req: any, _res: any, next: any) => next(),
-}));
 
 import supertest from 'supertest';
 import router from './timersMutations';
 import {
-  getStreamerByDiscordId, addTimerCommand, countTimerCommandsForStreamer, updateTimerCommand,
-  removeTimerCommand, setTimerCommandEnabled, TimerCommandNotFoundError,
+  addTimerCommand, updateTimerCommand, removeTimerCommand, setTimerCommandEnabled,
+  assignUsersToTimer, findUsersByIds, TimerCommandNotFoundError,
 } from '../../db';
+import { AccessLevel } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 
-type SessionUser = { discordId: string; discordName: string; discordAvatar: string | null; accessLevel: 0 | 1 | 2 | 3; isOwner: boolean };
-const USER: SessionUser = { discordId: '100000000000000001', discordName: 'TestUser', discordAvatar: null, accessLevel: 0, isOwner: false };
-
-const MOCK_STREAMER = { id: 123, discord_id: USER.discordId };
-
-const VALID_TIMER_FORM = {
-  name: 'Discord plug',
-  message: 'Join our Discord!',
-  interval_seconds: '600',
-  min_messages: '0',
-  require_live: 'on',
-  enabled: 'on',
-};
-
-function buildApp(sessionUser: SessionUser = USER) {
-  return buildTestApp({ router, bodyParser: 'urlencoded', sessionUser });
+/** Builds a supertest-ready app: the timer mutations router with a urlencoded body parser (no session or render stub needed). */
+function buildApp() {
+  return buildTestApp({ router, bodyParser: 'urlencoded' });
 }
+
+const VALID_DISCORD_ID = '123456789012345678';
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
-  vi.mocked(countTimerCommandsForStreamer).mockResolvedValue(0);
+  vi.mocked(addTimerCommand).mockResolvedValue(1);
+  vi.mocked(updateTimerCommand).mockResolvedValue(undefined);
+  vi.mocked(removeTimerCommand).mockResolvedValue(undefined);
+  vi.mocked(setTimerCommandEnabled).mockResolvedValue(undefined);
+  vi.mocked(assignUsersToTimer).mockResolvedValue(undefined);
+  vi.mocked(findUsersByIds).mockResolvedValue(new Map());
 });
 
-describe('POST /add', () => {
-  it('redirects with error when user is not a streamer', async () => {
-    const res = await supertest(buildApp()).post('/add').type('form').send(VALID_TIMER_FORM);
-    expect(res.headers.location).toBe('/timers?error=not_a_streamer');
-    expect(addTimerCommand).not.toHaveBeenCalled();
+const VALID_FIELDS = 'name=Discord+plug&message=Join+our+Discord&interval_seconds=600&min_messages=0';
+
+// ─── POST /timers/add ─────────────────────────────────────────────────────────
+
+describe('POST /timers/add', () => {
+  it('redirects to /timers on success', async () => {
+    const res = await supertest(buildApp()).post('/timers/add').send(VALID_FIELDS);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/timers');
   });
 
-  it.each([
-    ['missing name', { name: '' }, 'missing_fields'],
-    ['missing message', { message: '' }, 'missing_fields'],
-    ['interval below the 60s floor', { interval_seconds: '59' }, 'invalid_interval'],
-    ['non-numeric interval', { interval_seconds: 'abc' }, 'invalid_interval'],
-    ['interval beyond the INT column range', { interval_seconds: '99999999999' }, 'invalid_interval'],
-    ['negative min_messages', { min_messages: '-1' }, 'invalid_min_messages'],
-    ['min_messages beyond the INT column range', { min_messages: '99999999999' }, 'invalid_min_messages'],
-  ])('redirects with the specific error code when %s', async (_label, override, expectedErrorCode) => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    const res = await supertest(buildApp()).post('/add').type('form').send({ ...VALID_TIMER_FORM, ...override });
-    expect(res.headers.location).toBe(`/timers?error=${expectedErrorCode}`);
-    expect(addTimerCommand).not.toHaveBeenCalled();
+  it('redirects to ?error=missing_fields when name is absent', async () => {
+    const res = await supertest(buildApp()).post('/timers/add').send('message=hi&interval_seconds=600&min_messages=0');
+    expect(res.headers.location).toBe('/timers?error=missing_fields');
   });
 
-  it('creates the timer and redirects to success', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    vi.mocked(addTimerCommand).mockResolvedValue(1);
-
-    const res = await supertest(buildApp()).post('/add').type('form').send(VALID_TIMER_FORM);
-
-    expect(res.headers.location).toBe('/timers?success=timer_added');
-    expect(addTimerCommand).toHaveBeenCalledWith(123, {
-      name: 'Discord plug',
-      message: 'Join our Discord!',
-      intervalSeconds: 600,
-      minMessages: 0,
-      requireLive: true,
-      enabled: true,
-    });
+  it('redirects to ?error=missing_fields when message is absent', async () => {
+    const res = await supertest(buildApp()).post('/timers/add').send('name=Plug&interval_seconds=600&min_messages=0');
+    expect(res.headers.location).toBe('/timers?error=missing_fields');
   });
 
-  it('redirects with add_failed when the insert throws', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    vi.mocked(addTimerCommand).mockRejectedValue(new Error('db down'));
+  it('redirects to ?error=invalid_interval when interval_seconds is below the minimum', async () => {
+    const res = await supertest(buildApp()).post('/timers/add').send('name=Plug&message=hi&interval_seconds=10&min_messages=0');
+    expect(res.headers.location).toBe('/timers?error=invalid_interval');
+  });
 
-    const res = await supertest(buildApp()).post('/add').type('form').send(VALID_TIMER_FORM);
+  it('redirects to ?error=invalid_interval when interval_seconds is non-numeric', async () => {
+    const res = await supertest(buildApp()).post('/timers/add').send('name=Plug&message=hi&interval_seconds=abc&min_messages=0');
+    expect(res.headers.location).toBe('/timers?error=invalid_interval');
+  });
+
+  it('redirects to ?error=invalid_min_messages when min_messages is non-numeric', async () => {
+    const res = await supertest(buildApp()).post('/timers/add').send('name=Plug&message=hi&interval_seconds=600&min_messages=abc');
+    expect(res.headers.location).toBe('/timers?error=invalid_min_messages');
+  });
+
+  it('redirects to ?error=add_failed on unexpected error', async () => {
+    vi.mocked(addTimerCommand).mockRejectedValueOnce(new Error('DB down'));
+    const res = await supertest(buildApp()).post('/timers/add').send(VALID_FIELDS);
     expect(res.headers.location).toBe('/timers?error=add_failed');
   });
 
-  it('redirects with add_failed when the count check throws', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    vi.mocked(countTimerCommandsForStreamer).mockRejectedValue(new Error('db down'));
-
-    const res = await supertest(buildApp()).post('/add').type('form').send(VALID_TIMER_FORM);
-    expect(res.headers.location).toBe('/timers?error=add_failed');
-    expect(addTimerCommand).not.toHaveBeenCalled();
+  it('assigns users when discord_ids are provided and user has twitch_name', async () => {
+    vi.mocked(findUsersByIds).mockResolvedValue(new Map([
+      [VALID_DISCORD_ID, { discord_id: VALID_DISCORD_ID, discord_name: 'Alice', twitch_name: 'alice', access_level: AccessLevel.USER } as any],
+    ]));
+    const res = await supertest(buildApp()).post('/timers/add').send(`${VALID_FIELDS}&discord_ids=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/timers');
+    expect(assignUsersToTimer).toHaveBeenCalledWith(1, [VALID_DISCORD_ID]);
   });
 
-  it('redirects with timer_limit_reached and skips the insert when the streamer is already at the cap', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    vi.mocked(countTimerCommandsForStreamer).mockResolvedValue(20);
-
-    const res = await supertest(buildApp()).post('/add').type('form').send(VALID_TIMER_FORM);
-
-    expect(res.headers.location).toBe('/timers?error=timer_limit_reached');
-    expect(addTimerCommand).not.toHaveBeenCalled();
+  it('skips assigning user when findUsersByIds does not return a matching entry', async () => {
+    vi.mocked(findUsersByIds).mockResolvedValue(new Map());
+    const res = await supertest(buildApp()).post('/timers/add').send(`${VALID_FIELDS}&discord_ids=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/timers');
+    expect(assignUsersToTimer).toHaveBeenCalledWith(1, []);
   });
 
-  it('allows the insert when the streamer is one below the cap', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    vi.mocked(countTimerCommandsForStreamer).mockResolvedValue(19);
-    vi.mocked(addTimerCommand).mockResolvedValue(1);
-
-    const res = await supertest(buildApp()).post('/add').type('form').send(VALID_TIMER_FORM);
-
-    expect(res.headers.location).toBe('/timers?success=timer_added');
-    expect(addTimerCommand).toHaveBeenCalled();
+  it('redirects to ?error=assign_failed on unexpected assign error, and cleans up the created timer', async () => {
+    vi.mocked(findUsersByIds).mockResolvedValue(new Map([
+      [VALID_DISCORD_ID, { discord_id: VALID_DISCORD_ID, twitch_name: 'alice', discord_name: null, access_level: AccessLevel.USER } as any],
+    ]));
+    vi.mocked(assignUsersToTimer).mockRejectedValueOnce(new Error('DB error'));
+    const res = await supertest(buildApp()).post('/timers/add').send(`${VALID_FIELDS}&discord_ids=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/timers?error=assign_failed');
+    expect(removeTimerCommand).toHaveBeenCalledWith(1);
   });
 
-  it('serializes concurrent requests for the same streamer so a race cannot exceed the cap', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    // Simulates the real DB: the count reflects however many inserts have actually landed so far.
-    let insertedCount = 19;
-    vi.mocked(countTimerCommandsForStreamer).mockImplementation(async () => insertedCount);
-    vi.mocked(addTimerCommand).mockImplementation(async () => { insertedCount += 1; return 1; });
+  it('redirects to ?error=assign_failed when findUsersByIds itself throws, and cleans up the created timer', async () => {
+    vi.mocked(findUsersByIds).mockRejectedValueOnce(new Error('DB down'));
+    const res = await supertest(buildApp()).post('/timers/add').send(`${VALID_FIELDS}&discord_ids=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/timers?error=assign_failed');
+    expect(removeTimerCommand).toHaveBeenCalledWith(1);
+  });
 
-    const app = buildApp();
-    const [res1, res2] = await Promise.all([
-      supertest(app).post('/add').type('form').send(VALID_TIMER_FORM),
-      supertest(app).post('/add').type('form').send(VALID_TIMER_FORM),
-    ]);
-
-    const locations = [res1.headers.location, res2.headers.location].sort();
-    expect(locations).toEqual(['/timers?error=timer_limit_reached', '/timers?success=timer_added']);
-    expect(addTimerCommand).toHaveBeenCalledTimes(1);
+  it('still redirects to ?error=assign_failed when the cleanup delete itself also fails', async () => {
+    vi.mocked(findUsersByIds).mockRejectedValueOnce(new Error('DB down'));
+    vi.mocked(removeTimerCommand).mockRejectedValueOnce(new Error('cleanup also failed'));
+    const res = await supertest(buildApp()).post('/timers/add').send(`${VALID_FIELDS}&discord_ids=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/timers?error=assign_failed');
+    expect(removeTimerCommand).toHaveBeenCalledWith(1);
   });
 });
 
-describe('POST /update', () => {
-  it('redirects with invalid_id when id is malformed', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    const res = await supertest(buildApp()).post('/update').type('form').send({ ...VALID_TIMER_FORM, id: 'abc' });
+// ─── POST /timers/update ──────────────────────────────────────────────────────
+
+describe('POST /timers/update', () => {
+  it('redirects to /timers on success', async () => {
+    const res = await supertest(buildApp()).post('/timers/update').send(`id=1&${VALID_FIELDS}`);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/timers');
+  });
+
+  it('redirects to ?error=invalid_id when id is non-numeric', async () => {
+    const res = await supertest(buildApp()).post('/timers/update').send(`id=abc&${VALID_FIELDS}`);
     expect(res.headers.location).toBe('/timers?error=invalid_id');
-    expect(updateTimerCommand).not.toHaveBeenCalled();
   });
 
-  it('updates and redirects to success, scoped to the requesting streamer', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-
-    const res = await supertest(buildApp()).post('/update').type('form').send({ ...VALID_TIMER_FORM, id: '5' });
-
-    expect(res.headers.location).toBe('/timers?success=timer_updated');
-    expect(updateTimerCommand).toHaveBeenCalledWith(5, 123, {
-      name: 'Discord plug',
-      message: 'Join our Discord!',
-      intervalSeconds: 600,
-      minMessages: 0,
-      requireLive: true,
-      enabled: true,
-    });
+  it('redirects to ?error=missing_fields when name is absent', async () => {
+    const res = await supertest(buildApp()).post('/timers/update').send('id=1&message=hi&interval_seconds=600&min_messages=0');
+    expect(res.headers.location).toBe('/timers?error=missing_fields');
   });
 
-  it('redirects with timer_not_found when the id belongs to another streamer', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    vi.mocked(updateTimerCommand).mockRejectedValue(new TimerCommandNotFoundError(5));
-
-    const res = await supertest(buildApp()).post('/update').type('form').send({ ...VALID_TIMER_FORM, id: '5' });
+  it('redirects to ?error=timer_not_found when TimerCommandNotFoundError is thrown', async () => {
+    vi.mocked(updateTimerCommand).mockRejectedValueOnce(new (TimerCommandNotFoundError as any)(1));
+    const res = await supertest(buildApp()).post('/timers/update').send(`id=1&${VALID_FIELDS}`);
     expect(res.headers.location).toBe('/timers?error=timer_not_found');
   });
 
-  it('redirects with update_failed when the update throws a non-NotFound error', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    vi.mocked(updateTimerCommand).mockRejectedValue(new Error('db down'));
-
-    const res = await supertest(buildApp()).post('/update').type('form').send({ ...VALID_TIMER_FORM, id: '5' });
+  it('redirects to ?error=update_failed on unexpected error', async () => {
+    vi.mocked(updateTimerCommand).mockRejectedValueOnce(new Error('DB error'));
+    const res = await supertest(buildApp()).post('/timers/update').send(`id=1&${VALID_FIELDS}`);
     expect(res.headers.location).toBe('/timers?error=update_failed');
+  });
+
+  it('passes require_live=true and enabled=true when checkboxes are "on"', async () => {
+    await supertest(buildApp()).post('/timers/update').send(`id=1&${VALID_FIELDS}&require_live=on&enabled=on`);
+    expect(updateTimerCommand).toHaveBeenCalledWith(1, {
+      name: 'Discord plug', message: 'Join our Discord', intervalSeconds: 600, minMessages: 0,
+      requireLive: true, enabled: true,
+    });
   });
 });
 
-describe('POST /remove', () => {
-  it('redirects with invalid_id when id is malformed', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    const res = await supertest(buildApp()).post('/remove').type('form').send({ id: 'abc' });
+// ─── POST /timers/remove ──────────────────────────────────────────────────────
+
+describe('POST /timers/remove', () => {
+  it('redirects to /timers on success', async () => {
+    const res = await supertest(buildApp()).post('/timers/remove').send('id=5');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/timers');
+  });
+
+  it('redirects to ?error=invalid_id when id is non-numeric', async () => {
+    const res = await supertest(buildApp()).post('/timers/remove').send('id=abc');
     expect(res.headers.location).toBe('/timers?error=invalid_id');
-    expect(removeTimerCommand).not.toHaveBeenCalled();
   });
 
-  it('removes and redirects to success, scoped to the requesting streamer', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    const res = await supertest(buildApp()).post('/remove').type('form').send({ id: '5' });
-    expect(res.headers.location).toBe('/timers?success=timer_removed');
-    expect(removeTimerCommand).toHaveBeenCalledWith(5, 123);
-  });
-
-  it('redirects with remove_failed when the delete throws', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    vi.mocked(removeTimerCommand).mockRejectedValue(new Error('db down'));
-
-    const res = await supertest(buildApp()).post('/remove').type('form').send({ id: '5' });
+  it('redirects to ?error=remove_failed on unexpected error', async () => {
+    vi.mocked(removeTimerCommand).mockRejectedValueOnce(new Error('DB error'));
+    const res = await supertest(buildApp()).post('/timers/remove').send('id=5');
     expect(res.headers.location).toBe('/timers?error=remove_failed');
   });
 });
 
-describe('POST /toggle', () => {
-  it('redirects with invalid_id when id is malformed', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    const res = await supertest(buildApp()).post('/toggle').type('form').send({ id: 'abc', enabled: 'true' });
-    expect(res.headers.location).toBe('/timers?error=invalid_id');
-    expect(setTimerCommandEnabled).not.toHaveBeenCalled();
-  });
+// ─── POST /timers/toggle ──────────────────────────────────────────────────────
 
-  it('toggles and redirects, scoped to the requesting streamer', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    const res = await supertest(buildApp()).post('/toggle').type('form').send({ id: '5', enabled: 'false' });
+describe('POST /timers/toggle', () => {
+  it('redirects to /timers on success', async () => {
+    const res = await supertest(buildApp()).post('/timers/toggle').send('id=1&enabled=true');
+    expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/timers');
-    expect(setTimerCommandEnabled).toHaveBeenCalledWith(5, 123, false);
+    expect(setTimerCommandEnabled).toHaveBeenCalledWith(1, true);
   });
 
-  it('redirects with timer_not_found when the id belongs to another streamer', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    vi.mocked(setTimerCommandEnabled).mockRejectedValue(new TimerCommandNotFoundError(5));
-    const res = await supertest(buildApp()).post('/toggle').type('form').send({ id: '5', enabled: 'true' });
+  it('redirects to ?error=invalid_id when id is non-numeric', async () => {
+    const res = await supertest(buildApp()).post('/timers/toggle').send('id=abc&enabled=true');
+    expect(res.headers.location).toBe('/timers?error=invalid_id');
+  });
+
+  it('redirects to ?error=timer_not_found when TimerCommandNotFoundError is thrown', async () => {
+    vi.mocked(setTimerCommandEnabled).mockRejectedValueOnce(new (TimerCommandNotFoundError as any)(1));
+    const res = await supertest(buildApp()).post('/timers/toggle').send('id=1&enabled=true');
     expect(res.headers.location).toBe('/timers?error=timer_not_found');
   });
 
-  it('redirects with toggle_failed when the update throws a non-NotFound error', async () => {
-    vi.mocked(getStreamerByDiscordId).mockResolvedValue(MOCK_STREAMER as any);
-    vi.mocked(setTimerCommandEnabled).mockRejectedValue(new Error('db down'));
-    const res = await supertest(buildApp()).post('/toggle').type('form').send({ id: '5', enabled: 'true' });
+  it('redirects to ?error=toggle_failed on unexpected error', async () => {
+    vi.mocked(setTimerCommandEnabled).mockRejectedValueOnce(new Error('DB error'));
+    const res = await supertest(buildApp()).post('/timers/toggle').send('id=1&enabled=true');
     expect(res.headers.location).toBe('/timers?error=toggle_failed');
   });
 });

--- a/src/web/routes/timersMutations.test.ts
+++ b/src/web/routes/timersMutations.test.ts
@@ -103,6 +103,13 @@ describe('POST /timers/add', () => {
     expect(assignUsersToTimer).toHaveBeenCalledWith(1, []);
   });
 
+  it('drops a malformed discord_id before looking up eligibility', async () => {
+    const res = await supertest(buildApp()).post('/timers/add').send(`${VALID_FIELDS}&discord_ids=not-a-snowflake`);
+    expect(res.headers.location).toBe('/timers');
+    expect(findUsersByIds).toHaveBeenCalledWith([]);
+    expect(assignUsersToTimer).toHaveBeenCalledWith(1, []);
+  });
+
   it('redirects to ?error=assign_failed on unexpected assign error, and cleans up the created timer', async () => {
     vi.mocked(findUsersByIds).mockResolvedValue(new Map([
       [VALID_DISCORD_ID, { discord_id: VALID_DISCORD_ID, twitch_name: 'alice', discord_name: null, access_level: AccessLevel.USER } as any],

--- a/src/web/routes/timersMutations.ts
+++ b/src/web/routes/timersMutations.ts
@@ -1,41 +1,22 @@
 import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import {
-  addTimerCommand, countTimerCommandsForStreamer, updateTimerCommand, removeTimerCommand,
+  addTimerCommand, assignUsersToTimer, findUsersByIds, removeTimerCommand, updateTimerCommand,
   setTimerCommandEnabled, TimerCommandNotFoundError,
 } from '../../db';
 import type { TimerCommandInput } from '../../db';
 import { csrfProtection } from '../csrf';
-import { requireAuth } from '../middleware';
-import { createMutationQueue } from '../../shared/mutationQueue';
+import { requireMod } from '../middleware';
 import {
-  logAndRedirectError, normalizeRequiredText, parseCheckboxField, parsePositiveIntId,
-  requireStreamer,
+  logAndRedirectError, normalizeDiscordId, normalizeRequiredText, parseCheckboxField, parsePositiveIntId,
 } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
 
-/**
- * Serializes the per-streamer timer count check and insert in `POST /timers/add` (keyed by
- * streamer id), so two concurrent requests for the same streamer can't both read a count under
- * {@link MAX_TIMER_COMMANDS_PER_STREAMER} and each insert, letting the cap be exceeded.
- */
-const timerAddQueue = createMutationQueue<number>();
-
-/** Redirect target used when the requester isn't a streamer, scoped to the timers admin page. */
-const NOT_A_STREAMER_REDIRECT = '/timers?error=not_a_streamer';
-
 const MIN_INTERVAL_SECONDS = 60;
 /** MySQL `INT` (4-byte signed) max — both `interval_seconds` and `min_messages` are stored in `INT` columns. */
 const MAX_INT_COLUMN_VALUE = 2147483647;
-/**
- * Per-streamer cap on the number of timer commands, enforced in `/timers/add`. Every enabled
- * timer across every streamer is processed on every ~15s scheduler tick, so this bounds that
- * per-tick work rather than letting one streamer's rows (accidental duplicates, or a scripted
- * client) grow it unboundedly.
- */
-const MAX_TIMER_COMMANDS_PER_STREAMER = 20;
 
 /**
  * Parses a required numeric form field: an integer within `[min, max]`. Shared by both
@@ -82,91 +63,111 @@ function parseTimerCommandFields(body: Record<string, string | string[] | undefi
 }
 
 /**
- * POST /timers/add — creates a new timer command for the requesting streamer. The count check
- * and insert are serialized per streamer through {@link timerAddQueue} so two concurrent
- * requests can't both observe a count under the cap and each insert, exceeding it.
- * @param req - Express request; reads `name`, `message`, `interval_seconds`, `min_messages`,
- *   `require_live`, `enabled` from `req.body`.
- * @param res - Express response; redirects to `/timers?success=timer_added` on success, or to
- *   `/timers?error=<code>` if the requester isn't a streamer (`not_a_streamer`), a field is
- *   invalid (`missing_fields`, `invalid_interval`, `invalid_min_messages`), the streamer has
- *   already reached {@link MAX_TIMER_COMMANDS_PER_STREAMER} timers (`timer_limit_reached`), or
- *   the count check or insert fails (`add_failed`).
+ * Assigns Twitch-linked users to a newly created timer, filtering out any id with no
+ * linked Twitch name. On any failure, deletes the timer to avoid leaving it in a
+ * partially-assigned state. Returns an error code, or null on success.
  */
-router.post('/add', requireAuth, csrfProtection, async (req, res) => {
+async function assignUsersToNewTimer(timerId: number, discordIds: string[]): Promise<string | null> {
   try {
-    const streamer = await requireStreamer(req, res, NOT_A_STREAMER_REDIRECT);
-    if (!streamer) return;
-
-    const body = req.body as Record<string, string | string[] | undefined>;
-    const result = parseTimerCommandFields(body);
-    if (!result.ok) return res.redirect(`/timers?error=${result.errorCode}`);
-
-    const added = await timerAddQueue.run(streamer.id, async () => {
-      const existingCount = await countTimerCommandsForStreamer(streamer.id);
-      if (existingCount >= MAX_TIMER_COMMANDS_PER_STREAMER) return false;
-      await addTimerCommand(streamer.id, result.input);
-      return true;
+    const users = await findUsersByIds(discordIds);
+    const eligibleDiscordIds = discordIds.filter((discordId) => {
+      const user = users.get(discordId);
+      return !!user && !!user.twitch_name;
     });
-    if (!added) return res.redirect('/timers?error=timer_limit_reached');
-    res.redirect('/timers?success=timer_added');
+    await assignUsersToTimer(timerId, eligibleDiscordIds);
   } catch (err) {
-    logAndRedirectError({ res, log, logLabel: 'Add timer command error:', err, basePath: '/timers', errorCode: 'add_failed' });
+    try {
+      await removeTimerCommand(timerId);
+    } catch (cleanupErr) {
+      log.error('Cleanup after failed timer assign error:', cleanupErr);
+    }
+    log.error('Assign user during timer creation error:', err);
+    return 'assign_failed';
   }
+  return null;
+}
+
+/**
+ * POST /timers/add — creates a new timer command and optionally assigns it to one or more
+ * Twitch-linked Discord users. If any assignment fails, the just-created timer is deleted
+ * to avoid a partially-assigned state.
+ * @param req - Express request; reads `name`, `message`, `interval_seconds`, `min_messages`,
+ *   `require_live`, `enabled`, and `discord_ids` from `req.body`.
+ * @param res - Express response; redirects to `/timers` on success, or to
+ *   `/timers?error=<code>` if a field is invalid (`missing_fields`, `invalid_interval`,
+ *   `invalid_min_messages`), the insert fails (`add_failed`), or an assignment fails
+ *   (`assign_failed`).
+ */
+router.post('/timers/add', requireMod, csrfProtection, async (req, res) => {
+  const body = req.body as Record<string, string | string[] | undefined>;
+  const result = parseTimerCommandFields(body);
+  if (!result.ok) return res.redirect(`/timers?error=${result.errorCode}`);
+
+  let timerId: number;
+  try {
+    timerId = await addTimerCommand(result.input);
+  } catch (err) {
+    return logAndRedirectError({ res, log, logLabel: 'Add timer command error:', err, basePath: '/timers', errorCode: 'add_failed' });
+  }
+
+  const rawDiscordIds = body.discord_ids;
+  const discordIds: string[] = (Array.isArray(rawDiscordIds) ? rawDiscordIds : rawDiscordIds ? [rawDiscordIds] : [])
+    .map((id) => normalizeDiscordId(id))
+    .filter((id): id is string => id !== null);
+
+  const assignError = await assignUsersToNewTimer(timerId, discordIds);
+  if (assignError) return res.redirect(`/timers?error=${assignError}`);
+
+  res.redirect('/timers');
 });
 
 /**
- * POST /timers/update — updates an existing timer command belonging to the requesting streamer.
+ * POST /timers/update — updates an existing timer command's fields.
  * @param req - Express request; reads `id`, plus the same fields as `/timers/add`, from `req.body`.
- * @param res - Express response; redirects to `/timers?success=timer_updated` on success, or to
- *   `/timers?error=<code>` if the requester isn't a streamer (`not_a_streamer`), `id` is
- *   malformed (`invalid_id`), a field is invalid (`missing_fields`, `invalid_interval`,
- *   `invalid_min_messages`), the timer doesn't exist or belongs to another streamer
+ * @param res - Express response; redirects to `/timers` on success, or to
+ *   `/timers?error=<code>` if `id` is malformed (`invalid_id`), a field is invalid
+ *   (`missing_fields`, `invalid_interval`, `invalid_min_messages`), the timer doesn't exist
  *   (`timer_not_found`), or the update fails (`update_failed`).
  */
-router.post('/update', requireAuth, csrfProtection, async (req, res) => {
+router.post('/timers/update', requireMod, csrfProtection, async (req, res) => {
+  const body = req.body as Record<string, string | string[] | undefined>;
+  const id = parsePositiveIntId(body.id);
+  if (id === null) return res.redirect('/timers?error=invalid_id');
+
+  const result = parseTimerCommandFields(body);
+  if (!result.ok) return res.redirect(`/timers?error=${result.errorCode}`);
+
   try {
-    const streamer = await requireStreamer(req, res, NOT_A_STREAMER_REDIRECT);
-    if (!streamer) return;
-
-    const body = req.body as Record<string, string | string[] | undefined>;
-    const id = parsePositiveIntId(body.id);
-    if (id === null) return res.redirect('/timers?error=invalid_id');
-
-    const result = parseTimerCommandFields(body);
-    if (!result.ok) return res.redirect(`/timers?error=${result.errorCode}`);
-
-    await updateTimerCommand(id, streamer.id, result.input);
-    res.redirect('/timers?success=timer_updated');
+    await updateTimerCommand(id, result.input);
   } catch (err) {
     if (err instanceof TimerCommandNotFoundError) {
       return res.redirect('/timers?error=timer_not_found');
     }
-    logAndRedirectError({ res, log, logLabel: 'Update timer command error:', err, basePath: '/timers', errorCode: 'update_failed' });
+    return logAndRedirectError({ res, log, logLabel: 'Update timer command error:', err, basePath: '/timers', errorCode: 'update_failed' });
   }
+
+  res.redirect('/timers');
 });
 
 /**
- * POST /timers/remove — deletes a timer command belonging to the requesting streamer.
- * No-ops (still redirects to success) if the id doesn't exist or belongs to another streamer.
+ * POST /timers/remove — deletes a timer command and all its streamer assignments.
+ * No-ops (still redirects to success) if the id doesn't exist.
  * @param req - Express request; reads `id` from `req.body`.
- * @param res - Express response; redirects to `/timers?success=timer_removed` on success, or to
- *   `/timers?error=<code>` if the requester isn't a streamer (`not_a_streamer`), `id` is
- *   malformed (`invalid_id`), or the delete fails (`remove_failed`).
+ * @param res - Express response; redirects to `/timers` on success, or to
+ *   `/timers?error=<code>` if `id` is malformed (`invalid_id`) or the delete fails
+ *   (`remove_failed`).
  */
-router.post('/remove', requireAuth, csrfProtection, async (req, res) => {
+router.post('/timers/remove', requireMod, csrfProtection, async (req, res) => {
+  const id = parsePositiveIntId((req.body as Record<string, string | string[] | undefined>).id);
+  if (id === null) return res.redirect('/timers?error=invalid_id');
+
   try {
-    const streamer = await requireStreamer(req, res, NOT_A_STREAMER_REDIRECT);
-    if (!streamer) return;
-
-    const id = parsePositiveIntId((req.body as Record<string, string | string[] | undefined>).id);
-    if (id === null) return res.redirect('/timers?error=invalid_id');
-
-    await removeTimerCommand(id, streamer.id);
-    res.redirect('/timers?success=timer_removed');
+    await removeTimerCommand(id);
   } catch (err) {
-    logAndRedirectError({ res, log, logLabel: 'Remove timer command error:', err, basePath: '/timers', errorCode: 'remove_failed' });
+    return logAndRedirectError({ res, log, logLabel: 'Remove timer command error:', err, basePath: '/timers', errorCode: 'remove_failed' });
   }
+
+  res.redirect('/timers');
 });
 
 /**
@@ -174,27 +175,24 @@ router.post('/remove', requireAuth, csrfProtection, async (req, res) => {
  * enable/disable control in the timer list without opening the full edit form.
  * @param req - Express request; reads `id` and `enabled` (`'true'`/`'false'`) from `req.body`.
  * @param res - Express response; redirects to `/timers` on success, or to `/timers?error=<code>`
- *   if the requester isn't a streamer (`not_a_streamer`), `id` is malformed (`invalid_id`), the
- *   timer doesn't exist or belongs to another streamer (`timer_not_found`), or the update fails
- *   (`toggle_failed`).
+ *   if `id` is malformed (`invalid_id`), the timer doesn't exist (`timer_not_found`), or the
+ *   update fails (`toggle_failed`).
  */
-router.post('/toggle', requireAuth, csrfProtection, async (req, res) => {
+router.post('/timers/toggle', requireMod, csrfProtection, async (req, res) => {
+  const body = req.body as Record<string, string | string[] | undefined>;
+  const id = parsePositiveIntId(body.id);
+  if (id === null) return res.redirect('/timers?error=invalid_id');
+
   try {
-    const streamer = await requireStreamer(req, res, NOT_A_STREAMER_REDIRECT);
-    if (!streamer) return;
-
-    const body = req.body as Record<string, string | string[] | undefined>;
-    const id = parsePositiveIntId(body.id);
-    if (id === null) return res.redirect('/timers?error=invalid_id');
-
-    await setTimerCommandEnabled(id, streamer.id, body.enabled === 'true');
-    res.redirect('/timers');
+    await setTimerCommandEnabled(id, body.enabled === 'true');
   } catch (err) {
     if (err instanceof TimerCommandNotFoundError) {
       return res.redirect('/timers?error=timer_not_found');
     }
-    logAndRedirectError({ res, log, logLabel: 'Toggle timer command error:', err, basePath: '/timers', errorCode: 'toggle_failed' });
+    return logAndRedirectError({ res, log, logLabel: 'Toggle timer command error:', err, basePath: '/timers', errorCode: 'toggle_failed' });
   }
+
+  res.redirect('/timers');
 });
 
 export default router;

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -218,6 +218,7 @@ rootAuthedRouter.use(sfxRouter);
 rootAuthedRouter.use(commandsRouter);
 rootAuthedRouter.use(countersRouter);
 rootAuthedRouter.use(counterHistoryRouter);
+rootAuthedRouter.use(timersRouter);
 rootAuthedRouter.use(rootGuildRouter);
 app.use('/', rootAuthedRouter);
 
@@ -233,7 +234,6 @@ app.use('/user/settings', requireAuth, userSettingsRouter);
 app.use('/overlay', requireAuth, overlayAdminRouter);
 app.use('/alerts', requireAuth, alertsAdminRouter);
 app.use('/channel-points', requireAuth, channelPointsAdminRouter);
-app.use('/timers', requireAuth, timersRouter);
 app.use('/dashboard', requireAuth, dashboardEventsRouter);
 app.use('/dashboard', requireAuth, dashboardStatusEventsRouter);
 

--- a/views/partials/nav.ejs
+++ b/views/partials/nav.ejs
@@ -8,10 +8,10 @@
         <button class="nav-group-label" aria-haspopup="true" aria-expanded="false">Bot Commands <span class="nav-caret">▾</span></button>
         <div class="nav-group-items">
           <a href="/sfx" class="nav-item">SFX</a>
-          <a href="/timers" class="nav-item">Timers</a>
           <% if (user && user.accessLevel >= 2) { %>
           <a href="/commands" class="nav-item">Commands</a>
           <a href="/counters" class="nav-item">Counters</a>
+          <a href="/timers" class="nav-item">Timers</a>
           <% } %>
         </div>
       </div>

--- a/views/timers.ejs
+++ b/views/timers.ejs
@@ -13,45 +13,27 @@
   <main class="container">
     <section class="section">
       <h2 class="section-title">Timer Commands</h2>
-      <p class="hint mb-075">Auto-posts a message into your own Twitch chat on a repeating schedule.</p>
+      <p class="hint mb-075">Auto-posts a message into an assigned streamer's Twitch chat on a repeating schedule.</p>
 
       <% if (error) { %>
       <% const errorMessages = {
-        not_a_streamer:      'You are not configured as a monitored streamer.',
         missing_fields:      'Please provide a name, a message, and a valid interval/minimum-messages value.',
         invalid_interval:    'Interval must be a whole number of at least 60 seconds.',
         invalid_min_messages: 'Minimum messages must be zero or a positive whole number.',
-        timer_limit_reached: 'You have reached the maximum number of timers allowed.',
         invalid_id:          'Invalid timer ID.',
         timer_not_found:     'That timer no longer exists.',
         add_failed:          'Failed to add the timer.',
         update_failed:       'Failed to update the timer.',
         remove_failed:       'Failed to remove the timer.',
         toggle_failed:       'Failed to update the timer.',
+        assign_failed:       'Failed to assign that user to the timer.',
+        unassign_failed:     'Failed to unassign that user from the timer.',
+        invalid_assignment_user: 'The selected user cannot be assigned to this timer.',
       }; %>
       <div class="card card-alert-danger" role="alert" aria-live="assertive" aria-atomic="true">
         <span class="text-danger">&#9888; <%= errorMessages[error] || `Operation failed: ${error.replace(/_/g, ' ')}` %></span>
       </div>
       <% } %>
-
-      <% if (success) { %>
-      <div class="card card-alert-success" role="status" aria-live="polite">
-        <% const successMessages = {
-          timer_added:   'Timer added.',
-          timer_updated: 'Timer updated.',
-          timer_removed: 'Timer removed.',
-        }; %>
-        <%= successMessages[success] ?? 'Done.' %>
-      </div>
-      <% } %>
-
-      <% if (!isStreamer) { %>
-      <div class="card">
-        <div class="card-body">
-          <p class="hint">You are not configured as a monitored streamer. Contact a Manager or Admin.</p>
-        </div>
-      </div>
-      <% } else { %>
 
       <div class="card card-spaced">
         <div class="card-header"><span class="card-icon">➕</span><span class="card-label">Add Timer</span></div>
@@ -82,6 +64,17 @@
               <label for="message" class="form-label">Message</label>
               <textarea id="message" class="input stream-textarea" name="message" rows="2" placeholder="Join our Discord at ..." required></textarea>
             </div>
+            <% if (assignableUsers.length > 0) { %>
+            <div class="form-section-gap">
+              <label for="add-discord-ids" class="form-label">Assign Streamers <span class="muted">(optional)</span></label>
+              <select id="add-discord-ids" class="input" name="discord_ids" multiple size="<%= Math.min(assignableUsers.length, 5) %>">
+                <% assignableUsers.forEach(function(u) { %>
+                  <option value="<%= u.discord_id %>"><%= u.discord_name || u.discord_id %> (<%= u.twitch_name %>)</option>
+                <% }) %>
+              </select>
+              <p class="hint hint-compact">Hold Ctrl / Cmd to select multiple streamers.</p>
+            </div>
+            <% } %>
             <button type="submit" class="btn">Add Timer</button>
           </form>
         </div>
@@ -98,6 +91,7 @@
                 <th scope="col">Min. Messages</th>
                 <th scope="col">Live Only</th>
                 <th scope="col">Status</th>
+                <th scope="col">Assigned Streamers</th>
                 <th scope="col">Actions</th>
               </tr>
             </thead>
@@ -119,6 +113,25 @@
                     </button>
                   </form>
                 </td>
+                <td class="assigned-users-cell">
+                  <% if (timer.assigned_users.length > 0) { %>
+                    <div class="badge-list-wrap">
+                      <% timer.assigned_users.forEach(function(assignedUser) { %>
+                        <% const isSelf = user && assignedUser.discord_id === user.discordId; %>
+                        <span class="badge badge-user-hue<%= isSelf ? ' badge-user-self' : '' %>" data-user-hue="<%= assignedUser.discord_id %>">
+                          <%= assignedUser.discord_name || assignedUser.discord_id %>
+                          <% if (assignedUser.twitch_name) { %>
+                            (<%= assignedUser.twitch_name %>)
+                          <% } else if (assignedUser.is_orphaned_user) { %>
+                            (missing user)
+                          <% } %>
+                        </span>
+                      <% }) %>
+                    </div>
+                  <% } else { %>
+                    <span class="muted">No streamers assigned</span>
+                  <% } %>
+                </td>
                 <td>
                   <div class="actions">
                     <button type="button" class="btn btn-sm btn-ghost btn-toggle-timer-edit" data-timer-id="<%= timer.id %>" aria-controls="timer-edit-<%= timer.id %>" aria-expanded="false">✏️ Edit</button>
@@ -131,7 +144,7 @@
                 </td>
               </tr>
               <tr class="files-row is-hidden" id="timer-edit-<%= timer.id %>">
-                <td colspan="7">
+                <td colspan="8">
                   <div class="command-edit-panel">
                     <form method="POST" action="/timers/update" class="stack-gap-md">
                       <input type="hidden" name="_csrf" value="<%= csrfToken %>">
@@ -165,20 +178,61 @@
                         <button type="button" class="btn btn-ghost btn-toggle-timer-edit" data-timer-id="<%= timer.id %>">Cancel</button>
                       </div>
                     </form>
+
+                    <div class="command-assignment-shell">
+                      <h3 class="command-assignment-title">Streamer Assignments</h3>
+                      <% if (timer.unassigned_users.length > 0) { %>
+                      <form method="POST" action="/timers/assign" class="inline-form inline-form-compact">
+                        <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                        <input type="hidden" name="timer_id" value="<%= timer.id %>">
+                        <label for="assign-discord-<%= timer.id %>" class="form-label">Assign streamer</label>
+                        <select id="assign-discord-<%= timer.id %>" class="input" name="discord_id">
+                          <% timer.unassigned_users.forEach(function(assignableUser) { %>
+                            <option value="<%= assignableUser.discord_id %>">
+                              <%= assignableUser.discord_name || assignableUser.discord_id %> (<%= assignableUser.twitch_name %>)
+                            </option>
+                          <% }) %>
+                        </select>
+                        <button type="submit" class="btn">Assign Streamer</button>
+                      </form>
+                      <% } %>
+
+                      <% if (timer.assigned_users.length > 0) { %>
+                      <div class="stack-gap-sm">
+                        <% timer.assigned_users.forEach(function(assignedUser) { %>
+                        <div class="assignment-user-row">
+                          <div>
+                            <div><strong><%= assignedUser.discord_name || assignedUser.discord_id %></strong></div>
+                            <div class="mono muted"><%= assignedUser.twitch_name || (assignedUser.is_orphaned_user ? 'Missing user record' : 'No Twitch name') %></div>
+                          </div>
+                          <form method="POST" action="/timers/unassign" class="inline-form-sm">
+                            <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                            <input type="hidden" name="timer_id" value="<%= timer.id %>">
+                            <input type="hidden" name="discord_id" value="<%= assignedUser.discord_id %>">
+                            <button type="submit" class="btn btn-danger btn-sm">Unassign</button>
+                          </form>
+                        </div>
+                        <% }) %>
+                      </div>
+                      <% } else if (assignableUsers.length > 0) { %>
+                      <div class="empty-msg">No streamers assigned yet.</div>
+                      <% } else { %>
+                      <div class="empty-msg">No users with a Twitch name are available for assignment.</div>
+                      <% } %>
+                    </div>
                   </div>
                 </td>
               </tr>
               <% }) %>
               <% if (timers.length === 0) { %>
               <tr>
-                <td colspan="7" class="empty-msg">No timers configured yet.</td>
+                <td colspan="8" class="empty-msg">No timers configured yet.</td>
               </tr>
               <% } %>
             </tbody>
           </table>
         </div>
       </div>
-      <% } %>
     </section>
   </main>
 


### PR DESCRIPTION
## Summary

Stacked on #486 (the shared-chat cooldown PR) — this is the follow-up the user actually wanted from the original Timers work: moving Timers from a self-service, single-streamer-owned feature to a Manager-only catalog that mirrors Custom Commands, where each timer can be assigned to a list of Twitch-linked streamers.

- **New join table** `timer_command_streamer` (mirrors `twitch_user_commands`) maps timer commands to the Discord users they're assigned to. A migration (`migrations/timer_command_streamer_assignment.sql`) backfills existing single-owner rows and drops `timer_command.streamer_id`.
- **Scheduler**: in-memory firing state is now keyed by `(timer id, channel)` instead of timer id alone — a timer assigned to several streamers fires independently on each one's own live/interval/message-count schedule. This composes with the shared-chat group cooldown from #486 (per-session, not per-timer).
- **`/timers` becomes a Manager-only admin page** mirroring `/commands`: add/edit/remove/enable-disable a timer, plus assign/unassign streamers via a multi-select (create) and per-row assign/unassign (edit panel). Nav link moved into the Manager-gated section of the Bot Commands dropdown, alongside Commands/Counters.
- Filed and updated issue #487 as a reminder that Commands/Timers are now both Manager-only, in case self-service should be reintroduced later.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 3018 tests passing)
- [x] New/updated tests: `src/db/timerCommands.test.ts`, `src/web/routes/timers.test.ts`, `src/web/routes/timersMutations.test.ts`, new `src/web/routes/timerAssignments.test.ts`, and `src/twitch/timers/timerCommandScheduler.test.ts` (composite-key independence across multiple assigned channels)
- [x] Updated `DATABASE-SCHEMA.md` for the new `timer_command`/`timer_command_streamer` shape

---
_Generated by [Claude Code](https://claude.ai/code/session_016JC7pwYyPfFgUiqA6Lx9vw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timers can now be created in a shared catalog and assigned to multiple Twitch-linked users.
  * Added multi-user assignment controls, assignment status, and orphaned-user visibility.
  * Timer schedules run independently for each assigned channel.
  * Timer management now requires elevated access.
  * User badges now display consistent color hues across commands and timers.

* **Bug Fixes**
  * Improved handling of invalid assignments, missing timers, and assignment failures.
  * Shared Chat timer behavior now maintains independent channel schedules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->