### PR TITLE
Fix ws DoS vulnerability (CVE-2026-62389) by bumping override to >=8.21.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5878,9 +5878,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "winston-daily-rotate-file": "^5.0.0"
   },
   "overrides": {
-    "ws": ">=8.21.0",
+    "ws": ">=8.21.1",
     "undici": "^7.24.1",
     "mysql2": "^3.23.1"
   },


### PR DESCRIPTION
## Summary
- `ws@8.21.0` (resolved via the `overrides` entry, pulled in transitively by `@discordjs/voice`, `discord.js`, `openai`, and `tmi.js`) is affected by [AIKIDO-2026-138234 / CVE-2026-62389](https://github.com/websockets/ws/releases/t...), a DoS vulnerability where an unauthenticated peer can pin unbounded heap by sending a text frame with `FIN=0` followed by many tiny incomplete continuation frames, since the default `maxFragments`/`maxBufferedChunks` values were too high.
- Bumped the `ws` override in `package.json` from `>=8.21.0` to `>=8.21.1` (the patched version) and ran `npm install` to update `package-lock.json`. Confirmed via `npm ls ws` that all four dependents now resolve to `ws@8.21.1`.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (161 files / 3020 tests passing)
- [x] `npm ls ws` confirms all instances resolve to `8.21.1`


---
_Generated by [Claude Code](https://claude.ai/code/session_01DfUqvATLnso6W385c49MRU)_