### PR TITLE
Point users.ts/guildCommandOverrides.ts writers at db.ts's cache wrapping

### DIFF
--- a/src/db/guildCommandOverrides.ts
+++ b/src/db/guildCommandOverrides.ts
@@ -58,6 +58,10 @@ export async function getAllOverrides(): Promise<DbGuildCommandOverride[]> {
 }
 
 // ─── Mutations ─────────────────────────────────────────────────────────────────
+//
+// This module is a pure DB layer with no cache knowledge — db.ts's upsertOverride/
+// removeOverride facades wrap these two functions with a cache invalidation call. A new write
+// function added here that affects custom-command resolution needs the same treatment in db.ts.
 
 /**
  * Inserts or updates a guild's override for a catalog command.

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -170,6 +170,10 @@ async function withShortLockTimeout<T>(fn: (conn: mysql.PoolConnection) => Promi
 
 /**
  * Upserts a user record.
+ *
+ * This module is a pure DB layer with no cache knowledge — `db.ts`'s `upsertUser` facade
+ * wraps this function with a cache invalidation call. A new write function added here that
+ * affects custom-command resolution needs the same treatment in `db.ts`.
  * @param discordId - Discord snowflake as a string.
  * @param discordName - Display name to store; blank after trimming is stored as null.
  * @param accessLevel - Legacy global access level; must be one of `AccessLevel`'s values.
@@ -274,6 +278,9 @@ export async function getAllTwitchLinkedUsers(): Promise<TwitchLinkedUser[]> {
 
 /**
  * Sets whether a user's Twitch bot integration is enabled.
+ *
+ * Pure DB layer — no cache invalidation here. `db.ts`'s `updateTwitchBotEnabled` facade wraps
+ * this function with `withInvalidation`.
  * @param discordId - Discord snowflake as a string.
  * @param enabled - True to enable the Twitch bot for this user, false to disable it.
  * @returns Resolves once the update completes.


### PR DESCRIPTION
## Summary
- `db/users.ts` and `db/guildCommandOverrides.ts` are "pure" DB layers with no cache knowledge — `db.ts`'s facade (`upsertUser`, `updateTwitchBotEnabled`, `upsertOverride`, `removeOverride`) wraps their write functions with a cache-invalidation call, unlike self-invalidating modules such as `customCommands.ts`/`counters.ts`/`alertConfig.ts`/`sfx.ts`.
- That split was documented only in `CLAUDE.md` and a comment inside `db.ts` — nothing at the source in `users.ts`/`guildCommandOverrides.ts` signalled it, so a new write function added there could easily be missed by the facade wrapper.
- Added a short pointer comment above `upsertUserRecord`, `setTwitchBotEnabledRecord`, and the `upsertOverride`/`removeOverride` mutation section noting the wrapping and where it lives.
- No regression test was needed — `src/db.test.ts` already asserts each facade wrapper calls `invalidateCustomCommandLookupCache`.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — all 3024 tests pass (comment-only change, no behavior change)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPkdbQ4diag7HpfNgvX3Y9)_