### PR TITLE
perf(4/4): small self-contained wins (CSRF, template fill, chart escaping)

### DIFF
--- a/src/db/streamdeckKeys.ts
+++ b/src/db/streamdeckKeys.ts
@@ -48,7 +48,7 @@ function initialStatus(accessLevel: number): 'pending' | 'approved' {
  */
 export async function hasApiKey(discordId: string): Promise<boolean> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    'SELECT 1 FROM streamdeck_api_keys WHERE discord_id = ?',
+    'SELECT 1 FROM streamdeck_api_keys WHERE discord_id = ? LIMIT 1',
     [discordId],
   );
   return rows.length > 0;
@@ -165,7 +165,7 @@ export async function rotateApiKey(discordId: string): Promise<{ plain: string }
  */
 export async function findKeyByHash(hash: string): Promise<{ discordId: string } | null> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    'SELECT discord_id, key_hash FROM streamdeck_api_keys WHERE key_hash = ?',
+    'SELECT discord_id, key_hash FROM streamdeck_api_keys WHERE key_hash = ? LIMIT 1',
     [hash],
   );
   if (rows.length === 0 || !hashesMatch(String(rows[0].key_hash), hash)) return null;

--- a/src/shared/textTemplate.ts
+++ b/src/shared/textTemplate.ts
@@ -1,6 +1,8 @@
 /** Strategy for handling `{key}` placeholders with no matching entry in `vars`. */
 export type FillTemplateFallback = 'empty' | 'keep';
 
