### PR TITLE
Bound Twitch join/part and per-login Discord calls with timeouts

### DIFF
--- a/src/shared/mutationQueue.ts
+++ b/src/shared/mutationQueue.ts
@@ -6,6 +6,18 @@
  * later operations on the same key from running.
  */
 export function createMutationQueue<K = string>(): {
+  /**
+   * Runs `operation` once any previously queued operation for `key` has settled. Two hazards
+   * to avoid when writing `operation`, both of which hang this key's queue forever with no
+   * error and nothing to log:
+   * - `operation` has no built-in timeout — if it awaits something that can stall indefinitely
+   *   (e.g. a network call with no timeout of its own), bound it yourself. See `withTimeout` in
+   *   `src/twitch/twitchSendQueue.ts` for the established pattern, reused by
+   *   `twitchChannelMembership.ts` and `twitchMonitorPoll.ts`.
+   * - `operation` must never call `run()` again for this same `key` and await the result — that
+   *   inner call queues behind the outer one, which is itself waiting on the inner call: a
+   *   circular wait that never resolves.
+   */
   run<T>(key: K, operation: () => Promise<T>): Promise<T>;
   /** Number of keys with at least one operation in flight. */
   size(): number;

--- a/src/shared/mutationQueue.ts
+++ b/src/shared/mutationQueue.ts
@@ -17,6 +17,10 @@ export function createMutationQueue<K = string>(): {
    * - `operation` must never call `run()` again for this same `key` and await the result — that
    *   inner call queues behind the outer one, which is itself waiting on the inner call: a
    *   circular wait that never resolves.
+   * @param key - Operations sharing a key are serialized; operations on different keys run
+   *   independently.
+   * @param operation - The async work to run once queued.
+   * @returns Resolves or rejects with `operation`'s own result.
    */
   run<T>(key: K, operation: () => Promise<T>): Promise<T>;
   /** Number of keys with at least one operation in flight. */

--- a/src/twitch/monitor/twitchMonitor.test.ts
+++ b/src/twitch/monitor/twitchMonitor.test.ts
@@ -147,7 +147,7 @@ describe('triggerImmediateLiveCheck', () => {
     await triggerImmediateLiveCheck('teststreamer'); // second check: title changed, game unchanged
 
     expect(editAnnouncementSpy).toHaveBeenCalledWith(
-      expect.anything(), expect.anything(), expect.objectContaining({ title: 'New title' }), 'live_message',
+      expect.anything(), expect.anything(), expect.objectContaining({ title: 'New title' }), 'live_message', expect.any(Function),
     );
     expect(getLiveStates('guild-1')[0].title).toBe('New title');
   });
@@ -160,7 +160,7 @@ describe('triggerImmediateLiveCheck', () => {
     await triggerImmediateLiveCheck('teststreamer'); // second check: game changed
 
     expect(editAnnouncementSpy).toHaveBeenCalledWith(
-      expect.anything(), expect.anything(), expect.objectContaining({ game_name: 'Valorant' }), 'new_game_message',
+      expect.anything(), expect.anything(), expect.objectContaining({ game_name: 'Valorant' }), 'new_game_message', expect.any(Function),
     );
   });
 

--- a/src/twitch/monitor/twitchMonitorAnnouncements.test.ts
+++ b/src/twitch/monitor/twitchMonitorAnnouncements.test.ts
@@ -147,6 +147,26 @@ describe('postAnnouncement', () => {
     await expect(postAnnouncement(new Map(), makeStreamer(), makeStream())).resolves.not.toThrow();
     expect(setStreamerLive).not.toHaveBeenCalled();
   });
+
+  // A withLoginLock timeout doesn't cancel postAnnouncement — it may still be running (and could
+  // still send/mutate) after a newer same-login operation has taken over. isCurrent must be
+  // re-checked after each await so a superseded call stops instead of racing the newer one
+  // (CodeRabbit review finding on PR #533).
+  it('sends the message but skips liveStates/DB updates once superseded partway through', async () => {
+    const channel = makeTextChannel();
+    vi.mocked(getDiscordClient).mockReturnValue(makeDiscordClient(channel) as any);
+    let current = true;
+    // Simulate a newer operation taking over while this send is in flight.
+    channel.send.mockImplementation(async () => { current = false; return { id: 'msg1', channelId: 'ch1' }; });
+    const liveStates = new Map<string, LiveState>();
+
+    await postAnnouncement(liveStates, makeStreamer(), makeStream(), () => current);
+
+    expect(channel.send).toHaveBeenCalled(); // already in flight before staleness could be observed
+    expect(liveStates.size).toBe(0);
+    expect(setStreamerLive).not.toHaveBeenCalled();
+    expect(updateMultitwitch).not.toHaveBeenCalled();
+  });
 });
 
 // ─── editAnnouncement ─────────────────────────────────────────────────────────
@@ -240,6 +260,39 @@ describe('editAnnouncement', () => {
     const state = makeLiveState({ group: makeGroup({ delete_old_posts: false }) });
     await expect(editAnnouncement(new Map(), state, makeStream(), 'live_message')).resolves.not.toThrow();
     // Error is caught by outer try/catch and logged; state is not updated.
+    expect(setStreamerLive).not.toHaveBeenCalled();
+  });
+
+  // Mirrors the postAnnouncement isCurrent fencing tests above (CodeRabbit review finding on PR
+  // #533) — a withLoginLock timeout doesn't cancel editAnnouncement, so isCurrent must be
+  // re-checked after each await so a superseded call stops instead of racing a newer operation.
+  it('edits the message but skips DB/multitwitch updates once superseded partway through', async () => {
+    const channel = makeTextChannel();
+    vi.mocked(getDiscordClient).mockReturnValue(makeDiscordClient(channel) as any);
+    let current = true;
+    channel._message.edit.mockImplementation(async () => { current = false; });
+    const state = makeLiveState({ group: makeGroup({ delete_old_posts: false }) });
+
+    await editAnnouncement(new Map(), state, makeStream(), 'live_message', () => current);
+
+    expect(channel._message.edit).toHaveBeenCalled();
+    expect(setStreamerLive).not.toHaveBeenCalled();
+    expect(updateMultitwitch).not.toHaveBeenCalled();
+  });
+
+  it('reposts the message but skips recording its id on state, and skips deleting the old one, once superseded partway through', async () => {
+    const channel = makeTextChannel();
+    vi.mocked(getDiscordClient).mockReturnValue(makeDiscordClient(channel) as any);
+    let current = true;
+    channel.send.mockImplementation(async () => { current = false; return { id: 'msg2', channelId: 'ch1' }; });
+    const state = makeLiveState({ group: makeGroup({ delete_old_posts: true }) });
+    const originalMessageId = state.messageId;
+
+    await editAnnouncement(new Map(), state, makeStream(), 'new_game_message', () => current);
+
+    expect(channel.send).toHaveBeenCalled();
+    expect(state.messageId).toBe(originalMessageId); // repost()'s own state mutation was skipped
+    expect(tryDeleteDiscordMessage).not.toHaveBeenCalled();
     expect(setStreamerLive).not.toHaveBeenCalled();
   });
 });

--- a/src/twitch/monitor/twitchMonitorAnnouncements.test.ts
+++ b/src/twitch/monitor/twitchMonitorAnnouncements.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mockLogger } from '../../test-utils/loggerMock';
+import { deferred } from '../../test-utils/deferredPromise';
+import { flushMicrotasks } from '../../test-utils/flushMicrotasks';
 
 // Shared with the discordUtils mock factory below so tests can still drive
 // isDiscordNotFoundError's return value directly, even though production code
@@ -166,6 +168,36 @@ describe('postAnnouncement', () => {
     expect(liveStates.size).toBe(0);
     expect(setStreamerLive).not.toHaveBeenCalled();
     expect(updateMultitwitch).not.toHaveBeenCalled();
+  });
+
+  // CodeRabbit review finding on PR #533: setStreamerLive's own DB write has no ordering
+  // guarantee against another in-flight write for the same streamer, so a slow, stale write could
+  // otherwise complete *after* a faster, newer write and silently overwrite it. Writes are now
+  // serialized per streamer ID, so the older call's write is guaranteed to fully complete (for
+  // better or worse) before the newer call's write can even start — the newer write always lands
+  // last, regardless of how long the older one takes to settle.
+  it('does not let a slow write for one call clobber a faster write from a later call for the same streamer', async () => {
+    const channel = makeTextChannel();
+    vi.mocked(getDiscordClient).mockReturnValue(makeDiscordClient(channel) as any);
+    const streamer = makeStreamer(); // same streamer (id: 10) for both calls
+    const liveStates = new Map<string, LiveState>();
+
+    const staleWrite = deferred<void>();
+    vi.mocked(setStreamerLive).mockReturnValueOnce(staleWrite.promise);
+
+    const stalePromise = postAnnouncement(liveStates, streamer, makeStream({ game_name: 'Stale Game' }));
+    await flushMicrotasks(); // let the first call reach and start its (deferred) DB write
+
+    const freshPromise = postAnnouncement(liveStates, streamer, makeStream({ game_name: 'Fresh Game' }));
+    await flushMicrotasks(); // the second call's write must be queued behind the first, not racing it
+    expect(setStreamerLive).toHaveBeenCalledTimes(1); // only the stale write has been issued so far
+
+    staleWrite.resolve();
+    await Promise.all([stalePromise, freshPromise]);
+
+    expect(setStreamerLive).toHaveBeenCalledTimes(2);
+    expect(setStreamerLive).toHaveBeenNthCalledWith(1, 10, 'msg1', 'ch1', 'Stale Game');
+    expect(setStreamerLive).toHaveBeenNthCalledWith(2, 10, 'msg1', 'ch1', 'Fresh Game'); // the newer write lands last
   });
 });
 

--- a/src/twitch/monitor/twitchMonitorAnnouncements.test.ts
+++ b/src/twitch/monitor/twitchMonitorAnnouncements.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mockLogger } from '../../test-utils/loggerMock';
 import { deferred } from '../../test-utils/deferredPromise';
 import { flushMicrotasks } from '../../test-utils/flushMicrotasks';
@@ -98,7 +98,12 @@ function makeLiveState(overrides: Partial<LiveState> = {}): LiveState {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.useFakeTimers();
   vi.mocked(isDiscordNotFoundError).mockReturnValue(false);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 // ─── postAnnouncement ─────────────────────────────────────────────────────────
@@ -198,6 +203,26 @@ describe('postAnnouncement', () => {
     expect(setStreamerLive).toHaveBeenCalledTimes(2);
     expect(setStreamerLive).toHaveBeenNthCalledWith(1, 10, 'msg1', 'ch1', 'Stale Game');
     expect(setStreamerLive).toHaveBeenNthCalledWith(2, 10, 'msg1', 'ch1', 'Fresh Game'); // the newer write lands last
+  });
+
+  // CodeRabbit review finding on PR #533: setStreamerLive ran inside the per-streamer persist
+  // queue with no timeout, so a stalled DB call could wedge that streamer's queue forever —
+  // exactly the class of bug this PR otherwise guards against for Twitch/Discord calls.
+  it('times out a hung setStreamerLive write and still releases the queue for a later write to the same streamer', async () => {
+    const channel = makeTextChannel();
+    vi.mocked(getDiscordClient).mockReturnValue(makeDiscordClient(channel) as any);
+    const streamer = makeStreamer(); // same streamer (id: 10) for both calls
+    vi.mocked(setStreamerLive).mockImplementationOnce(() => new Promise(() => {})); // hangs
+
+    const hungPromise = postAnnouncement(new Map(), streamer, makeStream());
+    await vi.advanceTimersByTimeAsync(10_000); // PERSIST_TIMEOUT_MS
+    // postAnnouncement's own try/catch swallows and logs the timeout — it must still resolve
+    // rather than hang forever waiting on the DB write.
+    await expect(hungPromise).resolves.toBeUndefined();
+
+    vi.mocked(setStreamerLive).mockResolvedValue(undefined);
+    await expect(postAnnouncement(new Map(), streamer, makeStream())).resolves.toBeUndefined();
+    expect(setStreamerLive).toHaveBeenCalledTimes(2); // the later write wasn't queued behind the hung one forever
   });
 });
 

--- a/src/twitch/monitor/twitchMonitorAnnouncements.ts
+++ b/src/twitch/monitor/twitchMonitorAnnouncements.ts
@@ -11,6 +11,7 @@ import { buildEmbed, templateVars } from './twitchMonitorEmbed';
 import { updateMultitwitch } from './twitchMonitorMultitwitch';
 import { fillTemplate } from '../../shared/textTemplate';
 import { createMutationQueue } from '../../shared/mutationQueue';
+import { withTimeout } from '../twitchSendQueue';
 
 // `setStreamerLive` performs an unconditional row UPDATE with no ordering guarantee against
 // another in-flight call for the same streamer — a stale, timed-out withLoginLock operation's
@@ -21,6 +22,9 @@ import { createMutationQueue } from '../../shared/mutationQueue';
 // turn only after a newer operation has since taken over.
 const persistQueue = createMutationQueue<string>();
 
