### PR TITLE
Use the existing trimField helper in overlayAdminRewardMutations.ts

### DIFF
--- a/src/web/routes/overlayAdminRewardMutations.ts
+++ b/src/web/routes/overlayAdminRewardMutations.ts
@@ -4,7 +4,7 @@ import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
 import { upsertReward, setRewardVideos, deleteReward } from '../../db';
 import {
-  logAndRedirectError, parsePositiveIntId, requireStreamer, parseWeight, parseRewardIdParam,
+  logAndRedirectError, parsePositiveIntId, requireStreamer, parseWeight, parseRewardIdParam, trimField,
 } from './shared';
 import { toStringArray } from './overlayAdminShared';
 
@@ -31,7 +31,7 @@ router.post('/settings/rewards', requireAuth, csrfProtection, async (req, res) =
     if (!streamer) return;
 
     const body = req.body as Record<string, string | string[] | undefined>;
-    const rawTwitchRewardId = (typeof body.twitch_reward_id === 'string' ? body.twitch_reward_id : '').trim();
+    const rawTwitchRewardId = trimField(body.twitch_reward_id);
     const twitchRewardId = parseRewardIdParam(rawTwitchRewardId);
 
     if (twitchRewardId === null) {


### PR DESCRIPTION
## Summary
- `src/web/routes/overlayAdminRewardMutations.ts:34` inline-narrowed `body.twitch_reward_id` with `typeof body.twitch_reward_id === 'string' ? body.twitch_reward_id : ''` then `.trim()`'d it — equivalent to the existing `trimField` helper already in `web/routes/shared.ts`.
- Replaced the inline ternary with `trimField(body.twitch_reward_id)`. No behavior change.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm test` — all 3024 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01XPkdbQ4diag7HpfNgvX3Y9)_