### PR TITLE
Scope Shared Chat cooldown per command; add cross-command channel floor

### DIFF
--- a/src/twitch/timers/timerCommandCooldowns.ts
+++ b/src/twitch/timers/timerCommandCooldowns.ts
@@ -1,0 +1,217 @@
+import type { TimerCommandForScheduler } from '../../db';
+
+// ─── Per-command Shared Chat cooldown ────────────────────────────────────────
+//
+// When several of one timer's assigned streamers are merged into the same Twitch Shared Chat
+// session (multitwitch), each of that timer's assigned channels otherwise keeps firing on its own
+// independent schedule — and since Shared Chat shows every participating channel's messages in one
+// merged view, that stacks up into the same command posting several times in a few minutes. This
+// caps a given timer to firing at most once per its own `interval_seconds` into a given session —
+// as if that whole session were one channel, for this command specifically — and rotates fairly
+// among the timer's channels sharing it (see `applyCommandSessionCooldown`) so each gets a turn
+// instead of one dominating. Scoped per (timer id, session id): a *different* timer assigned to the
+// same shared-chat streamers gets its own independent cooldown, sized to its own interval, and
+// never competes with this one for a turn.
+
+interface CommandSessionCooldown {
+  firedAt: number;
+  /** The interval (ms) that was actually applied when this cooldown was reserved — needed to prune it correctly later, since different timers (and a live-edited interval) can each imply a different cooldown length. */
+  cooldownMs: number;
+}
+
+const commandSessionLastFiredAt = new Map<string, CommandSessionCooldown>();
+
+/** Composite key for {@link commandSessionLastFiredAt}: one cooldown per (timer, Shared Chat session). */
+function commandSessionKey(timerId: number, sessionId: string): string {
+  return `${timerId}::${sessionId}`;
+}
+
+/** A stale command-session cooldown entry is kept around for this many multiples of its own cooldown length before being pruned, so the map doesn't grow unbounded as Shared Chat sessions come and go over long uptimes. */
+const COMMAND_SESSION_COOLDOWN_PRUNE_FACTOR = 10;
+
+/** Drops command-session cooldown entries old enough (relative to their own recorded cooldown length) that the session or assignment behind them is almost certainly gone. */
+function pruneStaleCommandSessionCooldowns(now: number): void {
+  for (const [key, entry] of commandSessionLastFiredAt) {
+    if (now - entry.firedAt > entry.cooldownMs * COMMAND_SESSION_COOLDOWN_PRUNE_FACTOR) {
+      commandSessionLastFiredAt.delete(key);
+    }
+  }
+}
+
+// ─── Cross-command channel floor ─────────────────────────────────────────────
+//
+// Independent of Shared Chat: if a single Twitch channel has several *different* timer commands
+// assigned to it, each fires on its own schedule with nothing otherwise stopping two of them from
+// landing seconds apart. This enforces a minimum gap between any two *different* commands posting
+// into the same channel, and — like the Shared Chat cooldown above — lets whichever has waited
+// longest go first. It deliberately does not slow down a single command's own cadence: the floor
+// only applies when the channel's last post came from a *different* timer than the one about to
+// post now, so a lone timer with a short interval (as low as `chk_timer_command_interval`'s 60s
+// floor) is never throttled below its own configured interval just for being alone on its channel.
+
+const CHANNEL_MIN_SPACING_MS = 120_000;
+
+interface ChannelCooldown {
+  firedAt: number;
+  timerId: number;
+}
+
+const channelLastFiredAt = new Map<string, ChannelCooldown>();
+
+const CHANNEL_MIN_SPACING_PRUNE_MS = 10 * CHANNEL_MIN_SPACING_MS;
+
+/** Drops channel-floor entries older than {@link CHANNEL_MIN_SPACING_PRUNE_MS} so the map doesn't grow unbounded as channels stop being assigned any timer over long uptimes. */
+function pruneStaleChannelCooldowns(now: number): void {
+  for (const [channel, entry] of channelLastFiredAt) {
+    if (now - entry.firedAt > CHANNEL_MIN_SPACING_PRUNE_MS) channelLastFiredAt.delete(channel);
+  }
+}
+
+/** Drops every stale cooldown entry in both maps. Call once per scheduler tick. */
+export function pruneStaleCooldowns(now: number): void {
+  pruneStaleCommandSessionCooldowns(now);
+  pruneStaleChannelCooldowns(now);
+}
+
+/** Clears all cooldown state in both maps. Call on scheduler stop. */
+export function clearCooldowns(): void {
+  commandSessionLastFiredAt.clear();
+  channelLastFiredAt.clear();
+}
+
+/** A row picked to fire this tick, paired with the reservations the caller must release if the send doesn't succeed. */
+export interface PickedRow {
+  row: TimerCommandForScheduler;
+  /** The {@link commandSessionKey} reserved for this pick, or null if its channel isn't in a Shared Chat session. */
+  sessionKey: string | null;
+}
+
+/** Resolves a row's current `lastFiredAt`, used to pick whichever of a group of contending rows has waited longest. Supplied by the caller since that state lives in the scheduler, not here. */
+export type LastFiredAtLookup = (row: TimerCommandForScheduler) => number;
+
+/** Picks whichever of `rows` has gone longest without firing (oldest per `lastFiredAtOf`), breaking ties by keeping the first. */
+function pickLongestWaiting(rows: readonly TimerCommandForScheduler[], lastFiredAtOf: LastFiredAtLookup): TimerCommandForScheduler {
+  return rows.reduce((oldest, row) => (lastFiredAtOf(row) < lastFiredAtOf(oldest) ? row : oldest));
+}
+
+/**
+ * Layer 1 of {@link pickRowsToFire}: groups `eligibleRows` by (timer id, Shared Chat session), and
+ * for a group off its own cooldown (sized to that timer's `interval_seconds`), picks the row that's
+ * gone longest without firing and reserves the cooldown. Rows whose channel isn't in a session pass
+ * straight through untouched. See the module doc above `commandSessionLastFiredAt`.
+ * @param eligibleRows - Rows that already passed their own per-timer fire-gate check.
+ * @param sessionIdByChannel - Each row's channel's resolved Shared Chat session id (or null).
+ * @param now - Current time in epoch ms, shared across the whole tick.
+ * @param lastFiredAtOf - Resolves a row's current `lastFiredAt`, for the longest-waiting tie-break.
+ * @returns One entry per row that cleared this layer, paired with the command-session cooldown key
+ *   reserved for it (or null if its channel isn't in a session).
+ */
+function applyCommandSessionCooldown(
+  eligibleRows: readonly TimerCommandForScheduler[],
+  sessionIdByChannel: ReadonlyMap<string, string | null>,
+  now: number,
+  lastFiredAtOf: LastFiredAtLookup,
+): PickedRow[] {
+  const survivors: PickedRow[] = [];
+  const bySessionAndTimer = new Map<string, TimerCommandForScheduler[]>();
+
+  for (const row of eligibleRows) {
+    const sessionId = sessionIdByChannel.get(row.channel) ?? null;
+    if (!sessionId) {
+      survivors.push({ row, sessionKey: null });
+      continue;
+    }
+    const key = commandSessionKey(row.id, sessionId);
+    const group = bySessionAndTimer.get(key);
+    if (group) group.push(row); else bySessionAndTimer.set(key, [row]);
+  }
+
+  for (const [key, rows] of bySessionAndTimer) {
+    const cooldownMs = rows[0].interval_seconds * 1000;
+    const entry = commandSessionLastFiredAt.get(key);
+    if (entry && now - entry.firedAt < cooldownMs) continue;
+
+    const picked = pickLongestWaiting(rows, lastFiredAtOf);
+    commandSessionLastFiredAt.set(key, { firedAt: now, cooldownMs }); // provisional — released by releaseReservations on failure
+    survivors.push({ row: picked, sessionKey: key });
+  }
+
+  return survivors;
+}
+
+/**
+ * Layer 2 of {@link pickRowsToFire}: groups whatever survived layer 1 by channel, and for a channel
+ * whose last post came from a *different* timer than the longest-waiting candidate here, within
+ * {@link CHANNEL_MIN_SPACING_MS}, defers it to a later tick — applied regardless of Shared Chat
+ * status. See the module doc above `channelLastFiredAt`.
+ * @param layer1Survivors - Rows (with their layer 1 session-key reservation, if any) that cleared {@link applyCommandSessionCooldown}.
+ * @param now - Current time in epoch ms, shared across the whole tick.
+ * @param lastFiredAtOf - Resolves a row's current `lastFiredAt`, for the longest-waiting tie-break.
+ * @returns The final set of rows to actually send this tick.
+ */
+function applyChannelFloor(layer1Survivors: readonly PickedRow[], now: number, lastFiredAtOf: LastFiredAtLookup): PickedRow[] {
+  const toFire: PickedRow[] = [];
+  const byChannel = new Map<string, PickedRow[]>();
+  for (const picked of layer1Survivors) {
+    const group = byChannel.get(picked.row.channel);
+    if (group) group.push(picked); else byChannel.set(picked.row.channel, [picked]);
+  }
+
+  for (const [channel, picks] of byChannel) {
+    const candidate = pickLongestWaiting(picks.map((p) => p.row), lastFiredAtOf);
+    const candidatePick = picks.find((p) => p.row === candidate)!;
+
+    const lastPoster = channelLastFiredAt.get(channel);
+    if (lastPoster && lastPoster.timerId !== candidate.id && now - lastPoster.firedAt < CHANNEL_MIN_SPACING_MS) continue;
+
+    channelLastFiredAt.set(channel, { firedAt: now, timerId: candidate.id }); // provisional — released by releaseReservations on failure
+    toFire.push(candidatePick);
+  }
+
+  return toFire;
+}
+
+/**
+ * From the rows that already passed their own per-timer fire-gate check, decides which ones
+ * actually get to fire this tick: {@link applyCommandSessionCooldown} (per-command Shared Chat
+ * cooldown), then {@link applyChannelFloor} (cross-command channel floor) on whatever survives.
+ * Both layers' reservations are only provisional: {@link releaseReservations} undoes them if the
+ * send doesn't actually succeed, so a failed send can't silence a session/channel for the full
+ * cooldown window. Rows not picked at either layer are left untouched so they're reconsidered on a
+ * later tick.
+ * @param eligibleRows - Rows that already passed their own per-timer fire-gate check.
+ * @param sessionIdByChannel - Each row's channel's resolved Shared Chat session id (or null).
+ * @param now - Current time in epoch ms, shared across the whole tick.
+ * @param lastFiredAtOf - Resolves a row's current `lastFiredAt`, for the longest-waiting tie-break.
+ */
+export function pickRowsToFire(
+  eligibleRows: readonly TimerCommandForScheduler[],
+  sessionIdByChannel: ReadonlyMap<string, string | null>,
+  now: number,
+  lastFiredAtOf: LastFiredAtLookup,
+): PickedRow[] {
+  const layer1Survivors = applyCommandSessionCooldown(eligibleRows, sessionIdByChannel, now, lastFiredAtOf);
+  return applyChannelFloor(layer1Survivors, now, lastFiredAtOf);
+}
+
+/**
+ * Releases the provisional cooldown reservations {@link pickRowsToFire} made for a row, if the send
+ * that would have justified them didn't actually happen (no runtime, or the send threw). Guarded by
+ * matching the reservation's own identity so a release can't clobber a newer reservation made by a
+ * different row on a later tick.
+ * @param sessionKey - The command-session cooldown key reserved for this row, or null.
+ * @param channel - The row's Twitch channel — the channel-floor reservation to potentially release.
+ * @param timerId - The row's timer id — must match the channel-floor reservation's own recorded id.
+ * @param now - The epoch-ms timestamp the reservations were made under, shared across the whole tick.
+ * @returns Nothing — mutates the module-level cooldown maps in place.
+ */
+export function releaseReservations(sessionKey: string | null, channel: string, timerId: number, now: number): void {
+  if (sessionKey) {
+    const entry = commandSessionLastFiredAt.get(sessionKey);
+    if (entry && entry.firedAt === now) commandSessionLastFiredAt.delete(sessionKey);
+  }
+  const channelEntry = channelLastFiredAt.get(channel);
+  if (channelEntry && channelEntry.firedAt === now && channelEntry.timerId === timerId) {
+    channelLastFiredAt.delete(channel);
+  }
+}

