### PR TITLE
Suppress @everyone/@here/role mentions in custom command and counter replies

### DIFF
--- a/src/commands/counterHandler.test.ts
+++ b/src/commands/counterHandler.test.ts
@@ -12,6 +12,7 @@ vi.mock('../db', () => ({
 
 vi.mock('../discord/discordUtils', () => ({
   isDiscordNotFoundError: vi.fn().mockReturnValue(false),
+  NO_MENTIONS: { parse: [] },
 }));
 
 import {
@@ -93,7 +94,7 @@ describe('executeCounterCommandForDiscord', () => {
 
     await executeCounterCommandForDiscord(msg as any, 'viewer1');
 
-    expect(msg.reply).toHaveBeenCalledWith('Count is now 5!');
+    expect(msg.reply).toHaveBeenCalledWith({ content: 'Count is now 5!', allowedMentions: { parse: [] } });
   });
 
   it('replies with check message (no increment) for a check counter', async () => {
@@ -103,7 +104,16 @@ describe('executeCounterCommandForDiscord', () => {
     await executeCounterCommandForDiscord(msg as any);
 
     expect(vi.mocked(incrementCounter)).not.toHaveBeenCalled();
-    expect(msg.reply).toHaveBeenCalledWith('Current count: 7');
+    expect(msg.reply).toHaveBeenCalledWith({ content: 'Current count: 7', allowedMentions: { parse: [] } });
+  });
+
+  it('sets allowedMentions to suppress parsing, so @everyone/@here text in an admin-authored template cannot ping', async () => {
+    vi.mocked(findCounterByCommand).mockResolvedValue({ ...CHECK_COUNTER, message: '@everyone current count: %d' } as any);
+    const msg = makeMockMessage('!count');
+
+    await executeCounterCommandForDiscord(msg as any);
+
+    expect(msg.reply).toHaveBeenCalledWith(expect.objectContaining({ allowedMentions: { parse: [] } }));
   });
 
   it('does NOT reply when incrementCounter fails', async () => {

--- a/src/commands/counterHandler.ts
+++ b/src/commands/counterHandler.ts
@@ -4,7 +4,7 @@ import { findCounterByCommand, incrementCounter } from '../db';
 
 const log = createLogger('Counter');
 import { extractCommand } from './commandUtils';
-import { isDiscordNotFoundError } from '../discord/discordUtils';
+import { isDiscordNotFoundError, NO_MENTIONS } from '../discord/discordUtils';
 import { createRuntimeRegistry, type TwitchSendRuntime } from './twitchRuntime';
 import { createCooldownGate } from './cooldownGate';
 
@@ -140,7 +140,7 @@ export async function executeCounterCommandForDiscord(
   if (!result.canReply) return;
 
   try {
-    await message.reply(result.response);
+    await message.reply({ content: result.response, allowedMentions: NO_MENTIONS });
     log.info(`[Discord] Sent ${result.label} '${command}'.`);
   } catch (err) {
     if (!isDiscordNotFoundError(err)) {

--- a/src/commands/customCommandHandler.test.ts
+++ b/src/commands/customCommandHandler.test.ts
@@ -16,6 +16,7 @@ vi.mock('../twitch/twitchApi', () => ({
 
 vi.mock('../discord/discordUtils', () => ({
   isDiscordNotFoundError: vi.fn().mockReturnValue(false),
+  NO_MENTIONS: { parse: [] },
 }));
 
 import {
@@ -89,7 +90,7 @@ describe('executeCustomCommandForDiscord', () => {
 
     await executeCustomCommandForDiscord(msg as any, 'viewer1');
 
-    expect(msg.reply).toHaveBeenCalledWith('Hello Discord!');
+    expect(msg.reply).toHaveBeenCalledWith({ content: 'Hello Discord!', allowedMentions: { parse: [] } });
   });
 
   it('swallows Discord not-found errors on reply failure', async () => {
@@ -141,7 +142,7 @@ describe('executeCustomCommandForDiscord', () => {
     await executeCustomCommandForDiscord(msg as any, 'viewer1');
 
     const expected = 'viewer1 said foo bar (first: foo)';
-    expect(msg.reply).toHaveBeenCalledWith(expected);
+    expect(msg.reply).toHaveBeenCalledWith({ content: expected, allowedMentions: { parse: [] } });
   });
 
   it('substitutes an unknown placeholder with an empty string', async () => {
@@ -153,7 +154,7 @@ describe('executeCustomCommandForDiscord', () => {
 
     await executeCustomCommandForDiscord(msg as any, 'viewer1');
 
-    expect(msg.reply).toHaveBeenCalledWith('Hi viewer1, unknown: []');
+    expect(msg.reply).toHaveBeenCalledWith({ content: 'Hi viewer1, unknown: []', allowedMentions: { parse: [] } });
   });
 
   it('substitutes {args} and {arg} as empty strings when no args are given', async () => {
@@ -165,7 +166,19 @@ describe('executeCustomCommandForDiscord', () => {
 
     await executeCustomCommandForDiscord(msg as any, 'viewer1');
 
-    expect(msg.reply).toHaveBeenCalledWith('args=[] arg=[]');
+    expect(msg.reply).toHaveBeenCalledWith({ content: 'args=[] arg=[]', allowedMentions: { parse: [] } });
+  });
+
+  it('sets allowedMentions to suppress parsing, so @everyone/@here/role text in {args}/{user} cannot ping', async () => {
+    vi.mocked(getCustomCommandForDiscord).mockResolvedValue({
+      output: 'Thanks {user}: {args}',
+      is_multi_twitch: false,
+    } as any);
+    const msg = mockMsg('!hello @everyone <@&123456789012345678>');
+
+    await executeCustomCommandForDiscord(msg as any, 'viewer1');
+
+    expect(msg.reply).toHaveBeenCalledWith(expect.objectContaining({ allowedMentions: { parse: [] } }));
   });
 });
 

--- a/src/commands/customCommandHandler.ts
+++ b/src/commands/customCommandHandler.ts
@@ -5,7 +5,7 @@ import { getCustomCommandForDiscord, getCustomCommandForTwitchChannel } from '..
 const log = createLogger('CustomCmd');
 import { getSharedChatSession } from '../twitch/twitchApi';
 import { extractCommand, extractArgs } from './commandUtils';
-import { isDiscordNotFoundError } from '../discord/discordUtils';
+import { isDiscordNotFoundError, NO_MENTIONS } from '../discord/discordUtils';
 import type { MultiTwitchGroupInfo } from '../twitch/monitor/twitchMonitorTypes';
 import { fillTemplate } from '../shared/textTemplate';
 import { sendDedupedBySession } from './twitchBroadcast';
@@ -237,7 +237,7 @@ export async function executeCustomCommandForDiscord(
   const filledResponse = buildFilledResponse(result.response, message.content, username);
 
   try {
-    await message.reply(filledResponse);
+    await message.reply({ content: filledResponse, allowedMentions: NO_MENTIONS });
     log.info(`[Discord] Sent custom command '${command}'.`);
   } catch (err) {
     if (!isDiscordNotFoundError(err)) {

--- a/src/discord/discordUtils.ts
+++ b/src/discord/discordUtils.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '../shared/logger';
-import { DiscordAPIError, HTTPError, RESTJSONErrorCodes, ChannelType, type Client, type MessageEditOptions, type TextBasedChannel } from 'discord.js';
+import { DiscordAPIError, HTTPError, RESTJSONErrorCodes, ChannelType, type Client, type MessageEditOptions, type MessageMentionOptions, type TextBasedChannel } from 'discord.js';
 import { getDiscordClient } from './discordClientStore';
 
 const log = createLogger('Discord');
@@ -8,6 +8,15 @@ const log = createLogger('Discord');
 // option, default 3) before giving up, so these delays are for outages that outlast
 // that internal retry budget (e.g. a multi-second Discord API blip).
 const TRANSIENT_ERROR_RETRY_DELAYS_MS = [5_000, 15_000];
+
+/**
+ * Passed as `allowedMentions` on any outbound message built from user-supplied or
+ * template text (e.g. custom command/counter output), so `@everyone`/`@here`/role/user
+ * mentions embedded in that text never actually ping — Discord's default behavior
+ * otherwise parses and triggers them whenever the bot holds the relevant permission
+ * in that channel, letting an unprivileged chat member ping via the bot's identity.
+ */
+export const NO_MENTIONS: MessageMentionOptions = { parse: [] };
 
 /**
  * Checks whether `err` is a transient Discord API failure (5xx `HTTPError`/`DiscordAPIError`)


### PR DESCRIPTION
## Summary

Part of a full-project bug/security review (the other two findings are landing as separate PRs; #528 is the first).

- `buildFilledResponse()` in `customCommandHandler.ts` fills `{args}` with the raw, unsanitized text typed after a custom command trigger, and `{user}` with the invoker's display name, then sends the result via `message.reply()`.
- `counterHandler.ts`'s `message.reply()` call shares the same pattern for admin-configured counter templates.
- Neither call sets `allowedMentions`, so Discord.js's default mention-parsing behavior applies to the reply content.
- **Impact:** this is a privilege-escalation pattern, not a user-input mistake — an unprivileged member doesn't need "Mention Everyone" themselves; they use the bot's reply (sent under the bot's own permissions) as a proxy to trigger a mass-ping they couldn't do directly, e.g. `!hello @everyone`. Impact is conditional on the bot's role actually holding "Mention Everyone" in that channel (where it doesn't, `@everyone` renders as inert text), but that's a common grant for general-purpose bots, and the fix costs nothing regardless.

## Changes

- Added a shared `NO_MENTIONS` constant (`{ parse: [] }`) to `src/discord/discordUtils.ts`.
- Applied it via `allowedMentions: NO_MENTIONS` on the `message.reply()` calls in `customCommandHandler.ts` and `counterHandler.ts`, so interpolated `{args}`/`{user}`/template text can never trigger a real mention.
- Updated existing tests for the new object-shaped `reply()` call, and added a regression test per file asserting mentions are suppressed even when the interpolated text contains `@everyone`/a role mention.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (3129 passed)
- [x] `npm run lint` (0 errors, pre-existing unrelated warnings only)
- [x] New tests assert `allowedMentions: { parse: [] }` is present on the reply even when the filled response contains `@everyone`/a role mention

---
_Generated by [Claude Code](https://claude.ai/code/session_01JUXQ7s1grRUArwY1uST9mV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Discord counter and custom-command replies no longer parse user, role, `@everyone`, or `@here` mentions.
  * User-provided command content is displayed safely without unintentionally notifying or pinging others.

* **Tests**
  * Added coverage confirming mention suppression across counter and custom-command replies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->