### PR TITLE
fix: restore package-lock.json after npm prune in deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -84,6 +84,14 @@ fi
 echo "==> Pruning dev dependencies..."
 npm prune --omit=dev
 
+# npm (as of npm 12) rewrites package-lock.json during `prune --omit=dev` to
+# drop dev-only entries, even though nothing in package.json changed. Left
+# alone, that leaves the working tree dirty and trips the next deploy's
+# uncommitted-changes check above. The pruned node_modules is unaffected by
+# discarding this rewrite — restore the tracked lockfile so it still reflects
+# the full dev+prod graph `npm ci` needs next time.
+git checkout -- package-lock.json
+
 trap - ERR  # Rollback no longer needed — code is good.
 
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"


### PR DESCRIPTION
## Summary

Follow-up to #519, which fixed a *different* cause of `deploy.sh`'s "Working directory has uncommitted changes or untracked files" error (a lockfile inconsistent with `package.json`). That fix didn't hold up on the actual deploy server (npm 12.0.2 / Node 24.16.0) — the same symptom kept recurring after every deploy.

Root cause this time: `npm prune --omit=dev` (`deploy.sh:85`) itself rewrites `package-lock.json` on npm 12, stripping dev-only entries (e.g. the nested `filing-cabinet/node_modules/typescript` block) from the lock file even though `package.json` hasn't changed. This doesn't happen on older npm (verified clean on npm 10.9.7 / Node 22, but reproduced exactly on npm 12.0.2 / Node 24 — matching the server's versions and the diff reported there).

Since `deploy.sh` never restores the lockfile after pruning, every successful deploy ends with a dirty working tree, which then fails `deploy.sh`'s own uncommitted-changes check (`deploy.sh:42-47`) on the *next* deploy — a self-inflicted loop independent of #519's fix.

## Changes

- `deploy.sh`: run `git checkout -- package-lock.json` immediately after `npm prune --omit=dev`, discarding npm's prune-time rewrite. This doesn't affect the already-pruned `node_modules`; it just keeps the tracked lockfile reflecting the full dev+prod graph that the next deploy's `npm ci` needs.

## Test plan

- [x] Reproduced the drift: cloned `main`, ran `npm ci` + `npm prune --omit=dev` under Node 24.19.0 / npm 12.0.2 — `package-lock.json` came out modified with a diff byte-for-byte matching what was reported on the deploy server.
- [x] Verified the fix: with the patched prune step (`npm prune --omit=dev && git checkout -- package-lock.json`), `package-lock.json` stays clean afterward under the same npm 12.0.2 environment.
- [x] `npx tsc --noEmit`
- [x] `npm test` (167 files / 3092 tests passed)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4MD2V7hVSTUUhtirpokFV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment cleanup now preserves the tracked package lockfile, preventing unintended working-tree changes after dependency pruning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->