--- a/src/twitch/timers/timerCommandCooldowns.ts
+++ b/src/twitch/timers/timerCommandCooldowns.ts
@@ -73,6 +73,19 @@ export function pruneStaleCooldowns(now: number): void {
   pruneStaleChannelCooldowns(now);
 }
 
+/** Releases a command-session cooldown reservation if it's still the one made at `now` (not a newer one made since). */
+function releaseCommandSessionReservation(sessionKey: string | null, now: number): void {
+  if (!sessionKey) return;
+  const entry = commandSessionLastFiredAt.get(sessionKey);
+  if (entry && entry.firedAt === now) commandSessionLastFiredAt.delete(sessionKey);
+}
+
+/** Releases a channel-floor reservation if it's still the one made at `now` for `timerId` (not a newer/different one made since). */
+function releaseChannelReservation(channel: string, timerId: number, now: number): void {
+  const entry = channelLastFiredAt.get(channel);
+  if (entry && entry.firedAt === now && entry.timerId === timerId) channelLastFiredAt.delete(channel);
+}
+
 /** Clears all cooldown state in both maps. Call on scheduler stop. */
 export function clearCooldowns(): void {
   commandSessionLastFiredAt.clear();
@@ -140,10 +153,16 @@ function applyCommandSessionCooldown(
 }
 
 /**
- * Layer 2 of {@link pickRowsToFire}: groups whatever survived layer 1 by channel, and for a channel
- * whose last post came from a *different* timer than the longest-waiting candidate here, within
- * {@link CHANNEL_MIN_SPACING_MS}, defers it to a later tick — applied regardless of Shared Chat
- * status. See the module doc above `channelLastFiredAt`.
+ * Layer 2 of {@link pickRowsToFire}: groups whatever survived layer 1 by channel. While the
+ * channel's floor is active (its last post was within {@link CHANNEL_MIN_SPACING_MS}), only a
+ * repeat of that *same* timer may post now — the floor exists to space out *different* commands,
+ * not to hold back the one that just posted from its own next cycle, so a lone fast timer is never
+ * throttled by this layer. If no such repeat is eligible this tick, the whole channel is deferred.
+ * Once the floor has cleared, whichever eligible row has waited longest wins as usual. Every row
+ * that loses its channel this tick — because a different row won it, or the floor deferred it
+ * outright — has its layer 1 (Shared Chat) reservation released immediately, since it never gets a
+ * chance to actually send: without this, it would sit "reserved" for its full command-session
+ * cooldown despite nothing having been posted for it. See the module doc above `channelLastFiredAt`.
  * @param layer1Survivors - Rows (with their layer 1 session-key reservation, if any) that cleared {@link applyCommandSessionCooldown}.
  * @param now - Current time in epoch ms, shared across the whole tick.
  * @param lastFiredAtOf - Resolves a row's current `lastFiredAt`, for the longest-waiting tie-break.
@@ -158,13 +177,20 @@ function applyChannelFloor(layer1Survivors: readonly PickedRow[], now: number, l
   }
 
   for (const [channel, picks] of byChannel) {
-    const candidate = pickLongestWaiting(picks.map((p) => p.row), lastFiredAtOf);
-    const candidatePick = picks.find((p) => p.row === candidate)!;
-
     const lastPoster = channelLastFiredAt.get(channel);
-    if (lastPoster && lastPoster.timerId !== candidate.id && now - lastPoster.firedAt < CHANNEL_MIN_SPACING_MS) continue;
+    const floorActive = !!lastPoster && now - lastPoster.firedAt < CHANNEL_MIN_SPACING_MS;
 
-    channelLastFiredAt.set(channel, { firedAt: now, timerId: candidate.id }); // provisional — released by releaseReservations on failure
+    const candidatePick = floorActive
+      ? picks.find((p) => p.row.id === lastPoster!.timerId)
+      : picks.find((p) => p.row === pickLongestWaiting(picks.map((p2) => p2.row), lastFiredAtOf));
+
+    for (const pick of picks) {
+      if (pick !== candidatePick) releaseCommandSessionReservation(pick.sessionKey, now);
+    }
+
+    if (!candidatePick) continue; // floor active and no eligible repeat of the last poster this tick
+
+    channelLastFiredAt.set(channel, { firedAt: now, timerId: candidatePick.row.id }); // provisional — released on failure
     toFire.push(candidatePick);
   }
 
@@ -206,12 +232,6 @@ export function pickRowsToFire(
  * @returns Nothing — mutates the module-level cooldown maps in place.
  */
 export function releaseReservations(sessionKey: string | null, channel: string, timerId: number, now: number): void {
-  if (sessionKey) {
-    const entry = commandSessionLastFiredAt.get(sessionKey);
-    if (entry && entry.firedAt === now) commandSessionLastFiredAt.delete(sessionKey);
-  }
-  const channelEntry = channelLastFiredAt.get(channel);
-  if (channelEntry && channelEntry.firedAt === now && channelEntry.timerId === timerId) {
-    channelLastFiredAt.delete(channel);
-  }
+  releaseCommandSessionReservation(sessionKey, now);
+  releaseChannelReservation(channel, timerId, now);
 }

--- a/src/twitch/timers/timerCommandScheduler.test.ts
+++ b/src/twitch/timers/timerCommandScheduler.test.ts
@@ -266,13 +266,64 @@ describe('block-reason logging', () => {
   });
 });
 
