### PR TITLE
Add tests for cooldownGate and the shared assignment router

### DIFF
--- a/src/commands/cooldownGate.test.ts
+++ b/src/commands/cooldownGate.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../shared/config', () => ({ GLOBAL_COOLDOWN_MS: 3_000 }));
+
+import { createCooldownGate } from './cooldownGate';
+
+const COOLDOWN_MS = 3_000;
+let mockNow = 1_000_000_000_000;
+
+beforeEach(() => {
+  mockNow = 1_000_000_000_000;
+  vi.spyOn(Date, 'now').mockImplementation(() => mockNow);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('createCooldownGate', () => {
+  it('allows the first claim for a key', () => {
+    const gate = createCooldownGate();
+    expect(gate.tryClaim('a')).toBe(true);
+  });
+
+  it('blocks a second claim for the same key within the cooldown window', () => {
+    const gate = createCooldownGate();
+    expect(gate.tryClaim('a')).toBe(true);
+    mockNow += COOLDOWN_MS - 1;
+    expect(gate.tryClaim('a')).toBe(false);
+  });
+
+  it('allows a claim again once the cooldown window has elapsed', () => {
+    const gate = createCooldownGate();
+    expect(gate.tryClaim('a')).toBe(true);
+    mockNow += COOLDOWN_MS;
+    expect(gate.tryClaim('a')).toBe(true);
+  });
+
+  it('does not move the recorded claim time when a claim is blocked', () => {
+    const gate = createCooldownGate();
+    expect(gate.tryClaim('a')).toBe(true);
+    mockNow += COOLDOWN_MS - 1;
+    expect(gate.tryClaim('a')).toBe(false);
+    mockNow += 1;
+    expect(gate.tryClaim('a')).toBe(true);
+  });
+
+  it('tracks keys independently', () => {
+    const gate = createCooldownGate();
+    expect(gate.tryClaim('a')).toBe(true);
+    expect(gate.tryClaim('b')).toBe(true);
+    expect(gate.tryClaim('a')).toBe(false);
+  });
+
+  it('forget clears a key so the next claim succeeds immediately', () => {
+    const gate = createCooldownGate();
+    expect(gate.tryClaim('a')).toBe(true);
+    gate.forget('a');
+    expect(gate.tryClaim('a')).toBe(true);
+  });
+
+  it('forget is a no-op for a key with no recorded claim', () => {
+    const gate = createCooldownGate();
+    expect(() => gate.forget('never-claimed')).not.toThrow();
+  });
+});

--- a/src/web/routes/assignmentRoutes.test.ts
+++ b/src/web/routes/assignmentRoutes.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mockLogger } from '../../test-utils/loggerMock';
+import { ACCESS_LEVEL_MOCK } from '../../test-utils/accessLevelMock';
+
+vi.mock('../../db', () => ({
+  findUser: vi.fn().mockResolvedValue(null),
+  AccessLevel: ACCESS_LEVEL_MOCK,
+}));
+vi.mock('../csrf', () => ({
+  csrfProtection: (_req: any, _res: any, next: any) => next(),
+}));
+vi.mock('../middleware', () => ({
+  requireMod: (_req: any, _res: any, next: any) => next(),
+}));
+
+import supertest from 'supertest';
+import { createAssignmentRouter } from './assignmentRoutes';
+import { findUser } from '../../db';
+import { buildTestApp } from '../../test-utils/expressTestApp';
+
+/** Builds a supertest-ready app mounting a `createAssignmentRouter` instance with a urlencoded body parser. */
+function buildApp(router: ReturnType<typeof createAssignmentRouter>) {
+  return buildTestApp({ router, bodyParser: 'urlencoded' });
+}
+
+const VALID_ID = '5';
+const VALID_DISCORD_ID = '123456789012345678'; // 18 digits
+
+const parseId = (raw: string): number | null => {
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : null;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(findUser).mockResolvedValue({ discord_id: VALID_DISCORD_ID, discord_name: 'Alice', twitch_name: 'alice' } as any);
+});
+
+describe('createAssignmentRouter — assign', () => {
+  it('redirects to basePath on success', async () => {
+    const assign = vi.fn().mockResolvedValue(undefined);
+    const router = createAssignmentRouter({
+      basePath: '/things', idField: 'thing_id', parseId, assign, unassign: vi.fn(), log: mockLogger() as any,
+    });
+    const res = await supertest(buildApp(router))
+      .post('/things/assign')
+      .send(`thing_id=${VALID_ID}&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/things');
+    expect(assign).toHaveBeenCalledWith(5, VALID_DISCORD_ID);
+  });
+
+  it('redirects to ?error=missing_fields when fields are absent', async () => {
+    const router = createAssignmentRouter({
+      basePath: '/things', idField: 'thing_id', parseId, assign: vi.fn(), unassign: vi.fn(), log: mockLogger() as any,
+    });
+    const res = await supertest(buildApp(router)).post('/things/assign').send('');
+    expect(res.headers.location).toBe('/things?error=missing_fields');
+  });
+
+  it('redirects to ?error=invalid_id when parseId rejects the id', async () => {
+    const router = createAssignmentRouter({
+      basePath: '/things', idField: 'thing_id', parseId, assign: vi.fn(), unassign: vi.fn(), log: mockLogger() as any,
+    });
+    const res = await supertest(buildApp(router))
+      .post('/things/assign')
+      .send(`thing_id=abc&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/things?error=invalid_id');
+  });
+
+  it('redirects to ?error=invalid_id for a malformed discord_id', async () => {
+    const router = createAssignmentRouter({
+      basePath: '/things', idField: 'thing_id', parseId, assign: vi.fn(), unassign: vi.fn(), log: mockLogger() as any,
+    });
+    const res = await supertest(buildApp(router))
+      .post('/things/assign')
+      .send(`thing_id=${VALID_ID}&discord_id=bad`);
+    expect(res.headers.location).toBe('/things?error=invalid_id');
+  });
+
+  it('redirects to ?error=invalid_assignment_user when the user does not exist', async () => {
+    vi.mocked(findUser).mockResolvedValue(null);
+    const router = createAssignmentRouter({
+      basePath: '/things', idField: 'thing_id', parseId, assign: vi.fn(), unassign: vi.fn(), log: mockLogger() as any,
+    });
+    const res = await supertest(buildApp(router))
+      .post('/things/assign')
+      .send(`thing_id=${VALID_ID}&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/things?error=invalid_assignment_user');
+  });
+
+  it('redirects to ?error=invalid_assignment_user when the user has no twitch_name', async () => {
+    vi.mocked(findUser).mockResolvedValue({ discord_id: VALID_DISCORD_ID, discord_name: 'Alice', twitch_name: null } as any);
+    const router = createAssignmentRouter({
+      basePath: '/things', idField: 'thing_id', parseId, assign: vi.fn(), unassign: vi.fn(), log: mockLogger() as any,
+    });
+    const res = await supertest(buildApp(router))
+      .post('/things/assign')
+      .send(`thing_id=${VALID_ID}&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/things?error=invalid_assignment_user');
+  });
+
+  it('redirects to the mapped error code without logging when mapAssignError handles the thrown error', async () => {
+    const assign = vi.fn().mockRejectedValueOnce(new Error('conflict'));
+    const log = mockLogger();
+    const router = createAssignmentRouter({
+      basePath: '/things',
+      idField: 'thing_id',
+      parseId,
+      assign,
+      unassign: vi.fn(),
+      mapAssignError: () => 'thing_taken',
+      log: log as any,
+    });
+    const res = await supertest(buildApp(router))
+      .post('/things/assign')
+      .send(`thing_id=${VALID_ID}&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/things?error=thing_taken');
+    expect(log.error).not.toHaveBeenCalled();
+  });
+
+  it('redirects to ?error=assign_failed and logs when the error is unmapped', async () => {
+    const assign = vi.fn().mockRejectedValueOnce(new Error('unexpected'));
+    const log = mockLogger();
+    const router = createAssignmentRouter({
+      basePath: '/things',
+      idField: 'thing_id',
+      parseId,
+      assign,
+      unassign: vi.fn(),
+      mapAssignError: () => null,
+      log: log as any,
+    });
+    const res = await supertest(buildApp(router))
+      .post('/things/assign')
+      .send(`thing_id=${VALID_ID}&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/things?error=assign_failed');
+    expect(log.error).toHaveBeenCalled();
+  });
+});
+
+describe('createAssignmentRouter — unassign', () => {
+  it('redirects to basePath on success', async () => {
+    const unassign = vi.fn().mockResolvedValue(undefined);
+    const router = createAssignmentRouter({
+      basePath: '/things', idField: 'thing_id', parseId, assign: vi.fn(), unassign, log: mockLogger() as any,
+    });
+    const res = await supertest(buildApp(router))
+      .post('/things/unassign')
+      .send(`thing_id=${VALID_ID}&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/things');
+    expect(unassign).toHaveBeenCalledWith(5, VALID_DISCORD_ID);
+  });
+
+  it('redirects to ?error=missing_fields when fields are absent', async () => {
+    const router = createAssignmentRouter({
+      basePath: '/things', idField: 'thing_id', parseId, assign: vi.fn(), unassign: vi.fn(), log: mockLogger() as any,
+    });
+    const res = await supertest(buildApp(router)).post('/things/unassign').send('');
+    expect(res.headers.location).toBe('/things?error=missing_fields');
+  });
+
+  it('redirects to ?error=invalid_id when parseId rejects the id', async () => {
+    const router = createAssignmentRouter({
+      basePath: '/things', idField: 'thing_id', parseId, assign: vi.fn(), unassign: vi.fn(), log: mockLogger() as any,
+    });
+    const res = await supertest(buildApp(router))
+      .post('/things/unassign')
+      .send(`thing_id=abc&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/things?error=invalid_id');
+  });
+
+  it('redirects to ?error=unassign_failed and logs on unexpected error', async () => {
+    const unassign = vi.fn().mockRejectedValueOnce(new Error('db error'));
+    const log = mockLogger();
+    const router = createAssignmentRouter({
+      basePath: '/things', idField: 'thing_id', parseId, assign: vi.fn(), unassign, log: log as any,
+    });
+    const res = await supertest(buildApp(router))
+      .post('/things/unassign')
+      .send(`thing_id=${VALID_ID}&discord_id=${VALID_DISCORD_ID}`);
+    expect(res.headers.location).toBe('/things?error=unassign_failed');
+    expect(log.error).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- `src/commands/cooldownGate.ts` (per-key throttle used by the custom-command and counter-trigger chat handlers) had no tests of its own — added `cooldownGate.test.ts` covering first claim, blocked claim within the window, claim allowed again after the window, `forget()`'s effect, and independent per-key tracking.
- `src/web/routes/assignmentRoutes.ts`'s `createAssignmentRouter` (the shared factory behind `commandAssignments.ts` and `timerAssignments.ts`) had no direct test of the factory itself — added `assignmentRoutes.test.ts` covering the assign/unassign validation branches, the `mapAssignError` short-circuit path, and the unmapped-error logging path, using a throwaway router built directly from the factory.
- The three SFX mutation route files initially flagged as untested (`sfxTriggerMutations.ts`, `sfxCategoryMutations.ts`, `sfxFileMutations.ts`) turned out to already be fully covered by `sfxMutations.test.ts` via the aggregator router, so no changes were needed there.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — all 3043 tests pass (19 new)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPkdbQ4diag7HpfNgvX3Y9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for cooldown behavior, including blocking, expiry, independent keys, and reset handling.
  * Added coverage for assignment and unassignment workflows, validation errors, invalid users, assignment failures, and unexpected errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->