### PR TITLE
Pause reward pricing scheduler polling when DB server is shutting down

### DIFF
--- a/src/twitch/pricing/rewardPricingScheduler.test.ts
+++ b/src/twitch/pricing/rewardPricingScheduler.test.ts
@@ -163,6 +163,43 @@ describe('startRewardPricingScheduler / stopRewardPricingScheduler', () => {
     expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(1);
   });
 
+  it('pauses polling when the DB server itself is shutting down, and resumes once it recovers', async () => {
+    const shutdownError = Object.assign(new Error('Server shutdown in progress'), { code: 'ER_SERVER_SHUTDOWN', errno: 1053 });
+    vi.mocked(getAllEnabledPricingRows).mockRejectedValueOnce(shutdownError);
+    startRewardPricingScheduler();
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(1);
+
+    // Regular 30s cadence should not fire again — polling is paused.
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(1);
+
+    // The DB recovers before the 60s probe fires.
+    vi.mocked(getAllEnabledPricingRows).mockResolvedValue([]);
+    await vi.advanceTimersByTimeAsync(30_000); // completes the 60s probe delay
+    expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(2);
+
+    // Normal cadence resumes.
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(3);
+  });
+
+  it('keeps retrying every 60s while the DB server stays down', async () => {
+    const shutdownError = Object.assign(new Error('Server shutdown in progress'), { code: 'ER_SERVER_SHUTDOWN', errno: 1053 });
+    vi.mocked(getAllEnabledPricingRows).mockRejectedValue(shutdownError);
+    startRewardPricingScheduler();
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(3);
+  });
+
   it('a reentrancy guard prevents overlapping ticks', async () => {
     let resolveFirst!: () => void;
     const gate = new Promise<void>((resolve) => { resolveFirst = resolve; });

--- a/src/twitch/pricing/rewardPricingScheduler.test.ts
+++ b/src/twitch/pricing/rewardPricingScheduler.test.ts
@@ -213,7 +213,9 @@ describe('startRewardPricingScheduler / stopRewardPricingScheduler', () => {
     expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(2);
 
     vi.mocked(getAllEnabledPricingRows).mockResolvedValue([]);
-    await vi.advanceTimersByTimeAsync(60_000); // scheduler kept retrying instead of stalling
+    await vi.advanceTimersByTimeAsync(59_999);
+    expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(2); // not yet — confirms the retry is on a 60s cadence, not something shorter
+    await vi.advanceTimersByTimeAsync(1); // scheduler kept retrying instead of stalling
     expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(3);
 
     // Normal cadence resumes.

--- a/src/twitch/pricing/rewardPricingScheduler.test.ts
+++ b/src/twitch/pricing/rewardPricingScheduler.test.ts
@@ -200,6 +200,40 @@ describe('startRewardPricingScheduler / stopRewardPricingScheduler', () => {
     expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(3);
   });
 
+  it('keeps retrying every 60s after a probe fails with something other than the shutdown error', async () => {
+    const shutdownError = Object.assign(new Error('Server shutdown in progress'), { code: 'ER_SERVER_SHUTDOWN', errno: 1053 });
+    vi.mocked(getAllEnabledPricingRows).mockRejectedValueOnce(shutdownError);
+    startRewardPricingScheduler();
+
+    await vi.advanceTimersByTimeAsync(30_000); // initial shutdown error pauses polling
+    expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(1);
+
+    vi.mocked(getAllEnabledPricingRows).mockRejectedValueOnce(new Error('connection reset'));
+    await vi.advanceTimersByTimeAsync(60_000); // probe hits a different transient error
+    expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(2);
+
+    vi.mocked(getAllEnabledPricingRows).mockResolvedValue([]);
+    await vi.advanceTimersByTimeAsync(60_000); // scheduler kept retrying instead of stalling
+    expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(3);
+
+    // Normal cadence resumes.
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(4);
+  });
+
+  it('cancels the pending recovery probe on stop, so it never fires', async () => {
+    const shutdownError = Object.assign(new Error('Server shutdown in progress'), { code: 'ER_SERVER_SHUTDOWN', errno: 1053 });
+    vi.mocked(getAllEnabledPricingRows).mockRejectedValueOnce(shutdownError);
+    startRewardPricingScheduler();
+
+    await vi.advanceTimersByTimeAsync(30_000); // shutdown error pauses polling and schedules a 60s probe
+    expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(1);
+
+    await stopRewardPricingScheduler();
+    await vi.advanceTimersByTimeAsync(60_000); // probe would have fired here if not cancelled
+    expect(getAllEnabledPricingRows).toHaveBeenCalledTimes(1);
+  });
+
   it('a reentrancy guard prevents overlapping ticks', async () => {
     let resolveFirst!: () => void;
     const gate = new Promise<void>((resolve) => { resolveFirst = resolve; });

--- a/src/twitch/pricing/rewardPricingScheduler.ts
+++ b/src/twitch/pricing/rewardPricingScheduler.ts
@@ -26,6 +26,7 @@ function isServerShutdownError(error: unknown): boolean {
  */
 function startTickTimer(): void {
   if (tickTimer) return;
+  /** Interval callback: fires a decay tick and logs (rather than throws) if the returned promise ever rejects. */
   tickTimer = setInterval(() => {
     runDecayTick().catch((err) => log.error('Decay tick error:', err));
   }, DECAY_POLL_INTERVAL_MS);
@@ -43,6 +44,7 @@ function pauseForDbShutdown(): void {
   awaitingDbRecovery = true;
   if (tickTimer) { clearInterval(tickTimer); tickTimer = null; }
   if (dbShutdownRetryTimer) return;
+  /** Probe callback: retries the tick once; `runDecayTick` reschedules another probe itself if it's still failing while `awaitingDbRecovery` is true. */
   dbShutdownRetryTimer = setTimeout(() => {
     dbShutdownRetryTimer = null;
     runDecayTick().catch((err) => log.error('Decay tick error while probing DB availability:', err));
@@ -106,6 +108,13 @@ export async function runDecayTick(): Promise<void> {
         pauseForDbShutdown();
       } else {
         log.error('Failed to load enabled pricing rows:', err);
+        // A recovery probe can fail with something other than the shutdown error it was
+        // triggered by (e.g. a transient network blip) — without this, that probe's own
+        // cleanup would already have cleared dbShutdownRetryTimer, leaving the scheduler
+        // paused forever since nothing else would ever schedule another probe.
+        if (awaitingDbRecovery) {
+          pauseForDbShutdown();
+        }
       }
     } finally {
       tickRunning = false;

--- a/src/twitch/pricing/rewardPricingScheduler.ts
+++ b/src/twitch/pricing/rewardPricingScheduler.ts
@@ -5,10 +5,57 @@ import { applyDecayTick } from './rewardPricingService';
 const log = createLogger('RewardPricingScheduler');
 
 const DECAY_POLL_INTERVAL_MS = 30_000;
+const DB_SHUTDOWN_RETRY_INTERVAL_MS = 60_000;
 
 let tickTimer: ReturnType<typeof setInterval> | null = null;
+let dbShutdownRetryTimer: ReturnType<typeof setTimeout> | null = null;
+let awaitingDbRecovery = false;
 let tickRunning = false;
 let currentTickPromise: Promise<void> = Promise.resolve();
+
+/** True if `error` is MySQL's `ER_SERVER_SHUTDOWN` (errno 1053) — the DB server itself is restarting/shutting down. */
+function isServerShutdownError(error: unknown): boolean {
+  const err = error as { code?: string; errno?: number };
+  return err?.code === 'ER_SERVER_SHUTDOWN' || err?.errno === 1053;
+}
+
+/**
+ * Starts (or no-ops if already running) the interval that fires `runDecayTick` on a fixed
+ * cadence. Shared by `startRewardPricingScheduler` and DB-shutdown recovery so both paths
+ * track the same `tickTimer` handle.
+ */
+function startTickTimer(): void {
+  if (tickTimer) return;
+  tickTimer = setInterval(() => {
+    runDecayTick().catch((err) => log.error('Decay tick error:', err));
+  }, DECAY_POLL_INTERVAL_MS);
+}
+
+/**
+ * Pauses the regular polling interval and schedules a single probe tick after
+ * `DB_SHUTDOWN_RETRY_INTERVAL_MS` — called when a tick discovers the DB server itself is
+ * shutting down, so the scheduler stops hammering it every 30s and instead waits for it to
+ * come back. No-ops if a probe is already pending. `runDecayTick` resumes normal polling
+ * (via `resumeAfterDbRecovery`) once it manages to fetch rows again, whether that happens
+ * on the scheduled probe or an externally-triggered call.
+ */
+function pauseForDbShutdown(): void {
+  awaitingDbRecovery = true;
+  if (tickTimer) { clearInterval(tickTimer); tickTimer = null; }
+  if (dbShutdownRetryTimer) return;
+  dbShutdownRetryTimer = setTimeout(() => {
+    dbShutdownRetryTimer = null;
+    runDecayTick().catch((err) => log.error('Decay tick error while probing DB availability:', err));
+  }, DB_SHUTDOWN_RETRY_INTERVAL_MS);
+}
+
+/** Resumes normal interval polling after a successful row fetch that follows a DB-shutdown pause. No-ops if not currently paused. */
+function resumeAfterDbRecovery(): void {
+  if (!awaitingDbRecovery) return;
+  awaitingDbRecovery = false;
+  log.info('Database reachable again — resuming decay tick polling.');
+  startTickTimer();
+}
 
 /**
  * Applies a decay-only pricing sync to every reward with dynamic pricing enabled, across
@@ -28,6 +75,7 @@ export async function runDecayTick(): Promise<void> {
   currentTickPromise = (async () => {
     try {
       const rows = await getAllEnabledPricingRows();
+      resumeAfterDbRecovery();
       const distinctStreamerIds = [...new Set(rows.map((row) => row.streamer_id))];
       // Settled (not Promise.all) so one streamer's settings-fetch failure doesn't abort
       // the whole tick — that streamer's rewards simply fall back to fetching their own
@@ -53,7 +101,12 @@ export async function runDecayTick(): Promise<void> {
         ),
       );
     } catch (err) {
-      log.error('Failed to load enabled pricing rows:', err);
+      if (isServerShutdownError(err)) {
+        log.warn('Database is shutting down — pausing decay tick polling until it recovers.');
+        pauseForDbShutdown();
+      } else {
+        log.error('Failed to load enabled pricing rows:', err);
+      }
     } finally {
       tickRunning = false;
     }
@@ -66,15 +119,17 @@ export async function runDecayTick(): Promise<void> {
  * No-ops if already started, so a second call can't leak the original interval handle.
  */
 export function startRewardPricingScheduler(): void {
-  if (tickTimer) return;
-  tickTimer = setInterval(() => {
-    runDecayTick().catch((err) => log.error('Decay tick error:', err));
-  }, DECAY_POLL_INTERVAL_MS);
+  startTickTimer();
   log.info(`Started — decay tick every ${DECAY_POLL_INTERVAL_MS / 1000}s`);
 }
 
-/** Stops the periodic decay-tick interval and awaits any in-flight tick before returning. */
+/**
+ * Stops the periodic decay-tick interval (and any pending DB-shutdown recovery probe) and
+ * awaits any in-flight tick before returning.
+ */
 export async function stopRewardPricingScheduler(): Promise<void> {
   if (tickTimer) { clearInterval(tickTimer); tickTimer = null; }
   await currentTickPromise;
+  if (dbShutdownRetryTimer) { clearTimeout(dbShutdownRetryTimer); dbShutdownRetryTimer = null; }
+  awaitingDbRecovery = false;
 }


### PR DESCRIPTION
## Summary
- `runDecayTick` was hitting MySQL's `ER_SERVER_SHUTDOWN` (errno 1053) every 30s while the DB server itself restarted, logged as `Failed to load enabled pricing rows: Server shutdown in progress`.
- Added `isServerShutdownError` to detect that specific transient error and `pauseForDbShutdown`/`resumeAfterDbRecovery` to stop the regular 30s interval and retry once after 60s instead of hammering the DB on every tick.
- Normal polling resumes automatically once a probe (or any subsequent call) successfully fetches rows again.
- `stopRewardPricingScheduler` now also clears the pending recovery probe so a graceful shutdown doesn't leave a stray timer.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 3022 tests passing)
- [x] Added scheduler tests covering pause-then-recover and continued-retry-while-down scenarios

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQCMR3oRM5p8JKsexQmjH3)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reward pricing updates during temporary database shutdowns.
  * Pauses regular updates while the database is unavailable and automatically checks for recovery after 60 seconds.
  * Resumes normal update polling once the database connection is restored.
  * Continues periodic recovery checks when the shutdown persists or temporary probe failures occur.
  * Ensures pending recovery checks are cleared when the scheduler stops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->