### PR TITLE
Add periodic reconciliation poll to catch missed channel-point redemptions

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -41,6 +41,10 @@ vi.mock('./twitch/eventsub/twitchEventSub', () => ({
   stopEventSub: vi.fn(),
   reloadEventSubSubscriptions: vi.fn(),
 }));
+vi.mock('./twitch/eventsub/twitchEventSubReconciliation', () => ({
+  startEventSubReconciliation: vi.fn(),
+  stopEventSubReconciliation: vi.fn().mockResolvedValue(undefined),
+}));
 vi.mock('./web/server', () => ({ startWebPanel: vi.fn() }));
 vi.mock('./audio/audioPlayer', () => ({ disconnect: vi.fn() }));
 vi.mock('./commands/customCommandHandler', () => ({ registerTwitchChatRuntime: vi.fn() }));
@@ -207,11 +211,13 @@ describe('startup — reward pricing scheduler', () => {
   it('starts the scheduler and continues startup through to startEventSub on a clean run', async () => {
     const { startRewardPricingScheduler } = await import('./twitch/pricing/rewardPricingScheduler.js');
     const { startEventSub } = await import('./twitch/eventsub/twitchEventSub.js');
+    const { startEventSubReconciliation } = await import('./twitch/eventsub/twitchEventSubReconciliation.js');
 
     await runMain();
 
     expect(vi.mocked(startRewardPricingScheduler)).toHaveBeenCalledOnce();
     expect(vi.mocked(startEventSub)).toHaveBeenCalledOnce();
+    expect(vi.mocked(startEventSubReconciliation)).toHaveBeenCalledOnce();
     expect(exitSpy).not.toHaveBeenCalled();
   });
 });
