### PR TITLE
perf(3/4): batch the bulk-assign Twitch-channel conflict check

### DIFF
--- a/src/db/commandConflicts.test.ts
+++ b/src/db/commandConflicts.test.ts
@@ -513,22 +513,40 @@ describe('assignUsersToCommandWithinTransaction', () => {
     expect(releaseNamedLock).toHaveBeenCalledOnce();
   });
 
-  it('runs a channel trigger conflict check for each eligible user', async () => {
+  it('runs a single batched channel trigger conflict check covering every eligible user', async () => {
     const connection = makeConnection([
       [{ trigger_string: '!clap' }],
       [
         { discord_id: 'user1', twitch_name: 'alice', is_twitch_bot_enabled: 1 },
         { discord_id: 'user2', twitch_name: 'bob', is_twitch_bot_enabled: 1 },
       ],
-      [], // conflict check for user1
-      [], // conflict check for user2
+      [], // one batched conflict check covering both eligible users
       [], // insert
     ]);
 
     await assignUsersToCommandWithinTransaction(connection, 1, ['user1', 'user2']);
 
     expect(connection.commit).toHaveBeenCalledOnce();
-    expect(connection.execute).toHaveBeenCalledTimes(5);
+    expect(connection.execute).toHaveBeenCalledTimes(4);
+    const [conflictSql, conflictParams] = connection.execute.mock.calls[2] as [string, unknown[]];
+    expect(conflictSql).toContain('IN (?, ?)');
+    expect(conflictParams).toEqual([1, '!clap', 'alice', 'bob']);
+  });
+
+  it('skips the conflict check entirely when no assigned user is Twitch-eligible', async () => {
+    const connection = makeConnection([
+      [{ trigger_string: '!clap' }],
+      [
+        { discord_id: 'user1', twitch_name: null, is_twitch_bot_enabled: 0 },
+        { discord_id: 'user2', twitch_name: 'bob', is_twitch_bot_enabled: 0 },
+      ],
+      [], // insert
+    ]);
+
+    await assignUsersToCommandWithinTransaction(connection, 1, ['user1', 'user2']);
+
+    expect(connection.commit).toHaveBeenCalledOnce();
+    expect(connection.execute).toHaveBeenCalledTimes(3);
   });
 
   it('rolls back and throws CommandConflictError when any eligible user has a channel conflict', async () => {

--- a/src/db/commandConflicts.ts
+++ b/src/db/commandConflicts.ts
@@ -461,43 +461,55 @@ export async function insertUserCommandAssignments(
 }
 
 /**
- * Throws if `discordId` has no matching eligibility entry, or if it's eligible for a
- * Twitch-channel conflict check and that check finds one.
- * @param connection Transaction-capable pool connection to query with.
- * @param commandId Command id being assigned.
- * @param discordId Discord snowflake of the user being checked.
- * @param normalizedTriggerString Normalized trigger string being assigned.
- * @param eligibilityByDiscordId Batch-fetched eligibility, keyed by `discordId`.
- * @throws {CommandConflictError} If the user's Twitch channel would create a trigger conflict.
- * @throws If `discordId` has no matching entry in `eligibilityByDiscordId`.
+ * Batched form of {@link hasTwitchChannelTriggerConflict}: checks whether `triggerString` is
+ * already used by another command that is either multi-Twitch or assigned to a user whose
+ * normalized Twitch channel name is in `normalizedTwitchNames` — one query covering every
+ * eligible user in a bulk assignment, instead of one query per user.
+ * @param executor Pool or transaction connection to query with.
+ * @param commandId Command id to exclude from the conflict check.
+ * @param triggerString Trigger string to check for conflicts.
+ * @param normalizedTwitchNames Normalized (lowercased) Twitch channel names to match against.
+ *   Must be non-empty.
+ * @returns True if a conflicting command exists for any of the given names.
  */
-async function assertUserAssignable(
-  connection: mysql.PoolConnection,
+async function hasAnyTwitchChannelTriggerConflict(
+  executor: SqlExecutor,
   commandId: number,
-  discordId: string,
-  normalizedTriggerString: string,
-  eligibilityByDiscordId: Map<string, UserTwitchEligibility>,
-): Promise<void> {
-  const eligibility = eligibilityByDiscordId.get(discordId);
-  if (!eligibility) {
-    throw new Error(`User not found: ${discordId}`);
-  }
-  if (eligibility.normalizedTwitchName && eligibility.isTwitchBotEnabled) {
-    await assertNoTwitchChannelTriggerConflict(connection, commandId, normalizedTriggerString, eligibility.normalizedTwitchName);
-  }
+  triggerString: string,
+  normalizedTwitchNames: string[],
+): Promise<boolean> {
+  const [conflictRows] = await executor.execute<mysql.RowDataPacket[]>(
+    `SELECT c.command_id
+     FROM custom_command c
+     LEFT JOIN twitch_user_commands tuc ON tuc.command_id = c.command_id
+     LEFT JOIN \`user\` u ON u.discord_id = tuc.discord_id
+     WHERE c.command_id <> ?
+       AND c.trigger_string = ?
+       AND (
+         c.is_multi_twitch = 1
+         OR (
+           u.twitch_name IS NOT NULL
+           AND u.is_twitch_bot_enabled = 1
+           AND LOWER(u.twitch_name) IN (${buildInClausePlaceholders(normalizedTwitchNames.length)})
+         )
+       )
+     LIMIT 1`,
+    [commandId, triggerString, ...normalizedTwitchNames],
+  );
+
+  return conflictRows.length > 0;
 }
 
 /**
- * Runs {@link assertUserAssignable} for every `discordId`, in order. A single MySQL connection
- * only ever has one command in flight (mysql2 queues, rather than pipelines, queries issued
- * without awaiting the previous one), so these checks are issued sequentially rather than via
- * `Promise.all` — that would add complexity without reducing round trips.
+ * Throws if any `discordId` has no matching eligibility entry, or if any Twitch-eligible user's
+ * channel would create a trigger conflict — checked in a single batched query across every
+ * eligible user (see {@link hasAnyTwitchChannelTriggerConflict}) rather than one query per user.
  * @param connection Transaction-capable pool connection to query with.
  * @param commandId Command id being assigned.
  * @param discordIds Discord snowflakes of the users being checked.
  * @param normalizedTriggerString Normalized trigger string being assigned.
  * @param eligibilityByDiscordId Batch-fetched eligibility, keyed by `discordId`.
- * @throws {CommandConflictError} If any user's Twitch channel would create a trigger conflict.
+ * @throws {CommandConflictError} If any eligible user's Twitch channel would create a trigger conflict.
  * @throws If any `discordId` has no matching entry in `eligibilityByDiscordId`.
  */
 async function assertAllUsersAssignable(
@@ -507,9 +519,21 @@ async function assertAllUsersAssignable(
   normalizedTriggerString: string,
   eligibilityByDiscordId: Map<string, UserTwitchEligibility>,
 ): Promise<void> {
+  const eligibleNames: string[] = [];
   for (const discordId of discordIds) {
-    await assertUserAssignable(connection, commandId, discordId, normalizedTriggerString, eligibilityByDiscordId);
+    const eligibility = eligibilityByDiscordId.get(discordId);
+    if (!eligibility) {
+      throw new Error(`User not found: ${discordId}`);
+    }
+    if (eligibility.normalizedTwitchName && eligibility.isTwitchBotEnabled) {
+      eligibleNames.push(eligibility.normalizedTwitchName);
+    }
   }
+
+  if (eligibleNames.length === 0) return;
+
+  await assertConflictFree(normalizedTriggerString, () =>
+    hasAnyTwitchChannelTriggerConflict(connection, commandId, normalizedTriggerString, eligibleNames));
 }
 
 /**


### PR DESCRIPTION
## Summary

Third of 4 prioritized PRs from an efficiency review of this codebase (see #512, #513 for the first two). This one fixes a textbook N+1 in the admin bulk-assign path:

- **`assignUsersToCommandWithinTransaction` / `assertAllUsersAssignable`**: bulk-assigning N users to a command fired `hasTwitchChannelTriggerConflict` once per eligible user (sequential — correctly so, since a single MySQL connection can't pipeline queries — but the *query itself* didn't need to be per-user).
- Added `hasAnyTwitchChannelTriggerConflict`, the same conflict query but with `LOWER(u.twitch_name) IN (...)` covering every eligible user's normalized Twitch name in a bulk assignment, instead of one query per name.
- `assertAllUsersAssignable` now: validates every `discordId` has an eligibility entry first (no query — same "User not found" behavior as before), collects the normalized names of Twitch-eligible users, and — if any exist — runs one batched conflict check instead of the per-user loop. If nobody in the batch is Twitch-eligible, no conflict query runs at all.
- Same observable semantics throughout: aborts the whole assignment on any conflict, same `CommandConflictError` shape (it never carried per-user detail, just the trigger string).

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm test` — full suite passes (3084 tests)
- [x] `npm run lint` — no new warnings/errors
- [x] `npm run check:circular` — no circular dependencies
- [x] Updated `commandConflicts.test.ts`: the multi-user conflict-check test now asserts a single batched query (`IN (?, ?)` with both normalized names) instead of one call per user, plus a new test confirming the conflict query is skipped entirely when no assigned user is Twitch-eligible. Existing single-user and "user not found" tests pass unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BNTwipjWM2SkRYueoPeR6a)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bulk assignment validation for Twitch channel conflicts.
  * Missing users are now handled correctly during bulk assignments.
  * Conflict checks are skipped when no assigned users are eligible for Twitch validation.

* **Performance**
  * Reduced bulk assignment validation to a single batched conflict check, improving efficiency for larger assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->