### PR TITLE
Reduce CommandRouter log spam for unresolved guild

### DIFF
--- a/src/commands/commandRouter.test.ts
+++ b/src/commands/commandRouter.test.ts
@@ -66,10 +66,21 @@ describe('handleCommand', () => {
     expect(vi.mocked(playFile)).not.toHaveBeenCalled();
   });
 
-  it('skips with a warning and does not look anything up when no guild is resolved', async () => {
+  it('skips without warning when no guild is resolved and the message is not a known trigger', async () => {
+    vi.mocked(findCachedSfxTrigger).mockResolvedValue(null);
+
+    await handleCommand('just chatting about stuff', 'twitch', null);
+
+    expect(vi.mocked(findCachedSfxTrigger)).toHaveBeenCalledWith('just');
+    expect(vi.mocked(playFile)).not.toHaveBeenCalled();
+  });
+
+  it('skips with a warning when a known trigger fires but no guild is resolved', async () => {
+    vi.mocked(findCachedSfxTrigger).mockResolvedValue(LOOKUP);
+
     await handleCommand('!ding', 'twitch', null);
 
-    expect(vi.mocked(findCachedSfxTrigger)).not.toHaveBeenCalled();
+    expect(vi.mocked(findCachedSfxTrigger)).toHaveBeenCalledWith('!ding');
     expect(vi.mocked(playFile)).not.toHaveBeenCalled();
   });
 

--- a/src/commands/commandRouter.test.ts
+++ b/src/commands/commandRouter.test.ts
@@ -3,6 +3,11 @@ import path from 'path';
 import type { SfxTrigger, SfxFile, SfxLookupResult } from '../db';
 
 const SFX_ROOT = '/sfx';
+const { log } = vi.hoisted(() => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../shared/logger', () => ({ createLogger: () => log }));
 
 vi.mock('../shared/config', () => ({
   SFX_FOLDER: '/sfx',
@@ -73,6 +78,7 @@ describe('handleCommand', () => {
 
     expect(vi.mocked(findCachedSfxTrigger)).toHaveBeenCalledWith('just');
     expect(vi.mocked(playFile)).not.toHaveBeenCalled();
+    expect(log.warn).not.toHaveBeenCalled();
   });
 
   it('skips with a warning when a known trigger fires but no guild is resolved', async () => {
@@ -82,6 +88,7 @@ describe('handleCommand', () => {
 
     expect(vi.mocked(findCachedSfxTrigger)).toHaveBeenCalledWith('!ding');
     expect(vi.mocked(playFile)).not.toHaveBeenCalled();
+    expect(log.warn).toHaveBeenCalledWith("[twitch] No active guild resolved for command '!ding', skipping");
   });
 
   it('ignores the command while audio is already playing in that guild', async () => {

--- a/src/commands/commandRouter.ts
+++ b/src/commands/commandRouter.ts
@@ -125,7 +125,9 @@ function tryClaimGuildSlot(
  * @param source     Label used for console logging ('twitch' | 'discord').
  * @param guildId    The guild to target; null when no active guild could be
  *   resolved (e.g. a Twitch command fired while the streamer isn't
- *   connected to voice anywhere) — the command is skipped with a warning.
+ *   connected to voice anywhere) — the command is skipped, with a warning
+ *   logged only if the message actually matches a known trigger (most chat
+ *   messages don't, and would otherwise spam this warning on every message).
  */
 export async function handleCommand(
   rawMessage: string,
@@ -138,7 +140,9 @@ export async function handleCommand(
   if (!command) return;
 
   if (guildId === null) {
-    log.warn(`[${source}] No active guild resolved for command '${command}', skipping`);
+    if (await findCachedSfxTrigger(command)) {
+      log.warn(`[${source}] No active guild resolved for command '${command}', skipping`);
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary
- `CommandRouter.handleCommand` runs on every Twitch chat message, not just SFX triggers. Whenever the streamer wasn't connected to voice anywhere (`guildId === null`), it logged a `WARN` for every message's first word, producing lines like `No active guild resolved for command 'lemme', skipping` for ordinary chat.
- The guild-resolution warning now only fires once the message is confirmed to match a real SFX trigger via `findCachedSfxTrigger`, so plain chat no longer triggers the warning.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 3099 tests passing)
- [x] Added/updated tests in `src/commands/commandRouter.test.ts` covering: no warning for non-trigger chat with unresolved guild, warning still logged for a real trigger with unresolved guild.

---
_Generated by [Claude Code](https://claude.ai/code/session_0156CzK7g3rCssdBvvDFFbtP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unknown chat messages no longer generate unnecessary warnings when no active guild is available.
  * Known sound triggers continue to provide appropriate warnings and skip playback when no active guild can be resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->