### PR TITLE
Fix CVE-2026-69152: bump brace-expansion to 5.0.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2108,9 +2108,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- `npm audit` flagged `brace-expansion@5.0.8` as vulnerable to CVE-2026-69152 (GHSA-rgw5-rvv9-x895), a high-severity DoS via unbounded intermediate arrays.
- Ran `npm audit fix`, bumping the transitive `eslint` → `minimatch` → `brace-expansion` dependency from 5.0.8 to the patched 5.0.9.
- `npm audit` now reports 0 vulnerabilities.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (161 test files, 3020 tests, all passing)
- [x] `npm audit` — 0 vulnerabilities


---
_Generated by [Claude Code](https://claude.ai/code/session_013cjoMBPoXVy88Z5wrdBgTa)_