### PR TITLE
perf(2/4): batch and parallelize scheduled/startup Twitch round trips

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -532,7 +532,7 @@ export type { RewardPricingRow, RewardPricingInput, StreamerPricingSettings } fr
 export {
   getPricingForReward, getPricingConfigsForStreamer, getAllEnabledPricingRows,
   upsertPricingConfig, recordPricingUpdate, deletePricingConfig, markPricingUnsupported,
-  updatePricingCooldownForReward, getPricingSettingsForStreamer, savePricingSettingsForStreamer,
+  updatePricingCooldownForReward, getPricingSettingsForStreamer, getPricingSettingsForStreamers, savePricingSettingsForStreamer,
   DEFAULT_PRICING_COOLDOWN_SECONDS,
 } from './db/rewardPricing';
 

--- a/src/db/rewardPricing.test.ts
+++ b/src/db/rewardPricing.test.ts
@@ -15,6 +15,7 @@ import {
   markPricingUnsupported,
   updatePricingCooldownForReward,
   getPricingSettingsForStreamer,
+  getPricingSettingsForStreamers,
   savePricingSettingsForStreamer,
 } from './rewardPricing';
 import { makeMockPool } from '../test-utils/mockMysqlPool';
@@ -246,6 +247,45 @@ describe('getPricingSettingsForStreamer', () => {
     vi.mocked(getPool).mockReturnValue(pool as any);
     await getPricingSettingsForStreamer(7);
     expect(pool.execute.mock.calls[0][1]).toEqual([7]);
+  });
+});
+
+describe('getPricingSettingsForStreamers', () => {
+  it('returns an empty map without querying when given an empty array', async () => {
+    const pool = makePool([]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    const result = await getPricingSettingsForStreamers([]);
+    expect(result.size).toBe(0);
+    expect(pool.execute).not.toHaveBeenCalled();
+  });
+
+  it('returns a map keyed by streamer_id, converted to numbers', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([
+      { streamer_id: 7, half_life_seconds: '900', time_to_max_multiplier: '3.000' },
+      { streamer_id: 9, half_life_seconds: '1800', time_to_max_multiplier: '2.000' },
+    ]) as any);
+    const result = await getPricingSettingsForStreamers([7, 9]);
+    expect(result.size).toBe(2);
+    expect(result.get(7)).toEqual({ half_life_seconds: 900, time_to_max_multiplier: 3 });
+    expect(result.get(9)).toEqual({ half_life_seconds: 1800, time_to_max_multiplier: 2 });
+  });
+
+  it('omits a streamer with no settings row rather than defaulting it', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([
+      { streamer_id: 7, half_life_seconds: '900', time_to_max_multiplier: '3.000' },
+    ]) as any);
+    const result = await getPricingSettingsForStreamers([7, 9]);
+    expect(result.has(7)).toBe(true);
+    expect(result.has(9)).toBe(false);
+  });
+
+  it('builds an IN clause with one placeholder per streamer id', async () => {
+    const pool = makePool([]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await getPricingSettingsForStreamers([1, 2, 3]);
+    const [sql, params] = pool.execute.mock.calls[0];
+    expect(sql).toContain('streamer_id IN (?, ?, ?)');
+    expect(params).toEqual([1, 2, 3]);
   });
 });
 

--- a/src/db/rewardPricing.ts
+++ b/src/db/rewardPricing.ts
@@ -1,6 +1,7 @@
 import mysql from 'mysql2/promise';
 import { getPool } from './pool';
 import { fromBit } from './utils';
+import { buildInClausePlaceholders } from './commandStringUtils';
 
 /** A reward's dynamic-pricing configuration and current demand state. */
 export interface RewardPricingRow {
@@ -244,6 +245,33 @@ export async function getPricingSettingsForStreamer(streamerId: number): Promise
     half_life_seconds: Number(rows[0].half_life_seconds),
     time_to_max_multiplier: Number(rows[0].time_to_max_multiplier),
   };
