### PR TITLE
Break Discord/audio circular dependency cluster

### DIFF
--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -11,20 +11,20 @@ import { isRegisteredGuild, reloadGuildRegistry } from './guildRegistry';
 import { upsertGuild, getGuildById, findUser, upsertUser, setMemberAccessLevel, AccessLevel } from '../db';
 import { userMutationQueue } from '../web/routes/adminUserMutationQueue';
 import { createLogger } from '../shared/logger';
+import { getDiscordClient, setDiscordClient } from './discordClientStore';
 
 const log = createLogger('Discord');
 
-let client: Client | null = null;
 let bootingClient: Client | null = null;
 
-/** Returns the Discord.js Client once it has fired `clientReady`, or null before then. */
-export function getDiscordClient(): Client | null { return client; }
+export { getDiscordClient };
 
 /**
  * Resolve a guild by ID from the discord.js cache, falling back to a fetch.
  * @throws if the client is not ready.
  */
 async function getGuild(guildId: string): Promise<Guild> {
+  const client = getDiscordClient();
   if (!client) {
     throw new Error('Discord client is not ready');
   }
@@ -47,7 +47,7 @@ export async function fetchMemberDisplayName(
   guildId: string,
   force = false,
 ): Promise<string | null> {
-  if (!client) return null;
+  if (!getDiscordClient()) return null;
   try {
     const guild = await getGuild(guildId);
     const member = await guild.members.fetch({ user: discordId, force });
@@ -115,7 +115,7 @@ async function provisionGuildOwner(guild: Guild): Promise<void> {
  * client connects, so the `messageCreate` gate can recognise registered guilds.
  */
 export function startDiscordBot(): void {
-  if (client || bootingClient) return;
+  if (getDiscordClient() || bootingClient) return;
   const localClient = new Client({
     intents: [
       GatewayIntentBits.Guilds,
@@ -183,7 +183,7 @@ export function startDiscordBot(): void {
       return;
     }
     bootingClient = null;
-    client = c;
+    setDiscordClient(c);
     log.info(`Logged in as ${c.user.tag}`);
     setDiscordReady(c.user.tag);
   });
@@ -204,9 +204,9 @@ export function startDiscordBot(): void {
  * `destroy()` rejections are caught and logged rather than left unhandled.
  */
 export function stopDiscordBot(): void {
-  const existingReady = client;
+  const existingReady = getDiscordClient();
   const existingBooting = bootingClient;
-  client = null;
+  setDiscordClient(null);
   bootingClient = null;
   existingReady?.destroy().catch((err: unknown) => log.error('Error destroying client:', err));
   existingBooting?.destroy().catch((err: unknown) => log.error('Error destroying booting client:', err));

--- a/src/discord/discordClientStore.ts
+++ b/src/discord/discordClientStore.ts
@@ -1,0 +1,9 @@
+import { type Client } from 'discord.js';
+
+let client: Client | null = null;
+
+/** Returns the Discord.js Client once it has fired `clientReady`, or null before then. */
+export function getDiscordClient(): Client | null { return client; }
+
+/** Sets the current Discord.js Client instance (or null on shutdown). */
+export function setDiscordClient(c: Client | null): void { client = c; }

--- a/src/discord/discordClientStore.ts
+++ b/src/discord/discordClientStore.ts
@@ -5,5 +5,9 @@ let client: Client | null = null;
 /** Returns the Discord.js Client once it has fired `clientReady`, or null before then. */
 export function getDiscordClient(): Client | null { return client; }
 
-/** Sets the current Discord.js Client instance (or null on shutdown). */
+/**
+ * Sets the current Discord.js Client instance, or clears it on shutdown.
+ * @param c - The client instance to store, or `null` to clear the store.
+ * @returns Nothing.
+ */
 export function setDiscordClient(c: Client | null): void { client = c; }

--- a/src/discord/discordUtils.test.ts
+++ b/src/discord/discordUtils.test.ts
@@ -3,7 +3,7 @@ import { mockLogger } from '../test-utils/loggerMock';
 
 /** Mocks the shared logger so this module's log calls don't produce real output during tests. */
 vi.mock('../shared/logger', () => ({ createLogger: mockLogger }));
-vi.mock('./discordBot', () => ({ getDiscordClient: vi.fn() }));
+vi.mock('./discordClientStore', () => ({ getDiscordClient: vi.fn() }));
 
 vi.mock('discord.js', () => {
   class DiscordAPIError extends Error {
@@ -39,7 +39,7 @@ import {
   tryEditDiscordMessage,
 } from './discordUtils';
 import { DiscordAPIError } from 'discord.js';
-import { getDiscordClient } from './discordBot';
+import { getDiscordClient } from './discordClientStore';
 
 // The mock above replaces DiscordAPIError with a simpler single-arg constructor.
 // Cast here so TypeScript accepts the mock's signature without casting at every call site.

--- a/src/discord/discordUtils.ts
+++ b/src/discord/discordUtils.ts
@@ -1,6 +1,6 @@
 import { createLogger } from '../shared/logger';
 import { DiscordAPIError, RESTJSONErrorCodes, ChannelType, type Client, type MessageEditOptions, type TextBasedChannel } from 'discord.js';
-import { getDiscordClient } from './discordBot';
+import { getDiscordClient } from './discordClientStore';
 
 const log = createLogger('Discord');
 


### PR DESCRIPTION
## Summary

Ran `madge --circular` against the codebase to look for structural issues. It found 9 circular-dependency cycles in two clusters:

1. **Discord/audio cluster (5 cycles)** — a real, fixable tangle. All 5 cycles shared one root edge: `discordUtils.ts` imported `getDiscordClient` from `discordBot.ts`, while `discordBot.ts` transitively depended back on `discordUtils.ts` through `audioPlayer.ts`, `commandRouter.ts`, `counterHandler.ts`, and `customCommandHandler.ts`. Fixed here.
2. **DB cache/data pairs (4 cycles)** — `db/alertConfig.ts↔alertConfigCache.ts`, `db/counterCache.ts↔counters.ts`, `db/customCommandCache.ts↔customCommands.ts`, `db/sfx.ts↔sfxCache.ts`. Investigated and confirmed to be an intentional, already-documented cache-invalidation pattern (each data file calls `invalidate*LookupCache()` after writes; each cache file lazily calls the bulk `getAll*()` reader on cache miss — every circular reference lives inside a function body, never at module-eval time, which is safe under this project's CommonJS output). Left as-is; not part of this PR.

## Changes

- New `src/discord/discordClientStore.ts`: holds the Discord client singleton (`getDiscordClient` / `setDiscordClient`), with no app-internal imports so it can never participate in a cycle.
- `src/discord/discordBot.ts`: delegates to the new store instead of holding `client` as a local variable; still re-exports `getDiscordClient` from `./discordBot` so the ~15 existing external consumers need no changes.
- `src/discord/discordUtils.ts`: imports `getDiscordClient` from the new store instead of from `discordBot.ts`, removing the cycle.
- `src/discord/discordUtils.test.ts`: updated mock target to match the new import.

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm test` — 3043 tests passing (163 files)
- [x] `npm run lint` — no new errors (4 pre-existing unrelated warnings)
- [x] Re-ran `npx madge --circular --extensions ts --ts-config tsconfig.json src` — confirms the 5 Discord/audio cycles are gone; only the 4 intentional DB cache/data cycles remain

---
_Generated by [Claude Code](https://claude.ai/code/session_0125vFhGvQe2N9DYKk5KSFGV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Discord client state management across startup, readiness checks, and shutdown.
  * Preserved existing client lifecycle behavior, including handling clients that are still starting.
* **Tests**
  * Updated Discord utility tests to use the shared client state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->