+const PLACEHOLDER_PATTERN = /\{(\w+)\}/g;
+
 /**
  * Substitutes `{key}` placeholders in `template` with values from `vars`.
  * Unknown placeholders (keys not present in `vars`) are handled per `fallback`:
@@ -18,7 +20,7 @@ export function fillTemplate(
   vars: Record<string, string>,
   fallback: FillTemplateFallback = 'empty',
 ): string {
-  return template.replace(/\{(\w+)\}/g, (match, k: string) => {
+  return template.replace(PLACEHOLDER_PATTERN, (match, k: string) => {
     const value = vars[k];
     if (value !== undefined) return value;
     return fallback === 'keep' ? match : '';

--- a/src/web/csrf.test.ts
+++ b/src/web/csrf.test.ts
@@ -52,6 +52,16 @@ describe('csrfProtection — body token', () => {
     expect(res.status).toBe(403);
     expect(res.body.code).toBe('EBADCSRFTOKEN');
   });
+
+  it('rejects a 64-char token that is not valid hex, without throwing', async () => {
+    const notHex = 'z'.repeat(64);
+    const res = await supertest(buildApp())
+      .post('/test')
+      .send(`_csrf=${notHex}`)
+      .set('Content-Type', 'application/x-www-form-urlencoded');
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('EBADCSRFTOKEN');
+  });
 });
 
 describe('csrfProtection — X-CSRF-Token header', () => {

--- a/src/web/csrf.ts
+++ b/src/web/csrf.ts
@@ -3,6 +3,20 @@ import type { RequestHandler } from 'express';
 
 const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
 
+// Session tokens are always 64 lowercase hex chars (crypto.randomBytes(32).toString('hex')).
+const CSRF_TOKEN_HEX_PATTERN = /^[0-9a-f]{64}$/i;
+
+/**
+ * Converts a CSRF token to a 32-byte buffer for constant-time comparison, or null if it isn't
+ * valid 64-char hex (an attacker-controlled submitted token can be any string). Format-checking
+ * the length here doesn't leak anything security-relevant — a CSRF token's expected length is
+ * public knowledge, not part of the secret — so this is just a cheap pre-check to guarantee both
+ * buffers passed to `timingSafeEqual` are always the same length, without hashing either token.
+ */
+function csrfTokenBuffer(token: string): Buffer | null {
+  return CSRF_TOKEN_HEX_PATTERN.test(token) ? Buffer.from(token, 'hex') : null;
+}
+
 function createCsrfError(): Error & { code: string } {
   const error = new Error('Invalid CSRF token') as Error & { code: string };
   error.code = 'EBADCSRFTOKEN';
@@ -62,11 +76,9 @@ export const csrfProtection: RequestHandler = (req, _res, next) => {
     return;
   }
 
-  // Compare hex digests so both buffers are always the same byte length,
-  // eliminating any timing side-channel from a length mismatch check.
-  const a = Buffer.from(crypto.createHash('sha256').update(submittedToken).digest('hex'));
-  const b = Buffer.from(crypto.createHash('sha256').update(sessionToken).digest('hex'));
-  if (!crypto.timingSafeEqual(a, b)) {
+  const submittedBuffer = csrfTokenBuffer(submittedToken);
+  const sessionBuffer = csrfTokenBuffer(sessionToken);
+  if (!submittedBuffer || !sessionBuffer || !crypto.timingSafeEqual(submittedBuffer, sessionBuffer)) {
     next(createCsrfError());
     return;
   }

--- a/src/web/priceHistoryChart.ts
+++ b/src/web/priceHistoryChart.ts
@@ -8,14 +8,18 @@ const WIDTH = 480;
 const HEIGHT = 120;
 const PADDING = { top: 10, right: 12, bottom: 20, left: 44 };
 
+const HTML_ESCAPES: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+const HTML_ESCAPE_PATTERN = /[&<>"']/g;
+
 /** Escapes HTML/XML special characters so a value is safe to embed as SVG text or an attribute value. */
 function escapeHtml(value: string | number): string {
-  return String(value)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
+  return String(value).replace(HTML_ESCAPE_PATTERN, (char) => HTML_ESCAPES[char]);
 }
 
 /**


### PR DESCRIPTION
## Summary

Last of 4 prioritized PRs from an efficiency review of this codebase (see #512, #513, #514 for the rest). This one is a grab-bag of small, self-contained, zero-risk wins that didn't warrant their own PR:

- **`csrfProtection`** (`src/web/csrf.ts`): hashed both the submitted and session CSRF tokens with SHA-256 on every mutating request, solely to equalize buffer length before `timingSafeEqual`. Both are always 64-char hex (`crypto.randomBytes(32).toString('hex')`), so now compares hex-decoded buffers directly — guarded by a regex/length check that fails closed (403, not a thrown exception) on a malformed submitted token. Two SHA-256 computations removed from every POST/PUT/DELETE.
- **`fillTemplate`** (`src/shared/textTemplate.ts`): the `/\{(\w+)\}/g` regex literal was allocated on every call; hoisted to a module-level constant.
- **`escapeHtml`** (`src/web/priceHistoryChart.ts`): replaced 5 sequential full-string `.replace()` passes with a single pass using a character-class regex and a replacer map. Called several times per reward row on the channel-points admin page.
- **`hasApiKey`/`findKeyByHash`** (`src/db/streamdeckKeys.ts`): added `LIMIT 1` to their existence-check queries for consistency with the rest of the codebase's `SELECT 1 ... LIMIT 1` pattern. `discord_id`/`key_hash` are already unique-indexed, so this is a style-consistency fix rather than a behavior or performance change.

All changes are behavior-preserving.

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm test` — full suite passes (3084 tests)
- [x] `npm run lint` — no new warnings/errors
- [x] `npm run check:circular` — no circular dependencies
- [x] Added a `csrf.test.ts` case for a 64-char non-hex submitted token (confirms it fails closed without throwing); existing `csrf.test.ts`/`priceHistoryChart.test.ts` coverage (which already exercises all 5 escaped characters together) passes unchanged, confirming output parity for the escaping/comparison rewrites.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BNTwipjWM2SkRYueoPeR6a)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved CSRF protection by rejecting malformed tokens safely and returning the appropriate authorization error.
  * Strengthened token comparisons to reduce the risk of timing-based attacks.

* **Bug Fixes**
  * Prevented invalid CSRF requests from causing unexpected errors.
  * Preserved safe HTML escaping for chart content.

* **Performance**
  * Streamlined database lookups and template processing for more efficient operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->