### PR TITLE
Enable TCP keepalive on the MySQL pool to evict silently dead connections

### DIFF
--- a/src/db/pool.test.ts
+++ b/src/db/pool.test.ts
@@ -40,6 +40,13 @@ describe('getPool', () => {
     );
   });
 
+  it('enables TCP keepalive so a silently dead connection is detected and evicted', () => {
+    getPool();
+    expect(createPool).toHaveBeenCalledWith(
+      expect.objectContaining({ enableKeepAlive: true, keepAliveInitialDelay: 10_000 }),
+    );
+  });
+
   it('returns the same pool instance on repeated calls (singleton)', () => {
     const first = getPool();
     const second = getPool();

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -18,6 +18,15 @@ export function getPool(): mysql.Pool {
       connectionLimit: 15,
       queueLimit: 100,
       connectTimeout: 10_000,
+      // `connectTimeout` only bounds opening a *new* connection. Without these, a
+      // connection whose socket goes silently dead (e.g. a network drop that never
+      // sends a TCP RST/FIN) can sit hung indefinitely — mysql2 only frees a pooled
+      // connection on an 'error'/'end' event, which a true black hole never fires,
+      // so stuck connections would otherwise leak out of the 15-connection pool
+      // permanently. TCP keepalive probes detect that dead socket and surface it as
+      // a connection error instead, so the pool can evict and replace it.
+      enableKeepAlive: true,
+      keepAliveInitialDelay: 10_000,
     });
   }
   return pool;


### PR DESCRIPTION
## Summary
- `connectTimeout` on the MySQL pool only bounds opening a *new* connection — a pooled connection whose socket goes silently dead (e.g. a network drop that never sends a TCP RST/FIN) could hang forever, since mysql2 only frees a connection on an `error`/`end` event that a true black hole never fires.
- Enough stuck connections eventually exhaust the 15-connection pool (`connectionLimit: 15`) with no self-heal, requiring a process restart.
- Adds `enableKeepAlive: true` / `keepAliveInitialDelay: 10_000` to `getPool()` in `src/db/pool.ts` so TCP keepalive probes detect a dead socket and surface it as a connection error, letting the pool evict and replace it instead of leaking the slot.

Part of a stability-hardening pass before an extended period without anyone available to manually restart the bot (see companion PRs for the mutation-queue timeout and Discord gateway watchdog fixes).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 3183 tests passing)
- [x] Added a test in `src/db/pool.test.ts` asserting the pool is created with `enableKeepAlive`/`keepAliveInitialDelay`

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQTcFjHcdT2P8boUi24V63)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability Improvements**
  * Improved database connection handling by detecting inactive connections sooner and replacing them when necessary.

* **Tests**
  * Added coverage to verify connection keepalive behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->