### PR TITLE
Break remaining db-layer circular deps and add a madge CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,10 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Check circular dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: npm run check:circular
+
       - name: Run tests with coverage
         run: npm run test:coverage
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -49,4 +49,18 @@ module.exports = tseslint.config(
       },
     },
   },
+  {
+    // Plain CommonJS CLI scripts, run directly via `node` — not part of the src/**/*.ts
+    // TypeScript program, so they need their own Node globals instead of tsconfig's.
+    files: ['scripts/**/*.js'],
+    languageOptions: {
+      sourceType: 'commonjs',
+      globals: {
+        require: 'readonly',
+        module: 'readonly',
+        process: 'readonly',
+        console: 'readonly',
+      },
+    },
+  },
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -3728,6 +3728,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/filing-cabinet/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "@types/ws": "^8.18.1",
         "@vitest/coverage-v8": "^4.1.10",
         "eslint": "^10.8.0",
+        "madge": "^8.0.0",
         "supertest": "^7.2.2",
         "ts-node": "^10.9.2",
         "typescript": "^6.0.3",
@@ -68,13 +69,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -84,9 +85,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -138,6 +139,20 @@
         "@so-ric/colorspace": "^1.1.6",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@dependents/detective-less": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@dependents/detective-less/-/detective-less-5.0.3.tgz",
+      "integrity": "sha512-v6oD9Ukp+N7V4n6p5I/+mM5fIohSfkrDSGlFm5w/pYmchvbk+sMIHsLxrFJ5Lnujewj1BzWL0K84d88lwZAMQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "gonzales-pe": "^4.3.0",
+        "node-source-walk": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@derhuerst/http-basic": {
@@ -329,6 +344,16 @@
       },
       "funding": {
         "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-1.1.0.tgz",
+      "integrity": "sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.17.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1226,6 +1251,96 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@ts-graphviz/adapter": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@ts-graphviz/adapter/-/adapter-2.0.6.tgz",
+      "integrity": "sha512-kJ10lIMSWMJkLkkCG5gt927SnGZcBuG0s0HHswGzcHTgvtUe7yk5/3zTEr0bafzsodsOq5Gi6FhQeV775nC35Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ts-graphviz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ts-graphviz"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ts-graphviz/common": "^2.1.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ts-graphviz/ast": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@ts-graphviz/ast/-/ast-2.0.7.tgz",
+      "integrity": "sha512-e6+2qtNV99UT6DJSoLbHfkzfyqY84aIuoV8Xlb9+hZAjgpum8iVHprGeAMQ4rF6sKUAxrmY8rfF/vgAwoPc3gw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ts-graphviz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ts-graphviz"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ts-graphviz/common": "^2.1.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ts-graphviz/common": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@ts-graphviz/common/-/common-2.1.5.tgz",
+      "integrity": "sha512-S6/9+T6x8j6cr/gNhp+U2olwo1n0jKj/682QVqsh7yXWV6ednHYqxFw0ZsY3LyzT0N8jaZ6jQY9YD99le3cmvg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ts-graphviz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ts-graphviz"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ts-graphviz/core": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@ts-graphviz/core/-/core-2.0.7.tgz",
+      "integrity": "sha512-w071DSzP94YfN6XiWhOxnLpYT3uqtxJBDYdh6Jdjzt+Ce6DNspJsPQgpC7rbts/B8tEkq0LHoYuIF/O5Jh5rPg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ts-graphviz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ts-graphviz"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ts-graphviz/ast": "^2.0.7",
+        "@ts-graphviz/common": "^2.1.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
@@ -1882,6 +1997,81 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.41.tgz",
+      "integrity": "sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@vue/shared": "3.5.41",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.41.tgz",
+      "integrity": "sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.41",
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.41.tgz",
+      "integrity": "sha512-XJhip7R2wy6vX3knCxdZN4KracFaZUef58s1KYewqluedHIJaPIVfXoYT7MF1F8nCvv6k8bWWxDC8opMkg1VTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@vue/compiler-core": "3.5.41",
+        "@vue/compiler-dom": "3.5.41",
+        "@vue/compiler-ssr": "3.5.41",
+        "@vue/shared": "3.5.41",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.19",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.41.tgz",
+      "integrity": "sha512-U3v5OejKEGqOI0Wy0+Sz7hGuIFZHA4LSXzrNM3IMIeDyJEBBfTpX26n3SDgToRpP2bLc9FfI2j/kSgcJ8Emq5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.41",
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.41.tgz",
+      "integrity": "sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -1985,6 +2175,66 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ansi-styles/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/app-module-path": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
+      "integrity": "sha512-gkco+qxENJV+8vFcDiiFhuoSvRXb2a/QPqpSoWhVz829VNJfOTnELbBmPmNKFxf3xdNnw4DWCkzkDaavcX/1YQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/append-field": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
@@ -2013,6 +2263,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-module-types": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-6.0.2.tgz",
+      "integrity": "sha512-6KuK/7nZ/2Qh7sGuVEiwxjCxzTY2Pdb5mTo5z1e6/J8BA0tvjR7G8vQJKrQMTqwmnA3UPEyKIFX4YUS1DO1Hvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ast-v8-to-istanbul": {
@@ -2070,6 +2330,39 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
@@ -2118,6 +2411,31 @@
       },
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -2191,6 +2509,59 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
@@ -2249,6 +2620,23 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/component-emitter": {
       "version": "1.3.1",
@@ -2368,12 +2756,35 @@
         }
       }
     },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -2403,6 +2814,36 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dependency-tree": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/dependency-tree/-/dependency-tree-11.5.0.tgz",
+      "integrity": "sha512-K9zBwKDZrot3RkxizugpVSdImxULAg4Ycp3+ydy2r561k96oiiw6nfsOR15fwNDQ5BF2UXe+2JFM/H5Xz4MGQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "^1.1.0",
+        "commander": "^12.1.0",
+        "filing-cabinet": "^5.5.1",
+        "precinct": "^12.3.2",
+        "typescript": "^5.9.3"
+      },
+      "bin": {
+        "dependency-tree": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/dependency-tree/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2411,6 +2852,147 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/detective-amd": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/detective-amd/-/detective-amd-6.1.0.tgz",
+      "integrity": "sha512-fmI6LGMvotqd49QaA3ZYw+q0aGp2yXmMjzIuY6fH9j9YFIXY/73yDhMwhX9cPbhWd+AH06NH1Di/LKOuCH0Ubg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-module-types": "^6.0.1",
+        "escodegen": "^2.1.0",
+        "get-amd-module-type": "^6.0.2",
+        "node-source-walk": "^7.0.1"
+      },
+      "bin": {
+        "detective-amd": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/detective-cjs": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/detective-cjs/-/detective-cjs-6.1.1.tgz",
+      "integrity": "sha512-pSh7mkCKEtLlmANqLu3KDFS3NV8Hx41jy/JF1/gAWOgU+Uo5QTkeI1tWNP4dWGo4L0E9j18Ez9EPsTleautKqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-module-types": "^6.0.1",
+        "node-source-walk": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/detective-es6": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/detective-es6/-/detective-es6-5.0.2.tgz",
+      "integrity": "sha512-+qHHGYhjupiVs4rnIpI9nZ5B130A4AmE35ZX1w33hb46vcZ7T3jfDbvmPw0FhWtMHn5BS5HHu7ZtnZ53bMcXZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-source-walk": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/detective-postcss": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/detective-postcss/-/detective-postcss-8.0.4.tgz",
+      "integrity": "sha512-DZ7M/hWPZyr17ZUdoQ+TVXaPj70mYr4XXrAE+GeJbca44haCvZgb191L/jLJmFYewhxRJuBd4lUtNSu986TXag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-url-superb": "^4.0.0",
+        "postcss-values-parser": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.47"
+      }
+    },
+    "node_modules/detective-sass": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/detective-sass/-/detective-sass-6.0.2.tgz",
+      "integrity": "sha512-i3xpXHDKS0qI2aFW4asQ7fqlPK00ndOVZELvQapFJCaF0VxYmsNWtd0AmvXbTLMk7bfO5VdIeorhY9KfmHVoVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "gonzales-pe": "^4.3.0",
+        "node-source-walk": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/detective-scss": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/detective-scss/-/detective-scss-5.0.2.tgz",
+      "integrity": "sha512-9JOEMZ8pDh3ShXmftq7hoQqqJsClaGgxo1hghfCeFlmKf5TC/Twtwb0PAaK8dXwpg9Z0uCmEYSrCxO+kel2eEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "gonzales-pe": "^4.3.0",
+        "node-source-walk": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/detective-stylus": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/detective-stylus/-/detective-stylus-5.0.1.tgz",
+      "integrity": "sha512-Dgn0bUqdGbE3oZJ+WCKf8Dmu7VWLcmRJGc6RCzBgG31DLIyai9WAoEhYRgIHpt/BCRMrnXLbGWGPQuBUrnF0TA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/detective-typescript": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-14.1.2.tgz",
+      "integrity": "sha512-bIeEn0eVi/JRsE1YizBR2ilnMlWRAIBJJ6kXCKNFxEEWhUcEY3R6I3KYIAy48ieURbD1hcb3Ebvl8AqeoPMSzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "^8.58.2",
+        "ast-module-types": "^6.0.1",
+        "node-source-walk": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "typescript": "^5.4.4 || ^6.0.2"
+      }
+    },
+    "node_modules/detective-vue2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/detective-vue2/-/detective-vue2-2.3.0.tgz",
+      "integrity": "sha512-3gwbZPqVTm9sL9XdZsgEJ7x4x99O853VVZHapQAiEkGuMJMpFPjHDrecSgfqnS5JW3FJfYXesLZGvUOibjn49g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dependents/detective-less": "^5.0.1",
+        "@vue/compiler-sfc": "^3.5.32",
+        "detective-es6": "^5.0.1",
+        "detective-sass": "^6.0.1",
+        "detective-scss": "^5.0.1",
+        "detective-stylus": "^5.0.1",
+        "detective-typescript": "^14.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "typescript": "^5.4.4 || ^6.0.2"
       }
     },
     "node_modules/dezalgo": {
@@ -2529,6 +3111,33 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -2608,6 +3217,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
       }
     },
     "node_modules/eslint": {
@@ -2717,6 +3348,20 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/esquery": {
@@ -3047,6 +3692,42 @@
         "moment": "^2.29.1"
       }
     },
+    "node_modules/filing-cabinet": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-5.5.1.tgz",
+      "integrity": "sha512-PzLBTChlVPn6LnNxF0KWs+XqPziVh3Sfmz/3TXOymHxu6a9yhrDcQn7YwgpcRM6mqhR2WHVGPR8RU4fmcF1IVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "app-module-path": "^2.2.0",
+        "commander": "^12.1.0",
+        "enhanced-resolve": "^5.21.0",
+        "module-definition": "^6.0.2",
+        "module-lookup-amd": "^9.1.3",
+        "resolve": "^1.22.12",
+        "resolve-dependency-path": "^4.0.1",
+        "sass-lookup": "^6.1.2",
+        "stylus-lookup": "^6.1.2",
+        "tsconfig-paths": "^4.2.0",
+        "typescript": "^5.9.3"
+      },
+      "bin": {
+        "filing-cabinet": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/filing-cabinet/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -3208,6 +3889,20 @@
         "is-property": "^1.0.2"
       }
     },
+    "node_modules/get-amd-module-type": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/get-amd-module-type/-/get-amd-module-type-6.0.2.tgz",
+      "integrity": "sha512-7zShVYAYtMnj9S65CfN+hvpBCByfuB1OY8xID01nZEzXTZbx4YyysAfi+nMl95JSR6odt4q8TCj2W63KAoyVLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-module-types": "^6.0.1",
+        "node-source-walk": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -3231,6 +3926,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/get-own-enumerable-property-symbols": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
+      "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
@@ -3258,6 +3960,22 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/gonzales-pe": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
+      "integrity": "sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "gonzales": "bin/gonzales.js"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -3269,6 +3987,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -3403,6 +4128,27 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3429,6 +4175,13 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/ip-address": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
@@ -3445,6 +4198,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extglob": {
@@ -3470,6 +4239,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -3481,6 +4270,42 @@
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
       "license": "MIT"
+    },
+    "node_modules/is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-url-superb": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-4.0.0.tgz",
+      "integrity": "sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3555,6 +4380,19 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/kuler": {
       "version": "2.0.0",
@@ -3880,6 +4718,23 @@
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
       "license": "MIT"
     },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/logform": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
