### PR TITLE
Fix POST /guild/select to use ?error=code redirects (#522)

### DIFF
--- a/src/web/routes/auth.test.ts
+++ b/src/web/routes/auth.test.ts
@@ -363,6 +363,18 @@ describe('GET /login', () => {
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/');
   });
+
+  it('passes a known ?error= code through to the view', async () => {
+    const res = await supertest(buildApp()).get('/login?error=no_guilds');
+    expect(res.status).toBe(200);
+    expect((res.body as any).locals.error).toBe('no_guilds');
+  });
+
+  it('filters out an unrecognized ?error= code', async () => {
+    const res = await supertest(buildApp()).get('/login?error=not_a_real_code');
+    expect(res.status).toBe(200);
+    expect((res.body as any).locals.error).toBeNull();
+  });
 });
 
 // ─── POST /logout ─────────────────────────────────────────────────────────────

--- a/src/web/routes/auth.ts
+++ b/src/web/routes/auth.ts
@@ -15,11 +15,14 @@ import {
 import { fetchMemberDisplayName } from '../../discord/discordBot';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
-import { renderError, isLoopbackRedirectUri, renderView } from './shared';
+import { renderError, filterQueryParam, isLoopbackRedirectUri, renderView } from './shared';
 import { userMutationQueue } from './adminUserMutationQueue';
 
 const log = createLogger('Web');
 const router = Router();
+
+/** Error codes `GET /auth/login` accepts via `?error=`, both originating from `POST /guild/select`. */
+const LOGIN_KNOWN_ERRORS = new Set(['user_not_found', 'no_guilds']);
 
 // ─── Redirect to Discord OAuth2 ─────────────────────────────────────────────
 
@@ -215,13 +218,14 @@ router.post('/logout', requireAuth, csrfProtection, (req, res) => {
 
 /**
  * GET /auth/login — renders the login page.
- * @param req - Express request; checked for an existing `session.user`.
+ * @param req - Express request; checked for an existing `session.user`, and reads
+ *   `req.query.error` (set by `POST /guild/select` on failure) to show a banner.
  * @param res - Express response; redirects to `/` if already logged in, otherwise
- *   renders the `login` view.
+ *   renders the `login` view with the sanitized `error` code, if any.
  */
 router.get('/login', (req, res) => {
   if (req.session.user) return res.redirect('/');
-  renderView(res, 'login', { user: null });
+  renderView(res, 'login', { user: null, error: filterQueryParam(req.query.error, LOGIN_KNOWN_ERRORS) });
 });
 
 export default router;

--- a/src/web/routes/guild.test.ts
+++ b/src/web/routes/guild.test.ts
@@ -221,10 +221,12 @@ describe('POST /guild/select', () => {
     expect(vi.mocked(getAllGuilds)).not.toHaveBeenCalled();
   });
 
-  it('refreshes the session guild list before rejecting a stale guild selection', async () => {
+  it('refreshes the session guild list before rejecting a stale guild selection, and still shows the error once guilds shrinks to one', async () => {
     // Membership was revoked after login; the session's cached guild list is stale.
     // Even though the request is rejected, the session must be refreshed with the
-    // live guild list so the picker doesn't keep rendering stale entries.
+    // live guild list so the picker doesn't keep rendering stale entries. That refresh
+    // can leave the session with only one guild — GET /guild/select must still render
+    // the error banner in that case instead of silently redirecting to `/`.
     vi.mocked(getGuildsForMember).mockResolvedValue([TWO_DB_GUILDS[0]] as any);
     const user: any = { discordId: 'u1', currentGuildId: null, accessLevel: AccessLevel.USER, guilds: TWO_GUILDS };
     const app = buildApp(user);
@@ -237,12 +239,25 @@ describe('POST /guild/select', () => {
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/guild/select?error=guild_not_found');
     expect(user.guilds).toEqual([{ guildId: '100000000000000001', name: 'Alpha' }]);
+
+    const followUp = await supertest(app).get(res.headers.location);
+    expect(followUp.status).toBe(200);
+    expect((followUp.body as any).view).toBe('guildSelect');
+    expect((followUp.body as any).locals.error).toBe('guild_not_found');
   });
 
-  it('redirects to login when the live guild list is empty', async () => {
+  it('destroys the session and redirects to login when the live guild list is empty', async () => {
     vi.mocked(getGuildsForMember).mockResolvedValue([]);
     const user: any = { discordId: 'u1', currentGuildId: '100000000000000001', accessLevel: AccessLevel.USER, guilds: TWO_GUILDS };
-    const app = buildApp(user);
+    const destroy = vi.fn((cb: () => void) => cb());
+    const app = express();
+    app.use(express.urlencoded({ extended: false }));
+    app.use((req: any, _res: any, next: any) => {
+      req.session = { user, destroy };
+      req.csrfToken = () => 'csrf-token';
+      next();
+    });
+    app.use('/guild', router);
 
     const res = await supertest(app)
       .post('/guild/select')
@@ -251,17 +266,18 @@ describe('POST /guild/select', () => {
 
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/auth/login?error=no_guilds');
-    expect(user.currentGuildId).toBeNull();
+    expect(destroy).toHaveBeenCalled();
     expect(vi.mocked(getEffectiveAccessLevelForUser)).not.toHaveBeenCalled();
   });
 
-  it('redirects to login when the session user no longer exists in the database', async () => {
+  it('destroys the session and redirects to login when the session user no longer exists in the database', async () => {
     vi.mocked(findUser).mockResolvedValue(null);
     const user: any = { discordId: 'u1', currentGuildId: null, accessLevel: AccessLevel.USER, guilds: TWO_GUILDS };
+    const destroy = vi.fn((cb: () => void) => cb());
     const app = express();
     app.use(express.urlencoded({ extended: false }));
     app.use((req: any, _res: any, next: any) => {
-      req.session = { user };
+      req.session = { user, destroy };
       req.csrfToken = () => 'csrf-token';
       next();
     });
@@ -274,6 +290,7 @@ describe('POST /guild/select', () => {
 
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/auth/login?error=user_not_found');
+    expect(destroy).toHaveBeenCalled();
     expect(vi.mocked(getEffectiveAccessLevelForUser)).not.toHaveBeenCalled();
   });
 

--- a/src/web/routes/guild.test.ts
+++ b/src/web/routes/guild.test.ts
@@ -72,6 +72,20 @@ describe('GET /guild/select', () => {
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/');
   });
+
+  it('passes a known ?error= code through to the view', async () => {
+    const res = await supertest(buildApp({ discordId: 'u1', currentGuildId: null, guilds: TWO_GUILDS }))
+      .get('/guild/select?error=guild_not_found');
+    expect(res.status).toBe(200);
+    expect((res.body as any).locals.error).toBe('guild_not_found');
+  });
+
+  it('filters out an unrecognized ?error= code', async () => {
+    const res = await supertest(buildApp({ discordId: 'u1', currentGuildId: null, guilds: TWO_GUILDS }))
+      .get('/guild/select?error=not_a_real_code');
+    expect(res.status).toBe(200);
+    expect((res.body as any).locals.error).toBeNull();
+  });
 });
 
 describe('POST /guild/select', () => {
@@ -116,7 +130,7 @@ describe('POST /guild/select', () => {
       .send({ guild_id: '999000999000999000' });
 
     expect(res.status).toBe(302);
-    expect(res.headers.location).toBe('/guild/select');
+    expect(res.headers.location).toBe('/guild/select?error=guild_not_found');
     expect(user.currentGuildId).toBeNull();
     expect(vi.mocked(getEffectiveAccessLevelForUser)).not.toHaveBeenCalled();
   });
@@ -141,7 +155,7 @@ describe('POST /guild/select', () => {
       .send({ guild_id: '100000000000000002' });
 
     expect(res.status).toBe(302);
-    expect(res.headers.location).toBe('/guild/select');
+    expect(res.headers.location).toBe('/guild/select?error=guild_not_found');
     expect(user.currentGuildId).toBeNull();
     expect(vi.mocked(getEffectiveAccessLevelForUser)).not.toHaveBeenCalled();
   });
@@ -221,7 +235,7 @@ describe('POST /guild/select', () => {
       .send({ guild_id: '100000000000000002' });
 
     expect(res.status).toBe(302);
-    expect(res.headers.location).toBe('/guild/select');
+    expect(res.headers.location).toBe('/guild/select?error=guild_not_found');
     expect(user.guilds).toEqual([{ guildId: '100000000000000001', name: 'Alpha' }]);
   });
 
@@ -236,7 +250,7 @@ describe('POST /guild/select', () => {
       .send({ guild_id: '100000000000000002' });
 
     expect(res.status).toBe(302);
-    expect(res.headers.location).toBe('/auth/login');
+    expect(res.headers.location).toBe('/auth/login?error=no_guilds');
     expect(user.currentGuildId).toBeNull();
     expect(vi.mocked(getEffectiveAccessLevelForUser)).not.toHaveBeenCalled();
   });
@@ -259,7 +273,7 @@ describe('POST /guild/select', () => {
       .send({ guild_id: '100000000000000002' });
 
     expect(res.status).toBe(302);
-    expect(res.headers.location).toBe('/auth/login');
+    expect(res.headers.location).toBe('/auth/login?error=user_not_found');
     expect(vi.mocked(getEffectiveAccessLevelForUser)).not.toHaveBeenCalled();
   });
 
@@ -280,7 +294,7 @@ describe('POST /guild/select', () => {
       .send({ guild_id: 'not-a-snowflake' });
 
     expect(res.status).toBe(302);
-    expect(res.headers.location).toBe('/guild/select');
+    expect(res.headers.location).toBe('/guild/select?error=invalid_guild');
     expect(vi.mocked(getEffectiveAccessLevelForUser)).not.toHaveBeenCalled();
   });
 
@@ -295,7 +309,7 @@ describe('POST /guild/select', () => {
       .send({ guild_id: '100000000000000002' });
 
     expect(res.status).toBe(302);
-    expect(res.headers.location).toBe('/guild/select');
+    expect(res.headers.location).toBe('/guild/select?error=select_failed');
     expect(user.currentGuildId).toBeNull();
   });
 });

--- a/src/web/routes/guild.test.ts
+++ b/src/web/routes/guild.test.ts
@@ -73,12 +73,15 @@ describe('GET /guild/select', () => {
     expect(res.headers.location).toBe('/');
   });
 
-  it('passes a known ?error= code through to the view', async () => {
-    const res = await supertest(buildApp({ discordId: 'u1', currentGuildId: null, guilds: TWO_GUILDS }))
-      .get('/guild/select?error=guild_not_found');
-    expect(res.status).toBe(200);
-    expect((res.body as any).locals.error).toBe('guild_not_found');
-  });
+  it.each(['invalid_guild', 'guild_not_found', 'select_failed'])(
+    'passes a known ?error=%s code through to the view',
+    async (error) => {
+      const res = await supertest(buildApp({ discordId: 'u1', currentGuildId: null, guilds: TWO_GUILDS }))
+        .get(`/guild/select?error=${error}`);
+      expect(res.status).toBe(200);
+      expect((res.body as any).locals.error).toBe(error);
+    },
+  );
 
   it('filters out an unrecognized ?error= code', async () => {
     const res = await supertest(buildApp({ discordId: 'u1', currentGuildId: null, guilds: TWO_GUILDS }))

--- a/src/web/routes/guild.ts
+++ b/src/web/routes/guild.ts
@@ -4,10 +4,13 @@ import { AccessLevel, findUser, getAllGuilds, getEffectiveAccessLevelForUser, ge
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
 import { getSessionUser } from '../session';
-import { normalizeDiscordId, renderView } from './shared';
+import { filterQueryParam, logAndRedirectError, normalizeDiscordId, renderView } from './shared';
 
 const log = createLogger('Web');
 const router = Router();
+
+/** Error codes `GET /guild/select` accepts via `?error=`, all originating from `POST /guild/select`. */
+const KNOWN_ERRORS = new Set(['invalid_guild', 'guild_not_found', 'select_failed']);
 
 // ─── Guild picker ──────────────────────────────────────────────────────────
 //
@@ -17,9 +20,11 @@ const router = Router();
 
 /**
  * Renders the guild picker page for multi-guild users.
- * @param req - Express request; reads `req.session.user.guilds`.
- * @param res - Express response; renders `guildSelect`, or redirects to `/` when the user
- *   has at most one guild (single-guild users are sent straight to the dashboard).
+ * @param req - Express request; reads `req.session.user.guilds` and `req.query.error`
+ *   (set by `POST /guild/select` on failure) to show a banner.
+ * @param res - Express response; renders `guildSelect` with the sanitized `error` code
+ *   if any, or redirects to `/` when the user has at most one guild (single-guild
+ *   users are sent straight to the dashboard).
  */
 router.get('/select', requireAuth, csrfProtection, (req, res) => {
   const user = getSessionUser(req);
@@ -30,6 +35,7 @@ router.get('/select', requireAuth, csrfProtection, (req, res) => {
     user,
     guilds: user.guilds,
     csrfToken: req.csrfToken(),
+    error: filterQueryParam(req.query.error, KNOWN_ERRORS),
   });
 });
 
@@ -46,13 +52,13 @@ router.post('/select', requireAuth, csrfProtection, async (req, res) => {
   const requestedGuildId = typeof guild_id === 'string' ? normalizeDiscordId(guild_id) : null;
 
   if (!requestedGuildId) {
-    return res.redirect('/guild/select');
+    return res.redirect('/guild/select?error=invalid_guild');
   }
 
   try {
     const dbUser = await findUser(user.discordId);
     if (!dbUser) {
-      return res.redirect('/auth/login');
+      return res.redirect('/auth/login?error=user_not_found');
     }
     const isOwner = dbUser.is_owner;
     const liveGuilds = isOwner ? await getAllGuilds() : await getGuildsForMember(user.discordId);
@@ -60,17 +66,23 @@ router.post('/select', requireAuth, csrfProtection, async (req, res) => {
     user.guilds = liveGuilds.map((g) => ({ guildId: g.guild_id, name: g.name }));
     if (user.guilds.length === 0) {
       user.currentGuildId = null;
-      return res.redirect('/auth/login');
+      return res.redirect('/auth/login?error=no_guilds');
     }
     if (!liveGuilds.some((g) => g.guild_id === requestedGuildId)) {
-      return res.redirect('/guild/select');
+      return res.redirect('/guild/select?error=guild_not_found');
     }
     const accessLevel = (await getEffectiveAccessLevelForUser(requestedGuildId, dbUser)) as (typeof AccessLevel)[keyof typeof AccessLevel];
     user.currentGuildId = requestedGuildId;
     user.accessLevel = accessLevel;
   } catch (err) {
-    log.error('Guild select failed:', err);
-    return res.redirect('/guild/select');
+    return logAndRedirectError({
+      res,
+      log,
+      logLabel: 'Guild select failed:',
+      err,
+      basePath: '/guild/select',
+      errorCode: 'select_failed',
+    });
   }
   res.redirect('/');
 });

--- a/src/web/routes/guild.ts
+++ b/src/web/routes/guild.ts
@@ -23,19 +23,22 @@ const KNOWN_ERRORS = new Set(['invalid_guild', 'guild_not_found', 'select_failed
  * @param req - Express request; reads `req.session.user.guilds` and `req.query.error`
  *   (set by `POST /guild/select` on failure) to show a banner.
  * @param res - Express response; renders `guildSelect` with the sanitized `error` code
- *   if any, or redirects to `/` when the user has at most one guild (single-guild
- *   users are sent straight to the dashboard).
+ *   if any, or redirects to `/` when the user has at most one guild and no error is
+ *   present (single-guild users are normally sent straight to the dashboard, but a
+ *   `guild_not_found`/`select_failed` error must still be shown even if the live-guild
+ *   refresh in `POST /guild/select` left the session with only one guild).
  */
 router.get('/select', requireAuth, csrfProtection, (req, res) => {
   const user = getSessionUser(req);
-  if (user.guilds.length <= 1) {
+  const error = filterQueryParam(req.query.error, KNOWN_ERRORS);
+  if (user.guilds.length <= 1 && !error) {
     return res.redirect('/');
   }
   renderView(res, 'guildSelect', {
     user,
     guilds: user.guilds,
     csrfToken: req.csrfToken(),
-    error: filterQueryParam(req.query.error, KNOWN_ERRORS),
+    error,
   });
 });
 
@@ -44,7 +47,11 @@ router.get('/select', requireAuth, csrfProtection, (req, res) => {
  * membership are re-read from the database (not the session's cached `isOwner`/`guilds`,
  * which can be stale if either was revoked after login) before the guild is accepted.
  * On success the effective access level is recomputed for that guild so authorization
- * reflects the current guild, never the previous one.
+ * reflects the current guild, never the previous one. When the session's user no longer
+ * exists in the DB or has no accessible guilds, the session is destroyed (not just
+ * partially cleared) before redirecting to `/auth/login` — otherwise `GET /auth/login`
+ * would see a still-populated `session.user` and bounce straight to `/` without ever
+ * rendering the error.
  */
 router.post('/select', requireAuth, csrfProtection, async (req, res) => {
   const user = getSessionUser(req);
@@ -58,15 +65,19 @@ router.post('/select', requireAuth, csrfProtection, async (req, res) => {
   try {
     const dbUser = await findUser(user.discordId);
     if (!dbUser) {
-      return res.redirect('/auth/login?error=user_not_found');
+      // The session's user no longer exists in the DB — destroy the session so GET
+      // /auth/login doesn't see a still-populated session.user and bounce straight
+      // back to `/` before the error banner ever renders.
+      return req.session.destroy(() => res.redirect('/auth/login?error=user_not_found'));
     }
     const isOwner = dbUser.is_owner;
     const liveGuilds = isOwner ? await getAllGuilds() : await getGuildsForMember(user.discordId);
     user.isOwner = isOwner;
     user.guilds = liveGuilds.map((g) => ({ guildId: g.guild_id, name: g.name }));
     if (user.guilds.length === 0) {
-      user.currentGuildId = null;
-      return res.redirect('/auth/login?error=no_guilds');
+      // Same reasoning as above: destroy the session rather than just clearing
+      // currentGuildId, so the login page's error banner actually reaches the user.
+      return req.session.destroy(() => res.redirect('/auth/login?error=no_guilds'));
     }
     if (!liveGuilds.some((g) => g.guild_id === requestedGuildId)) {
       return res.redirect('/guild/select?error=guild_not_found');

--- a/views/guildSelect.ejs
+++ b/views/guildSelect.ejs
@@ -15,6 +15,17 @@
       <h2 class="section-title">Choose a Server</h2>
       <p class="section-subtitle">You manage more than one server. Pick which one to work in.</p>
 
+      <% if (error) { %>
+      <% const errorMessages = {
+        invalid_guild: 'That server selection was invalid. Please try again.',
+        guild_not_found: 'That server is no longer available to you. Please choose another.',
+        select_failed: 'Something went wrong while switching servers. Please try again.',
+      }; %>
+      <div class="card card-alert-danger" role="alert" aria-live="assertive" aria-atomic="true">
+        <span class="text-danger">&#9888; <%= errorMessages[error] || `Operation failed: ${error.replace(/_/g, ' ')}` %></span>
+      </div>
+      <% } %>
+
       <div class="guild-list">
         <% guilds.forEach(function (g) { %>
         <form method="POST" action="/guild/select" class="guild-select-form">

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -12,6 +12,17 @@
     <div class="login-logo">🤖</div>
     <h1 class="login-title">BCUK Bot</h1>
     <p class="login-subtitle">Sign in with Discord to access the control panel</p>
+
+    <% if (error) { %>
+    <% const errorMessages = {
+      user_not_found: 'Your account could not be found. Please sign in again.',
+      no_guilds: 'You no longer have access to any servers. Contact an admin if this seems wrong.',
+    }; %>
+    <div class="card card-alert-danger" role="alert" aria-live="assertive" aria-atomic="true">
+      <span class="text-danger">&#9888; <%= errorMessages[error] || `Operation failed: ${error.replace(/_/g, ' ')}` %></span>
+    </div>
+    <% } %>
+
     <a href="/auth/discord" class="btn btn-discord">
       <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
         <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>


### PR DESCRIPTION
## Summary

Closes #522.

`POST /guild/select` (`src/web/routes/guild.ts`) redirected on every failure branch with a bare URL instead of the project's documented convention: *"POST routes redirect to `?error=code` on failure; GET reads it and passes to EJS."* This mirrors the pattern already used by ~12 other route files (`commands.ts`, `streams.ts`, `sfx.ts`, `counters.ts`, etc.) via the shared `filterQueryParam`/`logAndRedirectError` helpers in `src/web/routes/shared.ts`.

Per the issue's own scope discussion, this fix covers both `/guild/select`-targeted and `/auth/login`-targeted failure branches (all 5), since neither `guildSelect.ejs` nor `login.ejs` had any error-display markup before this change.

- `src/web/routes/guild.ts`
  - `GET /select` now reads `?error=` (sanitized against a `KNOWN_ERRORS` set) and passes it to the `guildSelect` view.
  - `POST /select`'s 5 failure branches now redirect with a specific error code: `invalid_guild`, `guild_not_found` (×2), `user_not_found`, `no_guilds`, `select_failed` (the catch-block branch now uses `logAndRedirectError` instead of manual `log.error` + bare redirect).
- `src/web/routes/auth.ts` — `GET /login` now reads `?error=` (`user_not_found` / `no_guilds`, both originating from `POST /guild/select`) and passes it to the `login` view.
- `views/guildSelect.ejs` / `views/login.ejs` — added an error banner (`card card-alert-danger`, matching the `commands.ejs` pattern) for the new error codes.
- Updated `src/web/routes/guild.test.ts` and `src/web/routes/auth.test.ts` to assert the new `?error=<code>` query strings and that the sanitized `error` local reaches each view (including that an unrecognized code is filtered to `null`).

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 3096 tests passed)
- [x] `npm run lint` (0 errors; pre-existing unrelated warnings only)
- [x] `npm run check:circular` (no circular dependencies)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4ua6recqxScbKDgukbYZh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Login and guild-selection pages now display clear, accessible error alerts.
  - Recognized errors provide specific guidance, while unexpected errors receive a helpful fallback message.
  - Guild-selection failures now distinguish issues such as invalid selections, unavailable guilds, and missing accounts.
  - Invalid or unsupported error parameters are safely handled without exposing misleading details.

- **Bug Fixes**
  - Improved session handling when account or guild access is unavailable.
  - Guild-selection errors now preserve the selection page when appropriate, helping users recover without unnecessary navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->