### PR TITLE
docs: add directory structure, tech stack, startup, and web server sections to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,52 @@ npm test      # Vitest
 
 ---
 
+## Directory Structure
+
+- **`src/index.ts`** — entry point (see Startup Sequence below).
+- **`src/db.ts` + `src/db/`** — DB facade + one module per domain (`users.ts`, `guilds.ts`, `customCommands.ts`, `counters.ts`, `sfx.ts`, `streamMonitor.ts`, `eventSub.ts`, etc.), each with a co-located `*.test.ts`. Import from `src/db.ts` only (see Critical Invariants).
+- **`src/discord/`** — Discord bot bootstrap, guild registry, voice presence.
+- **`src/twitch/`** — Twitch chat bot + Helix API client, with `eventsub/`, `monitor/`, `pricing/`, `timers/` subfolders.
+- **`src/commands/`** — command routing/cooldowns/handlers shared by both platforms.
+- **`src/audio/`** — voice playback and SFX (see Voice adapter design decision below).
+- **`src/web/`** — Express app (`server.ts`) + route/controller files under `web/routes/` (see Web Server below).
+- **`src/shared/`** — cross-cutting utilities: `config.ts` (env vars), `logger.ts`, `crypto.ts`, `mutationQueue.ts`, `statusStore.ts`, `textTemplate.ts`.
+- **`src/types/`** — Express `Request`/session type augmentation.
+- **`src/test-utils/`** — shared test fixtures/mocks.
+
+---
+
+## Tech Stack
+
+- **Runtime:** discord.js v14, tmi.js (Twitch chat), `mediaplex` (Opus), express v5 + `express-session`/`express-mysql-session`, `mysql2`, `helmet`, `winston`.
+- **TypeScript:** `strict: true`, target ES2024, `moduleResolution: NodeNext`. No `engines` field in `package.json`.
+- **ESLint** (flat config, type-aware): `no-floating-promises`, `no-misused-promises`, and `no-console` are all **errors**, not warnings — these affect how code must be written (await/void everything, use `logger` not `console.*`). `no-explicit-any` is a warning; relaxed for `*.test.ts`.
+- **Test/build scripts:** `npm run build` (`tsc -p tsconfig.build.json`), `npm run lint`, `npm run check:circular` (madge).
+
+---
+
+## Startup Sequence (`src/index.ts`)
+
+Boot order in `main()`: verify DB connectivity (ping, exit 1 on failure) → wire Twitch/EventSub runtime callbacks → `reloadGuildRegistry()` (must complete before Discord connects, exit 1 on failure) → start Discord bot → start Twitch bot → start web panel → start schedulers (counter/reward-pricing/timer) → start Twitch monitor + EventSub (fire-and-forget, catch-and-log only, doesn't crash the process).
+
+- **`uncaughtException`/`unhandledRejection`** both log and `process.exit(1)` — deliberate: there's no process supervisor, so the app fails loudly instead of limping on with a corrupted state. Don't add a handler that swallows and continues.
+- **`shutdown()`** runs on `SIGINT`/`SIGTERM`: stops schedulers/EventSub/monitor/bots, disconnects audio, closes the DB pool, then exits 0.
+
+---
+
+## Web Server (`src/web/server.ts`)
+
+Middleware order: `helmet` (custom CSP) → EJS views → static → rate limiters (general/streamdeck/session) → body parsers → `trust proxy: 1` → session (`express-mysql-session`, backed by the `sessions` MySQL table) → `res.locals.user`/csrfToken.
+
+Auth middleware (`src/web/middleware.ts`), applied in this order:
+1. **`requireAuth`** — session check.
+2. **`requireGuildContext`** — re-derives the user's access level from the DB for the active guild on every request. **Must run before any `requireAccessLevel` check** — skipping it leaves a stale or absent access level that could bypass a mod/manager/admin gate.
+3. **`requireAccessLevel(level)`** factory → `requireMod`/`requireManager`/`requireAdmin`.
+4. **`requireOwner`** — separate global super-admin check via `is_owner`, not part of the `AccessLevel` ladder.
+5. **`authenticateBearerToken()`** factory → `requireApiKey` (Streamdeck) / `requireCompanionKey` (companion app), for API routes that bypass session auth entirely.
+
+---
+
 ## Critical Invariants
 
 - **`mediaplex` must be the first import in `src/index.ts`** — registers the Opus provider. Never reorder.
@@ -44,6 +90,8 @@ npm test      # Vitest
 **`customCommands.ts` owns its cache:** Write functions call `invalidateCustomCommandLookupCache()` internally — don't add a second call in `db.ts`.
 
 **MySQL 8 upsert:** Row-alias form only: `VALUES (...) AS new_row`. Deprecated `VALUES(col)` not used.
+
+**Docs:** `DATABASE-SCHEMA.md` is the schema reference — the DB is managed outside this repo, don't infer schema from migrations. `.devin/wiki.json` is a purpose-only architecture outline (no full prose) — useful as a map before diving into source, not a substitute for reading it.
 
 ---
 


### PR DESCRIPTION
## Summary

Agents working in this repo were repeatedly re-deriving the same basic facts from scratch each session — the `src/` directory layout, the dependency/tooling stack, how `src/index.ts` boots services and handles fatal errors, and how the Express web server's middleware/auth pipeline is wired. None of it was documented in `CLAUDE.md`, which jumped straight to invariants and design decisions assuming that context already existed.

This adds four new sections (purely additive, no existing content changed):

- **Directory Structure** — one-line map of each top-level `src/` folder (`db/`, `discord/`, `twitch/`, `commands/`, `audio/`, `web/`, `shared/`, `types/`, `test-utils/`).
- **Tech Stack** — key runtime deps, TypeScript strictness settings, and the ESLint rules that are errors (`no-floating-promises`, `no-misused-promises`, `no-console`) since those affect how code must be written.
- **Startup Sequence** — the `src/index.ts` boot order and the deliberate `uncaughtException`/`unhandledRejection` → `process.exit(1)` policy (no process supervisor, fail loud not silent).
- **Web Server** — Express middleware order and the auth middleware chain in `src/web/middleware.ts`, calling out that `requireGuildContext` must run before any `requireAccessLevel` check or a stale/absent access level could bypass a mod/manager/admin gate.

Also added two bullets to the existing **Design Decisions** section pointing at `DATABASE-SCHEMA.md` (schema reference) and `.devin/wiki.json` (architecture-map outline) so agents check those instead of re-deriving schema/architecture from scratch.

All facts were verified against the current source (`src/index.ts`, `src/web/server.ts`, `src/web/middleware.ts`, `src/db/users.ts`, `package.json`, `tsconfig.json`, `eslint.config.js`) before being written down.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (166 files, 3068 tests)
- [x] Diff reviewed — documentation-only change, no source files touched

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmmTJs2zqktogxdEmvzKDg)_