@@ -3916,6 +4771,45 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wellwelwel"
+      }
+    },
+    "node_modules/madge": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/madge/-/madge-8.0.0.tgz",
+      "integrity": "sha512-9sSsi3TBPhmkTCIpVQF0SPiChj1L7Rq9kU2KDG1o6v2XH9cCw086MopjVCD+vuoL5v8S77DTbVopTO8OUiQpIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "commander": "^7.2.0",
+        "commondir": "^1.0.1",
+        "debug": "^4.3.4",
+        "dependency-tree": "^11.0.0",
+        "ora": "^5.4.1",
+        "pluralize": "^8.0.0",
+        "pretty-ms": "^7.0.1",
+        "rc": "^1.2.8",
+        "stream-to-array": "^2.3.0",
+        "ts-graphviz": "^2.1.2",
+        "walkdir": "^0.4.1"
+      },
+      "bin": {
+        "madge": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://www.paypal.me/pahen"
+      },
+      "peerDependencies": {
+        "typescript": "^5.4.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/magic-bytes.js": {
@@ -4323,6 +5217,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -4337,6 +5241,61 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/module-definition": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-6.0.2.tgz",
+      "integrity": "sha512-SvAU3lB0+Yjbq55yHY3wkRZBOh+fhU1SnIF3IFbTewv6mtAh7yUT8ACHAJ2mGIJ7tCes2QuCL/cl6m0JSZ/ArA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-module-types": "^6.0.1",
+        "node-source-walk": "^7.0.1"
+      },
+      "bin": {
+        "module-definition": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/module-lookup-amd": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/module-lookup-amd/-/module-lookup-amd-9.1.3.tgz",
+      "integrity": "sha512-Jc3XmOaR9FdfMJSK8+vyLgsCkzm8z2L0NS6vrlRWi12DjS7MY7TMNE7E1yj8yXx837xtMDbKSSgcdXnFlJ2YLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^12.1.0",
+        "requirejs": "^2.3.8",
+        "requirejs-config-file": "^4.0.0"
+      },
+      "bin": {
+        "lookup-amd": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/module-lookup-amd/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/moment": {
@@ -4484,6 +5443,19 @@
         }
       }
     },
+    "node_modules/node-source-walk": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-7.0.2.tgz",
+      "integrity": "sha512-71kFFjYaSshDTA8/a2HiTYPLdASWjLJxUyJxGE+ffxU+KhxSBtM9kiLUX+R2yooFdSFKMFpi4n3PFtDy6qXv8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/object-hash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
@@ -4555,6 +5527,22 @@
         "fn.name": "1.x.x"
       }
     },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/openai": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/openai/-/openai-7.3.0.tgz",
@@ -4606,6 +5594,30 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -4643,6 +5655,16 @@
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
       "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
     },
+    "node_modules/parse-ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
+      "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -4671,6 +5693,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-to-regexp": {
       "version": "8.4.0",
@@ -4709,6 +5738,16 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.23",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
@@ -4738,6 +5777,71 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-values-parser": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-6.0.2.tgz",
+      "integrity": "sha512-YLJpK0N1brcNJrs9WatuJFtHaV9q5aAOj+S4DI5S7jgHlRfm0PIbDCAFRYMQD5SHq7Fy6xsDhyutgS0QOAs0qw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "is-url-superb": "^4.0.0",
+        "quote-unquote": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.9"
+      }
+    },
+    "node_modules/postcss-values-parser/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/precinct": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/precinct/-/precinct-12.3.2.tgz",
+      "integrity": "sha512-JbJevI1K80z8e/WIyDt/4vUN/4qcfBSKKqOjJA4mosPPPb7zODKRJQV7YN7apVWN3k58nZYm/vEsLgEGYmnxwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dependents/detective-less": "^5.0.3",
+        "commander": "^12.1.0",
+        "detective-amd": "^6.1.0",
+        "detective-cjs": "^6.1.1",
+        "detective-es6": "^5.0.2",
+        "detective-postcss": "^8.0.3",
+        "detective-sass": "^6.0.2",
+        "detective-scss": "^5.0.2",
+        "detective-stylus": "^5.0.1",
+        "detective-typescript": "^14.1.2",
+        "detective-vue2": "^2.3.0",
+        "module-definition": "^6.0.2",
+        "node-source-walk": "^7.0.2",
+        "postcss": "^8.5.14",
+        "typescript": "^5.9.3"
+      },
+      "bin": {
+        "precinct": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/precinct/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4746,6 +5850,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
+      "integrity": "sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/progress": {
@@ -4795,6 +5915,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/quote-unquote": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/quote-unquote/-/quote-unquote-1.0.0.tgz",
+      "integrity": "sha512-twwRO/ilhlG/FIgYeKGFqyHhoEhqgnKVkcmqMKi2r524gz3ZbDTcyFt38E9xjJI2vT+KbRNHVbnJ/e0I25Azwg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/random-bytes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
@@ -4828,6 +5955,22 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -4840,6 +5983,80 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/requirejs": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.8.tgz",
+      "integrity": "sha512-7/cTSLOdYkNBNJcDMWf+luFvMriVm7eYxp4BcFCsAX0wF421Vyce5SXP17c+Jd5otXKGNehIonFlyQXSowL6Mw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "r_js": "bin/r.js",
+        "r.js": "bin/r.js"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/requirejs-config-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/requirejs-config-file/-/requirejs-config-file-4.0.0.tgz",
+      "integrity": "sha512-jnIre8cbWOyvr8a5F2KuqBnY+SDA4NXr/hzEZJG79Mxm2WiFQz2dzhC8ibtPJS7zkmBEl1mxSwp5HhC1W4qpxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esprima": "^4.0.0",
+        "stringify-object": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-dependency-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dependency-path/-/resolve-dependency-path-4.0.1.tgz",
+      "integrity": "sha512-YQftIIC4vzO9UMhO/sCgXukNyiwVRCVaxiWskCBy7Zpqkplm8kTAISZ8O1MoKW1ca6xzgLUBjZTcDgypXvXxiQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/rolldown": {
@@ -4926,6 +6143,33 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/sass-lookup": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/sass-lookup/-/sass-lookup-6.1.2.tgz",
+      "integrity": "sha512-GjmndmKQBtlPil79RK72L7yc5kDXZPCQeH97bP8R8DcxtXQJO6vECExb3WP/m6+cxaV9h4ZxrSRvCkPG2v/VSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^12.1.0",
+        "enhanced-resolve": "^5.20.0"
+      },
+      "bin": {
+        "sass-lookup": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/sass-lookup/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/semver": {
       "version": "7.8.1",
@@ -5118,6 +6362,24 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5175,6 +6437,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stream-to-array": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/stream-to-array/-/stream-to-array-2.3.0.tgz",
+      "integrity": "sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.1.0"
+      }
+    },
     "node_modules/streamsearch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
@@ -5190,6 +6462,80 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/stringify-object": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+      "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "get-own-enumerable-property-symbols": "^3.0.0",
+        "is-obj": "^1.0.1",
+        "is-regexp": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stylus-lookup": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/stylus-lookup/-/stylus-lookup-6.1.2.tgz",
+      "integrity": "sha512-O+Q/SJ8s1X2aMLh4213fQ9X/bND9M3dhSsyTRe+O1OXPcewGLiYmAtKCrnP7FDvDBaXB2ZHPkCt3zi4cJXBlCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "stylus-lookup": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/stylus-lookup/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/superagent": {
@@ -5239,6 +6585,33 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/text-hex": {
@@ -5341,6 +6714,32 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-graphviz": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/ts-graphviz/-/ts-graphviz-2.1.6.tgz",
+      "integrity": "sha512-XyLVuhBVvdJTJr2FJJV2L1pc4MwSjMhcunRVgDE9k4wbb2ee7ORYnPewxMWUav12vxyfUM686MSGsqnVRIInuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ts-graphviz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ts-graphviz"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ts-graphviz/adapter": "^2.0.6",
+        "@ts-graphviz/ast": "^2.0.7",
+        "@ts-graphviz/common": "^2.1.5",
+        "@ts-graphviz/core": "^2.0.7"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/ts-mixer": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
@@ -5389,6 +6788,21 @@
         "@swc/wasm": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tslib": {
@@ -5744,6 +7158,26 @@
         "vite": {
           "optional": false
         }
+      }
+    },
+    "node_modules/walkdir": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.4.1.tgz",
+      "integrity": "sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint .",
-    "check:circular": "madge --circular --extensions ts --ts-config tsconfig.json src",
+    "check:circular": "node scripts/checkCircularDeps.js",
     "graphify:hook": "graphify hook install",
     "deploy": "bash deploy.sh"
   },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint .",
+    "check:circular": "madge --circular --extensions ts --ts-config tsconfig.json src",
     "graphify:hook": "graphify hook install",
     "deploy": "bash deploy.sh"
   },
