### PR TITLE
Clarify JSDoc convention exceptions for tests and inline callbacks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,8 @@ Auth middleware (`src/web/middleware.ts`), applied in this order:
 
 - All functions — including exported functions, internal helpers, and anonymous functions (e.g. inline Express route handlers) — **must** have a JSDoc comment describing what they do, their parameters, and return value — one line is enough for simple cases.
 - When you change a function's signature or behaviour, update its JSDoc to match — stale docs are worse than no docs.
+- **Test files (`*.test.ts`) are exempt.** Test-local helpers (mock builders like `mockLog`/`mockRes`, response/fixture factories, etc.) and `describe`/`it`/`vi.mock` callbacks don't need JSDoc — a descriptive `it('...')` name documents the behaviour instead. This applies only inside `*.test.ts` files; source files still follow the rule above.
+- **Concise inline callbacks** (e.g. `.map()` row mappers, a `Promise` executor, a `setTimeout` callback, a `catch` handler) don't need a separate JSDoc block. Add a short inline comment only when the behaviour isn't obvious from the code itself.
 
 ---
 


### PR DESCRIPTION
## Summary

- CodeRabbit's "Docstrings" review rule (sourced from CLAUDE.md) keeps flagging missing JSDoc on test-local mock helpers (e.g. `mockLog`/`mockRes`) and trivial inline callbacks (a `setTimeout` delay, a `Promise` executor), reading the current rule literally.
- Its own review-comment history on this repo shows it has already "learned" the actual convention ad hoc, PR by PR (e.g. PR #293, #482, #513: test helpers and concise inline callbacks don't need JSDoc) — but that learning doesn't persist forward automatically, so the same finding keeps recurring on unrelated PRs and has to be re-argued each time.
- This PR encodes those exceptions directly in `CLAUDE.md`'s Docstrings section so the written rule matches what's actually enforced, instead of relying on CodeRabbit re-deriving it per PR.

## Test plan

- Documentation-only change, no code affected.
- [x] `npx tsc --noEmit` (unaffected)
- [x] `npm test` (unaffected)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KiawqvP1ScYr4FQaPyuXJc)_