### PR TITLE
Normalize timer scheduler channel to match chat-activity lookup key

### DIFF
--- a/src/db/timerCommands.test.ts
+++ b/src/db/timerCommands.test.ts
@@ -265,13 +265,13 @@ describe('getAllEnabledTimerCommandsWithChannel', () => {
 
   it('returns one row per assigned channel when a timer has multiple assignments', async () => {
     const rows = [
-      { id: 1, channel: 'streamer-a', message: 'hi', interval_seconds: 600, min_messages: 0, require_live: 1 },
-      { id: 1, channel: 'streamer-b', message: 'hi', interval_seconds: 600, min_messages: 0, require_live: 1 },
+      { id: 1, channel: 'streamer_a', message: 'hi', interval_seconds: 600, min_messages: 0, require_live: 1 },
+      { id: 1, channel: 'streamer_b', message: 'hi', interval_seconds: 600, min_messages: 0, require_live: 1 },
     ];
     vi.mocked(getPool).mockReturnValue(makeMockPool({ rows }) as any);
     const result = await getAllEnabledTimerCommandsWithChannel();
     expect(result).toHaveLength(2);
-    expect(result.map((r) => r.channel)).toEqual(['streamer-a', 'streamer-b']);
+    expect(result.map((r) => r.channel)).toEqual(['streamer_a', 'streamer_b']);
   });
 
   it('queries with no parameters (filtering happens in SQL)', async () => {
@@ -279,5 +279,28 @@ describe('getAllEnabledTimerCommandsWithChannel', () => {
     vi.mocked(getPool).mockReturnValue(pool as any);
     await getAllEnabledTimerCommandsWithChannel();
     expect(pool.execute.mock.calls[0][1]).toBeUndefined();
+  });
+
+  it('normalizes the channel so it matches the lowercased key chat activity is recorded under', async () => {
+    // If this returned the raw stored value unnormalized, a channel with any uppercase
+    // characters would produce a `row.channel` that never matches the lowercase key
+    // `recordChatMessage` stores counts under — silently and permanently blocking
+    // `min_messages` with no error, since a message-count miss looks identical to "no chat yet."
+    const joinedRow = {
+      id: 1, channel: 'SomeStreamer', message: 'hi', interval_seconds: 600, min_messages: 0, require_live: 1,
+    };
+    vi.mocked(getPool).mockReturnValue(makeMockPool({ rows: [joinedRow] }) as any);
+    const rows = await getAllEnabledTimerCommandsWithChannel();
+    expect(rows).toEqual([expect.objectContaining({ channel: 'somestreamer' })]);
+  });
+
+  it('drops a row whose stored channel fails to normalize', async () => {
+    const rows = [
+      { id: 1, channel: 'validname', message: 'hi', interval_seconds: 600, min_messages: 0, require_live: 1 },
+      { id: 2, channel: 'x', message: 'hi', interval_seconds: 600, min_messages: 0, require_live: 1 }, // too short to be a valid channel name
+    ];
+    vi.mocked(getPool).mockReturnValue(makeMockPool({ rows }) as any);
+    const result = await getAllEnabledTimerCommandsWithChannel();
+    expect(result.map((r) => r.id)).toEqual([1]);
   });
 });

--- a/src/db/timerCommands.ts
+++ b/src/db/timerCommands.ts
@@ -3,6 +3,7 @@ import { getPool } from './pool';
 import { fromBit, affectedOrExists, rowExists } from './utils';
 import { AccessLevel } from './users';
 import type { AccessLevelValue } from './users';
+import { normalizeTwitchChannelName } from '../twitch/twitchChannelName';
 
 /** A timer command row from the database. */
 export interface DbTimerCommand {
@@ -231,9 +232,14 @@ export async function unassignUserFromTimer(timerId: number, discordId: string):
 /**
  * Lists every enabled timer command joined with each of its assigned users' linked Twitch
  * channel, for the scheduler's per-tick read. A timer assigned to several streamers appears
- * once per assigned channel, each firing independently — assignees with no linked Twitch name
- * are excluded, since there's no channel to post to. Queried fresh every scheduler tick rather
- * than cached, mirroring `getAllEnabledPricingRows()`.
+ * once per assigned channel, each firing independently — assignees with no linked Twitch name,
+ * or one that fails to normalize, are excluded, since there's no channel to post to. The channel
+ * is normalized here (matching `getTwitchEnabledChannels`/`getAllTwitchLinkedUsers`) rather than
+ * trusting `user.twitch_name` as stored: the scheduler uses this same string as the lookup key
+ * into `twitchChatActivity`'s per-channel message counts, which are always recorded under the
+ * normalized (lowercased) form — an un-normalized channel here would silently and permanently
+ * miss that counter, blocking `min_messages` forever with no error. Queried fresh every
+ * scheduler tick rather than cached, mirroring `getAllEnabledPricingRows()`.
  */
 export async function getAllEnabledTimerCommandsWithChannel(): Promise<TimerCommandForScheduler[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
@@ -244,12 +250,18 @@ export async function getAllEnabledTimerCommandsWithChannel(): Promise<TimerComm
      WHERE tc.enabled = 1 AND u.twitch_name IS NOT NULL AND u.twitch_name <> ''
      ORDER BY tc.id, u.discord_id`,
   );
-  return rows.map((r) => ({
-    id: r.id,
-    channel: r.channel,
-    message: r.message,
-    interval_seconds: r.interval_seconds,
-    min_messages: r.min_messages,
-    require_live: fromBit(r.require_live),
-  }));
+  return rows
+    .map((r) => {
+      const channel = normalizeTwitchChannelName(String(r.channel));
+      if (!channel) return null;
+      return {
+        id: r.id,
+        channel,
+        message: r.message,
+        interval_seconds: r.interval_seconds,
+        min_messages: r.min_messages,
+        require_live: fromBit(r.require_live),
+      };
+    })
+    .filter((row): row is TimerCommandForScheduler => row !== null);
 }


### PR DESCRIPTION
## Summary

Follow-up to #503, which added diagnostic logging to the timer command scheduler. That logging just paid off in production: `require_live` correctly cleared once the streamer went live, but `min_messages` stayed stuck at `0/N messages since last fire` indefinitely, despite confirmed real chat activity above the threshold — with no error logged, since a message-count miss looks identical to "no chat yet."

Root cause: `getAllEnabledTimerCommandsWithChannel()` (`src/db/timerCommands.ts`) returned `user.twitch_name` as-is, unlike its siblings `getTwitchEnabledChannels()`/`getAllTwitchLinkedUsers()` in `src/db/users.ts`, which both explicitly re-normalize the value on every read (their docstrings say so directly). The scheduler uses this same string as the lookup key into `twitchChatActivity`'s per-channel message counts (`src/twitch/twitchChatActivity.ts`), which are always recorded under the *normalized* (lowercased) form via `normalizeTwitchChannelName` in `handleTwitchMessage` (`src/twitch/twitchBot.ts`). Any channel stored with different casing than its lowercase form would silently and permanently miss that counter — a Map lookup with a mismatched key, not an error — blocking `min_messages` forever. `isChannelLive()` was unaffected because it already lowercases internally before its own lookup; `sayInChannel()` was unaffected because it also normalizes before sending. Only the message-count lookup was exposed to the raw, unnormalized value.

## Changes
- `getAllEnabledTimerCommandsWithChannel()` now normalizes `channel` via `normalizeTwitchChannelName`, matching the convention already used by its sibling functions, and drops any row whose channel fails to normalize (mirroring how those siblings silently drop unparseable names).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite: 167 files / 3085 tests passing)
- [x] Added unit tests: normalizes a mixed-case channel to match the chat-activity lookup key; drops a row whose stored channel fails to normalize.

---
_Generated by [Claude Code](https://claude.ai/code/session_016zbgyMNTvn4MKcGezwwXUw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Timer channels are now consistently normalized to lowercase.
  - Timers with missing or invalid channel names are excluded from scheduling.
  - Channel names containing underscores are handled correctly.
- **Tests**
  - Added coverage for channel normalization and filtering invalid timer entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->