@@ -36,7 +37,10 @@
   "overrides": {
     "ws": ">=8.21.1",
     "undici": "^7.29.0",
-    "mysql2": "^3.23.1"
+    "mysql2": "^3.23.1",
+    "madge": {
+      "typescript": "$typescript"
+    }
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
@@ -51,6 +55,7 @@
     "@types/ws": "^8.18.1",
     "@vitest/coverage-v8": "^4.1.10",
     "eslint": "^10.8.0",
+    "madge": "^8.0.0",
     "supertest": "^7.2.2",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.3",

--- a/scripts/checkCircularDeps.js
+++ b/scripts/checkCircularDeps.js
@@ -15,18 +15,20 @@ madge('src', {
   if (skipped.length > 0) {
     console.error('madge could not resolve the following files, so its circular-dependency check is incomplete:');
     for (const file of skipped) console.error(`  - ${file}`);
-    process.exit(2);
+    process.exitCode = 2;
+    return;
   }
 
   const circular = result.circular();
   if (circular.length > 0) {
     console.error(`Found ${circular.length} circular dependencies:`);
     for (const cycle of circular) console.error(`  ${cycle.join(' > ')}`);
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   console.log('No circular dependencies found.');
 }).catch((error) => {
   console.error(error);
-  process.exit(2);
+  process.exitCode = 2;
 });

--- a/scripts/checkCircularDeps.js
+++ b/scripts/checkCircularDeps.js
@@ -1,0 +1,32 @@
+'use strict';
+
+// Uses the madge Node API (rather than its CLI) because the CLI's --circular
+// flag only exits non-zero on discovered cycles — it silently ignores files
+// madge couldn't resolve, which would let an incomplete (and therefore
+// unreliable) analysis pass CI. Failing on warnings first means an import madge
+// can't follow is caught explicitly, instead of just quietly not checked.
+const madge = require('madge');
+
+madge('src', {
+  fileExtensions: ['ts'],
+  tsConfig: 'tsconfig.json',
+}).then((result) => {
+  const skipped = result.warnings().skipped;
+  if (skipped.length > 0) {
+    console.error('madge could not resolve the following files, so its circular-dependency check is incomplete:');
+    for (const file of skipped) console.error(`  - ${file}`);
+    process.exit(2);
+  }
+
+  const circular = result.circular();
+  if (circular.length > 0) {
+    console.error(`Found ${circular.length} circular dependencies:`);
+    for (const cycle of circular) console.error(`  ${cycle.join(' > ')}`);
+    process.exit(1);
+  }
+
+  console.log('No circular dependencies found.');
+}).catch((error) => {
+  console.error(error);
+  process.exit(2);
+});

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -35,10 +35,12 @@ vi.mock('./db/guildCommandOverrides', () => ({
 
 vi.mock('./db/customCommands', () => ({
   getAllCustomCommandsWithAssignments: vi.fn(),
+  getCustomCommandCount: vi.fn(),
   addCustomCommand: vi.fn(),
   updateCustomCommand: vi.fn(),
   removeCustomCommand: vi.fn(),
   assignUserToCommand: vi.fn(),
+  assignUsersToCommand: vi.fn(),
   unassignUserFromCommand: vi.fn(),
 }));
 
@@ -57,6 +59,8 @@ vi.mock('./db/reservedCommands', () => ({
 vi.mock('./db/counters', () => ({
   CounterNotFoundError: class extends Error {},
   getAllCounters: vi.fn(),
+  getCounterCount: vi.fn(),
+  getCounterHistory: vi.fn(),
   addCounter: vi.fn(),
   updateCounter: vi.fn(),
   removeCounter: vi.fn(),
@@ -98,7 +102,41 @@ vi.mock('./db/sfx', () => ({
   findTrigger: vi.fn(),
   findSoundFiles: vi.fn(),
   getAllSfxTriggers: vi.fn(),
+  getSfxTriggerCount: vi.fn(),
   getPublicSfxTriggers: vi.fn(),
+  getAllCategories: vi.fn(),
+  createCategory: vi.fn(),
+  renameCategory: vi.fn(),
+  deleteCategory: vi.fn(),
+  getSfxFileById: vi.fn(),
+  createSfxTrigger: vi.fn(),
+  updateSfxTrigger: vi.fn(),
+  deleteSfxTrigger: vi.fn(),
+  addSfxFile: vi.fn(),
+  updateSfxFile: vi.fn(),
+  deleteSfxFile: vi.fn(),
+}));
+
+vi.mock('./db/sfxCache', () => ({
+  invalidateSfxLookupCache: vi.fn(),
+  findCachedSfxTrigger: vi.fn(),
+}));
+
+vi.mock('./db/alertConfig', () => ({
+  ALERT_EVENT_TYPES: [],
+  ALERT_TEXT_ANIMATIONS: [],
+  getAlertConfigsForStreamer: vi.fn(),
+  getAlertConfig: vi.fn(),
+  getEnabledAlertEventTypesBatch: vi.fn(),
+  initAlertConfigs: vi.fn(),
+  saveAlertConfig: vi.fn(),
+  setAlertImage: vi.fn(),
+  setAlertSound: vi.fn(),
+}));
+
+vi.mock('./db/alertConfigCache', () => ({
+  invalidateAlertConfigLookupCache: vi.fn(),
+  findCachedAlertConfig: vi.fn(),
 }));
 
 vi.mock('./db/overlayVideos', () => ({
@@ -139,7 +177,49 @@ vi.mock('./db/lookupCache', () => ({
 import { upsertUserRecord, setTwitchBotEnabledRecord } from './db/users';
 import { invalidateCustomCommandLookupCache } from './db/customCommandCache';
 import { upsertOverride as upsertOverrideRecord, removeOverride as removeOverrideRecord } from './db/guildCommandOverrides';
-import { upsertUser, updateTwitchBotEnabled, upsertOverride, removeOverride } from './db';
+import {
+  addCustomCommand as addCustomCommandRecord,
+  updateCustomCommand as updateCustomCommandRecord,
+  removeCustomCommand as removeCustomCommandRecord,
+  assignUserToCommand as assignUserToCommandRecord,
+  assignUsersToCommand as assignUsersToCommandRecord,
+  unassignUserFromCommand as unassignUserFromCommandRecord,
+} from './db/customCommands';
+import { invalidateCounterLookupCache } from './db/counterCache';
+import {
+  addCounter as addCounterRecord,
+  updateCounter as updateCounterRecord,
+  removeCounter as removeCounterRecord,
+  resetCounterCurrentValue as resetCounterCurrentValueRecord,
+  incrementCounter as incrementCounterRecord,
+  archiveAndResetYearlyCounters as archiveAndResetYearlyCountersRecord,
+} from './db/counters';
+import { invalidateAlertConfigLookupCache } from './db/alertConfigCache';
+import {
+  initAlertConfigs as initAlertConfigsRecord,
+  saveAlertConfig as saveAlertConfigRecord,
+  setAlertImage as setAlertImageRecord,
+  setAlertSound as setAlertSoundRecord,
+} from './db/alertConfig';
+import { invalidateSfxLookupCache } from './db/sfxCache';
+import {
+  createSfxTrigger as createSfxTriggerRecord,
+  updateSfxTrigger as updateSfxTriggerRecord,
+  deleteSfxTrigger as deleteSfxTriggerRecord,
+  addSfxFile as addSfxFileRecord,
+  updateSfxFile as updateSfxFileRecord,
+  deleteSfxFile as deleteSfxFileRecord,
+} from './db/sfx';
+import {
+  upsertUser, updateTwitchBotEnabled, upsertOverride, removeOverride,
+  addCustomCommand, updateCustomCommand, removeCustomCommand,
+  assignUserToCommand, assignUsersToCommand, unassignUserFromCommand,
+  addCounter, updateCounter, removeCounter, resetCounterCurrentValue,
+  incrementCounter, archiveAndResetYearlyCounters,
+  initAlertConfigs, saveAlertConfig, setAlertImage, setAlertSound,
+  createSfxTrigger, updateSfxTrigger, deleteSfxTrigger,
+  addSfxFile, updateSfxFile, deleteSfxFile,
+} from './db';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -147,6 +227,28 @@ beforeEach(() => {
   vi.mocked(setTwitchBotEnabledRecord).mockResolvedValue(undefined);
   vi.mocked(upsertOverrideRecord).mockResolvedValue(undefined);
   vi.mocked(removeOverrideRecord).mockResolvedValue(undefined);
+  vi.mocked(addCustomCommandRecord).mockResolvedValue(1);
+  vi.mocked(updateCustomCommandRecord).mockResolvedValue(undefined);
+  vi.mocked(removeCustomCommandRecord).mockResolvedValue(undefined);
+  vi.mocked(assignUserToCommandRecord).mockResolvedValue(undefined);
+  vi.mocked(assignUsersToCommandRecord).mockResolvedValue(undefined);
+  vi.mocked(unassignUserFromCommandRecord).mockResolvedValue(undefined);
+  vi.mocked(addCounterRecord).mockResolvedValue(undefined);
+  vi.mocked(updateCounterRecord).mockResolvedValue(undefined);
+  vi.mocked(removeCounterRecord).mockResolvedValue(undefined);
+  vi.mocked(resetCounterCurrentValueRecord).mockResolvedValue(undefined);
+  vi.mocked(incrementCounterRecord).mockResolvedValue(1);
+  vi.mocked(archiveAndResetYearlyCountersRecord).mockResolvedValue(0);
+  vi.mocked(initAlertConfigsRecord).mockResolvedValue(undefined);
+  vi.mocked(saveAlertConfigRecord).mockResolvedValue(undefined);
+  vi.mocked(setAlertImageRecord).mockResolvedValue(null);
+  vi.mocked(setAlertSoundRecord).mockResolvedValue(null);
+  vi.mocked(createSfxTriggerRecord).mockResolvedValue(1n);
+  vi.mocked(updateSfxTriggerRecord).mockResolvedValue(true);
+  vi.mocked(deleteSfxTriggerRecord).mockResolvedValue({ files: [] });
+  vi.mocked(addSfxFileRecord).mockResolvedValue(1);
+  vi.mocked(updateSfxFileRecord).mockResolvedValue(true);
+  vi.mocked(deleteSfxFileRecord).mockResolvedValue('file.mp3');
 });
 
 // ─── upsertUser ───────────────────────────────────────────────────────────────
@@ -226,5 +328,270 @@ describe('removeOverride', () => {
     vi.mocked(removeOverrideRecord).mockRejectedValue(new Error('DB error'));
     await expect(removeOverride('1', 5)).rejects.toThrow('DB error');
     expect(invalidateCustomCommandLookupCache).not.toHaveBeenCalled();
+  });
+});
+
+// ─── addCustomCommand / updateCustomCommand / removeCustomCommand ─────────────
+// ─── assignUserToCommand / assignUsersToCommand / unassignUserFromCommand ─────
+//
+// customCommands.ts is a pure DB layer with no cache knowledge (see comment above
+// its wrappers in db.ts); these tests verify db.ts's wrappers invalidate the
+// custom-command lookup cache after each write.
+
+describe('addCustomCommand', () => {
+  it('calls the record function and invalidates the cache on success', async () => {
+    const id = await addCustomCommand('!clap', 'Clap!', true, false);
+    expect(id).toBe(1);
+    expect(addCustomCommandRecord).toHaveBeenCalledWith('!clap', 'Clap!', true, false);
+    expect(invalidateCustomCommandLookupCache).toHaveBeenCalledOnce();
+  });
+
+  it('propagates errors without calling invalidate', async () => {
+    vi.mocked(addCustomCommandRecord).mockRejectedValue(new Error('DB error'));
+    await expect(addCustomCommand('!clap', 'Clap!', true, false)).rejects.toThrow('DB error');
+    expect(invalidateCustomCommandLookupCache).not.toHaveBeenCalled();
+  });
+});
+
+describe('updateCustomCommand', () => {
+  it('calls the record function and invalidates the cache on success', async () => {
+    await updateCustomCommand(1, '!clap', 'Clap!', true, false);
+    expect(updateCustomCommandRecord).toHaveBeenCalledWith(1, '!clap', 'Clap!', true, false);
+    expect(invalidateCustomCommandLookupCache).toHaveBeenCalledOnce();
+  });
+});
+
+describe('removeCustomCommand', () => {
+  it('calls the record function and invalidates the cache on success', async () => {
+    await removeCustomCommand(1);
+    expect(removeCustomCommandRecord).toHaveBeenCalledWith(1);
+    expect(invalidateCustomCommandLookupCache).toHaveBeenCalledOnce();
+  });
+});
+
+describe('assignUserToCommand', () => {
+  it('calls the record function and invalidates the cache on success', async () => {
+    await assignUserToCommand(1, 'user1');
+    expect(assignUserToCommandRecord).toHaveBeenCalledWith(1, 'user1');
+    expect(invalidateCustomCommandLookupCache).toHaveBeenCalledOnce();
+  });
+});
+
+describe('assignUsersToCommand', () => {
+  it('calls the record function and invalidates the cache once, even for an empty array', async () => {
+    await assignUsersToCommand(1, []);
+    expect(assignUsersToCommandRecord).toHaveBeenCalledWith(1, []);
+    expect(invalidateCustomCommandLookupCache).toHaveBeenCalledOnce();
+  });
+});
+
+describe('unassignUserFromCommand', () => {
+  it('calls the record function and invalidates the cache on success', async () => {
+    await unassignUserFromCommand(1, 'user1');
+    expect(unassignUserFromCommandRecord).toHaveBeenCalledWith(1, 'user1');
+    expect(invalidateCustomCommandLookupCache).toHaveBeenCalledOnce();
+  });
+});
+
+// ─── Counter write wrappers ────────────────────────────────────────────────────
+//
+// counters.ts is a pure DB layer with no cache knowledge; these tests verify
+// db.ts's wrappers invalidate the counter lookup cache after each write.
+
+describe('addCounter', () => {
+  it('calls the record function and invalidates the cache on success', async () => {
+    await addCounter('!hits', '!checkhits', 'msg', 'inc', false);
+    expect(addCounterRecord).toHaveBeenCalledWith('!hits', '!checkhits', 'msg', 'inc', false);
+    expect(invalidateCounterLookupCache).toHaveBeenCalledOnce();
+  });
+
+  it('propagates errors without calling invalidate', async () => {
+    vi.mocked(addCounterRecord).mockRejectedValue(new Error('DB error'));
+    await expect(addCounter('!hits', '!checkhits', 'msg', 'inc', false)).rejects.toThrow('DB error');
+    expect(invalidateCounterLookupCache).not.toHaveBeenCalled();
+  });
+});
+
+describe('updateCounter', () => {
+  it('calls the record function and invalidates the cache on success', async () => {
+    const input = { id: 1, triggerCommand: '!hits', checkCommand: '!checkhits', message: 'm', incrementMessage: 'i', resetYearly: false };
+    await updateCounter(input);
+    expect(updateCounterRecord).toHaveBeenCalledWith(input);
+    expect(invalidateCounterLookupCache).toHaveBeenCalledOnce();
+  });
+});
+
+describe('removeCounter', () => {
+  it('calls the record function and invalidates the cache on success', async () => {
+    await removeCounter(1);
+    expect(removeCounterRecord).toHaveBeenCalledWith(1);
+    expect(invalidateCounterLookupCache).toHaveBeenCalledOnce();
+  });
+});
+
+describe('resetCounterCurrentValue', () => {
+  it('calls the record function and invalidates the cache on success', async () => {
+    await resetCounterCurrentValue(1);
+    expect(resetCounterCurrentValueRecord).toHaveBeenCalledWith(1);
+    expect(invalidateCounterLookupCache).toHaveBeenCalledOnce();
+  });
+});
+
+describe('incrementCounter', () => {
+  it('calls the record function, returns its value, and invalidates the cache on success', async () => {
+    vi.mocked(incrementCounterRecord).mockResolvedValue(7);
+    const result = await incrementCounter(1);
+    expect(result).toBe(7);
+    expect(incrementCounterRecord).toHaveBeenCalledWith(1);
+    expect(invalidateCounterLookupCache).toHaveBeenCalledOnce();
+  });
+});
+
+describe('archiveAndResetYearlyCounters', () => {
+  it('calls the record function, returns its value, and invalidates the cache on success', async () => {
+    vi.mocked(archiveAndResetYearlyCountersRecord).mockResolvedValue(3);
+    const result = await archiveAndResetYearlyCounters(2024);
+    expect(result).toBe(3);
+    expect(archiveAndResetYearlyCountersRecord).toHaveBeenCalledWith(2024);
+    expect(invalidateCounterLookupCache).toHaveBeenCalledOnce();
+  });
+});
+
+// ─── Alert config write wrappers ───────────────────────────────────────────────
+//
+// alertConfig.ts is a pure DB layer with no cache knowledge; these tests verify
+// db.ts's wrappers invalidate the alert config lookup cache after each write.
+
+describe('initAlertConfigs', () => {
+  it('calls the record function and invalidates the cache on success', async () => {
+    await initAlertConfigs(3);
+    expect(initAlertConfigsRecord).toHaveBeenCalledWith(3);
+    expect(invalidateAlertConfigLookupCache).toHaveBeenCalledOnce();
+  });
+
+  it('propagates errors without calling invalidate', async () => {
+    vi.mocked(initAlertConfigsRecord).mockRejectedValue(new Error('DB error'));
+    await expect(initAlertConfigs(3)).rejects.toThrow('DB error');
+    expect(invalidateAlertConfigLookupCache).not.toHaveBeenCalled();
+  });
+});
+
+describe('saveAlertConfig', () => {
+  it('calls the record function and invalidates the cache on success', async () => {
+    const config = { enabled: true, message_template: 'hi', duration_ms: 5000, text_animation: 'none' as const };
+    await saveAlertConfig(1, 'follow', config);
+    expect(saveAlertConfigRecord).toHaveBeenCalledWith(1, 'follow', config);
+    expect(invalidateAlertConfigLookupCache).toHaveBeenCalledOnce();
+  });
+});
+
+describe('setAlertImage', () => {
+  it('calls the record function, returns its value, and invalidates the cache on success', async () => {
+    vi.mocked(setAlertImageRecord).mockResolvedValue('old.png');
+    const result = await setAlertImage(1, 'follow', 'new.png');
+    expect(result).toBe('old.png');
+    expect(setAlertImageRecord).toHaveBeenCalledWith(1, 'follow', 'new.png');
+    expect(invalidateAlertConfigLookupCache).toHaveBeenCalledOnce();
+  });
+});
+
+describe('setAlertSound', () => {
+  it('calls the record function, returns its value, and invalidates the cache on success', async () => {
+    vi.mocked(setAlertSoundRecord).mockResolvedValue('old.mp3');
+    const result = await setAlertSound(1, 'follow', 'new.mp3');
+    expect(result).toBe('old.mp3');
+    expect(setAlertSoundRecord).toHaveBeenCalledWith(1, 'follow', 'new.mp3');
+    expect(invalidateAlertConfigLookupCache).toHaveBeenCalledOnce();
+  });
+});
+
+// ─── SFX write wrappers ─────────────────────────────────────────────────────────
+//
+// sfx.ts is a pure DB layer with no cache knowledge; these tests verify db.ts's
+// wrappers invalidate the SFX lookup cache after each write — unconditionally for
+// createSfxTrigger/addSfxFile, and only when the record function reports a match
+// for updateSfxTrigger/deleteSfxTrigger/updateSfxFile/deleteSfxFile.
+
+describe('createSfxTrigger', () => {
+  it('calls the record function, returns its id, and invalidates the cache', async () => {
+    vi.mocked(createSfxTriggerRecord).mockResolvedValue(42n);
+    const id = await createSfxTrigger('!clap', 3, 'Clap', true);
+    expect(id).toBe(42n);
+    expect(createSfxTriggerRecord).toHaveBeenCalledWith('!clap', 3, 'Clap', true);
+    expect(invalidateSfxLookupCache).toHaveBeenCalledOnce();
+  });
+});
+
+describe('updateSfxTrigger', () => {
+  it('invalidates the cache when the record function reports a match', async () => {
+    vi.mocked(updateSfxTriggerRecord).mockResolvedValue(true);
+    const result = await updateSfxTrigger(5n, '!clap', 2, 'desc', false);
+    expect(result).toBe(true);
+    expect(invalidateSfxLookupCache).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT invalidate the cache when no row matched', async () => {
+    vi.mocked(updateSfxTriggerRecord).mockResolvedValue(false);
+    const result = await updateSfxTrigger(999n, '!clap', null, null, false);
+    expect(result).toBe(false);
+    expect(invalidateSfxLookupCache).not.toHaveBeenCalled();
+  });
+});
+
+describe('deleteSfxTrigger', () => {
+  it('invalidates the cache when a trigger was deleted', async () => {
+    vi.mocked(deleteSfxTriggerRecord).mockResolvedValue({ files: ['a.mp3'] });
+    const result = await deleteSfxTrigger(7n);
+    expect(result).toEqual({ files: ['a.mp3'] });
+    expect(invalidateSfxLookupCache).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT invalidate the cache when no trigger existed', async () => {
+    vi.mocked(deleteSfxTriggerRecord).mockResolvedValue(null);
+    const result = await deleteSfxTrigger(999n);
+    expect(result).toBeNull();
+    expect(invalidateSfxLookupCache).not.toHaveBeenCalled();
+  });
+});
+
+describe('addSfxFile', () => {
+  it('calls the record function, returns its id, and invalidates the cache', async () => {
+    vi.mocked(addSfxFileRecord).mockResolvedValue(100);
+    const id = await addSfxFile(7n, 'clap.mp3', 2, false);
+    expect(id).toBe(100);
+    expect(addSfxFileRecord).toHaveBeenCalledWith(7n, 'clap.mp3', 2, false);
+    expect(invalidateSfxLookupCache).toHaveBeenCalledOnce();
+  });
+});
+
+describe('updateSfxFile', () => {
+  it('invalidates the cache when the record function reports a match', async () => {
+    vi.mocked(updateSfxFileRecord).mockResolvedValue(true);
+    const result = await updateSfxFile(11, 3, true);
+    expect(result).toBe(true);
+    expect(invalidateSfxLookupCache).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT invalidate the cache when no row matched', async () => {
+    vi.mocked(updateSfxFileRecord).mockResolvedValue(false);
+    const result = await updateSfxFile(999, 3, true);
+    expect(result).toBe(false);
+    expect(invalidateSfxLookupCache).not.toHaveBeenCalled();
+  });
+});
+
+describe('deleteSfxFile', () => {
+  it('invalidates the cache when a file was deleted', async () => {
+    vi.mocked(deleteSfxFileRecord).mockResolvedValue('clap.mp3');
+    const result = await deleteSfxFile(11);
+    expect(result).toBe('clap.mp3');
+    expect(invalidateSfxLookupCache).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT invalidate the cache when no file existed', async () => {
+    vi.mocked(deleteSfxFileRecord).mockResolvedValue(null);
+    const result = await deleteSfxFile(999);
+    expect(result).toBeNull();
+    expect(invalidateSfxLookupCache).not.toHaveBeenCalled();
   });
 });

--- a/src/db.ts
+++ b/src/db.ts
@@ -116,11 +116,15 @@ export async function updateTwitchBotEnabled(discordId: string, enabled: boolean
 // ─── Custom commands ────────────────────────────────────────────────────────
 
 import { invalidateCustomCommandLookupCache } from './db/customCommandCache';
-export {
-  getAllCustomCommandsWithAssignments, getCustomCommandCount,
-  addCustomCommand, updateCustomCommand, removeCustomCommand,
-  assignUserToCommand, assignUsersToCommand, unassignUserFromCommand,
+import {
+  addCustomCommand as addCustomCommandRecord,
+  updateCustomCommand as updateCustomCommandRecord,
+  removeCustomCommand as removeCustomCommandRecord,
+  assignUserToCommand as assignUserToCommandRecord,
+  assignUsersToCommand as assignUsersToCommandRecord,
+  unassignUserFromCommand as unassignUserFromCommandRecord,
 } from './db/customCommands';
+export { getAllCustomCommandsWithAssignments, getCustomCommandCount } from './db/customCommands';
 export type {
   DbCustomCommand, DbCustomCommandAssignedUser, DbCustomCommandWithAssignments,
 } from './db/customCommands';
@@ -128,6 +132,83 @@ export {
   invalidateCustomCommandLookupCache,
   getCustomCommandForTwitchChannel, getCustomCommandForDiscord,
 } from './db/customCommandCache';
+
+// customCommands.ts is now a pure DB layer with no cache knowledge (breaks its import cycle
+// with customCommandCache.ts); these wrappers add the cache invalidation that used to live
+// there, reusing the same withInvalidation() helper already used above for users.ts/
+// guildCommandOverrides.ts.
+
+/**
+ * Creates a new custom command and invalidates the custom-command lookup cache.
+ * @param triggerString - Full prefixed command string (e.g. `!clap`).
+ * @param output - Response text.
+ * @param isDiscordEnabled - When true, the command responds in Discord.
+ * @param isMultiTwitch - When true, the command can be assigned to multiple Twitch streamers.
+ * @returns The auto-incremented `command_id` of the newly created row.
+ */
+export async function addCustomCommand(
+  triggerString: string, output: string, isDiscordEnabled: boolean, isMultiTwitch: boolean,
+): Promise<number> {
+  return withInvalidation(() => addCustomCommandRecord(triggerString, output, isDiscordEnabled, isMultiTwitch));
+}
+
+/**
+ * Updates an existing custom command and invalidates the custom-command lookup cache.
+ * @param commandId - ID of the command to update.
+ * @param triggerString - New trigger string.
+ * @param output - New response text.
+ * @param isDiscordEnabled - Whether the command responds in Discord.
+ * @param isMultiTwitch - Whether the command can be assigned to multiple Twitch streamers.
+ * @returns Resolves once the update (and cache invalidation) completes.
+ */
+export async function updateCustomCommand(
+  commandId: number, triggerString: string, output: string, isDiscordEnabled: boolean, isMultiTwitch: boolean,
+): Promise<void> {
+  return withInvalidation(
+    () => updateCustomCommandRecord(commandId, triggerString, output, isDiscordEnabled, isMultiTwitch),
+  );
+}
+
+/**
+ * Deletes a custom command and invalidates the custom-command lookup cache.
+ * @param commandId - ID of the command to delete.
+ * @returns Resolves once the deletion (and cache invalidation) completes.
+ */
+export async function removeCustomCommand(commandId: number): Promise<void> {
+  return withInvalidation(() => removeCustomCommandRecord(commandId));
+}
+
+/**
+ * Assigns a Discord user to a custom command and invalidates the custom-command lookup cache.
+ * @param commandId - ID of the command to assign the user to.
+ * @param discordId - Discord snowflake of the user to assign.
+ * @returns Resolves once the assignment (and cache invalidation) completes.
+ */
+export async function assignUserToCommand(commandId: number, discordId: string): Promise<void> {
+  return withInvalidation(() => assignUserToCommandRecord(commandId, discordId));
+}
+
+/**
+ * Assigns multiple Discord users to a custom command and invalidates the custom-command
+ * lookup cache.
+ * @param commandId - ID of the command to assign the users to.
+ * @param discordIds - Discord snowflakes of the users to assign.
+ * @returns Resolves once the assignment (and cache invalidation) completes.
+ */
+export async function assignUsersToCommand(commandId: number, discordIds: string[]): Promise<void> {
+  return withInvalidation(() => assignUsersToCommandRecord(commandId, discordIds));
+}
+
+/**
+ * Removes a Discord user's assignment from a custom command and invalidates the
+ * custom-command lookup cache.
+ * @param commandId - ID of the command to remove the assignment from.
+ * @param discordId - Discord snowflake of the user to unassign.
+ * @returns Resolves once the removal (and cache invalidation) completes.
+ */
+export async function unassignUserFromCommand(commandId: number, discordId: string): Promise<void> {
+  return withInvalidation(() => unassignUserFromCommandRecord(commandId, discordId));
+}
 export {
   CommandNotFoundError, CommandConflictError, isMysqlDuplicateEntryError,
   isCustomCommandTriggerTaken,
@@ -137,14 +218,92 @@ export type { SqlExecutor } from './db/commandLocks';
 
 // ─── Counter commands ───────────────────────────────────────────────────────
 
-export {
-  CounterNotFoundError,
-  getAllCounters, getCounterCount, addCounter, updateCounter, removeCounter,
-  resetCounterCurrentValue, incrementCounter, archiveAndResetYearlyCounters,
-  getCounterHistory,
-} from './db/counters';
+export { CounterNotFoundError, getAllCounters, getCounterCount, getCounterHistory } from './db/counters';
 export type { DbCounter, CounterMatchType, DbMatchedCounter, UpdateCounterInput, CounterHistoryEntry } from './db/counters';
 export { invalidateCounterLookupCache, findCounterByCommand, isCounterCommandTaken } from './db/counterCache';
+
+import {
+  addCounter as addCounterRecord,
+  updateCounter as updateCounterRecord,
+  removeCounter as removeCounterRecord,
+  resetCounterCurrentValue as resetCounterCurrentValueRecord,
+  incrementCounter as incrementCounterRecord,
+  archiveAndResetYearlyCounters as archiveAndResetYearlyCountersRecord,
+} from './db/counters';
+import type { UpdateCounterInput } from './db/counters';
+import { invalidateCounterLookupCache } from './db/counterCache';
+
+// counters.ts is now a pure DB layer with no cache knowledge (breaks its import cycle with
+// counterCache.ts); these wrappers add the cache invalidation that used to live there.
+
+/**
+ * Creates a new counter and invalidates the counter lookup cache.
+ * @param triggerCommand - Command that increments the counter.
+ * @param checkCommand - Command that reports the counter's current value.
+ * @param message - Message shown when the counter is checked.
+ * @param incrementMessage - Message shown when the counter is incremented.
+ * @param resetYearly - Whether the counter's value is archived and reset each new year.
+ * @returns Resolves once the insert (and cache invalidation) completes.
+ */
+export async function addCounter(
+  triggerCommand: string, checkCommand: string, message: string, incrementMessage: string, resetYearly: boolean,
+): Promise<void> {
+  await addCounterRecord(triggerCommand, checkCommand, message, incrementMessage, resetYearly);
+  invalidateCounterLookupCache();
+}
+
+/**
+ * Updates an existing counter's fields and invalidates the counter lookup cache.
+ * @param input - The counter's id and updated fields.
+ * @returns Resolves once the update (and cache invalidation) completes.
+ */
+export async function updateCounter(input: UpdateCounterInput): Promise<void> {
+  await updateCounterRecord(input);
+  invalidateCounterLookupCache();
+}
+
+/**
+ * Deletes a counter by id and invalidates the counter lookup cache.
+ * @param id - The counter's numeric id.
+ * @returns Resolves once the deletion (and cache invalidation) completes.
+ */
+export async function removeCounter(id: number): Promise<void> {
+  await removeCounterRecord(id);
+  invalidateCounterLookupCache();
+}
+
+/**
+ * Resets a counter's current value to 0 and invalidates the counter lookup cache.
+ * @param id - The counter's numeric id.
+ * @returns Resolves once the update (and cache invalidation) completes.
+ */
+export async function resetCounterCurrentValue(id: number): Promise<void> {
+  await resetCounterCurrentValueRecord(id);
+  invalidateCounterLookupCache();
+}
+
+/**
+ * Atomically increments a counter's current value and invalidates the counter lookup cache.
+ * @param id - The counter's numeric id.
+ * @returns The counter's current value after the increment.
+ */
+export async function incrementCounter(id: number): Promise<number> {
+  const newValue = await incrementCounterRecord(id);
+  invalidateCounterLookupCache();
+  return newValue;
+}
+
+/**
+ * Archives and resets every yearly-reset counter for the given year, and invalidates the
+ * counter lookup cache.
+ * @param year - Calendar year to archive into.
+ * @returns The number of counters archived and reset.
+ */
+export async function archiveAndResetYearlyCounters(year: number): Promise<number> {
+  const affectedRows = await archiveAndResetYearlyCountersRecord(year);
+  invalidateCounterLookupCache();
+  return affectedRows;
+}
 
 // ─── Stream monitor ──────────────────────────────────────────────────────────
 
@@ -172,11 +331,78 @@ export type { DbStreamerEventSub, EventSubConfig } from './db/eventSub';
 
 export type { AlertConfig, AlertEventType, TextAnimation } from './db/alertConfig';
 export { ALERT_EVENT_TYPES, ALERT_TEXT_ANIMATIONS } from './db/alertConfig';
-export {
-  getAlertConfigsForStreamer, getAlertConfig, getEnabledAlertEventTypesBatch, initAlertConfigs,
-  saveAlertConfig, setAlertImage, setAlertSound,
-} from './db/alertConfig';
+export { getAlertConfigsForStreamer, getAlertConfig, getEnabledAlertEventTypesBatch } from './db/alertConfig';
 export { findCachedAlertConfig } from './db/alertConfigCache';
+
+import {
+  initAlertConfigs as initAlertConfigsRecord,
+  saveAlertConfig as saveAlertConfigRecord,
+  setAlertImage as setAlertImageRecord,
+  setAlertSound as setAlertSoundRecord,
+} from './db/alertConfig';
+import type { AlertEventType, TextAnimation } from './db/alertConfig';
+import { invalidateAlertConfigLookupCache } from './db/alertConfigCache';
+
+// alertConfig.ts is now a pure DB layer with no cache knowledge (breaks its import cycle with
+// alertConfigCache.ts); these wrappers add the cache invalidation that used to live there.
+
+/**
+ * Inserts default (disabled) alert config rows for all event types for a streamer and
+ * invalidates the alert config lookup cache.
+ * @param streamerId - DB row ID of the streamer to initialise alert config for.
+ * @returns Resolves once the insert (and cache invalidation) completes.
+ */
+export async function initAlertConfigs(streamerId: number): Promise<void> {
+  await initAlertConfigsRecord(streamerId);
+  invalidateAlertConfigLookupCache();
+}
+
+/**
+ * Upserts a streamer's alert config for one event type and invalidates the alert config
+ * lookup cache.
+ * @param streamerId - DB row ID of the streamer.
+ * @param eventType - The alert event type being configured.
+ * @param config - The fields to persist.
+ * @returns Resolves once the upsert (and cache invalidation) completes.
+ */
+export async function saveAlertConfig(
+  streamerId: number,
+  eventType: AlertEventType,
+  config: { enabled: boolean; message_template: string; duration_ms: number; text_animation: TextAnimation },
+): Promise<void> {
+  await saveAlertConfigRecord(streamerId, eventType, config);
+  invalidateAlertConfigLookupCache();
+}
+
+/**
+ * Sets (or clears) a streamer's alert image and invalidates the alert config lookup cache.
+ * @param streamerId - DB row ID of the streamer.
+ * @param eventType - The alert event type being configured.
+ * @param filename - The new stored filename, or null to clear the image.
+ * @returns The previous filename, or null if there was none.
+ */
+export async function setAlertImage(
+  streamerId: number, eventType: AlertEventType, filename: string | null,
+): Promise<string | null> {
+  const previous = await setAlertImageRecord(streamerId, eventType, filename);
+  invalidateAlertConfigLookupCache();
+  return previous;
+}
+
+/**
+ * Sets (or clears) a streamer's alert sound and invalidates the alert config lookup cache.
+ * @param streamerId - DB row ID of the streamer.
+ * @param eventType - The alert event type being configured.
+ * @param filename - The new stored filename, or null to clear the sound.
+ * @returns The previous filename, or null if there was none.
+ */
+export async function setAlertSound(
+  streamerId: number, eventType: AlertEventType, filename: string | null,
+): Promise<string | null> {
+  const previous = await setAlertSoundRecord(streamerId, eventType, filename);
+  invalidateAlertConfigLookupCache();
+  return previous;
+}
 
 // ─── Streamer event log ──────────────────────────────────────────────────────
 
@@ -188,12 +414,108 @@ export { recordStreamerEvent, getRecentStreamerEvents } from './db/eventLog';
 export type { SfxTrigger, SfxFile, SfxTriggerRow, PublicSfxTrigger, SfxCategory } from './db/sfx';
 export {
   findTrigger, findSoundFiles, getAllSfxTriggers, getSfxTriggerCount, getPublicSfxTriggers,
-  getAllCategories, createCategory, renameCategory, deleteCategory,
-  createSfxTrigger, updateSfxTrigger, deleteSfxTrigger,
-  addSfxFile, updateSfxFile, deleteSfxFile, getSfxFileById,
+  getAllCategories, createCategory, renameCategory, deleteCategory, getSfxFileById,
 } from './db/sfx';
 export type { SfxLookupResult } from './db/sfxCache';
 export { findCachedSfxTrigger } from './db/sfxCache';
+
+import {
+  createSfxTrigger as createSfxTriggerRecord,
+  updateSfxTrigger as updateSfxTriggerRecord,
+  deleteSfxTrigger as deleteSfxTriggerRecord,
+  addSfxFile as addSfxFileRecord,
+  updateSfxFile as updateSfxFileRecord,
+  deleteSfxFile as deleteSfxFileRecord,
+} from './db/sfx';
+import { invalidateSfxLookupCache } from './db/sfxCache';
+
+// sfx.ts is now a pure DB layer with no cache knowledge (breaks its import cycle with
+// sfxCache.ts); these wrappers add the cache invalidation that used to live there.
+
+/**
+ * Creates a new SFX trigger and invalidates the SFX lookup cache.
+ * @param command - Full prefixed command string, e.g. `!clap`.
+ * @param categoryId - Category id, or null for uncategorised.
+ * @param description - Optional public description, or null.
+ * @param hidden - Whether the trigger is hidden from the public listing.
+ * @returns The new trigger id.
+ */
+export async function createSfxTrigger(
+  command: string, categoryId: number | null, description: string | null, hidden: boolean,
+): Promise<bigint> {
+  const id = await createSfxTriggerRecord(command, categoryId, description, hidden);
+  invalidateSfxLookupCache();
+  return id;
+}
+
+/**
+ * Updates an existing SFX trigger and invalidates the SFX lookup cache if it existed.
+ * @param id - Trigger id.
+ * @param command - Full prefixed command string, e.g. `!clap`.
+ * @param categoryId - Category id, or null for uncategorised.
+ * @param description - Optional public description, or null.
+ * @param hidden - Whether the trigger is hidden from the public listing.
+ * @returns true if the trigger exists, false if no trigger with that id existed.
+ */
+export async function updateSfxTrigger(
+  id: bigint, command: string, categoryId: number | null, description: string | null, hidden: boolean,
+): Promise<boolean> {
+  const updated = await updateSfxTriggerRecord(id, command, categoryId, description, hidden);
+  if (updated) invalidateSfxLookupCache();
+  return updated;
+}
+
+/**
+ * Deletes an SFX trigger and its sound files, invalidating the SFX lookup cache if it existed.
+ * @param id - Trigger id.
+ * @returns The relative paths of the deleted sound files, or null if no trigger with that id
+ *   existed.
+ */
+export async function deleteSfxTrigger(id: bigint): Promise<{ files: string[] } | null> {
+  const result = await deleteSfxTriggerRecord(id);
+  if (result !== null) invalidateSfxLookupCache();
+  return result;
+}
+
+/**
+ * Adds a sound file to a trigger and invalidates the SFX lookup cache.
+ * @param triggerId - Owning trigger id.
+ * @param file - Relative path (within SFX_FOLDER) of the stored audio file.
+ * @param weight - Weighted-random selection weight (>= 1).
+ * @param hidden - Whether the file is hidden from the public listing.
+ * @returns The new sfx row id.
+ */
+export async function addSfxFile(
+  triggerId: bigint, file: string, weight: number, hidden: boolean,
+): Promise<number> {
+  const id = await addSfxFileRecord(triggerId, file, weight, hidden);
+  invalidateSfxLookupCache();
+  return id;
+}
+
+/**
+ * Updates a sound file's weight/hidden flag, invalidating the SFX lookup cache if it existed.
+ * @param id - sfx row id.
+ * @param weight - Weighted-random selection weight (>= 1).
+ * @param hidden - Whether the file is hidden from the public listing.
+ * @returns true if the sfx row exists, false if no sfx row with that id existed.
+ */
+export async function updateSfxFile(id: number, weight: number, hidden: boolean): Promise<boolean> {
+  const updated = await updateSfxFileRecord(id, weight, hidden);
+  if (updated) invalidateSfxLookupCache();
+  return updated;
+}
+
+/**
+ * Deletes a sound file row, invalidating the SFX lookup cache if it existed.
+ * @param id - sfx row id.
+ * @returns The deleted file's relative path, or null if no such row existed.
+ */
+export async function deleteSfxFile(id: number): Promise<string | null> {
+  const file = await deleteSfxFileRecord(id);
+  if (file !== null) invalidateSfxLookupCache();
+  return file;
+}
 
 // ─── Overlay videos ─────────────────────────────────────────────────────────
 

--- a/src/db/alertConfig.test.ts
+++ b/src/db/alertConfig.test.ts
@@ -25,7 +25,6 @@ vi.mock('./pool', () => {
   };
 });
 vi.mock('mysql2/promise', () => ({ default: {} }));
-vi.mock('./alertConfigCache', () => ({ invalidateAlertConfigLookupCache: vi.fn() }));
 
 import { getPool } from './pool';
 import {
@@ -40,7 +39,6 @@ import {
   setAlertImage,
   setAlertSound,
 } from './alertConfig';
-import { invalidateAlertConfigLookupCache } from './alertConfigCache';
 import { makeMockPool, makeMockConnection } from '../test-utils/mockMysqlPool';
 
 /** Builds a fake mysql pool whose `execute`/`query` resolve to the given rows. */
@@ -244,13 +242,6 @@ describe('initAlertConfigs', () => {
     }
     expect(params.filter((p) => p === 5)).toHaveLength(ALERT_EVENT_TYPES.length);
   });
-
-  it('invalidates the alert config lookup cache after inserting', async () => {
-    const pool = makePool();
-    vi.mocked(getPool).mockReturnValue(pool as any);
-    await initAlertConfigs(3);
-    expect(invalidateAlertConfigLookupCache).toHaveBeenCalledOnce();
-  });
 });
 
 // ─── saveAlertConfig ───────────────────────────────────────────────────────────
@@ -287,13 +278,6 @@ describe('saveAlertConfig', () => {
     await saveAlertConfig(1, 'sub', { enabled: false, message_template: 'msg', duration_ms: 4000, text_animation: 'glitch' });
     const params: unknown[] = pool.execute.mock.calls[0][1];
     expect(params).toEqual([1, 'sub', 0, 'msg', 4000, 'glitch']);
-  });
-
-  it('invalidates the alert config lookup cache after saving', async () => {
-    const pool = makePool();
-    vi.mocked(getPool).mockReturnValue(pool as any);
-    await saveAlertConfig(1, 'follow', { enabled: true, message_template: 'hi', duration_ms: 5000, text_animation: 'none' });
-    expect(invalidateAlertConfigLookupCache).toHaveBeenCalledOnce();
   });
 });
 
@@ -335,15 +319,6 @@ describe('setAlertImage', () => {
     await setAlertImage(1, 'follow', null);
     expect(conn.commit).toHaveBeenCalledTimes(1);
     expect(conn.rollback).not.toHaveBeenCalled();
-  });
-
-  it('invalidates the alert config lookup cache after committing', async () => {
-    const conn = makeMockConnection({
-      execute: vi.fn().mockResolvedValue([[{ image_filename: null }], []]),
-    });
-    vi.mocked(getPool).mockReturnValue(makeMockPool({ connection: conn }) as any);
-    await setAlertImage(1, 'follow', 'new.png');
-    expect(invalidateAlertConfigLookupCache).toHaveBeenCalledOnce();
   });
 });
 

--- a/src/db/alertConfig.ts
+++ b/src/db/alertConfig.ts
@@ -1,11 +1,6 @@
 import mysql from 'mysql2/promise';
 import { getPool, withTransaction } from './pool';
 import { fromBit } from './utils';
-// invalidateAlertConfigLookupCache lives in alertConfigCache.ts, which imports getAllAlertConfigs
-// from this file for its read-side load. Both calls happen inside function bodies (never at
-// module-eval time), so the cyclic import between the two files is safe — mirrors sfx.ts's own
-// import of invalidateSfxLookupCache from sfxCache.ts.
-import { invalidateAlertConfigLookupCache } from './alertConfigCache';
 
 /** Twitch event types the alerts overlay can react to. */
 export type AlertEventType = 'follow' | 'sub' | 'resub' | 'giftsub' | 'raid';
@@ -141,7 +136,6 @@ export async function initAlertConfigs(streamerId: number): Promise<void> {
      VALUES ${placeholders}`,
     params,
   );
-  invalidateAlertConfigLookupCache();
 }
 
 /**
@@ -166,7 +160,6 @@ export async function saveAlertConfig(
        text_animation=new_row.text_animation`,
     [streamerId, eventType, config.enabled ? 1 : 0, config.message_template, config.duration_ms, config.text_animation],
   );
-  invalidateAlertConfigLookupCache();
 }
 
 /**
@@ -217,7 +210,6 @@ async function setAlertAssetColumn(
     );
     return previous;
   });
-  invalidateAlertConfigLookupCache();
   return previous;
 }
 

--- a/src/db/counterCache.ts
+++ b/src/db/counterCache.ts
@@ -8,9 +8,6 @@ import {
 } from './lookupCache';
 import { normalizeCommandList, normalizeCommand } from './commandStringUtils';
 import { isAnyCommandTakenAcrossTables } from './commandLocks';
-// counters imports invalidateCounterLookupCache from this module;
-// this module imports getAllCounters from counters.
-// Both calls happen inside function bodies, so CommonJS resolves the cycle correctly.
 import { getAllCounters, type DbCounter, type DbMatchedCounter, type CounterMatchType } from './counters';
 
 const log = createLogger('DB');

--- a/src/db/counters.test.ts
+++ b/src/db/counters.test.ts
@@ -57,9 +57,6 @@ vi.mock('./utils', () => ({
   }),
   getRowCount: vi.fn(),
 }));
-vi.mock('./counterCache', () => ({
-  invalidateCounterLookupCache: vi.fn(),
-}));
 
 import { makeMockConnection } from '../test-utils/mockMysqlPool';
 
@@ -82,7 +79,6 @@ import {
 } from './counters';
 import { runSerializedCommandWrite } from './commandLocks';
 import { assertNotReservedCommand } from './reservedCommands';
-import { invalidateCounterLookupCache } from './counterCache';
 import { getRowCount } from './utils';
 import { makeMockPool } from '../test-utils/mockMysqlPool';
 
@@ -313,13 +309,6 @@ describe('addCounter', () => {
     );
   });
 
-  it('invalidates the counter cache after success', async () => {
-    vi.mocked(getPool).mockReturnValue(makePool() as any);
-    mockConnection.execute.mockResolvedValue([{}, []]);
-    await addCounter('!hits', '!checkhits', 'msg', 'inc', false);
-    expect(invalidateCounterLookupCache).toHaveBeenCalled();
-  });
-
   it('throws when trigger and check differ only by case (normalized to same value)', async () => {
     vi.mocked(getPool).mockReturnValue(makePool() as any);
     await expect(addCounter('!HITS', '!hits', 'msg', 'inc', false)).rejects.toThrow('must be different');
@@ -349,12 +338,6 @@ describe('updateCounter', () => {
     expect(assertNotReservedCommand).toHaveBeenCalledWith('!newcheck');
   });
 
-  it('invalidates the counter cache after success', async () => {
-    vi.mocked(getPool).mockReturnValue(makePool([{ trigger_command: '!old', check_command: '!oldcheck' }]) as any);
-    mockConnection.execute.mockResolvedValue([{ affectedRows: 1 }, []]);
-    await updateCounter({ id: 1, triggerCommand: '!new', checkCommand: '!check', message: 'm', incrementMessage: 'i', resetYearly: false });
-    expect(invalidateCounterLookupCache).toHaveBeenCalled();
-  });
 });
 
 // ─── removeCounter ────────────────────────────────────────────────────────────
@@ -376,12 +359,6 @@ describe('removeCounter', () => {
     );
   });
 
-  it('invalidates cache after removal', async () => {
-    vi.mocked(getPool).mockReturnValue(makePool([{ trigger_command: '!hits', check_command: '!checkhits' }]) as any);
-    mockConnection.execute.mockResolvedValue([{ affectedRows: 1 }, []]);
-    await removeCounter(1);
-    expect(invalidateCounterLookupCache).toHaveBeenCalled();
-  });
 });
 
 // ─── resetCounterCurrentValue ─────────────────────────────────────────────────
@@ -401,14 +378,6 @@ describe('resetCounterCurrentValue', () => {
     pool.execute.mockResolvedValue([{ affectedRows: 1 }, []]);
     vi.mocked(getPool).mockReturnValue(pool as any);
     await expect(resetCounterCurrentValue(1)).resolves.not.toThrow();
-  });
-
-  it('invalidates cache on success', async () => {
-    const pool = makePool();
-    pool.execute.mockResolvedValue([{ affectedRows: 1 }, []]);
-    vi.mocked(getPool).mockReturnValue(pool as any);
-    await resetCounterCurrentValue(1);
-    expect(invalidateCounterLookupCache).toHaveBeenCalled();
   });
 });
 
@@ -444,17 +413,6 @@ describe('incrementCounter', () => {
     vi.mocked(getPool).mockReturnValue(pool as any);
     await expect(incrementCounter(1)).rejects.toThrow('DB error');
     expect(conn.release).toHaveBeenCalled();
-  });
-
-  it('invalidates cache on success', async () => {
-    const pool = makePool();
-    const conn = pool._conn;
-    conn.execute
-      .mockResolvedValueOnce([{ affectedRows: 1 }, []])
-      .mockResolvedValueOnce([[{ current_value: 3 }], []]);
-    vi.mocked(getPool).mockReturnValue(pool as any);
-    await incrementCounter(1);
-    expect(invalidateCounterLookupCache).toHaveBeenCalled();
   });
 });
 
@@ -499,13 +457,5 @@ describe('archiveAndResetYearlyCounters', () => {
     await archiveAndResetYearlyCounters(2024);
     const [sql] = pool.execute.mock.calls[0] as [string];
     expect(sql).toContain('value2024');
-  });
-
-  it('invalidates cache after archiving', async () => {
-    const pool = makePool();
-    pool.execute.mockResolvedValue([{ affectedRows: 2 }, []]);
-    vi.mocked(getPool).mockReturnValue(pool as any);
-    await archiveAndResetYearlyCounters(2025);
-    expect(invalidateCounterLookupCache).toHaveBeenCalled();
   });
 });

--- a/src/db/counters.ts
+++ b/src/db/counters.ts
@@ -4,7 +4,6 @@ import { requireTrimmedString, normalizeCommand, type SqlExecutor } from './comm
 import { runSerializedCommandWrite } from './commandLocks';
 import { assertNotReservedCommand } from './reservedCommands';
 import { fromBit, rowExists, affectedOrExists, getRowCount } from './utils';
-import { invalidateCounterLookupCache } from './counterCache';
 import {
   createManagedLookupCache,
   type RefreshingLookupCache,
@@ -274,8 +273,6 @@ export async function addCounter(
       );
     },
   );
-
-  invalidateCounterLookupCache();
 }
 
 /**
@@ -357,8 +354,6 @@ export async function updateCounter(input: UpdateCounterInput): Promise<void> {
       }
     },
   );
-
-  invalidateCounterLookupCache();
 }
 
 /**
@@ -381,8 +376,6 @@ export async function removeCounter(id: number): Promise<void> {
       if (result.affectedRows === 0) throw new CounterNotFoundError(id);
     },
   );
-
-  invalidateCounterLookupCache();
 }
 
 /**
@@ -399,12 +392,6 @@ export async function resetCounterCurrentValue(id: number): Promise<void> {
   if (!(await affectedOrExists(result.affectedRows, () => counterExists(id)))) {
     throw new CounterNotFoundError(id);
   }
-  if (result.affectedRows === 0) {
-    // Counter exists but value was already 0 — nothing changed, skip invalidation.
-    return;
-  }
-
-  invalidateCounterLookupCache();
 }
 
 /**
@@ -426,7 +413,6 @@ export async function incrementCounter(id: number): Promise<number> {
     );
     return (rows[0] as mysql.RowDataPacket).current_value as number;
   });
-  invalidateCounterLookupCache();
   return newValue;
 }
 
@@ -445,6 +431,5 @@ export async function archiveAndResetYearlyCounters(year: number): Promise<numbe
   const [result] = await getPool().execute<mysql.ResultSetHeader>(
     `UPDATE counter SET \`${columnName}\` = current_value, current_value = 0 WHERE reset_yearly = 1 AND \`${columnName}\` IS NULL`,
   );
-  invalidateCounterLookupCache();
   return result.affectedRows;
 }

--- a/src/db/customCommandCache.ts
+++ b/src/db/customCommandCache.ts
@@ -9,9 +9,6 @@ import {
 } from './lookupCache';
 import { normalizeCommand } from './commandStringUtils';
 import { getTwitchEnabledChannels } from './users';
-// customCommands imports invalidateCustomCommandLookupCache from this module;
-// this module imports getAllCustomCommandsWithAssignments from customCommands.
-// Both calls happen inside function bodies, so CommonJS resolves the cycle correctly.
 import {
   getAllCustomCommandsWithAssignments,
   type DbCustomCommand,

--- a/src/db/customCommands.test.ts
+++ b/src/db/customCommands.test.ts
@@ -18,9 +18,6 @@ vi.mock('./commandConflicts', () => ({
   assignUserToCommandWithinTransaction: vi.fn().mockResolvedValue(undefined),
   assignUsersToCommandWithinTransaction: vi.fn().mockResolvedValue(undefined),
 }));
-vi.mock('./customCommandCache', () => ({
-  invalidateCustomCommandLookupCache: vi.fn(),
-}));
 vi.mock('./reservedCommands', () => ({
   assertNotReservedCommand: vi.fn(),
 }));
@@ -51,7 +48,6 @@ import {
   assignUserToCommandWithinTransaction,
   assignUsersToCommandWithinTransaction,
 } from './commandConflicts';
-import { invalidateCustomCommandLookupCache } from './customCommandCache';
 import { assertNotReservedCommand } from './reservedCommands';
 import { makeMockPool } from '../test-utils/mockMysqlPool';
 
@@ -243,13 +239,6 @@ describe('addCustomCommand', () => {
     expect(assertMultiTwitchTriggerAvailable).not.toHaveBeenCalled();
   });
 
-  it('calls invalidateCustomCommandLookupCache on success', async () => {
-    const conn = makeWriteConn([[{ insertId: 1 }, []]]);
-    setupRunSerializedCommandWrite(conn);
-    await addCustomCommand('!clap', 'Clap!', false, false);
-    expect(invalidateCustomCommandLookupCache).toHaveBeenCalled();
-  });
-
   it('propagates errors from assertNotReservedCommand', async () => {
     vi.mocked(assertNotReservedCommand).mockImplementationOnce(() => { throw new Error('Reserved!'); });
     await expect(addCustomCommand('!sfx', 'output', false, false)).rejects.toThrow('Reserved!');
@@ -291,12 +280,6 @@ describe('updateCustomCommand', () => {
     await expect(updateCustomCommand(99, '!clap', 'Clap!', false, false)).rejects.toThrow('Command not found: 99');
   });
 
-  it('calls invalidateCustomCommandLookupCache on success', async () => {
-    const conn = makeWriteConn([[{ affectedRows: 1 }, []]]);
-    setupRunSerializedCommandWrite(conn);
-    await updateCustomCommand(1, '!clap', 'Clap!', false, false);
-    expect(invalidateCustomCommandLookupCache).toHaveBeenCalled();
-  });
 });
 
 // ─── removeCustomCommand ──────────────────────────────────────────────────────
@@ -328,17 +311,6 @@ describe('removeCustomCommand', () => {
     expect(conn.rollback).toHaveBeenCalled();
   });
 
-  it('invalidates cache on success', async () => {
-    const pool = makePool();
-    const conn = pool._conn;
-    conn.execute
-      .mockResolvedValueOnce([{ affectedRows: 1 }, []])
-      .mockResolvedValueOnce([{ affectedRows: 1 }, []]);
-    vi.mocked(getPool).mockReturnValue(pool as any);
-    await removeCustomCommand(5);
-    expect(invalidateCustomCommandLookupCache).toHaveBeenCalled();
-  });
-
   it('releases connection even when an error is thrown', async () => {
     const pool = makePool();
     const conn = pool._conn;
@@ -362,12 +334,6 @@ describe('assignUserToCommand', () => {
     expect(assignUserToCommandWithinTransaction).toHaveBeenCalledWith(conn, 3, 'user1');
     expect(releaseNamedLock).toHaveBeenCalledWith(conn, 'bcuk_cmdid_3');
     expect(conn.release).toHaveBeenCalled();
-  });
-
-  it('calls invalidateCustomCommandLookupCache on success', async () => {
-    vi.mocked(getPool).mockReturnValue(makePool() as any);
-    await assignUserToCommand(3, 'user1');
-    expect(invalidateCustomCommandLookupCache).toHaveBeenCalled();
   });
 
   it('releases lock and connection even when assignUserToCommandWithinTransaction throws', async () => {
@@ -402,13 +368,6 @@ describe('assignUsersToCommand', () => {
     expect(conn.release).toHaveBeenCalled();
   });
 
-  it('calls invalidateCustomCommandLookupCache once on success', async () => {
-    vi.mocked(getPool).mockReturnValue(makePool() as any);
-    vi.mocked(invalidateCustomCommandLookupCache).mockClear();
-    await assignUsersToCommand(3, ['user1', 'user2']);
-    expect(invalidateCustomCommandLookupCache).toHaveBeenCalledTimes(1);
-  });
-
   it('releases lock and connection even when assignUsersToCommandWithinTransaction throws', async () => {
     const pool = makePool();
     vi.mocked(getPool).mockReturnValue(pool as any);
@@ -430,11 +389,5 @@ describe('unassignUserFromCommand', () => {
     expect(sql).toContain('DELETE FROM twitch_user_commands');
     expect(params).toContain(4);
     expect(params).toContain('user2');
-  });
-
-  it('calls invalidateCustomCommandLookupCache', async () => {
-    vi.mocked(getPool).mockReturnValue(makePool() as any);
-    await unassignUserFromCommand(4, 'user2');
-    expect(invalidateCustomCommandLookupCache).toHaveBeenCalled();
   });
 });

--- a/src/db/customCommands.ts
+++ b/src/db/customCommands.ts
@@ -10,7 +10,6 @@ import {
   assertDiscordTriggerAvailable, assertMultiTwitchTriggerAvailable, assertNoSingleTwitchAssignmentOverlap,
   assignUserToCommandWithinTransaction, assignUsersToCommandWithinTransaction,
 } from './commandConflicts';
-import { invalidateCustomCommandLookupCache } from './customCommandCache';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -99,7 +98,7 @@ export async function getAllCustomCommandsWithAssignments(): Promise<DbCustomCom
 
 /**
  * Create a new custom command. Validates and normalises the trigger string, checks for
- * conflicts, and invalidates the lookup cache on success.
+ * conflicts.
  *
  * @param triggerString - Full prefixed command string (e.g. `!clap`); lowercased before storing.
  * @param output - Response text, max 2000 characters.
@@ -141,15 +140,13 @@ export async function addCustomCommand(
     { includeCustomCommandTable: false, includeCounterTable: true },
   );
 
-  invalidateCustomCommandLookupCache();
-
   return commandId;
 }
 
 /**
  * Update an existing custom command's trigger string, output, and flags.
  * Validates conflicts against other commands, throws {@link CommandNotFoundError}
- * if the command does not exist, and invalidates the lookup cache on success.
+ * if the command does not exist.
  *
  * @param commandId - ID of the command to update.
  * @param triggerString - New trigger string; lowercased before storing.
@@ -196,14 +193,11 @@ export async function updateCustomCommand(
     },
     { includeCustomCommandTable: false, includeCounterTable: true },
   );
-
-  invalidateCustomCommandLookupCache();
 }
 
 /**
  * Delete a custom command and all its user assignments within a transaction.
  * Throws {@link CommandNotFoundError} if the command does not exist.
- * Invalidates the lookup cache only after a successful commit.
  *
  * @param commandId - ID of the command to delete.
  */
@@ -226,8 +220,6 @@ export async function removeCustomCommand(commandId: number): Promise<void> {
       throw new CommandNotFoundError(commandId);
     }
     await connection.commit();
-    // Invalidate only after a successful commit; refresh remains lazy on next lookup.
-    invalidateCustomCommandLookupCache();
   } catch (error) {
     await connection.rollback();
     throw error;
@@ -241,7 +233,7 @@ export async function removeCustomCommand(commandId: number): Promise<void> {
  * Assign a Discord user to a custom command's Twitch streamer list.
  * Acquires a named lock for the command ID, then delegates to
  * {@link assignUserToCommandWithinTransaction} to check cross-command conflicts
- * before inserting. Invalidates the lookup cache on success.
+ * before inserting.
  *
  * @param commandId - ID of the command to assign the user to.
  * @param discordId - Discord snowflake of the user to assign.
@@ -259,9 +251,6 @@ export async function assignUserToCommand(commandId: number, discordId: string):
     await acquireNamedLock(connection, lockNameById);
 
     await assignUserToCommandWithinTransaction(connection, commandId, discordId);
-
-    // Invalidate only after commit; keep lock ownership and connection lifecycle deterministic.
-    invalidateCustomCommandLookupCache();
   } finally {
     // Always release the id lock
     await releaseNamedLock(connection, lockNameById);
@@ -273,8 +262,7 @@ export async function assignUserToCommand(commandId: number, discordId: string):
  * Assign multiple Discord users to a custom command's Twitch streamer list in one transaction.
  * Acquires the command ID's named lock once, then delegates to
  * {@link assignUsersToCommandWithinTransaction} to check cross-command conflicts and insert all
- * assignments before invalidating the lookup cache once. A no-op (no connection opened) when
- * `discordIds` is empty.
+ * assignments. A no-op (no connection opened) when `discordIds` is empty.
  *
  * @param commandId - ID of the command to assign the users to.
  * @param discordIds - Discord snowflakes of the users to assign.
@@ -289,8 +277,6 @@ export async function assignUsersToCommand(commandId: number, discordIds: string
     await acquireNamedLock(connection, lockNameById);
 
     await assignUsersToCommandWithinTransaction(connection, commandId, discordIds);
-
-    invalidateCustomCommandLookupCache();
   } finally {
     await releaseNamedLock(connection, lockNameById);
     connection.release();
@@ -298,7 +284,7 @@ export async function assignUsersToCommand(commandId: number, discordIds: string
 }
 
 /**
- * Remove a Discord user's assignment from a custom command and invalidate the lookup cache.
+ * Remove a Discord user's assignment from a custom command.
  *
  * @param commandId - ID of the command to remove the assignment from.
  * @param discordId - Discord snowflake of the user to unassign.
@@ -308,8 +294,6 @@ export async function unassignUserFromCommand(commandId: number, discordId: stri
     'DELETE FROM twitch_user_commands WHERE command_id = ? AND discord_id = ?',
     [commandId, discordId],
   );
-
-  invalidateCustomCommandLookupCache();
 }
 
 // Unused in this module but exported so commandLocks.ts helpers remain type-safe

--- a/src/db/sfx.test.ts
+++ b/src/db/sfx.test.ts
@@ -25,9 +25,6 @@ vi.mock('./pool', () => {
   };
 });
 vi.mock('mysql2/promise', () => ({ default: {} }));
-vi.mock('./sfxCache', () => ({
-  invalidateSfxLookupCache: vi.fn(),
-}));
 
 import { getPool } from './pool';
 import {
@@ -36,7 +33,6 @@ import {
   createSfxTrigger, updateSfxTrigger, deleteSfxTrigger,
   addSfxFile, updateSfxFile, deleteSfxFile, getSfxFileById,
 } from './sfx';
-import { invalidateSfxLookupCache } from './sfxCache';
 import { makeMockPool } from '../test-utils/mockMysqlPool';
 
 /** Pool whose top-level execute returns row data (for SELECT queries). */
@@ -319,13 +315,6 @@ describe('createSfxTrigger', () => {
     await createSfxTrigger('!bang', null, null, false);
     expect(pool.execute.mock.calls[0][1]).toEqual(['!bang', null, null, 0]);
   });
-
-  it('calls invalidateSfxLookupCache on success', async () => {
-    const pool = makeResultPool({ insertId: 1 });
-    vi.mocked(getPool).mockReturnValue(pool as any);
-    await createSfxTrigger('!bang', null, null, false);
-    expect(invalidateSfxLookupCache).toHaveBeenCalledOnce();
-  });
 });
 
 describe('updateSfxTrigger', () => {
@@ -344,7 +333,6 @@ describe('updateSfxTrigger', () => {
       .mockResolvedValueOnce([[], []]); // fallback SELECT — id not found
     vi.mocked(getPool).mockReturnValue(pool as any);
     expect(await updateSfxTrigger(999n, '!clap', null, null, false)).toBe(false);
-    expect(invalidateSfxLookupCache).not.toHaveBeenCalled();
   });
 
   it('returns true on a no-op update (all fields unchanged) when the row exists', async () => {
@@ -354,13 +342,6 @@ describe('updateSfxTrigger', () => {
       .mockResolvedValueOnce([[{ id: '5' }], []]); // fallback SELECT — id exists
     vi.mocked(getPool).mockReturnValue(pool as any);
     expect(await updateSfxTrigger(5n, '!clap', 2, 'desc', false)).toBe(true);
-  });
-
-  it('calls invalidateSfxLookupCache when a row matched', async () => {
-    const pool = makeResultPool({ affectedRows: 1 });
-    vi.mocked(getPool).mockReturnValue(pool as any);
-    await updateSfxTrigger(5n, '!clap', 2, 'desc', false);
-    expect(invalidateSfxLookupCache).toHaveBeenCalledOnce();
   });
 });
 
@@ -382,7 +363,6 @@ describe('deleteSfxTrigger', () => {
     expect(pool._conn.execute.mock.calls[1][0]).toContain('FOR UPDATE');
     expect(pool._conn.commit).toHaveBeenCalled();
     expect(pool._conn.release).toHaveBeenCalled();
-    expect(invalidateSfxLookupCache).toHaveBeenCalledOnce();
   });
 
   it('rolls back and returns null when the trigger row does not exist', async () => {
@@ -397,7 +377,6 @@ describe('deleteSfxTrigger', () => {
     expect(pool._conn.release).toHaveBeenCalled();
     // No child queries should run once the lock finds no trigger.
     expect(pool._conn.execute).toHaveBeenCalledTimes(1);
-    expect(invalidateSfxLookupCache).not.toHaveBeenCalled();
   });
 
   it('rolls back and rethrows on error', async () => {
@@ -408,7 +387,6 @@ describe('deleteSfxTrigger', () => {
     await expect(deleteSfxTrigger(7n)).rejects.toThrow('boom');
     expect(pool._conn.rollback).toHaveBeenCalled();
     expect(pool._conn.release).toHaveBeenCalled();
-    expect(invalidateSfxLookupCache).not.toHaveBeenCalled();
   });
 });
 
@@ -421,13 +399,6 @@ describe('addSfxFile', () => {
     const id = await addSfxFile(7n, 'clap.mp3', 2, false);
     expect(id).toBe(100);
     expect(pool.execute.mock.calls[0][1]).toEqual(['7', 'clap.mp3', 2, 0]);
-  });
-
-  it('calls invalidateSfxLookupCache on success', async () => {
-    const pool = makeResultPool({ insertId: 100 });
-    vi.mocked(getPool).mockReturnValue(pool as any);
-    await addSfxFile(7n, 'clap.mp3', 2, false);
-    expect(invalidateSfxLookupCache).toHaveBeenCalledOnce();
   });
 });
 
@@ -447,7 +418,6 @@ describe('updateSfxFile', () => {
       .mockResolvedValueOnce([[], []]); // fallback SELECT — id not found
     vi.mocked(getPool).mockReturnValue(pool as any);
     expect(await updateSfxFile(999, 3, true)).toBe(false);
-    expect(invalidateSfxLookupCache).not.toHaveBeenCalled();
   });
 
   it('returns true on a no-op update (weight/hidden unchanged) when the row exists', async () => {
@@ -457,13 +427,6 @@ describe('updateSfxFile', () => {
       .mockResolvedValueOnce([[{ id: 11 }], []]); // fallback SELECT — id exists
     vi.mocked(getPool).mockReturnValue(pool as any);
     expect(await updateSfxFile(11, 3, true)).toBe(true);
-  });
-
-  it('calls invalidateSfxLookupCache when a row matched', async () => {
-    const pool = makeResultPool({ affectedRows: 1 });
-    vi.mocked(getPool).mockReturnValue(pool as any);
-    await updateSfxFile(11, 3, true);
-    expect(invalidateSfxLookupCache).toHaveBeenCalledOnce();
   });
 });
 
@@ -493,7 +456,6 @@ describe('deleteSfxFile', () => {
     const file = await deleteSfxFile(11);
     expect(file).toBe('clap.mp3');
     expect(pool._conn.commit).toHaveBeenCalled();
-    expect(invalidateSfxLookupCache).toHaveBeenCalledOnce();
   });
 
   it('returns null and rolls back when no row exists', async () => {
@@ -505,7 +467,6 @@ describe('deleteSfxFile', () => {
     expect(file).toBeNull();
     expect(pool._conn.rollback).toHaveBeenCalled();
     expect(pool._conn.commit).not.toHaveBeenCalled();
-    expect(invalidateSfxLookupCache).not.toHaveBeenCalled();
   });
 
   it('returns null and rolls back when the row is deleted concurrently between the locked SELECT and DELETE', async () => {
@@ -519,7 +480,6 @@ describe('deleteSfxFile', () => {
     expect(file).toBeNull();
     expect(pool._conn.rollback).toHaveBeenCalled();
     expect(pool._conn.commit).not.toHaveBeenCalled();
-    expect(invalidateSfxLookupCache).not.toHaveBeenCalled();
   });
 
   it('rolls back, releases and rethrows on error', async () => {
@@ -530,6 +490,5 @@ describe('deleteSfxFile', () => {
     await expect(deleteSfxFile(11)).rejects.toThrow('boom');
     expect(pool._conn.rollback).toHaveBeenCalled();
     expect(pool._conn.release).toHaveBeenCalled();
-    expect(invalidateSfxLookupCache).not.toHaveBeenCalled();
   });
 });

--- a/src/db/sfx.ts
+++ b/src/db/sfx.ts
@@ -1,10 +1,6 @@
 import mysql from 'mysql2/promise';
 import { getPool, withTransaction } from './pool';
 import { fromBit, affectedOrExists, rowExists, getRowCount } from './utils';
-// sfxCache imports getAllSfxTriggers from this module; this module imports
-// invalidateSfxLookupCache from sfxCache. Both calls happen inside function
-// bodies, so CommonJS resolves the cycle correctly.
-import { invalidateSfxLookupCache } from './sfxCache';
 
 export interface SfxTrigger {
   id: bigint;
@@ -178,7 +174,6 @@ export async function createSfxTrigger(
      VALUES (?, ?, ?, ?)`,
     [command, categoryId, description, hidden ? 1 : 0],
   );
-  invalidateSfxLookupCache();
   return BigInt(result.insertId);
 }
 
@@ -208,9 +203,7 @@ export async function updateSfxTrigger(
      WHERE id = ?`,
     [command, categoryId, description, hidden ? 1 : 0, id.toString()],
   );
-  const updated = await affectedOrExists(result.affectedRows, () => rowExists(getPool(), 'sfxtrigger', 'id', id.toString()));
-  if (updated) invalidateSfxLookupCache();
-  return updated;
+  return affectedOrExists(result.affectedRows, () => rowExists(getPool(), 'sfxtrigger', 'id', id.toString()));
 }
 
 /**
@@ -247,7 +240,6 @@ export async function deleteSfxTrigger(id: bigint): Promise<{ files: string[] } 
       await conn.execute(`DELETE FROM sfxtrigger WHERE id = ?`, [id.toString()]);
       return { files };
     });
-    invalidateSfxLookupCache();
     return result;
   } catch (err) {
     if (err instanceof TriggerNotFoundError) return null;
@@ -272,7 +264,6 @@ export async function addSfxFile(
     `INSERT INTO sfx (trigger_id, file, weight, hidden) VALUES (?, ?, ?, ?)`,
     [triggerId.toString(), file, weight, hidden ? 1 : 0],
   );
-  invalidateSfxLookupCache();
   return result.insertId;
 }
 
@@ -306,9 +297,7 @@ export async function updateSfxFile(id: number, weight: number, hidden: boolean)
     `UPDATE sfx SET weight = ?, hidden = ? WHERE id = ?`,
     [weight, hidden ? 1 : 0, id],
   );
-  const updated = await affectedOrExists(result.affectedRows, () => rowExists(getPool(), 'sfx', 'id', id));
-  if (updated) invalidateSfxLookupCache();
-  return updated;
+  return affectedOrExists(result.affectedRows, () => rowExists(getPool(), 'sfx', 'id', id));
 }
 
 /**
@@ -339,7 +328,6 @@ export async function deleteSfxFile(id: number): Promise<string | null> {
       }
       return file;
     });
-    invalidateSfxLookupCache();
     return file;
   } catch (err) {
     if (err instanceof FileNotFoundError) return null;


### PR DESCRIPTION
## Summary

Follow-up to #504. `madge --circular` still reported 4 cycles after that fix, all in the db layer: `db/alertConfig.ts↔alertConfigCache.ts`, `db/counterCache.ts↔counters.ts`, `db/customCommandCache.ts↔customCommands.ts`, `db/sfx.ts↔sfxCache.ts`. These were previously judged safe-but-cyclic — decided to fix them anyway and add a CI guard now that the graph can be fully clean.

**Note on approach**: the initially-considered fix (extracting each pair's cache state into a third file) turns out not to work — it just relocates the cycle, since the new file would still need value-import edges in both directions (verified against `madge`'s actual cycle-detection logic). The fix that does work: move cache-invalidation calls out of the 4 low-level data files entirely and into `db.ts`'s facade, mirroring the `withInvalidation()` pattern already used there for `users.ts`/`guildCommandOverrides.ts`.

## Changes

- `src/db/alertConfig.ts`, `src/db/counters.ts`, `src/db/customCommands.ts`, `src/db/sfx.ts`: removed their `invalidate*LookupCache` imports and call sites. They're now pure DB layers with no cache knowledge.
- `src/db/counterCache.ts`, `src/db/customCommandCache.ts`: removed now-stale comments explaining the (former) safe-cycle rationale. No functional changes.
- `src/db.ts`: added thin wrapper functions for the 16 write functions across the 4 pairs, importing the underlying `*Record` functions and invalidating the appropriate lookup cache after each call. All exported symbol names, signatures, and import paths are unchanged for every consumer of `db.ts`.
- Test files for the 4 data modules: removed their `invalidate*LookupCache` mocks/assertions (no longer applicable). `src/db.test.ts`: added equivalent assertions for the new wrappers, including the conditional invalidation cases for `updateSfxTrigger`/`deleteSfxTrigger`/`updateSfxFile`/`deleteSfxFile`.
- Added `madge` as a devDependency (with a `typescript` override to resolve its peer-dependency range against this project's TypeScript 6) and a `check:circular` npm script.
- Wired `check:circular` into `.github/workflows/ci.yml` after the lint step (ubuntu-only, since it's static analysis).

Two small, deliberate behavior deltas (harmless — an occasional extra cache refresh, not a correctness issue):
- `resetCounterCurrentValue` now invalidates unconditionally instead of skipping when the counter was already 0.
- `assignUsersToCommand([])` now invalidates unconditionally instead of skipping on the empty-array no-op.

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm test` — 3053 tests passing (163 files)
- [x] `npm run lint` — no new errors (4 pre-existing unrelated warnings)
- [x] `npm run build` — passes
- [x] `npm run check:circular` (`madge --circular`) — **zero** circular dependencies (down from 4)

---
_Generated by [Claude Code](https://claude.ai/code/session_0125vFhGvQe2N9DYKk5KSFGV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data consistency after creating, updating, deleting, assigning, or resetting custom commands, counters, alert configurations, and sound effects.
  - Ensured lookup data refreshes correctly after successful database changes.

- **Tests**
  - Expanded coverage for database write operations, cache refresh behavior, returned results, and error handling.

- **Chores**
  - Added automated circular-dependency checks to continuous integration.
  - Improved linting support for project scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->