### PR TITLE
fix: sync package-lock.json with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4092,6 +4092,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/filing-cabinet/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",


### PR DESCRIPTION
## Summary

`deploy.sh` was reporting "Working directory has uncommitted changes or untracked files" at its dirty-check (`deploy.sh:42-47`) whenever `npm install` ran, because the committed `package-lock.json` was out of sync with `package.json`.

Root cause: `package-lock.json` was missing the nested `filing-cabinet/node_modules/typescript@5.9.3` entry required to satisfy `filing-cabinet`'s `typescript@^5.9.3` dependency (top-level `typescript` is `^6.0.3`, so npm must nest a private copy for `filing-cabinet`, which is used by `npm run check:circular` via madge). Because that entry was missing, the lockfile was inconsistent:

- `npm ci` failed outright with `EUSAGE`: `Missing: typescript@5.9.3 from lock file`.
- Any plain `npm install` would silently rewrite the lockfile to add the missing entry, which then tripped `deploy.sh`'s `git diff-index --quiet HEAD --` uncommitted-changes check before the next deploy.

## Changes

- Regenerated `package-lock.json` via `npm install` to add the missing nested `typescript@5.9.3` entry for `filing-cabinet`.

## Test plan

- [x] `npm ci --dry-run` completes cleanly against the regenerated lockfile (previously failed with `EUSAGE` / `Missing: typescript@5.9.3 from lock file`)
- [x] `npx tsc --noEmit`
- [x] `npm test`


---
_Generated by [Claude Code](https://claude.ai/code/session_01J4MD2V7hVSTUUhtirpokFV)_