### PR TITLE
Document {user}/{args}/{arg} custom command variables on the Commands page

### DIFF
--- a/views/commands.ejs
+++ b/views/commands.ejs
@@ -54,7 +54,12 @@
             <div class="form-section-gap">
               <label for="output" class="form-label">Output</label>
               <p class="hint hint-compact">Reply text to send when the trigger matches.</p>
-              <p class="hint hint-compact">Variables: <code>{user} {args} {arg}</code></p>
+              <p class="hint hint-compact">
+                Variables: <code>{user}</code> sender's name, <code>{args}</code> everything typed after the trigger, <code>{arg}</code> just the first word of that. Unknown <code>{...}</code> placeholders are left blank.
+              </p>
+              <p class="hint hint-compact">
+                Example: trigger <code>!greet</code>, output <code>Thanks {user}, {arg} says: {args}</code> &mdash; <code>!greet hello there</code> from Alice replies <code>Thanks Alice, hello says: hello there</code>.
+              </p>
               <textarea id="output" class="input stream-textarea" name="output" rows="3" placeholder="Hello chat!" required></textarea>
             </div>
             <% if (assignableUsers.length > 0) { %>
@@ -156,7 +161,12 @@
                       </div>
                       <div class="form-section-gap">
                         <label for="output_<%= command.command_id %>" class="form-label">Output</label>
-                        <p class="hint hint-compact">Variables: <code>{user} {args} {arg}</code></p>
+                        <p class="hint hint-compact">
+                          Variables: <code>{user}</code> sender's name, <code>{args}</code> everything typed after the trigger, <code>{arg}</code> just the first word of that. Unknown <code>{...}</code> placeholders are left blank.
+                        </p>
+                        <p class="hint hint-compact">
+                          Example: trigger <code>!greet</code>, output <code>Thanks {user}, {arg} says: {args}</code> &mdash; <code>!greet hello there</code> from Alice replies <code>Thanks Alice, hello says: hello there</code>.
+                        </p>
                         <textarea id="output_<%= command.command_id %>" class="input stream-textarea" name="output" rows="3" required><%= command.output %></textarea>
                       </div>
                       <div class="button-row-wrap">


### PR DESCRIPTION
## Summary

Docs-only follow-up from the same bug/security review as #528 and #529.

- The Custom Commands page (`views/commands.ejs`) showed a bare hint — `Variables: {user} {args} {arg}` — on both the "Add Command" form and the per-command "Edit" form, with no explanation of what each placeholder resolves to.
- Expanded both hints to describe each variable (`{user}` = sender's display name, `{args}` = everything typed after the trigger, `{arg}` = just the first word of that, unknown placeholders resolve to blank) plus a worked example: trigger `!greet`, output `Thanks {user}, {arg} says: {args}` → `!greet hello there` from Alice → `Thanks Alice, hello says: hello there`.
- Semantics match `buildFilledResponse()` in `src/commands/customCommandHandler.ts` and `fillTemplate()` in `src/shared/textTemplate.ts`.

## Changes

- `views/commands.ejs` only — reused the existing `.hint`/`.hint-compact` classes, no new CSS or partial.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (3127 passed)
- [x] `npm run lint` (0 errors, pre-existing unrelated warnings only)
- [x] Rendered the template standalone with `ejs.render()` to confirm both hint blocks (add-form and edit-form) render without error

---
_Generated by [Claude Code](https://claude.ai/code/session_01JUXQ7s1grRUArwY1uST9mV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for command output variables in add and edit forms.
  * Documented `{user}`, `{args}`, and `{arg}` placeholders.
  * Clarified that unknown placeholders produce blank output.
  * Added a concrete greeting example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->