+/** Bounds each queued {@link persistStreamerLive} write so a stalled DB call can't wedge {@link persistQueue} for that streamer forever. */
+const PERSIST_TIMEOUT_MS = 10_000;
+
 /**
  * Writes `streamerId`'s live status to the DB, serialized per streamer ID via {@link persistQueue}
  * so overlapping writes for the same streamer can't complete out of order. No-ops if `isCurrent`
@@ -30,12 +34,13 @@ const persistQueue = createMutationQueue<string>();
  * @param channelId - Discord channel id the announcement was posted in.
  * @param gameName - Current game name to record.
  * @param isCurrent - See `withLoginLock` in twitchMonitorPoll.ts.
- * @returns Resolves once the write has completed or been skipped as stale.
+ * @returns Resolves once the write has completed or been skipped as stale. Rejects if the write
+ *   fails or times out.
  */
 async function persistStreamerLive(streamerId: number, messageId: string, channelId: string, gameName: string, isCurrent: () => boolean): Promise<void> {
   await persistQueue.run(String(streamerId), async () => {
     if (!isCurrent()) return;
-    await setStreamerLive(streamerId, messageId, channelId, gameName);
+    await withTimeout(setStreamerLive(streamerId, messageId, channelId, gameName), PERSIST_TIMEOUT_MS, 'Persist streamer live status');
   });
 }
 

--- a/src/twitch/monitor/twitchMonitorAnnouncements.ts
+++ b/src/twitch/monitor/twitchMonitorAnnouncements.ts
@@ -112,53 +112,80 @@ async function repost(textChannel: TextChannel, content: string, embed: EmbedBui
   state.channelId = msg.channelId;
 }
 
+/** Shared context for {@link publishByDeleteAndRepost}/{@link publishByEditWithFallback}. */
+interface PublishContext {
+  textChannel: TextChannel;
+  content: string;
+  embed: EmbedBuilder;
+  state: LiveState;
+  isCurrent: () => boolean;
+}
+
+/**
+ * Publishes via delete-old-then-post-new, for `editAnnouncement`'s `delete_old_posts` branch.
+ * @param ctx - See {@link PublishContext}.
+ * @returns `true` if the repost succeeded and the caller wasn't superseded partway through
+ *   (the old message's deletion is best-effort and doesn't affect this — see
+ *   {@link editAnnouncement}'s doc). `false` if superseded before the repost could be recorded.
+ */
+async function publishByDeleteAndRepost(ctx: PublishContext): Promise<boolean> {
+  const { textChannel, content, embed, state, isCurrent } = ctx;
+  const staleMessageId = state.messageId!;
+  const staleChannelId = state.channelId!;
+  await repost(textChannel, content, embed, state, isCurrent);
+  if (!isCurrent()) return false;
+  try {
+    await tryDeleteDiscordMessage(staleChannelId, staleMessageId);
+  } catch (err) {
+    log.error(`Failed to delete old announcement for ${state.login}, continuing:`, err);
+  }
+  return true;
+}
+
+/**
+ * Publishes via in-place edit, falling back to a fresh repost if the original message is gone,
+ * for `editAnnouncement`'s non-`delete_old_posts` branch.
+ * @param ctx - See {@link PublishContext}, plus the Discord client the edit attempt needs.
+ * @returns `true` if the edit (or fallback repost) succeeded and the caller wasn't superseded
+ *   partway through. `false` otherwise.
+ */
+async function publishByEditWithFallback(ctx: PublishContext & { discordClient: NonNullable<ReturnType<typeof getDiscordClient>> }): Promise<boolean> {
+  const { discordClient, textChannel, content, embed, state, isCurrent } = ctx;
+  const edited = await tryEditDiscordMessage(discordClient, state.channelId!, state.messageId!, { content, embeds: [embed] });
+  if (!isCurrent()) return false;
+  if (edited) return true;
+  await repost(textChannel, content, embed, state, isCurrent);
+  return isCurrent();
+}
+
 /**
  * Resolves `state`'s Discord channel and applies the edit/repost, per `editAnnouncement`'s
  * delete-and-repost vs. edit-in-place-with-fallback-repost rules. Split out from
  * `editAnnouncement` to keep each function's branching (and return-point count) manageable.
- * @param discordClient - The ready Discord client.
- * @param state - Current live state for the streamer being updated (mutated in place on success).
- * @param content - Rendered message content.
- * @param embed - Rendered stream embed.
- * @param templateKey - Which group template was rendered: 'live_message' or 'new_game_message'.
- * @param isCurrent - See {@link editAnnouncement}.
+ * @param params - Bundles the Discord client, live state, rendered content/embed, which template
+ *   was rendered, and the `isCurrent` staleness check (see {@link editAnnouncement}).
  * @returns `true` if the caller should continue on to persisting the new state — the channel was
  *   found and the caller wasn't superseded at any checkpoint. `false` otherwise (channel missing,
  *   or superseded partway through — see {@link editAnnouncement}'s doc for what "superseded" means
  *   for in-flight Discord calls that already can't be undone).
  */