-describe('Shared Chat group cooldown', () => {
+describe('Per-command Shared Chat cooldown', () => {
   /** Routes `resolveSharedChatSessionId` to a fixed session id per Twitch user id. */
   function stubSessions(sessionIdByUserId: Record<string, string>): void {
     vi.mocked(resolveSharedChatSessionId).mockImplementation(async (userId: string) => sessionIdByUserId[userId] ?? null);
   }
 
-  it('suppresses a second ready timer sharing the same session, then fires it once the group cooldown elapses', async () => {
+  it("suppresses a second ready channel for the same command sharing a session, then fires it once the command's own interval elapses as the group cooldown", async () => {
+    getLoginUserIds.mockReturnValue(new Map([['streamer-a', 'uid-a'], ['streamer-b', 'uid-b']]));
+    stubSessions({ 'uid-a': 'session-1', 'uid-b': 'session-1' });
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([
+      timerRow({ id: 1, channel: 'streamer-a', message: 'msg', interval_seconds: 60 }),
+      timerRow({ id: 1, channel: 'streamer-b', message: 'msg', interval_seconds: 60 }),
+    ] as any);
+
+    await runTimerCommandTick(); // seed both
+    await vi.advanceTimersByTimeAsync(60_000);
+    await runTimerCommandTick(); // both ready, command-session cooldown off -> only the oldest (streamer-a) fires
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith('streamer-a', 'msg');
+
+    send.mockClear();
+    await vi.advanceTimersByTimeAsync(45_000); // streamer-b still eligible on its own gate, but the command's own 60s cooldown hasn't elapsed
+    await runTimerCommandTick();
+    expect(send).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(15_000); // now exactly 60s since streamer-a's fire — cooldown elapsed
+    await runTimerCommandTick();
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith('streamer-b', 'msg');
+  });
+
+  it('rotates fairly among three channels of the same command sharing a session instead of favoring the same one', async () => {
+    getLoginUserIds.mockReturnValue(new Map([
+      ['streamer-a', 'uid-a'], ['streamer-b', 'uid-b'], ['streamer-c', 'uid-c'],
+    ]));
+    stubSessions({ 'uid-a': 'session-1', 'uid-b': 'session-1', 'uid-c': 'session-1' });
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([
+      timerRow({ id: 1, channel: 'streamer-a', message: 'msg', interval_seconds: 60 }),
+      timerRow({ id: 1, channel: 'streamer-b', message: 'msg', interval_seconds: 60 }),
+      timerRow({ id: 1, channel: 'streamer-c', message: 'msg', interval_seconds: 60 }),
+    ] as any);
+
+    await runTimerCommandTick(); // seed all three
+
+    const fired: string[] = [];
+    for (let round = 0; round < 3; round++) {
+      await vi.advanceTimersByTimeAsync(60_000); // clears both each channel's own interval and the command's own session cooldown
+      await runTimerCommandTick();
+      expect(send).toHaveBeenCalledTimes(1);
+      fired.push(send.mock.calls[0][0]); // channel arg, since the message is identical across all three
+      send.mockClear();
+    }
+
+    // Each of the three channels gets a turn — none is skipped in favor of another.
+    expect(new Set(fired)).toEqual(new Set(['streamer-a', 'streamer-b', 'streamer-c']));
+  });
+
+  it('does not let two different commands sharing the same session block each other, each governed by its own interval', async () => {
     getLoginUserIds.mockReturnValue(new Map([['streamer-a', 'uid-a'], ['streamer-b', 'uid-b']]));
     stubSessions({ 'uid-a': 'session-1', 'uid-b': 'session-1' });
     vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([
@@ -282,45 +333,11 @@ describe('Shared Chat group cooldown', () => {
 
     await runTimerCommandTick(); // seed both
     await vi.advanceTimersByTimeAsync(60_000);
-    await runTimerCommandTick(); // both ready, same session off cooldown -> only the oldest (streamer-a) fires
-    expect(send).toHaveBeenCalledTimes(1);
+    await runTimerCommandTick(); // both commands' own interval elapsed — different timer ids, so neither's cooldown blocks the other
+
+    expect(send).toHaveBeenCalledTimes(2);
     expect(send).toHaveBeenCalledWith('streamer-a', 'msg-a');
-
-    send.mockClear();
-    await vi.advanceTimersByTimeAsync(60_000); // both ready again, but group cooldown (120s) not yet elapsed
-    await runTimerCommandTick();
-    expect(send).not.toHaveBeenCalled();
-
-    await vi.advanceTimersByTimeAsync(60_000); // group cooldown now elapsed (120s since streamer-a fired)
-    await runTimerCommandTick();
-    expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenCalledWith('streamer-b', 'msg-b');
-  });
-
-  it('rotates fairly among three timers sharing a session instead of favoring the same one', async () => {
-    getLoginUserIds.mockReturnValue(new Map([
-      ['streamer-a', 'uid-a'], ['streamer-b', 'uid-b'], ['streamer-c', 'uid-c'],
-    ]));
-    stubSessions({ 'uid-a': 'session-1', 'uid-b': 'session-1', 'uid-c': 'session-1' });
-    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([
-      timerRow({ id: 1, channel: 'streamer-a', message: 'msg-a', interval_seconds: 60 }),
-      timerRow({ id: 2, channel: 'streamer-b', message: 'msg-b', interval_seconds: 60 }),
-      timerRow({ id: 3, channel: 'streamer-c', message: 'msg-c', interval_seconds: 60 }),
-    ] as any);
-
-    await runTimerCommandTick(); // seed all three
-
-    const fired: string[] = [];
-    for (let window = 0; window < 3; window++) {
-      await vi.advanceTimersByTimeAsync(120_000); // clears both each timer's own interval and the group cooldown
-      await runTimerCommandTick();
-      expect(send).toHaveBeenCalledTimes(1);
-      fired.push(send.mock.calls[0][1]);
-      send.mockClear();
-    }
-
-    // Each of the three distinct messages gets a turn — none is skipped in favor of another.
-    expect(new Set(fired)).toEqual(new Set(['msg-a', 'msg-b', 'msg-c']));
   });
 
   it('fires independently when timers resolve to different sessions', async () => {
@@ -339,12 +356,12 @@ describe('Shared Chat group cooldown', () => {
     expect(send).toHaveBeenCalledWith('streamer-b', 'msg-b');
   });
 
-  it('releases the group cooldown reservation when the picked row fails to send', async () => {
+  it('releases the command-session cooldown reservation when the picked row fails to send', async () => {
     getLoginUserIds.mockReturnValue(new Map([['streamer-a', 'uid-a'], ['streamer-b', 'uid-b']]));
     stubSessions({ 'uid-a': 'session-1', 'uid-b': 'session-1' });
     vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([
-      timerRow({ id: 1, channel: 'streamer-a', message: 'msg-a', interval_seconds: 60 }),
-      timerRow({ id: 2, channel: 'streamer-b', message: 'msg-b', interval_seconds: 60 }),
+      timerRow({ id: 1, channel: 'streamer-a', message: 'msg', interval_seconds: 60 }),
+      timerRow({ id: 1, channel: 'streamer-b', message: 'msg', interval_seconds: 60 }),
     ] as any);
 
     await runTimerCommandTick(); // seed both
@@ -353,14 +370,14 @@ describe('Shared Chat group cooldown', () => {
     send.mockRejectedValueOnce(new Error('helix down')); // fails for whichever row is picked (streamer-a, being oldest)
     await runTimerCommandTick();
     expect(send).toHaveBeenCalledTimes(1);
-    expect(send).toHaveBeenCalledWith('streamer-a', 'msg-a');
+    expect(send).toHaveBeenCalledWith('streamer-a', 'msg');
 
     // The failed send released the reservation, so the session can be retried on the very next
-    // tick instead of being blocked for the full 120s group cooldown.
+    // tick instead of being blocked for the command's full cooldown.
     send.mockClear();
     await runTimerCommandTick();
     expect(send).toHaveBeenCalledTimes(1);
-    expect(send).toHaveBeenCalledWith('streamer-a', 'msg-a');
+    expect(send).toHaveBeenCalledWith('streamer-a', 'msg');
   });
 
   it('fires normally when the session lookup fails (treated as not in Shared Chat)', async () => {
@@ -375,6 +392,84 @@ describe('Shared Chat group cooldown', () => {
     await runTimerCommandTick();
 
     expect(send).toHaveBeenCalledWith('streamer-a', 'msg-a');
+  });
+});
+
+describe('Cross-command channel floor', () => {
+  it("defers a different command from posting to the same channel within 120s of another command's post there", async () => {
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([
+      timerRow({ id: 1, channel: 'somestreamer', message: 'msg-a', interval_seconds: 60 }),
+      timerRow({ id: 2, channel: 'somestreamer', message: 'msg-b', interval_seconds: 90 }),
+    ] as any);
+
+    await runTimerCommandTick(); // seed both
+
+    await vi.advanceTimersByTimeAsync(60_000); // timer 1 eligible; timer 2 needs 90s, not yet
+    await runTimerCommandTick();
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith('somestreamer', 'msg-a');
+
+    send.mockClear();
+    await vi.advanceTimersByTimeAsync(30_000); // t=90s: timer 2 now eligible on its own gate, but only 30s since timer 1's post — different command, floor not yet clear
+    await runTimerCommandTick();
+    expect(send).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(90_000); // t=180s: 120s have now passed since timer 1's post at t=60s
+    await runTimerCommandTick();
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith('somestreamer', 'msg-b');
+  });
+
+  it('does not throttle a lone command below its own interval just for having no competition on its channel', async () => {
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue(
+      [timerRow({ id: 1, channel: 'somestreamer', interval_seconds: 90 })] as any,
+    );
+
+    await runTimerCommandTick(); // seed
+    await vi.advanceTimersByTimeAsync(90_000);
+    await runTimerCommandTick();
+    expect(send).toHaveBeenCalledTimes(1);
+
+    send.mockClear();
+    await vi.advanceTimersByTimeAsync(90_000); // only 90s later — would still be blocked if the 120s floor applied to a lone command's own repeats
+    await runTimerCommandTick();
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('picks whichever different command has waited longest when both are eligible for the same channel at once', async () => {
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([
+      timerRow({ id: 1, channel: 'somestreamer', message: 'msg-a', interval_seconds: 60 }),
+      timerRow({ id: 2, channel: 'somestreamer', message: 'msg-b', interval_seconds: 30 }),
+    ] as any);
+
+    await runTimerCommandTick(); // seed both, both lastFiredAt = 0
+
+    await vi.advanceTimersByTimeAsync(60_000); // both eligible; equal lastFiredAt so the first (timer 1) is picked
+    await runTimerCommandTick();
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith('somestreamer', 'msg-a');
+  });
+
+  it('releases the channel-floor reservation when the picked command fails to send', async () => {
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([
+      timerRow({ id: 1, channel: 'somestreamer', message: 'msg-a', interval_seconds: 60 }),
+      timerRow({ id: 2, channel: 'somestreamer', message: 'msg-b', interval_seconds: 60 }),
+    ] as any);
+
+    await runTimerCommandTick(); // seed both
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    send.mockRejectedValueOnce(new Error('boom')); // fails for whichever is picked (timer 1, tie broken to first)
+    await runTimerCommandTick();
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith('somestreamer', 'msg-a');
+
+    // The failed send released the channel-floor reservation, so it can be retried on the very
+    // next tick instead of being blocked for the full 120s floor.
+    send.mockClear();
+    await runTimerCommandTick();
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith('somestreamer', 'msg-a');
   });
 });
 

--- a/src/twitch/timers/timerCommandScheduler.test.ts
+++ b/src/twitch/timers/timerCommandScheduler.test.ts
@@ -393,6 +393,36 @@ describe('Per-command Shared Chat cooldown', () => {
 
     expect(send).toHaveBeenCalledWith('streamer-a', 'msg-a');
   });
+
+  it('releases a command-session reservation for a timer that loses the cross-command channel floor, instead of leaving it stuck for its own full interval', async () => {
+    // Two different timers both assigned to one shared-chat channel: each clears its own
+    // per-command session cooldown independently at layer 1 (they don't share one), but only one
+    // of them can actually post to the channel this tick at layer 2. The loser's layer-1
+    // reservation must be released — otherwise it would sit "used" until its own (long) interval
+    // elapses despite never having posted, even once the channel floor reopens well before then.
+    getLoginUserIds.mockReturnValue(new Map([['streamer-a', 'uid-a']]));
+    stubSessions({ 'uid-a': 'session-1' });
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([
+      timerRow({ id: 1, channel: 'streamer-a', message: 'msg-a', interval_seconds: 60 }),
+      timerRow({ id: 2, channel: 'streamer-a', message: 'msg-b', interval_seconds: 300 }),
+    ] as any);
+
+    await runTimerCommandTick(); // seed both
+
+    await vi.advanceTimersByTimeAsync(300_000); // both eligible together for the first time; tie broken to timer 1
+    await runTimerCommandTick();
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith('streamer-a', 'msg-a');
+
+    send.mockClear();
+    // Only 120s later — well under timer 2's own 300s interval, so timer 2 can only be a candidate
+    // again this soon if its layer-1 reservation was actually released rather than left to expire
+    // naturally on its own schedule.
+    await vi.advanceTimersByTimeAsync(120_000);
+    await runTimerCommandTick();
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith('streamer-a', 'msg-b');
+  });
 });
 
 describe('Cross-command channel floor', () => {
@@ -445,6 +475,30 @@ describe('Cross-command channel floor', () => {
     await runTimerCommandTick(); // seed both, both lastFiredAt = 0
 
     await vi.advanceTimersByTimeAsync(60_000); // both eligible; equal lastFiredAt so the first (timer 1) is picked
+    await runTimerCommandTick();
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith('somestreamer', 'msg-a');
+  });
+
+  it('lets the same timer repeat during an active floor even when a longer-waiting different timer is also eligible', async () => {
+    // The floor exists to space out *different* commands, not to hold the poster back from its own
+    // next cycle. Picking the globally-longest-waiting row first (ignoring who set the floor) would
+    // pick timer 2 here, find it blocked by the floor, and defer the whole channel — silently
+    // skipping timer 1's due repeat too. It must fall back to timer 1 specifically.
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([
+      timerRow({ id: 1, channel: 'somestreamer', message: 'msg-a', interval_seconds: 60 }),
+      timerRow({ id: 2, channel: 'somestreamer', message: 'msg-b', interval_seconds: 30 }),
+    ] as any);
+
+    await runTimerCommandTick(); // seed both
+
+    await vi.advanceTimersByTimeAsync(60_000); // both eligible, no floor yet, tie broken to timer 1
+    await runTimerCommandTick();
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith('somestreamer', 'msg-a');
+
+    send.mockClear();
+    await vi.advanceTimersByTimeAsync(60_000); // t=120s: timer 1 due again (own 60s interval); timer 2 still starved and eligible; floor still active (60s since timer 1's post)
     await runTimerCommandTick();
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenCalledWith('somestreamer', 'msg-a');

--- a/src/twitch/timers/timerCommandScheduler.ts
+++ b/src/twitch/timers/timerCommandScheduler.ts
@@ -43,23 +43,79 @@ function rowKey(row: { id: number; channel: string }): string {
 
 const timerState = new Map<string, TimerRuntimeState>();
 
-// ─── Shared Chat group cooldown ──────────────────────────────────────────────
+/** Picks whichever of `rows` has gone longest without firing (oldest `timerState.lastFiredAt`), breaking ties by keeping the first. */
+function pickLongestWaiting(rows: readonly TimerCommandForScheduler[]): TimerCommandForScheduler {
+  return rows.reduce((oldest, row) => {
+    const oldestState = timerState.get(rowKey(oldest))!;
+    const rowState = timerState.get(rowKey(row))!;
+    return rowState.lastFiredAt < oldestState.lastFiredAt ? row : oldest;
+  });
+}
+
+// ─── Per-command Shared Chat cooldown ────────────────────────────────────────
 //
-// When several streamers' channels are merged into one Twitch Shared Chat session
-// (multitwitch), each streamer's timer otherwise keeps firing on its own independent
-// schedule — and since Shared Chat shows every participating channel's messages in
-// one merged view, that stacks up and floods it. This caps how often ANY timer may
-// post into a given session, and rotates fairly among the timers sharing it (see
-// `pickRowsToFire`) so distinct messages take turns instead of one dominating.
+// When several of one timer's assigned streamers are merged into the same Twitch Shared Chat
+// session (multitwitch), each of that timer's assigned channels otherwise keeps firing on its own
+// independent schedule — and since Shared Chat shows every participating channel's messages in one
+// merged view, that stacks up into the same command posting several times in a few minutes. This
+// caps a given timer to firing at most once per its own `interval_seconds` into a given session —
+// as if that whole session were one channel, for this command specifically — and rotates fairly
+// among the timer's channels sharing it (see `pickRowsToFire`) so each gets a turn instead of one
+// dominating. Scoped per (timer id, session id): a *different* timer assigned to the same
+// shared-chat streamers gets its own independent cooldown, sized to its own interval, and never
+// competes with this one for a turn.
 
-const SHARED_SESSION_COOLDOWN_MS = 120_000;
-const sessionLastFiredAt = new Map<string, number>();
-const SESSION_COOLDOWN_ENTRY_MAX_AGE_MS = 10 * SHARED_SESSION_COOLDOWN_MS;
+interface CommandSessionCooldown {
+  firedAt: number;
+  /** The interval (ms) that was actually applied when this cooldown was reserved — needed to prune it correctly later, since different timers (and a live-edited interval) can each imply a different cooldown length. */
+  cooldownMs: number;
+}
 
-/** Drops session-cooldown entries older than {@link SESSION_COOLDOWN_ENTRY_MAX_AGE_MS} so the map doesn't grow unbounded as Shared Chat sessions come and go over long uptimes. */
-function pruneStaleSessionCooldowns(now: number): void {
-  for (const [sessionId, firedAt] of sessionLastFiredAt) {
-    if (now - firedAt > SESSION_COOLDOWN_ENTRY_MAX_AGE_MS) sessionLastFiredAt.delete(sessionId);
+const commandSessionLastFiredAt = new Map<string, CommandSessionCooldown>();
+
+/** Composite key for {@link commandSessionLastFiredAt}: one cooldown per (timer, Shared Chat session). */
+function commandSessionKey(timerId: number, sessionId: string): string {
+  return `${timerId}::${sessionId}`;
+}
+
+/** A stale command-session cooldown entry is kept around for this many multiples of its own cooldown length before being pruned, so the map doesn't grow unbounded as Shared Chat sessions come and go over long uptimes. */
+const COMMAND_SESSION_COOLDOWN_PRUNE_FACTOR = 10;
+
+/** Drops command-session cooldown entries old enough (relative to their own recorded cooldown length) that the session or assignment behind them is almost certainly gone. */
+function pruneStaleCommandSessionCooldowns(now: number): void {
+  for (const [key, entry] of commandSessionLastFiredAt) {
+    if (now - entry.firedAt > entry.cooldownMs * COMMAND_SESSION_COOLDOWN_PRUNE_FACTOR) {
+      commandSessionLastFiredAt.delete(key);
+    }
+  }
+}
+
+// ─── Cross-command channel floor ─────────────────────────────────────────────
+//
+// Independent of Shared Chat: if a single Twitch channel has several *different* timer commands
+// assigned to it, each fires on its own schedule with nothing otherwise stopping two of them from
+// landing seconds apart. This enforces a minimum gap between any two *different* commands posting
+// into the same channel, and — like the Shared Chat cooldown above — lets whichever has waited
+// longest go first. It deliberately does not slow down a single command's own cadence: the floor
+// only applies when the channel's last post came from a *different* timer than the one about to
+// post now, so a lone timer with a short interval (as low as `chk_timer_command_interval`'s 60s
+// floor) is never throttled below its own configured interval just for being alone on its channel.
+
+const CHANNEL_MIN_SPACING_MS = 120_000;
+
+interface ChannelCooldown {
+  firedAt: number;
+  timerId: number;
+}
+
+const channelLastFiredAt = new Map<string, ChannelCooldown>();
+
+const CHANNEL_MIN_SPACING_PRUNE_MS = 10 * CHANNEL_MIN_SPACING_MS;
+
+/** Drops channel-floor entries older than {@link CHANNEL_MIN_SPACING_PRUNE_MS} so the map doesn't grow unbounded as channels stop being assigned any timer over long uptimes. */
+function pruneStaleChannelCooldowns(now: number): void {
+  for (const [channel, entry] of channelLastFiredAt) {
+    if (now - entry.firedAt > CHANNEL_MIN_SPACING_PRUNE_MS) channelLastFiredAt.delete(channel);
   }
 }
 
@@ -105,24 +161,29 @@ async function resolveSessionIdsByChannel(
   return sessionIdByChannel;
 }
 
-/** A row picked to fire this tick, paired with the Shared Chat session (if any) it was picked for. */
+/** A row picked to fire this tick, paired with the reservations {@link sendTimerRow} must release if the send doesn't succeed. */
 interface PickedRow {
   row: TimerCommandForScheduler;
-  sessionId: string | null;
+  /** The {@link commandSessionKey} reserved for this pick, or null if its channel isn't in a Shared Chat session. */
+  sessionKey: string | null;
 }
 
 /**
  * From the rows that already passed their own {@link evaluateFireBlock} check, decides which ones
- * actually get to fire this tick, applying the Shared Chat group cooldown: rows with no resolved
- * session always fire (unaffected — this is the fully-independent, outside-of-multitwitch case).
- * For rows sharing a session that's currently off cooldown, only the single row that has gone
- * longest without firing (oldest `lastFiredAt`) is picked, and the session is tentatively reserved
- * — this rotates fairly among the timers sharing a session (instead of one perpetually winning) and
- * prevents two rows in the same session both firing in one tick. The reservation is only
- * provisional: {@link sendTimerRow} releases it if the send doesn't actually succeed, so a failed
- * send can't silence the whole group for the full cooldown window. Rows in a session still on
- * cooldown, and rows not picked from an eligible session, are left untouched so they're
- * reconsidered on a later tick.
+ * actually get to fire this tick, in two layers:
+ *
+ * 1. Per-command Shared Chat cooldown: groups rows by (timer id, Shared Chat session), and for a
+ *    group off its own cooldown (sized to that timer's `interval_seconds`), picks the row that's
+ *    gone longest without firing and reserves the cooldown. Rows whose channel isn't in a session
+ *    pass straight through. See the module doc above `commandSessionLastFiredAt`.
+ * 2. Cross-command channel floor: groups whatever survived layer 1 by channel, and for a channel
+ *    whose last post came from a *different* timer than the longest-waiting candidate here, within
+ *    {@link CHANNEL_MIN_SPACING_MS}, defers it to a later tick. See the module doc above
+ *    `channelLastFiredAt`.
+ *
+ * Both reservations are only provisional: {@link sendTimerRow} releases them if the send doesn't
+ * actually succeed, so a failed send can't silence a session/channel for the full cooldown window.
+ * Rows not picked at either layer are left untouched so they're reconsidered on a later tick.
  * @param eligibleRows - Rows that already passed their own per-timer {@link evaluateFireBlock} check.
  * @param sessionIdByChannel - Each row's channel's resolved Shared Chat session id (or null).
  * @param now - Current time in epoch ms, shared across the whole tick.
@@ -132,50 +193,89 @@ function pickRowsToFire(
   sessionIdByChannel: ReadonlyMap<string, string | null>,
   now: number,
 ): PickedRow[] {
-  const toFire: PickedRow[] = [];
-  const bySession = new Map<string, TimerCommandForScheduler[]>();
+  // Layer 1 — per-command Shared Chat cooldown.
+  const layer1Survivors: PickedRow[] = [];
+  const bySessionAndTimer = new Map<string, TimerCommandForScheduler[]>();
 
   for (const row of eligibleRows) {
     const sessionId = sessionIdByChannel.get(row.channel) ?? null;
     if (!sessionId) {
-      toFire.push({ row, sessionId: null });
+      layer1Survivors.push({ row, sessionKey: null });
       continue;
     }
-    const group = bySession.get(sessionId);
-    if (group) group.push(row); else bySession.set(sessionId, [row]);
+    const key = commandSessionKey(row.id, sessionId);
+    const group = bySessionAndTimer.get(key);
+    if (group) group.push(row); else bySessionAndTimer.set(key, [row]);
   }
 
-  for (const [sessionId, rows] of bySession) {
-    const lastFired = sessionLastFiredAt.get(sessionId) ?? 0;
-    if (now - lastFired < SHARED_SESSION_COOLDOWN_MS) continue;
+  for (const [key, rows] of bySessionAndTimer) {
+    const cooldownMs = rows[0].interval_seconds * 1000;
+    const entry = commandSessionLastFiredAt.get(key);
+    if (entry && now - entry.firedAt < cooldownMs) continue;
 
-    const picked = rows.reduce((oldest, row) => {
-      const oldestState = timerState.get(rowKey(oldest))!;
-      const rowState = timerState.get(rowKey(row))!;
-      return rowState.lastFiredAt < oldestState.lastFiredAt ? row : oldest;
-    });
-    sessionLastFiredAt.set(sessionId, now); // provisional — released by sendTimerRow on failure
-    toFire.push({ row: picked, sessionId });
+    const picked = pickLongestWaiting(rows);
+    commandSessionLastFiredAt.set(key, { firedAt: now, cooldownMs }); // provisional — released by sendTimerRow on failure
+    layer1Survivors.push({ row: picked, sessionKey: key });
+  }
+
+  // Layer 2 — cross-command channel floor, applied regardless of Shared Chat status.
+  const toFire: PickedRow[] = [];
+  const byChannel = new Map<string, PickedRow[]>();
+  for (const picked of layer1Survivors) {
+    const group = byChannel.get(picked.row.channel);
+    if (group) group.push(picked); else byChannel.set(picked.row.channel, [picked]);
+  }
+
+  for (const [channel, picks] of byChannel) {
+    const candidate = pickLongestWaiting(picks.map((p) => p.row));
+    const candidatePick = picks.find((p) => p.row === candidate)!;
+
+    const lastPoster = channelLastFiredAt.get(channel);
+    if (lastPoster && lastPoster.timerId !== candidate.id && now - lastPoster.firedAt < CHANNEL_MIN_SPACING_MS) continue;
+
+    channelLastFiredAt.set(channel, { firedAt: now, timerId: candidate.id }); // provisional — released by sendTimerRow on failure
+    toFire.push(candidatePick);
   }
 
   return toFire;
 }
 
 /**
+ * Releases the provisional cooldown reservations {@link pickRowsToFire} made for a row, if the send
+ * that would have justified them didn't actually happen (no runtime, or `runtime.send` threw).
+ * Guarded by matching the reservation's own identity so a release can't clobber a newer reservation
+ * made by a different row on a later tick.
+ * @param sessionKey - The command-session cooldown key reserved for this row, or null.
+ * @param channel - The row's Twitch channel — the channel-floor reservation to potentially release.
+ * @param timerId - The row's timer id — must match the channel-floor reservation's own recorded id.
+ * @param now - The epoch-ms timestamp the reservations were made under, shared across the whole tick.
+ * @returns Nothing — mutates the module-level cooldown maps in place.
+ */
+function releaseReservations(sessionKey: string | null, channel: string, timerId: number, now: number): void {
+  if (sessionKey) {
+    const entry = commandSessionLastFiredAt.get(sessionKey);
+    if (entry && entry.firedAt === now) commandSessionLastFiredAt.delete(sessionKey);
+  }
+  const channelEntry = channelLastFiredAt.get(channel);
+  if (channelEntry && channelEntry.firedAt === now && channelEntry.timerId === timerId) {
+    channelLastFiredAt.delete(channel);
+  }
+}
+
+/**
  * Posts one selected timer row to its channel and records the fire in the in-memory state.
  * No-ops if no runtime is registered. Never throws — a send failure is logged and swallowed so it
- * can't block other rows in the same tick. If `sessionId` is set and the send doesn't succeed (no
- * runtime, or `runtime.send` throws), releases that session's cooldown reservation made by
- * {@link pickRowsToFire} — guarded by a timestamp match so it can't clobber a newer reservation
- * made by another row in the same session on a later tick.
+ * can't block other rows in the same tick. If the send doesn't succeed (no runtime, or
+ * `runtime.send` throws), releases the cooldown reservation(s) {@link pickRowsToFire} made for this
+ * row — see {@link releaseReservations}.
  * @param row - The timer's config, joined with its Twitch channel.
  * @param now - Current time in epoch ms, shared across the whole tick.
- * @param sessionId - The Shared Chat session this row was provisionally reserved for, or null.
+ * @param sessionKey - The command-session cooldown key this row was provisionally reserved for, or null.
  */
-async function sendTimerRow(row: TimerCommandForScheduler, now: number, sessionId: string | null): Promise<void> {
+async function sendTimerRow(row: TimerCommandForScheduler, now: number, sessionKey: string | null): Promise<void> {
   const runtime = timerCommandsRuntime.get();
   if (!runtime) {
-    if (sessionId && sessionLastFiredAt.get(sessionId) === now) sessionLastFiredAt.delete(sessionId);
+    releaseReservations(sessionKey, row.channel, row.id, now);
     return;
   }
 
@@ -188,7 +288,7 @@ async function sendTimerRow(row: TimerCommandForScheduler, now: number, sessionI
     forgetBlockReason(key);
     log.info(`Posted timer ${row.id} to ${row.channel}`);
   } catch (err) {
-    if (sessionId && sessionLastFiredAt.get(sessionId) === now) sessionLastFiredAt.delete(sessionId);
+    releaseReservations(sessionKey, row.channel, row.id, now);
     log.error(`Failed to post timer command ${row.id} to ${row.channel}:`, err);
   }
 }
@@ -200,9 +300,10 @@ async function sendTimerRow(row: TimerCommandForScheduler, now: number, sessionI
  * newly blocked on being offline or on chat activity, so a stuck gate is diagnosable from logs
  * instead of looking identical to a healthy row still waiting out its interval), resolves Shared
  * Chat sessions for the ones that are ready, picks which of those actually get to fire this tick
- * (applying the group cooldown — see {@link pickRowsToFire}), and sends the picked rows
- * concurrently via `Promise.allSettled` so one channel's send failure can't block another's.
- * No-ops (re-uses the in-flight promise) if a tick is already running.
+ * (applying the per-command Shared Chat cooldown and the cross-command channel floor — see
+ * {@link pickRowsToFire}), and sends the picked rows concurrently via `Promise.allSettled` so one
+ * channel's send failure can't block another's. No-ops (re-uses the in-flight promise) if a tick
+ * is already running.
  */
 export async function runTimerCommandTick(): Promise<void> {
   if (tickRunning) return currentTickPromise;
@@ -213,7 +314,8 @@ export async function runTimerCommandTick(): Promise<void> {
       pruneStaleTimerState(new Set(rows.map(rowKey)));
 
       const now = Date.now();
-      pruneStaleSessionCooldowns(now);
+      pruneStaleCommandSessionCooldowns(now);
+      pruneStaleChannelCooldowns(now);
 
       const eligibleRows: TimerCommandForScheduler[] = [];
       for (const row of rows) {
@@ -232,7 +334,7 @@ export async function runTimerCommandTick(): Promise<void> {
       const sessionIdByChannel = await resolveSessionIdsByChannel(eligibleRows.map((row) => row.channel), loginUserIds);
       const toFire = pickRowsToFire(eligibleRows, sessionIdByChannel, now);
 
-      await Promise.allSettled(toFire.map(({ row, sessionId }) => sendTimerRow(row, now, sessionId)));
+      await Promise.allSettled(toFire.map(({ row, sessionKey }) => sendTimerRow(row, now, sessionKey)));
     } catch (err) {
       log.error('Failed to load enabled timer commands:', err);
     } finally {
@@ -259,6 +361,7 @@ export async function stopTimerCommandScheduler(): Promise<void> {
   if (tickTimer) { clearInterval(tickTimer); tickTimer = null; }
   await currentTickPromise;
   timerState.clear();
-  sessionLastFiredAt.clear();
+  commandSessionLastFiredAt.clear();
+  channelLastFiredAt.clear();
   clearBlockReasonLog();
 }

--- a/src/twitch/timers/timerCommandScheduler.ts
+++ b/src/twitch/timers/timerCommandScheduler.ts
@@ -169,38 +169,28 @@ interface PickedRow {
 }
 
 /**
- * From the rows that already passed their own {@link evaluateFireBlock} check, decides which ones
- * actually get to fire this tick, in two layers:
- *
- * 1. Per-command Shared Chat cooldown: groups rows by (timer id, Shared Chat session), and for a
- *    group off its own cooldown (sized to that timer's `interval_seconds`), picks the row that's
- *    gone longest without firing and reserves the cooldown. Rows whose channel isn't in a session
- *    pass straight through. See the module doc above `commandSessionLastFiredAt`.
- * 2. Cross-command channel floor: groups whatever survived layer 1 by channel, and for a channel
- *    whose last post came from a *different* timer than the longest-waiting candidate here, within
- *    {@link CHANNEL_MIN_SPACING_MS}, defers it to a later tick. See the module doc above
- *    `channelLastFiredAt`.
- *
- * Both reservations are only provisional: {@link sendTimerRow} releases them if the send doesn't
- * actually succeed, so a failed send can't silence a session/channel for the full cooldown window.
- * Rows not picked at either layer are left untouched so they're reconsidered on a later tick.
+ * Layer 1 of {@link pickRowsToFire}: groups `eligibleRows` by (timer id, Shared Chat session), and
+ * for a group off its own cooldown (sized to that timer's `interval_seconds`), picks the row that's
+ * gone longest without firing and reserves the cooldown. Rows whose channel isn't in a session pass
+ * straight through untouched. See the module doc above `commandSessionLastFiredAt`.
  * @param eligibleRows - Rows that already passed their own per-timer {@link evaluateFireBlock} check.
  * @param sessionIdByChannel - Each row's channel's resolved Shared Chat session id (or null).
  * @param now - Current time in epoch ms, shared across the whole tick.
+ * @returns One entry per row that cleared this layer, paired with the command-session cooldown key
+ *   reserved for it (or null if its channel isn't in a session).
  */
-function pickRowsToFire(
+function applyCommandSessionCooldown(
   eligibleRows: readonly TimerCommandForScheduler[],
   sessionIdByChannel: ReadonlyMap<string, string | null>,
   now: number,
 ): PickedRow[] {
-  // Layer 1 — per-command Shared Chat cooldown.
-  const layer1Survivors: PickedRow[] = [];
+  const survivors: PickedRow[] = [];
   const bySessionAndTimer = new Map<string, TimerCommandForScheduler[]>();
 
   for (const row of eligibleRows) {
     const sessionId = sessionIdByChannel.get(row.channel) ?? null;
     if (!sessionId) {
-      layer1Survivors.push({ row, sessionKey: null });
+      survivors.push({ row, sessionKey: null });
       continue;
     }
     const key = commandSessionKey(row.id, sessionId);
@@ -215,10 +205,22 @@ function pickRowsToFire(
 
     const picked = pickLongestWaiting(rows);
     commandSessionLastFiredAt.set(key, { firedAt: now, cooldownMs }); // provisional — released by sendTimerRow on failure
-    layer1Survivors.push({ row: picked, sessionKey: key });
+    survivors.push({ row: picked, sessionKey: key });
   }
 
-  // Layer 2 — cross-command channel floor, applied regardless of Shared Chat status.
+  return survivors;
+}
+
+/**
+ * Layer 2 of {@link pickRowsToFire}: groups whatever survived layer 1 by channel, and for a channel
+ * whose last post came from a *different* timer than the longest-waiting candidate here, within
+ * {@link CHANNEL_MIN_SPACING_MS}, defers it to a later tick — applied regardless of Shared Chat
+ * status. See the module doc above `channelLastFiredAt`.
+ * @param layer1Survivors - Rows (with their layer 1 session-key reservation, if any) that cleared {@link applyCommandSessionCooldown}.
+ * @param now - Current time in epoch ms, shared across the whole tick.
+ * @returns The final set of rows to actually send this tick.
+ */
+function applyChannelFloor(layer1Survivors: readonly PickedRow[], now: number): PickedRow[] {
   const toFire: PickedRow[] = [];
   const byChannel = new Map<string, PickedRow[]>();
   for (const picked of layer1Survivors) {
@@ -238,6 +240,26 @@ function pickRowsToFire(
   }
 
   return toFire;
+}
+
+/**
+ * From the rows that already passed their own {@link evaluateFireBlock} check, decides which ones
+ * actually get to fire this tick: {@link applyCommandSessionCooldown} (per-command Shared Chat
+ * cooldown), then {@link applyChannelFloor} (cross-command channel floor) on whatever survives.
+ * Both layers' reservations are only provisional: {@link sendTimerRow} releases them if the send
+ * doesn't actually succeed, so a failed send can't silence a session/channel for the full cooldown
+ * window. Rows not picked at either layer are left untouched so they're reconsidered on a later tick.
+ * @param eligibleRows - Rows that already passed their own per-timer {@link evaluateFireBlock} check.
+ * @param sessionIdByChannel - Each row's channel's resolved Shared Chat session id (or null).
+ * @param now - Current time in epoch ms, shared across the whole tick.
+ */
+function pickRowsToFire(
+  eligibleRows: readonly TimerCommandForScheduler[],
+  sessionIdByChannel: ReadonlyMap<string, string | null>,
+  now: number,
+): PickedRow[] {
+  const layer1Survivors = applyCommandSessionCooldown(eligibleRows, sessionIdByChannel, now);
+  return applyChannelFloor(layer1Survivors, now);
 }
 
 /**

--- a/src/twitch/timers/timerCommandScheduler.ts
+++ b/src/twitch/timers/timerCommandScheduler.ts
@@ -7,6 +7,7 @@ import {
   evaluateFireBlock, logBlockReasonChange, forgetBlockReason, pruneBlockReasonLog, clearBlockReasonLog,
   type TimerRuntimeState,
 } from './timerCommandFireGate';
+import { pickRowsToFire, releaseReservations, pruneStaleCooldowns, clearCooldowns } from './timerCommandCooldowns';
 
 const log = createLogger('TimerCommandScheduler');
 
@@ -42,82 +43,6 @@ function rowKey(row: { id: number; channel: string }): string {
 }
 
 const timerState = new Map<string, TimerRuntimeState>();
-
-/** Picks whichever of `rows` has gone longest without firing (oldest `timerState.lastFiredAt`), breaking ties by keeping the first. */
-function pickLongestWaiting(rows: readonly TimerCommandForScheduler[]): TimerCommandForScheduler {
-  return rows.reduce((oldest, row) => {
-    const oldestState = timerState.get(rowKey(oldest))!;
-    const rowState = timerState.get(rowKey(row))!;
-    return rowState.lastFiredAt < oldestState.lastFiredAt ? row : oldest;
-  });
-}
-
-// ─── Per-command Shared Chat cooldown ────────────────────────────────────────
-//
-// When several of one timer's assigned streamers are merged into the same Twitch Shared Chat
-// session (multitwitch), each of that timer's assigned channels otherwise keeps firing on its own
-// independent schedule — and since Shared Chat shows every participating channel's messages in one
-// merged view, that stacks up into the same command posting several times in a few minutes. This
-// caps a given timer to firing at most once per its own `interval_seconds` into a given session —
-// as if that whole session were one channel, for this command specifically — and rotates fairly
-// among the timer's channels sharing it (see `pickRowsToFire`) so each gets a turn instead of one
-// dominating. Scoped per (timer id, session id): a *different* timer assigned to the same
-// shared-chat streamers gets its own independent cooldown, sized to its own interval, and never
-// competes with this one for a turn.
-
-interface CommandSessionCooldown {
-  firedAt: number;
-  /** The interval (ms) that was actually applied when this cooldown was reserved — needed to prune it correctly later, since different timers (and a live-edited interval) can each imply a different cooldown length. */
-  cooldownMs: number;
-}
-
-const commandSessionLastFiredAt = new Map<string, CommandSessionCooldown>();
-
-/** Composite key for {@link commandSessionLastFiredAt}: one cooldown per (timer, Shared Chat session). */
-function commandSessionKey(timerId: number, sessionId: string): string {
-  return `${timerId}::${sessionId}`;
-}
-
-/** A stale command-session cooldown entry is kept around for this many multiples of its own cooldown length before being pruned, so the map doesn't grow unbounded as Shared Chat sessions come and go over long uptimes. */
-const COMMAND_SESSION_COOLDOWN_PRUNE_FACTOR = 10;
-
-/** Drops command-session cooldown entries old enough (relative to their own recorded cooldown length) that the session or assignment behind them is almost certainly gone. */
-function pruneStaleCommandSessionCooldowns(now: number): void {
-  for (const [key, entry] of commandSessionLastFiredAt) {
-    if (now - entry.firedAt > entry.cooldownMs * COMMAND_SESSION_COOLDOWN_PRUNE_FACTOR) {
-      commandSessionLastFiredAt.delete(key);
-    }
-  }
-}
-
-// ─── Cross-command channel floor ─────────────────────────────────────────────
-//
-// Independent of Shared Chat: if a single Twitch channel has several *different* timer commands
-// assigned to it, each fires on its own schedule with nothing otherwise stopping two of them from
-// landing seconds apart. This enforces a minimum gap between any two *different* commands posting
-// into the same channel, and — like the Shared Chat cooldown above — lets whichever has waited
-// longest go first. It deliberately does not slow down a single command's own cadence: the floor
-// only applies when the channel's last post came from a *different* timer than the one about to
-// post now, so a lone timer with a short interval (as low as `chk_timer_command_interval`'s 60s
-// floor) is never throttled below its own configured interval just for being alone on its channel.
-
-const CHANNEL_MIN_SPACING_MS = 120_000;
-
-interface ChannelCooldown {
-  firedAt: number;
-  timerId: number;
-}
-
-const channelLastFiredAt = new Map<string, ChannelCooldown>();
-
-const CHANNEL_MIN_SPACING_PRUNE_MS = 10 * CHANNEL_MIN_SPACING_MS;
-
-/** Drops channel-floor entries older than {@link CHANNEL_MIN_SPACING_PRUNE_MS} so the map doesn't grow unbounded as channels stop being assigned any timer over long uptimes. */
-function pruneStaleChannelCooldowns(now: number): void {
-  for (const [channel, entry] of channelLastFiredAt) {
-    if (now - entry.firedAt > CHANNEL_MIN_SPACING_PRUNE_MS) channelLastFiredAt.delete(channel);
-  }
-}
 
 let tickTimer: ReturnType<typeof setInterval> | null = null;
 let tickRunning = false;
@@ -161,135 +86,12 @@ async function resolveSessionIdsByChannel(
   return sessionIdByChannel;
 }
 
-/** A row picked to fire this tick, paired with the reservations {@link sendTimerRow} must release if the send doesn't succeed. */
-interface PickedRow {
-  row: TimerCommandForScheduler;
-  /** The {@link commandSessionKey} reserved for this pick, or null if its channel isn't in a Shared Chat session. */
-  sessionKey: string | null;
-}
-
-/**
- * Layer 1 of {@link pickRowsToFire}: groups `eligibleRows` by (timer id, Shared Chat session), and
- * for a group off its own cooldown (sized to that timer's `interval_seconds`), picks the row that's
- * gone longest without firing and reserves the cooldown. Rows whose channel isn't in a session pass
- * straight through untouched. See the module doc above `commandSessionLastFiredAt`.
- * @param eligibleRows - Rows that already passed their own per-timer {@link evaluateFireBlock} check.
- * @param sessionIdByChannel - Each row's channel's resolved Shared Chat session id (or null).
- * @param now - Current time in epoch ms, shared across the whole tick.
- * @returns One entry per row that cleared this layer, paired with the command-session cooldown key
- *   reserved for it (or null if its channel isn't in a session).
- */
-function applyCommandSessionCooldown(
-  eligibleRows: readonly TimerCommandForScheduler[],
-  sessionIdByChannel: ReadonlyMap<string, string | null>,
-  now: number,
-): PickedRow[] {
-  const survivors: PickedRow[] = [];
-  const bySessionAndTimer = new Map<string, TimerCommandForScheduler[]>();
-
-  for (const row of eligibleRows) {
-    const sessionId = sessionIdByChannel.get(row.channel) ?? null;
-    if (!sessionId) {
-      survivors.push({ row, sessionKey: null });
-      continue;
-    }
-    const key = commandSessionKey(row.id, sessionId);
-    const group = bySessionAndTimer.get(key);
-    if (group) group.push(row); else bySessionAndTimer.set(key, [row]);
-  }
-
-  for (const [key, rows] of bySessionAndTimer) {
-    const cooldownMs = rows[0].interval_seconds * 1000;
-    const entry = commandSessionLastFiredAt.get(key);
-    if (entry && now - entry.firedAt < cooldownMs) continue;
-
-    const picked = pickLongestWaiting(rows);
-    commandSessionLastFiredAt.set(key, { firedAt: now, cooldownMs }); // provisional — released by sendTimerRow on failure
-    survivors.push({ row: picked, sessionKey: key });
-  }
-
-  return survivors;
-}
-
-/**
- * Layer 2 of {@link pickRowsToFire}: groups whatever survived layer 1 by channel, and for a channel
- * whose last post came from a *different* timer than the longest-waiting candidate here, within
- * {@link CHANNEL_MIN_SPACING_MS}, defers it to a later tick — applied regardless of Shared Chat
- * status. See the module doc above `channelLastFiredAt`.
- * @param layer1Survivors - Rows (with their layer 1 session-key reservation, if any) that cleared {@link applyCommandSessionCooldown}.
- * @param now - Current time in epoch ms, shared across the whole tick.
- * @returns The final set of rows to actually send this tick.
- */
-function applyChannelFloor(layer1Survivors: readonly PickedRow[], now: number): PickedRow[] {
-  const toFire: PickedRow[] = [];
-  const byChannel = new Map<string, PickedRow[]>();
-  for (const picked of layer1Survivors) {
-    const group = byChannel.get(picked.row.channel);
-    if (group) group.push(picked); else byChannel.set(picked.row.channel, [picked]);
-  }
-
-  for (const [channel, picks] of byChannel) {
-    const candidate = pickLongestWaiting(picks.map((p) => p.row));
-    const candidatePick = picks.find((p) => p.row === candidate)!;
-
-    const lastPoster = channelLastFiredAt.get(channel);
-    if (lastPoster && lastPoster.timerId !== candidate.id && now - lastPoster.firedAt < CHANNEL_MIN_SPACING_MS) continue;
-
-    channelLastFiredAt.set(channel, { firedAt: now, timerId: candidate.id }); // provisional — released by sendTimerRow on failure
-    toFire.push(candidatePick);
-  }
-
-  return toFire;
-}
-
-/**
- * From the rows that already passed their own {@link evaluateFireBlock} check, decides which ones
- * actually get to fire this tick: {@link applyCommandSessionCooldown} (per-command Shared Chat
- * cooldown), then {@link applyChannelFloor} (cross-command channel floor) on whatever survives.
- * Both layers' reservations are only provisional: {@link sendTimerRow} releases them if the send
- * doesn't actually succeed, so a failed send can't silence a session/channel for the full cooldown
- * window. Rows not picked at either layer are left untouched so they're reconsidered on a later tick.
- * @param eligibleRows - Rows that already passed their own per-timer {@link evaluateFireBlock} check.
- * @param sessionIdByChannel - Each row's channel's resolved Shared Chat session id (or null).
- * @param now - Current time in epoch ms, shared across the whole tick.
- */
-function pickRowsToFire(
-  eligibleRows: readonly TimerCommandForScheduler[],
-  sessionIdByChannel: ReadonlyMap<string, string | null>,
-  now: number,
-): PickedRow[] {
-  const layer1Survivors = applyCommandSessionCooldown(eligibleRows, sessionIdByChannel, now);
-  return applyChannelFloor(layer1Survivors, now);
-}
-
-/**
- * Releases the provisional cooldown reservations {@link pickRowsToFire} made for a row, if the send
- * that would have justified them didn't actually happen (no runtime, or `runtime.send` threw).
- * Guarded by matching the reservation's own identity so a release can't clobber a newer reservation
- * made by a different row on a later tick.
- * @param sessionKey - The command-session cooldown key reserved for this row, or null.
- * @param channel - The row's Twitch channel — the channel-floor reservation to potentially release.
- * @param timerId - The row's timer id — must match the channel-floor reservation's own recorded id.
- * @param now - The epoch-ms timestamp the reservations were made under, shared across the whole tick.
- * @returns Nothing — mutates the module-level cooldown maps in place.
- */
-function releaseReservations(sessionKey: string | null, channel: string, timerId: number, now: number): void {
-  if (sessionKey) {
-    const entry = commandSessionLastFiredAt.get(sessionKey);
-    if (entry && entry.firedAt === now) commandSessionLastFiredAt.delete(sessionKey);
-  }
-  const channelEntry = channelLastFiredAt.get(channel);
-  if (channelEntry && channelEntry.firedAt === now && channelEntry.timerId === timerId) {
-    channelLastFiredAt.delete(channel);
-  }
-}
-
 /**
  * Posts one selected timer row to its channel and records the fire in the in-memory state.
  * No-ops if no runtime is registered. Never throws — a send failure is logged and swallowed so it
  * can't block other rows in the same tick. If the send doesn't succeed (no runtime, or
- * `runtime.send` throws), releases the cooldown reservation(s) {@link pickRowsToFire} made for this
- * row — see {@link releaseReservations}.
+ * `runtime.send` throws), releases the cooldown reservation(s) `pickRowsToFire` made for this row
+ * — see {@link releaseReservations}.
  * @param row - The timer's config, joined with its Twitch channel.
  * @param now - Current time in epoch ms, shared across the whole tick.
  * @param sessionKey - The command-session cooldown key this row was provisionally reserved for, or null.
@@ -323,9 +125,9 @@ async function sendTimerRow(row: TimerCommandForScheduler, now: number, sessionK
  * instead of looking identical to a healthy row still waiting out its interval), resolves Shared
  * Chat sessions for the ones that are ready, picks which of those actually get to fire this tick
  * (applying the per-command Shared Chat cooldown and the cross-command channel floor — see
- * {@link pickRowsToFire}), and sends the picked rows concurrently via `Promise.allSettled` so one
- * channel's send failure can't block another's. No-ops (re-uses the in-flight promise) if a tick
- * is already running.
+ * `pickRowsToFire` in `timerCommandCooldowns.ts`), and sends the picked rows concurrently via
+ * `Promise.allSettled` so one channel's send failure can't block another's. No-ops (re-uses the
+ * in-flight promise) if a tick is already running.
  */
 export async function runTimerCommandTick(): Promise<void> {
   if (tickRunning) return currentTickPromise;
@@ -336,8 +138,7 @@ export async function runTimerCommandTick(): Promise<void> {
       pruneStaleTimerState(new Set(rows.map(rowKey)));
 
       const now = Date.now();
-      pruneStaleCommandSessionCooldowns(now);
-      pruneStaleChannelCooldowns(now);
+      pruneStaleCooldowns(now);
 
       const eligibleRows: TimerCommandForScheduler[] = [];
       for (const row of rows) {
@@ -354,7 +155,8 @@ export async function runTimerCommandTick(): Promise<void> {
 
       const loginUserIds = timerCommandsRuntime.get()?.getLoginUserIds() ?? new Map<string, string>();
       const sessionIdByChannel = await resolveSessionIdsByChannel(eligibleRows.map((row) => row.channel), loginUserIds);
-      const toFire = pickRowsToFire(eligibleRows, sessionIdByChannel, now);
+      const lastFiredAtOf = (row: TimerCommandForScheduler): number => timerState.get(rowKey(row))!.lastFiredAt;
+      const toFire = pickRowsToFire(eligibleRows, sessionIdByChannel, now, lastFiredAtOf);
 
       await Promise.allSettled(toFire.map(({ row, sessionKey }) => sendTimerRow(row, now, sessionKey)));
     } catch (err) {
@@ -383,7 +185,6 @@ export async function stopTimerCommandScheduler(): Promise<void> {
   if (tickTimer) { clearInterval(tickTimer); tickTimer = null; }
   await currentTickPromise;
   timerState.clear();
-  commandSessionLastFiredAt.clear();
-  channelLastFiredAt.clear();
+  clearCooldowns();
   clearBlockReasonLog();
 }

--- a/views/timers.ejs
+++ b/views/timers.ejs
@@ -14,6 +14,7 @@
     <section class="section">
       <h2 class="section-title">Timer Commands</h2>
       <p class="hint mb-075">Auto-posts a message into an assigned streamer's Twitch chat on a repeating schedule.</p>
+      <p class="hint hint-compact mb-075">Two different timers are never allowed to post into the same Twitch channel within 2 minutes of each other — if both come due close together, whichever has waited longest posts first and the other waits its turn. A single timer's own interval is never affected by this. If a timer's assigned streamers are co-streaming together in a Shared Chat session, that timer also won't post into their shared chat more often than its own interval, no matter how many of those streamers it's assigned to.</p>
 
       <% if (error) { %>
       <% const errorMessages = {


### PR DESCRIPTION
## Summary

Follow-up to #503/#516 (the timer-command investigation), prompted by walking through a concrete scenario: 3 streamers assigned the same 10-minute timer, all in a Shared Chat session together. Under the old fixed 120s cooldown, that command would post 3 times within ~4 minutes (rotating every 2 minutes) instead of once per 10 minutes as configured.

Two related but distinct behavior changes:

**1. Shared Chat cooldown is now per-command, sized to that command's own interval.**
Previously, `SHARED_SESSION_COOLDOWN_MS` (a fixed 120s) was shared by *every* timer command whose assigned channels happened to be in the same Shared Chat session — grouped purely by session id. Now it's grouped by `(timer id, session id)`, and the cooldown length is that command's own `interval_seconds`. A 10-minute command posts at most once per 10 minutes into a shared session regardless of how many co-streaming channels it's assigned to; a *different* command sharing the same streamers gets its own independent clock and doesn't compete with the first for a turn.

**2. New: a 120s floor between different commands posting to the same channel, independent of Shared Chat.**
Previously nothing stopped two *different* timer commands assigned to one (non-shared-chat) streamer from posting seconds apart if their gates happened to clear around the same time. This adds a minimum 120s gap between any two *different* commands' posts to the same channel, picking whichever has waited longest when the floor opens. It deliberately does **not** throttle a single command's own cadence — the floor only applies when the channel's last post came from a different timer than the one about to post — so a lone timer with a fast interval (down to the DB's 60s minimum) on an otherwise-unshared channel is unaffected.

**3. Added a short explanation of both to the Timers admin page**, so this isn't a surprise to whoever's configuring commands.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite: 167 files / 3090 tests passing)
- [x] Rewrote the Shared Chat cooldown tests that relied on the old cross-command pooling behavior (two different timer ids sharing one 120s pool), and added a test proving two different commands sharing a session no longer block each other.
- [x] Added a new test suite for the cross-command channel floor: defers a different command within 120s, does not throttle a lone command below its own interval, picks longest-waiting on a tie, and releases its reservation on a failed send.

---
_Generated by [Claude Code](https://claude.ai/code/session_016zbgyMNTvn4MKcGezwwXUw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved timer command scheduling across Twitch channels and Shared Chat sessions.
  * Prioritizes the longest-waiting eligible timer while preserving individual timer intervals.
  * Coordinates posts from different timer commands to prevent channel overposting.
  * Automatically retries cooldown reservations when a send fails.

* **Documentation**
  * Added guidance to the Timer Commands page explaining posting coordination, prioritization, and Shared Chat frequency limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->