### PR TITLE
Fix duplicate channel point redemption events on the dashboard

### DIFF
--- a/src/twitch/eventsub/twitchEventSubDispatch.test.ts
+++ b/src/twitch/eventsub/twitchEventSubDispatch.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { logMock } = vi.hoisted(() => ({
+  logMock: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+vi.mock('../../shared/logger', () => ({ createLogger: () => logMock }));
+vi.mock('../../shared/config', () => ({}));
+vi.mock('../../db', () => ({
+  clearStreamerToken: vi.fn().mockResolvedValue(undefined),
+  DEFAULT_EVENT_CONFIG: {
+    follow_enabled: false,
+    follow_message: 'Thanks {display_name} for the follow!',
+    sub_enabled: false,
+    sub_message: 'Thanks {display_name} for subscribing! ({tier_name})',
+    resub_message: 'Thanks {display_name} for {months} months! ({tier_name})',
+    giftsub_message: '{gifter_display} gifted {count} sub(s) to the community!',
+    raid_enabled: false,
+    raid_message: 'Welcome raiders from {from_display}! Thank you for the {viewers} person raid!',
+    raid_shoutout_enabled: false,
+  },
+}));
+vi.mock('./twitchEventSubHandler', () => ({
+  handleFollow: vi.fn().mockResolvedValue(undefined),
+  handleSub: vi.fn().mockResolvedValue(undefined),
+  handleResub: vi.fn().mockResolvedValue(undefined),
+  handleGiftSub: vi.fn().mockResolvedValue(undefined),
+  handleRaid: vi.fn().mockResolvedValue(undefined),
+  handleRedemption: vi.fn().mockResolvedValue(undefined),
+  handleStreamOnline: vi.fn().mockResolvedValue(undefined),
+  handleStreamOffline: vi.fn().mockResolvedValue(undefined),
+  handleChannelUpdate: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { setStreamerInfo, removeStreamerFromMap, dispatchNotification, handleRevocation } from './twitchEventSubDispatch';
+import { clearStreamerToken, DEFAULT_EVENT_CONFIG } from '../../db';
+import {
+  handleStreamOnline, handleStreamOffline, handleChannelUpdate,
+  handleFollow, handleSub, handleResub, handleGiftSub, handleRaid, handleRedemption,
+} from './twitchEventSubHandler';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// dispatchNotification — stream.online / stream.offline routing
+// ---------------------------------------------------------------------------
+describe('dispatchNotification routes stream.online/offline', () => {
+  beforeEach(() => {
+    setStreamerInfo('uid-dispatch', {
+      login: 'liveStreamer', streamerId: 30,
+      config: { follow_enabled: false, sub_enabled: false, raid_enabled: false } as any,
+    });
+  });
+
+  it('calls handleStreamOnline for a stream.online notification', () => {
+    dispatchNotification('stream.online', {}, { broadcaster_user_id: 'uid-dispatch' });
+    expect(handleStreamOnline).toHaveBeenCalledWith('liveStreamer');
+  });
+
+  it('calls handleStreamOffline for a stream.offline notification', () => {
+    dispatchNotification('stream.offline', {}, { broadcaster_user_id: 'uid-dispatch' });
+    expect(handleStreamOffline).toHaveBeenCalledWith('liveStreamer');
+  });
+
+  it('calls handleChannelUpdate for a channel.update notification', () => {
+    dispatchNotification('channel.update', {}, { broadcaster_user_id: 'uid-dispatch' });
+    expect(handleChannelUpdate).toHaveBeenCalledWith('liveStreamer');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dispatchNotification — remaining notification types
+// ---------------------------------------------------------------------------
+describe('dispatchNotification routes chat-alert and redemption events', () => {
+  beforeEach(() => {
+    setStreamerInfo('uid-alert', {
+      login: 'alertStreamer', streamerId: 50,
+      config: { follow_enabled: true, sub_enabled: true, raid_enabled: true } as any,
+    });
+  });
+
+  it('routes channel.follow to handleFollow', () => {
+    dispatchNotification('channel.follow', { user_name: 'follower' }, { broadcaster_user_id: 'uid-alert' });
+    expect(handleFollow).toHaveBeenCalledWith('alertStreamer', { user_name: 'follower' }, expect.anything(), 50);
+  });
+
+  it('routes channel.subscribe to handleSub', () => {
+    dispatchNotification('channel.subscribe', { tier: '1000' }, { broadcaster_user_id: 'uid-alert' });
+    expect(handleSub).toHaveBeenCalledWith('alertStreamer', { tier: '1000' }, expect.anything(), 50);
+  });
+
+  it('routes channel.subscription.message to handleResub', () => {
+    dispatchNotification('channel.subscription.message', { cumulative_months: 5 }, { broadcaster_user_id: 'uid-alert' });
+    expect(handleResub).toHaveBeenCalledWith('alertStreamer', { cumulative_months: 5 }, expect.anything(), 50);
+  });
+
+  it('routes channel.subscription.gift to handleGiftSub', () => {
+    dispatchNotification('channel.subscription.gift', { total: 3 }, { broadcaster_user_id: 'uid-alert' });
+    expect(handleGiftSub).toHaveBeenCalledWith('alertStreamer', { total: 3 }, expect.anything(), 50);
+  });
+
+  it('routes channel.raid to handleRaid using to_broadcaster_user_id', () => {
+    dispatchNotification('channel.raid', { from_broadcaster_user_name: 'raider' }, { to_broadcaster_user_id: 'uid-alert' });
+    expect(handleRaid).toHaveBeenCalledWith('alertStreamer', { from_broadcaster_user_name: 'raider' }, expect.anything(), 50);
+  });
+
+  it('routes a channel-points redemption to handleRedemption with the streamerId', () => {
+    dispatchNotification(
+      'channel.channel_points_custom_reward_redemption.add',
+      { reward: { id: 'r1' } },
+      { broadcaster_user_id: 'uid-alert' },
+    );
+    expect(handleRedemption).toHaveBeenCalledWith('alertStreamer', { reward: { id: 'r1' } }, expect.anything(), 50);
+  });
+
+  it('logs a warning and does nothing for an unsupported notification type', () => {
+    dispatchNotification('channel.cheer', {}, { broadcaster_user_id: 'uid-alert' });
+    expect(logMock.warn).toHaveBeenCalledWith('Unsupported EventSub notification type: channel.cheer');
+    expect(handleFollow).not.toHaveBeenCalled();
+  });
+
+  it('logs an error when the routed handler rejects', async () => {
+    vi.mocked(handleFollow).mockRejectedValueOnce(new Error('handler exploded'));
+
+    dispatchNotification('channel.follow', {}, { broadcaster_user_id: 'uid-alert' });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(logMock.error).toHaveBeenCalledWith('channel.follow handler error:', expect.any(Error));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dispatchNotification — streamer with no streamer_event_config row
+// ---------------------------------------------------------------------------
+describe('dispatchNotification with a null streamer config (alert-only streamer)', () => {
+  beforeEach(() => {
+    setStreamerInfo('uid-alert-only', { login: 'alertOnlyStreamer', streamerId: 60, config: null });
+  });
+
+  it('still routes the notification, falling back to DEFAULT_EVENT_CONFIG instead of dropping it', () => {
+    dispatchNotification('channel.follow', { user_name: 'follower' }, { broadcaster_user_id: 'uid-alert-only' });
+    expect(handleFollow).toHaveBeenCalledWith('alertOnlyStreamer', { user_name: 'follower' }, DEFAULT_EVENT_CONFIG, 60);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeStreamerFromMap
+// ---------------------------------------------------------------------------
+describe('removeStreamerFromMap', () => {
+  beforeEach(() => {
+    setStreamerInfo('uid-rm', {
+      login: 'removable', streamerId: 60,
+      config: { follow_enabled: false, sub_enabled: false, raid_enabled: false } as any,
+    });
+  });
+
+  it('removes the streamer so dispatchNotification no longer routes to it', () => {
+    removeStreamerFromMap('uid-rm');
+
+    dispatchNotification('stream.online', {}, { broadcaster_user_id: 'uid-rm' });
+
+    expect(handleStreamOnline).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleRevocation
+// ---------------------------------------------------------------------------
+describe('handleRevocation', () => {
+  beforeEach(() => {
+    vi.mocked(clearStreamerToken).mockResolvedValue(true as any);
+    setStreamerInfo('uid-revoke', {
+      login: 'revokedStreamer', streamerId: 100,
+      config: { follow_enabled: false, sub_enabled: false, raid_enabled: false } as any,
+    });
+  });
+
+  it('logs the revocation but does not clear a token for an unknown broadcaster', () => {
+    handleRevocation({ type: 'channel.follow', status: 'authorization_revoked', condition: { broadcaster_user_id: 'unknown-uid' } });
+
+    expect(logMock.warn).toHaveBeenCalledWith('Subscription revoked: type=channel.follow status=authorization_revoked');
+    expect(clearStreamerToken).not.toHaveBeenCalled();
+  });
+
+  it('clears the token when status is authorization_revoked for a known broadcaster', () => {
+    handleRevocation({ type: 'channel.follow', status: 'authorization_revoked', condition: { broadcaster_user_id: 'uid-revoke' } });
+
+    expect(clearStreamerToken).toHaveBeenCalledWith(100);
+    expect(logMock.warn).toHaveBeenCalledWith('Cleared token for revokedStreamer (authorization_revoked)');
+  });
+
+  it('clears the token when status is user_removed, using to_broadcaster_user_id', () => {
+    handleRevocation({ type: 'channel.raid', status: 'user_removed', condition: { to_broadcaster_user_id: 'uid-revoke' } });
+
+    expect(clearStreamerToken).toHaveBeenCalledWith(100);
+    expect(logMock.warn).toHaveBeenCalledWith('Cleared token for revokedStreamer (user_removed)');
+  });
+
+  it('does not clear the token for other revocation statuses', () => {
+    handleRevocation({ type: 'channel.follow', status: 'moderator_removed', condition: { broadcaster_user_id: 'uid-revoke' } });
+
+    expect(clearStreamerToken).not.toHaveBeenCalled();
+  });
+
+  it('logs an error if clearing the token itself fails', async () => {
+    vi.mocked(clearStreamerToken).mockRejectedValueOnce(new Error('db down'));
+
+    handleRevocation({ type: 'channel.follow', status: 'authorization_revoked', condition: { broadcaster_user_id: 'uid-revoke' } });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(logMock.error).toHaveBeenCalledWith('Clear token error:', expect.any(Error));
+  });
+});

--- a/src/twitch/eventsub/twitchEventSubDispatch.test.ts
+++ b/src/twitch/eventsub/twitchEventSubDispatch.test.ts
@@ -183,15 +183,17 @@ describe('handleRevocation', () => {
     expect(clearStreamerToken).not.toHaveBeenCalled();
   });
 
-  it('clears the token when status is authorization_revoked for a known broadcaster', () => {
+  it('clears the token when status is authorization_revoked for a known broadcaster', async () => {
     handleRevocation({ type: 'channel.follow', status: 'authorization_revoked', condition: { broadcaster_user_id: 'uid-revoke' } });
+    await new Promise((resolve) => setImmediate(resolve));
 
     expect(clearStreamerToken).toHaveBeenCalledWith(100);
     expect(logMock.warn).toHaveBeenCalledWith('Cleared token for revokedStreamer (authorization_revoked)');
   });
 
-  it('clears the token when status is user_removed, using to_broadcaster_user_id', () => {
+  it('clears the token when status is user_removed, using to_broadcaster_user_id', async () => {
     handleRevocation({ type: 'channel.raid', status: 'user_removed', condition: { to_broadcaster_user_id: 'uid-revoke' } });
+    await new Promise((resolve) => setImmediate(resolve));
 
     expect(clearStreamerToken).toHaveBeenCalledWith(100);
     expect(logMock.warn).toHaveBeenCalledWith('Cleared token for revokedStreamer (user_removed)');

--- a/src/twitch/eventsub/twitchEventSubDispatch.ts
+++ b/src/twitch/eventsub/twitchEventSubDispatch.ts
@@ -80,8 +80,8 @@ export function handleRevocation(sub: { type: string; status: string; condition:
       const info = streamerMap.get(broadcasterId);
       if (info) {
         clearStreamerToken(info.streamerId)
+          .then(() => log.warn(`Cleared token for ${info.login} (${sub.status})`))
           .catch((err) => log.error('Clear token error:', err));
-        log.warn(`Cleared token for ${info.login} (${sub.status})`);
       }
     }
   }

--- a/src/twitch/eventsub/twitchEventSubDispatch.ts
+++ b/src/twitch/eventsub/twitchEventSubDispatch.ts
@@ -1,0 +1,88 @@
+import { createLogger } from '../../shared/logger';
+import { clearStreamerToken, DEFAULT_EVENT_CONFIG } from '../../db';
+import type { EventSubConfig } from '../../db';
+import {
+  handleFollow, handleSub, handleResub, handleGiftSub, handleRaid, handleRedemption,
+  handleStreamOnline, handleStreamOffline, handleChannelUpdate,
+  FollowEvent, SubEvent, ResubEvent, GiftSubEvent, RaidEvent, RedemptionEvent,
+} from './twitchEventSubHandler';
+
+const log = createLogger('EventSub');
+
+/** In-memory streamer info keyed by broadcaster user ID. */
+export interface StreamerInfo { login: string; streamerId: number; config: EventSubConfig | null }
+const streamerMap = new Map<string, StreamerInfo>();
+
+/** Records or updates a streamer's dispatch info, keyed by their broadcaster user ID. */
+export function setStreamerInfo(uid: string, info: StreamerInfo): void {
+  streamerMap.set(uid, info);
+}
+
+/** Removes a streamer from the in-memory map (called when their connection is stopped). */
+export function removeStreamerFromMap(uid: string): void {
+  streamerMap.delete(uid);
+}
+
+// Maps EventSub notification types to their handler functions.
+// Using Map instead of a plain object prevents prototype-chain lookup on user-controlled keys.
+type NotificationHandler = (login: string, event: unknown, config: EventSubConfig, streamerId: number) => Promise<void>;
+const notificationHandlers = new Map<string, NotificationHandler>([
+  ['channel.follow',                                   (l, e, c, sid) => handleFollow(l, e as FollowEvent, c, sid)],
+  ['channel.subscribe',                                (l, e, c, sid) => handleSub(l, e as SubEvent, c, sid)],
+  ['channel.subscription.message',                     (l, e, c, sid) => handleResub(l, e as ResubEvent, c, sid)],
+  ['channel.subscription.gift',                        (l, e, c, sid) => handleGiftSub(l, e as GiftSubEvent, c, sid)],
+  ['channel.raid',                                     (l, e, c, sid) => handleRaid(l, e as RaidEvent, c, sid)],
+  ['channel.channel_points_custom_reward_redemption.add',  (l, e, c, sid) => handleRedemption(l, e as RedemptionEvent, c, sid)],
+  ['stream.online',                                    (l) => handleStreamOnline(l)],
+  ['stream.offline',                                   (l) => handleStreamOffline(l)],
+  ['channel.update',                                    (l) => handleChannelUpdate(l)],
+]);
+
+/**
+ * Routes an EventSub notification to the appropriate handler based on subscription type.
+ * A streamer with no `streamer_event_config` row (`info.config` null) — e.g. one who has only
+ * ever enabled a browser-source alert and never completed the chat-message OAuth setup — still
+ * dispatches, using `DEFAULT_EVENT_CONFIG` (every chat-message flag disabled) in place of the
+ * missing config, so their alert-only subscriptions aren't silently discarded here. Without
+ * this fallback, `isGroupEnabled`'s alert-driven subscription creation and this dispatch gate
+ * would disagree: the subscription would exist but every notification for it would be dropped.
+ */
+export function dispatchNotification(type: string, event: Record<string, unknown>, condition: Record<string, string>): void {
+  const broadcasterId = condition.broadcaster_user_id ?? condition.to_broadcaster_user_id;
+  if (!broadcasterId) return;
+
+  const info = streamerMap.get(broadcasterId);
+  if (!info) return;
+  const config = info.config ?? DEFAULT_EVENT_CONFIG;
+
+  const handler = notificationHandlers.get(type);
+  if (!handler) {
+    log.warn(`Unsupported EventSub notification type: ${type}`);
+    return;
+  }
+  // TypeScript has already narrowed handler to NotificationHandler here, but the explicit
+  // typeof check is required for CodeQL's taint analysis to trust the call is safe.
+  if (typeof handler !== 'function') {
+    log.warn(`Invalid EventSub handler for type: ${type}`);
+    return;
+  }
+  handler(info.login, event, config, info.streamerId)
+    .catch((err) => log.error(`${type} handler error:`, err));
+}
+
+/** Handles a subscription revocation message, clearing the broadcaster's token if authorisation was revoked. */
+export function handleRevocation(sub: { type: string; status: string; condition: Record<string, string> }): void {
+  log.warn(`Subscription revoked: type=${sub.type} status=${sub.status}`);
+
+  if (sub.status === 'authorization_revoked' || sub.status === 'user_removed') {
+    const broadcasterId = sub.condition.broadcaster_user_id ?? sub.condition.to_broadcaster_user_id;
+    if (broadcasterId) {
+      const info = streamerMap.get(broadcasterId);
+      if (info) {
+        clearStreamerToken(info.streamerId)
+          .catch((err) => log.error('Clear token error:', err));
+        log.warn(`Cleared token for ${info.login} (${sub.status})`);
+      }
+    }
+  }
+}

--- a/src/twitch/eventsub/twitchEventSubHandler.test.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.test.ts
@@ -12,7 +12,7 @@ vi.mock('../pricing/rewardPricingService', () => ({ applyRedemptionPricing: vi.f
 
 import {
   handleFollow, handleSub, handleResub, handleGiftSub, handleRaid, handleRedemption,
-  handleStreamOnline, handleStreamOffline, handleChannelUpdate,
+  handleStreamOnline, handleStreamOffline, handleChannelUpdate, seenRedemptionIds,
 } from './twitchEventSubHandler';
 import {
   registerEventSubOverlayRuntime, registerEventSubTwitchRuntime, registerEventSubCompanionRuntime,
@@ -728,6 +728,7 @@ describe('handleRedemption', () => {
 
   beforeEach(() => {
     vi.mocked(getStreamerById).mockResolvedValue({ discord_id: '999888777' } as any);
+    seenRedemptionIds.clear();
   });
 
   it('does not call pushOverlayEvent when getVideosForReward returns an empty array', async () => {
@@ -833,6 +834,27 @@ describe('handleRedemption', () => {
     await handleRedemption('streamer', event, makeConfig(), streamerId);
 
     expect(mockPushOverlayEvent).toHaveBeenCalledWith('streamer', '/overlay/videos/7/clip1.mp4');
+  });
+
+  it('ignores a second notification carrying the same redemption id', async () => {
+    vi.mocked(getVideosForReward).mockResolvedValue([]);
+
+    await handleRedemption('streamer', event, makeConfig(), streamerId);
+    await handleRedemption('streamer', event, makeConfig(), streamerId);
+
+    expect(recordStreamerEvent).toHaveBeenCalledOnce();
+    expect(mockPushDashboardEvent).toHaveBeenCalledOnce();
+    expect(mockPushCompanionEvent).toHaveBeenCalledOnce();
+    expect(applyRedemptionPricing).toHaveBeenCalledOnce();
+  });
+
+  it('processes two notifications with different redemption ids normally', async () => {
+    vi.mocked(getVideosForReward).mockResolvedValue([]);
+
+    await handleRedemption('streamer', event, makeConfig(), streamerId);
+    await handleRedemption('streamer', { ...event, id: 'redemption-2' }, makeConfig(), streamerId);
+
+    expect(recordStreamerEvent).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/twitch/eventsub/twitchEventSubHandler.test.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.test.ts
@@ -12,8 +12,9 @@ vi.mock('../pricing/rewardPricingService', () => ({ applyRedemptionPricing: vi.f
 
 import {
   handleFollow, handleSub, handleResub, handleGiftSub, handleRaid, handleRedemption,
-  handleStreamOnline, handleStreamOffline, handleChannelUpdate, seenRedemptionIds,
+  handleStreamOnline, handleStreamOffline, handleChannelUpdate,
 } from './twitchEventSubHandler';
+import { seenRedemptionIds } from './twitchEventSubRedemptionDedup';
 import {
   registerEventSubOverlayRuntime, registerEventSubTwitchRuntime, registerEventSubCompanionRuntime,
   registerEventSubAlertRuntime, registerEventSubDashboardRuntime,

--- a/src/twitch/eventsub/twitchEventSubHandler.test.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.test.ts
@@ -838,7 +838,9 @@ describe('handleRedemption', () => {
   });
 
   it('ignores a second notification carrying the same redemption id', async () => {
-    vi.mocked(getVideosForReward).mockResolvedValue([]);
+    const videos = [{ file: 'clip1.mp4', weight: 1 }] as any[];
+    vi.mocked(getVideosForReward).mockResolvedValue(videos);
+    vi.mocked(pickWeightedRandom).mockReturnValue('clip1.mp4');
 
     await handleRedemption('streamer', event, makeConfig(), streamerId);
     await handleRedemption('streamer', event, makeConfig(), streamerId);
@@ -847,6 +849,8 @@ describe('handleRedemption', () => {
     expect(mockPushDashboardEvent).toHaveBeenCalledOnce();
     expect(mockPushCompanionEvent).toHaveBeenCalledOnce();
     expect(applyRedemptionPricing).toHaveBeenCalledOnce();
+    expect(getVideosForReward).toHaveBeenCalledOnce();
+    expect(mockPushOverlayEvent).toHaveBeenCalledOnce();
   });
 
   it('processes two notifications with different redemption ids normally', async () => {

--- a/src/twitch/eventsub/twitchEventSubHandler.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.ts
@@ -68,6 +68,30 @@ function tierName(tier: string): string {
   return ({ '1000': 'Tier 1', '2000': 'Tier 2', '3000': 'Tier 3' } as Record<string, string>)[tier] ?? tier;
 }
 
+/** How long a redemption id is remembered for deduplication (ms). */
+const REDEMPTION_DEDUP_TTL_MS = 10 * 60 * 1000;
+
+// TTL-based dedup keyed by Twitch's own redemption id, not the EventSub message envelope id.
+// twitchEventSubConnection.ts's message_id dedup only catches the same WebSocket delivery being
+// replayed (e.g. during a documented session-migration window); it can't catch the same physical
+// redemption arriving via two independently-created "enabled" subscriptions (e.g. a stale
+// subscription left over from a prior process that Twitch hasn't yet revoked, or two bot
+// instances briefly running against the same channel) — those arrive as distinct messages with
+// distinct message_ids but carry the same redemption `event.id`. Exported so tests can reset it.
+export const seenRedemptionIds = new Map<string, number>();
+
+/** Returns true if redemptionId has been seen within REDEMPTION_DEDUP_TTL_MS; records it otherwise. */
+function isDuplicateRedemption(redemptionId: string): boolean {
+  const now = Date.now();
+  const expiry = seenRedemptionIds.get(redemptionId);
+  if (expiry !== undefined && now <= expiry) return true;
+  seenRedemptionIds.set(redemptionId, now + REDEMPTION_DEDUP_TTL_MS);
+  for (const [id, exp] of seenRedemptionIds) {
+    if (exp < now) seenRedemptionIds.delete(id);
+  }
+  return false;
+}
+
 /**
  * Sends a chat message via the injected Twitch runtime, logging and swallowing any failure
  * (e.g. the bot lacking channel access, or a transient Twitch API error) instead of letting it
@@ -341,6 +365,11 @@ export async function handleRaid(login: string, event: RaidEvent, config: EventS
  * caught via `.catch` instead of awaited), so its network latency truly can't delay the
  * overlay-video logic below.
  *
+ * Deduplicates on Twitch's own redemption id ({@link isDuplicateRedemption}) before doing
+ * anything else — a duplicate is dropped silently, since every effect below (companion push,
+ * dashboard record, pricing, overlay trigger) would otherwise double-fire for one physical
+ * redemption.
+ *
  * @param login - Broadcaster login name.
  * @param event - Redemption event payload including reward ID and user details.
  * @param _config - Streamer event config (unused for redemptions; reserved for future use).
@@ -352,6 +381,11 @@ export async function handleRedemption(
   _config: EventSubConfig,
   streamerId: number,
 ): Promise<void> {
+  if (isDuplicateRedemption(event.id)) {
+    log.warn(`Duplicate redemption notification for "${event.reward.title}" (id=${event.id}) — ignoring`);
+    return;
+  }
+
   try {
     const streamer = await getStreamerById(streamerId);
     if (streamer) {

--- a/src/twitch/eventsub/twitchEventSubHandler.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.ts
@@ -6,6 +6,7 @@ import { createLogger } from '../../shared/logger';
 import { triggerImmediateLiveCheck } from '../monitor/twitchMonitor';
 import { fillTemplate } from '../../shared/textTemplate';
 import { applyRedemptionPricing } from '../pricing/rewardPricingService';
+import { isDuplicateRedemption } from './twitchEventSubRedemptionDedup';
 import {
   overlayRuntimeRegistry,
   companionRuntimeRegistry,
@@ -66,30 +67,6 @@ export interface RedemptionEvent {
 
 function tierName(tier: string): string {
   return ({ '1000': 'Tier 1', '2000': 'Tier 2', '3000': 'Tier 3' } as Record<string, string>)[tier] ?? tier;
-}
-
-/** How long a redemption id is remembered for deduplication (ms). */
-const REDEMPTION_DEDUP_TTL_MS = 10 * 60 * 1000;
-
-// TTL-based dedup keyed by Twitch's own redemption id, not the EventSub message envelope id.
-// twitchEventSubConnection.ts's message_id dedup only catches the same WebSocket delivery being
-// replayed (e.g. during a documented session-migration window); it can't catch the same physical
-// redemption arriving via two independently-created "enabled" subscriptions (e.g. a stale
-// subscription left over from a prior process that Twitch hasn't yet revoked, or two bot
-// instances briefly running against the same channel) — those arrive as distinct messages with
-// distinct message_ids but carry the same redemption `event.id`. Exported so tests can reset it.
-export const seenRedemptionIds = new Map<string, number>();
-
-/** Returns true if redemptionId has been seen within REDEMPTION_DEDUP_TTL_MS; records it otherwise. */
-function isDuplicateRedemption(redemptionId: string): boolean {
-  const now = Date.now();
-  const expiry = seenRedemptionIds.get(redemptionId);
-  if (expiry !== undefined && now <= expiry) return true;
-  seenRedemptionIds.set(redemptionId, now + REDEMPTION_DEDUP_TTL_MS);
-  for (const [id, exp] of seenRedemptionIds) {
-    if (exp < now) seenRedemptionIds.delete(id);
-  }
-  return false;
 }
 
 /**

--- a/src/twitch/eventsub/twitchEventSubRedemptionDedup.test.ts
+++ b/src/twitch/eventsub/twitchEventSubRedemptionDedup.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { isDuplicateRedemption, purgeExpiredRedemptionIds, seenRedemptionIds, REDEMPTION_DEDUP_TTL_MS } from './twitchEventSubRedemptionDedup';
+
+beforeEach(() => {
+  seenRedemptionIds.clear();
+});
+
+// ---------------------------------------------------------------------------
+// isDuplicateRedemption
+// ---------------------------------------------------------------------------
+describe('isDuplicateRedemption', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns false on first call with a given redemption ID', () => {
+    expect(isDuplicateRedemption('redemption-unique-1')).toBe(false);
+  });
+
+  it('returns true on second call with the same redemption ID', () => {
+    isDuplicateRedemption('redemption-dup-1');
+    expect(isDuplicateRedemption('redemption-dup-1')).toBe(true);
+  });
+
+  it('returns false again after TTL has expired', () => {
+    isDuplicateRedemption('redemption-expired-1');
+    vi.advanceTimersByTime(REDEMPTION_DEDUP_TTL_MS + 1);
+    expect(isDuplicateRedemption('redemption-expired-1')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// purgeExpiredRedemptionIds
+// ---------------------------------------------------------------------------
+describe('purgeExpiredRedemptionIds', () => {
+  it('removes only entries past their expiry', () => {
+    seenRedemptionIds.set('expired', Date.now() - 1);
+    seenRedemptionIds.set('live', Date.now() + REDEMPTION_DEDUP_TTL_MS);
+
+    purgeExpiredRedemptionIds();
+
+    expect(seenRedemptionIds.has('expired')).toBe(false);
+    expect(seenRedemptionIds.has('live')).toBe(true);
+  });
+});

--- a/src/twitch/eventsub/twitchEventSubRedemptionDedup.ts
+++ b/src/twitch/eventsub/twitchEventSubRedemptionDedup.ts
@@ -1,0 +1,32 @@
+/** How long a redemption id is remembered for deduplication (ms). */
+export const REDEMPTION_DEDUP_TTL_MS = 10 * 60 * 1000;
+
+// TTL-based dedup keyed by Twitch's own redemption id, not the EventSub message envelope id.
+// twitchEventSubConnection.ts's message_id dedup (isDuplicate/seenMessageIds) only catches the
+// same WebSocket delivery being replayed (e.g. during a documented session-migration window); it
+// can't catch the same physical redemption arriving via two independently-"enabled" subscriptions
+// (e.g. a stale subscription left over from a prior process that Twitch hasn't yet revoked, or
+// two bot instances briefly running against the same channel) — those arrive as distinct messages
+// with distinct message_ids but carry the same redemption `event.id`. Mirrors that module's
+// TTL-map-plus-interval-purge shape so both dedup caches behave the same way operationally.
+export const seenRedemptionIds = new Map<string, number>();
+
+/** Removes all expired entries from the deduplication map. */
+export function purgeExpiredRedemptionIds(): void {
+  const now = Date.now();
+  for (const [id, expiry] of seenRedemptionIds) {
+    if (expiry < now) seenRedemptionIds.delete(id);
+  }
+}
+
+// Purge expired entries on a fixed interval so isDuplicateRedemption stays O(1).
+setInterval(purgeExpiredRedemptionIds, REDEMPTION_DEDUP_TTL_MS).unref();
+
+/** Returns true if redemptionId has been seen within REDEMPTION_DEDUP_TTL_MS; records it otherwise. */
+export function isDuplicateRedemption(redemptionId: string): boolean {
+  const now = Date.now();
+  const expiry = seenRedemptionIds.get(redemptionId);
+  if (expiry !== undefined && now <= expiry) return true;
+  seenRedemptionIds.set(redemptionId, now + REDEMPTION_DEDUP_TTL_MS);
+  return false;
+}

--- a/src/twitch/eventsub/twitchEventSubSubscriptionGroups.test.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptionGroups.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../shared/config', () => ({}));
+
+import { getAlertTypesCoveredBySubscriptionGroups } from './twitchEventSubSubscriptionGroups';
+import { ALERT_EVENT_TYPES } from '../../db/alertConfig';
+
+// ---------------------------------------------------------------------------
+// Subscription-group alert-type coverage (exhaustiveness)
+//
+// Guards against a new AlertEventType being added (to ALERT_EVENT_TYPES / the DB schema) without
+// also wiring it into a SUBSCRIPTION_GROUPS entry's `alertTypes` — a gap that would otherwise
+// compile fine and only surface at runtime as "the EventSub subscription is never created, so
+// the alert silently never fires."
+// ---------------------------------------------------------------------------
+describe('subscription-group alert-type coverage', () => {
+  it('covers every ALERT_EVENT_TYPES member in some subscription group', () => {
+    const covered = getAlertTypesCoveredBySubscriptionGroups();
+    for (const type of ALERT_EVENT_TYPES) {
+      expect(covered.has(type)).toBe(true);
+    }
+  });
+
+  it('does not cover any type outside ALERT_EVENT_TYPES (catches stale/typo\'d entries)', () => {
+    const covered = getAlertTypesCoveredBySubscriptionGroups();
+    for (const type of covered) {
+      expect(ALERT_EVENT_TYPES).toContain(type);
+    }
+  });
+});

--- a/src/twitch/eventsub/twitchEventSubSubscriptionGroups.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptionGroups.ts
@@ -1,0 +1,115 @@
+import type { EventSubConfig, AlertEventType } from '../../db';
+
+/** Describes a single EventSub subscription to create. */
+export interface SubSpec { type: string; version: string; condition: Record<string, string> }
+
+/** One gated group of EventSub subscriptions: created together whenever `isGroupEnabled` passes. */
+interface SubscriptionGroup {
+  /**
+   * Alert event types that share this group's subscription(s) — declaring these as data (rather
+   * than each group hand-writing its own `enabledAlerts.has('literal')` checks) lets
+   * `getAlertTypesCoveredBySubscriptionGroups` verify every {@link AlertEventType} is wired to a
+   * group; a test in `twitchEventSubSubscriptions.test.ts` fails if a new alert type is added
+   * without adding it here, instead of the gap silently compiling.
+   */
+  alertTypes: AlertEventType[];
+  /**
+   * Returns true if this group's subscriptions should be created based on the streamer's config
+   * alone — either a genuine chat-message toggle, or (for a group with no `alertTypes`)
+   * {@link hasCompletedEventSubSetup} as a proxy for "this streamer is set up enough to want this
+   * subscription at all". Independent of `alertTypes` — `isGroupEnabled` ORs the alerts-overlay
+   * gating in generically, since a streamer can want the subscription created purely to drive a
+   * browser-source alert, with chat messages off.
+   * @param config - The streamer's event response configuration, or null if unset.
+   */
+  configGate: (config: EventSubConfig | null) => boolean;
+  /**
+   * Builds this group's subscription specs.
+   * @param uid - The broadcaster's Twitch user ID.
+   * @returns The subscription specs to create for this group.
+   */
+  specs: (uid: string) => SubSpec[];
+}
+
+/**
+ * Returns true if `group`'s subscriptions should be created: either its `configGate` passes, or
+ * any of its `alertTypes` has an enabled alerts-overlay config.
+ * @param group - The subscription group to evaluate.
+ * @param config - The streamer's event response configuration, or null if unset.
+ * @param enabledAlerts - Event types with an enabled alerts-overlay config row for this streamer.
+ */
+export function isGroupEnabled(
+  group: SubscriptionGroup,
+  config: EventSubConfig | null,
+  enabledAlerts: ReadonlySet<AlertEventType>,
+): boolean {
+  return group.configGate(config) || group.alertTypes.some((type) => enabledAlerts.has(type));
+}
+
+/**
+ * `configGate` for a group with no `alertTypes` — unlike the alert-driven groups, there's no
+ * alert-only path that needs the subscription without a real config row, so a row's mere
+ * existence is used as a proxy for "this streamer completed the full EventSub/chat-message
+ * setup". (`dispatchNotification` itself no longer early-exits without config — it falls back to
+ * `DEFAULT_EVENT_CONFIG` for alert-only streamers — but that's moot for these groups since they
+ * never subscribe for one.)
+ * @param config - The streamer's event response configuration, or null if unset.
+ */
+function hasCompletedEventSubSetup(config: EventSubConfig | null): boolean {
+  return Boolean(config);
+}
+
+// Every group also requires a broadcaster token (WebSocket transport only works with a user
+// token, not an app token — see createSubscriptionsForStreamer's upfront `!token` check).
+export const SUBSCRIPTION_GROUPS: SubscriptionGroup[] = [
+  {
+    alertTypes: ['follow'],
+    configGate: (config) => Boolean(config?.follow_enabled),
+    specs: (uid) => [{ type: 'channel.follow', version: '2', condition: { broadcaster_user_id: uid, moderator_user_id: uid } }],
+  },
+  {
+    alertTypes: ['sub', 'resub', 'giftsub'],
+    configGate: (config) => Boolean(config?.sub_enabled),
+    specs: (uid) => [
+      { type: 'channel.subscribe', version: '1', condition: { broadcaster_user_id: uid } },
+      { type: 'channel.subscription.message', version: '1', condition: { broadcaster_user_id: uid } },
+      { type: 'channel.subscription.gift', version: '1', condition: { broadcaster_user_id: uid } },
+    ],
+  },
+  {
+    // Subscribe when the welcome message, the auto-shoutout toggle, or the raid alert is on —
+    // handleRaid gates its three behaviours independently, but the subscription itself must
+    // exist for any of them to fire.
+    alertTypes: ['raid'],
+    configGate: (config) => Boolean(config?.raid_enabled || config?.raid_shoutout_enabled),
+    specs: (uid) => [{ type: 'channel.raid', version: '1', condition: { to_broadcaster_user_id: uid } }],
+  },
+  {
+    alertTypes: [],
+    configGate: hasCompletedEventSubSetup,
+    specs: (uid) => [{ type: 'channel.channel_points_custom_reward_redemption.add', version: '1', condition: { broadcaster_user_id: uid } }],
+  },
+  {
+    // stream.online/offline and channel.update require no scope beyond a valid token. This
+    // drives an immediate live-check that supplements (not replaces) the 60s poller. Not tied to
+    // any alert type.
+    alertTypes: [],
+    configGate: hasCompletedEventSubSetup,
+    specs: (uid) => [
+      { type: 'stream.online', version: '1', condition: { broadcaster_user_id: uid } },
+      { type: 'stream.offline', version: '1', condition: { broadcaster_user_id: uid } },
+      { type: 'channel.update', version: '2', condition: { broadcaster_user_id: uid } },
+    ],
+  },
+];
+
+/**
+ * Returns the set of alert event types covered by at least one subscription group. Exported for
+ * the exhaustiveness test in `twitchEventSubSubscriptions.test.ts`, which asserts this covers
+ * every member of `ALERT_EVENT_TYPES` — catching a new alert type being added without also being
+ * wired into a subscription group's `alertTypes` (which would otherwise compile fine and only
+ * surface as "the subscription is never created" at runtime).
+ */
+export function getAlertTypesCoveredBySubscriptionGroups(): Set<AlertEventType> {
+  return new Set(SUBSCRIPTION_GROUPS.flatMap((group) => group.alertTypes));
+}

--- a/src/twitch/eventsub/twitchEventSubSubscriptionGroups.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptionGroups.ts
@@ -9,7 +9,7 @@ interface SubscriptionGroup {
    * Alert event types that share this group's subscription(s) — declaring these as data (rather
    * than each group hand-writing its own `enabledAlerts.has('literal')` checks) lets
    * `getAlertTypesCoveredBySubscriptionGroups` verify every {@link AlertEventType} is wired to a
-   * group; a test in `twitchEventSubSubscriptions.test.ts` fails if a new alert type is added
+   * group; a test in `twitchEventSubSubscriptionGroups.test.ts` fails if a new alert type is added
    * without adding it here, instead of the gap silently compiling.
    */
   alertTypes: AlertEventType[];
@@ -105,7 +105,7 @@ export const SUBSCRIPTION_GROUPS: SubscriptionGroup[] = [
 
 /**
  * Returns the set of alert event types covered by at least one subscription group. Exported for
- * the exhaustiveness test in `twitchEventSubSubscriptions.test.ts`, which asserts this covers
+ * the exhaustiveness test in `twitchEventSubSubscriptionGroups.test.ts`, which asserts this covers
  * every member of `ALERT_EVENT_TYPES` — catching a new alert type being added without also being
  * wired into a subscription group's `alertTypes` (which would otherwise compile fine and only
  * surface as "the subscription is never created" at runtime).

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
@@ -6,13 +6,25 @@ const { logMock } = vi.hoisted(() => ({
 vi.mock('../../shared/logger', () => ({ createLogger: () => logMock }));
 vi.mock('../../shared/config', () => ({}));
 // './twitchEventSubSubscriptions' re-exports dispatchNotification/handleRevocation/
-// removeStreamerFromMap from './twitchEventSubDispatch', which in turn imports these two real
-// modules — mocked here purely so that transitive import chain resolves, even though this
-// file's own tests exercise subscribeForStreamer/loadStreamersForEventSub, not dispatch.
+// removeStreamerFromMap from './twitchEventSubDispatch', which in turn imports
+// clearStreamerToken/DEFAULT_EVENT_CONFIG from '../../db' — both mocked here purely so that
+// transitive import chain resolves, even though this file's own tests exercise
+// subscribeForStreamer/loadStreamersForEventSub, not dispatch.
 vi.mock('../../db', () => ({
   getAllEventSubStreamers: vi.fn(),
   clearStreamerToken: vi.fn().mockResolvedValue(undefined),
   getEnabledAlertEventTypesBatch: vi.fn().mockResolvedValue(new Map()),
+  DEFAULT_EVENT_CONFIG: {
+    follow_enabled: false,
+    follow_message: 'Thanks {display_name} for the follow!',
+    sub_enabled: false,
+    sub_message: 'Thanks {display_name} for subscribing! ({tier_name})',
+    resub_message: 'Thanks {display_name} for {months} months! ({tier_name})',
+    giftsub_message: '{gifter_display} gifted {count} sub(s) to the community!',
+    raid_enabled: false,
+    raid_message: 'Welcome raiders from {from_display}! Thank you for the {viewers} person raid!',
+    raid_shoutout_enabled: false,
+  },
 }));
 vi.mock('../twitchApi', () => ({ getUsers: vi.fn() }));
 vi.mock('../twitchChannelMembership', () => ({ getActiveChannels: vi.fn().mockReturnValue(new Set<string>()) }));
@@ -571,6 +583,31 @@ describe('error handling in subscription setup', () => {
 
     expect(logMock.error).toHaveBeenCalledWith('Subscription cleanup failed for uid uid-err:', expect.any(Error));
     expect(count).toBeGreaterThan(0);
+  });
+
+  it('continues deleting remaining stale subscriptions after one deletion fails', async () => {
+    vi.mocked(createEventSubSubscription).mockResolvedValue('sub-id');
+    vi.mocked(listEventSubSubscriptions).mockResolvedValue([
+      { id: 'stale-1', type: 'channel.subscribe' },
+      { id: 'stale-2', type: 'channel.raid' },
+    ] as any);
+    vi.mocked(deleteEventSubSubscription)
+      .mockRejectedValueOnce(new Error('delete failed'))
+      .mockResolvedValueOnce(undefined);
+
+    await subscribeForStreamer('sess-delete-err', {
+      uid: 'uid-delete-err',
+      token: 'tok-delete-err',
+      name: 'errStreamer',
+      config: { follow_enabled: true, sub_enabled: false, raid_enabled: false } as any,
+      streamerId: 71,
+    });
+
+    expect(deleteEventSubSubscription).toHaveBeenCalledWith('stale-1', 'tok-delete-err');
+    expect(deleteEventSubSubscription).toHaveBeenCalledWith('stale-2', 'tok-delete-err');
+    expect(logMock.error).toHaveBeenCalledWith(
+      'Failed to delete subscription stale-1 (channel.subscribe) for uid uid-delete-err:', expect.any(Error),
+    );
   });
 
   it('logs and excludes the streamer when resolving a raid-only streamer\'s Twitch user ID fails', async () => {

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
@@ -318,6 +318,47 @@ describe('subscribeForStreamer', () => {
     expect(deleteEventSubSubscription).toHaveBeenCalledWith('stale-sub', 'tok-z');
   });
 
+  it('prunes a duplicate subscription of a still-desired type left over from a prior session', async () => {
+    vi.mocked(getActiveChannels).mockReturnValue(new Set(['botinchannel']));
+    vi.mocked(createEventSubSubscription).mockResolvedValue('sub-new-follow');
+    // The old, orphaned subscription (e.g. from a process that died without stop()) is still
+    // "enabled" and shows up alongside the one just created this round.
+    vi.mocked(listEventSubSubscriptions).mockResolvedValue([
+      { id: 'sub-new-follow', type: 'channel.follow' },
+      { id: 'sub-stale-follow', type: 'channel.follow' },
+    ] as any);
+
+    await subscribeForStreamer('sess-dup', {
+      uid: 'uid-dup',
+      token: 'tok-dup',
+      name: 'botInChannel',
+      config: { follow_enabled: true, sub_enabled: false, raid_enabled: false } as any,
+      streamerId: 22,
+    });
+
+    expect(deleteEventSubSubscription).toHaveBeenCalledWith('sub-stale-follow', 'tok-dup');
+    expect(deleteEventSubSubscription).not.toHaveBeenCalledWith('sub-new-follow', 'tok-dup');
+  });
+
+  it('does not prune any existing subscription of a type when creating it hit a 409 (already exists)', async () => {
+    vi.mocked(getActiveChannels).mockReturnValue(new Set(['botinchannel']));
+    // 409 -> createEventSubSubscription resolves null, so subscribe() has no fresh id for this type.
+    vi.mocked(createEventSubSubscription).mockResolvedValue(null);
+    vi.mocked(listEventSubSubscriptions).mockResolvedValue([
+      { id: 'sub-existing-follow', type: 'channel.follow' },
+    ] as any);
+
+    await subscribeForStreamer('sess-409', {
+      uid: 'uid-409',
+      token: 'tok-409',
+      name: 'botInChannel',
+      config: { follow_enabled: true, sub_enabled: false, raid_enabled: false } as any,
+      streamerId: 23,
+    });
+
+    expect(deleteEventSubSubscription).not.toHaveBeenCalledWith('sub-existing-follow', 'tok-409');
+  });
+
   it('subscribes to stream.online and stream.offline whenever config and token are present', async () => {
     vi.mocked(getActiveChannels).mockReturnValue(new Set(['botinchannel']));
     vi.mocked(createEventSubSubscription).mockResolvedValue('sub-new');

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
@@ -4,32 +4,16 @@ const { logMock } = vi.hoisted(() => ({
   logMock: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 vi.mock('../../shared/logger', () => ({ createLogger: () => logMock }));
-// Pulled in transitively via '../../db/alertConfig' (for the real ALERT_EVENT_TYPES below)
-// importing './pool', which reads real env vars at module load time — an empty mock keeps
-// that side effect out.
 vi.mock('../../shared/config', () => ({}));
-vi.mock('../../db', async () => {
-  // Reuses the real ALERT_EVENT_TYPES (rather than a hard-coded copy) so this file's
-  // exhaustiveness test can't silently go stale if a new alert type is ever added there.
-  const { ALERT_EVENT_TYPES } = await vi.importActual<typeof import('../../db/alertConfig')>('../../db/alertConfig');
-  return {
-    getAllEventSubStreamers: vi.fn(),
-    clearStreamerToken: vi.fn().mockResolvedValue(undefined),
-    getEnabledAlertEventTypesBatch: vi.fn().mockResolvedValue(new Map()),
-    ALERT_EVENT_TYPES,
-    DEFAULT_EVENT_CONFIG: {
-      follow_enabled: false,
-      follow_message: 'Thanks {display_name} for the follow!',
-      sub_enabled: false,
-      sub_message: 'Thanks {display_name} for subscribing! ({tier_name})',
-      resub_message: 'Thanks {display_name} for {months} months! ({tier_name})',
-      giftsub_message: '{gifter_display} gifted {count} sub(s) to the community!',
-      raid_enabled: false,
-      raid_message: 'Welcome raiders from {from_display}! Thank you for the {viewers} person raid!',
-      raid_shoutout_enabled: false,
-    },
-  };
-});
+// './twitchEventSubSubscriptions' re-exports dispatchNotification/handleRevocation/
+// removeStreamerFromMap from './twitchEventSubDispatch', which in turn imports these two real
+// modules — mocked here purely so that transitive import chain resolves, even though this
+// file's own tests exercise subscribeForStreamer/loadStreamersForEventSub, not dispatch.
+vi.mock('../../db', () => ({
+  getAllEventSubStreamers: vi.fn(),
+  clearStreamerToken: vi.fn().mockResolvedValue(undefined),
+  getEnabledAlertEventTypesBatch: vi.fn().mockResolvedValue(new Map()),
+}));
 vi.mock('../twitchApi', () => ({ getUsers: vi.fn() }));
 vi.mock('../twitchChannelMembership', () => ({ getActiveChannels: vi.fn().mockReturnValue(new Set<string>()) }));
 vi.mock('../twitchChannelName', () => ({ normalizeTwitchChannelName: vi.fn((n: string) => n.toLowerCase()) }));
@@ -57,21 +41,11 @@ import {
   clearAuthFailedSubs,
   loadStreamersForEventSub,
   subscribeForStreamer,
-  dispatchNotification,
-  removeStreamerFromMap,
-  handleRevocation,
-  getAlertTypesCoveredBySubscriptionGroups,
 } from './twitchEventSubSubscriptions';
-import {
-  getAllEventSubStreamers, clearStreamerToken, getEnabledAlertEventTypesBatch, ALERT_EVENT_TYPES, DEFAULT_EVENT_CONFIG,
-} from '../../db';
+import { getAllEventSubStreamers, getEnabledAlertEventTypesBatch } from '../../db';
 import { getValidToken, createEventSubSubscription, listEventSubSubscriptions, deleteEventSubSubscription, TwitchAuthError } from './twitchApiEventSub';
 import { getUsers } from '../twitchApi';
 import { getActiveChannels } from '../twitchChannelMembership';
-import {
-  handleStreamOnline, handleStreamOffline, handleChannelUpdate,
-  handleFollow, handleSub, handleResub, handleGiftSub, handleRaid, handleRedemption,
-} from './twitchEventSubHandler';
 
 // ---------------------------------------------------------------------------
 // hasAuthFailedSubs / clearAuthFailedSubs
@@ -526,42 +500,6 @@ describe('subscribeForStreamer', () => {
 });
 
 // ---------------------------------------------------------------------------
-// dispatchNotification — stream.online / stream.offline routing
-// ---------------------------------------------------------------------------
-describe('dispatchNotification routes stream.online/offline', () => {
-  beforeEach(async () => {
-    vi.clearAllMocks();
-    clearAuthFailedSubs('liveStreamer');
-    vi.mocked(getActiveChannels).mockReturnValue(new Set(['livestreamer']));
-    vi.mocked(createEventSubSubscription).mockResolvedValue('sub-id');
-    vi.mocked(listEventSubSubscriptions).mockResolvedValue([]);
-    // Populate streamerMap with a known config so dispatchNotification doesn't early-exit.
-    await subscribeForStreamer('sess-dispatch', {
-      uid: 'uid-dispatch',
-      token: 'tok-dispatch',
-      name: 'liveStreamer',
-      config: { follow_enabled: false, sub_enabled: false, raid_enabled: false } as any,
-      streamerId: 30,
-    });
-  });
-
-  it('calls handleStreamOnline for a stream.online notification', () => {
-    dispatchNotification('stream.online', {}, { broadcaster_user_id: 'uid-dispatch' });
-    expect(handleStreamOnline).toHaveBeenCalledWith('liveStreamer');
-  });
-
-  it('calls handleStreamOffline for a stream.offline notification', () => {
-    dispatchNotification('stream.offline', {}, { broadcaster_user_id: 'uid-dispatch' });
-    expect(handleStreamOffline).toHaveBeenCalledWith('liveStreamer');
-  });
-
-  it('calls handleChannelUpdate for a channel.update notification', () => {
-    dispatchNotification('channel.update', {}, { broadcaster_user_id: 'uid-dispatch' });
-    expect(handleChannelUpdate).toHaveBeenCalledWith('liveStreamer');
-  });
-});
-
-// ---------------------------------------------------------------------------
 // subscribeForStreamer — sub_enabled subscription creation
 // ---------------------------------------------------------------------------
 describe('subscribeForStreamer with sub_enabled', () => {
@@ -606,128 +544,6 @@ describe('subscribeForStreamer with sub_enabled', () => {
     expect(createEventSubSubscription).not.toHaveBeenCalledWith(
       'channel.subscribe', expect.anything(), expect.anything(), expect.anything(), expect.anything(),
     );
-  });
-});
-
-// ---------------------------------------------------------------------------
-// dispatchNotification — remaining notification types
-// ---------------------------------------------------------------------------
-describe('dispatchNotification routes chat-alert and redemption events', () => {
-  beforeEach(async () => {
-    vi.clearAllMocks();
-    clearAuthFailedSubs('alertStreamer');
-    vi.mocked(getActiveChannels).mockReturnValue(new Set(['alertstreamer']));
-    vi.mocked(createEventSubSubscription).mockResolvedValue('sub-id');
-    vi.mocked(listEventSubSubscriptions).mockResolvedValue([]);
-    await subscribeForStreamer('sess-alert', {
-      uid: 'uid-alert',
-      token: 'tok-alert',
-      name: 'alertStreamer',
-      config: { follow_enabled: true, sub_enabled: true, raid_enabled: true } as any,
-      streamerId: 50,
-    });
-  });
-
-  it('routes channel.follow to handleFollow', () => {
-    dispatchNotification('channel.follow', { user_name: 'follower' }, { broadcaster_user_id: 'uid-alert' });
-    expect(handleFollow).toHaveBeenCalledWith('alertStreamer', { user_name: 'follower' }, expect.anything(), 50);
-  });
-
-  it('routes channel.subscribe to handleSub', () => {
-    dispatchNotification('channel.subscribe', { tier: '1000' }, { broadcaster_user_id: 'uid-alert' });
-    expect(handleSub).toHaveBeenCalledWith('alertStreamer', { tier: '1000' }, expect.anything(), 50);
-  });
-
-  it('routes channel.subscription.message to handleResub', () => {
-    dispatchNotification('channel.subscription.message', { cumulative_months: 5 }, { broadcaster_user_id: 'uid-alert' });
-    expect(handleResub).toHaveBeenCalledWith('alertStreamer', { cumulative_months: 5 }, expect.anything(), 50);
-  });
-
-  it('routes channel.subscription.gift to handleGiftSub', () => {
-    dispatchNotification('channel.subscription.gift', { total: 3 }, { broadcaster_user_id: 'uid-alert' });
-    expect(handleGiftSub).toHaveBeenCalledWith('alertStreamer', { total: 3 }, expect.anything(), 50);
-  });
-
-  it('routes channel.raid to handleRaid using to_broadcaster_user_id', () => {
-    dispatchNotification('channel.raid', { from_broadcaster_user_name: 'raider' }, { to_broadcaster_user_id: 'uid-alert' });
-    expect(handleRaid).toHaveBeenCalledWith('alertStreamer', { from_broadcaster_user_name: 'raider' }, expect.anything(), 50);
-  });
-
-  it('routes a channel-points redemption to handleRedemption with the streamerId', () => {
-    dispatchNotification(
-      'channel.channel_points_custom_reward_redemption.add',
-      { reward: { id: 'r1' } },
-      { broadcaster_user_id: 'uid-alert' },
-    );
-    expect(handleRedemption).toHaveBeenCalledWith('alertStreamer', { reward: { id: 'r1' } }, expect.anything(), 50);
-  });
-
-  it('logs a warning and does nothing for an unsupported notification type', () => {
-    dispatchNotification('channel.cheer', {}, { broadcaster_user_id: 'uid-alert' });
-    expect(logMock.warn).toHaveBeenCalledWith('Unsupported EventSub notification type: channel.cheer');
-    expect(handleFollow).not.toHaveBeenCalled();
-  });
-
-  it('logs an error when the routed handler rejects', async () => {
-    vi.mocked(handleFollow).mockRejectedValueOnce(new Error('handler exploded'));
-
-    dispatchNotification('channel.follow', {}, { broadcaster_user_id: 'uid-alert' });
-    await new Promise((resolve) => setImmediate(resolve));
-
-    expect(logMock.error).toHaveBeenCalledWith('channel.follow handler error:', expect.any(Error));
-  });
-});
-
-// ---------------------------------------------------------------------------
-// dispatchNotification — streamer with no streamer_event_config row
-// ---------------------------------------------------------------------------
-describe('dispatchNotification with a null streamer config (alert-only streamer)', () => {
-  beforeEach(async () => {
-    vi.clearAllMocks();
-    clearAuthFailedSubs('alertOnlyStreamer');
-    vi.mocked(getActiveChannels).mockReturnValue(new Set(['alertonlystreamer']));
-    vi.mocked(createEventSubSubscription).mockResolvedValue('sub-id');
-    vi.mocked(listEventSubSubscriptions).mockResolvedValue([]);
-    await subscribeForStreamer('sess-alert-only', {
-      uid: 'uid-alert-only',
-      token: 'tok-alert-only',
-      name: 'alertOnlyStreamer',
-      config: null,
-      streamerId: 60,
-    });
-  });
-
-  it('still routes the notification, falling back to DEFAULT_EVENT_CONFIG instead of dropping it', () => {
-    dispatchNotification('channel.follow', { user_name: 'follower' }, { broadcaster_user_id: 'uid-alert-only' });
-    expect(handleFollow).toHaveBeenCalledWith('alertOnlyStreamer', { user_name: 'follower' }, DEFAULT_EVENT_CONFIG, 60);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// removeStreamerFromMap
-// ---------------------------------------------------------------------------
-describe('removeStreamerFromMap', () => {
-  beforeEach(async () => {
-    vi.clearAllMocks();
-    clearAuthFailedSubs('removable');
-    vi.mocked(getActiveChannels).mockReturnValue(new Set(['removable']));
-    vi.mocked(createEventSubSubscription).mockResolvedValue('sub-id');
-    vi.mocked(listEventSubSubscriptions).mockResolvedValue([]);
-    await subscribeForStreamer('sess-rm', {
-      uid: 'uid-rm',
-      token: 'tok-rm',
-      name: 'removable',
-      config: { follow_enabled: false, sub_enabled: false, raid_enabled: false } as any,
-      streamerId: 60,
-    });
-  });
-
-  it('removes the streamer so dispatchNotification no longer routes to it', () => {
-    removeStreamerFromMap('uid-rm');
-
-    dispatchNotification('stream.online', {}, { broadcaster_user_id: 'uid-rm' });
-
-    expect(handleStreamOnline).not.toHaveBeenCalled();
   });
 });
 
@@ -789,86 +605,5 @@ describe('error handling in subscription setup', () => {
       'Failed to subscribe to channel.follow for errStreamer:', expect.any(Error),
     );
     expect(hasAuthFailedSubs('errStreamer')).toBe(false);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// handleRevocation
-// ---------------------------------------------------------------------------
-describe('handleRevocation', () => {
-  beforeEach(async () => {
-    vi.clearAllMocks();
-    clearAuthFailedSubs('revokedStreamer');
-    vi.mocked(getActiveChannels).mockReturnValue(new Set(['revokedstreamer']));
-    vi.mocked(createEventSubSubscription).mockResolvedValue('sub-id');
-    vi.mocked(listEventSubSubscriptions).mockResolvedValue([]);
-    vi.mocked(clearStreamerToken).mockResolvedValue(true);
-    await subscribeForStreamer('sess-revoke', {
-      uid: 'uid-revoke',
-      token: 'tok-revoke',
-      name: 'revokedStreamer',
-      config: { follow_enabled: false, sub_enabled: false, raid_enabled: false } as any,
-      streamerId: 100,
-    });
-  });
-
-  it('logs the revocation but does not clear a token for an unknown broadcaster', () => {
-    handleRevocation({ type: 'channel.follow', status: 'authorization_revoked', condition: { broadcaster_user_id: 'unknown-uid' } });
-
-    expect(logMock.warn).toHaveBeenCalledWith('Subscription revoked: type=channel.follow status=authorization_revoked');
-    expect(clearStreamerToken).not.toHaveBeenCalled();
-  });
-
-  it('clears the token when status is authorization_revoked for a known broadcaster', () => {
-    handleRevocation({ type: 'channel.follow', status: 'authorization_revoked', condition: { broadcaster_user_id: 'uid-revoke' } });
-
-    expect(clearStreamerToken).toHaveBeenCalledWith(100);
-    expect(logMock.warn).toHaveBeenCalledWith('Cleared token for revokedStreamer (authorization_revoked)');
-  });
-
-  it('clears the token when status is user_removed, using to_broadcaster_user_id', () => {
-    handleRevocation({ type: 'channel.raid', status: 'user_removed', condition: { to_broadcaster_user_id: 'uid-revoke' } });
-
-    expect(clearStreamerToken).toHaveBeenCalledWith(100);
-    expect(logMock.warn).toHaveBeenCalledWith('Cleared token for revokedStreamer (user_removed)');
-  });
-
-  it('does not clear the token for other revocation statuses', () => {
-    handleRevocation({ type: 'channel.follow', status: 'moderator_removed', condition: { broadcaster_user_id: 'uid-revoke' } });
-
-    expect(clearStreamerToken).not.toHaveBeenCalled();
-  });
-
-  it('logs an error if clearing the token itself fails', async () => {
-    vi.mocked(clearStreamerToken).mockRejectedValueOnce(new Error('db down'));
-
-    handleRevocation({ type: 'channel.follow', status: 'authorization_revoked', condition: { broadcaster_user_id: 'uid-revoke' } });
-    await new Promise((resolve) => setImmediate(resolve));
-
-    expect(logMock.error).toHaveBeenCalledWith('Clear token error:', expect.any(Error));
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Subscription-group alert-type coverage (exhaustiveness)
-//
-// Guards against a new AlertEventType being added (to ALERT_EVENT_TYPES / the DB schema) without
-// also wiring it into a SUBSCRIPTION_GROUPS entry's `alertTypes` — a gap that would otherwise
-// compile fine and only surface at runtime as "the EventSub subscription is never created, so
-// the alert silently never fires."
-// ---------------------------------------------------------------------------
-describe('subscription-group alert-type coverage', () => {
-  it('covers every ALERT_EVENT_TYPES member in some subscription group', () => {
-    const covered = getAlertTypesCoveredBySubscriptionGroups();
-    for (const type of ALERT_EVENT_TYPES) {
-      expect(covered.has(type)).toBe(true);
-    }
-  });
-
-  it('does not cover any type outside ALERT_EVENT_TYPES (catches stale/typo\'d entries)', () => {
-    const covered = getAlertTypesCoveredBySubscriptionGroups();
-    for (const type of covered) {
-      expect(ALERT_EVENT_TYPES).toContain(type);
-    }
   });
 });

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -52,12 +52,37 @@ const notificationHandlers = new Map<string, NotificationHandler>([
   ['channel.update',                                    (l) => handleChannelUpdate(l)],
 ]);
 
-async function deleteStaleSubscriptions(uid: string, desired: Set<string>, userToken: string | null): Promise<void> {
+/**
+ * Deletes subscriptions that shouldn't be active any more: those whose type isn't in
+ * `desired` at all (e.g. the streamer turned off raid alerts), and — for types that were
+ * freshly (re)created this round — any *other* existing subscription of that same type, i.e.
+ * a duplicate left over from a session whose owning process died without calling
+ * `StreamerConnection.stop()` (crash, container restart, redeploy). Twitch eventually revokes
+ * an orphaned WebSocket subscription on its own, but not instantaneously — until then it stays
+ * "enabled" and delivers notifications alongside the new one, double-firing the type's handler
+ * for every event (e.g. `handleRedemption` recording two dashboard entries for one redemption).
+ * A type whose subscribe() returned null this round (409 — Twitch says an identical
+ * type+condition subscription already exists) is left untouched: `created` has no entry for
+ * it, so none of its existing subscriptions get pruned, since we can't tell which one Twitch
+ * considers the live one without risking deleting the subscription actually receiving events.
+ *
+ * @param uid - Broadcaster's Twitch user ID, used only for error logging.
+ * @param desired - Subscription types that should exist after this call.
+ * @param created - Type → subscription id for subscriptions freshly created this round (see
+ *   {@link createSubscriptionsForStreamer}); a type present here has any other existing
+ *   subscription of that type pruned as a stale duplicate.
+ * @param userToken - Broadcaster's valid user token; no-ops if null (no token to authenticate with).
+ */
+async function deleteStaleSubscriptions(
+  uid: string, desired: Set<string>, created: ReadonlyMap<string, string>, userToken: string | null,
+): Promise<void> {
   if (!userToken) return;
   try {
     const existing = await listEventSubSubscriptions(userToken);
     for (const sub of existing) {
-      if (!desired.has(sub.type)) await deleteEventSubSubscription(sub.id, userToken);
+      const keptId = created.get(sub.type);
+      const isStaleDuplicate = keptId !== undefined && sub.id !== keptId;
+      if (!desired.has(sub.type) || isStaleDuplicate) await deleteEventSubSubscription(sub.id, userToken);
     }
   } catch (err) {
     log.error(`Subscription cleanup failed for uid ${uid}:`, err);
@@ -203,29 +228,44 @@ export interface StreamerEventSubData {
   enabledAlerts?: ReadonlySet<AlertEventType>;
 }
 
-/** Creates all desired EventSub subscriptions for a single streamer and returns the desired-types set. */
+/** Desired subscription types alongside the ones freshly created this round, keyed by type
+ *  (see {@link createSubscriptionsForStreamer}). */
+interface SubscriptionResult {
+  desired: Set<string>;
+  created: Map<string, string>;
+}
+
+/**
+ * Creates all desired EventSub subscriptions for a single streamer.
+ * @returns The desired-types set alongside a type → id map of subscriptions actually created
+ *   this round (a type is absent from `created` if `subscribe` hit a 409 — Twitch already has
+ *   an identical type+condition subscription active — so the caller has no id to prefer over
+ *   whatever else `listEventSubSubscriptions` later reports for that type).
+ */
 async function createSubscriptionsForStreamer(
   sessionId: string, data: StreamerEventSubData,
-): Promise<Set<string>> {
+): Promise<SubscriptionResult> {
   const { uid, token, name, config, enabledAlerts = new Set<AlertEventType>() } = data;
   const normalizedName = normalizeTwitchChannelName(name) ?? name.toLowerCase();
   if (!getActiveChannels().has(normalizedName)) {
     log.info(`Skipping EventSub subscriptions for ${name} — bot not in channel`);
-    return new Set();
+    return { desired: new Set(), created: new Map() };
   }
 
   const desired = new Set<string>();
-  if (!token) return desired;
+  const created = new Map<string, string>();
+  if (!token) return { desired, created };
 
   for (const group of SUBSCRIPTION_GROUPS) {
     if (!isGroupEnabled(group, config, enabledAlerts)) continue;
     for (const spec of group.specs(uid)) {
       desired.add(spec.type);
-      await subscribe(sessionId, spec, token, name);
+      const id = await subscribe(sessionId, spec, token, name);
+      if (id !== null) created.set(spec.type, id);
     }
   }
 
-  return desired;
+  return { desired, created };
 }
 
 /**
@@ -256,8 +296,8 @@ export async function subscribeForStreamer(
 ): Promise<number> {
   const { uid, token, name, config, streamerId } = data;
   streamerMap.set(uid, { login: name, streamerId, config });
-  const desired = await createSubscriptionsForStreamer(sessionId, data);
-  await deleteStaleSubscriptions(uid, desired, token);
+  const { desired, created } = await createSubscriptionsForStreamer(sessionId, data);
+  await deleteStaleSubscriptions(uid, desired, created, token);
   return desired.size;
 }
 
@@ -266,15 +306,20 @@ export function removeStreamerFromMap(uid: string): void {
   streamerMap.delete(uid);
 }
 
-async function subscribe(sessionId: string, spec: SubSpec, token: string, login: string): Promise<void> {
+/** Creates a single EventSub subscription. Returns the created subscription's id, or null if
+ *  it was skipped (previously auth-failed), Twitch reported it already exists (409), or the
+ *  create call failed — callers use a non-null id to identify "the subscription created this
+ *  round" when pruning stale duplicates in {@link deleteStaleSubscriptions}. */
+async function subscribe(sessionId: string, spec: SubSpec, token: string, login: string): Promise<string | null> {
   const skipKey = `${login}:${spec.type}:${token}`;
-  if (authFailedSubs.has(skipKey)) return;
+  if (authFailedSubs.has(skipKey)) return null;
   try {
     const id = await createEventSubSubscription(spec.type, spec.version, spec.condition, sessionId, token);
     if (id !== null) {
       authFailedSubs.delete(skipKey);
       log.info(`Subscribed to ${spec.type} for ${login}`);
     }
+    return id;
   } catch (err) {
     if (err instanceof TwitchAuthError) {
       authFailedSubs.add(skipKey);
@@ -282,6 +327,7 @@ async function subscribe(sessionId: string, spec: SubSpec, token: string, login:
     } else {
       log.error(`Failed to subscribe to ${spec.type} for ${login}:`, err);
     }
+    return null;
   }
 }
 

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -54,15 +54,26 @@ async function deleteStaleSubscriptions(
   uid: string, desired: Set<string>, created: ReadonlyMap<string, string>, userToken: string | null,
 ): Promise<void> {
   if (!userToken) return;
+  let existing: Array<{ id: string; type: string }>;
   try {
-    const existing = await listEventSubSubscriptions(userToken);
-    for (const sub of existing) {
-      const keptId = created.get(sub.type);
-      const isStaleDuplicate = keptId !== undefined && sub.id !== keptId;
-      if (!desired.has(sub.type) || isStaleDuplicate) await deleteEventSubSubscription(sub.id, userToken);
-    }
+    existing = await listEventSubSubscriptions(userToken);
   } catch (err) {
     log.error(`Subscription cleanup failed for uid ${uid}:`, err);
+    return;
+  }
+  // Each deletion is isolated so one failure (e.g. a transient Twitch API error) doesn't abort
+  // the rest of the cleanup — leaving a still-undeleted stale duplicate would keep delivering
+  // notifications and double-firing the type's handler, the exact failure this cleanup targets.
+  for (const sub of existing) {
+    const keptId = created.get(sub.type);
+    const isStaleDuplicate = keptId !== undefined && sub.id !== keptId;
+    if (!desired.has(sub.type) || isStaleDuplicate) {
+      try {
+        await deleteEventSubSubscription(sub.id, userToken);
+      } catch (err) {
+        log.error(`Failed to delete subscription ${sub.id} (${sub.type}) for uid ${uid}:`, err);
+      }
+    }
   }
 }
 

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -1,25 +1,17 @@
 import { createLogger } from '../../shared/logger';
-import { getAllEventSubStreamers, clearStreamerToken, getEnabledAlertEventTypesBatch, DEFAULT_EVENT_CONFIG } from '../../db';
+import { getAllEventSubStreamers, getEnabledAlertEventTypesBatch } from '../../db';
 import type { DbStreamerEventSub, EventSubConfig, AlertEventType } from '../../db';
 import { getUsers } from '../twitchApi';
 import { getActiveChannels } from '../twitchChannelMembership';
 import { normalizeTwitchChannelName } from '../twitchChannelName';
 import { createEventSubSubscription, listEventSubSubscriptions, deleteEventSubSubscription, getValidToken, TwitchAuthError } from './twitchApiEventSub';
-import {
-  handleFollow, handleSub, handleResub, handleGiftSub, handleRaid, handleRedemption,
-  handleStreamOnline, handleStreamOffline, handleChannelUpdate,
-  FollowEvent, SubEvent, ResubEvent, GiftSubEvent, RaidEvent, RedemptionEvent,
-} from './twitchEventSubHandler';
+import { SubSpec, SUBSCRIPTION_GROUPS, isGroupEnabled } from './twitchEventSubSubscriptionGroups';
+import { setStreamerInfo } from './twitchEventSubDispatch';
 
 const log = createLogger('EventSub');
 
-
-/** Describes a single EventSub subscription to create. */
-export interface SubSpec { type: string; version: string; condition: Record<string, string> }
-
-/** In-memory streamer info keyed by broadcaster user ID. */
-export interface StreamerInfo { login: string; streamerId: number; config: EventSubConfig | null }
-const streamerMap = new Map<string, StreamerInfo>();
+export { dispatchNotification, handleRevocation, removeStreamerFromMap } from './twitchEventSubDispatch';
+export { getAlertTypesCoveredBySubscriptionGroups } from './twitchEventSubSubscriptionGroups';
 
 // Tracks "login:type:token" triples that failed with 403 — skipped until bot restarts or token changes
 const authFailedSubs = new Set<string>();
@@ -36,21 +28,6 @@ export function clearAuthFailedSubs(login: string): void {
   const prefix = `${login}:`;
   for (const key of authFailedSubs) if (key.startsWith(prefix)) authFailedSubs.delete(key);
 }
-
-// Maps EventSub notification types to their handler functions.
-// Using Map instead of a plain object prevents prototype-chain lookup on user-controlled keys.
-type NotificationHandler = (login: string, event: unknown, config: EventSubConfig, streamerId: number) => Promise<void>;
-const notificationHandlers = new Map<string, NotificationHandler>([
-  ['channel.follow',                                   (l, e, c, sid) => handleFollow(l, e as FollowEvent, c, sid)],
-  ['channel.subscribe',                                (l, e, c, sid) => handleSub(l, e as SubEvent, c, sid)],
-  ['channel.subscription.message',                     (l, e, c, sid) => handleResub(l, e as ResubEvent, c, sid)],
-  ['channel.subscription.gift',                        (l, e, c, sid) => handleGiftSub(l, e as GiftSubEvent, c, sid)],
-  ['channel.raid',                                     (l, e, c, sid) => handleRaid(l, e as RaidEvent, c, sid)],
-  ['channel.channel_points_custom_reward_redemption.add',  (l, e, c, sid) => handleRedemption(l, e as RedemptionEvent, c, sid)],
-  ['stream.online',                                    (l) => handleStreamOnline(l)],
-  ['stream.offline',                                   (l) => handleStreamOffline(l)],
-  ['channel.update',                                    (l) => handleChannelUpdate(l)],
-]);
 
 /**
  * Deletes subscriptions that shouldn't be active any more: those whose type isn't in
@@ -103,117 +80,6 @@ async function resolveBroadcasterId(streamer: DbStreamerEventSub, config: EventS
     log.error(`Failed to resolve Twitch user ID for ${streamer.twitch_name}:`, err);
     return null;
   }
-}
-
-/** One gated group of EventSub subscriptions: created together whenever `isGroupEnabled` passes. */
-interface SubscriptionGroup {
-  /**
-   * Alert event types that share this group's subscription(s) — declaring these as data (rather
-   * than each group hand-writing its own `enabledAlerts.has('literal')` checks) lets
-   * `getAlertTypesCoveredBySubscriptionGroups` verify every {@link AlertEventType} is wired to a
-   * group; a test in `twitchEventSubSubscriptions.test.ts` fails if a new alert type is added
-   * without adding it here, instead of the gap silently compiling.
-   */
-  alertTypes: AlertEventType[];
-  /**
-   * Returns true if this group's subscriptions should be created based on the streamer's config
-   * alone — either a genuine chat-message toggle, or (for a group with no `alertTypes`)
-   * {@link hasCompletedEventSubSetup} as a proxy for "this streamer is set up enough to want this
-   * subscription at all". Independent of `alertTypes` — `isGroupEnabled` ORs the alerts-overlay
-   * gating in generically, since a streamer can want the subscription created purely to drive a
-   * browser-source alert, with chat messages off.
-   * @param config - The streamer's event response configuration, or null if unset.
-   */
-  configGate: (config: EventSubConfig | null) => boolean;
-  /**
-   * Builds this group's subscription specs.
-   * @param uid - The broadcaster's Twitch user ID.
-   * @returns The subscription specs to create for this group.
-   */
-  specs: (uid: string) => SubSpec[];
-}
-
-/**
- * Returns true if `group`'s subscriptions should be created: either its `configGate` passes, or
- * any of its `alertTypes` has an enabled alerts-overlay config.
- * @param group - The subscription group to evaluate.
- * @param config - The streamer's event response configuration, or null if unset.
- * @param enabledAlerts - Event types with an enabled alerts-overlay config row for this streamer.
- */
-function isGroupEnabled(
-  group: SubscriptionGroup,
-  config: EventSubConfig | null,
-  enabledAlerts: ReadonlySet<AlertEventType>,
-): boolean {
-  return group.configGate(config) || group.alertTypes.some((type) => enabledAlerts.has(type));
-}
-
-/**
- * `configGate` for a group with no `alertTypes` — unlike the alert-driven groups, there's no
- * alert-only path that needs the subscription without a real config row, so a row's mere
- * existence is used as a proxy for "this streamer completed the full EventSub/chat-message
- * setup". (`dispatchNotification` itself no longer early-exits without config — it falls back to
- * `DEFAULT_EVENT_CONFIG` for alert-only streamers — but that's moot for these groups since they
- * never subscribe for one.)
- * @param config - The streamer's event response configuration, or null if unset.
- */
-function hasCompletedEventSubSetup(config: EventSubConfig | null): boolean {
-  return Boolean(config);
-}
-
-// Every group also requires a broadcaster token (WebSocket transport only works with a user
-// token, not an app token — see createSubscriptionsForStreamer's upfront `!token` check).
-const SUBSCRIPTION_GROUPS: SubscriptionGroup[] = [
-  {
-    alertTypes: ['follow'],
-    configGate: (config) => Boolean(config?.follow_enabled),
-    specs: (uid) => [{ type: 'channel.follow', version: '2', condition: { broadcaster_user_id: uid, moderator_user_id: uid } }],
-  },
-  {
-    alertTypes: ['sub', 'resub', 'giftsub'],
-    configGate: (config) => Boolean(config?.sub_enabled),
-    specs: (uid) => [
-      { type: 'channel.subscribe', version: '1', condition: { broadcaster_user_id: uid } },
-      { type: 'channel.subscription.message', version: '1', condition: { broadcaster_user_id: uid } },
-      { type: 'channel.subscription.gift', version: '1', condition: { broadcaster_user_id: uid } },
-    ],
-  },
-  {
-    // Subscribe when the welcome message, the auto-shoutout toggle, or the raid alert is on —
-    // handleRaid gates its three behaviours independently, but the subscription itself must
-    // exist for any of them to fire.
-    alertTypes: ['raid'],
-    configGate: (config) => Boolean(config?.raid_enabled || config?.raid_shoutout_enabled),
-    specs: (uid) => [{ type: 'channel.raid', version: '1', condition: { to_broadcaster_user_id: uid } }],
-  },
-  {
-    alertTypes: [],
-    configGate: hasCompletedEventSubSetup,
-    specs: (uid) => [{ type: 'channel.channel_points_custom_reward_redemption.add', version: '1', condition: { broadcaster_user_id: uid } }],
-  },
-  {
-    // stream.online/offline and channel.update require no scope beyond a valid token. This
-    // drives an immediate live-check that supplements (not replaces) the 60s poller. Not tied to
-    // any alert type.
-    alertTypes: [],
-    configGate: hasCompletedEventSubSetup,
-    specs: (uid) => [
-      { type: 'stream.online', version: '1', condition: { broadcaster_user_id: uid } },
-      { type: 'stream.offline', version: '1', condition: { broadcaster_user_id: uid } },
-      { type: 'channel.update', version: '2', condition: { broadcaster_user_id: uid } },
-    ],
-  },
-];
-
-/**
- * Returns the set of alert event types covered by at least one subscription group. Exported for
- * the exhaustiveness test in `twitchEventSubSubscriptions.test.ts`, which asserts this covers
- * every member of `ALERT_EVENT_TYPES` — catching a new alert type being added without also being
- * wired into a subscription group's `alertTypes` (which would otherwise compile fine and only
- * surface as "the subscription is never created" at runtime).
- */
-export function getAlertTypesCoveredBySubscriptionGroups(): Set<AlertEventType> {
-  return new Set(SUBSCRIPTION_GROUPS.flatMap((group) => group.alertTypes));
 }
 
 /** Data bundle passed to a StreamerConnection for setting up EventSub subscriptions. */
@@ -289,21 +155,17 @@ export async function loadStreamersForEventSub(): Promise<StreamerEventSubData[]
   return result;
 }
 
-/** Creates all subscriptions for one streamer on their dedicated session, updates streamerMap,
- *  and cleans up stale subscriptions. Returns the count of desired subscriptions. */
+/** Creates all subscriptions for one streamer on their dedicated session, updates the
+ *  dispatch-side streamer map, and cleans up stale subscriptions. Returns the count of
+ *  desired subscriptions. */
 export async function subscribeForStreamer(
   sessionId: string, data: StreamerEventSubData,
 ): Promise<number> {
   const { uid, token, name, config, streamerId } = data;
-  streamerMap.set(uid, { login: name, streamerId, config });
+  setStreamerInfo(uid, { login: name, streamerId, config });
   const { desired, created } = await createSubscriptionsForStreamer(sessionId, data);
   await deleteStaleSubscriptions(uid, desired, created, token);
   return desired.size;
-}
-
-/** Removes a streamer from the in-memory map (called when their connection is stopped). */
-export function removeStreamerFromMap(uid: string): void {
-  streamerMap.delete(uid);
 }
 
 /** Creates a single EventSub subscription. Returns the created subscription's id, or null if
@@ -328,55 +190,5 @@ async function subscribe(sessionId: string, spec: SubSpec, token: string, login:
       log.error(`Failed to subscribe to ${spec.type} for ${login}:`, err);
     }
     return null;
-  }
-}
-
-
-/**
- * Routes an EventSub notification to the appropriate handler based on subscription type.
- * A streamer with no `streamer_event_config` row (`info.config` null) — e.g. one who has only
- * ever enabled a browser-source alert and never completed the chat-message OAuth setup — still
- * dispatches, using `DEFAULT_EVENT_CONFIG` (every chat-message flag disabled) in place of the
- * missing config, so their alert-only subscriptions aren't silently discarded here. Without
- * this fallback, `isGroupEnabled`'s alert-driven subscription creation and this dispatch gate
- * would disagree: the subscription would exist but every notification for it would be dropped.
- */
-export function dispatchNotification(type: string, event: Record<string, unknown>, condition: Record<string, string>): void {
-  const broadcasterId = condition.broadcaster_user_id ?? condition.to_broadcaster_user_id;
-  if (!broadcasterId) return;
-
-  const info = streamerMap.get(broadcasterId);
-  if (!info) return;
-  const config = info.config ?? DEFAULT_EVENT_CONFIG;
-
-  const handler = notificationHandlers.get(type);
-  if (!handler) {
-    log.warn(`Unsupported EventSub notification type: ${type}`);
-    return;
-  }
-  // TypeScript has already narrowed handler to NotificationHandler here, but the explicit
-  // typeof check is required for CodeQL's taint analysis to trust the call is safe.
-  if (typeof handler !== 'function') {
-    log.warn(`Invalid EventSub handler for type: ${type}`);
-    return;
-  }
-  handler(info.login, event, config, info.streamerId)
-    .catch((err) => log.error(`${type} handler error:`, err));
-}
-
-/** Handles a subscription revocation message, clearing the broadcaster's token if authorisation was revoked. */
-export function handleRevocation(sub: { type: string; status: string; condition: Record<string, string> }): void {
-  log.warn(`Subscription revoked: type=${sub.type} status=${sub.status}`);
-
-  if (sub.status === 'authorization_revoked' || sub.status === 'user_removed') {
-    const broadcasterId = sub.condition.broadcaster_user_id ?? sub.condition.to_broadcaster_user_id;
-    if (broadcasterId) {
-      const info = streamerMap.get(broadcasterId);
-      if (info) {
-        clearStreamerToken(info.streamerId)
-          .catch((err) => log.error('Clear token error:', err));
-        log.warn(`Cleared token for ${info.login} (${sub.status})`);
-      }
-    }
   }
 }


### PR DESCRIPTION
## Summary
- Channel point redemptions were sometimes recorded twice in the "Recent Events" dashboard feed (and double-triggering the companion push, dynamic pricing, and overlay video).
- **Symptom-level fix:** the existing EventSub `message_id` dedup (`twitchEventSubConnection.ts`) only catches the same WebSocket delivery being replayed during a documented session-migration window. It can't catch the same physical redemption arriving via two independently-"enabled" subscriptions for the same broadcaster+reward — those arrive as distinct messages with distinct `message_id`s but carry the same underlying redemption `event.id`. `handleRedemption` now deduplicates on Twitch's own redemption id before doing anything else, dropping a repeat notification for the same redemption within a 10-minute window.
- **Root-cause fix:** `deleteStaleSubscriptions` previously only removed subscriptions whose *type* had fallen out of the desired set — it never pruned a duplicate subscription of a type that's still wanted. If the bot process died without calling `StreamerConnection.stop()` (crash, container restart, redeploy), the subscriptions it created weren't explicitly deleted; Twitch eventually revokes an orphaned WebSocket subscription on its own, but not instantaneously, so a fresh process's newly-created subscription of the same type could coexist with the orphaned one — both "enabled," both delivering notifications. `subscribe()` now returns the created subscription's id, and `createSubscriptionsForStreamer` tracks a type → id map of what was actually (re)created this round, which `deleteStaleSubscriptions` uses to prune any *other* existing subscription of a still-desired type. A type is left untouched if this round's create hit a 409 (already exists), since there's no fresh id to prefer over whatever's already there and pruning blind could delete the subscription actually receiving events.

The redemption-id dedup stays in place as defense in depth against duplicate delivery from causes other than this specific lifecycle gap.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 3047 tests passing)
- [x] Added tests: a second redemption notification with the same id is ignored; two notifications with different ids are both processed; a duplicate same-type subscription left over from a prior session gets pruned; a still-existing subscription is left alone when this round's create hit a 409.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added structured Twitch EventSub support for follows, subscriptions, raids, redemptions, stream updates, and channel updates.
  - Added configuration-aware subscription management for supported alerts and channel features.

- **Bug Fixes**
  - Prevented duplicate Twitch redemption notifications from triggering repeated rewards or effects.
  - Improved subscription cleanup while preserving valid existing subscriptions.
  - Added handling for revoked authorizations and removed streamers.
  - Improved reliability when unsupported events or notification-handler errors occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->