### PR TITLE
Force-reconnect EventSub WebSocket on error instead of only logging

### DIFF
--- a/src/twitch/eventsub/twitchEventSubConnection.test.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.test.ts
@@ -369,6 +369,24 @@ describe('StreamerConnection lifecycle', () => {
     expect((conn as any).ws).not.toBeNull();
   });
 
+  it('reconnects on a socket error even if no close event ever follows', () => {
+    const conn = new StreamerConnection(makeStreamerData());
+    conn.start();
+    const firstWs = (conn as any).ws as MockWebSocket;
+
+    firstWs.listeners.get('error')!();
+    expect((conn as any).ws).toBeNull();
+    expect((conn as any).reconnectAttempts).toBe(1);
+
+    vi.advanceTimersByTime(1_000);
+    const secondWs = (conn as any).ws as MockWebSocket;
+    expect(secondWs).not.toBe(firstWs);
+
+    // The stale socket's close event (if it ever arrives) must not affect the new connection.
+    firstWs.listeners.get('close')!({ code: 1006, reason: 'abnormal' } as any);
+    expect((conn as any).ws).toBe(secondWs);
+  });
+
   /** Verifies the keepalive-timeout path force-reconnects without waiting on the socket's own 'close' event; returns void. */
   it('reconnects on a keepalive timeout even if the socket never fires its own close event', () => {
     const conn = new StreamerConnection(makeStreamerData());

--- a/src/twitch/eventsub/twitchEventSubConnection.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.ts
@@ -156,7 +156,7 @@ export class StreamerConnection {
     socket.addEventListener('open', () => this.onOpen());
     socket.addEventListener('message', (ev: MessageEvent) => this.onMessage(ev));
     socket.addEventListener('close', (ev: CloseEvent) => this.onClose(ev, socket));
-    socket.addEventListener('error', () => { log.warn(`[${this.name}] WebSocket error`); });
+    socket.addEventListener('error', () => this.onError(socket));
     this.ws = socket;
   }
 
@@ -189,9 +189,23 @@ export class StreamerConnection {
   }
 
   /**
+   * Handles the socket's `'error'` event: logs it and immediately force-reconnects, without
+   * waiting for a `'close'` event that a dead-but-not-yet-torn-down socket may never actually
+   * emit (observed in production: an `error` with no following `close`, leaving the connection
+   * silently stuck until the keepalive-timeout backstop eventually caught it minutes later).
+   * @param socket - The socket that emitted the event.
+   */
+  private onError(socket: WebSocket): void {
+    if (this.ws !== socket) return;
+    log.warn(`[${this.name}] WebSocket error`);
+    this.forceReconnect(socket);
+  }
+
+  /**
    * Tears down `socket` as this connection's active WebSocket and schedules a reconnect,
    * without depending on the socket ever emitting its own `'close'` event. Shared by
-   * {@link onClose} (a real close event did arrive) and the keepalive-timeout path in
+   * {@link onClose} (a real close event did arrive), {@link onError} (a socket error arrived
+   * but its `'close'` may never follow), and the keepalive-timeout path in
    * {@link resetKeepaliveTimer} (a close was requested but might never actually fire — a
    * half-dead TCP connection, e.g. after a silent NAT/load-balancer drop, can leave `close()`
    * pending forever with no `'close'` event ever following it, which would otherwise strand

--- a/src/twitch/eventsub/twitchEventSubConnection.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.ts
@@ -194,6 +194,7 @@ export class StreamerConnection {
    * emit (observed in production: an `error` with no following `close`, leaving the connection
    * silently stuck until the keepalive-timeout backstop eventually caught it minutes later).
    * @param socket - The socket that emitted the event.
+   * @returns Nothing.
    */
   private onError(socket: WebSocket): void {
     if (this.ws !== socket) return;


### PR DESCRIPTION
## Summary

Production logs showed an EventSub connection log a `WebSocket error` WARN with no follow-up `close` line and no subsequent activity at all — the connection got permanently stuck:

```
2026-08-13 06:45:51 [WARN] [EventSub] [ExpiredMinotaur] WebSocket error
```
(nothing after)

The `error` listener in `StreamerConnection.connect()` only logged the event; all reconnect logic lived in the `close` handler. Per the WebSocket spec, `close` almost always follows `error`, but this instance proved that assumption isn't reliable — a dead-but-not-torn-down socket can emit `error` with no `close` ever following, the same class of failure `forceReconnect`'s keepalive-timeout path was already written to guard against.

- `onError()` now force-reconnects immediately on a socket `error`, reusing the existing idempotent `forceReconnect()` path (same one used by `onClose` and the keepalive-timeout backstop), instead of waiting on a `close` event that may never arrive.
- Added a lifecycle test asserting a reconnect happens on `error` alone, and that a stale socket's `close` event arriving afterward doesn't disturb the new connection.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite — 168 files / 3147 tests passed)
- [x] New test: `reconnects on a socket error even if no close event ever follows`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCPr3MF952Eikfo8fqaqUE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection reliability by automatically reconnecting when a WebSocket error occurs, even if no follow-up close event is received.
  * Prevented delayed events from an older connection from disrupting the replacement connection.
  * Added error logging to make connection issues easier to identify.
* **Documentation**
  * Clarified reconnection behavior when connection errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->