### PR TITLE
Fix nanoid advisory, pin Node engines floor, test timerCommandFireGate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4089,6 +4089,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/filing-cabinet/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -5750,9 +5764,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,9 @@
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.66.0",
         "vitest": "^4.1.10"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "bcuk-bot-4",
   "version": "1.0.0",
   "description": "Community bot",
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "dev": "ts-node src/index.ts",
     "build": "tsc -p tsconfig.build.json",

--- a/src/twitch/timers/timerCommandFireGate.test.ts
+++ b/src/twitch/timers/timerCommandFireGate.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockLogger, loggerInstance } = vi.hoisted(() => {
+  const loggerInstance = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+  return { mockLogger: () => loggerInstance, loggerInstance };
+});
+
+vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
+vi.mock('../twitchChatActivity', () => ({ getMessageCount: vi.fn() }));
+vi.mock('../monitor/twitchMonitor', () => ({ isChannelLive: vi.fn() }));
+
+import { getMessageCount } from '../twitchChatActivity';
+import { isChannelLive } from '../monitor/twitchMonitor';
+import type { TimerCommandForScheduler } from '../../db';
+import {
+  evaluateFireBlock, logBlockReasonChange, forgetBlockReason, pruneBlockReasonLog, clearBlockReasonLog,
+  type TimerRuntimeState,
+} from './timerCommandFireGate';
+
+function row(overrides: Partial<TimerCommandForScheduler> = {}): TimerCommandForScheduler {
+  return {
+    id: 1,
+    channel: 'somestreamer',
+    message: 'hello',
+    interval_seconds: 600,
+    min_messages: 0,
+    require_live: true,
+    ...overrides,
+  };
+}
+
+function state(overrides: Partial<TimerRuntimeState> = {}): TimerRuntimeState {
+  return { lastFiredAt: 0, messagesAtLastFire: 0, ...overrides };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearBlockReasonLog();
+  vi.mocked(isChannelLive).mockReturnValue(true);
+  vi.mocked(getMessageCount).mockReturnValue(0);
+});
+
+describe('evaluateFireBlock', () => {
+  it('blocks on offline when require_live is set and the channel is not live', () => {
+    vi.mocked(isChannelLive).mockReturnValue(false);
+    expect(evaluateFireBlock(row({ require_live: true }), state(), 700_000)).toBe('offline');
+  });
+
+  it('does not check liveness when require_live is false', () => {
+    vi.mocked(isChannelLive).mockReturnValue(false);
+    expect(evaluateFireBlock(row({ require_live: false, interval_seconds: 0 }), state(), 0)).toBeNull();
+  });
+
+  it('blocks on interval when the interval has not elapsed', () => {
+    expect(evaluateFireBlock(row({ interval_seconds: 600 }), state({ lastFiredAt: 0 }), 599_000)).toBe('interval');
+  });
+
+  it('clears the interval block exactly at the boundary', () => {
+    expect(evaluateFireBlock(row({ interval_seconds: 600, min_messages: 0 }), state({ lastFiredAt: 0 }), 600_000)).toBeNull();
+  });
+
+  it('blocks on messages when min_messages is not yet met', () => {
+    vi.mocked(getMessageCount).mockReturnValue(2);
+    const result = evaluateFireBlock(
+      row({ interval_seconds: 600, min_messages: 5 }), state({ lastFiredAt: 0, messagesAtLastFire: 0 }), 600_000,
+    );
+    expect(result).toBe('messages');
+  });
+
+  it('skips the messages check entirely when min_messages is 0', () => {
+    vi.mocked(getMessageCount).mockReturnValue(0);
+    const result = evaluateFireBlock(
+      row({ interval_seconds: 600, min_messages: 0 }), state({ lastFiredAt: 0, messagesAtLastFire: 0 }), 600_000,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('returns null when every condition is clear', () => {
+    vi.mocked(isChannelLive).mockReturnValue(true);
+    vi.mocked(getMessageCount).mockReturnValue(10);
+    const result = evaluateFireBlock(
+      row({ require_live: true, interval_seconds: 600, min_messages: 5 }),
+      state({ lastFiredAt: 0, messagesAtLastFire: 0 }),
+      600_000,
+    );
+    expect(result).toBeNull();
+  });
+});
+
+describe('logBlockReasonChange', () => {
+  it('logs the first time a non-interval reason is seen', () => {
+    logBlockReasonChange('1::somestreamer', row(), 'offline', state());
+    expect(loggerInstance.info).toHaveBeenCalledTimes(1);
+    expect(loggerInstance.info).toHaveBeenCalledWith(expect.stringContaining('waiting — channel not live'));
+  });
+
+  it('does not re-log the same reason on a repeat tick', () => {
+    logBlockReasonChange('1::somestreamer', row(), 'offline', state());
+    logBlockReasonChange('1::somestreamer', row(), 'offline', state());
+    expect(loggerInstance.info).toHaveBeenCalledTimes(1);
+  });
+
+  it('never logs the routine interval-wait reason', () => {
+    logBlockReasonChange('1::somestreamer', row(), 'interval', state());
+    expect(loggerInstance.info).not.toHaveBeenCalled();
+  });
+
+  it('does not log when the reason is null (clear to fire)', () => {
+    logBlockReasonChange('1::somestreamer', row(), null, state());
+    expect(loggerInstance.info).not.toHaveBeenCalled();
+  });
+
+  it('logs again when the reason changes from offline to messages', () => {
+    logBlockReasonChange('1::somestreamer', row(), 'offline', state());
+    vi.mocked(getMessageCount).mockReturnValue(1);
+    logBlockReasonChange('1::somestreamer', row({ min_messages: 5 }), 'messages', state({ messagesAtLastFire: 0 }));
+    expect(loggerInstance.info).toHaveBeenCalledTimes(2);
+    expect(loggerInstance.info).toHaveBeenLastCalledWith(expect.stringContaining('waiting on chat activity (1/5 messages'));
+  });
+});
+
+describe('forgetBlockReason / pruneBlockReasonLog / clearBlockReasonLog', () => {
+  it('forgetBlockReason makes a later repeat of the same reason log again', () => {
+    logBlockReasonChange('1::somestreamer', row(), 'offline', state());
+    forgetBlockReason('1::somestreamer');
+    logBlockReasonChange('1::somestreamer', row(), 'offline', state());
+    expect(loggerInstance.info).toHaveBeenCalledTimes(2);
+  });
+
+  it('pruneBlockReasonLog drops keys no longer present, keeping current ones', () => {
+    logBlockReasonChange('1::somestreamer', row(), 'offline', state());
+    logBlockReasonChange('2::otherstreamer', row({ id: 2, channel: 'otherstreamer' }), 'offline', state());
+
+    pruneBlockReasonLog(new Set(['1::somestreamer']));
+
+    // Pruned key logs again (state was forgotten); surviving key stays deduped.
+    logBlockReasonChange('2::otherstreamer', row({ id: 2, channel: 'otherstreamer' }), 'offline', state());
+    logBlockReasonChange('1::somestreamer', row(), 'offline', state());
+    expect(loggerInstance.info).toHaveBeenCalledTimes(3);
+  });
+
+  it('clearBlockReasonLog resets all tracked state', () => {
+    logBlockReasonChange('1::somestreamer', row(), 'offline', state());
+    clearBlockReasonLog();
+    logBlockReasonChange('1::somestreamer', row(), 'offline', state());
+    expect(loggerInstance.info).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

Ran a broad improvement audit of the codebase (security, bugs, quality, future-proofing) via three parallel research passes covering architecture/dependencies, security (SQL injection, auth, access control, secrets, XSS, CSRF, rate limiting), and code quality (test coverage, error handling, `mutationQueue`, BIGINT-coercion discipline, cache invalidation, JSDoc).

**Headline result: the codebase is in good shape.** No SQL injection risk, solid OAuth/session/CSRF/access-level handling, no XSS, no hardcoded secrets, consistent error handling, and disciplined BIGINT/cache-invalidation conventions. Two candidate findings turned out to already be non-issues on closer inspection (an inline BIGINT-coercion comment that was already present, and "missing" SFX mutation tests that are actually covered via the aggregator router's test file). This PR addresses the two genuine gaps found, plus adds unit coverage for a previously only-indirectly-tested module:

- **`npm audit fix`** resolves the one high-severity advisory (`nanoid < 3.3.17`, indefinite loop on `size=0` generators, GHSA-2v37-7h3g-55p8) — a transitive dev dependency, low real exploitability here, but a one-line fix.
- **Pin `engines.node: ">=24"`** in `package.json` — nothing previously pinned a Node floor despite CI (`.github/workflows/ci.yml`) targeting `node-version: '24.x'`. `engine-strict` is off, so this only warns rather than blocks on an older local Node.
- **Add `src/twitch/timers/timerCommandFireGate.test.ts`** — this module's pure logic (`evaluateFireBlock`, `logBlockReasonChange`'s log-dedup behavior, `forgetBlockReason`/`pruneBlockReasonLog`/`clearBlockReasonLog`) was previously only reachable indirectly through `timerCommandScheduler.test.ts`'s integration tests. New tests directly cover the interval boundary, `min_messages === 0` short-circuit, and the log-dedup/prune/clear lifecycle.

## Test plan

- [x] `npx tsc --noEmit` — passes clean
- [x] `npm test` — 167 test files / 3083 tests pass, including 15 new tests in `timerCommandFireGate.test.ts`
- [x] `npm run lint` — 0 errors (4 pre-existing warnings, unrelated to this change)
- [x] `npm audit` — 0 vulnerabilities (was 1 high)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAfePbwcngZrW3mEq5CRvr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Compatibility**
  - Updated the minimum supported Node.js runtime to version 24 or later.

- **Reliability**
  - Improved timer command fire-gating behavior across offline, interval, message-count, and reset scenarios.
  - Enhanced handling of block-reason tracking, deduplication, expiration, and state clearing.

- **Testing**
  - Added comprehensive automated coverage for timer command decisions and state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->