### PR TITLE
Fix stale accessLevel bypass on commands, counters, timers, and voice API routes

### DIFF
--- a/src/web/routes/api.test.ts
+++ b/src/web/routes/api.test.ts
@@ -123,6 +123,11 @@ describe('GET /voice/channels', () => {
 });
 
 describe('POST /voice/join', () => {
+  it('runs requireGuildContext before requireMod, so a demoted session is re-checked with a fresh access level', async () => {
+    await supertest(buildApp()).post('/voice/join').send({ channelId: '123456789012345678' });
+    expect(middlewareCallOrder).toEqual(['requireGuildContext', 'requireMod']);
+  });
+
   it('disconnects then joins the requested channel for the session guild', async () => {
     const res = await supertest(buildApp())
       .post('/voice/join')
@@ -178,6 +183,11 @@ describe('POST /voice/join', () => {
 });
 
 describe('POST /voice/leave', () => {
+  it('runs requireGuildContext before requireMod, so a demoted session is re-checked with a fresh access level', async () => {
+    await supertest(buildApp()).post('/voice/leave');
+    expect(middlewareCallOrder).toEqual(['requireGuildContext', 'requireMod']);
+  });
+
   it('disconnects the session guild and returns ok', async () => {
     const res = await supertest(buildApp()).post('/voice/leave').expect(200);
     expect(res.body).toEqual({ ok: true });

--- a/src/web/routes/api.test.ts
+++ b/src/web/routes/api.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mockLogger } from '../../test-utils/loggerMock';
 
+const { middlewareCallOrder } = vi.hoisted(() => ({ middlewareCallOrder: [] as string[] }));
 vi.mock('../middleware', () => ({
   requireAuth: (_req: any, _res: any, next: any) => next(),
-  requireMod: (_req: any, _res: any, next: any) => next(),
+  requireGuildContext: (_req: any, _res: any, next: any) => { middlewareCallOrder.push('requireGuildContext'); next(); },
+  requireMod: (_req: any, _res: any, next: any) => { middlewareCallOrder.push('requireMod'); next(); },
 }));
 
 vi.mock('../csrf', () => ({
@@ -56,6 +58,7 @@ function buildApp(currentGuildId: string | null = GUILD_ID) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  middlewareCallOrder.length = 0;
   vi.mocked(getGuildScopedStatus).mockResolvedValue({ discord: {}, voice: {}, twitch: {} } as never);
   vi.mocked(getDiscordClient).mockReturnValue({} as never);
   vi.mocked(connect).mockResolvedValue(undefined);
@@ -85,6 +88,11 @@ describe('GET /status', () => {
 });
 
 describe('GET /voice/channels', () => {
+  it('runs requireGuildContext before requireMod, so a demoted session is re-checked with a fresh access level', async () => {
+    await supertest(buildApp()).get('/voice/channels');
+    expect(middlewareCallOrder).toEqual(['requireGuildContext', 'requireMod']);
+  });
+
   it('reports the current channel and DB default for the session guild', async () => {
     const res = await supertest(buildApp()).get('/voice/channels').expect(200);
     expect(res.body).toMatchObject({

--- a/src/web/routes/api.ts
+++ b/src/web/routes/api.ts
@@ -18,6 +18,11 @@ const router = Router();
  * a separate connection per guild — and the guild is taken from the session
  * (never the request body) so a Mod cannot drive or view another guild's state.
  *
+ * The 400 branch is the normal path for `/status` (gated only by `requireAuth`),
+ * but is a defensive fallback rather than the normal path on the `/voice/*` routes
+ * below — those run `requireGuildContext` first, which already guarantees
+ * `currentGuildId` is set (or redirects away) before this function ever runs.
+ *
  * @returns The current guild ID, or null when the response has already been sent.
  */
 function getSessionGuildId(req: Request, res: Response): string | null {
@@ -55,8 +60,10 @@ router.get('/status', requireAuth, async (req, res) => {
  * along with the configured default and currently-connected channel (Mod+).
  * @param req - Express request; guild is taken from the session.
  * @param res - Express response; JSON `{ ok: true, channels, defaultChannelId,
- *   currentChannelId }` on success, 400 if no guild is selected, or 500 on
- *   failure.
+ *   currentChannelId }` on success, or 500 on failure. `requireGuildContext`
+ *   guarantees `currentGuildId` is set before this handler runs (or redirects
+ *   away otherwise), so `getSessionGuildId`'s 400 branch is a defensive
+ *   fallback here, not the normal path.
  */
 router.get('/voice/channels', requireGuildContext, requireMod, async (req, res) => {
   const guildId = getSessionGuildId(req, res);
@@ -83,9 +90,12 @@ router.get('/voice/channels', requireGuildContext, requireMod, async (req, res) 
  * default channel if none is supplied (Mod+).
  * @param req - Express request; reads `channelId` from `req.body`; guild is
  *   taken from the session.
- * @param res - Express response; JSON `{ ok: true }` on success, 400 if no
- *   guild is selected, `channelId` is malformed, or no channel is resolvable,
- *   503 if the Discord client isn't ready, or 500 on failure.
+ * @param res - Express response; JSON `{ ok: true }` on success, 400 if
+ *   `channelId` is malformed or no channel is resolvable, 503 if the Discord
+ *   client isn't ready, or 500 on failure. `requireGuildContext` guarantees
+ *   `currentGuildId` is set before this handler runs (or redirects away
+ *   otherwise), so `getSessionGuildId`'s "no guild selected" 400 is a
+ *   defensive fallback here, not the normal path.
  */
 router.post('/voice/join', requireGuildContext, requireMod, csrfProtection, async (req, res) => {
   const guildId = getSessionGuildId(req, res);
@@ -124,8 +134,10 @@ router.post('/voice/join', requireGuildContext, requireMod, csrfProtection, asyn
  * POST /voice/leave — disconnects from the current guild's voice channel
  * (Mod+).
  * @param req - Express request; guild is taken from the session.
- * @param res - Express response; JSON `{ ok: true }` on success, or 400 if no
- *   guild is selected.
+ * @param res - Express response; JSON `{ ok: true }` on success.
+ *   `requireGuildContext` guarantees `currentGuildId` is set before this
+ *   handler runs (or redirects away otherwise), so `getSessionGuildId`'s 400
+ *   branch is a defensive fallback here, not the normal path.
  */
 router.post('/voice/leave', requireGuildContext, requireMod, csrfProtection, (req, res) => {
   const guildId = getSessionGuildId(req, res);

--- a/src/web/routes/api.ts
+++ b/src/web/routes/api.ts
@@ -1,7 +1,7 @@
 import { createLogger } from '../../shared/logger';
 import { Router, type Request, type Response } from 'express';
 import { getGuildScopedStatus } from '../guildScopedStatus';
-import { requireAuth, requireMod } from '../middleware';
+import { requireAuth, requireGuildContext, requireMod } from '../middleware';
 import { connect, disconnect, getCurrentChannelId } from '../../audio/audioPlayer';
 import { csrfProtection } from '../csrf';
 import { getAvailableVoiceChannels } from '../../discord/discordUtils';
@@ -58,7 +58,7 @@ router.get('/status', requireAuth, async (req, res) => {
  *   currentChannelId }` on success, 400 if no guild is selected, or 500 on
  *   failure.
  */
-router.get('/voice/channels', requireMod, async (req, res) => {
+router.get('/voice/channels', requireGuildContext, requireMod, async (req, res) => {
   const guildId = getSessionGuildId(req, res);
   if (!guildId) return;
   try {
@@ -87,7 +87,7 @@ router.get('/voice/channels', requireMod, async (req, res) => {
  *   guild is selected, `channelId` is malformed, or no channel is resolvable,
  *   503 if the Discord client isn't ready, or 500 on failure.
  */
-router.post('/voice/join', requireMod, csrfProtection, async (req, res) => {
+router.post('/voice/join', requireGuildContext, requireMod, csrfProtection, async (req, res) => {
   const guildId = getSessionGuildId(req, res);
   if (!guildId) return;
 
@@ -127,7 +127,7 @@ router.post('/voice/join', requireMod, csrfProtection, async (req, res) => {
  * @param res - Express response; JSON `{ ok: true }` on success, or 400 if no
  *   guild is selected.
  */
-router.post('/voice/leave', requireMod, csrfProtection, (req, res) => {
+router.post('/voice/leave', requireGuildContext, requireMod, csrfProtection, (req, res) => {
   const guildId = getSessionGuildId(req, res);
   if (!guildId) return;
   disconnect(guildId);

--- a/src/web/routes/assignmentRoutes.test.ts
+++ b/src/web/routes/assignmentRoutes.test.ts
@@ -9,8 +9,10 @@ vi.mock('../../db', () => ({
 vi.mock('../csrf', () => ({
   csrfProtection: (_req: any, _res: any, next: any) => next(),
 }));
+const { middlewareCallOrder } = vi.hoisted(() => ({ middlewareCallOrder: [] as string[] }));
 vi.mock('../middleware', () => ({
-  requireMod: (_req: any, _res: any, next: any) => next(),
+  requireGuildContext: (_req: any, _res: any, next: any) => { middlewareCallOrder.push('requireGuildContext'); next(); },
+  requireMod: (_req: any, _res: any, next: any) => { middlewareCallOrder.push('requireMod'); next(); },
 }));
 
 import supertest from 'supertest';
@@ -33,10 +35,21 @@ const parseId = (raw: string): number | null => {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  middlewareCallOrder.length = 0;
   vi.mocked(findUser).mockResolvedValue({ discord_id: VALID_DISCORD_ID, discord_name: 'Alice', twitch_name: 'alice' } as any);
 });
 
 describe('createAssignmentRouter — assign', () => {
+  it('runs requireGuildContext before requireMod, so a demoted session is re-checked with a fresh access level', async () => {
+    const router = createAssignmentRouter({
+      basePath: '/things', idField: 'thing_id', parseId, assign: vi.fn(), unassign: vi.fn(), log: mockLogger() as any,
+    });
+    await supertest(buildApp(router))
+      .post('/things/assign')
+      .send(`thing_id=${VALID_ID}&discord_id=${VALID_DISCORD_ID}`);
+    expect(middlewareCallOrder).toEqual(['requireGuildContext', 'requireMod']);
+  });
+
   it('redirects to basePath on success', async () => {
     const assign = vi.fn().mockResolvedValue(undefined);
     const router = createAssignmentRouter({

--- a/src/web/routes/assignmentRoutes.test.ts
+++ b/src/web/routes/assignmentRoutes.test.ts
@@ -153,6 +153,16 @@ describe('createAssignmentRouter — assign', () => {
 });
 
 describe('createAssignmentRouter — unassign', () => {
+  it('runs requireGuildContext before requireMod, so a demoted session is re-checked with a fresh access level', async () => {
+    const router = createAssignmentRouter({
+      basePath: '/things', idField: 'thing_id', parseId, assign: vi.fn(), unassign: vi.fn(), log: mockLogger() as any,
+    });
+    await supertest(buildApp(router))
+      .post('/things/unassign')
+      .send(`thing_id=${VALID_ID}&discord_id=${VALID_DISCORD_ID}`);
+    expect(middlewareCallOrder).toEqual(['requireGuildContext', 'requireMod']);
+  });
+
   it('redirects to basePath on success', async () => {
     const unassign = vi.fn().mockResolvedValue(undefined);
     const router = createAssignmentRouter({

--- a/src/web/routes/assignmentRoutes.ts
+++ b/src/web/routes/assignmentRoutes.ts
@@ -2,7 +2,7 @@ import { Router, type Request, type Response } from 'express';
 import type { Logger } from 'winston';
 import { findUser } from '../../db';
 import { csrfProtection } from '../csrf';
-import { requireMod } from '../middleware';
+import { requireGuildContext, requireMod } from '../middleware';
 import { normalizeDiscordId, logAndRedirectError } from './shared';
 
 /** Options for {@link createAssignmentRouter}. */
@@ -134,13 +134,14 @@ async function handleUnassign<TId>(req: Request, res: Response, options: Assignm
 /**
  * Builds a `POST {basePath}/assign` / `POST {basePath}/unassign` router pair: assigns or removes
  * a Twitch-linked Discord user's association with an entity (a custom command, a timer command,
- * ...). Both routes are gated `requireMod` + `csrfProtection`. Shared by `commandAssignments.ts`
- * and `timerAssignments.ts`, which previously duplicated this same shape end to end.
+ * ...). Both routes are gated `requireGuildContext` + `requireMod` + `csrfProtection`. Shared by
+ * `commandAssignments.ts` and `timerAssignments.ts`, which previously duplicated this same shape
+ * end to end.
  * @param options - See {@link AssignmentRouterOptions}.
  */
 export function createAssignmentRouter<TId>(options: AssignmentRouterOptions<TId>): Router {
   const router = Router();
-  router.post(`${options.basePath}/assign`, requireMod, csrfProtection, (req, res) => handleAssign(req, res, options));
-  router.post(`${options.basePath}/unassign`, requireMod, csrfProtection, (req, res) => handleUnassign(req, res, options));
+  router.post(`${options.basePath}/assign`, requireGuildContext, requireMod, csrfProtection, (req, res) => handleAssign(req, res, options));
+  router.post(`${options.basePath}/unassign`, requireGuildContext, requireMod, csrfProtection, (req, res) => handleUnassign(req, res, options));
   return router;
 }

--- a/src/web/routes/commandAssignments.test.ts
+++ b/src/web/routes/commandAssignments.test.ts
@@ -17,6 +17,7 @@ vi.mock('../csrf', () => ({
   csrfProtection: (_req: any, _res: any, next: any) => next(),
 }));
 vi.mock('../middleware', () => ({
+  requireGuildContext: (_req: any, _res: any, next: any) => next(),
   requireMod: (_req: any, _res: any, next: any) => next(),
 }));
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));

--- a/src/web/routes/commandAssignments.test.ts
+++ b/src/web/routes/commandAssignments.test.ts
@@ -16,9 +16,10 @@ vi.mock('../../db', () => {
 vi.mock('../csrf', () => ({
   csrfProtection: (_req: any, _res: any, next: any) => next(),
 }));
+const { middlewareCallOrder } = vi.hoisted(() => ({ middlewareCallOrder: [] as string[] }));
 vi.mock('../middleware', () => ({
-  requireGuildContext: (_req: any, _res: any, next: any) => next(),
-  requireMod: (_req: any, _res: any, next: any) => next(),
+  requireGuildContext: (_req: any, _res: any, next: any) => { middlewareCallOrder.push('requireGuildContext'); next(); },
+  requireMod: (_req: any, _res: any, next: any) => { middlewareCallOrder.push('requireMod'); next(); },
 }));
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
 
@@ -38,6 +39,7 @@ const VALID_DISCORD_ID = '123456789012345678'; // 18 digits
 
 beforeEach(() => {
   vi.clearAllMocks();
+  middlewareCallOrder.length = 0;
   vi.mocked(findUser).mockResolvedValue({ discord_id: VALID_DISCORD_ID, discord_name: 'Alice', is_twitch_bot_enabled: true, twitch_name: 'alice', access_level: AccessLevel.USER } as any);
   vi.mocked(assignUserToCommand).mockResolvedValue(undefined);
   vi.mocked(unassignUserFromCommand).mockResolvedValue(undefined);
@@ -47,6 +49,13 @@ beforeEach(() => {
 // ─── POST /commands/assign ────────────────────────────────────────────────────
 
 describe('POST /commands/assign', () => {
+  it('runs requireGuildContext before requireMod, so a demoted session is re-checked with a fresh access level', async () => {
+    await supertest(buildApp())
+      .post('/commands/assign')
+      .send(`command_id=${VALID_COMMAND_ID}&discord_id=${VALID_DISCORD_ID}`);
+    expect(middlewareCallOrder).toEqual(['requireGuildContext', 'requireMod']);
+  });
+
   it('redirects to /commands on success', async () => {
     const res = await supertest(buildApp())
       .post('/commands/assign')
@@ -119,6 +128,13 @@ describe('POST /commands/assign', () => {
 // ─── POST /commands/unassign ──────────────────────────────────────────────────
 
 describe('POST /commands/unassign', () => {
+  it('runs requireGuildContext before requireMod, so a demoted session is re-checked with a fresh access level', async () => {
+    await supertest(buildApp())
+      .post('/commands/unassign')
+      .send(`command_id=${VALID_COMMAND_ID}&discord_id=${VALID_DISCORD_ID}`);
+    expect(middlewareCallOrder).toEqual(['requireGuildContext', 'requireMod']);
+  });
+
   it('redirects to /commands on success', async () => {
     const res = await supertest(buildApp())
       .post('/commands/unassign')

--- a/src/web/routes/commandMutations.test.ts
+++ b/src/web/routes/commandMutations.test.ts
@@ -173,6 +173,13 @@ describe('POST /commands/add', () => {
 // ─── POST /commands/update ────────────────────────────────────────────────────
 
 describe('POST /commands/update', () => {
+  it('runs requireGuildContext before requireMod, so a demoted session is re-checked with a fresh access level', async () => {
+    await supertest(buildApp())
+      .post('/commands/update')
+      .send('command_id=1&trigger_string=!clap&output=Clap');
+    expect(middlewareCallOrder).toEqual(['requireGuildContext', 'requireMod']);
+  });
+
   it('redirects to /commands on success', async () => {
     const res = await supertest(buildApp())
       .post('/commands/update')
@@ -223,6 +230,11 @@ describe('POST /commands/update', () => {
 // ─── POST /commands/remove ────────────────────────────────────────────────────
 
 describe('POST /commands/remove', () => {
+  it('runs requireGuildContext before requireMod, so a demoted session is re-checked with a fresh access level', async () => {
+    await supertest(buildApp()).post('/commands/remove').send('command_id=5');
+    expect(middlewareCallOrder).toEqual(['requireGuildContext', 'requireMod']);
+  });
+
   it('redirects to /commands on success', async () => {
     const res = await supertest(buildApp()).post('/commands/remove').send('command_id=5');
     expect(res.status).toBe(302);

--- a/src/web/routes/commandMutations.test.ts
+++ b/src/web/routes/commandMutations.test.ts
@@ -20,7 +20,11 @@ vi.mock('../../db', () => {
   };
 });
 vi.mock('../csrf', () => ({ csrfProtection: (_req: any, _res: any, next: any) => next() }));
-vi.mock('../middleware', () => ({ requireMod: (_req: any, _res: any, next: any) => next() }));
+const { middlewareCallOrder } = vi.hoisted(() => ({ middlewareCallOrder: [] as string[] }));
+vi.mock('../middleware', () => ({
+  requireGuildContext: (_req: any, _res: any, next: any) => { middlewareCallOrder.push('requireGuildContext'); next(); },
+  requireMod: (_req: any, _res: any, next: any) => { middlewareCallOrder.push('requireMod'); next(); },
+}));
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
 
 import supertest from 'supertest';
@@ -43,6 +47,7 @@ const VALID_DISCORD_ID = '123456789012345678';
 
 beforeEach(() => {
   vi.clearAllMocks();
+  middlewareCallOrder.length = 0;
   vi.mocked(addCustomCommand).mockResolvedValue(1);
   vi.mocked(updateCustomCommand).mockResolvedValue(undefined);
   vi.mocked(removeCustomCommand).mockResolvedValue(undefined);
@@ -54,6 +59,13 @@ beforeEach(() => {
 // ─── POST /commands/add ───────────────────────────────────────────────────────
 
 describe('POST /commands/add', () => {
+  it('runs requireGuildContext before requireMod, so a demoted session is re-checked with a fresh access level', async () => {
+    await supertest(buildApp())
+      .post('/commands/add')
+      .send('trigger_string=!clap&output=Clap%21');
+    expect(middlewareCallOrder).toEqual(['requireGuildContext', 'requireMod']);
+  });
+
   it('redirects to /commands on success', async () => {
     const res = await supertest(buildApp())
       .post('/commands/add')

--- a/src/web/routes/commandMutations.ts
+++ b/src/web/routes/commandMutations.ts
@@ -11,7 +11,7 @@ import {
   updateCustomCommand,
 } from '../../db';
 import { csrfProtection } from '../csrf';
-import { requireMod } from '../middleware';
+import { requireGuildContext, requireMod } from '../middleware';
 import {
   logAndRedirectError,
   normalizeRequiredText,
@@ -64,7 +64,7 @@ async function assignUsersToNewCommand(commandId: number, discordIds: string[]):
  *   command insert fails (`add_failed`), or an assignment fails (`command_taken` or
  *   `assign_failed`).
  */
-router.post('/commands/add', requireMod, csrfProtection, async (req, res) => {
+router.post('/commands/add', requireGuildContext, requireMod, csrfProtection, async (req, res) => {
   const { trigger_string, output } = req.body as Record<string, string | undefined>;
   const isDiscordEnabled = parseCheckboxField(req.body.is_discord_enabled);
   const isMultiTwitch = parseCheckboxField(req.body.is_multi_twitch);
@@ -105,7 +105,7 @@ router.post('/commands/add', requireMod, csrfProtection, async (req, res) => {
  *   (`command_not_found`), the trigger is reserved (`reserved_command`) or already
  *   taken (`command_taken`), or the update fails (`update_failed`).
  */
-router.post('/commands/update', requireMod, csrfProtection, async (req, res) => {
+router.post('/commands/update', requireGuildContext, requireMod, csrfProtection, async (req, res) => {
   const { command_id, trigger_string, output } = req.body as Record<string, string | undefined>;
   const isDiscordEnabled = parseCheckboxField(req.body.is_discord_enabled);
   const isMultiTwitch = parseCheckboxField(req.body.is_multi_twitch);
@@ -141,7 +141,7 @@ router.post('/commands/update', requireMod, csrfProtection, async (req, res) => 
  *   `command_id` is absent, or to `/commands?error=<code>` if it's malformed
  *   (`invalid_id`) or the delete fails (`remove_failed`).
  */
-router.post('/commands/remove', requireMod, csrfProtection, async (req, res) => {
+router.post('/commands/remove', requireGuildContext, requireMod, csrfProtection, async (req, res) => {
   const { command_id } = req.body as { command_id?: string };
   if (!command_id) return res.redirect('/commands');
 

--- a/src/web/routes/counters.test.ts
+++ b/src/web/routes/counters.test.ts
@@ -224,6 +224,11 @@ describe('POST /counters/add', () => {
 // --- POST /counters/update ---
 
 describe('POST /counters/update', () => {
+  it('runs requireGuildContext before requireMod, so a demoted session is re-checked with a fresh access level', async () => {
+    await supertest(buildApp()).post('/counters/update').type('form').send(VALID_UPDATE);
+    expect(middlewareCallOrder).toEqual(['requireGuildContext', 'requireMod']);
+  });
+
   it('11. redirects ?error=missing_fields when required fields are absent', async () => {
     const res = await supertest(buildApp())
       .post('/counters/update')
@@ -284,6 +289,11 @@ describe('POST /counters/update', () => {
 // --- POST /counters/remove ---
 
 describe('POST /counters/remove', () => {
+  it('runs requireGuildContext before requireMod, so a demoted session is re-checked with a fresh access level', async () => {
+    await supertest(buildApp()).post('/counters/remove').type('form').send({ id: '5' });
+    expect(middlewareCallOrder).toEqual(['requireGuildContext', 'requireMod']);
+  });
+
   it('17. redirects ?error=invalid_id when id is non-numeric', async () => {
     const res = await supertest(buildApp())
       .post('/counters/remove')

--- a/src/web/routes/counters.test.ts
+++ b/src/web/routes/counters.test.ts
@@ -27,10 +27,12 @@ vi.mock('../csrf', () => ({
   },
 }));
 
+const { middlewareCallOrder } = vi.hoisted(() => ({ middlewareCallOrder: [] as string[] }));
 vi.mock('../middleware', () => ({
   requireAuth: (_req: any, _res: any, next: any) => next(),
-  requireMod: (_req: any, _res: any, next: any) => next(),
-  requireManager: (_req: any, _res: any, next: any) => next(),
+  requireGuildContext: (_req: any, _res: any, next: any) => { middlewareCallOrder.push('requireGuildContext'); next(); },
+  requireMod: (_req: any, _res: any, next: any) => { middlewareCallOrder.push('requireMod'); next(); },
+  requireManager: (_req: any, _res: any, next: any) => { middlewareCallOrder.push('requireManager'); next(); },
 }));
 
 vi.mock('../../logger', () => ({
@@ -81,6 +83,7 @@ const VALID_UPDATE = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  middlewareCallOrder.length = 0;
   vi.mocked(getAllCounters).mockResolvedValue([]);
   vi.mocked(addCounter).mockResolvedValue(undefined);
   vi.mocked(updateCounter).mockResolvedValue(undefined);
@@ -116,6 +119,11 @@ describe('GET /counters', () => {
 // --- POST /counters/add ---
 
 describe('POST /counters/add', () => {
+  it('runs requireGuildContext before requireMod, so a demoted session is re-checked with a fresh access level', async () => {
+    await supertest(buildApp()).post('/counters/add').type('form').send(VALID_ADD);
+    expect(middlewareCallOrder).toEqual(['requireGuildContext', 'requireMod']);
+  });
+
   it('1. redirects ?error=missing_fields when trigger_command is absent', async () => {
     const res = await supertest(buildApp())
       .post('/counters/add')
@@ -308,6 +316,11 @@ describe('POST /counters/remove', () => {
 // --- POST /counters/reset/:id ---
 
 describe('POST /counters/reset/:id', () => {
+  it('runs requireGuildContext before requireManager, so a demoted session is re-checked with a fresh access level', async () => {
+    await supertest(buildApp()).post('/counters/reset/7');
+    expect(middlewareCallOrder).toEqual(['requireGuildContext', 'requireManager']);
+  });
+
   it('20. redirects ?error=invalid_id when :id is non-numeric', async () => {
     const res = await supertest(buildApp())
       .post('/counters/reset/notanumber');

--- a/src/web/routes/counters.ts
+++ b/src/web/routes/counters.ts
@@ -10,7 +10,7 @@ import {
   updateCounter,
 } from '../../db';
 import { csrfProtection } from '../csrf';
-import { requireAuth, requireMod, requireManager } from '../middleware';
+import { requireAuth, requireGuildContext, requireMod, requireManager } from '../middleware';
 import {
   logAndRedirectError,
   normalizeRequiredText,
@@ -116,7 +116,7 @@ router.get('/counters', requireAuth, csrfProtection, async (req, res) => {
  *   `same_commands`, `duplicate_command`, `reserved_command`) or a DB failure
  *   (`add_failed`).
  */
-router.post('/counters/add', requireMod, csrfProtection, async (req, res) => {
+router.post('/counters/add', requireGuildContext, requireMod, csrfProtection, async (req, res) => {
   const form = validateAndNormalizeCounterForm(req.body as Record<string, string | undefined>);
   if (form.error) {
     return res.redirect(`/counters?error=${form.error}`);
@@ -157,7 +157,7 @@ router.post('/counters/add', requireMod, csrfProtection, async (req, res) => {
  *   counter no longer exists (`counter_not_found`), or the update fails
  *   (`update_failed`).
  */
-router.post('/counters/update', requireMod, csrfProtection, async (req, res) => {
+router.post('/counters/update', requireGuildContext, requireMod, csrfProtection, async (req, res) => {
   const { id } = req.body as Record<string, string | undefined>;
 
   const parsedId = parsePositiveIntId(id);
@@ -205,7 +205,7 @@ router.post('/counters/update', requireMod, csrfProtection, async (req, res) => 
  *   `/counters?error=<code>` if `id` is malformed (`invalid_id`), the counter
  *   doesn't exist (`counter_not_found`), or the delete fails (`remove_failed`).
  */
-router.post('/counters/remove', requireMod, csrfProtection, async (req, res) => {
+router.post('/counters/remove', requireGuildContext, requireMod, csrfProtection, async (req, res) => {
   const { id } = req.body as { id?: string };
   const parsedId = parsePositiveIntId(id);
 
@@ -234,7 +234,7 @@ router.post('/counters/remove', requireMod, csrfProtection, async (req, res) => 
  *   to `/counters?error=<code>` if `id` is malformed (`invalid_id`), the counter
  *   doesn't exist (`counter_not_found`), or the reset fails (`reset_failed`).
  */
-router.post('/counters/reset/:id', requireManager, csrfProtection, async (req, res) => {
+router.post('/counters/reset/:id', requireGuildContext, requireManager, csrfProtection, async (req, res) => {
   const rawId = req.params.id;
   const parsedId = parsePositiveIntId(typeof rawId === 'string' ? rawId : undefined);
   if (parsedId === null) {

--- a/src/web/routes/timerAssignments.test.ts
+++ b/src/web/routes/timerAssignments.test.ts
@@ -12,6 +12,7 @@ vi.mock('../csrf', () => ({
   csrfProtection: (_req: any, _res: any, next: any) => next(),
 }));
 vi.mock('../middleware', () => ({
+  requireGuildContext: (_req: any, _res: any, next: any) => next(),
   requireMod: (_req: any, _res: any, next: any) => next(),
 }));
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));

--- a/src/web/routes/timers.test.ts
+++ b/src/web/routes/timers.test.ts
@@ -17,8 +17,10 @@ vi.mock('../csrf', () => ({
   },
 }));
 
+const { middlewareCallOrder } = vi.hoisted(() => ({ middlewareCallOrder: [] as string[] }));
 vi.mock('../middleware', () => ({
-  requireManager: (_req: any, _res: any, next: any) => next(),
+  requireGuildContext: (_req: any, _res: any, next: any) => { middlewareCallOrder.push('requireGuildContext'); next(); },
+  requireManager: (_req: any, _res: any, next: any) => { middlewareCallOrder.push('requireManager'); next(); },
 }));
 
 // This module composes timersMutations's and timerAssignments's routers too; stub them out so
@@ -46,11 +48,17 @@ function buildApp() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  middlewareCallOrder.length = 0;
   vi.mocked(getAllTimerCommandsWithAssignments).mockResolvedValue([]);
   vi.mocked(getAllUsers).mockResolvedValue([]);
 });
 
 describe('GET /timers', () => {
+  it('runs requireGuildContext before requireManager, so a demoted session is re-checked with a fresh access level', async () => {
+    await supertest(buildApp()).get('/timers');
+    expect(middlewareCallOrder).toEqual(['requireGuildContext', 'requireManager']);
+  });
+
   it('renders the timers view with an empty list when there are no timers', async () => {
     const res = await supertest(buildApp()).get('/timers');
     expect(res.status).toBe(200);

--- a/src/web/routes/timers.ts
+++ b/src/web/routes/timers.ts
@@ -2,7 +2,7 @@ import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import { DbTimerCommandWithAssignments, DbUser, getAllTimerCommandsWithAssignments, getAllUsers } from '../../db';
 import { csrfProtection } from '../csrf';
-import { requireManager } from '../middleware';
+import { requireGuildContext, requireManager } from '../middleware';
 import { renderError, filterQueryParam, renderView } from './shared';
 import timersMutationsRouter from './timersMutations';
 import timerAssignmentsRouter from './timerAssignments';
@@ -26,7 +26,7 @@ interface TimerViewModel extends DbTimerCommandWithAssignments {
  * lists every Twitch-linked user's discord_id/discord_name/twitch_name plus every timer's
  * assignments, so authentication alone isn't enough (mutations additionally require Mod+).
  */
-router.get('/timers', requireManager, csrfProtection, async (req, res) => {
+router.get('/timers', requireGuildContext, requireManager, csrfProtection, async (req, res) => {
   try {
     const [timers, users] = await Promise.all([
       getAllTimerCommandsWithAssignments(),

--- a/src/web/routes/timersMutations.test.ts
+++ b/src/web/routes/timersMutations.test.ts
@@ -149,6 +149,11 @@ describe('POST /timers/add', () => {
 // ─── POST /timers/update ──────────────────────────────────────────────────────
 
 describe('POST /timers/update', () => {
+  it('runs requireGuildContext before requireMod, so a demoted session is re-checked with a fresh access level', async () => {
+    await supertest(buildApp()).post('/timers/update').send(`id=1&${VALID_FIELDS}`);
+    expect(middlewareCallOrder).toEqual(['requireGuildContext', 'requireMod']);
+  });
+
   it('redirects to /timers on success', async () => {
     const res = await supertest(buildApp()).post('/timers/update').send(`id=1&${VALID_FIELDS}`);
     expect(res.status).toBe(302);
@@ -189,6 +194,11 @@ describe('POST /timers/update', () => {
 // ─── POST /timers/remove ──────────────────────────────────────────────────────
 
 describe('POST /timers/remove', () => {
+  it('runs requireGuildContext before requireMod, so a demoted session is re-checked with a fresh access level', async () => {
+    await supertest(buildApp()).post('/timers/remove').send('id=5');
+    expect(middlewareCallOrder).toEqual(['requireGuildContext', 'requireMod']);
+  });
+
   it('redirects to /timers on success', async () => {
     const res = await supertest(buildApp()).post('/timers/remove').send('id=5');
     expect(res.status).toBe(302);
@@ -210,6 +220,11 @@ describe('POST /timers/remove', () => {
 // ─── POST /timers/toggle ──────────────────────────────────────────────────────
 
 describe('POST /timers/toggle', () => {
+  it('runs requireGuildContext before requireMod, so a demoted session is re-checked with a fresh access level', async () => {
+    await supertest(buildApp()).post('/timers/toggle').send('id=1&enabled=true');
+    expect(middlewareCallOrder).toEqual(['requireGuildContext', 'requireMod']);
+  });
+
   it('redirects to /timers on success', async () => {
     const res = await supertest(buildApp()).post('/timers/toggle').send('id=1&enabled=true');
     expect(res.status).toBe(302);

--- a/src/web/routes/timersMutations.test.ts
+++ b/src/web/routes/timersMutations.test.ts
@@ -16,7 +16,11 @@ vi.mock('../../db', () => {
   };
 });
 vi.mock('../csrf', () => ({ csrfProtection: (_req: any, _res: any, next: any) => next() }));
-vi.mock('../middleware', () => ({ requireMod: (_req: any, _res: any, next: any) => next() }));
+const { middlewareCallOrder } = vi.hoisted(() => ({ middlewareCallOrder: [] as string[] }));
+vi.mock('../middleware', () => ({
+  requireGuildContext: (_req: any, _res: any, next: any) => { middlewareCallOrder.push('requireGuildContext'); next(); },
+  requireMod: (_req: any, _res: any, next: any) => { middlewareCallOrder.push('requireMod'); next(); },
+}));
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
 
 import supertest from 'supertest';
@@ -37,6 +41,7 @@ const VALID_DISCORD_ID = '123456789012345678';
 
 beforeEach(() => {
   vi.clearAllMocks();
+  middlewareCallOrder.length = 0;
   vi.mocked(addTimerCommand).mockResolvedValue(1);
   vi.mocked(updateTimerCommand).mockResolvedValue(undefined);
   vi.mocked(removeTimerCommand).mockResolvedValue(undefined);
@@ -50,6 +55,11 @@ const VALID_FIELDS = 'name=Discord+plug&message=Join+our+Discord&interval_second
 // ─── POST /timers/add ─────────────────────────────────────────────────────────
 
 describe('POST /timers/add', () => {
+  it('runs requireGuildContext before requireMod, so a demoted session is re-checked with a fresh access level', async () => {
+    await supertest(buildApp()).post('/timers/add').send(VALID_FIELDS);
+    expect(middlewareCallOrder).toEqual(['requireGuildContext', 'requireMod']);
+  });
+
   it('redirects to /timers on success', async () => {
     const res = await supertest(buildApp()).post('/timers/add').send(VALID_FIELDS);
     expect(res.status).toBe(302);

--- a/src/web/routes/timersMutations.ts
+++ b/src/web/routes/timersMutations.ts
@@ -6,7 +6,7 @@ import {
 } from '../../db';
 import type { TimerCommandInput } from '../../db';
 import { csrfProtection } from '../csrf';
-import { requireMod } from '../middleware';
+import { requireGuildContext, requireMod } from '../middleware';
 import {
   logAndRedirectError, normalizeDiscordId, normalizeRequiredText, parseCheckboxField, parsePositiveIntId,
 } from './shared';
@@ -98,7 +98,7 @@ async function assignUsersToNewTimer(timerId: number, discordIds: string[]): Pro
  *   `invalid_min_messages`), the insert fails (`add_failed`), or an assignment fails
  *   (`assign_failed`).
  */
-router.post('/timers/add', requireMod, csrfProtection, async (req, res) => {
+router.post('/timers/add', requireGuildContext, requireMod, csrfProtection, async (req, res) => {
   const body = req.body as Record<string, string | string[] | undefined>;
   const result = parseTimerCommandFields(body);
   if (!result.ok) return res.redirect(`/timers?error=${result.errorCode}`);
@@ -129,7 +129,7 @@ router.post('/timers/add', requireMod, csrfProtection, async (req, res) => {
  *   (`missing_fields`, `invalid_interval`, `invalid_min_messages`), the timer doesn't exist
  *   (`timer_not_found`), or the update fails (`update_failed`).
  */
-router.post('/timers/update', requireMod, csrfProtection, async (req, res) => {
+router.post('/timers/update', requireGuildContext, requireMod, csrfProtection, async (req, res) => {
   const body = req.body as Record<string, string | string[] | undefined>;
   const id = parsePositiveIntId(body.id);
   if (id === null) return res.redirect('/timers?error=invalid_id');
@@ -157,7 +157,7 @@ router.post('/timers/update', requireMod, csrfProtection, async (req, res) => {
  *   `/timers?error=<code>` if `id` is malformed (`invalid_id`) or the delete fails
  *   (`remove_failed`).
  */
-router.post('/timers/remove', requireMod, csrfProtection, async (req, res) => {
+router.post('/timers/remove', requireGuildContext, requireMod, csrfProtection, async (req, res) => {
   const id = parsePositiveIntId((req.body as Record<string, string | string[] | undefined>).id);
   if (id === null) return res.redirect('/timers?error=invalid_id');
 
@@ -178,7 +178,7 @@ router.post('/timers/remove', requireMod, csrfProtection, async (req, res) => {
  *   if `id` is malformed (`invalid_id`), the timer doesn't exist (`timer_not_found`), or the
  *   update fails (`toggle_failed`).
  */
-router.post('/timers/toggle', requireMod, csrfProtection, async (req, res) => {
+router.post('/timers/toggle', requireGuildContext, requireMod, csrfProtection, async (req, res) => {
   const body = req.body as Record<string, string | string[] | undefined>;
   const id = parsePositiveIntId(body.id);
   if (id === null) return res.redirect('/timers?error=invalid_id');


### PR DESCRIPTION
## Summary

Part of a full-project bug/security review (findings for the other two issues found are landing as separate PRs). This one is the highest-severity finding.

- `commandMutations.ts`, `counters.ts`, `timers.ts`/`timersMutations.ts`, the shared `assignmentRoutes.ts` (used by both command and timer assign/unassign), and the voice routes in `api.ts` all gated on `requireMod`/`requireManager` **without** `requireGuildContext` running first.
- `requireGuildContext` is what re-derives `req.session.user.accessLevel` from the DB on every request; skipping it leaves the session's cached (and potentially stale) access level in place.
- **Impact:** if an Admin/Manager demotes or removes a user's guild membership, that user's already-open session kept its stale (higher) `accessLevel` until something else happened to trigger `requireGuildContext` (e.g. visiting `/dashboard`). Until then they could keep mutating commands, counters, timers, and driving the voice bot via `/api/voice/*`.
- `commandGuildOverrides.ts` already used the correct pattern (`requireGuildContext, requireMod`) — this PR applies the same pattern to the sibling routers that were missing it.

## Changes

- Added `requireGuildContext` ahead of every `requireMod`/`requireManager` check that was missing it, in: `commandMutations.ts`, `counters.ts`, `timers.ts` (its `GET /timers` route was also gating on `requireManager` alone), `timersMutations.ts`, `assignmentRoutes.ts`, and `api.ts`'s voice routes.
- Left `GET /commands` and `GET /counters` untouched — those are deliberately guild-context-optional (they render without a selected guild for multi-guild users) and don't gate on an access level, so they don't have the bug.
- Updated the corresponding test mocks and added a regression test per file asserting `requireGuildContext` runs before `requireMod`/`requireManager` in the middleware chain.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (3134 passed)
- [x] `npm run lint` (0 errors, pre-existing unrelated warnings only)
- [x] New tests assert middleware call order (`requireGuildContext` → `requireMod`/`requireManager`) for one representative route per affected router

---
_Generated by [Claude Code](https://claude.ai/code/session_01JUXQ7s1grRUArwY1uST9mV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Access Control**
  * Added guild-context validation across voice, assignment, command, counter, and timer routes.
  * Ensured guild context is verified before role authorization and request processing.
  * Preserved existing moderator, manager, and CSRF protections.

* **Tests**
  * Added coverage confirming middleware runs in the correct order across affected routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->