### PR TITLE
Serialize login-time discord_name write through userMutationQueue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ npm test      # Vitest
 - **Blank Twitch names → `NULL`** — `user.twitch_name` has a unique index; empty strings collide.
 - **`mutationQueue`** for concurrent-unsafe DB writes — user mutations serialise through it.
 - **POST routes redirect to `?error=code`** on failure; GET reads it and passes to EJS. Never render errors from a POST handler.
-- **`src/discordUtils.ts`** has `isDiscordNotFoundError` and `tryDeleteDiscordMessage` — import, don't duplicate.
+- **`src/discord/discordUtils.ts`** has `isDiscordNotFoundError` and `tryDeleteDiscordMessage` — import, don't duplicate.
 
 ---
 

--- a/src/web/routes/auth.test.ts
+++ b/src/web/routes/auth.test.ts
@@ -40,6 +40,7 @@ import {
   AccessLevel,
 } from '../../db';
 import { fetchMemberDisplayName } from '../../discord/discordBot';
+import { userMutationQueue } from './adminUserMutationQueue';
 
 function buildApp(sessionOverrides: Record<string, unknown> = {}, captureSession?: (session: any) => void) {
   const app = express();
@@ -239,6 +240,24 @@ describe('GET /discord/callback', () => {
     const res = await supertest(buildApp({ oauthState: { value: 'state123', expiresAt: Date.now() + 60_000 } }))
       .get('/discord/callback?code=code&state=state123');
     expect(res.status).toBe(302);
+    expect(updateDiscordName).toHaveBeenCalledWith('111', 'NewDisplayName');
+  });
+
+  it('serializes the discord_name update through userMutationQueue', async () => {
+    mockFetch([
+      { ok: true, json: () => Promise.resolve({ access_token: 'tok' }) },
+      { ok: true, json: () => Promise.resolve({ id: '111', username: 'alice', avatar: null }) },
+    ]);
+    vi.mocked(findUser).mockResolvedValue({ discord_id: '111', discord_name: 'OldName', is_twitch_bot_enabled: false, twitch_name: null, access_level: AccessLevel.USER, is_owner: false } as any);
+    vi.mocked(getGuildsForMember).mockResolvedValue([{ guild_id: '555', name: 'Guild', voice_channel_id: null }] as any);
+    vi.mocked(fetchMemberDisplayName).mockResolvedValue('NewDisplayName');
+    const runSpy = vi.spyOn(userMutationQueue, 'run');
+
+    const res = await supertest(buildApp({ oauthState: { value: 'state123', expiresAt: Date.now() + 60_000 } }))
+      .get('/discord/callback?code=code&state=state123');
+
+    expect(res.status).toBe(302);
+    expect(runSpy).toHaveBeenCalledWith('111', expect.any(Function));
     expect(updateDiscordName).toHaveBeenCalledWith('111', 'NewDisplayName');
   });
 

--- a/src/web/routes/auth.ts
+++ b/src/web/routes/auth.ts
@@ -55,7 +55,10 @@ router.get('/discord', (req, res) => {
  * syncing the display name, regenerating the session), or — if this login was
  * initiated via the companion app's loopback flow (`req.session.companionOAuth`
  * set by companionAuth.ts) — skips session creation entirely and redirects to
- * the companion app's `redirectUri` with a one-time code instead.
+ * the companion app's `redirectUri` with a one-time code instead. The
+ * `discord_name` sync is serialized per Discord ID through `userMutationQueue`,
+ * so it can't race a concurrent admin edit or the name-refresh job on the same
+ * user row.
  * @param req - Express request; reads `code`/`state` query params and the stored
  *   `oauthState` session value.
  * @param res - Express response; redirects to `/` on success, or to the

--- a/src/web/routes/auth.ts
+++ b/src/web/routes/auth.ts
@@ -16,6 +16,7 @@ import { fetchMemberDisplayName } from '../../discord/discordBot';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
 import { renderError, isLoopbackRedirectUri, renderView } from './shared';
+import { userMutationQueue } from './adminUserMutationQueue';
 
 const log = createLogger('Web');
 const router = Router();
@@ -153,7 +154,7 @@ router.get('/discord/callback', async (req, res) => {
         syncedDiscordName = trimmedDisplayName;
       }
       if (syncedDiscordName !== dbUser.discord_name) {
-        await updateDiscordName(profile.id, syncedDiscordName);
+        await userMutationQueue.run(profile.id, () => updateDiscordName(profile.id, syncedDiscordName));
       }
     } catch (syncErr) {
       log.warn('Non-blocking discord_name sync failed:', syncErr);


### PR DESCRIPTION
## Summary

A codebase-wide audit of the invariants in `CLAUDE.md` (db facade usage, BIGINT handling, `twitch_name` nulling, `mutationQueue` usage, Discord error-helper reuse, POST error-redirect pattern) plus a general code-quality pass turned up one real concurrency bug and one doc-path drift. Everything else checked out clean.

- **Bug fix:** `src/web/routes/auth.ts`'s `/auth/discord/callback` handler wrote `discord_name` directly via `updateDiscordName(...)`, unlike every other writer of user-row fields — `adminRefresh.ts`, `admin.ts`, `discordBot.ts`, and `streamdeckKeys.ts` all serialize through `userMutationQueue`, keyed by Discord ID. The unqueued write let a login race against a queued admin edit or the name-refresh job on the same user row. Now wrapped in `userMutationQueue.run(profile.id, () => updateDiscordName(...))`, matching the pattern already used in `adminRefresh.ts:44`.
- **Doc fix:** `CLAUDE.md` pointed at `src/discordUtils.ts` for the `isDiscordNotFoundError`/`tryDeleteDiscordMessage` helpers; the file actually lives at `src/discord/discordUtils.ts`. Fixed so the "import, don't duplicate" invariant is actually discoverable at the stated path.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` — all 3068 tests pass, including a new case in `auth.test.ts` asserting the `discord_name` update goes through `userMutationQueue.run` keyed by discord id


---
_Generated by [Claude Code](https://claude.ai/code/session_01GoYotJtBn2RMmeqe5XxSoh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Discord display-name updates during sign-in by preventing conflicting updates from occurring simultaneously.
  * Preserved existing best-effort handling when a display-name update cannot be completed.

* **Tests**
  * Added coverage to verify that Discord name updates are processed safely while still applying the requested change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->