### PR TITLE
Retry transient 5xx errors when deleting Discord messages

### DIFF
--- a/src/discord/discordUtils.test.ts
+++ b/src/discord/discordUtils.test.ts
@@ -15,8 +15,10 @@ vi.mock('discord.js', () => {
       this.status = status;
     }
   }
+  /** Minimal mock of `@discordjs/rest`'s HTTPError, carrying just the `status` this module reads. */
   class HTTPError extends Error {
     status: number;
+    /** Builds a mock HTTPError with the given HTTP status. */
     constructor(status: number) {
       super('Service Unavailable');
       this.status = status;

--- a/src/discord/discordUtils.test.ts
+++ b/src/discord/discordUtils.test.ts
@@ -15,8 +15,16 @@ vi.mock('discord.js', () => {
       this.status = status;
     }
   }
+  class HTTPError extends Error {
+    status: number;
+    constructor(status: number) {
+      super('Service Unavailable');
+      this.status = status;
+    }
+  }
   return {
     DiscordAPIError,
+    HTTPError,
     RESTJSONErrorCodes: {
       UnknownMessage: 10008,
       UnknownChannel: 10003,
@@ -38,12 +46,14 @@ import {
   getTextChannel,
   tryEditDiscordMessage,
 } from './discordUtils';
-import { DiscordAPIError } from 'discord.js';
+import { DiscordAPIError, HTTPError } from 'discord.js';
 import { getDiscordClient } from './discordClientStore';
 
 // The mock above replaces DiscordAPIError with a simpler single-arg constructor.
 // Cast here so TypeScript accepts the mock's signature without casting at every call site.
 const MockedDiscordAPIError = DiscordAPIError as unknown as new (opts: { code: number; status: number }) => DiscordAPIError;
+// Same story for HTTPError, mocked with a single-arg (status) constructor.
+const MockedHTTPError = HTTPError as unknown as new (status: number) => HTTPError;
 
 describe('isDiscordNotFoundError', () => {
   it('returns true for UnknownMessage code', () => {
@@ -172,6 +182,44 @@ describe('tryDeleteDiscordMessage', () => {
     vi.mocked(getDiscordClient).mockReturnValue({ channels: { fetch: channelsFetch } } as any);
 
     await expect(tryDeleteDiscordMessage('chan1', 'msg1')).rejects.toThrow('network blip');
+  });
+
+  it('retries a transient 5xx error and succeeds once the channel fetch recovers', async () => {
+    vi.useFakeTimers();
+    try {
+      const deleteMessage = vi.fn().mockResolvedValue(undefined);
+      const fetchMessage = vi.fn().mockResolvedValue({ delete: deleteMessage });
+      const channelsFetch = vi.fn()
+        .mockRejectedValueOnce(new MockedHTTPError(503))
+        .mockResolvedValueOnce({ isTextBased: () => true, messages: { fetch: fetchMessage } });
+      vi.mocked(getDiscordClient).mockReturnValue({ channels: { fetch: channelsFetch } } as any);
+
+      const promise = tryDeleteDiscordMessage('chan1', 'msg1');
+      await vi.advanceTimersByTimeAsync(5_000);
+      await expect(promise).resolves.toBeUndefined();
+      expect(channelsFetch).toHaveBeenCalledTimes(2);
+      expect(deleteMessage).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('rethrows a transient 5xx error once retries are exhausted', async () => {
+    vi.useFakeTimers();
+    try {
+      const err = new MockedHTTPError(503);
+      const channelsFetch = vi.fn().mockRejectedValue(err);
+      vi.mocked(getDiscordClient).mockReturnValue({ channels: { fetch: channelsFetch } } as any);
+
+      const promise = tryDeleteDiscordMessage('chan1', 'msg1');
+      const assertion = expect(promise).rejects.toBe(err);
+      await vi.advanceTimersByTimeAsync(5_000);
+      await vi.advanceTimersByTimeAsync(15_000);
+      await assertion;
+      expect(channelsFetch).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/src/discord/discordUtils.ts
+++ b/src/discord/discordUtils.ts
@@ -60,6 +60,16 @@ export function isPermanentVoiceMisconfigurationError(err: unknown): boolean {
 }
 
 /**
+ * Resolves after `ms` milliseconds.
+ *
+ * @param ms - Delay in milliseconds.
+ * @returns Resolves once the delay has elapsed.
+ */
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
  * Fetches `messageId` from `channelId` and deletes it, if a Discord client is
  * available and the channel is text-based. Not-found errors (message/channel
  * already gone) are swallowed. Transient 5xx errors are retried with backoff
@@ -86,7 +96,7 @@ export async function tryDeleteDiscordMessage(channelId: string, messageId: stri
       if (isTransientDiscordError(err) && attempt < TRANSIENT_ERROR_RETRY_DELAYS_MS.length) {
         const wait = TRANSIENT_ERROR_RETRY_DELAYS_MS[attempt];
         log.warn(`Transient error deleting Discord message ${messageId} in channel ${channelId} (attempt ${attempt + 1}), retrying in ${wait}ms:`, err);
-        await new Promise<void>((resolve) => setTimeout(resolve, wait));
+        await delay(wait);
         continue;
       }
       log.error(`Failed to delete Discord message ${messageId} in channel ${channelId}:`, err);

--- a/src/discord/discordUtils.ts
+++ b/src/discord/discordUtils.ts
@@ -1,8 +1,26 @@
 import { createLogger } from '../shared/logger';
-import { DiscordAPIError, RESTJSONErrorCodes, ChannelType, type Client, type MessageEditOptions, type TextBasedChannel } from 'discord.js';
+import { DiscordAPIError, HTTPError, RESTJSONErrorCodes, ChannelType, type Client, type MessageEditOptions, type TextBasedChannel } from 'discord.js';
 import { getDiscordClient } from './discordClientStore';
 
 const log = createLogger('Discord');
+
+// @discordjs/rest already retries 5xx responses internally (up to its own `retries`
+// option, default 3) before giving up, so these delays are for outages that outlast
+// that internal retry budget (e.g. a multi-second Discord API blip).
+const TRANSIENT_ERROR_RETRY_DELAYS_MS = [5_000, 15_000];
+
+/**
+ * Checks whether `err` is a transient Discord API failure (5xx `HTTPError`/`DiscordAPIError`)
+ * worth retrying, as opposed to a permanent failure like missing access or malformed input.
+ *
+ * @param err - Caught error to inspect.
+ * @returns True if `err` represents a 5xx Discord API/HTTP error.
+ */
+function isTransientDiscordError(err: unknown): boolean {
+  if (err instanceof HTTPError) return err.status >= 500 && err.status < 600;
+  if (err instanceof DiscordAPIError) return err.status >= 500 && err.status < 600;
+  return false;
+}
 
 /**
  * Checks whether `err` represents a Discord "not found" condition (unknown
@@ -44,7 +62,9 @@ export function isPermanentVoiceMisconfigurationError(err: unknown): boolean {
 /**
  * Fetches `messageId` from `channelId` and deletes it, if a Discord client is
  * available and the channel is text-based. Not-found errors (message/channel
- * already gone) are swallowed; any other error is logged and rethrown.
+ * already gone) are swallowed. Transient 5xx errors are retried with backoff
+ * (see {@link TRANSIENT_ERROR_RETRY_DELAYS_MS}); any other error — including a
+ * transient error that exhausts its retries — is logged and rethrown.
  *
  * @param channelId - ID of the channel containing the message.
  * @param messageId - ID of the message to delete.
@@ -53,15 +73,25 @@ export function isPermanentVoiceMisconfigurationError(err: unknown): boolean {
 export async function tryDeleteDiscordMessage(channelId: string, messageId: string): Promise<void> {
   const discordClient = getDiscordClient();
   if (!discordClient) return;
-  try {
-    const ch = await discordClient.channels.fetch(channelId);
-    if (!ch || !ch.isTextBased()) return;
-    const msg = await ch.messages.fetch(messageId);
-    await msg.delete();
-  } catch (err) {
-    if (isDiscordNotFoundError(err)) return;
-    log.error(`Failed to delete Discord message ${messageId} in channel ${channelId}:`, err);
-    throw err;
+
+  for (let attempt = 0; ; attempt++) {
+    try {
+      const ch = await discordClient.channels.fetch(channelId);
+      if (!ch || !ch.isTextBased()) return;
+      const msg = await ch.messages.fetch(messageId);
+      await msg.delete();
+      return;
+    } catch (err) {
+      if (isDiscordNotFoundError(err)) return;
+      if (isTransientDiscordError(err) && attempt < TRANSIENT_ERROR_RETRY_DELAYS_MS.length) {
+        const wait = TRANSIENT_ERROR_RETRY_DELAYS_MS[attempt];
+        log.warn(`Transient error deleting Discord message ${messageId} in channel ${channelId} (attempt ${attempt + 1}), retrying in ${wait}ms:`, err);
+        await new Promise<void>((resolve) => setTimeout(resolve, wait));
+        continue;
+      }
+      log.error(`Failed to delete Discord message ${messageId} in channel ${channelId}:`, err);
+      throw err;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Add backoff retries (5s, then 15s) in `tryDeleteDiscordMessage` for transient Discord 5xx errors (`HTTPError`/`DiscordAPIError` with status 500-599), addressing the `Service Unavailable` error seen on 2026-08-07 when deleting a stale stream announcement message.
- `@discordjs/rest` already retries 5xx responses internally (up to its own retry budget), so this only kicks in for outages that outlast that budget. Not-found and other error types are handled exactly as before (swallowed / rethrown immediately).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (added coverage for retry-then-succeed and retry-exhausted-then-rethrow cases in `discordUtils.test.ts`)
- [x] `npm run lint`

---
_Generated by [Claude Code](https://claude.ai/code/session_015YCu3kcEe3j6ydutuVxaJx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when deleting Discord messages by automatically retrying temporary server errors.
  * Added backoff delays between retry attempts.
  * Preserved silent handling for messages that no longer exist.
  * Errors are now reported and surfaced after all retry attempts are exhausted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->