### PR TITLE
Remove timer command diagnostic logging

### DIFF
--- a/src/twitch/timers/timerCommandFireGate.test.ts
+++ b/src/twitch/timers/timerCommandFireGate.test.ts
@@ -1,21 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockLogger, loggerInstance } = vi.hoisted(() => {
-  const loggerInstance = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
-  return { mockLogger: () => loggerInstance, loggerInstance };
-});
-
-vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
 vi.mock('../twitchChatActivity', () => ({ getMessageCount: vi.fn() }));
 vi.mock('../monitor/twitchMonitor', () => ({ isChannelLive: vi.fn() }));
 
 import { getMessageCount } from '../twitchChatActivity';
 import { isChannelLive } from '../monitor/twitchMonitor';
 import type { TimerCommandForScheduler } from '../../db';
-import {
-  evaluateFireBlock, logBlockReasonChange, forgetBlockReason, pruneBlockReasonLog, clearBlockReasonLog,
-  type TimerRuntimeState,
-} from './timerCommandFireGate';
+import { shouldFire, type TimerRuntimeState } from './timerCommandFireGate';
 
 function row(overrides: Partial<TimerCommandForScheduler> = {}): TimerCommandForScheduler {
   return {
@@ -35,114 +26,53 @@ function state(overrides: Partial<TimerRuntimeState> = {}): TimerRuntimeState {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  clearBlockReasonLog();
   vi.mocked(isChannelLive).mockReturnValue(true);
   vi.mocked(getMessageCount).mockReturnValue(0);
 });
 
-describe('evaluateFireBlock', () => {
+describe('shouldFire', () => {
   it('blocks on offline when require_live is set and the channel is not live', () => {
     vi.mocked(isChannelLive).mockReturnValue(false);
-    expect(evaluateFireBlock(row({ require_live: true }), state(), 700_000)).toBe('offline');
+    expect(shouldFire(row({ require_live: true }), state(), 700_000)).toBe(false);
   });
 
   it('does not check liveness when require_live is false', () => {
     vi.mocked(isChannelLive).mockReturnValue(false);
-    expect(evaluateFireBlock(row({ require_live: false, interval_seconds: 0 }), state(), 0)).toBeNull();
+    expect(shouldFire(row({ require_live: false, interval_seconds: 0 }), state(), 0)).toBe(true);
   });
 
   it('blocks on interval when the interval has not elapsed', () => {
-    expect(evaluateFireBlock(row({ interval_seconds: 600 }), state({ lastFiredAt: 0 }), 599_000)).toBe('interval');
+    expect(shouldFire(row({ interval_seconds: 600 }), state({ lastFiredAt: 0 }), 599_000)).toBe(false);
   });
 
   it('clears the interval block exactly at the boundary', () => {
-    expect(evaluateFireBlock(row({ interval_seconds: 600, min_messages: 0 }), state({ lastFiredAt: 0 }), 600_000)).toBeNull();
+    expect(shouldFire(row({ interval_seconds: 600, min_messages: 0 }), state({ lastFiredAt: 0 }), 600_000)).toBe(true);
   });
 
   it('blocks on messages when min_messages is not yet met', () => {
     vi.mocked(getMessageCount).mockReturnValue(2);
-    const result = evaluateFireBlock(
+    const result = shouldFire(
       row({ interval_seconds: 600, min_messages: 5 }), state({ lastFiredAt: 0, messagesAtLastFire: 0 }), 600_000,
     );
-    expect(result).toBe('messages');
+    expect(result).toBe(false);
   });
 
   it('skips the messages check entirely when min_messages is 0', () => {
     vi.mocked(getMessageCount).mockReturnValue(0);
-    const result = evaluateFireBlock(
+    const result = shouldFire(
       row({ interval_seconds: 600, min_messages: 0 }), state({ lastFiredAt: 0, messagesAtLastFire: 0 }), 600_000,
     );
-    expect(result).toBeNull();
+    expect(result).toBe(true);
   });
 
-  it('returns null when every condition is clear', () => {
+  it('returns true when every condition is clear', () => {
     vi.mocked(isChannelLive).mockReturnValue(true);
     vi.mocked(getMessageCount).mockReturnValue(10);
-    const result = evaluateFireBlock(
+    const result = shouldFire(
       row({ require_live: true, interval_seconds: 600, min_messages: 5 }),
       state({ lastFiredAt: 0, messagesAtLastFire: 0 }),
       600_000,
     );
-    expect(result).toBeNull();
-  });
-});
-
-describe('logBlockReasonChange', () => {
-  it('logs the first time a non-interval reason is seen', () => {
-    logBlockReasonChange('1::somestreamer', row(), 'offline', state());
-    expect(loggerInstance.info).toHaveBeenCalledTimes(1);
-    expect(loggerInstance.info).toHaveBeenCalledWith(expect.stringContaining('waiting — channel not live'));
-  });
-
-  it('does not re-log the same reason on a repeat tick', () => {
-    logBlockReasonChange('1::somestreamer', row(), 'offline', state());
-    logBlockReasonChange('1::somestreamer', row(), 'offline', state());
-    expect(loggerInstance.info).toHaveBeenCalledTimes(1);
-  });
-
-  it('never logs the routine interval-wait reason', () => {
-    logBlockReasonChange('1::somestreamer', row(), 'interval', state());
-    expect(loggerInstance.info).not.toHaveBeenCalled();
-  });
-
-  it('does not log when the reason is null (clear to fire)', () => {
-    logBlockReasonChange('1::somestreamer', row(), null, state());
-    expect(loggerInstance.info).not.toHaveBeenCalled();
-  });
-
-  it('logs again when the reason changes from offline to messages', () => {
-    logBlockReasonChange('1::somestreamer', row(), 'offline', state());
-    vi.mocked(getMessageCount).mockReturnValue(1);
-    logBlockReasonChange('1::somestreamer', row({ min_messages: 5 }), 'messages', state({ messagesAtLastFire: 0 }));
-    expect(loggerInstance.info).toHaveBeenCalledTimes(2);
-    expect(loggerInstance.info).toHaveBeenLastCalledWith(expect.stringContaining('waiting on chat activity (1/5 messages'));
-  });
-});
-
-describe('forgetBlockReason / pruneBlockReasonLog / clearBlockReasonLog', () => {
-  it('forgetBlockReason makes a later repeat of the same reason log again', () => {
-    logBlockReasonChange('1::somestreamer', row(), 'offline', state());
-    forgetBlockReason('1::somestreamer');
-    logBlockReasonChange('1::somestreamer', row(), 'offline', state());
-    expect(loggerInstance.info).toHaveBeenCalledTimes(2);
-  });
-
-  it('pruneBlockReasonLog drops keys no longer present, keeping current ones', () => {
-    logBlockReasonChange('1::somestreamer', row(), 'offline', state());
-    logBlockReasonChange('2::otherstreamer', row({ id: 2, channel: 'otherstreamer' }), 'offline', state());
-
-    pruneBlockReasonLog(new Set(['1::somestreamer']));
-
-    // Pruned key logs again (state was forgotten); surviving key stays deduped.
-    logBlockReasonChange('2::otherstreamer', row({ id: 2, channel: 'otherstreamer' }), 'offline', state());
-    logBlockReasonChange('1::somestreamer', row(), 'offline', state());
-    expect(loggerInstance.info).toHaveBeenCalledTimes(3);
-  });
-
-  it('clearBlockReasonLog resets all tracked state', () => {
-    logBlockReasonChange('1::somestreamer', row(), 'offline', state());
-    clearBlockReasonLog();
-    logBlockReasonChange('1::somestreamer', row(), 'offline', state());
-    expect(loggerInstance.info).toHaveBeenCalledTimes(2);
+    expect(result).toBe(true);
   });
 });

--- a/src/twitch/timers/timerCommandFireGate.ts
+++ b/src/twitch/timers/timerCommandFireGate.ts
@@ -1,9 +1,5 @@
-import { createLogger } from '../../shared/logger';
-import type { TimerCommandForScheduler } from '../../db';
 import { getMessageCount } from '../twitchChatActivity';
 import { isChannelLive } from '../monitor/twitchMonitor';
-
-const log = createLogger('TimerCommandScheduler');
 
 /** A timer's in-memory firing state — never persisted, so a restart simply restarts the countdown. */
 export interface TimerRuntimeState {
@@ -11,93 +7,23 @@ export interface TimerRuntimeState {
   messagesAtLastFire: number;
 }
 
-/** Why a row didn't fire on a given tick — `null` means it's clear to fire. */
-export type FireBlockReason = 'offline' | 'interval' | 'messages' | null;
-
 /**
- * Evaluates whether a timer is currently blocked from firing, and why. Does not account for the
- * Shared Chat group cooldown — that's applied separately, across the rows this already clears,
- * by `timerCommandScheduler.ts`'s `pickRowsToFire`.
+ * Decides whether a timer should fire right now, given its config and current in-memory state.
+ * Does not account for the Shared Chat group cooldown or cross-command channel floor — those are
+ * applied separately, across the rows this already clears, by `timerCommandScheduler.ts` /
+ * `timerCommandCooldowns.ts`.
  * @param row - The timer's config, joined with its Twitch channel.
  * @param state - The timer's current in-memory firing state.
  * @param now - Current time in epoch ms.
- * @returns The reason the row can't fire right now (`'offline'`, `'interval'`, or `'messages'`), or `null` if it's clear to fire.
+ * @returns True if the row is clear to fire right now.
  */
-export function evaluateFireBlock(
+export function shouldFire(
   row: { interval_seconds: number; min_messages: number; require_live: boolean; channel: string },
   state: TimerRuntimeState,
   now: number,
-): FireBlockReason {
-  if (row.require_live && !isChannelLive(row.channel)) return 'offline';
-  if (now - state.lastFiredAt < row.interval_seconds * 1000) return 'interval';
-  if (row.min_messages > 0 && getMessageCount(row.channel) - state.messagesAtLastFire < row.min_messages) return 'messages';
-  return null;
-}
-
-/**
- * Firing-block reason last logged for each (timer id, channel) — keyed the same way as the
- * scheduler's `timerState` (see `rowKey` there) — so a stuck gate (e.g. `min_messages` never
- * being met) is logged once when entered rather than every 15s tick, while still being visible
- * at all: previously a blocked timer produced no log output whatsoever, indistinguishable from a
- * healthy one that just hasn't reached its interval yet.
- */
-const lastLoggedBlockReason = new Map<string, FireBlockReason>();
-
-/**
- * Logs a timer's block reason the first tick it's seen — skips the routine `'interval'` wait
- * (expected on every row, every cycle) and only logs `'offline'`/`'messages'`, the two states
- * that can silently persist for hours if something upstream (live tracking, chat-activity
- * counting) is broken.
- * @param key - The row's `timerState` key (`"{id}::{channel}"`).
- * @param row - The timer's config, joined with its Twitch channel.
- * @param reason - This tick's block reason, from {@link evaluateFireBlock}.
- * @param state - The timer's current in-memory firing state.
- * @returns Nothing — logs as a side effect and updates the module-level `lastLoggedBlockReason` map.
- */
-export function logBlockReasonChange(
-  key: string,
-  row: TimerCommandForScheduler,
-  reason: FireBlockReason,
-  state: TimerRuntimeState,
-): void {
-  const previous = lastLoggedBlockReason.get(key);
-  lastLoggedBlockReason.set(key, reason);
-  if (reason === previous || reason === 'interval' || reason === null) return;
-
-  if (reason === 'offline') {
-    log.info(`Timer ${row.id} (${row.channel}): waiting — channel not live`);
-  } else if (reason === 'messages') {
-    const have = getMessageCount(row.channel) - state.messagesAtLastFire;
-    log.info(`Timer ${row.id} (${row.channel}): interval elapsed, waiting on chat activity (${have}/${row.min_messages} messages since last fire)`);
-  }
-}
-
-/**
- * Clears the logged block reason for one row — call once a row actually fires, so a future
- * re-block logs fresh instead of staying suppressed by an unrelated, older block episode.
- * @param key - The row's `timerState` key (`"{id}::{channel}"`) to forget.
- * @returns Nothing — mutates the module-level `lastLoggedBlockReason` map in place.
- */
-export function forgetBlockReason(key: string): void {
-  lastLoggedBlockReason.delete(key);
-}
-
-/**
- * Drops logged-block-reason entries for any key no longer present in `currentKeys` — mirrors the
- * scheduler's own `timerState` pruning.
- * @param currentKeys - Every row key present in the latest enabled-rows fetch; anything else is stale.
- * @returns Nothing — mutates the module-level `lastLoggedBlockReason` map in place.
- */
-export function pruneBlockReasonLog(currentKeys: ReadonlySet<string>): void {
-  for (const key of lastLoggedBlockReason.keys()) {
-    if (!currentKeys.has(key)) lastLoggedBlockReason.delete(key);
-  }
-}
-
-/**
- * Clears all logged block-reason state. Call on scheduler stop.
- * @returns Nothing — mutates the module-level `lastLoggedBlockReason` map in place.
- */
-export function clearBlockReasonLog(): void {
-  lastLoggedBlockReason.clear();
+): boolean {
+  if (row.require_live && !isChannelLive(row.channel)) return false;
+  if (now - state.lastFiredAt < row.interval_seconds * 1000) return false;
+  if (row.min_messages > 0 && getMessageCount(row.channel) - state.messagesAtLastFire < row.min_messages) return false;
+  return true;
 }

--- a/src/twitch/timers/timerCommandScheduler.test.ts
+++ b/src/twitch/timers/timerCommandScheduler.test.ts
@@ -1,12 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
 
-/** Hoisted so the `vi.mock('../../shared/logger', ...)` factory below can safely reference it. */
-const { mockLogger, loggerInstance } = vi.hoisted(() => {
-  const loggerInstance = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
-  return { mockLogger: () => loggerInstance, loggerInstance };
-});
-
-vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
+vi.mock('../../shared/logger', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
 vi.mock('../../db', () => ({ getAllEnabledTimerCommandsWithChannel: vi.fn() }));
 vi.mock('../twitchChatActivity', () => ({ getMessageCount: vi.fn() }));
 vi.mock('../monitor/twitchMonitor', () => ({ isChannelLive: vi.fn() }));
@@ -203,66 +199,6 @@ describe('runTimerCommandTick', () => {
     await Promise.all([first, second]);
 
     expect(getAllEnabledTimerCommandsWithChannel).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe('block-reason logging', () => {
-  it('logs once when a row becomes stuck waiting on chat activity after its interval elapses, and does not repeat the log on later ticks in the same state', async () => {
-    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue(
-      [timerRow({ interval_seconds: 600, min_messages: 5 })] as any,
-    );
-    await runTimerCommandTick(); // seeds messagesAtLastFire at the current count (0)
-    await vi.advanceTimersByTimeAsync(600_000);
-    vi.mocked(getMessageCount).mockReturnValue(3); // below the 5-message threshold
-
-    await runTimerCommandTick();
-    expect(loggerInstance.info).toHaveBeenCalledWith(
-      expect.stringContaining('interval elapsed, waiting on chat activity (3/5 messages since last fire)'),
-    );
-
-    loggerInstance.info.mockClear();
-    await vi.advanceTimersByTimeAsync(15_000);
-    await runTimerCommandTick(); // still stuck on the same reason — must not log again
-    expect(loggerInstance.info).not.toHaveBeenCalled();
-  });
-
-  it('logs once when a row goes offline, and again once it comes back and gets blocked on messages', async () => {
-    vi.mocked(isChannelLive).mockReturnValue(false);
-    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue(
-      [timerRow({ interval_seconds: 600, min_messages: 5, require_live: true })] as any,
-    );
-    await runTimerCommandTick(); // seed
-    await vi.advanceTimersByTimeAsync(600_000);
-
-    await runTimerCommandTick();
-    expect(loggerInstance.info).toHaveBeenCalledWith(expect.stringContaining('waiting — channel not live'));
-
-    loggerInstance.info.mockClear();
-    vi.mocked(isChannelLive).mockReturnValue(true);
-    vi.mocked(getMessageCount).mockReturnValue(3);
-    await runTimerCommandTick();
-    expect(loggerInstance.info).toHaveBeenCalledWith(
-      expect.stringContaining('interval elapsed, waiting on chat activity (3/5 messages since last fire)'),
-    );
-  });
-
-  it('does not log anything for the routine interval wait', async () => {
-    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([timerRow({ interval_seconds: 600 })] as any);
-    await runTimerCommandTick(); // seed
-    loggerInstance.info.mockClear();
-    await vi.advanceTimersByTimeAsync(300_000);
-
-    await runTimerCommandTick(); // interval not yet elapsed
-    expect(loggerInstance.info).not.toHaveBeenCalled();
-  });
-
-  it('logs a successful post', async () => {
-    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([timerRow({ interval_seconds: 600 })] as any);
-    await runTimerCommandTick(); // seed
-    await vi.advanceTimersByTimeAsync(600_000);
-
-    await runTimerCommandTick();
-    expect(loggerInstance.info).toHaveBeenCalledWith(expect.stringContaining('Posted timer 1 to somestreamer'));
   });
 });
 

--- a/src/twitch/timers/timerCommandScheduler.ts
+++ b/src/twitch/timers/timerCommandScheduler.ts
@@ -3,10 +3,7 @@ import { getAllEnabledTimerCommandsWithChannel, type TimerCommandForScheduler } 
 import { getMessageCount } from '../twitchChatActivity';
 import { resolveSharedChatSessionId } from '../../commands/customCommandHandler';
 import { createRuntimeRegistry, type TwitchSendRuntime } from '../../commands/twitchRuntime';
-import {
-  evaluateFireBlock, logBlockReasonChange, forgetBlockReason, pruneBlockReasonLog, clearBlockReasonLog,
-  type TimerRuntimeState,
-} from './timerCommandFireGate';
+import { shouldFire, type TimerRuntimeState } from './timerCommandFireGate';
 import { pickRowsToFire, releaseReservations, pruneStaleCooldowns, clearCooldowns } from './timerCommandCooldowns';
 
 const log = createLogger('TimerCommandScheduler');
@@ -52,14 +49,12 @@ let currentTickPromise: Promise<void> = Promise.resolve();
  * Removes in-memory state for any (timer id, channel) pair no longer present in the latest
  * enabled-rows fetch.
  * @param currentKeys - {@link rowKey} values for every row in the latest enabled-rows fetch.
- * @returns Nothing — mutates the module-level `timerState` map (and the fire-gate's own
- *   block-reason log — see {@link pruneBlockReasonLog}) in place.
+ * @returns Nothing — mutates the module-level `timerState` map in place.
  */
 function pruneStaleTimerState(currentKeys: ReadonlySet<string>): void {
   for (const key of timerState.keys()) {
     if (!currentKeys.has(key)) timerState.delete(key);
   }
-  pruneBlockReasonLog(currentKeys);
 }
 
 /**
@@ -109,8 +104,6 @@ async function sendTimerRow(row: TimerCommandForScheduler, now: number, sessionK
     await runtime.send(row.channel, row.message);
     state.lastFiredAt = now;
     state.messagesAtLastFire = getMessageCount(row.channel);
-    forgetBlockReason(key);
-    log.info(`Posted timer ${row.id} to ${row.channel}`);
   } catch (err) {
     releaseReservations(sessionKey, row.channel, row.id, now);
     log.error(`Failed to post timer command ${row.id} to ${row.channel}:`, err);
@@ -120,14 +113,12 @@ async function sendTimerRow(row: TimerCommandForScheduler, now: number, sessionK
 /**
  * Runs one scheduler tick: fetches every enabled timer, prunes in-memory state for timers that no
  * longer exist/are disabled, seeds any newly-seen timer without firing it, then for the rest:
- * evaluates each row's own fire condition (logging via {@link logBlockReasonChange} when a row is
- * newly blocked on being offline or on chat activity, so a stuck gate is diagnosable from logs
- * instead of looking identical to a healthy row still waiting out its interval), resolves Shared
- * Chat sessions for the ones that are ready, picks which of those actually get to fire this tick
- * (applying the per-command Shared Chat cooldown and the cross-command channel floor — see
- * `pickRowsToFire` in `timerCommandCooldowns.ts`), and sends the picked rows concurrently via
- * `Promise.allSettled` so one channel's send failure can't block another's. No-ops (re-uses the
- * in-flight promise) if a tick is already running.
+ * evaluates each row's own fire condition ({@link shouldFire}), resolves Shared Chat sessions for
+ * the ones that are ready, picks which of those actually get to fire this tick (applying the
+ * per-command Shared Chat cooldown and the cross-command channel floor — see `pickRowsToFire` in
+ * `timerCommandCooldowns.ts`), and sends the picked rows concurrently via `Promise.allSettled` so
+ * one channel's send failure can't block another's. No-ops (re-uses the in-flight promise) if a
+ * tick is already running.
  */
 export async function runTimerCommandTick(): Promise<void> {
   if (tickRunning) return currentTickPromise;
@@ -148,9 +139,7 @@ export async function runTimerCommandTick(): Promise<void> {
           timerState.set(key, { lastFiredAt: now, messagesAtLastFire: getMessageCount(row.channel) });
           continue;
         }
-        const blockReason = evaluateFireBlock(row, state, now);
-        logBlockReasonChange(key, row, blockReason, state);
-        if (blockReason === null) eligibleRows.push(row);
+        if (shouldFire(row, state, now)) eligibleRows.push(row);
       }
 
       const loginUserIds = timerCommandsRuntime.get()?.getLoginUserIds() ?? new Map<string, string>();
@@ -186,5 +175,4 @@ export async function stopTimerCommandScheduler(): Promise<void> {
   await currentTickPromise;
   timerState.clear();
   clearCooldowns();
-  clearBlockReasonLog();
 }


### PR DESCRIPTION
## Summary

The block-reason logging and per-post success log added in #503 served their purpose — they're what surfaced the channel-normalization bug fixed in #516 and confirmed the Shared Chat cooldown fix in #520 actually worked in production. With the underlying issue fixed and confirmed working, this removes the diagnostic instrumentation:

- `timerCommandFireGate.ts` reverts to a plain boolean `shouldFire()` (was `evaluateFireBlock()` returning a reason enum purely for logging). Drops the block-reason log/debounce map and its prune/clear/forget helpers entirely.
- `timerCommandScheduler.ts` drops the `Posted timer X to Y` success log and the block-reason-log wiring (pruning on stale state, clearing on stop).

No behavior change to the actual firing/gating logic — this only removes logging. The channel normalization fix (#516) and the Shared Chat cooldown/channel floor logic (#520) are untouched.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite: 168 files / 3107 tests passing)
- [x] `npm run lint` (0 errors, same 4 pre-existing warnings unrelated to this change)
- [x] Rewrote `timerCommandFireGate.test.ts` for the simplified boolean `shouldFire()`, and removed the "block-reason logging" test suite from `timerCommandScheduler.test.ts`.

---
_Generated by [Claude Code](https://claude.ai/code/session_016zbgyMNTvn4MKcGezwwXUw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timer command scheduling so commands only fire when channels are live and configured timing and message thresholds are met.
  * Corrected eligibility handling at interval boundaries and when message checks are disabled.
  * Simplified firing decisions for more consistent timer behavior.
* **Refactor**
  * Streamlined internal timer eligibility and scheduling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->