### PR TITLE
Bump mysql2 to 3.23.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4396,9 +4396,9 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.23.1",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.23.1.tgz",
-      "integrity": "sha512-tTuRnC7qCet2IOfSNMYZ5SwXuBnfvBPAcIA28P0gtruXyZlU1LMxA6uha32kYypoFgyYklMqhLWwt4laYwXR/Q==",
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.23.2.tgz",
+      "integrity": "sha512-fxh3HpQ8vJtu/Mmnd4Xsur19jGjHGzRLMxptiDtOkbX7EVBgnafGSGDx1WGGVmJLClVh2LeeBMMo24IFv8wCyQ==",
       "license": "MIT",
       "dependencies": {
         "aws-ssl-profiles": "^1.1.2",


### PR DESCRIPTION
## Summary
- mysql2 was one patch behind (3.23.1 → 3.23.2), still within the existing `^3.23.1` range in `package.json`/`overrides`
- Ran `npm update mysql2` to refresh `package-lock.json` to the latest satisfying version; no `package.json` changes needed

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (163 files / 3043 tests passing)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VVm6E51wBDxr3mFfKbkofk)_