-async function publishEditedAnnouncement(
-  discordClient: NonNullable<ReturnType<typeof getDiscordClient>>,
-  state: LiveState,
-  content: string,
-  embed: EmbedBuilder,
-  templateKey: 'live_message' | 'new_game_message',
-  isCurrent: () => boolean,
-): Promise<boolean> {
+async function publishEditedAnnouncement(params: {
+  discordClient: NonNullable<ReturnType<typeof getDiscordClient>>;
+  state: LiveState;
+  content: string;
+  embed: EmbedBuilder;
+  templateKey: 'live_message' | 'new_game_message';
+  isCurrent: () => boolean;
+}): Promise<boolean> {
+  const { discordClient, state, content, embed, templateKey, isCurrent } = params;
   const channel = await getTextChannel(discordClient, state.channelId!);
   if (!isCurrent() || !channel) return false;
-  const textChannel = channel as TextChannel;
+  const ctx: PublishContext = { textChannel: channel as TextChannel, content, embed, state, isCurrent };
 
   if (state.group.delete_old_posts && templateKey === 'new_game_message') {
-    const staleMessageId = state.messageId!;
-    const staleChannelId = state.channelId!;
-    await repost(textChannel, content, embed, state, isCurrent);
-    if (!isCurrent()) return false;
-    try {
-      await tryDeleteDiscordMessage(staleChannelId, staleMessageId);
-    } catch (err) {
-      log.error(`Failed to delete old announcement for ${state.login}, continuing:`, err);
-    }
-    return true;
+    return publishByDeleteAndRepost(ctx);
   }
-
-  const edited = await tryEditDiscordMessage(discordClient, state.channelId!, state.messageId!, { content, embeds: [embed] });
-  if (!isCurrent()) return false;
-  if (!edited) {
-    await repost(textChannel, content, embed, state, isCurrent);
-    if (!isCurrent()) return false;
-  }
-  return true;
+  return publishByEditWithFallback({ ...ctx, discordClient });
 }
 
 /**
@@ -202,7 +229,7 @@ export async function editAnnouncement(
   const embed = buildEmbed(stream);
 
   try {
-    const published = await publishEditedAnnouncement(discordClient, state, content, embed, templateKey, isCurrent);
+    const published = await publishEditedAnnouncement({ discordClient, state, content, embed, templateKey, isCurrent });
     if (!published) return;
 
     await persistStreamerLive(state.streamerId, state.messageId!, state.channelId!, stream.game_name, isCurrent);

--- a/src/twitch/monitor/twitchMonitorAnnouncements.ts
+++ b/src/twitch/monitor/twitchMonitorAnnouncements.ts
@@ -18,12 +18,17 @@ import { fillTemplate } from '../../shared/textTemplate';
  * @param liveStates - Map of live streamer states, keyed by streamer DB row id.
  * @param streamerData - Full streamer record (including its stream group) from the database.
  * @param stream - The live Twitch stream data.
+ * @param isCurrent - See `withLoginLock` in twitchMonitorPoll.ts; checked after each `await` so a
+ *   caller superseded by a newer same-login operation stops instead of mutating `liveStates` or
+ *   writing to the DB with stale context. A Discord message already sent before staleness is
+ *   detected can't be un-sent, but nothing further is applied on top of it once stale.
  * @returns Resolves once the announcement is posted (or skipped) and state is updated.
  */
 export async function postAnnouncement(
   liveStates: Map<string, LiveState>,
   streamerData: DbStreamerFull,
   stream: TwitchStream,
+  isCurrent: () => boolean = () => true,
 ): Promise<void> {
   // Key by DB row id so each streamer×group pair has independent state
   const key = String(streamerData.id);
@@ -41,16 +46,19 @@ export async function postAnnouncement(
 
   try {
     const channel = await getTextChannel(discordClient, group.discord_channel);
+    if (!isCurrent()) return; // superseded while resolving the channel — don't post using stale context
     if (!channel) {
       log.error(`Channel ${group.discord_channel} not found or not text-based`);
       return;
     }
     const textChannel = channel as TextChannel;
     const msg = await textChannel.send({ content, embeds: [embed] });
+    if (!isCurrent()) return; // superseded while sending — don't record this message against newer state
 
     liveStates.set(key, makeLiveState(streamerData, stream, msg.id, msg.channelId));
 
     await setStreamerLive(streamerData.id, msg.id, msg.channelId, stream.game_name);
+    if (!isCurrent()) return;
     await updateMultitwitch(group.id, liveStates);
   } catch (err) {
     log.error(`Failed to post announcement for ${stream.user_login}:`, err);
@@ -64,10 +72,14 @@ export async function postAnnouncement(
  * @param content - Rendered message content.
  * @param embed - Rendered stream embed.
  * @param state - Live state to update with the new message's id/channel.
- * @returns Resolves once the message is sent and `state` is updated.
+ * @param isCurrent - See {@link editAnnouncement}; checked after sending so a superseded caller
+ *   doesn't record a sent message's id against state a newer operation now owns.
+ * @returns Resolves once the message is sent and `state` is updated (or updating is skipped
+ *   because the caller has since been superseded).
  */
-async function repost(textChannel: TextChannel, content: string, embed: EmbedBuilder, state: LiveState): Promise<void> {
+async function repost(textChannel: TextChannel, content: string, embed: EmbedBuilder, state: LiveState, isCurrent: () => boolean): Promise<void> {
   const msg = await textChannel.send({ content, embeds: [embed] });
+  if (!isCurrent()) return;
   state.messageId = msg.id;
   state.channelId = msg.channelId;
 }
@@ -84,6 +96,9 @@ async function repost(textChannel: TextChannel, content: string, embed: EmbedBui
  * @param state - Current live state for the streamer being updated.
  * @param stream - The updated Twitch stream data.
  * @param templateKey - Which group template to render: 'live_message' or 'new_game_message'.
+ * @param isCurrent - See `withLoginLock` in twitchMonitorPoll.ts; checked after each `await` so a
+ *   caller superseded by a newer same-login operation stops instead of editing/reposting or
+ *   writing to the DB with stale context.
  * @returns Resolves once the announcement is edited or reposted and state is updated.
  */
 export async function editAnnouncement(
@@ -91,6 +106,7 @@ export async function editAnnouncement(
   state: LiveState,
   stream: TwitchStream,
   templateKey: 'live_message' | 'new_game_message',
+  isCurrent: () => boolean = () => true,
 ): Promise<void> {
   state.currentGame = stream.game_name;
   state.title = stream.title;
@@ -110,13 +126,15 @@ export async function editAnnouncement(
 
   try {
     const channel = await getTextChannel(discordClient, state.channelId);
+    if (!isCurrent()) return;
     if (!channel) return;
     const textChannel = channel as TextChannel;
 
     if (group.delete_old_posts && templateKey === 'new_game_message') {
       const staleMessageId = state.messageId;
       const staleChannelId = state.channelId;
-      await repost(textChannel, content, embed, state);
+      await repost(textChannel, content, embed, state, isCurrent);
+      if (!isCurrent()) return;
       try {
         await tryDeleteDiscordMessage(staleChannelId, staleMessageId);
       } catch (err) {
@@ -124,12 +142,15 @@ export async function editAnnouncement(
       }
     } else {
       const edited = await tryEditDiscordMessage(discordClient, state.channelId, state.messageId, { content, embeds: [embed] });
+      if (!isCurrent()) return;
       if (!edited) {
-        await repost(textChannel, content, embed, state);
+        await repost(textChannel, content, embed, state, isCurrent);
+        if (!isCurrent()) return;
       }
     }
 
     await setStreamerLive(state.streamerId, state.messageId!, state.channelId!, stream.game_name);
+    if (!isCurrent()) return;
     await updateMultitwitch(group.id, liveStates);
   } catch (err) {
     log.error(`Failed to edit announcement for ${state.login}:`, err);

--- a/src/twitch/monitor/twitchMonitorAnnouncements.ts
+++ b/src/twitch/monitor/twitchMonitorAnnouncements.ts
@@ -10,6 +10,34 @@ import { LiveState, makeLiveState } from './twitchMonitorTypes';
 import { buildEmbed, templateVars } from './twitchMonitorEmbed';
 import { updateMultitwitch } from './twitchMonitorMultitwitch';
 import { fillTemplate } from '../../shared/textTemplate';
+import { createMutationQueue } from '../../shared/mutationQueue';
+
+// `setStreamerLive` performs an unconditional row UPDATE with no ordering guarantee against
+// another in-flight call for the same streamer — a stale, timed-out withLoginLock operation's
+// write could otherwise land after a newer operation's, silently overwriting fresher message/game
+// state with stale data. Serializing writes per streamer ID guarantees a write can't start until
+// any earlier one has fully completed, and re-checking `isCurrent` immediately before writing
+// (inside the queued operation, not just before enqueueing) catches a stale write that reaches its
+// turn only after a newer operation has since taken over.
+const persistQueue = createMutationQueue<string>();
+
+/**
+ * Writes `streamerId`'s live status to the DB, serialized per streamer ID via {@link persistQueue}
+ * so overlapping writes for the same streamer can't complete out of order. No-ops if `isCurrent`
+ * reports superseded by the time this write reaches the front of the queue.
+ * @param streamerId - DB row id of the streamer being written.
+ * @param messageId - Discord message id of the live announcement.
+ * @param channelId - Discord channel id the announcement was posted in.
+ * @param gameName - Current game name to record.
+ * @param isCurrent - See `withLoginLock` in twitchMonitorPoll.ts.
+ * @returns Resolves once the write has completed or been skipped as stale.
+ */
+async function persistStreamerLive(streamerId: number, messageId: string, channelId: string, gameName: string, isCurrent: () => boolean): Promise<void> {
+  await persistQueue.run(String(streamerId), async () => {
+    if (!isCurrent()) return;
+    await setStreamerLive(streamerId, messageId, channelId, gameName);
+  });
+}
 
 /**
  * Posts a new "now live" announcement message for a streamer and records the
@@ -57,7 +85,7 @@ export async function postAnnouncement(
 
     liveStates.set(key, makeLiveState(streamerData, stream, msg.id, msg.channelId));
 
-    await setStreamerLive(streamerData.id, msg.id, msg.channelId, stream.game_name);
+    await persistStreamerLive(streamerData.id, msg.id, msg.channelId, stream.game_name, isCurrent);
     if (!isCurrent()) return;
     await updateMultitwitch(group.id, liveStates);
   } catch (err) {
@@ -149,7 +177,7 @@ export async function editAnnouncement(
       }
     }
 
-    await setStreamerLive(state.streamerId, state.messageId!, state.channelId!, stream.game_name);
+    await persistStreamerLive(state.streamerId, state.messageId!, state.channelId!, stream.game_name, isCurrent);
     if (!isCurrent()) return;
     await updateMultitwitch(group.id, liveStates);
   } catch (err) {

--- a/src/twitch/monitor/twitchMonitorAnnouncements.ts
+++ b/src/twitch/monitor/twitchMonitorAnnouncements.ts
@@ -113,6 +113,55 @@ async function repost(textChannel: TextChannel, content: string, embed: EmbedBui
 }
 
 /**
+ * Resolves `state`'s Discord channel and applies the edit/repost, per `editAnnouncement`'s
+ * delete-and-repost vs. edit-in-place-with-fallback-repost rules. Split out from
+ * `editAnnouncement` to keep each function's branching (and return-point count) manageable.
+ * @param discordClient - The ready Discord client.
+ * @param state - Current live state for the streamer being updated (mutated in place on success).
+ * @param content - Rendered message content.
+ * @param embed - Rendered stream embed.
+ * @param templateKey - Which group template was rendered: 'live_message' or 'new_game_message'.
+ * @param isCurrent - See {@link editAnnouncement}.
+ * @returns `true` if the caller should continue on to persisting the new state — the channel was
+ *   found and the caller wasn't superseded at any checkpoint. `false` otherwise (channel missing,
+ *   or superseded partway through — see {@link editAnnouncement}'s doc for what "superseded" means
+ *   for in-flight Discord calls that already can't be undone).
+ */
+async function publishEditedAnnouncement(
+  discordClient: NonNullable<ReturnType<typeof getDiscordClient>>,
+  state: LiveState,
+  content: string,
+  embed: EmbedBuilder,
+  templateKey: 'live_message' | 'new_game_message',
+  isCurrent: () => boolean,
+): Promise<boolean> {
+  const channel = await getTextChannel(discordClient, state.channelId!);
+  if (!isCurrent() || !channel) return false;
+  const textChannel = channel as TextChannel;
+
+  if (state.group.delete_old_posts && templateKey === 'new_game_message') {
+    const staleMessageId = state.messageId!;
+    const staleChannelId = state.channelId!;
+    await repost(textChannel, content, embed, state, isCurrent);
+    if (!isCurrent()) return false;
+    try {
+      await tryDeleteDiscordMessage(staleChannelId, staleMessageId);
+    } catch (err) {
+      log.error(`Failed to delete old announcement for ${state.login}, continuing:`, err);
+    }
+    return true;
+  }
+
+  const edited = await tryEditDiscordMessage(discordClient, state.channelId!, state.messageId!, { content, embeds: [embed] });
+  if (!isCurrent()) return false;
+  if (!edited) {
+    await repost(textChannel, content, embed, state, isCurrent);
+    if (!isCurrent()) return false;
+  }
+  return true;
+}
+
+/**
  * Updates an existing "now live" announcement to reflect a new game/title.
  * Delete+repost (when the group has `delete_old_posts` enabled) is reserved
  * for actual game changes (`templateKey === 'new_game_message'`) — title-only
@@ -153,29 +202,8 @@ export async function editAnnouncement(
   const embed = buildEmbed(stream);
 
   try {
-    const channel = await getTextChannel(discordClient, state.channelId);
-    if (!isCurrent()) return;
-    if (!channel) return;
-    const textChannel = channel as TextChannel;
-
-    if (group.delete_old_posts && templateKey === 'new_game_message') {
-      const staleMessageId = state.messageId;
-      const staleChannelId = state.channelId;
-      await repost(textChannel, content, embed, state, isCurrent);
-      if (!isCurrent()) return;
-      try {
-        await tryDeleteDiscordMessage(staleChannelId, staleMessageId);
-      } catch (err) {
-        log.error(`Failed to delete old announcement for ${state.login}, continuing:`, err);
-      }
-    } else {
-      const edited = await tryEditDiscordMessage(discordClient, state.channelId, state.messageId, { content, embeds: [embed] });
-      if (!isCurrent()) return;
-      if (!edited) {
-        await repost(textChannel, content, embed, state, isCurrent);
-        if (!isCurrent()) return;
-      }
-    }
+    const published = await publishEditedAnnouncement(discordClient, state, content, embed, templateKey, isCurrent);
+    if (!published) return;
 
     await persistStreamerLive(state.streamerId, state.messageId!, state.channelId!, stream.game_name, isCurrent);
     if (!isCurrent()) return;

--- a/src/twitch/monitor/twitchMonitorPoll.test.ts
+++ b/src/twitch/monitor/twitchMonitorPoll.test.ts
@@ -72,7 +72,7 @@ describe('handlePollStreamer', () => {
     await handlePollStreamer(liveStates, loginToUserId, makeStreamer(), liveByUserId);
 
     expect(setTwitchChannelLive).toHaveBeenCalledWith('teststreamer', true);
-    expect(postAnnouncement).toHaveBeenCalledWith(liveStates, expect.objectContaining({ id: 5 }), expect.objectContaining({ user_id: 'uid-5' }));
+    expect(postAnnouncement).toHaveBeenCalledWith(liveStates, expect.objectContaining({ id: 5 }), expect.objectContaining({ user_id: 'uid-5' }), expect.any(Function));
   });
 
   it('cancels offline timers when a streamer with a running grace period comes back live', async () => {
@@ -92,7 +92,7 @@ describe('handlePollStreamer', () => {
 
     await handlePollStreamer(liveStates, loginToUserId, makeStreamer(), liveByUserId);
 
-    expect(editAnnouncement).toHaveBeenCalledWith(liveStates, expect.anything(), expect.objectContaining({ game_name: 'Valorant' }), 'new_game_message');
+    expect(editAnnouncement).toHaveBeenCalledWith(liveStates, expect.anything(), expect.objectContaining({ game_name: 'Valorant' }), 'new_game_message', expect.any(Function));
   });
 
   it('edits with live_message when only the title changes', async () => {
@@ -102,7 +102,7 @@ describe('handlePollStreamer', () => {
 
     await handlePollStreamer(liveStates, loginToUserId, makeStreamer(), liveByUserId);
 
-    expect(editAnnouncement).toHaveBeenCalledWith(liveStates, expect.anything(), expect.objectContaining({ title: 'New title' }), 'live_message');
+    expect(editAnnouncement).toHaveBeenCalledWith(liveStates, expect.anything(), expect.objectContaining({ title: 'New title' }), 'live_message', expect.any(Function));
   });
 
   it('syncs currentStream without posting or editing when nothing changed', async () => {

--- a/src/twitch/monitor/twitchMonitorPoll.test.ts
+++ b/src/twitch/monitor/twitchMonitorPoll.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mockLogger } from '../../test-utils/loggerMock';
 
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
@@ -42,6 +42,11 @@ function makeLiveState(overrides: Partial<LiveState> = {}): LiveState {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 // ─── handlePollStreamer ───────────────────────────────────────────────────────
@@ -210,5 +215,16 @@ describe('withLoginLock', () => {
   it('resolves with the wrapped function\'s return value', async () => {
     const result = await withLoginLock('alice', async () => 42);
     expect(result).toBe(42);
+  });
+
+  it('times out a hung fn and still releases the queue for a later operation on the same login', async () => {
+    const hung = withLoginLock('alice', () => new Promise<void>(() => {}));
+    const assertion = expect(hung).rejects.toThrow('Login lock (alice) timed out after 20000ms');
+    await vi.advanceTimersByTimeAsync(20_000); // LOGIN_LOCK_TIMEOUT_MS
+    await assertion;
+
+    const order: string[] = [];
+    await withLoginLock('alice', async () => { order.push('after-timeout'); });
+    expect(order).toEqual(['after-timeout']);
   });
 });

--- a/src/twitch/monitor/twitchMonitorPoll.test.ts
+++ b/src/twitch/monitor/twitchMonitorPoll.test.ts
@@ -119,6 +119,18 @@ describe('handlePollStreamer', () => {
     expect(liveState.currentStream).toBe(newStream);
   });
 
+  it('skips the direct state sync when isCurrent() reports superseded (a newer same-login operation has since taken over)', async () => {
+    const liveState = makeLiveState({ messageId: 'msg1' });
+    const liveStates = new Map<string, LiveState>([['5', liveState]]);
+    const loginToUserId = new Map([['teststreamer', 'uid-5']]);
+    const newStream = makeStream();
+    const liveByUserId = new Map([['uid-5', newStream]]);
+
+    await handlePollStreamer(liveStates, loginToUserId, makeStreamer(), liveByUserId, () => false);
+
+    expect(liveState.currentStream).not.toBe(newStream);
+  });
+
   it('starts the offline grace period when a previously-live streamer is now offline', async () => {
     const liveStates = new Map<string, LiveState>([['5', makeLiveState()]]);
     const loginToUserId = new Map([['teststreamer', 'uid-5']]);
@@ -226,5 +238,34 @@ describe('withLoginLock', () => {
     const order: string[] = [];
     await withLoginLock('alice', async () => { order.push('after-timeout'); });
     expect(order).toEqual(['after-timeout']);
+  });
+
+  it('reports isCurrent() as true for the duration of a normal (non-superseded) run', async () => {
+    const seen: boolean[] = [];
+    await withLoginLock('alice', async (isCurrent) => {
+      seen.push(isCurrent());
+      await Promise.resolve();
+      seen.push(isCurrent());
+    });
+    expect(seen).toEqual([true, true]);
+  });
+
+  it('flips isCurrent() to false for a timed-out fn once a later operation for the same login has started', async () => {
+    let isCurrentAfterResume!: () => boolean;
+    let resumeStalled!: () => void;
+    const stalled = withLoginLock('alice', (isCurrent) => {
+      isCurrentAfterResume = isCurrent;
+      return new Promise<void>((resolve) => { resumeStalled = resolve; });
+    });
+    const stalledAssertion = expect(stalled).rejects.toThrow('Login lock (alice) timed out after 20000ms');
+    await vi.advanceTimersByTimeAsync(20_000); // LOGIN_LOCK_TIMEOUT_MS — frees the queue, stalled fn keeps "running"
+    await stalledAssertion;
+
+    // A later operation for the same login takes over the queue.
+    await withLoginLock('alice', async () => {});
+
+    // The original (still-running-in-the-background) fn must now see itself as superseded.
+    expect(isCurrentAfterResume()).toBe(false);
+    resumeStalled(); // let the original fn actually settle so it doesn't leak into later tests
   });
 });

--- a/src/twitch/monitor/twitchMonitorPoll.ts
+++ b/src/twitch/monitor/twitchMonitorPoll.ts
@@ -59,6 +59,7 @@ export function withLoginLock<T>(login: string, fn: (isCurrent: () => boolean) =
     // entire run — a concurrently *enqueued* call isn't "newer" until it actually gets its turn.
     const generation = (loginGenerations.get(login) ?? 0) + 1;
     loginGenerations.set(login, generation);
+    /** Returns whether this call is still the newest operation started for `login`. */
     const isCurrent = () => loginGenerations.get(login) === generation;
     return withTimeout(fn(isCurrent), LOGIN_LOCK_TIMEOUT_MS, `Login lock (${login})`);
   });

--- a/src/twitch/monitor/twitchMonitorPoll.ts
+++ b/src/twitch/monitor/twitchMonitorPoll.ts
@@ -89,17 +89,17 @@ async function handleLiveStreamer(params: LiveStreamerParams): Promise<void> {
   const isNew = !liveStates.has(stateKey);
   if (isNew || (existing && !existing.messageId)) {
     // Went live, or state exists with no Discord message (e.g. Discord wasn't ready at startup)
-    await postAnnouncement(liveStates, streamer, pollStream);
+    await postAnnouncement(liveStates, streamer, pollStream, isCurrent);
     if (!isCurrent()) return; // superseded while awaiting — a newer op already owns this login's state
     if (isNew) log.info(`${loginKey} went live in group ${streamer.group.name}`);
   } else if (existing && existing.currentGame !== pollStream.game_name) {
     // Game changed
-    await editAnnouncement(liveStates, existing, pollStream, 'new_game_message');
+    await editAnnouncement(liveStates, existing, pollStream, 'new_game_message', isCurrent);
     if (!isCurrent()) return;
     log.info(`${loginKey} game changed to ${pollStream.game_name}`);
   } else if (existing && existing.title !== pollStream.title) {
     // Title-only change — refresh the existing post without re-announcing a game change
-    await editAnnouncement(liveStates, existing, pollStream, 'live_message');
+    await editAnnouncement(liveStates, existing, pollStream, 'live_message', isCurrent);
     if (!isCurrent()) return;
     log.info(`${loginKey} title changed`);
   } else if (existing) {

--- a/src/twitch/monitor/twitchMonitorPoll.ts
+++ b/src/twitch/monitor/twitchMonitorPoll.ts
@@ -13,6 +13,13 @@ const log = createLogger('TwitchMonitor');
 // immediate checks never call handlePollStreamer concurrently for the same login.
 const loginQueues = new Map<string, Promise<void>>();
 
+// The generation number of the most recently *started* operation for each login — bumped right
+// before `fn` runs, i.e. exactly when a new operation takes over the login's queue (whether the
+// previous one finished normally or timed out). Lets a timed-out `fn` that's still running in the
+// background (see LOGIN_LOCK_TIMEOUT_MS) recognize it's been superseded and stop short of any
+// further state mutation or Discord call once it notices — see {@link withLoginLock}'s `isCurrent`.
+const loginGenerations = new Map<string, number>();
+
 /**
  * `fn` ultimately calls into discord.js `send`/`edit`/`fetch` (via postAnnouncement/
  * editAnnouncement/handleStreamOffline), none of which have an explicit timeout configured in
@@ -30,10 +37,31 @@ const LOGIN_LOCK_TIMEOUT_MS = 20_000;
  * stalled Discord call inside it can't wedge the queue for this login forever. A failure in
  * `fn` (including a timeout) rejects the caller's promise but does not block subsequent
  * operations queued for the same login.
+ *
+ * A timeout only stops *waiting* on `fn` — it does not cancel it, so `fn` may still be running
+ * when the queue moves on to a later operation for the same login. `fn` receives an `isCurrent`
+ * check (backed by {@link loginGenerations}) it must call before performing any further state
+ * mutation or Discord call after an `await`, so a stale resumption notices it's been superseded
+ * and stops instead of racing the newer operation.
+ * @param login - The (already-lowercased) Twitch login whose queue `fn` should run behind.
+ * @param fn - The operation to run once queued and any previous same-login operation has settled.
+ *   Receives `isCurrent`, which returns false once a later operation for the same login has
+ *   started (including one that started because this call's own timeout freed the queue).
+ * @returns Resolves/rejects with `fn`'s own result, or rejects with a timeout error if `fn`
+ *   doesn't settle within {@link LOGIN_LOCK_TIMEOUT_MS}.
  */
-export function withLoginLock<T>(login: string, fn: () => Promise<T>): Promise<T> {
+export function withLoginLock<T>(login: string, fn: (isCurrent: () => boolean) => Promise<T>): Promise<T> {
   const previous = loginQueues.get(login) ?? Promise.resolve();
-  const run = previous.then(() => withTimeout(fn(), LOGIN_LOCK_TIMEOUT_MS, `Login lock (${login})`));
+  // Chains this call's timeout-bounded run onto `previous`; both branches resolve so a failure
+  // here never poisons the chain for later same-login calls (mirrors mutationQueue's `release()`).
+  const run = previous.then(() => {
+    // Bumped here, not at withLoginLock() call time, so `isCurrent` stays true for this op's
+    // entire run — a concurrently *enqueued* call isn't "newer" until it actually gets its turn.
+    const generation = (loginGenerations.get(login) ?? 0) + 1;
+    loginGenerations.set(login, generation);
+    const isCurrent = () => loginGenerations.get(login) === generation;
+    return withTimeout(fn(isCurrent), LOGIN_LOCK_TIMEOUT_MS, `Login lock (${login})`);
+  });
   loginQueues.set(login, run.then(() => undefined, () => undefined));
   return run;
 }
@@ -45,26 +73,37 @@ interface LiveStreamerParams {
   loginKey: string;
   existing: LiveState | undefined;
   pollStream: TwitchStream;
+  /** See {@link withLoginLock} — false once a newer operation has superseded this one. */
+  isCurrent: () => boolean;
 }
 
-/** Posts, edits, or no-ops the Discord announcement for a streamer who is currently live. */
+/**
+ * Posts, edits, or no-ops the Discord announcement for a streamer who is currently live.
+ * @param params - See {@link LiveStreamerParams}.
+ * @returns Resolves once the announcement (if any) has been sent/edited, or once this call
+ *   notices — after its own `await` — that it's been superseded and stops without acting further.
+ */
 async function handleLiveStreamer(params: LiveStreamerParams): Promise<void> {
-  const { liveStates, streamer, loginKey, existing, pollStream } = params;
+  const { liveStates, streamer, loginKey, existing, pollStream, isCurrent } = params;
   const stateKey = String(streamer.id);
   const isNew = !liveStates.has(stateKey);
   if (isNew || (existing && !existing.messageId)) {
     // Went live, or state exists with no Discord message (e.g. Discord wasn't ready at startup)
     await postAnnouncement(liveStates, streamer, pollStream);
+    if (!isCurrent()) return; // superseded while awaiting — a newer op already owns this login's state
     if (isNew) log.info(`${loginKey} went live in group ${streamer.group.name}`);
   } else if (existing && existing.currentGame !== pollStream.game_name) {
     // Game changed
     await editAnnouncement(liveStates, existing, pollStream, 'new_game_message');
+    if (!isCurrent()) return;
     log.info(`${loginKey} game changed to ${pollStream.game_name}`);
   } else if (existing && existing.title !== pollStream.title) {
     // Title-only change — refresh the existing post without re-announcing a game change
     await editAnnouncement(liveStates, existing, pollStream, 'live_message');
+    if (!isCurrent()) return;
     log.info(`${loginKey} title changed`);
   } else if (existing) {
+    if (!isCurrent()) return;
     // Still live, nothing changed — keep currentStream in sync (e.g. thumbnail refresh)
     existing.currentGame = pollStream.game_name;
     existing.title = pollStream.title;
@@ -72,12 +111,23 @@ async function handleLiveStreamer(params: LiveStreamerParams): Promise<void> {
   }
 }
 
-/** Applies the live/offline/game/title transition for one streamer based on the latest poll result. */
+/**
+ * Applies the live/offline/game/title transition for one streamer based on the latest poll result.
+ * @param liveStates - Shared per-streamer live-state map, keyed by streamer ID.
+ * @param loginToUserId - Resolved Twitch login → user ID map for the current poll batch.
+ * @param streamer - The streamer row being processed.
+ * @param liveByUserId - Currently-live streams from the poll, keyed by Twitch user ID.
+ * @param isCurrent - See {@link withLoginLock}; checked after each `await` so a resumption that's
+ *   been superseded by a newer same-login operation stops instead of racing it.
+ * @returns Resolves once the transition (if any) has been applied, or once this call notices it's
+ *   been superseded and stops.
+ */
 export async function handlePollStreamer(
   liveStates: Map<string, LiveState>,
   loginToUserId: Map<string, string>,
   streamer: DbStreamerFull,
   liveByUserId: Map<string, TwitchStream>,
+  isCurrent: () => boolean = () => true,
 ): Promise<void> {
   const loginKey = streamer.twitch_name?.toLowerCase();
   if (!loginKey) return;
@@ -95,10 +145,11 @@ export async function handlePollStreamer(
       log.info(`${loginKey} came back — offline timer(s) cancelled`);
     }
     setTwitchChannelLive(loginKey, true);
-    await handleLiveStreamer({ liveStates, streamer, loginKey, existing, pollStream });
+    await handleLiveStreamer({ liveStates, streamer, loginKey, existing, pollStream, isCurrent });
   } else if (existing && !existing.offlineTimer) {
     // Appears offline — start grace period (handleStreamOffline handles all groups for this login)
     await handleStreamOffline(liveStates, loginToUserId, loginKey);
+    if (!isCurrent()) return;
   }
 }
 
@@ -122,7 +173,7 @@ export async function dispatchStreamerPolls(
     Array.from(byLogin.entries()).map(async ([loginKey, group]) => {
       for (const streamer of group) {
         try {
-          await withLoginLock(loginKey, () => handlePollStreamer(liveStates, loginToUserId, streamer, liveByUserId));
+          await withLoginLock(loginKey, (isCurrent) => handlePollStreamer(liveStates, loginToUserId, streamer, liveByUserId, isCurrent));
         } catch (err) {
           log.error(`Error handling streamer poll for ${streamer.twitch_name ?? 'unknown'} in group ${streamer.group.name}:`, err);
         }

--- a/src/twitch/monitor/twitchMonitorPoll.ts
+++ b/src/twitch/monitor/twitchMonitorPoll.ts
@@ -150,7 +150,6 @@ export async function handlePollStreamer(
   } else if (existing && !existing.offlineTimer) {
     // Appears offline — start grace period (handleStreamOffline handles all groups for this login)
     await handleStreamOffline(liveStates, loginToUserId, loginKey);
-    if (!isCurrent()) return;
   }
 }
 

--- a/src/twitch/monitor/twitchMonitorPoll.ts
+++ b/src/twitch/monitor/twitchMonitorPoll.ts
@@ -5,6 +5,7 @@ import { LiveState } from './twitchMonitorTypes';
 import { postAnnouncement, editAnnouncement } from './twitchMonitorAnnouncements';
 import { cancelOfflineTimersForLogin, handleStreamOffline } from './twitchMonitorOffline';
 import { setTwitchChannelLive } from '../../shared/statusStore';
+import { withTimeout } from '../twitchSendQueue';
 
 const log = createLogger('TwitchMonitor');
 
@@ -13,14 +14,26 @@ const log = createLogger('TwitchMonitor');
 const loginQueues = new Map<string, Promise<void>>();
 
 /**
+ * `fn` ultimately calls into discord.js `send`/`edit`/`fetch` (via postAnnouncement/
+ * editAnnouncement/handleStreamOffline), none of which have an explicit timeout configured in
+ * this codebase. Since those calls run behind {@link loginQueues}, a stalled one would otherwise
+ * wedge every later poll and immediate-check for that login forever. Bounding the whole queued
+ * operation guarantees the queue always frees up, even though the underlying call may still be
+ * stuck.
+ */
+const LOGIN_LOCK_TIMEOUT_MS = 20_000;
+
+/**
  * Runs `fn` after any previously queued operation for `login` has settled, so callers
  * from different entrypoints (60s poll loop vs. triggerImmediateLiveCheck) never race on
- * the same login's liveStates entry. A failure in `fn` rejects the caller's promise but
- * does not block subsequent operations queued for the same login.
+ * the same login's liveStates entry. `fn` is bounded by {@link LOGIN_LOCK_TIMEOUT_MS} so a
+ * stalled Discord call inside it can't wedge the queue for this login forever. A failure in
+ * `fn` (including a timeout) rejects the caller's promise but does not block subsequent
+ * operations queued for the same login.
  */
 export function withLoginLock<T>(login: string, fn: () => Promise<T>): Promise<T> {
   const previous = loginQueues.get(login) ?? Promise.resolve();
-  const run = previous.then(() => fn());
+  const run = previous.then(() => withTimeout(fn(), LOGIN_LOCK_TIMEOUT_MS, `Login lock (${login})`));
   loginQueues.set(login, run.then(() => undefined, () => undefined));
   return run;
 }

--- a/src/twitch/twitchChannelMembership.test.ts
+++ b/src/twitch/twitchChannelMembership.test.ts
@@ -268,6 +268,49 @@ describe('joinTwitchChannel global join throttle', () => {
   });
 });
 
+// ─── join/part timeout safeguard ───────────────────────────────────────────
+
+describe('join/part timeout safeguard', () => {
+  it('times out a hung client.join and still releases the join gate for a later join', async () => {
+    const client = makeMockClient();
+    setTmiClient(client as any);
+    setConnected(true);
+    client.join.mockImplementation((channel: string) => (channel === 'alice' ? new Promise<void>(() => {}) : Promise.resolve()));
+
+    const alicePromise = joinTwitchChannel('alice');
+    const aliceAssertion = expect(alicePromise).rejects.toThrow('Twitch join timed out after 10000ms');
+    await vi.advanceTimersByTimeAsync(10_000); // JOIN_PART_TIMEOUT_MS
+    await aliceAssertion;
+
+    // The global join gate must have been released by throttledJoin's `finally` despite the
+    // timeout — a later join for a different channel must still go through instead of queuing
+    // behind the hung one forever.
+    const carolPromise = joinTwitchChannel('carol');
+    const carolAssertion = expect(carolPromise).resolves.toBeUndefined();
+    await vi.advanceTimersByTimeAsync(600); // JOIN_THROTTLE_MS
+    await carolAssertion;
+    expect(client.join).toHaveBeenCalledWith('carol');
+  });
+
+  it('times out a hung client.part and still releases the per-channel queue for a later operation on the same channel', async () => {
+    const client = makeMockClient(['alice']);
+    setTmiClient(client as any);
+    setConnected(true);
+    await joinTwitchChannel('alice'); // already-joined branch — syncs local state, no client.join call
+    client.part.mockImplementation(() => new Promise<void>(() => {}));
+
+    const partPromise = partTwitchChannel('alice');
+    const partAssertion = expect(partPromise).rejects.toThrow('Twitch part timed out after 10000ms');
+    await vi.advanceTimersByTimeAsync(10_000); // JOIN_PART_TIMEOUT_MS
+    await partAssertion;
+
+    // membershipMutationQueue's 'alice' entry must have released — a later same-key operation
+    // (still seeing the channel as joined, since the hung part never actually completed) must
+    // resolve instead of queuing behind the timed-out part forever.
+    await expect(joinTwitchChannel('alice')).resolves.toBeUndefined();
+  });
+});
+
 // ─── reconcileJoinedChannels ────────────────────────────────────────────────
 
 describe('reconcileJoinedChannels', () => {

--- a/src/twitch/twitchChannelMembership.test.ts
+++ b/src/twitch/twitchChannelMembership.test.ts
@@ -311,6 +311,76 @@ describe('join/part timeout safeguard', () => {
   });
 });
 
+// ─── stale join/part compensation ──────────────────────────────────────────
+// A timeout only stops *waiting* on client.join()/client.part() — it doesn't cancel the real
+// network call. If that call later actually succeeds, after the caller already gave up and moved
+// on, its effect on real Twitch-side membership must be reconciled against activeChannels instead
+// of being trusted blindly (CodeRabbit review finding on PR #533).
+
+describe('stale join/part compensation', () => {
+  it('reverts a stale join that lands late, after the channel is no longer desired active', async () => {
+    const client = makeMockClient();
+    setTmiClient(client as any);
+    setConnected(true);
+    let resolveJoin!: () => void;
+    client.join.mockImplementation(() => new Promise<void>((resolve) => { resolveJoin = resolve; }));
+
+    const joinPromise = joinTwitchChannel('alice');
+    const assertion = expect(joinPromise).rejects.toThrow('Twitch join timed out after 10000ms');
+    await vi.advanceTimersByTimeAsync(10_000); // JOIN_PART_TIMEOUT_MS — the caller gives up and rolls back
+    await assertion;
+    expect(getActiveChannels().has('alice')).toBe(false);
+
+    // The real join now actually lands, out of band, well after the caller stopped waiting.
+    client.getChannels.mockReturnValue(['alice']);
+    resolveJoin();
+    await flushMicrotasks();
+
+    // Actual membership no longer matches desired state (not active) — compensateIfStale must
+    // notice and part the channel again rather than leaving a stale, unwanted join in place.
+    expect(client.part).toHaveBeenCalledWith('alice');
+  });
+
+  it('rejoins after a stale part lands late, while the channel is still desired active', async () => {
+    const client = makeMockClient(['alice']);
+    setTmiClient(client as any);
+    setConnected(true);
+    await joinTwitchChannel('alice'); // already-joined branch — syncs local state, no client.join call
+    let resolvePart!: () => void;
+    client.part.mockImplementation(() => new Promise<void>((resolve) => { resolvePart = resolve; }));
+
+    const partPromise = partTwitchChannel('alice');
+    const assertion = expect(partPromise).rejects.toThrow('Twitch part timed out after 10000ms');
+    await vi.advanceTimersByTimeAsync(10_000); // JOIN_PART_TIMEOUT_MS — the caller gives up
+    await assertion;
+
+    // Channel is re-requested while the stale part is still hanging in the background — since
+    // the client still reports it joined, this is the already-joined branch (no network call).
+    await joinTwitchChannel('alice');
+    expect(getActiveChannels().has('alice')).toBe(true);
+
+    // The real part now actually lands, out of band, well after its caller stopped waiting.
+    client.getChannels.mockReturnValue([]);
+    resolvePart();
+    await flushMicrotasks();
+
+    // Actual membership no longer matches desired state (still active) — compensateIfStale must
+    // notice and rejoin rather than leaving the channel stuck parted.
+    expect(client.join).toHaveBeenCalledWith('alice');
+  });
+
+  it('does not compensate a join that settles normally, within the timeout window', async () => {
+    const client = makeMockClient();
+    setTmiClient(client as any);
+    setConnected(true);
+
+    await joinTwitchChannel('alice');
+    await flushMicrotasks();
+
+    expect(client.part).not.toHaveBeenCalled();
+  });
+});
+
 // ─── reconcileJoinedChannels ────────────────────────────────────────────────
 
 describe('reconcileJoinedChannels', () => {

--- a/src/twitch/twitchChannelMembership.ts
+++ b/src/twitch/twitchChannelMembership.ts
@@ -6,6 +6,7 @@ import { getUsers } from './twitchApi';
 import { createMutationQueue } from '../shared/mutationQueue';
 import { withTimeout } from './twitchSendQueue';
 import { createLogger } from '../shared/logger';
+import { throttledJoin, compensateIfStale, resetJoinGate, JOIN_PART_TIMEOUT_MS, MembershipDeps } from './twitchChannelNetworkOps';
 
 const log = createLogger('Twitch');
 
@@ -15,90 +16,23 @@ let _connected = false;
 const activeChannels = new Set<string>();
 const activeChannelUserIds = new Map<string, string>();
 const membershipMutationQueue = createMutationQueue();
-// Twitch rate-limits JOIN to 20 per 10 s (2/s). 600 ms ≈ 1.67/s, ~83% of the ceiling.
-const JOIN_THROTTLE_MS = 600;
-
-/**
- * Like `client.say()`, tmi.js's `client.join()`/`client.part()` have no built-in timeout and can
- * hang indefinitely on a stalled socket. Both calls are made from inside a serializing
- * queue/gate ({@link joinGate}, {@link membershipMutationQueue}), so an unbounded hang here would
- * wedge every later join/part — across every channel — forever. Bounding it guarantees those
- * always free up, even though the underlying call may still be stuck.
- */
-const JOIN_PART_TIMEOUT_MS = 10_000;
 let _onChannelJoined: ((channel: string) => void) | null = null;
 
-// A chain of promises gating client.join() calls so they're spaced JOIN_THROTTLE_MS apart
-// globally — across both the reconnect-reconciliation path and ad-hoc single joins (e.g. from
-// the admin panel) — since those are only serialised per-channel by membershipMutationQueue and
-// could otherwise collectively exceed Twitch's IRC JOIN rate limit.
-let joinGate: Promise<void> = Promise.resolve();
-
 /**
- * Watches `call` — a `client.join()`/`client.part()` promise — for a late successful settlement
- * that arrives only after its caller has already stopped waiting on it via
- * {@link JOIN_PART_TIMEOUT_MS}. Detected directly from `call`'s own timing (settling at or past
- * the timeout window means the caller's `withTimeout` race already gave up on it) rather than
- * tracking a separate "newer operation" marker, so this catches a timed-out call landing late
- * even when nothing else has since touched the channel — e.g. the timed-out `joinTwitchChannel`
- * call's own rollback of `activeChannels` is itself enough to make a late join stale.
- *
- * A late rejection needs no compensation (the call never took effect). A late *success* did take
- * effect on the real Twitch-side membership, so if it no longer matches what `activeChannels`
- * wants, this reconciles it: reverts a stale late join by parting again, or restores a stale late
- * part by rejoining. Runs detached from the caller's own await, which already observed the
- * timeout race independently. The corrective action itself goes through
- * {@link membershipMutationQueue} so it can't interleave with a concurrent legitimate operation
- * on the same channel.
- * @param channel - The channel the call was for.
- * @param call - The raw (un-timed-out) `client.join()`/`client.part()` promise to watch.
- * @param kind - Which operation `call` performed.
- * @returns Nothing — returns immediately without waiting on `call`. Reconciliation (if any) runs
- *   asynchronously in the background whenever `call` eventually settles.
+ * Bundles this module's live client/membership state for {@link compensateIfStale} — see
+ * `twitchChannelNetworkOps.ts`'s {@link MembershipDeps}. Built fresh at each join/part call site
+ * so `runExclusive` closes over the current `channel`, but its accessor functions still read
+ * `_client`/`_connected`/`activeChannels` live, not a snapshot, since reconciliation can run long
+ * after this bundle was built.
  */
-function compensateIfStale(channel: string, call: Promise<unknown>, kind: 'join' | 'part'): void {
-  const startedAt = Date.now();
-  call.then(() => {
-    // Settled within the normal window — the caller's own withTimeout race never gave up on
-    // this call, so there's nothing to reconcile.
-    if (Date.now() - startedAt < JOIN_PART_TIMEOUT_MS) return;
-    void membershipMutationQueue.run(channel, async () => {
-      if (!_client || !_connected) return;
-      const desiredJoined = activeChannels.has(channel);
-      if (kind === 'join' && !desiredJoined && isChannelJoined(channel)) {
-        log.warn(`[Twitch] Stale join for ${channel} landed after it was no longer desired active — reverting`);
-        await withTimeout(_client.part(channel), JOIN_PART_TIMEOUT_MS, 'Twitch part');
-      } else if (kind === 'part' && desiredJoined && !isChannelJoined(channel) && _client) {
-        log.warn(`[Twitch] Stale part for ${channel} landed while it was still desired active — rejoining`);
-        await throttledJoin(_client, channel);
-      }
-    }).catch((err) => log.error(`Failed to reconcile stale ${kind} for ${channel}:`, err));
-  }, () => {});
-}
-
-/**
- * Calls `client.join(channel)`, globally throttled to JOIN_THROTTLE_MS between joins across all
- * channels. Bounded by {@link JOIN_PART_TIMEOUT_MS} so a stalled join can't wedge {@link joinGate}
- * — and every join queued behind it — forever. A join that times out but later actually succeeds
- * is reconciled against `activeChannels` by {@link compensateIfStale} instead of being trusted
- * blindly.
- * @param client - The connected tmi.js client to join with.
- * @param channel - The already-normalized channel name to join.
- * @returns Resolves once the join call itself has completed (not once the throttle window has
- *   elapsed — the throttle only delays the *next* queued join). Rejects if the join times out.
- */
-async function throttledJoin(client: tmi.Client, channel: string): Promise<void> {
-  const previousGate = joinGate;
-  let releaseGate!: () => void;
-  joinGate = new Promise((resolve) => { releaseGate = resolve; });
-  await previousGate;
-  const joinCall = client.join(channel);
-  compensateIfStale(channel, joinCall, 'join');
-  try {
-    await withTimeout(joinCall, JOIN_PART_TIMEOUT_MS, 'Twitch join');
-  } finally {
-    setTimeout(releaseGate, JOIN_THROTTLE_MS);
-  }
+function membershipDeps(): MembershipDeps {
+  return {
+    getClient: () => _client,
+    isConnected: () => _connected,
+    isChannelJoined,
+    isDesiredJoined: (channel) => activeChannels.has(channel),
+    runExclusive: (channel, op) => membershipMutationQueue.run(channel, op),
+  };
 }
 
 /** Sets the active tmi.js client instance (called from twitchBot after connect). */
@@ -151,7 +85,7 @@ async function partStaleChannel(channel: string): Promise<void> {
     return;
   }
   const partCall = _client.part(channel);
-  compensateIfStale(channel, partCall, 'part');
+  compensateIfStale(membershipDeps(), channel, partCall, 'part');
   await withTimeout(partCall, JOIN_PART_TIMEOUT_MS, 'Twitch part');
   setTwitchChannel(channel, false);
   log.info(`Parted stale channel after reconnect: ${channel}`);
@@ -168,7 +102,7 @@ async function joinMissingChannel(channel: string): Promise<void> {
     cacheChannelUserId(channel);
     return;
   }
-  await throttledJoin(_client, channel);
+  await throttledJoin(_client, channel, (call) => compensateIfStale(membershipDeps(), channel, call, 'join'));
   setTwitchChannel(channel, true);
   cacheChannelUserId(channel);
   fireChannelJoinedHook(channel);
@@ -261,7 +195,7 @@ export async function joinTwitchChannel(channel: string): Promise<void> {
     activeChannels.add(normalized);
     setTwitchChannel(normalized, false);
     try {
-      await throttledJoin(_client, normalized);
+      await throttledJoin(_client, normalized, (call) => compensateIfStale(membershipDeps(), normalized, call, 'join'));
       setTwitchChannel(normalized, true);
       cacheChannelUserId(normalized);
     } catch (err) {
@@ -305,7 +239,7 @@ export async function partTwitchChannel(channel: string): Promise<void> {
       setTwitchChannel(normalized, false);
       if (isChannelJoined(normalized)) {
         const partCall = _client.part(normalized);
-        compensateIfStale(normalized, partCall, 'part');
+        compensateIfStale(membershipDeps(), normalized, partCall, 'part');
         await withTimeout(partCall, JOIN_PART_TIMEOUT_MS, 'Twitch part');
       }
     } catch (err) {
@@ -331,5 +265,5 @@ export function getActiveChannelUserIds(): ReadonlyMap<string, string> {
 export function clearMembershipState(): void {
   activeChannels.clear();
   activeChannelUserIds.clear();
-  joinGate = Promise.resolve();
+  resetJoinGate();
 }

--- a/src/twitch/twitchChannelMembership.ts
+++ b/src/twitch/twitchChannelMembership.ts
@@ -4,6 +4,7 @@ import { getTwitchEnabledChannels } from '../db';
 import { normalizeTwitchChannelName } from './twitchChannelName';
 import { getUsers } from './twitchApi';
 import { createMutationQueue } from '../shared/mutationQueue';
+import { withTimeout } from './twitchSendQueue';
 import { createLogger } from '../shared/logger';
 
 const log = createLogger('Twitch');
@@ -16,6 +17,15 @@ const activeChannelUserIds = new Map<string, string>();
 const membershipMutationQueue = createMutationQueue();
 // Twitch rate-limits JOIN to 20 per 10 s (2/s). 600 ms ≈ 1.67/s, ~83% of the ceiling.
 const JOIN_THROTTLE_MS = 600;
+
+/**
+ * Like `client.say()`, tmi.js's `client.join()`/`client.part()` have no built-in timeout and can
+ * hang indefinitely on a stalled socket. Both calls are made from inside a serializing
+ * queue/gate ({@link joinGate}, {@link membershipMutationQueue}), so an unbounded hang here would
+ * wedge every later join/part — across every channel — forever. Bounding it guarantees those
+ * always free up, even though the underlying call may still be stuck.
+ */
+const JOIN_PART_TIMEOUT_MS = 10_000;
 let _onChannelJoined: ((channel: string) => void) | null = null;
 
 // A chain of promises gating client.join() calls so they're spaced JOIN_THROTTLE_MS apart
@@ -26,11 +36,12 @@ let joinGate: Promise<void> = Promise.resolve();
 
 /**
  * Calls `client.join(channel)`, globally throttled to JOIN_THROTTLE_MS between joins across all
- * channels.
+ * channels. Bounded by {@link JOIN_PART_TIMEOUT_MS} so a stalled join can't wedge {@link joinGate}
+ * — and every join queued behind it — forever.
  * @param client - The connected tmi.js client to join with.
  * @param channel - The already-normalized channel name to join.
  * @returns Resolves once the join call itself has completed (not once the throttle window has
- *   elapsed — the throttle only delays the *next* queued join).
+ *   elapsed — the throttle only delays the *next* queued join). Rejects if the join times out.
  */
 async function throttledJoin(client: tmi.Client, channel: string): Promise<void> {
   const previousGate = joinGate;
@@ -38,7 +49,7 @@ async function throttledJoin(client: tmi.Client, channel: string): Promise<void>
   joinGate = new Promise((resolve) => { releaseGate = resolve; });
   await previousGate;
   try {
-    await client.join(channel);
+    await withTimeout(client.join(channel), JOIN_PART_TIMEOUT_MS, 'Twitch join');
   } finally {
     setTimeout(releaseGate, JOIN_THROTTLE_MS);
   }
@@ -74,6 +85,7 @@ function fireChannelJoinedHook(channel: string): void {
   try { _onChannelJoined?.(channel); } catch (err) { log.error('Channel joined hook error:', err); }
 }
 
+/** Parts `channel` if it's no longer active, bounded by {@link JOIN_PART_TIMEOUT_MS} so a stalled part can't wedge {@link membershipMutationQueue} for this channel forever. */
 async function partStaleChannel(channel: string): Promise<void> {
   if (activeChannels.has(channel)) {
     setTwitchChannel(channel, true);
@@ -84,7 +96,7 @@ async function partStaleChannel(channel: string): Promise<void> {
     setTwitchChannel(channel, false);
     return;
   }
-  await _client.part(channel);
+  await withTimeout(_client.part(channel), JOIN_PART_TIMEOUT_MS, 'Twitch part');
   setTwitchChannel(channel, false);
   log.info(`Parted stale channel after reconnect: ${channel}`);
 }
@@ -207,7 +219,7 @@ export async function joinTwitchChannel(channel: string): Promise<void> {
   });
 }
 
-/** Parts a Twitch channel and removes it from active tracking. Serialised via mutationQueue. */
+/** Parts a Twitch channel and removes it from active tracking. Serialised via mutationQueue; the part call itself is bounded by {@link JOIN_PART_TIMEOUT_MS}. */
 export async function partTwitchChannel(channel: string): Promise<void> {
   const normalized = normalizeTwitchChannelName(channel);
   if (!normalized) return;
@@ -229,7 +241,7 @@ export async function partTwitchChannel(channel: string): Promise<void> {
       activeChannelUserIds.delete(normalized);
       setTwitchChannel(normalized, false);
       if (isChannelJoined(normalized)) {
-        await _client.part(normalized);
+        await withTimeout(_client.part(normalized), JOIN_PART_TIMEOUT_MS, 'Twitch part');
       }
     } catch (err) {
       // Keep desired membership removed so later reconciliation can retry

--- a/src/twitch/twitchChannelMembership.ts
+++ b/src/twitch/twitchChannelMembership.ts
@@ -53,6 +53,8 @@ let joinGate: Promise<void> = Promise.resolve();
  * @param channel - The channel the call was for.
  * @param call - The raw (un-timed-out) `client.join()`/`client.part()` promise to watch.
  * @param kind - Which operation `call` performed.
+ * @returns Nothing — returns immediately without waiting on `call`. Reconciliation (if any) runs
+ *   asynchronously in the background whenever `call` eventually settles.
  */
 function compensateIfStale(channel: string, call: Promise<unknown>, kind: 'join' | 'part'): void {
   const startedAt = Date.now();
@@ -136,6 +138,7 @@ function fireChannelJoinedHook(channel: string): void {
  * {@link membershipMutationQueue} for this channel forever.
  * @param channel - The already-normalized channel name to reconcile.
  * @returns Resolves once the channel's status has been synced (and parted, if it was stale).
+ *   Rejects if the part call fails or times out — the channel's status is not synced in that case.
  */
 async function partStaleChannel(channel: string): Promise<void> {
   if (activeChannels.has(channel)) {

--- a/src/twitch/twitchChannelMembership.ts
+++ b/src/twitch/twitchChannelMembership.ts
@@ -35,9 +35,51 @@ let _onChannelJoined: ((channel: string) => void) | null = null;
 let joinGate: Promise<void> = Promise.resolve();
 
 /**
+ * Watches `call` — a `client.join()`/`client.part()` promise — for a late successful settlement
+ * that arrives only after its caller has already stopped waiting on it via
+ * {@link JOIN_PART_TIMEOUT_MS}. Detected directly from `call`'s own timing (settling at or past
+ * the timeout window means the caller's `withTimeout` race already gave up on it) rather than
+ * tracking a separate "newer operation" marker, so this catches a timed-out call landing late
+ * even when nothing else has since touched the channel — e.g. the timed-out `joinTwitchChannel`
+ * call's own rollback of `activeChannels` is itself enough to make a late join stale.
+ *
+ * A late rejection needs no compensation (the call never took effect). A late *success* did take
+ * effect on the real Twitch-side membership, so if it no longer matches what `activeChannels`
+ * wants, this reconciles it: reverts a stale late join by parting again, or restores a stale late
+ * part by rejoining. Runs detached from the caller's own await, which already observed the
+ * timeout race independently. The corrective action itself goes through
+ * {@link membershipMutationQueue} so it can't interleave with a concurrent legitimate operation
+ * on the same channel.
+ * @param channel - The channel the call was for.
+ * @param call - The raw (un-timed-out) `client.join()`/`client.part()` promise to watch.
+ * @param kind - Which operation `call` performed.
+ */
+function compensateIfStale(channel: string, call: Promise<unknown>, kind: 'join' | 'part'): void {
+  const startedAt = Date.now();
+  call.then(() => {
+    // Settled within the normal window — the caller's own withTimeout race never gave up on
+    // this call, so there's nothing to reconcile.
+    if (Date.now() - startedAt < JOIN_PART_TIMEOUT_MS) return;
+    void membershipMutationQueue.run(channel, async () => {
+      if (!_client || !_connected) return;
+      const desiredJoined = activeChannels.has(channel);
+      if (kind === 'join' && !desiredJoined && isChannelJoined(channel)) {
+        log.warn(`[Twitch] Stale join for ${channel} landed after it was no longer desired active — reverting`);
+        await withTimeout(_client.part(channel), JOIN_PART_TIMEOUT_MS, 'Twitch part');
+      } else if (kind === 'part' && desiredJoined && !isChannelJoined(channel) && _client) {
+        log.warn(`[Twitch] Stale part for ${channel} landed while it was still desired active — rejoining`);
+        await throttledJoin(_client, channel);
+      }
+    }).catch((err) => log.error(`Failed to reconcile stale ${kind} for ${channel}:`, err));
+  }, () => {});
+}
+
+/**
  * Calls `client.join(channel)`, globally throttled to JOIN_THROTTLE_MS between joins across all
  * channels. Bounded by {@link JOIN_PART_TIMEOUT_MS} so a stalled join can't wedge {@link joinGate}
- * — and every join queued behind it — forever.
+ * — and every join queued behind it — forever. A join that times out but later actually succeeds
+ * is reconciled against `activeChannels` by {@link compensateIfStale} instead of being trusted
+ * blindly.
  * @param client - The connected tmi.js client to join with.
  * @param channel - The already-normalized channel name to join.
  * @returns Resolves once the join call itself has completed (not once the throttle window has
@@ -48,8 +90,10 @@ async function throttledJoin(client: tmi.Client, channel: string): Promise<void>
   let releaseGate!: () => void;
   joinGate = new Promise((resolve) => { releaseGate = resolve; });
   await previousGate;
+  const joinCall = client.join(channel);
+  compensateIfStale(channel, joinCall, 'join');
   try {
-    await withTimeout(client.join(channel), JOIN_PART_TIMEOUT_MS, 'Twitch join');
+    await withTimeout(joinCall, JOIN_PART_TIMEOUT_MS, 'Twitch join');
   } finally {
     setTimeout(releaseGate, JOIN_THROTTLE_MS);
   }
@@ -85,7 +129,14 @@ function fireChannelJoinedHook(channel: string): void {
   try { _onChannelJoined?.(channel); } catch (err) { log.error('Channel joined hook error:', err); }
 }
 
-/** Parts `channel` if it's no longer active, bounded by {@link JOIN_PART_TIMEOUT_MS} so a stalled part can't wedge {@link membershipMutationQueue} for this channel forever. */
+/**
+ * Parts `channel` via the tmi.js client if it's currently joined but no longer in
+ * `activeChannels` (a "stale" membership left over from before a reconnect); otherwise just
+ * syncs the status store. Bounded by {@link JOIN_PART_TIMEOUT_MS} so a stalled part can't wedge
+ * {@link membershipMutationQueue} for this channel forever.
+ * @param channel - The already-normalized channel name to reconcile.
+ * @returns Resolves once the channel's status has been synced (and parted, if it was stale).
+ */
 async function partStaleChannel(channel: string): Promise<void> {
   if (activeChannels.has(channel)) {
     setTwitchChannel(channel, true);
@@ -96,7 +147,9 @@ async function partStaleChannel(channel: string): Promise<void> {
     setTwitchChannel(channel, false);
     return;
   }
-  await withTimeout(_client.part(channel), JOIN_PART_TIMEOUT_MS, 'Twitch part');
+  const partCall = _client.part(channel);
+  compensateIfStale(channel, partCall, 'part');
+  await withTimeout(partCall, JOIN_PART_TIMEOUT_MS, 'Twitch part');
   setTwitchChannel(channel, false);
   log.info(`Parted stale channel after reconnect: ${channel}`);
 }
@@ -219,7 +272,14 @@ export async function joinTwitchChannel(channel: string): Promise<void> {
   });
 }
 
-/** Parts a Twitch channel and removes it from active tracking. Serialised via mutationQueue; the part call itself is bounded by {@link JOIN_PART_TIMEOUT_MS}. */
+/**
+ * Parts a Twitch channel and removes it from active tracking. Serialised per-channel via
+ * {@link membershipMutationQueue}; the underlying `client.part()` call is bounded by
+ * {@link JOIN_PART_TIMEOUT_MS} so a stalled part can't wedge that channel's queue forever.
+ * @param channel - The channel name to part (normalized internally; a no-op if invalid).
+ * @returns Resolves once local tracking is updated and, if applicable, the client has parted —
+ *   or the part attempt has timed out. Rejects if the underlying part call fails or times out.
+ */
 export async function partTwitchChannel(channel: string): Promise<void> {
   const normalized = normalizeTwitchChannelName(channel);
   if (!normalized) return;
@@ -241,7 +301,9 @@ export async function partTwitchChannel(channel: string): Promise<void> {
       activeChannelUserIds.delete(normalized);
       setTwitchChannel(normalized, false);
       if (isChannelJoined(normalized)) {
-        await withTimeout(_client.part(normalized), JOIN_PART_TIMEOUT_MS, 'Twitch part');
+        const partCall = _client.part(normalized);
+        compensateIfStale(normalized, partCall, 'part');
+        await withTimeout(partCall, JOIN_PART_TIMEOUT_MS, 'Twitch part');
       }
     } catch (err) {
       // Keep desired membership removed so later reconciliation can retry

--- a/src/twitch/twitchChannelNetworkOps.test.ts
+++ b/src/twitch/twitchChannelNetworkOps.test.ts
@@ -120,6 +120,41 @@ describe('compensateIfStale', () => {
     expect(client.part).toHaveBeenCalledWith('alice');
   });
 
+  // CodeRabbit review finding on PR #533: the revert branch's own corrective client.part() call
+  // wasn't itself registered with compensateIfStale, so if THAT call timed out but later actually
+  // succeeded after membership became desired again, nothing would notice and rejoin.
+  it("rejoins after a stale join's own corrective part times out but later settles while membership is desired again", async () => {
+    const client = makeMockClient(['alice']);
+    const deps = makeDeps();
+    deps.setClient(client);
+    deps.setDesired('alice', false); // triggers the initial revert
+
+    let resolveRevertPart!: () => void;
+    client.part.mockImplementation(() => new Promise<void>((resolve) => { resolveRevertPart = resolve; }));
+
+    const staleJoin = new Promise<void>((resolve) => setTimeout(resolve, JOIN_PART_TIMEOUT_MS));
+    compensateIfStale(deps, 'alice', staleJoin, 'join');
+    await vi.advanceTimersByTimeAsync(JOIN_PART_TIMEOUT_MS); // staleJoin settles, the revert's part() is issued
+    await flushMicrotasks();
+    expect(client.part).toHaveBeenCalledWith('alice'); // revert issued, but hangs
+
+    // While the revert is still hanging, membership becomes desired again (e.g. a fresh join request).
+    deps.setDesired('alice', true);
+
+    // The revert's own withTimeout gives up waiting on it (logged and swallowed internally), and
+    // compensateIfStale's watch on the revert call itself is now also past its own timeout window.
+    await vi.advanceTimersByTimeAsync(JOIN_PART_TIMEOUT_MS);
+
+    // The revert call finally settles late — simulate it having actually removed the channel.
+    client.getChannels.mockReturnValue([]);
+    resolveRevertPart();
+    await flushMicrotasks();
+
+    // Actual membership (parted) no longer matches desired (active again) — the revert's own
+    // staleness watcher must notice and rejoin.
+    expect(client.join).toHaveBeenCalledWith('alice');
+  });
+
   it('rejoins after a stale part lands while the channel is still desired active', async () => {
     const client = makeMockClient([]); // part already "took effect" per the mock's channel list
     const deps = makeDeps();

--- a/src/twitch/twitchChannelNetworkOps.test.ts
+++ b/src/twitch/twitchChannelNetworkOps.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { throttledJoin, compensateIfStale, resetJoinGate, JOIN_PART_TIMEOUT_MS, MembershipDeps } from './twitchChannelNetworkOps';
+import { flushMicrotasks } from '../test-utils/flushMicrotasks';
+
+/** Builds a minimal fake tmi.js client, pre-seeded with the given already-joined channels. */
+function makeMockClient(channels: string[] = []) {
+  return {
+    getChannels: vi.fn(() => channels),
+    join: vi.fn().mockResolvedValue(undefined),
+    part: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+/** Builds a {@link MembershipDeps} bundle backed by mutable test state, overridable per test. */
+function makeDeps(overrides: Partial<MembershipDeps> = {}): MembershipDeps & { setClient: (c: unknown) => void; setDesired: (channel: string, desired: boolean) => void } {
+  let client: unknown = null;
+  const connected = true;
+  const desired = new Set<string>();
+  const runs: string[] = [];
+  const deps: MembershipDeps = {
+    getClient: () => client as any,
+    isConnected: () => connected,
+    isChannelJoined: (channel) => (client as any)?.getChannels().includes(channel) ?? false,
+    isDesiredJoined: (channel) => desired.has(channel),
+    runExclusive: (channel, op) => { runs.push(channel); return op(); },
+    ...overrides,
+  };
+  return {
+    ...deps,
+    setClient: (c: unknown) => { client = c; },
+    setDesired: (channel: string, isDesired: boolean) => {
+      if (isDesired) desired.add(channel);
+      else desired.delete(channel);
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  resetJoinGate();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('throttledJoin', () => {
+  it('calls client.join and resolves once it settles', async () => {
+    const client = makeMockClient();
+    await throttledJoin(client as any, 'alice', () => {});
+    expect(client.join).toHaveBeenCalledWith('alice');
+  });
+
+  it('throttles successive joins by JOIN_THROTTLE_MS', async () => {
+    const client = makeMockClient();
+    const first = throttledJoin(client as any, 'alice', () => {});
+    const second = throttledJoin(client as any, 'carol', () => {});
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(client.join).toHaveBeenCalledTimes(1);
+    expect(client.join).toHaveBeenCalledWith('alice');
+
+    await vi.advanceTimersByTimeAsync(599);
+    expect(client.join).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await Promise.all([first, second]);
+    expect(client.join).toHaveBeenNthCalledWith(2, 'carol');
+  });
+
+  it('rejects with a timeout error when client.join hangs, and still releases the gate for a later join', async () => {
+    const client = makeMockClient();
+    client.join.mockImplementation((channel: string) => (channel === 'alice' ? new Promise(() => {}) : Promise.resolve()));
+
+    const alicePromise = throttledJoin(client as any, 'alice', () => {});
+    const assertion = expect(alicePromise).rejects.toThrow('Twitch join timed out after 10000ms');
+    await vi.advanceTimersByTimeAsync(JOIN_PART_TIMEOUT_MS);
+    await assertion;
+
+    const carolPromise = throttledJoin(client as any, 'carol', () => {});
+    const carolAssertion = expect(carolPromise).resolves.toBeUndefined();
+    await vi.advanceTimersByTimeAsync(600);
+    await carolAssertion;
+    expect(client.join).toHaveBeenCalledWith('carol');
+  });
+
+  it('calls onSettled with the raw join promise right after issuing it', async () => {
+    const client = makeMockClient();
+    const seen: unknown[] = [];
+    await throttledJoin(client as any, 'alice', (call) => seen.push(call));
+    expect(seen).toHaveLength(1);
+    await expect(seen[0]).resolves.toBeUndefined();
+  });
+});
+
+describe('compensateIfStale', () => {
+  it('does not reconcile a call that settles within JOIN_PART_TIMEOUT_MS', async () => {
+    const client = makeMockClient(['alice']);
+    const deps = makeDeps();
+    deps.setClient(client);
+    deps.setDesired('alice', false); // desired state disagrees with actual — would trigger revert if considered stale
+
+    compensateIfStale(deps, 'alice', Promise.resolve(), 'join');
+    await flushMicrotasks();
+
+    expect(client.part).not.toHaveBeenCalled();
+  });
+
+  it('reverts a stale join that lands after the channel is no longer desired active', async () => {
+    const client = makeMockClient(['alice']);
+    const deps = makeDeps();
+    deps.setClient(client);
+    deps.setDesired('alice', false);
+
+    const staleCall = new Promise<void>((resolve) => setTimeout(resolve, JOIN_PART_TIMEOUT_MS));
+    compensateIfStale(deps, 'alice', staleCall, 'join');
+    await vi.advanceTimersByTimeAsync(JOIN_PART_TIMEOUT_MS);
+    await flushMicrotasks(); // let the reconciliation's own await chain settle
+
+    expect(client.part).toHaveBeenCalledWith('alice');
+  });
+
+  it('rejoins after a stale part lands while the channel is still desired active', async () => {
+    const client = makeMockClient([]); // part already "took effect" per the mock's channel list
+    const deps = makeDeps();
+    deps.setClient(client);
+    deps.setDesired('alice', true);
+
+    const staleCall = new Promise<void>((resolve) => setTimeout(resolve, JOIN_PART_TIMEOUT_MS));
+    compensateIfStale(deps, 'alice', staleCall, 'part');
+    await vi.advanceTimersByTimeAsync(JOIN_PART_TIMEOUT_MS);
+    await flushMicrotasks();
+
+    expect(client.join).toHaveBeenCalledWith('alice');
+  });
+
+  it('does not reconcile when actual state already matches desired state', async () => {
+    const client = makeMockClient(['alice']);
+    const deps = makeDeps();
+    deps.setClient(client);
+    deps.setDesired('alice', true); // desired matches actual (joined) — a "stale" join here is a non-issue
+
+    const staleCall = new Promise<void>((resolve) => setTimeout(resolve, JOIN_PART_TIMEOUT_MS));
+    compensateIfStale(deps, 'alice', staleCall, 'join');
+    await vi.advanceTimersByTimeAsync(JOIN_PART_TIMEOUT_MS);
+    await flushMicrotasks();
+
+    expect(client.part).not.toHaveBeenCalled();
+  });
+
+  it('does not reconcile a late rejection', async () => {
+    const client = makeMockClient(['alice']);
+    const deps = makeDeps();
+    deps.setClient(client);
+    deps.setDesired('alice', false);
+
+    const staleCall = new Promise<void>((_resolve, reject) => setTimeout(() => reject(new Error('boom')), JOIN_PART_TIMEOUT_MS));
+    compensateIfStale(deps, 'alice', staleCall, 'join');
+    await vi.advanceTimersByTimeAsync(JOIN_PART_TIMEOUT_MS);
+    await flushMicrotasks();
+
+    expect(client.part).not.toHaveBeenCalled();
+  });
+
+  it('runs the reconciliation through runExclusive for the affected channel', async () => {
+    const client = makeMockClient(['alice']);
+    const runs: string[] = [];
+    const deps = makeDeps({ runExclusive: (channel, op) => { runs.push(channel); return op(); } });
+    deps.setClient(client);
+    deps.setDesired('alice', false);
+
+    const staleCall = new Promise<void>((resolve) => setTimeout(resolve, JOIN_PART_TIMEOUT_MS));
+    compensateIfStale(deps, 'alice', staleCall, 'join');
+    await vi.advanceTimersByTimeAsync(JOIN_PART_TIMEOUT_MS);
+    await flushMicrotasks();
+
+    expect(runs).toEqual(['alice']);
+  });
+});

--- a/src/twitch/twitchChannelNetworkOps.test.ts
+++ b/src/twitch/twitchChannelNetworkOps.test.ts
@@ -12,22 +12,22 @@ function makeMockClient(channels: string[] = []) {
 }
 
 /** Builds a {@link MembershipDeps} bundle backed by mutable test state, overridable per test. */
-function makeDeps(overrides: Partial<MembershipDeps> = {}): MembershipDeps & { setClient: (c: unknown) => void; setDesired: (channel: string, desired: boolean) => void } {
+function makeDeps(overrides: Partial<MembershipDeps> = {}): MembershipDeps & { setClient: (c: unknown) => void; setConnected: (v: boolean) => void; setDesired: (channel: string, desired: boolean) => void } {
   let client: unknown = null;
-  const connected = true;
+  let connected = true;
   const desired = new Set<string>();
-  const runs: string[] = [];
   const deps: MembershipDeps = {
     getClient: () => client as any,
     isConnected: () => connected,
     isChannelJoined: (channel) => (client as any)?.getChannels().includes(channel) ?? false,
     isDesiredJoined: (channel) => desired.has(channel),
-    runExclusive: (channel, op) => { runs.push(channel); return op(); },
+    runExclusive: (_channel, op) => op(),
     ...overrides,
   };
   return {
     ...deps,
     setClient: (c: unknown) => { client = c; },
+    setConnected: (v: boolean) => { connected = v; },
     setDesired: (channel: string, isDesired: boolean) => {
       if (isDesired) desired.add(channel);
       else desired.delete(channel);
@@ -104,6 +104,22 @@ describe('compensateIfStale', () => {
     await flushMicrotasks();
 
     expect(client.part).not.toHaveBeenCalled();
+  });
+
+  it('does not attempt a corrective join/part when the client has since disconnected', async () => {
+    const client = makeMockClient(['alice']);
+    const deps = makeDeps();
+    deps.setClient(client);
+    deps.setDesired('alice', false); // would trigger a revert if the client were still connected
+
+    const staleCall = new Promise<void>((resolve) => setTimeout(resolve, JOIN_PART_TIMEOUT_MS));
+    compensateIfStale(deps, 'alice', staleCall, 'join');
+    deps.setConnected(false);
+    await vi.advanceTimersByTimeAsync(JOIN_PART_TIMEOUT_MS);
+    await flushMicrotasks();
+
+    expect(client.part).not.toHaveBeenCalled();
+    expect(client.join).not.toHaveBeenCalled();
   });
 
   it('reverts a stale join that lands after the channel is no longer desired active', async () => {

--- a/src/twitch/twitchChannelNetworkOps.ts
+++ b/src/twitch/twitchChannelNetworkOps.ts
@@ -1,0 +1,116 @@
+import tmi from 'tmi.js';
+import { createLogger } from '../shared/logger';
+import { withTimeout } from './twitchSendQueue';
+
+const log = createLogger('Twitch');
+
+/**
+ * Like `client.say()`, tmi.js's `client.join()`/`client.part()` have no built-in timeout and can
+ * hang indefinitely on a stalled socket. Callers serialize these behind their own queue/gate, so
+ * an unbounded hang here would wedge every later join/part — across every channel — forever.
+ * Bounding it guarantees those always free up, even though the underlying call may still be stuck.
+ */
+export const JOIN_PART_TIMEOUT_MS = 10_000;
+
+// Twitch rate-limits JOIN to 20 per 10 s (2/s). 600 ms ≈ 1.67/s, ~83% of the ceiling.
+const JOIN_THROTTLE_MS = 600;
+
+// A chain of promises gating client.join() calls so they're spaced JOIN_THROTTLE_MS apart
+// globally — across both the reconnect-reconciliation path and ad-hoc single joins (e.g. from
+// the admin panel) — since those are only serialised per-channel by the caller's own mutation
+// queue and could otherwise collectively exceed Twitch's IRC JOIN rate limit.
+let joinGate: Promise<void> = Promise.resolve();
+
+/** Resets the global join throttle gate (used in tests). */
+export function resetJoinGate(): void {
+  joinGate = Promise.resolve();
+}
+
+/**
+ * Dependencies {@link compensateIfStale} needs to reconcile real Twitch-side membership against
+ * desired state. Passed explicitly (rather than imported directly) so this module doesn't need
+ * to reach back into twitchChannelMembership.ts's private state — the accessor functions still
+ * read that state live (not a one-time snapshot), since a late-settling call can be watched for
+ * minutes after the caller assembled this bundle.
+ */
+export interface MembershipDeps {
+  /** Returns the current tmi.js client, or null if not set. */
+  getClient: () => tmi.Client | null;
+  /** Whether the client is currently connected. */
+  isConnected: () => boolean;
+  /** Whether `channel` is currently joined per the live tmi.js client's own channel list. */
+  isChannelJoined: (channel: string) => boolean;
+  /** Whether `channel` is currently desired to be joined (the source of truth for intent). */
+  isDesiredJoined: (channel: string) => boolean;
+  /** Runs `op` serialized per-channel, so it can't interleave with a concurrent operation on `channel`. */
+  runExclusive: (channel: string, op: () => Promise<unknown>) => Promise<unknown>;
+}
+
+/**
+ * Watches `call` — a `client.join()`/`client.part()` promise — for a late successful settlement
+ * that arrives only after its caller has already stopped waiting on it via
+ * {@link JOIN_PART_TIMEOUT_MS}. Detected directly from `call`'s own timing (settling at or past
+ * the timeout window means the caller's `withTimeout` race already gave up on it) rather than
+ * tracking a separate "newer operation" marker, so this catches a timed-out call landing late
+ * even when nothing else has since touched the channel — e.g. the timed-out caller's own rollback
+ * of its desired-membership state is itself enough to make a late join stale.
+ *
+ * A late rejection needs no compensation (the call never took effect). A late *success* did take
+ * effect on the real Twitch-side membership, so if it no longer matches what's desired, this
+ * reconciles it: reverts a stale late join by parting again, or restores a stale late part by
+ * rejoining. Runs detached from the caller's own await, which already observed the timeout race
+ * independently. The corrective action itself goes through `deps.runExclusive` so it can't
+ * interleave with a concurrent legitimate operation on the same channel.
+ * @param deps - Accessors for the caller's live client/membership state — see {@link MembershipDeps}.
+ * @param channel - The channel the call was for.
+ * @param call - The raw (un-timed-out) `client.join()`/`client.part()` promise to watch.
+ * @param kind - Which operation `call` performed.
+ * @returns Nothing — returns immediately without waiting on `call`. Reconciliation (if any) runs
+ *   asynchronously in the background whenever `call` eventually settles.
+ */
+export function compensateIfStale(deps: MembershipDeps, channel: string, call: Promise<unknown>, kind: 'join' | 'part'): void {
+  const startedAt = Date.now();
+  call.then(() => {
+    // Settled within the normal window — the caller's own withTimeout race never gave up on
+    // this call, so there's nothing to reconcile.
+    if (Date.now() - startedAt < JOIN_PART_TIMEOUT_MS) return;
+    void deps.runExclusive(channel, async () => {
+      const client = deps.getClient();
+      if (!client || !deps.isConnected()) return;
+      const desiredJoined = deps.isDesiredJoined(channel);
+      if (kind === 'join' && !desiredJoined && deps.isChannelJoined(channel)) {
+        log.warn(`[Twitch] Stale join for ${channel} landed after it was no longer desired active — reverting`);
+        await withTimeout(client.part(channel), JOIN_PART_TIMEOUT_MS, 'Twitch part');
+      } else if (kind === 'part' && desiredJoined && !deps.isChannelJoined(channel)) {
+        log.warn(`[Twitch] Stale part for ${channel} landed while it was still desired active — rejoining`);
+        await throttledJoin(client, channel, (joinCall) => compensateIfStale(deps, channel, joinCall, 'join'));
+      }
+    }).catch((err) => log.error(`Failed to reconcile stale ${kind} for ${channel}:`, err));
+  }, () => {});
+}
+
+/**
+ * Calls `client.join(channel)`, globally throttled to JOIN_THROTTLE_MS between joins across all
+ * channels. Bounded by {@link JOIN_PART_TIMEOUT_MS} so a stalled join can't wedge the throttle
+ * gate — and every join queued behind it — forever.
+ * @param client - The connected tmi.js client to join with.
+ * @param channel - The already-normalized channel name to join.
+ * @param onSettled - Called with the raw (un-timed-out) join promise right after it's issued, so
+ *   the caller can watch for a late settlement after giving up on it via the timeout race — see
+ *   {@link compensateIfStale}.
+ * @returns Resolves once the join call itself has completed (not once the throttle window has
+ *   elapsed — the throttle only delays the *next* queued join). Rejects if the join times out.
+ */
+export async function throttledJoin(client: tmi.Client, channel: string, onSettled: (call: Promise<unknown>) => void): Promise<void> {
+  const previousGate = joinGate;
+  let releaseGate!: () => void;
+  joinGate = new Promise((resolve) => { releaseGate = resolve; });
+  await previousGate;
+  const joinCall = client.join(channel);
+  onSettled(joinCall);
+  try {
+    await withTimeout(joinCall, JOIN_PART_TIMEOUT_MS, 'Twitch join');
+  } finally {
+    setTimeout(releaseGate, JOIN_THROTTLE_MS);
+  }
+}

--- a/src/twitch/twitchChannelNetworkOps.ts
+++ b/src/twitch/twitchChannelNetworkOps.ts
@@ -80,7 +80,11 @@ export function compensateIfStale(deps: MembershipDeps, channel: string, call: P
       const desiredJoined = deps.isDesiredJoined(channel);
       if (kind === 'join' && !desiredJoined && deps.isChannelJoined(channel)) {
         log.warn(`[Twitch] Stale join for ${channel} landed after it was no longer desired active — reverting`);
-        await withTimeout(client.part(channel), JOIN_PART_TIMEOUT_MS, 'Twitch part');
+        const revertCall = client.part(channel);
+        // The revert itself can time out and land late, same as any other part call — watch it
+        // too, so a stale revert can't silently undo a join that's since become desired again.
+        compensateIfStale(deps, channel, revertCall, 'part');
+        await withTimeout(revertCall, JOIN_PART_TIMEOUT_MS, 'Twitch part');
       } else if (kind === 'part' && desiredJoined && !deps.isChannelJoined(channel)) {
         log.warn(`[Twitch] Stale part for ${channel} landed while it was still desired active — rejoining`);
         await throttledJoin(client, channel, (joinCall) => compensateIfStale(deps, channel, joinCall, 'join'));

--- a/src/twitch/twitchChannelNetworkOps.ts
+++ b/src/twitch/twitchChannelNetworkOps.ts
@@ -21,7 +21,7 @@ const JOIN_THROTTLE_MS = 600;
 // queue and could otherwise collectively exceed Twitch's IRC JOIN rate limit.
 let joinGate: Promise<void> = Promise.resolve();
 
-/** Resets the global join throttle gate (used in tests). */
+/** Resets the global join throttle gate. */
 export function resetJoinGate(): void {
   joinGate = Promise.resolve();
 }


### PR DESCRIPTION
## Summary

Following the EventSub WebSocket hang fix (`06ed0b8` — a socket `error` event that wasn't wired into reconnect logic could strand a connection forever), this audits the codebase for the same class of bug: an unbounded `await` sitting inside a serializing queue/gate, where one stuck call wedges every later call behind it forever, with no crash and nothing to log.

Two of these were found and fixed by reusing the existing `withTimeout()` helper (`src/twitch/twitchSendQueue.ts`, already used to bound Twitch chat sends and `client.disconnect()`):

- **`src/twitch/twitchChannelMembership.ts`** — `client.join()` (in `throttledJoin`, gated by a single *global* `joinGate` across every channel) and `client.part()` (in `partStaleChannel`/`partTwitchChannel`, gated per-channel by `membershipMutationQueue`) had no timeout. tmi.js gives no timeout guarantee on either call, same as `.say()`. A stuck join would wedge every future join, for every channel, forever; a stuck part would wedge that channel's queue — and since `reconcileJoinedChannels()` awaits these sequentially in a for-loop, it would also block reconciliation of every later channel in that pass.
- **`src/twitch/monitor/twitchMonitorPoll.ts`** — `withLoginLock()`'s per-login queue guards `handlePollStreamer` → `postAnnouncement`/`editAnnouncement`/`handleStreamOffline`, which call discord.js `send`/`edit`/`fetch` with no explicit timeout configured anywhere in this codebase. A stalled Discord call would wedge that login's queue forever, silently breaking both the 60s poll loop and EventSub-triggered immediate checks for that streamer.

Also added a doc-only note on `mutationQueue.run()` itself, warning future callers about the two ways to reintroduce this class of bug (no timeout on `operation()`; recursing into `run()` for the same key). No runtime change there — nothing in the current codebase triggers it, so runtime reentrancy detection would be speculative.

Not in scope: `reloadGuildRegistry()` has a genuine concurrent-overwrite race (last-write-wins by completion order, not start order), but it's a race, not a deadlock — nothing ever hangs — so it's a separate issue.

## Changes

- `src/twitch/twitchChannelMembership.ts`: wrap `client.join()`/`client.part()` calls in `withTimeout(..., 10_000, ...)`.
- `src/twitch/monitor/twitchMonitorPoll.ts`: wrap `withLoginLock`'s `fn()` invocation in `withTimeout(..., 20_000, ...)`.
- `src/shared/mutationQueue.ts`: JSDoc-only hazard note on `run()`.
- JSDoc updated on every touched function to document the new timeout guarantee.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 3152 tests)
- [x] `npm run lint` (0 errors, pre-existing unrelated warnings only)
- [x] New tests added to `twitchChannelMembership.test.ts` and `twitchMonitorPoll.test.ts`: a hung `client.join`/`client.part`/`withLoginLock` operation now rejects with a timeout error instead of hanging, and — critically — a later operation on the same key/gate still completes afterward instead of queuing behind the timed-out one forever.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K2ft1xqxhqB8Ki9DLuDsVP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added timeout safeguards for stalled Twitch channel join, leave, and monitoring operations.
  * Ensured timed-out operations release queues and locks so subsequent actions can continue.
  * Prevented outdated monitoring actions from overwriting newer announcements or state updates.
  * Added reconciliation when delayed channel membership operations complete.

* **Documentation**
  * Documented potential queue stalls and recommended timeout protection.

* **Tests**
  * Expanded coverage for timeout handling, queue recovery, superseded operations, and state synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->