@@ -219,12 +225,14 @@ describe('startup — reward pricing scheduler', () => {
 describe('shutdown', () => {
   it('stops the reward pricing scheduler on SIGINT', async () => {
     const { stopRewardPricingScheduler } = await import('./twitch/pricing/rewardPricingScheduler.js');
+    const { stopEventSubReconciliation } = await import('./twitch/eventsub/twitchEventSubReconciliation.js');
 
     await runMain();
     process.emit('SIGINT');
     await new Promise<void>((resolve) => setImmediate(resolve));
 
     expect(vi.mocked(stopRewardPricingScheduler)).toHaveBeenCalledOnce();
+    expect(vi.mocked(stopEventSubReconciliation)).toHaveBeenCalledOnce();
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { startDiscordBot, stopDiscordBot } from './discord/discordBot';
 import { reloadGuildRegistry } from './discord/guildRegistry';
 import { startTwitchMonitor, stopTwitchMonitor, getMultiTwitchDataForChannel } from './twitch/monitor/twitchMonitor';
 import { startEventSub, stopEventSub, reloadEventSubSubscriptions } from './twitch/eventsub/twitchEventSub';
+import { startEventSubReconciliation, stopEventSubReconciliation } from './twitch/eventsub/twitchEventSubReconciliation';
 import { startWebPanel } from './web/server';
 import { disconnect } from './audio/audioPlayer';
 import { registerTwitchChatRuntime } from './commands/customCommandHandler';
@@ -39,6 +40,7 @@ async function shutdown(signal: string): Promise<void> {
   stopCounterScheduler();
   await stopRewardPricingScheduler();
   await stopTimerCommandScheduler();
+  await stopEventSubReconciliation();
   stopEventSub();
   await stopTwitchMonitor();
   await stopTwitchBot();
@@ -132,6 +134,7 @@ async function main(): Promise<void> {
 
   startTwitchMonitor().catch((err) => log.error('TwitchMonitor startup error:', err));
   startEventSub();
+  startEventSubReconciliation();
 }
 
 main().catch((err) => {

--- a/src/twitch/eventsub/twitchEventSubConnection.test.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.test.ts
@@ -369,6 +369,42 @@ describe('StreamerConnection lifecycle', () => {
     expect((conn as any).ws).not.toBeNull();
   });
 
+  it('reconnects on a keepalive timeout even if the socket never fires its own close event', () => {
+    const conn = new StreamerConnection(makeStreamerData());
+    conn.start();
+    const firstWs = (conn as any).ws as MockWebSocket;
+    firstWs.listeners.get('open')!();
+
+    // Default keepaliveTimeoutSecs is 10 (set in the constructor, before any session_welcome
+    // sets a Twitch-provided value), so the timer fires after (10 + 10) * 1000ms.
+    vi.advanceTimersByTime(20_000);
+    expect(firstWs.close).toHaveBeenCalledWith(4000, 'keepalive timeout');
+
+    vi.advanceTimersByTime(1_000); // first reconnect attempt's backoff delay
+    // Reconnected without the mock socket ever invoking its 'close' listener — this is the
+    // half-dead-connection scenario a real close() call can silently never resolve.
+    const secondWs = (conn as any).ws as MockWebSocket;
+    expect(secondWs).not.toBeNull();
+    expect(secondWs).not.toBe(firstWs);
+    expect((conn as any).reconnectAttempts).toBe(1);
+  });
+
+  it('ignores a late close event from a socket already superseded by a keepalive-triggered reconnect', () => {
+    const conn = new StreamerConnection(makeStreamerData());
+    conn.start();
+    const firstWs = (conn as any).ws as MockWebSocket;
+    firstWs.listeners.get('open')!();
+
+    vi.advanceTimersByTime(20_000); // keepalive timeout fires
+    vi.advanceTimersByTime(1_000); // first reconnect attempt's backoff delay
+    const secondWs = (conn as any).ws as MockWebSocket;
+
+    // The first socket's close() eventually does fire its 'close' listener, late.
+    firstWs.listeners.get('close')!({ code: 4000, reason: 'keepalive timeout' } as any);
+
+    expect((conn as any).ws).toBe(secondWs); // unaffected by the stale event
+  });
+
   it('ignores a close event from a stale socket replaced during session migration', () => {
     const conn = new StreamerConnection(makeStreamerData());
     conn.start();

--- a/src/twitch/eventsub/twitchEventSubConnection.test.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.test.ts
@@ -369,6 +369,7 @@ describe('StreamerConnection lifecycle', () => {
     expect((conn as any).ws).not.toBeNull();
   });
 
+  /** Verifies the keepalive-timeout path force-reconnects without waiting on the socket's own 'close' event; returns void. */
   it('reconnects on a keepalive timeout even if the socket never fires its own close event', () => {
     const conn = new StreamerConnection(makeStreamerData());
     conn.start();
@@ -389,6 +390,7 @@ describe('StreamerConnection lifecycle', () => {
     expect((conn as any).reconnectAttempts).toBe(1);
   });
 
+  /** Verifies a stale close event arriving after a keepalive-triggered reconnect is ignored; returns void. */
   it('ignores a late close event from a socket already superseded by a keepalive-triggered reconnect', () => {
     const conn = new StreamerConnection(makeStreamerData());
     conn.start();

--- a/src/twitch/eventsub/twitchEventSubConnection.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.ts
@@ -175,6 +175,13 @@ export class StreamerConnection {
     }
   }
 
+  /**
+   * Handles the socket's `'close'` event: ignores it if `socket` is no longer this connection's
+   * active socket (a stale event from a socket already superseded by a force-reconnect or
+   * session migration), otherwise tears it down and schedules a reconnect via {@link forceReconnect}.
+   * @param ev - The close event, used only for logging the code/reason.
+   * @param socket - The socket that emitted the event.
+   */
   private onClose(ev: CloseEvent, socket: WebSocket): void {
     if (this.ws !== socket) return; // old socket closed during session migration, or already force-reconnected — ignore
     log.warn(`[${this.name}] WebSocket closed: ${ev.code} ${ev.reason}`);
@@ -192,6 +199,8 @@ export class StreamerConnection {
    * this connection's current socket any more (e.g. a session migration or an earlier
    * force-reconnect already superseded it) — including the case where `socket`'s real
    * `'close'` event does eventually land after this already ran.
+   * @param socket - The socket to tear down, or `null` (always a no-op in that case).
+   * @returns Nothing.
    */
   private forceReconnect(socket: WebSocket | null): void {
     if (this.ws !== socket) return;
@@ -281,6 +290,11 @@ export class StreamerConnection {
     if (this.keepaliveTimer) { clearTimeout(this.keepaliveTimer); this.keepaliveTimer = null; }
   }
 
+  /**
+   * (Re)starts the keepalive watchdog: clears any existing timer and arms a new one that, if no
+   * message (including `session_keepalive`) arrives before it fires, force-reconnects immediately
+   * rather than waiting on the socket's own `'close'` event — see {@link forceReconnect}.
+   */
   private resetKeepaliveTimer(): void {
     this.clearKeepaliveTimer();
     this.keepaliveTimer = setTimeout(() => {

--- a/src/twitch/eventsub/twitchEventSubConnection.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.ts
@@ -176,8 +176,25 @@ export class StreamerConnection {
   }
 
   private onClose(ev: CloseEvent, socket: WebSocket): void {
-    if (this.ws !== socket) return; // old socket closed during session migration — ignore
+    if (this.ws !== socket) return; // old socket closed during session migration, or already force-reconnected — ignore
     log.warn(`[${this.name}] WebSocket closed: ${ev.code} ${ev.reason}`);
+    this.forceReconnect(socket);
+  }
+
+  /**
+   * Tears down `socket` as this connection's active WebSocket and schedules a reconnect,
+   * without depending on the socket ever emitting its own `'close'` event. Shared by
+   * {@link onClose} (a real close event did arrive) and the keepalive-timeout path in
+   * {@link resetKeepaliveTimer} (a close was requested but might never actually fire — a
+   * half-dead TCP connection, e.g. after a silent NAT/load-balancer drop, can leave `close()`
+   * pending forever with no `'close'` event ever following it, which would otherwise strand
+   * this connection permanently until the whole process restarts). No-ops if `socket` isn't
+   * this connection's current socket any more (e.g. a session migration or an earlier
+   * force-reconnect already superseded it) — including the case where `socket`'s real
+   * `'close'` event does eventually land after this already ran.
+   */
+  private forceReconnect(socket: WebSocket | null): void {
+    if (this.ws !== socket) return;
     this.clearKeepaliveTimer();
     this.ws = null;
     this.sessionId = null;
@@ -268,7 +285,11 @@ export class StreamerConnection {
     this.clearKeepaliveTimer();
     this.keepaliveTimer = setTimeout(() => {
       log.warn(`[${this.name}] Keepalive timeout — reconnecting`);
-      this.ws?.close(4000, 'keepalive timeout');
+      const socket = this.ws;
+      // Best-effort: ask the socket to close, but don't wait on its 'close' event — see
+      // forceReconnect's doc comment for why that event can never arrive.
+      socket?.close(4000, 'keepalive timeout');
+      this.forceReconnect(socket);
     }, (this.keepaliveTimeoutSecs + 10) * 1_000);
   }
 }

--- a/src/twitch/eventsub/twitchEventSubDispatch.test.ts
+++ b/src/twitch/eventsub/twitchEventSubDispatch.test.ts
@@ -31,7 +31,7 @@ vi.mock('./twitchEventSubHandler', () => ({
   handleChannelUpdate: vi.fn().mockResolvedValue(undefined),
 }));
 
-import { setStreamerInfo, removeStreamerFromMap, dispatchNotification, handleRevocation } from './twitchEventSubDispatch';
+import { setStreamerInfo, removeStreamerFromMap, dispatchNotification, handleRevocation, getAllStreamerInfo } from './twitchEventSubDispatch';
 import { clearStreamerToken, DEFAULT_EVENT_CONFIG } from '../../db';
 import {
   handleStreamOnline, handleStreamOffline, handleChannelUpdate,
@@ -212,5 +212,15 @@ describe('handleRevocation', () => {
     await new Promise((resolve) => setImmediate(resolve));
 
     expect(logMock.error).toHaveBeenCalledWith('Clear token error:', expect.any(Error));
+  });
+});
+
+describe('getAllStreamerInfo', () => {
+  it('reflects entries added via setStreamerInfo and removed via removeStreamerFromMap', () => {
+    setStreamerInfo('uid-getall', { login: 'getAllStreamer', streamerId: 999, config: null });
+    expect(getAllStreamerInfo().get('uid-getall')).toEqual({ login: 'getAllStreamer', streamerId: 999, config: null });
+
+    removeStreamerFromMap('uid-getall');
+    expect(getAllStreamerInfo().has('uid-getall')).toBe(false);
   });
 });

--- a/src/twitch/eventsub/twitchEventSubDispatch.ts
+++ b/src/twitch/eventsub/twitchEventSubDispatch.ts
@@ -23,6 +23,15 @@ export function removeStreamerFromMap(uid: string): void {
   streamerMap.delete(uid);
 }
 
+/**
+ * Returns the live streamer-dispatch map, keyed by broadcaster Twitch user ID. Read-only view
+ * used by the EventSub reconciliation poll to enumerate every streamer currently connected via
+ * EventSub, without duplicating this module's connection-tracking state.
+ */
+export function getAllStreamerInfo(): ReadonlyMap<string, StreamerInfo> {
+  return streamerMap;
+}
+
 // Maps EventSub notification types to their handler functions.
 // Using Map instead of a plain object prevents prototype-chain lookup on user-controlled keys.
 type NotificationHandler = (login: string, event: unknown, config: EventSubConfig, streamerId: number) => Promise<void>;

--- a/src/twitch/eventsub/twitchEventSubReconciliation.test.ts
+++ b/src/twitch/eventsub/twitchEventSubReconciliation.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
+vi.mock('../../db', () => ({
+  getStreamerById: vi.fn(),
+  DEFAULT_EVENT_CONFIG: { follow_enabled: false, sub_enabled: false, raid_enabled: false },
+}));
+vi.mock('./twitchEventSubDispatch', () => ({ getAllStreamerInfo: vi.fn() }));
+vi.mock('./twitchApiEventSub', () => ({ getValidToken: vi.fn() }));
+vi.mock('../twitchApi', () => ({ getCustomRewards: vi.fn(), getRewardRedemptions: vi.fn() }));
+vi.mock('./twitchEventSubHandler', () => ({ handleRedemption: vi.fn() }));
+
+import { getStreamerById } from '../../db';
+import { getAllStreamerInfo } from './twitchEventSubDispatch';
+import { getValidToken } from './twitchApiEventSub';
+import { getCustomRewards, getRewardRedemptions } from '../twitchApi';
+import { handleRedemption } from './twitchEventSubHandler';
+import {
+  runReconciliationTick, startEventSubReconciliation, stopEventSubReconciliation,
+  __resetReconciliationCursorsForTests,
+} from './twitchEventSubReconciliation';
+
+const streamer = { id: 1, twitch_name: 'streamerA', eventsub_access_token: 'tok' } as any;
+const config = { follow_enabled: true } as any;
+const info = { login: 'streamerA', streamerId: 1, config };
+
+function redemption(id: string, redeemedAt: string, overrides: Partial<any> = {}) {
+  return {
+    id, user_id: 'u1', user_login: 'viewer', user_name: 'Viewer', user_input: '',
+    status: 'FULFILLED', redeemed_at: redeemedAt,
+    reward: { id: 'rwd1', title: 'Cool Reward', prompt: '', cost: 100 },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  __resetReconciliationCursorsForTests();
+  vi.mocked(getStreamerById).mockResolvedValue(streamer);
+  vi.mocked(getValidToken).mockResolvedValue('user-token');
+  vi.mocked(getCustomRewards).mockResolvedValue([{ id: 'rwd1' } as any]);
+  vi.mocked(getRewardRedemptions).mockResolvedValue([]);
+  vi.mocked(handleRedemption).mockResolvedValue(undefined);
+});
+
+afterEach(async () => {
+  await stopEventSubReconciliation();
+  vi.useRealTimers();
+});
+
+describe('runReconciliationTick', () => {
+  it('only baselines a reward on its first tick, without calling handleRedemption', async () => {
+    vi.mocked(getAllStreamerInfo).mockReturnValue(new Map([['uid1', info]]));
+    vi.mocked(getRewardRedemptions).mockResolvedValue([redemption('r1', new Date().toISOString())]);
+
+    await runReconciliationTick();
+
+    expect(handleRedemption).not.toHaveBeenCalled();
+  });
+
+  it('replays a redemption newer than the cursor on a later tick', async () => {
+    vi.mocked(getAllStreamerInfo).mockReturnValue(new Map([['uid1', info]]));
+    await runReconciliationTick(); // baseline
+
+    const future = new Date(Date.now() + 5_000).toISOString();
+    vi.mocked(getRewardRedemptions).mockImplementation(async (_uid, _rewardId, status) =>
+      (status === 'FULFILLED' ? [redemption('r1', future)] : []));
+    await runReconciliationTick();
+
+    expect(handleRedemption).toHaveBeenCalledTimes(1);
+    expect(handleRedemption).toHaveBeenCalledWith(
+      'streamerA',
+      expect.objectContaining({ id: 'r1', reward: { id: 'rwd1', title: 'Cool Reward' } }),
+      config,
+      1,
+    );
+  });
+
+  it('does not replay a redemption older than or equal to the cursor', async () => {
+    vi.mocked(getAllStreamerInfo).mockReturnValue(new Map([['uid1', info]]));
+    await runReconciliationTick(); // baseline at "now"
+
+    const past = new Date(Date.now() - 60_000).toISOString();
+    vi.mocked(getRewardRedemptions).mockResolvedValue([redemption('r1', past)]);
+    await runReconciliationTick();
+
+    expect(handleRedemption).not.toHaveBeenCalled();
+  });
+
+  it('skips a streamer with no config row — they never got the redemption subscription in the first place', async () => {
+    vi.mocked(getAllStreamerInfo).mockReturnValue(new Map([['uid1', { ...info, config: null }]]));
+    await runReconciliationTick();
+    expect(getStreamerById).not.toHaveBeenCalled();
+  });
+
+  it('skips a streamer with no valid broadcaster token', async () => {
+    vi.mocked(getAllStreamerInfo).mockReturnValue(new Map([['uid1', info]]));
+    vi.mocked(getValidToken).mockResolvedValue(null);
+
+    await runReconciliationTick();
+
+    expect(getCustomRewards).not.toHaveBeenCalled();
+  });
+
+  it('continues to the next streamer when one fails to list custom rewards', async () => {
+    vi.mocked(getAllStreamerInfo).mockReturnValue(new Map([
+      ['uid1', info],
+      ['uid2', { login: 'streamerB', streamerId: 2, config }],
+    ]));
+    vi.mocked(getStreamerById).mockImplementation(async (id) => (id === 1 ? streamer : { ...streamer, id: 2 }));
+    vi.mocked(getCustomRewards).mockImplementation(async (uid) => {
+      if (uid === 'uid1') throw new Error('helix down');
+      return [{ id: 'rwd2' } as any];
+    });
+
+    await expect(runReconciliationTick()).resolves.toBeUndefined();
+    expect(getCustomRewards).toHaveBeenCalledTimes(2);
+  });
+
+  it('reuses the in-flight tick promise instead of starting a second concurrent tick', async () => {
+    let resolveFirst!: () => void;
+    const gate = new Promise<void>((resolve) => { resolveFirst = resolve; });
+    vi.mocked(getAllStreamerInfo).mockReturnValue(new Map([['uid1', info]]));
+    vi.mocked(getStreamerById).mockImplementation(async () => { await gate; return streamer; });
+
+    const first = runReconciliationTick();
+    const second = runReconciliationTick();
+
+    resolveFirst();
+    await Promise.all([first, second]);
+
+    expect(getStreamerById).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('startEventSubReconciliation / stopEventSubReconciliation', () => {
+  it('fires runReconciliationTick on the configured interval and stops on request', async () => {
+    vi.mocked(getAllStreamerInfo).mockReturnValue(new Map());
+    startEventSubReconciliation();
+
+    expect(getAllStreamerInfo).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(getAllStreamerInfo).toHaveBeenCalledTimes(1);
+
+    await stopEventSubReconciliation();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(getAllStreamerInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not leak the interval when started twice without stopping', async () => {
+    vi.mocked(getAllStreamerInfo).mockReturnValue(new Map());
+    startEventSubReconciliation();
+    startEventSubReconciliation();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(getAllStreamerInfo).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/twitch/eventsub/twitchEventSubReconciliation.test.ts
+++ b/src/twitch/eventsub/twitchEventSubReconciliation.test.ts
@@ -37,6 +37,17 @@ function redemption(id: string, redeemedAt: string, overrides: Partial<any> = {}
   };
 }
 
+/** Only the FULFILLED status call returns `redemptions`; UNFULFILLED always returns an empty page. */
+function mockFulfilledOnly(...pages: Array<{ redemptions: ReturnType<typeof redemption>[]; cursor: string | null }>) {
+  let call = 0;
+  vi.mocked(getRewardRedemptions).mockImplementation(async (_uid, _rewardId, status) => {
+    if (status !== 'FULFILLED') return { redemptions: [], cursor: null };
+    const page = pages[Math.min(call, pages.length - 1)];
+    call++;
+    return page;
+  });
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   vi.useFakeTimers();
@@ -44,7 +55,7 @@ beforeEach(() => {
   vi.mocked(getStreamerById).mockResolvedValue(streamer);
   vi.mocked(getValidToken).mockResolvedValue('user-token');
   vi.mocked(getCustomRewards).mockResolvedValue([{ id: 'rwd1' } as any]);
-  vi.mocked(getRewardRedemptions).mockResolvedValue([]);
+  vi.mocked(getRewardRedemptions).mockResolvedValue({ redemptions: [], cursor: null });
   vi.mocked(handleRedemption).mockResolvedValue(undefined);
 });
 
@@ -54,9 +65,25 @@ afterEach(async () => {
 });
 
 describe('runReconciliationTick', () => {
-  it('only baselines a reward on its first tick, without calling handleRedemption', async () => {
+  it('on the very first tick, replays a redemption within the one-poll-interval lookback window', async () => {
     vi.mocked(getAllStreamerInfo).mockReturnValue(new Map([['uid1', info]]));
-    vi.mocked(getRewardRedemptions).mockResolvedValue([redemption('r1', new Date().toISOString())]);
+    mockFulfilledOnly({ redemptions: [redemption('r1', new Date().toISOString())], cursor: null });
+
+    await runReconciliationTick();
+
+    expect(handleRedemption).toHaveBeenCalledTimes(1);
+    expect(handleRedemption).toHaveBeenCalledWith(
+      'streamerA',
+      expect.objectContaining({ id: 'r1', reward: { id: 'rwd1', title: 'Cool Reward' } }),
+      config,
+      1,
+    );
+  });
+
+  it('does not replay a redemption older than the initial one-poll-interval lookback', async () => {
+    vi.mocked(getAllStreamerInfo).mockReturnValue(new Map([['uid1', info]]));
+    const tooOld = new Date(Date.now() - 120_000).toISOString(); // 2 intervals ago
+    mockFulfilledOnly({ redemptions: [redemption('r1', tooOld)], cursor: null });
 
     await runReconciliationTick();
 
@@ -65,11 +92,10 @@ describe('runReconciliationTick', () => {
 
   it('replays a redemption newer than the cursor on a later tick', async () => {
     vi.mocked(getAllStreamerInfo).mockReturnValue(new Map([['uid1', info]]));
-    await runReconciliationTick(); // baseline
+    await runReconciliationTick(); // establishes the cursor
 
     const future = new Date(Date.now() + 5_000).toISOString();
-    vi.mocked(getRewardRedemptions).mockImplementation(async (_uid, _rewardId, status) =>
-      (status === 'FULFILLED' ? [redemption('r1', future)] : []));
+    mockFulfilledOnly({ redemptions: [redemption('r1', future)], cursor: null });
     await runReconciliationTick();
 
     expect(handleRedemption).toHaveBeenCalledTimes(1);
@@ -83,13 +109,56 @@ describe('runReconciliationTick', () => {
 
   it('does not replay a redemption older than or equal to the cursor', async () => {
     vi.mocked(getAllStreamerInfo).mockReturnValue(new Map([['uid1', info]]));
-    await runReconciliationTick(); // baseline at "now"
+    await runReconciliationTick(); // cursor lands at "now"
 
     const past = new Date(Date.now() - 60_000).toISOString();
-    vi.mocked(getRewardRedemptions).mockResolvedValue([redemption('r1', past)]);
+    mockFulfilledOnly({ redemptions: [redemption('r1', past)], cursor: null });
     await runReconciliationTick();
 
     expect(handleRedemption).not.toHaveBeenCalled();
+  });
+
+  it('pages through results, stopping as soon as a page reaches the cutoff', async () => {
+    vi.mocked(getAllStreamerInfo).mockReturnValue(new Map([['uid1', info]]));
+    await runReconciliationTick(); // establishes the cursor one poll interval before "now"
+
+    const cutoff = Date.now() - 60_000; // the cursor established by the tick above
+    const page1 = [redemption('r3', new Date(cutoff + 3_000).toISOString()), redemption('r2', new Date(cutoff + 2_000).toISOString())];
+    // page 2 includes one redemption at-or-before the cutoff — pagination must stop there without using its cursor.
+    const page2 = [redemption('r1', new Date(cutoff + 1_000).toISOString()), redemption('r0', new Date(cutoff - 5_000).toISOString())];
+    mockFulfilledOnly(
+      { redemptions: page1, cursor: 'page-2-cursor' },
+      { redemptions: page2, cursor: 'page-3-cursor' },
+    );
+    vi.mocked(getRewardRedemptions).mockClear();
+
+    await runReconciliationTick();
+
+    const handledIds = vi.mocked(handleRedemption).mock.calls.map(([, event]) => (event as any).id);
+    expect(handledIds.sort()).toEqual(['r1', 'r2', 'r3']);
+    // Only 2 pages fetched for the FULFILLED status — page 2's cutoff redemption stopped a 3rd page fetch.
+    const fulfilledCalls = vi.mocked(getRewardRedemptions).mock.calls.filter(([, , status]) => status === 'FULFILLED');
+    expect(fulfilledCalls).toHaveLength(2);
+    expect(fulfilledCalls[1][4]).toBe('page-2-cursor'); // second call passed the first page's cursor as `after`
+  });
+
+  it('does not advance the cursor when a redemption fails to handle, so it is retried on the next tick', async () => {
+    vi.mocked(getAllStreamerInfo).mockReturnValue(new Map([['uid1', info]]));
+    await runReconciliationTick(); // establishes the cursor at "now"
+
+    const redeemedAt = new Date(Date.now() + 1_000).toISOString();
+    mockFulfilledOnly({ redemptions: [redemption('r1', redeemedAt)], cursor: null });
+    vi.mocked(handleRedemption).mockRejectedValueOnce(new Error('handler boom'));
+
+    await runReconciliationTick();
+    expect(handleRedemption).toHaveBeenCalledTimes(1);
+
+    // Cursor wasn't advanced past the failure — the same redemption is fetched and retried.
+    vi.mocked(handleRedemption).mockResolvedValue(undefined);
+    await runReconciliationTick();
+
+    expect(handleRedemption).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(handleRedemption).mock.calls[1][1]).toEqual(expect.objectContaining({ id: 'r1' }));
   });
 
   it('skips a streamer with no config row — they never got the redemption subscription in the first place', async () => {

--- a/src/twitch/eventsub/twitchEventSubReconciliation.ts
+++ b/src/twitch/eventsub/twitchEventSubReconciliation.ts
@@ -1,0 +1,154 @@
+import { createLogger } from '../../shared/logger';
+import { getStreamerById, DEFAULT_EVENT_CONFIG } from '../../db';
+import { getAllStreamerInfo, type StreamerInfo } from './twitchEventSubDispatch';
+import { getValidToken } from './twitchApiEventSub';
+import { getCustomRewards, getRewardRedemptions, TwitchRewardRedemption } from '../twitchApi';
+import { handleRedemption, RedemptionEvent } from './twitchEventSubHandler';
+
+const log = createLogger('EventSubReconciliation');
+
+const POLL_INTERVAL_MS = 60_000;
+
+/**
+ * Last-seen redemption timestamp (epoch ms) per `${broadcasterUserId}:${twitchRewardId}`,
+ * tracked purely in memory (mirrors the existing WebSocket/redemption dedup caches). A key's
+ * first poll only records the current time as a baseline instead of replaying history — this
+ * poll exists to catch redemptions missed *while the bot was running* (a WebSocket reconnect
+ * gap, a keepalive timeout, a session migration window), not to backfill everything that
+ * happened before this process started or before a reward was first seen.
+ */
+const lastSeenRedeemedAt = new Map<string, number>();
+
+let tickTimer: ReturnType<typeof setInterval> | null = null;
+let tickRunning = false;
+let currentTickPromise: Promise<void> = Promise.resolve();
+
+/** Maps a Helix redemption row to the shape `handleRedemption` expects from a live EventSub notification. */
+function toRedemptionEvent(broadcasterLogin: string, r: TwitchRewardRedemption): RedemptionEvent {
+  return {
+    id: r.id,
+    user_login: r.user_login,
+    user_name: r.user_name,
+    broadcaster_user_login: broadcasterLogin,
+    reward: { id: r.reward.id, title: r.reward.title },
+    user_input: r.user_input,
+  };
+}
+
+/**
+ * Fetches recent redemptions for one reward (both UNFULFILLED — still in the queue — and
+ * FULFILLED — including rewards with `should_redemptions_skip_request_queue` set, which never
+ * appear as UNFULFILLED) and replays any redeemed after the reward's tracked cursor through
+ * {@link handleRedemption}. `handleRedemption` itself dedupes on the redemption id, so a
+ * redemption already delivered live via the WebSocket is a safe no-op here — this only ever
+ * has an effect for a redemption the WebSocket never delivered at all.
+ *
+ * @param info - Dispatch info for the redemption's streamer (login/streamerId/config).
+ * @param uid - Broadcaster's Twitch user ID.
+ * @param token - Broadcaster's currently-valid OAuth user token.
+ * @param rewardId - Twitch reward UUID to reconcile.
+ */
+async function reconcileReward(info: StreamerInfo, uid: string, token: string, rewardId: string): Promise<void> {
+  const key = `${uid}:${rewardId}`;
+  const cutoff = lastSeenRedeemedAt.get(key);
+  if (cutoff === undefined) {
+    lastSeenRedeemedAt.set(key, Date.now());
+    return;
+  }
+
+  let redemptions: TwitchRewardRedemption[];
+  try {
+    const [unfulfilled, fulfilled] = await Promise.all([
+      getRewardRedemptions(uid, rewardId, 'UNFULFILLED', token),
+      getRewardRedemptions(uid, rewardId, 'FULFILLED', token),
+    ]);
+    redemptions = [...unfulfilled, ...fulfilled];
+  } catch (err) {
+    log.error(`Failed to fetch redemptions for reward ${rewardId} (${info.login}):`, err);
+    return;
+  }
+
+  let maxSeen = cutoff;
+  for (const r of redemptions) {
+    const redeemedAt = Date.parse(r.redeemed_at);
+    if (!Number.isFinite(redeemedAt) || redeemedAt <= cutoff) continue;
+    if (redeemedAt > maxSeen) maxSeen = redeemedAt;
+    log.warn(`Reconciliation caught a redemption missed by EventSub: "${r.reward.title}" (id=${r.id}) for ${info.login}`);
+    try {
+      await handleRedemption(info.login, toRedemptionEvent(info.login, r), info.config ?? DEFAULT_EVENT_CONFIG, info.streamerId);
+    } catch (err) {
+      log.error(`Reconciled-redemption handler error for redemption ${r.id} (${info.login}):`, err);
+    }
+  }
+  lastSeenRedeemedAt.set(key, maxSeen);
+}
+
+/**
+ * Reconciles one streamer: resolves their broadcaster token, lists their custom rewards, and
+ * reconciles each one via {@link reconcileReward}. No-ops silently if the streamer has no
+ * usable token (nothing to authenticate the Helix calls with — the same condition that would
+ * already be blocking their EventSub subscriptions from existing).
+ *
+ * @param uid - Broadcaster's Twitch user ID (the streamer map's key).
+ * @param info - Dispatch info for this streamer.
+ */
+async function reconcileStreamer(uid: string, info: StreamerInfo): Promise<void> {
+  const streamer = await getStreamerById(info.streamerId);
+  const token = streamer ? await getValidToken(streamer) : null;
+  if (!token) return;
+
+  let rewards;
+  try {
+    rewards = await getCustomRewards(uid, token);
+  } catch (err) {
+    log.error(`Failed to list custom rewards for ${info.login}:`, err);
+    return;
+  }
+
+  await Promise.allSettled(rewards.map((reward) => reconcileReward(info, uid, token, reward.id)));
+}
+
+/**
+ * Runs one reconciliation pass across every streamer currently connected via EventSub with a
+ * completed setup (`info.config` non-null — the same gate `hasCompletedEventSubSetup` uses to
+ * decide whether the channel-points redemption subscription itself exists; a streamer without
+ * it was never subscribed, so there's nothing for this poll to have missed). Streamers are
+ * reconciled concurrently and independently — one streamer's failure can't block another's.
+ */
+export async function runReconciliationTick(): Promise<void> {
+  if (tickRunning) return currentTickPromise;
+  tickRunning = true;
+  currentTickPromise = (async () => {
+    try {
+      const entries = [...getAllStreamerInfo()].filter(([, info]) => info.config !== null);
+      await Promise.allSettled(entries.map(([uid, info]) => reconcileStreamer(uid, info)));
+    } finally {
+      tickRunning = false;
+    }
+  })();
+  return currentTickPromise;
+}
+
+/**
+ * Starts the periodic redemption-reconciliation interval. Call once at bot startup, after
+ * EventSub has started (so `getAllStreamerInfo()` has something to iterate).
+ * No-ops if already started, so a second call can't leak the original interval handle.
+ */
+export function startEventSubReconciliation(): void {
+  if (tickTimer) return;
+  tickTimer = setInterval(() => {
+    runReconciliationTick().catch((err) => log.error('Reconciliation tick error:', err));
+  }, POLL_INTERVAL_MS);
+  log.info(`Started — redemption reconciliation every ${POLL_INTERVAL_MS / 1000}s`);
+}
+
+/** Stops the periodic reconciliation interval and awaits any in-flight tick before returning. */
+export async function stopEventSubReconciliation(): Promise<void> {
+  if (tickTimer) { clearInterval(tickTimer); tickTimer = null; }
+  await currentTickPromise;
+}
+
+/** Test-only: clears the in-memory per-reward cursor cache so each test starts from a clean slate. */
+export function __resetReconciliationCursorsForTests(): void {
+  lastSeenRedeemedAt.clear();
+}

--- a/src/twitch/eventsub/twitchEventSubReconciliation.ts
+++ b/src/twitch/eventsub/twitchEventSubReconciliation.ts
@@ -12,10 +12,10 @@ const POLL_INTERVAL_MS = 60_000;
 /**
  * Last-seen redemption timestamp (epoch ms) per `${broadcasterUserId}:${twitchRewardId}`,
  * tracked purely in memory (mirrors the existing WebSocket/redemption dedup caches). A key's
- * first poll only records the current time as a baseline instead of replaying history — this
- * poll exists to catch redemptions missed *while the bot was running* (a WebSocket reconnect
- * gap, a keepalive timeout, a session migration window), not to backfill everything that
- * happened before this process started or before a reward was first seen.
+ * first poll looks back only one {@link POLL_INTERVAL_MS} instead of the reward's full history —
+ * this poll exists to catch redemptions missed *while the bot was running* (a WebSocket
+ * reconnect gap, a keepalive timeout, a session migration window, including the window right
+ * after startup), not to backfill everything that ever happened for a reward.
  */
 const lastSeenRedeemedAt = new Map<string, number>();
 
@@ -36,12 +36,52 @@ function toRedemptionEvent(broadcasterLogin: string, r: TwitchRewardRedemption):
 }
 
 /**
+ * Fetches every redemption for one reward+status newer than `cutoff`, paging (newest first)
+ * until a page contains a redemption at or before `cutoff` — everything after that point, and on
+ * every later page, is even older, so pagination stops there rather than walking the reward's
+ * entire history. This bounds the call count even for a reward with heavy redemption volume: a
+ * long-lived reward with thousands of past redemptions only ever pages through however many are
+ * actually newer than the cursor, typically zero or one page at the normal poll cadence.
+ *
+ * @param uid - Broadcaster's Twitch user ID.
+ * @param rewardId - Twitch reward UUID.
+ * @param status - Redemption status to query (see {@link getRewardRedemptions}).
+ * @param token - Broadcaster's currently-valid OAuth user token.
+ * @param cutoff - Epoch ms; only redemptions redeemed strictly after this are returned.
+ */
+async function fetchRedemptionsNewerThan(
+  uid: string, rewardId: string, status: 'UNFULFILLED' | 'FULFILLED', token: string, cutoff: number,
+): Promise<TwitchRewardRedemption[]> {
+  const result: TwitchRewardRedemption[] = [];
+  let after: string | undefined;
+  for (;;) {
+    const page = await getRewardRedemptions(uid, rewardId, status, token, after);
+    let hitCutoff = false;
+    for (const r of page.redemptions) {
+      const redeemedAt = Date.parse(r.redeemed_at);
+      if (!Number.isFinite(redeemedAt) || redeemedAt <= cutoff) { hitCutoff = true; break; }
+      result.push(r);
+    }
+    if (hitCutoff || !page.cursor || page.redemptions.length === 0) break;
+    after = page.cursor;
+  }
+  return result;
+}
+
+/**
  * Fetches recent redemptions for one reward (both UNFULFILLED — still in the queue — and
  * FULFILLED — including rewards with `should_redemptions_skip_request_queue` set, which never
  * appear as UNFULFILLED) and replays any redeemed after the reward's tracked cursor through
  * {@link handleRedemption}. `handleRedemption` itself dedupes on the redemption id, so a
  * redemption already delivered live via the WebSocket is a safe no-op here — this only ever
  * has an effect for a redemption the WebSocket never delivered at all.
+ *
+ * The cursor only advances past a redemption once `handleRedemption` has actually succeeded for
+ * it; if any redemption in this tick fails to handle, the cursor is left exactly where it was
+ * before this tick, so every redemption fetched this tick (including ones that already
+ * succeeded) is retried on the next tick. That reprocessing is safe: it lands well within
+ * `handleRedemption`'s own redemption-id dedup TTL, so an already-handled redemption is a no-op
+ * there rather than a real duplicate.
  *
  * @param info - Dispatch info for the redemption's streamer (login/streamerId/config).
  * @param uid - Broadcaster's Twitch user ID.
@@ -50,17 +90,16 @@ function toRedemptionEvent(broadcasterLogin: string, r: TwitchRewardRedemption):
  */
 async function reconcileReward(info: StreamerInfo, uid: string, token: string, rewardId: string): Promise<void> {
   const key = `${uid}:${rewardId}`;
-  const cutoff = lastSeenRedeemedAt.get(key);
-  if (cutoff === undefined) {
-    lastSeenRedeemedAt.set(key, Date.now());
-    return;
-  }
+  // First time seeing this reward: look back one poll interval rather than the reward's full
+  // history — this still covers the window right after the bot (re)started or first subscribed
+  // for this streamer, instead of leaving it as a permanent blind spot.
+  const cutoff = lastSeenRedeemedAt.get(key) ?? Date.now() - POLL_INTERVAL_MS;
 
   let redemptions: TwitchRewardRedemption[];
   try {
     const [unfulfilled, fulfilled] = await Promise.all([
-      getRewardRedemptions(uid, rewardId, 'UNFULFILLED', token),
-      getRewardRedemptions(uid, rewardId, 'FULFILLED', token),
+      fetchRedemptionsNewerThan(uid, rewardId, 'UNFULFILLED', token, cutoff),
+      fetchRedemptionsNewerThan(uid, rewardId, 'FULFILLED', token, cutoff),
     ]);
     redemptions = [...unfulfilled, ...fulfilled];
   } catch (err) {
@@ -69,18 +108,20 @@ async function reconcileReward(info: StreamerInfo, uid: string, token: string, r
   }
 
   let maxSeen = cutoff;
+  let hadFailure = false;
   for (const r of redemptions) {
     const redeemedAt = Date.parse(r.redeemed_at);
-    if (!Number.isFinite(redeemedAt) || redeemedAt <= cutoff) continue;
-    if (redeemedAt > maxSeen) maxSeen = redeemedAt;
+    if (!Number.isFinite(redeemedAt)) continue;
     log.warn(`Reconciliation caught a redemption missed by EventSub: "${r.reward.title}" (id=${r.id}) for ${info.login}`);
     try {
       await handleRedemption(info.login, toRedemptionEvent(info.login, r), info.config ?? DEFAULT_EVENT_CONFIG, info.streamerId);
+      if (redeemedAt > maxSeen) maxSeen = redeemedAt;
     } catch (err) {
       log.error(`Reconciled-redemption handler error for redemption ${r.id} (${info.login}):`, err);
+      hadFailure = true;
     }
   }
-  lastSeenRedeemedAt.set(key, maxSeen);
+  if (!hadFailure) lastSeenRedeemedAt.set(key, maxSeen);
 }
 
 /**

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -10,7 +10,7 @@ import { setStreamerInfo } from './twitchEventSubDispatch';
 
 const log = createLogger('EventSub');
 
-export { dispatchNotification, handleRevocation, removeStreamerFromMap } from './twitchEventSubDispatch';
+export { dispatchNotification, handleRevocation, removeStreamerFromMap, getAllStreamerInfo } from './twitchEventSubDispatch';
 export { getAlertTypesCoveredBySubscriptionGroups } from './twitchEventSubSubscriptionGroups';
 
 // Tracks "login:type:token" triples that failed with 403 — skipped until bot restarts or token changes

--- a/src/twitch/twitchApi.test.ts
+++ b/src/twitch/twitchApi.test.ts
@@ -10,6 +10,7 @@ vi.mock('../shared/config', () => ({
 import {
   getUsers, getStreams, getChannelInfo, getSharedChatSession, getAppToken,
   getCustomRewards, updateRewardCost, createCustomReward, updateCustomReward, deleteCustomReward,
+  getRewardRedemptions,
   TwitchRewardUnsupportedError, TwitchRewardAuthError,
 } from './twitchApi';
 
@@ -183,6 +184,38 @@ describe('getCustomRewards', () => {
   it('throws a generic error for other non-OK statuses', async () => {
     vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(500, {}));
     await expect(getCustomRewards('bc1', 'user-token')).rejects.toThrow('getCustomRewards failed: 500');
+  });
+});
+
+describe('getRewardRedemptions', () => {
+  it('sends a GET with broadcaster_id, reward_id, and status query params, returning the redemption list', async () => {
+    const redemptions = [{ id: 'redemp1', user_login: 'viewer1', status: 'UNFULFILLED' }];
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(200, { data: redemptions }));
+
+    const result = await getRewardRedemptions('bc1', 'rwd1', 'UNFULFILLED', 'user-token');
+
+    const [url, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+    expect(String(url)).toContain('broadcaster_id=bc1');
+    expect(String(url)).toContain('reward_id=rwd1');
+    expect(String(url)).toContain('status=UNFULFILLED');
+    expect(String(url)).toContain('sort=NEWEST_FIRST');
+    expect(init?.method).toBeUndefined(); // defaults to GET
+    expect(result).toEqual(redemptions);
+  });
+
+  it('throws with the response status on a 401 response', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(401, {}));
+    await expect(getRewardRedemptions('bc1', 'rwd1', 'FULFILLED', 'user-token')).rejects.toThrow('getRewardRedemptions failed: 401');
+  });
+
+  it('returns an empty array on a 403 response, rather than throwing', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(403, {}));
+    expect(await getRewardRedemptions('bc1', 'rwd1', 'UNFULFILLED', 'user-token')).toEqual([]);
+  });
+
+  it('throws a generic error for other non-OK statuses', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(500, {}));
+    await expect(getRewardRedemptions('bc1', 'rwd1', 'UNFULFILLED', 'user-token')).rejects.toThrow('getRewardRedemptions failed: 500');
   });
 });
 

--- a/src/twitch/twitchApi.test.ts
+++ b/src/twitch/twitchApi.test.ts
@@ -188,9 +188,9 @@ describe('getCustomRewards', () => {
 });
 
 describe('getRewardRedemptions', () => {
-  it('sends a GET with broadcaster_id, reward_id, and status query params, returning the redemption list', async () => {
+  it('sends a GET with broadcaster_id, reward_id, and status query params, returning the redemption page', async () => {
     const redemptions = [{ id: 'redemp1', user_login: 'viewer1', status: 'UNFULFILLED' }];
-    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(200, { data: redemptions }));
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(200, { data: redemptions, pagination: { cursor: 'next-page' } }));
 
     const result = await getRewardRedemptions('bc1', 'rwd1', 'UNFULFILLED', 'user-token');
 
@@ -198,9 +198,25 @@ describe('getRewardRedemptions', () => {
     expect(String(url)).toContain('broadcaster_id=bc1');
     expect(String(url)).toContain('reward_id=rwd1');
     expect(String(url)).toContain('status=UNFULFILLED');
-    expect(String(url)).toContain('sort=NEWEST_FIRST');
+    expect(String(url)).toContain('sort=NEWEST');
+    expect(String(url)).not.toContain('after=');
     expect(init?.method).toBeUndefined(); // defaults to GET
-    expect(result).toEqual(redemptions);
+    expect(result).toEqual({ redemptions, cursor: 'next-page' });
+  });
+
+  it('includes the after cursor when paginating to a later page', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(200, { data: [] }));
+
+    await getRewardRedemptions('bc1', 'rwd1', 'UNFULFILLED', 'user-token', 'cursor-abc');
+
+    const [url] = vi.mocked(globalThis.fetch).mock.calls[0];
+    expect(String(url)).toContain('after=cursor-abc');
+  });
+
+  it('returns a null cursor when the response has no pagination field', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(200, { data: [] }));
+    const result = await getRewardRedemptions('bc1', 'rwd1', 'UNFULFILLED', 'user-token');
+    expect(result.cursor).toBeNull();
   });
 
   it('throws with the response status on a 401 response', async () => {
@@ -208,9 +224,9 @@ describe('getRewardRedemptions', () => {
     await expect(getRewardRedemptions('bc1', 'rwd1', 'FULFILLED', 'user-token')).rejects.toThrow('getRewardRedemptions failed: 401');
   });
 
-  it('returns an empty array on a 403 response, rather than throwing', async () => {
+  it('returns an empty page with a null cursor on a 403 response, rather than throwing', async () => {
     vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(403, {}));
-    expect(await getRewardRedemptions('bc1', 'rwd1', 'UNFULFILLED', 'user-token')).toEqual([]);
+    expect(await getRewardRedemptions('bc1', 'rwd1', 'UNFULFILLED', 'user-token')).toEqual({ redemptions: [], cursor: null });
   });
 
   it('throws a generic error for other non-OK statuses', async () => {

--- a/src/twitch/twitchApi.ts
+++ b/src/twitch/twitchApi.ts
@@ -277,11 +277,18 @@ export interface TwitchRewardRedemption {
   reward: { id: string; title: string; prompt: string; cost: number };
 }
 
+/** One page of {@link getRewardRedemptions} results, plus the cursor to fetch the next page (if any). */
+export interface TwitchRewardRedemptionPage {
+  redemptions: TwitchRewardRedemption[];
+  /** Pass as `after` to fetch the next page; null once there are no more pages. */
+  cursor: string | null;
+}
+
 /**
- * Lists a broadcaster's most recent redemptions for one custom reward and status, via Helix,
- * newest first. Used by the EventSub reconciliation poll to catch redemptions the WebSocket
- * connection missed (e.g. during a reconnect gap) — the live notification path is driven
- * entirely by EventSub and never calls this.
+ * Lists one page (up to 50) of a broadcaster's redemptions for one custom reward and status, via
+ * Helix, newest first. Used by the EventSub reconciliation poll to catch redemptions the
+ * WebSocket connection missed (e.g. during a reconnect gap) — the live notification path is
+ * driven entirely by EventSub and never calls this.
  *
  * @param broadcasterId - Twitch user ID whose reward redemptions to list.
  * @param rewardId - Twitch reward UUID to scope the query to.
@@ -289,19 +296,22 @@ export interface TwitchRewardRedemption {
  *   'FULFILLED' to cover both queue-held and auto-fulfilled (`should_redemptions_skip_request_queue`)
  *   redemptions — Twitch requires exactly one status per call.
  * @param userToken - Broadcaster OAuth user token with the channel:manage:redemptions scope.
- * @returns Up to the 50 most recent matching redemptions, or `[]` on a 403 (reward not owned by
- *   this app's client_id, or channel points unavailable for the broadcaster).
+ * @param after - Pagination cursor from a previous call's `cursor`, to fetch the next page.
+ * @returns Up to 50 matching redemptions (newest first) plus a cursor for the next page, or an
+ *   empty page with a null cursor on a 403 (reward not owned by this app's client_id, or channel
+ *   points unavailable for the broadcaster).
  * @throws If Twitch returns a non-OK, non-403 status.
  */
 export async function getRewardRedemptions(
-  broadcasterId: string, rewardId: string, status: 'UNFULFILLED' | 'FULFILLED', userToken: string,
-): Promise<TwitchRewardRedemption[]> {
-  const url = `https://api.twitch.tv/helix/channel_points/custom_rewards/redemptions?broadcaster_id=${encodeURIComponent(broadcasterId)}&reward_id=${encodeURIComponent(rewardId)}&status=${status}&sort=NEWEST_FIRST&first=50`;
+  broadcasterId: string, rewardId: string, status: 'UNFULFILLED' | 'FULFILLED', userToken: string, after?: string,
+): Promise<TwitchRewardRedemptionPage> {
+  let url = `https://api.twitch.tv/helix/channel_points/custom_rewards/redemptions?broadcaster_id=${encodeURIComponent(broadcasterId)}&reward_id=${encodeURIComponent(rewardId)}&status=${status}&sort=NEWEST&first=50`;
+  if (after) url += `&after=${encodeURIComponent(after)}`;
   const res = await twitchFetch(url, { headers: authHeaders(userToken) });
-  if (res.status === 403) return [];
+  if (res.status === 403) return { redemptions: [], cursor: null };
   if (!res.ok) throw new Error(`[TwitchAPI] getRewardRedemptions failed: ${res.status}`);
-  const data = await res.json() as { data: TwitchRewardRedemption[] };
-  return data.data;
+  const data = await res.json() as { data: TwitchRewardRedemption[]; pagination?: { cursor?: string } };
+  return { redemptions: data.data, cursor: data.pagination?.cursor ?? null };
 }
 
 /**

--- a/src/twitch/twitchApi.ts
+++ b/src/twitch/twitchApi.ts
@@ -265,6 +265,45 @@ export async function getCustomRewards(broadcasterId: string, userToken: string)
   return data.data;
 }
 
+/** A single channel-points redemption, as returned by Twitch's Get Custom Reward Redemptions endpoint. */
+export interface TwitchRewardRedemption {
+  id: string;
+  user_id: string;
+  user_login: string;
+  user_name: string;
+  user_input: string;
+  status: string;
+  redeemed_at: string;
+  reward: { id: string; title: string; prompt: string; cost: number };
+}
+
+/**
+ * Lists a broadcaster's most recent redemptions for one custom reward and status, via Helix,
+ * newest first. Used by the EventSub reconciliation poll to catch redemptions the WebSocket
+ * connection missed (e.g. during a reconnect gap) — the live notification path is driven
+ * entirely by EventSub and never calls this.
+ *
+ * @param broadcasterId - Twitch user ID whose reward redemptions to list.
+ * @param rewardId - Twitch reward UUID to scope the query to.
+ * @param status - Redemption status to filter on. Callers must check both 'UNFULFILLED' and
+ *   'FULFILLED' to cover both queue-held and auto-fulfilled (`should_redemptions_skip_request_queue`)
+ *   redemptions — Twitch requires exactly one status per call.
+ * @param userToken - Broadcaster OAuth user token with the channel:manage:redemptions scope.
+ * @returns Up to the 50 most recent matching redemptions, or `[]` on a 403 (reward not owned by
+ *   this app's client_id, or channel points unavailable for the broadcaster).
+ * @throws If Twitch returns a non-OK, non-403 status.
+ */
+export async function getRewardRedemptions(
+  broadcasterId: string, rewardId: string, status: 'UNFULFILLED' | 'FULFILLED', userToken: string,
+): Promise<TwitchRewardRedemption[]> {
+  const url = `https://api.twitch.tv/helix/channel_points/custom_rewards/redemptions?broadcaster_id=${encodeURIComponent(broadcasterId)}&reward_id=${encodeURIComponent(rewardId)}&status=${status}&sort=NEWEST_FIRST&first=50`;
+  const res = await twitchFetch(url, { headers: authHeaders(userToken) });
+  if (res.status === 403) return [];
+  if (!res.ok) throw new Error(`[TwitchAPI] getRewardRedemptions failed: ${res.status}`);
+  const data = await res.json() as { data: TwitchRewardRedemption[] };
+  return data.data;
+}
+
 /**
  * Thrown when Twitch returns 403 for a reward create/update/delete/cost-update call — Twitch
  * only allows the app that created a reward to manage it (or, on create, the broadcaster may


### PR DESCRIPTION
## Summary

A streamer's channel-point redemption was missed by the bot, and it turned out the EventSub WebSocket connection had gotten stuck and stayed broken until a full process restart.

Two related fixes:

**1. Reconciliation poll (independent safety net)** — `handleRedemption` only ever fired from live EventSub WebSocket notifications, which is purely reactive. Twitch's WebSocket transport never replays a notification missed during a reconnect gap, keepalive timeout, or session-migration window. Added:
- `getRewardRedemptions` (Helix `GET /channel_points/custom_rewards/redemptions`, paginated) in `twitchApi.ts`.
- `getAllStreamerInfo()` on `twitchEventSubDispatch.ts` so the poller can enumerate every streamer connected via EventSub.
- `twitchEventSubReconciliation.ts`: a 60s poll that, for each streamer with a completed EventSub setup, lists their custom rewards and checks recent `UNFULFILLED` + `FULFILLED` redemptions (the latter needed for rewards with `should_redemptions_skip_request_queue` set) against a per-reward in-memory cursor, replaying anything newer through `handleRedemption` — which already dedupes by redemption id. The cursor only advances past redemptions that were actually handled successfully (so a transient failure retries next tick), and a reward's first-seen baseline looks back one poll interval rather than a pure no-op. This poll authenticates over plain Helix HTTP, independent of the WebSocket, so it keeps working even during an episode like the one reported below.
- Wired `startEventSubReconciliation`/`stopEventSubReconciliation` into `index.ts`'s startup/shutdown sequence.

**2. Root-cause fix: WebSocket could get stuck forever (`twitchEventSubConnection.ts`)** — the keepalive-timeout handler only called `ws.close()` and waited for the socket's own `'close'` event to trigger reconnect logic. A half-dead TCP connection (e.g. a silently dropped NAT/load-balancer mapping) can leave `close()` pending indefinitely without ever emitting `'close'`, stranding the connection — and every EventSub notification for that streamer, not just redemptions — until the whole process was restarted. This matches the reported symptom exactly ("redeems were not working until a reboot"). Fixed by reconnecting immediately on a keepalive timeout instead of depending on the close event; the existing socket-identity check (shared with `onClose`) safely no-ops if the old socket's close event does eventually arrive late.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (3119 passed)
- [x] `npm run lint` (0 errors, pre-existing unrelated warnings only)
- [x] Unit tests for `getRewardRedemptions` (incl. pagination), `getAllStreamerInfo`, the reconciliation poller (baseline lookback, replay-newer-than-cursor, skip-older-than-cursor, pagination stopping at cutoff, failure-preserves-cursor-for-retry, skip-no-token, skip-no-config, concurrent-tick reentrancy guard, start/stop interval), and the WebSocket keepalive-timeout reconnect (including a simulated socket that never fires its own `'close'` event, and a late/stale close event after a keepalive-triggered reconnect)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic reconciliation of Twitch EventSub redemptions, including pagination, retries, and cursor tracking.
  * Reconciliation now starts with the application and stops during graceful shutdown.
  * Added support for retrieving paginated reward redemption data.

* **Bug Fixes**
  * Improved EventSub recovery when keepalive timeouts occur, ensuring reconnection without waiting for a close event.

* **Tests**
  * Expanded coverage for reconciliation, redemption retrieval, lifecycle handling, retries, pagination, and reconnection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->