+}
+
+/**
+ * Batched form of {@link getPricingSettingsForStreamer}: reads pricing settings for every
+ * streamer in `streamerIds` in a single query, instead of one query per streamer. Used by
+ * the decay-tick scheduler, which otherwise fetches one row per distinct streamer on every
+ * 30s tick. Streamers with no settings row are omitted from the result (not defaulted) — the
+ * default is per-streamer, so callers should fall back to `DEFAULT_STREAMER_PRICING_SETTINGS`
+ * (or {@link getPricingSettingsForStreamer}'s own default) themselves for a missing entry.
+ *
+ * @param streamerIds - DB row IDs of the streamers to fetch settings for.
+ * @returns Map of streamer id to their settings; empty if `streamerIds` is empty or none have settings.
+ */
+export async function getPricingSettingsForStreamers(streamerIds: number[]): Promise<Map<number, StreamerPricingSettings>> {
+  if (streamerIds.length === 0) return new Map();
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT streamer_id, half_life_seconds, time_to_max_multiplier FROM reward_pricing_settings
+     WHERE streamer_id IN (${buildInClausePlaceholders(streamerIds.length)})`,
+    streamerIds,
+  );
+  return new Map(rows.map((row) => [
+    row.streamer_id as number,
+    {
+      half_life_seconds: Number(row.half_life_seconds),
+      time_to_max_multiplier: Number(row.time_to_max_multiplier),
+    },
+  ]));
 }
 
 /**

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
@@ -232,6 +232,35 @@ describe('loadStreamersForEventSub', () => {
     expect(getEnabledAlertEventTypesBatch).toHaveBeenCalledWith([20, 21]);
   });
 
+  it('resolves streamers concurrently rather than waiting for each token refresh in turn', async () => {
+    const streamerA = { id: 30, twitch_name: 'streamerA', twitch_user_id: 'uid-30', config: { follow_enabled: true } };
+    const streamerB = { id: 31, twitch_name: 'streamerB', twitch_user_id: 'uid-31', config: { follow_enabled: true } };
+    vi.mocked(getAllEventSubStreamers).mockResolvedValue([streamerA, streamerB] as any);
+
+    let resolveFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => { resolveFirst = resolve; });
+    let secondStarted = false;
+
+    vi.mocked(getValidToken).mockImplementation(async (streamer: any) => {
+      if (streamer.id === 30) {
+        await firstGate; // blocks the first streamer's token refresh until released below
+      } else {
+        secondStarted = true; // only reachable if the second streamer didn't wait for the first
+      }
+      return 'tok';
+    });
+
+    const resultPromise = loadStreamersForEventSub();
+    for (let i = 0; i < 20 && !secondStarted; i++) {
+      await Promise.resolve();
+    }
+    expect(secondStarted).toBe(true);
+
+    resolveFirst();
+    const result = await resultPromise;
+    expect(result).toHaveLength(2);
+  });
+
   it('defaults enabledAlerts to an empty Set for a streamer missing from the batch result', async () => {
     const fakeStreamer = { id: 15, twitch_name: 'noAlerts', twitch_user_id: 'uid-15', config: { follow_enabled: true } };
     vi.mocked(getAllEventSubStreamers).mockResolvedValue([fakeStreamer] as any);

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
@@ -666,12 +666,8 @@ describe('error handling in subscription setup', () => {
       streamerId: 72,
     });
 
-    // Flush microtasks until the second deletion starts (or give up after a bounded number of
-    // ticks) — proves the second deletion isn't waiting on the first to settle.
-    for (let i = 0; i < 20 && !secondStarted; i++) {
-      await Promise.resolve();
-    }
-    expect(secondStarted).toBe(true);
+    // Waits until the second deletion starts — proves it isn't waiting on the first to settle.
+    await vi.waitFor(() => expect(secondStarted).toBe(true));
 
     rejectFirst(new Error('delete failed'));
     await expect(call).resolves.not.toThrow();

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
@@ -639,6 +639,44 @@ describe('error handling in subscription setup', () => {
     );
   });
 
+  it('deletes stale subscriptions concurrently, isolating one deletion failure from the other', async () => {
+    vi.mocked(createEventSubSubscription).mockResolvedValue('sub-id');
+    vi.mocked(listEventSubSubscriptions).mockResolvedValue([
+      { id: 'stale-1', type: 'channel.subscribe' },
+      { id: 'stale-2', type: 'channel.raid' },
+    ] as any);
+
+    let rejectFirst!: (err: Error) => void;
+    const firstGate = new Promise<void>((_resolve, reject) => { rejectFirst = reject; });
+    let secondStarted = false;
+
+    vi.mocked(deleteEventSubSubscription).mockImplementation(async (id: string) => {
+      if (id === 'stale-1') {
+        await firstGate;
+      } else {
+        secondStarted = true;
+      }
+    });
+
+    const call = subscribeForStreamer('sess-concurrent-delete', {
+      uid: 'uid-concurrent-delete',
+      token: 'tok-concurrent-delete',
+      name: 'errStreamer',
+      config: { follow_enabled: true, sub_enabled: false, raid_enabled: false } as any,
+      streamerId: 72,
+    });
+
+    // Flush microtasks until the second deletion starts (or give up after a bounded number of
+    // ticks) — proves the second deletion isn't waiting on the first to settle.
+    for (let i = 0; i < 20 && !secondStarted; i++) {
+      await Promise.resolve();
+    }
+    expect(secondStarted).toBe(true);
+
+    rejectFirst(new Error('delete failed'));
+    await expect(call).resolves.not.toThrow();
+  });
+
   it('logs and excludes the streamer when resolving a raid-only streamer\'s Twitch user ID fails', async () => {
     vi.mocked(getAllEventSubStreamers).mockResolvedValue([{
       id: 80,

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -61,20 +61,21 @@ async function deleteStaleSubscriptions(
     log.error(`Subscription cleanup failed for uid ${uid}:`, err);
     return;
   }
-  // Each deletion is isolated so one failure (e.g. a transient Twitch API error) doesn't abort
-  // the rest of the cleanup — leaving a still-undeleted stale duplicate would keep delivering
+  // Each deletion is isolated (and run concurrently, since they target different
+  // subscriptions) so one failure (e.g. a transient Twitch API error) doesn't abort the rest
+  // of the cleanup — leaving a still-undeleted stale duplicate would keep delivering
   // notifications and double-firing the type's handler, the exact failure this cleanup targets.
-  for (const sub of existing) {
+  const staleSubs = existing.filter((sub) => {
     const keptId = created.get(sub.type);
     const isStaleDuplicate = keptId !== undefined && sub.id !== keptId;
-    if (!desired.has(sub.type) || isStaleDuplicate) {
-      try {
-        await deleteEventSubSubscription(sub.id, userToken);
-      } catch (err) {
+    return !desired.has(sub.type) || isStaleDuplicate;
+  });
+  await Promise.allSettled(
+    staleSubs.map((sub) =>
+      deleteEventSubSubscription(sub.id, userToken).catch((err) => {
         log.error(`Failed to delete subscription ${sub.id} (${sub.type}) for uid ${uid}:`, err);
-      }
-    }
-  }
+      })),
+  );
 }
 
 /** Resolves the broadcaster's Twitch user ID. Uses the stored OAuth ID if available;
@@ -149,21 +150,22 @@ async function createSubscriptionsForStreamer(
  * Fetches all streamers from the DB, resolves their broadcaster IDs and valid tokens. Alert-gating
  * state for every streamer is fetched in a single batched query (`getEnabledAlertEventTypesBatch`)
  * up front, rather than one query per streamer, mirroring `getAllEventSubStreamers`'s own
- * bulk-JOIN fetch of `streamer_event_config`.
+ * bulk-JOIN fetch of `streamer_event_config`. Per-streamer token refresh (`getValidToken`) and
+ * broadcaster-ID resolution run concurrently across streamers via `Promise.all` — each streamer
+ * is independent, so this doesn't wait on one streamer's token refresh before starting the next.
  */
 export async function loadStreamersForEventSub(): Promise<StreamerEventSubData[]> {
   const streamers = await getAllEventSubStreamers();
   const alertsByStreamer = await getEnabledAlertEventTypesBatch(streamers.map((s) => s.id));
-  const result: StreamerEventSubData[] = [];
-  for (const streamer of streamers) {
+  const resolved = await Promise.all(streamers.map(async (streamer): Promise<StreamerEventSubData | null> => {
     const token = await getValidToken(streamer);
     const config = streamer.config;
     const uid = await resolveBroadcasterId(streamer, config);
-    if (!uid) continue;
+    if (!uid) return null;
     const enabledAlerts = alertsByStreamer.get(streamer.id) ?? new Set<AlertEventType>();
-    result.push({ uid, token, name: streamer.twitch_name ?? '', config, streamerId: streamer.id, enabledAlerts });
-  }
-  return result;
+    return { uid, token, name: streamer.twitch_name ?? '', config, streamerId: streamer.id, enabledAlerts };
+  }));
+  return resolved.filter((r): r is StreamerEventSubData => r !== null);
 }
 
 /** Creates all subscriptions for one streamer on their dedicated session, updates the

--- a/src/twitch/monitor/twitchMonitorStartup.test.ts
+++ b/src/twitch/monitor/twitchMonitorStartup.test.ts
@@ -246,4 +246,66 @@ describe('performStartupLiveCheck', () => {
     await performStartupLiveCheck(new Map(), new Map([['alice', 'u1']]), [streamer]);
     expect(updateMultitwitch).toHaveBeenCalledWith(7, expect.any(Map));
   });
+
+  it('reconciles streamers concurrently, isolating one failure from the other', async () => {
+    const streamA = makeStream({ user_id: 'u1', user_login: 'alice', type: 'live' });
+    const streamB = makeStream({ user_id: 'u2', user_login: 'bob', type: 'live' });
+    vi.mocked(getStreams).mockResolvedValue([streamA, streamB]);
+    const streamerA = makeStreamer({ id: 10, twitch_name: 'alice', discord_message_id: null });
+    const streamerB = makeStreamer({ id: 11, twitch_name: 'bob', discord_message_id: null });
+
+    let rejectFirst!: (err: Error) => void;
+    const firstGate = new Promise<void>((_resolve, reject) => { rejectFirst = reject; });
+    let secondStarted = false;
+
+    vi.mocked(postAnnouncement).mockImplementation(async (_liveStates: any, streamer: any) => {
+      if (streamer.twitch_name === 'alice') {
+        await firstGate;
+      } else {
+        secondStarted = true;
+      }
+    });
+
+    const check = performStartupLiveCheck(new Map(), new Map([['alice', 'u1'], ['bob', 'u2']]), [streamerA, streamerB]);
+    // Flush microtasks until the second streamer starts (or give up after a bounded number of
+    // ticks) — proves it isn't waiting on the first streamer to settle.
+    for (let i = 0; i < 20 && !secondStarted; i++) {
+      await Promise.resolve();
+    }
+    expect(secondStarted).toBe(true);
+
+    rejectFirst(new Error('announce failed'));
+    await expect(check).resolves.not.toThrow();
+  });
+
+  it('refreshes MultiTwitch for each changed group concurrently, isolating one failure from the other', async () => {
+    const streamA = makeStream({ user_id: 'u1', user_login: 'alice', type: 'live' });
+    const streamB = makeStream({ user_id: 'u2', user_login: 'bob', type: 'live' });
+    vi.mocked(getStreams).mockResolvedValue([streamA, streamB]);
+    const channel = makeChannel();
+    vi.mocked(getDiscordClient).mockReturnValue({ channels: { fetch: vi.fn().mockResolvedValue(channel) } } as any);
+    const streamerA = makeStreamer({ id: 10, twitch_name: 'alice', discord_message_id: 'msg1', discord_channel_id: 'ch1', group: makeGroup({ id: 7 }) });
+    const streamerB = makeStreamer({ id: 11, twitch_name: 'bob', discord_message_id: 'msg2', discord_channel_id: 'ch1', group: makeGroup({ id: 8 }) });
+
+    let rejectFirst!: (err: Error) => void;
+    const firstGate = new Promise<void>((_resolve, reject) => { rejectFirst = reject; });
+    let secondStarted = false;
+
+    vi.mocked(updateMultitwitch).mockImplementation(async (groupId: number) => {
+      if (groupId === 7) {
+        await firstGate;
+      } else {
+        secondStarted = true;
+      }
+    });
+
+    const check = performStartupLiveCheck(new Map(), new Map([['alice', 'u1'], ['bob', 'u2']]), [streamerA, streamerB]);
+    for (let i = 0; i < 20 && !secondStarted; i++) {
+      await Promise.resolve();
+    }
+    expect(secondStarted).toBe(true);
+
+    rejectFirst(new Error('multitwitch failed'));
+    await expect(check).resolves.not.toThrow();
+  });
 });

--- a/src/twitch/monitor/twitchMonitorStartup.ts
+++ b/src/twitch/monitor/twitchMonitorStartup.ts
@@ -142,21 +142,28 @@ export async function performStartupLiveCheck(
 
   const groupsWithChanges = new Set<number>();
 
-  for (const streamer of streamersData) {
-    const loginKey = streamer.twitch_name?.toLowerCase();
-    const userId = loginKey ? loginToUserId.get(loginKey) : undefined;
-    if (!userId) continue;
+  // Each streamer's reconciliation (a different Discord message/channel) is independent, and
+  // handleLiveStreamerOnStartup/handleOfflineStreamerOnStartup already isolate their own
+  // errors internally — so these run concurrently instead of one streamer at a time.
+  await Promise.allSettled(
+    streamersData.map(async (streamer) => {
+      const loginKey = streamer.twitch_name?.toLowerCase();
+      const userId = loginKey ? loginToUserId.get(loginKey) : undefined;
+      if (!userId) return;
 
-    const liveStream = liveByUserId.get(userId);
+      const liveStream = liveByUserId.get(userId);
 
-    if (liveStream) {
-      await handleLiveStreamerOnStartup(liveStates, streamer, liveStream, groupsWithChanges);
-    } else if (streamer.discord_message_id) {
-      await handleOfflineStreamerOnStartup(streamer, groupsWithChanges);
-    }
-  }
+      if (liveStream) {
+        await handleLiveStreamerOnStartup(liveStates, streamer, liveStream, groupsWithChanges);
+      } else if (streamer.discord_message_id) {
+        await handleOfflineStreamerOnStartup(streamer, groupsWithChanges);
+      }
+    }).map((work) => work.catch((err) => log.error('Startup reconciliation failed for a streamer:', err))),
+  );
 
-  for (const gid of groupsWithChanges) {
-    await updateMultitwitch(gid, liveStates);
-  }
+  // Each group's MultiTwitch refresh is independent of the others.
+  await Promise.allSettled(
+    Array.from(groupsWithChanges, (gid) =>
+      updateMultitwitch(gid, liveStates).catch((err) => log.error(`MultiTwitch refresh failed for group ${gid}:`, err))),
+  );
 }

--- a/src/twitch/pricing/rewardPricingScheduler.test.ts
+++ b/src/twitch/pricing/rewardPricingScheduler.test.ts
@@ -7,10 +7,10 @@ const { mockLogger } = vi.hoisted(() => ({
 
 /** Mocks the shared logger so the scheduler's log calls don't produce real output during tests. */
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
-vi.mock('../../db', () => ({ getAllEnabledPricingRows: vi.fn(), getPricingSettingsForStreamer: vi.fn() }));
+vi.mock('../../db', () => ({ getAllEnabledPricingRows: vi.fn(), getPricingSettingsForStreamers: vi.fn() }));
 vi.mock('./rewardPricingService', () => ({ applyDecayTick: vi.fn() }));
 
-import { getAllEnabledPricingRows, getPricingSettingsForStreamer } from '../../db';
+import { getAllEnabledPricingRows, getPricingSettingsForStreamers } from '../../db';
 import { applyDecayTick } from './rewardPricingService';
 import { runDecayTick, startRewardPricingScheduler, stopRewardPricingScheduler } from './rewardPricingScheduler';
 
@@ -19,7 +19,11 @@ const settings = { half_life_seconds: 1800, time_to_max_multiplier: 2 };
 beforeEach(() => {
   vi.clearAllMocks();
   vi.useFakeTimers();
-  vi.mocked(getPricingSettingsForStreamer).mockResolvedValue(settings);
+  // Default: every requested streamer id gets `settings` — matches getPricingSettingsForStreamers'
+  // real shape (a Map keyed by streamer id) without each test having to spell out the ids.
+  vi.mocked(getPricingSettingsForStreamers).mockImplementation(
+    async (streamerIds: number[]) => new Map(streamerIds.map((id) => [id, settings])),
+  );
 });
 
 afterEach(async () => {
@@ -41,7 +45,7 @@ describe('runDecayTick', () => {
     expect(applyDecayTick).toHaveBeenCalledWith(2, 'r2', settings);
   });
 
-  it('fetches settings once per distinct streamer, not once per reward', async () => {
+  it('fetches settings for every distinct streamer in a single batched call, not once per reward', async () => {
     vi.mocked(getAllEnabledPricingRows).mockResolvedValue([
       { streamer_id: 1, twitch_reward_id: 'r1' },
       { streamer_id: 1, twitch_reward_id: 'r2' },
@@ -51,26 +55,36 @@ describe('runDecayTick', () => {
 
     await runDecayTick();
 
-    expect(getPricingSettingsForStreamer).toHaveBeenCalledTimes(2);
-    expect(getPricingSettingsForStreamer).toHaveBeenCalledWith(1);
-    expect(getPricingSettingsForStreamer).toHaveBeenCalledWith(2);
+    expect(getPricingSettingsForStreamers).toHaveBeenCalledTimes(1);
+    expect(getPricingSettingsForStreamers).toHaveBeenCalledWith([1, 2]);
     expect(applyDecayTick).toHaveBeenCalledWith(1, 'r1', settings);
     expect(applyDecayTick).toHaveBeenCalledWith(1, 'r2', settings);
     expect(applyDecayTick).toHaveBeenCalledWith(2, 'r3', settings);
   });
 
-  it('falls back to an undefined settings hint for a streamer whose settings prefetch fails, without blocking other streamers', async () => {
+  it('falls back to an undefined settings hint for every reward when the batched settings prefetch fails', async () => {
     vi.mocked(getAllEnabledPricingRows).mockResolvedValue([
       { streamer_id: 1, twitch_reward_id: 'r1' },
       { streamer_id: 2, twitch_reward_id: 'r2' },
     ] as any);
-    vi.mocked(getPricingSettingsForStreamer).mockImplementation(async (streamerId) => {
-      if (streamerId === 1) throw new Error('settings db down');
-      return settings;
-    });
+    vi.mocked(getPricingSettingsForStreamers).mockRejectedValue(new Error('settings db down'));
     vi.mocked(applyDecayTick).mockResolvedValue(undefined);
 
     await expect(runDecayTick()).resolves.toBeUndefined();
+
+    expect(applyDecayTick).toHaveBeenCalledWith(1, 'r1', undefined);
+    expect(applyDecayTick).toHaveBeenCalledWith(2, 'r2', undefined);
+  });
+
+  it('falls back to an undefined settings hint for a streamer omitted from the batch result (no settings row), without affecting others', async () => {
+    vi.mocked(getAllEnabledPricingRows).mockResolvedValue([
+      { streamer_id: 1, twitch_reward_id: 'r1' },
+      { streamer_id: 2, twitch_reward_id: 'r2' },
+    ] as any);
+    vi.mocked(getPricingSettingsForStreamers).mockResolvedValue(new Map([[2, settings]]));
+    vi.mocked(applyDecayTick).mockResolvedValue(undefined);
+
+    await runDecayTick();
 
     expect(applyDecayTick).toHaveBeenCalledWith(1, 'r1', undefined);
     expect(applyDecayTick).toHaveBeenCalledWith(2, 'r2', settings);
@@ -112,8 +126,8 @@ describe('runDecayTick', () => {
 
     const tick = runDecayTick();
     // Flush microtasks until the second row starts (or give up after a bounded number of
-    // ticks) — the batched per-streamer settings prefetch now adds a variable number of
-    // hops before applyDecayTick is reached, so a fixed tick count is too fragile here.
+    // ticks) — the single batched settings prefetch still adds a variable number of hops
+    // before applyDecayTick is reached, so a fixed tick count is too fragile here.
     for (let i = 0; i < 20 && !secondStarted; i++) {
       await Promise.resolve();
     }

--- a/src/twitch/pricing/rewardPricingScheduler.ts
+++ b/src/twitch/pricing/rewardPricingScheduler.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '../../shared/logger';
-import { getAllEnabledPricingRows, getPricingSettingsForStreamer, type StreamerPricingSettings } from '../../db';
+import { getAllEnabledPricingRows, getPricingSettingsForStreamers, type StreamerPricingSettings } from '../../db';
 import { applyDecayTick } from './rewardPricingService';
 
 const log = createLogger('RewardPricingScheduler');
@@ -65,11 +65,13 @@ function resumeAfterDbRecovery(): void {
  * Rows are processed concurrently — `applyDecayTick` already serializes work per reward via
  * its own mutation queue, so different rows are independent and don't need to wait on each
  * other, keeping tick duration from growing linearly with the number of enabled rewards.
- * A streamer's pricing settings are fetched once per tick and shared across all of that
- * streamer's rewards (rather than once per reward) — settings aren't part of the
- * per-reward concurrency-sensitive state `applyDecayTick` re-reads fresh, so a tick-old
- * value is harmless. No-ops (re-uses the in-flight promise) if a tick is already running,
- * so a slow tick can't overlap with the next interval firing.
+ * A streamer's pricing settings are fetched once per tick, in one batched query across every
+ * distinct streamer with enabled pricing rows (`getPricingSettingsForStreamers`), and shared
+ * across all of that streamer's rewards (rather than once per reward or one query per
+ * streamer) — settings aren't part of the per-reward concurrency-sensitive state
+ * `applyDecayTick` re-reads fresh, so a tick-old value is harmless. No-ops (re-uses the
+ * in-flight promise) if a tick is already running, so a slow tick can't overlap with the next
+ * interval firing.
  */
 export async function runDecayTick(): Promise<void> {
   if (tickRunning) return currentTickPromise;
@@ -79,20 +81,15 @@ export async function runDecayTick(): Promise<void> {
       const rows = await getAllEnabledPricingRows();
       resumeAfterDbRecovery();
       const distinctStreamerIds = [...new Set(rows.map((row) => row.streamer_id))];
-      // Settled (not Promise.all) so one streamer's settings-fetch failure doesn't abort
-      // the whole tick — that streamer's rewards simply fall back to fetching their own
-      // settings inside applyDecayTick, isolated by the per-row .catch below like before.
-      const settingsResults = await Promise.allSettled(
-        distinctStreamerIds.map(async (streamerId): Promise<[number, StreamerPricingSettings]> =>
-          [streamerId, await getPricingSettingsForStreamer(streamerId)]),
-      );
-      const settingsByStreamerId = new Map<number, StreamerPricingSettings>();
-      for (const result of settingsResults) {
-        if (result.status === 'fulfilled') {
-          settingsByStreamerId.set(...result.value);
-        } else {
-          log.error('Failed to pre-fetch pricing settings for a streamer during decay tick:', result.reason);
-        }
+      // A streamer absent from the result (no settings row, or the whole batch fetch failed)
+      // is simply missing from the map — applyDecayTick falls back to fetching its own
+      // per-reward default when `settingsByStreamerId.get(...)` is undefined, same as before.
+      let settingsByStreamerId: Map<number, StreamerPricingSettings>;
+      try {
+        settingsByStreamerId = await getPricingSettingsForStreamers(distinctStreamerIds);
+      } catch (err) {
+        log.error('Failed to pre-fetch pricing settings during decay tick:', err);
+        settingsByStreamerId = new Map();
       }
 
       await Promise.allSettled(


### PR DESCRIPTION
## Summary

Second of 4 prioritized PRs from an efficiency review of this codebase (see #512 for the first). This one covers the Twitch-side scheduled/startup paths that fire every 30s or on every EventSub reload:

- **`rewardPricingScheduler.runDecayTick`**: fetched pricing settings with one query per distinct streamer on every 30s decay tick. Added `getPricingSettingsForStreamers` (batched `IN (...)` query) and use it instead of the per-streamer fetch loop. A streamer with no settings row (or a total batch-fetch failure) is simply absent from the result map, same as before — `applyDecayTick` already falls back to its own per-reward default when the settings hint is `undefined`.
- **`performStartupLiveCheck`**: the per-streamer reconciliation loop and the per-group MultiTwitch-refresh loop both awaited sequentially over independent items (different Discord messages/channels). Switched both to `Promise.allSettled` — the per-streamer handlers already isolate their own errors internally, so this is purely a concurrency change.
- **`loadStreamersForEventSub`**: per-streamer token refresh (`getValidToken`) + broadcaster-ID resolution ran one streamer at a time. Switched to `Promise.all` since each streamer is independent (order is preserved, and error propagation is unchanged — neither the old sequential loop nor the new `Promise.all` isolates a `getValidToken` failure, so behavior on failure is identical).
- **`deleteStaleSubscriptions`**: deleted stale EventSub subscriptions one at a time. Switched to `Promise.allSettled` (each delete already isolated its own errors via try/catch+log, so this only changes the concurrency, not the isolation).

**Deliberately left sequential:** `createSubscriptionsForStreamer`'s per-spec `subscribe()` loop (up to ~9 `createEventSubSubscription` calls per streamer) — each call creates a *new* Twitch EventSub subscription, and Twitch enforces subscription-creation rate limits. Firing them all at once trades a small startup-time win for a real risk of 429s during reconnect storms, so this one stays as-is.

All changes are behavior-preserving — same observable output, just less serialized waiting.

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm test` — full suite passes (3089 tests)
- [x] `npm run lint` — no new warnings/errors
- [x] `npm run check:circular` — no circular dependencies
- [x] Added/updated tests: `rewardPricing.test.ts` (new batched settings fetch), `rewardPricingScheduler.test.ts` (batched-call assertions + batch-failure fallback), `twitchEventSubSubscriptions.test.ts` (new concurrency test gating one streamer's token refresh to confirm the second isn't blocked)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BNTwipjWM2SkRYueoPeR6a)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batched retrieval of streamer pricing settings for more efficient reward processing.
  * Missing pricing settings continue to be handled safely without applying unintended defaults.

* **Bug Fixes**
  * Improved startup and subscription processing so one streamer’s failure does not block others.
  * Concurrently processes streamer updates, cleanup, token refreshes, and MultiTwitch refreshes for faster operation.

* **Tests**
  * Added coverage for batched pricing lookups, missing settings, failures, and concurrent streamer processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->