### PR TITLE
Add Discord gateway watchdog logging and auto-recovery on shard death

### DIFF
--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -39,7 +39,7 @@ vi.mock('../db', () => ({
   setMemberAccessLevel: vi.fn().mockResolvedValue(undefined),
   AccessLevel: ACCESS_LEVEL_MOCK,
 }));
-vi.mock('../shared/logger', () => ({ createLogger: mockLogger }));
+vi.mock('../shared/logger', () => ({ createLogger: vi.fn(mockLogger) }));
 vi.mock('discord.js', () => ({
   Client: vi.fn(),
   GatewayIntentBits: { Guilds: 1, GuildMessages: 2, MessageContent: 4, GuildVoiceStates: 8 },
@@ -54,6 +54,7 @@ let commands: CommandRouterModule;
 let customCmds: CustomCommandModule;
 let mockInstance: ReturnType<typeof makeMockClient>;
 let mockGuild: { name: string; members: { fetch: ReturnType<typeof vi.fn> } };
+let mockLog: ReturnType<typeof mockLogger>;
 
 function makeMockClient() {
   mockGuild = { name: 'TestGuild', members: { fetch: vi.fn().mockResolvedValue({ displayName: 'Alice' }) } };
@@ -81,7 +82,9 @@ beforeEach(async () => {
   // Import commandRouter first so discordBot.ts picks up the same cached instance
   commands = await import('../commands/commandRouter.js') as CommandRouterModule;
   customCmds = await import('../commands/customCommandHandler.js') as CustomCommandModule;
+  const loggerModule = await import('../shared/logger.js');
   mod = await import('./discordBot.js') as DiscordBotModule;
+  mockLog = vi.mocked(loggerModule.createLogger).mock.results[0]?.value;
 });
 
 // ─── getDiscordClient ─────────────────────────────────────────────────────────
@@ -397,16 +400,19 @@ describe('startDiscordBot — gateway watchdog', () => {
     return mockInstance.on.mock.calls.find(([e]: string[]) => e === event)?.[1];
   }
 
-  it('logs a warning when a shard is reconnecting, without throwing', () => {
+  it('logs a warning with the shard id when a shard is reconnecting, without throwing', () => {
     mod.startDiscordBot();
     const handler = findHandler('shardReconnecting');
     expect(() => handler(0)).not.toThrow();
+    expect(mockLog.warn).toHaveBeenCalledWith(expect.stringContaining('0'));
   });
 
-  it('logs an error when a shard reports a gateway connection error, without throwing', () => {
+  it('logs an error with the shard id and error when a shard reports a gateway connection error, without throwing', () => {
     mod.startDiscordBot();
     const handler = findHandler('shardError');
-    expect(() => handler(new Error('gateway socket error'), 0)).not.toThrow();
+    const gatewayError = new Error('gateway socket error');
+    expect(() => handler(gatewayError, 0)).not.toThrow();
+    expect(mockLog.error).toHaveBeenCalledWith(expect.stringContaining('0'), gatewayError);
   });
 
   it('forces a fresh login when a shard disconnects permanently', () => {

--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -389,6 +389,40 @@ describe('startDiscordBot — error event', () => {
   });
 });
 
+// ─── startDiscordBot — gateway watchdog ────────────────────────────────────────
+
+describe('startDiscordBot — gateway watchdog', () => {
+  /** Finds the handler registered for `event` via `mockInstance.on`. */
+  function findHandler(event: string): (...args: any[]) => unknown {
+    return mockInstance.on.mock.calls.find(([e]: string[]) => e === event)?.[1];
+  }
+
+  it('logs a warning when a shard is reconnecting, without throwing', () => {
+    mod.startDiscordBot();
+    const handler = findHandler('shardReconnecting');
+    expect(() => handler(0)).not.toThrow();
+  });
+
+  it('logs an error when a shard reports a gateway connection error, without throwing', () => {
+    mod.startDiscordBot();
+    const handler = findHandler('shardError');
+    expect(() => handler(new Error('gateway socket error'), 0)).not.toThrow();
+  });
+
+  it('forces a fresh login when a shard disconnects permanently', () => {
+    mod.startDiscordBot();
+    expect(mockInstance.login).toHaveBeenCalledOnce();
+
+    const handler = findHandler('shardDisconnect');
+    handler({ code: 4004 }, 0);
+
+    // stopDiscordBot() destroyed the dead client, and startDiscordBot() logged back in.
+    expect(mockInstance.destroy).toHaveBeenCalledOnce();
+    expect(mockInstance.login).toHaveBeenCalledTimes(2);
+    expect(mod.getDiscordClient()).toBeNull();
+  });
+});
+
 // ─── stopDiscordBot ───────────────────────────────────────────────────────────
 
 describe('stopDiscordBot', () => {

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -192,6 +192,30 @@ export function startDiscordBot(): void {
     log.error('Client error:', err);
   });
 
+  // discord.js's own WebSocketManager already retries every recoverable gateway
+  // disconnect on its own (reflected by 'shardReconnecting'), so these are purely
+  // visibility logging — without them, a reconnect cycle produces zero log output,
+  // making post-incident diagnosis impossible. 'shardError' is a connection-level
+  // error on the gateway socket itself (distinct from the generic 'error' handler
+  // above); the manager keeps retrying after it, so it's also log-only.
+  localClient.on('shardReconnecting', (shardId) => {
+    log.warn(`Shard ${shardId} lost its connection and is reconnecting...`);
+  });
+  localClient.on('shardError', (err, shardId) => {
+    log.error(`Shard ${shardId} gateway connection error:`, err);
+  });
+
+  // 'shardDisconnect' fires only for an unrecoverable close code — the one case
+  // where discord.js gives up and will *not* reconnect that shard on its own. With
+  // this bot running a single (unsharded) client, that means every guild silently
+  // stops receiving events. Force a fresh login so the process self-heals instead
+  // of sitting alive-but-dead until someone notices and restarts it manually.
+  localClient.on('shardDisconnect', (event, shardId) => {
+    log.error(`Shard ${shardId} disconnected permanently (code ${event.code}) — reconnecting client.`);
+    stopDiscordBot();
+    startDiscordBot();
+  });
+
   localClient.login(DISCORD_TOKEN).catch((err) => {
     log.error('Login failed:', err);
     bootingClient = null; // clear so the next startDiscordBot() call can retry


### PR DESCRIPTION
## Summary
- `discordBot.ts` only listened for the generic `error` event on the Discord client. discord.js's `WebSocketManager` already retries every recoverable gateway disconnect on its own (surfaced as `shardReconnecting`), but that produced zero log output — even manual post-incident diagnosis was impossible.
- More importantly, its one genuinely unrecoverable case — `shardDisconnect`, which discord.js only fires when a shard's close code means it has given up and will **not** reconnect that shard on its own — went completely unhandled. Verified in the installed `discord.js@14.27` source (`WebSocketManager.js`): `shardDisconnect` fires only for `UNRECOVERABLE_CLOSE_CODES`, while every recoverable close instead triggers `shardReconnecting`, which discord.js already handles internally.
- With this bot running a single (unsharded) client, an unrecoverable shard death meant the process kept running while sitting silently unresponsive in every guild — no log line, no crash, no restart, nothing to explain why the bot just stopped responding.
- Adds `shardReconnecting`/`shardError` listeners purely for visibility logging, and a `shardDisconnect` listener that logs the close code and forces a fresh login (`stopDiscordBot()` + `startDiscordBot()`) so the client self-heals instead of hanging alive-but-dead.
- (Note: `discord.js` also declares an `invalidated` event constant, but it is not actually emitted anywhere in the installed version's source — the `@discordjs/ws`-based `WebSocketManager` handles session invalidation internally via `shardReconnecting`/`shardDisconnect` instead, so no listener was added for it.)

Part of a stability-hardening pass before an extended period without anyone available to manually restart the bot (see #537 for the DB pool fix and #538 for the mutation-queue timeout fix).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 3186 tests passing)
- [x] `npm run lint` (no new warnings/errors)
- [x] Added tests in `src/discord/discordBot.test.ts` covering the new `shardReconnecting`/`shardError` log-only handlers and that `shardDisconnect` destroys the dead client and logs back in

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQTcFjHcdT2P8boUi24V63)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when a Discord connection permanently disconnects by automatically restarting the bot connection.
  * Added clearer logging for shard reconnections and gateway errors to improve connection status visibility.
  * Verified that disconnected clients are properly reset before reconnecting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->