### PR TITLE
Maintainability: fix stale doc, dedup token hashing, unify deadlock-retry loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ Auth middleware (`src/web/middleware.ts`), applied in this order:
 
 **Voice adapter:** `audioPlayer.ts` uses a custom `DiscordGatewayAdapterCreator` via `client.on('raw', ...)`. `guild.voiceAdapterCreator` is unused — discord.js v14 incompatibility.
 
-**`customCommands.ts` owns its cache:** Write functions call `invalidateCustomCommandLookupCache()` internally — don't add a second call in `db.ts`.
+**`customCommands.ts` does not own its cache:** it's a pure DB layer with no cache knowledge, to break its import cycle with `customCommandCache.ts`. `db.ts` owns invalidation instead, via `withInvalidation()`-wrapped write functions that call `invalidateCustomCommandLookupCache()` after the underlying `customCommands.ts` write succeeds (same pattern used for `counters.ts`/`alertConfig.ts`/`sfx.ts`). Don't add a second invalidation call inside `customCommands.ts` itself.
 
 **MySQL 8 upsert:** Row-alias form only: `VALUES (...) AS new_row`. Deprecated `VALUES(col)` not used.
 

--- a/src/db/commandConflicts.test.ts
+++ b/src/db/commandConflicts.test.ts
@@ -7,13 +7,39 @@ vi.mock('mysql2/promise', () => ({ default: {} }));
 vi.mock('../twitch/twitchChannelName', () => ({
   normalizeTwitchChannelName: vi.fn((s: string) => (s ? s.toLowerCase() : null)),
 }));
-vi.mock('./commandLocks', () => ({
-  acquireNamedLock: vi.fn().mockResolvedValue(undefined),
-  releaseNamedLock: vi.fn().mockResolvedValue(undefined),
-  getCommandWriteLockName: vi.fn((s: string) => `bcuk_cmd_${s}`),
-  isDeadlockError: vi.fn().mockReturnValue(false),
-  MAX_DEADLOCK_RETRIES: 3,
-}));
+vi.mock('./commandLocks', () => {
+  const isDeadlockError = vi.fn().mockReturnValue(false);
+  const MAX_DEADLOCK_RETRIES = 3;
+  // Faithful re-implementation of the real runWithDeadlockRetry (commandLocks.ts), wired to
+  // this factory's own isDeadlockError/MAX_DEADLOCK_RETRIES mocks so tests can drive retry
+  // behavior by queuing isDeadlockError return values, same as they did before this helper
+  // was extracted out of commandConflicts.ts.
+  const runWithDeadlockRetry = vi.fn(async (connection: any, retryLogLabel: string, body: (attempt: number) => Promise<unknown>, exhaustedErrorMessage?: string) => {
+    for (let attempt = 0; attempt < MAX_DEADLOCK_RETRIES; attempt++) {
+      await connection.beginTransaction();
+      try {
+        const result = await body(attempt);
+        await connection.commit();
+        return result;
+      } catch (error) {
+        await connection.rollback();
+        const deadlock = isDeadlockError(error);
+        if (deadlock && attempt < MAX_DEADLOCK_RETRIES - 1) continue;
+        if (deadlock && exhaustedErrorMessage !== undefined) throw new Error(exhaustedErrorMessage, { cause: error });
+        throw error;
+      }
+    }
+    throw new Error(`[DB] Deadlock retry limit reached in ${retryLogLabel}.`);
+  });
+  return {
+    acquireNamedLock: vi.fn().mockResolvedValue(undefined),
+    releaseNamedLock: vi.fn().mockResolvedValue(undefined),
+    getCommandWriteLockName: vi.fn((s: string) => `bcuk_cmd_${s}`),
+    isDeadlockError,
+    MAX_DEADLOCK_RETRIES,
+    runWithDeadlockRetry,
+  };
+});
 vi.mock('./commandStringUtils', () => ({
   CommandConflictError: class CommandConflictError extends Error {
     commands: string[];

--- a/src/db/commandConflicts.ts
+++ b/src/db/commandConflicts.ts
@@ -8,8 +8,7 @@ import {
   acquireNamedLock,
   releaseNamedLock,
   getCommandWriteLockName,
-  isDeadlockError,
-  MAX_DEADLOCK_RETRIES,
+  runWithDeadlockRetry,
 } from './commandLocks';
 import { fromBit } from './utils';
 
@@ -330,12 +329,13 @@ export async function insertUserCommandAssignment(
 
 /**
  * Runs `body` inside a transaction guarded by a named lock on `commandId`'s trigger string,
- * retrying on deadlock up to `MAX_DEADLOCK_RETRIES` times. The named lock is session-scoped:
- * acquired once (on the first attempt, after the trigger string is known) and released in the
- * outer `finally`, so deadlock retries on the inner transaction still hold the lock between
- * attempts. Factors out the retry/lock/transaction scaffolding shared by
- * {@link assignUserToCommandWithinTransaction} and {@link assignUsersToCommandWithinTransaction},
- * which differ only in the eligibility lookup, conflict checks, and insert `body` performs.
+ * retrying on deadlock up to `MAX_DEADLOCK_RETRIES` times (via {@link runWithDeadlockRetry}).
+ * The named lock is session-scoped: acquired once (on the first attempt, after the trigger
+ * string is known) and released in the outer `finally`, so deadlock retries on the inner
+ * transaction still hold the lock between attempts. Factors out the retry/lock/transaction
+ * scaffolding shared by {@link assignUserToCommandWithinTransaction} and
+ * {@link assignUsersToCommandWithinTransaction}, which differ only in the eligibility lookup,
+ * conflict checks, and insert `body` performs.
  * @param connection Transaction-capable pool connection to run the work on.
  * @param commandId Command id whose trigger string the named lock is scoped to.
  * @param retryLogLabel Short name of the calling function, used in the deadlock-retry log message.
@@ -357,9 +357,10 @@ async function withDeadlockRetryAndTriggerLock(
   let lockNameByTrigger: string | null = null;
 
   try {
-    for (let attempt = 0; attempt < MAX_DEADLOCK_RETRIES; attempt++) {
-      await connection.beginTransaction();
-      try {
+    await runWithDeadlockRetry(
+      connection,
+      retryLogLabel,
+      async () => {
         const normalizedTriggerString = await getCommandTriggerStringById(connection, commandId);
 
         if (!lockNameByTrigger) {
@@ -368,22 +369,9 @@ async function withDeadlockRetryAndTriggerLock(
         }
 
         await body(normalizedTriggerString);
-        await connection.commit();
-        return;
-      } catch (error) {
-        await connection.rollback();
-        if (isDeadlockError(error)) {
-          if (attempt < MAX_DEADLOCK_RETRIES - 1) {
-            log.warn(`Deadlock in ${retryLogLabel}, retrying (attempt ${attempt + 1}/${MAX_DEADLOCK_RETRIES}).`);
-            continue;
-          }
-          break;
-        }
-        throw error;
-      }
-    }
-
-    throw new Error(`[DB] Deadlock retry limit reached in ${retryLimitFnName}.`);
+      },
+      `[DB] Deadlock retry limit reached in ${retryLimitFnName}.`,
+    );
   } finally {
     if (lockNameByTrigger) {
       try { await releaseNamedLock(connection, lockNameByTrigger); } catch (err) { log.warn('Failed to release named lock:', err); }

--- a/src/db/commandConflicts.ts
+++ b/src/db/commandConflicts.ts
@@ -360,6 +360,11 @@ async function withDeadlockRetryAndTriggerLock(
     await runWithDeadlockRetry(
       connection,
       retryLogLabel,
+      // Looks up the command's current trigger string, acquires the session-scoped named lock
+      // on it if this is the first attempt to reach here, then runs the caller's `body`. Returns
+      // nothing — `body` performs the actual write; a thrown error (e.g. a fresh
+      // `CommandConflictError`) propagates up through `runWithDeadlockRetry`, which rolls back
+      // and either retries (on deadlock) or rethrows.
       async () => {
         const normalizedTriggerString = await getCommandTriggerStringById(connection, commandId);
 

--- a/src/db/commandLocks.ts
+++ b/src/db/commandLocks.ts
@@ -327,6 +327,11 @@ export async function runSerializedCommandWrite<T>(
     await acquireNamedLocks(conn, lockNames);
 
     return await runWithDeadlockRetry(conn, 'runSerializedCommandWrite', async () => {
+      // Re-checks for a trigger collision on every attempt (a race between the caller's earlier
+      // check and now, or a fresh collision from another writer since the last attempt), then
+      // runs the caller's write. Returns `writeOperation`'s result, or throws
+      // `CommandConflictError` on a collision — `runWithDeadlockRetry` rolls back and rethrows
+      // either way, retrying only if the error is a deadlock.
       if (await isAnyCommandTakenAcrossTables(normalizedCommands, options, conn, checks)) {
         throw new CommandConflictError(normalizedCommands);
       }

--- a/src/db/commandLocks.ts
+++ b/src/db/commandLocks.ts
@@ -110,6 +110,55 @@ async function releaseNamedLocks(connection: mysql.PoolConnection, lockNames: st
   }
 }
 
+/**
+ * Runs `body` inside a transaction on `connection`, for up to {@link MAX_DEADLOCK_RETRIES}
+ * attempts: begins a transaction, runs `body`, and commits on success. On error, rolls back;
+ * if the error is a deadlock and this wasn't the final attempt, logs and retries; otherwise
+ * rethrows the original error, unless `exhaustedErrorMessage` is given, in which case a
+ * deadlock on the final attempt throws a new `Error(exhaustedErrorMessage)` instead of the raw
+ * driver error (a non-deadlock error always rethrows as-is, on any attempt). Factors out the
+ * retry/transaction scaffolding shared by {@link runSerializedCommandWrite} (in `commandLocks.ts`)
+ * and `withDeadlockRetryAndTriggerLock` (in `commandConflicts.ts`), which differ only in how
+ * their named lock(s) are acquired around this loop.
+ * @param connection Transaction-capable pool connection to run `body` on.
+ * @param retryLogLabel Short label for the deadlock-retry log message.
+ * @param body Per-attempt work to run inside the transaction, given the 0-based attempt index.
+ *   Must not itself begin/commit/rollback a transaction.
+ * @param exhaustedErrorMessage When given, thrown instead of the raw deadlock error if a
+ *   deadlock persists through every attempt.
+ * @returns The value returned by `body` on the attempt that commits successfully.
+ * @throws Whatever `body` throws, when not a deadlock (or once retries are exhausted and
+ *   `exhaustedErrorMessage` isn't given); {@link Error}(`exhaustedErrorMessage`) if retries
+ *   are exhausted and it is given.
+ */
+export async function runWithDeadlockRetry<T>(
+  connection: mysql.PoolConnection,
+  retryLogLabel: string,
+  body: (attempt: number) => Promise<T>,
+  exhaustedErrorMessage?: string,
+): Promise<T> {
+  for (let attempt = 0; attempt < MAX_DEADLOCK_RETRIES; attempt++) {
+    await connection.beginTransaction();
+    try {
+      const result = await body(attempt);
+      await connection.commit();
+      return result;
+    } catch (error) {
+      await connection.rollback();
+      const deadlock = isDeadlockError(error);
+      if (deadlock && attempt < MAX_DEADLOCK_RETRIES - 1) {
+        log.warn(`Deadlock in ${retryLogLabel}, retrying (attempt ${attempt + 1}/${MAX_DEADLOCK_RETRIES}).`);
+        continue;
+      }
+      if (deadlock && exhaustedErrorMessage !== undefined) {
+        throw new Error(exhaustedErrorMessage, { cause: error });
+      }
+      throw error;
+    }
+  }
+  throw new Error(`[DB] Deadlock retry limit reached in ${retryLogLabel}.`);
+}
+
 // ─── Exists checks ────────────────────────────────────────────────────────────
 
 interface SqlExistsCheckPlan {
@@ -274,29 +323,15 @@ export async function runSerializedCommandWrite<T>(
 
   try {
     connection = await getPool().getConnection();
-    await acquireNamedLocks(connection, lockNames);
+    const conn = connection;
+    await acquireNamedLocks(conn, lockNames);
 
-    for (let attempt = 0; attempt < MAX_DEADLOCK_RETRIES; attempt++) {
-      await connection.beginTransaction();
-      try {
-        if (await isAnyCommandTakenAcrossTables(normalizedCommands, options, connection, checks)) {
-          throw new CommandConflictError(normalizedCommands);
-        }
-
-        const result = await writeOperation(connection);
-        await connection.commit();
-        return result;
-      } catch (error) {
-        await connection.rollback();
-        if (isDeadlockError(error) && attempt < MAX_DEADLOCK_RETRIES - 1) {
-          log.warn(`Deadlock detected, retrying transaction (attempt ${attempt + 1}/${MAX_DEADLOCK_RETRIES}).`);
-          continue;
-        }
-        throw error;
+    return await runWithDeadlockRetry(conn, 'runSerializedCommandWrite', async () => {
+      if (await isAnyCommandTakenAcrossTables(normalizedCommands, options, conn, checks)) {
+        throw new CommandConflictError(normalizedCommands);
       }
-    }
-
-    throw new Error('[DB] Deadlock retry limit reached without success.');
+      return await writeOperation(conn);
+    });
   } finally {
     if (connection) {
       try { await releaseNamedLocks(connection, lockNames); } catch (err) { log.warn('Failed to release named locks:', err); }

--- a/src/db/companionOAuthCodes.ts
+++ b/src/db/companionOAuthCodes.ts
@@ -1,7 +1,8 @@
-import { randomBytes, createHash } from 'crypto';
+import { createHash } from 'crypto';
 import mysql from 'mysql2/promise';
 import { getPool, withTransaction } from './pool';
 import { issueTokenOnConnection } from './companionTokens';
+import { generateSecretAndHash } from '../shared/crypto';
 
 const CODE_TTL_SECONDS = 60;
 
@@ -16,8 +17,7 @@ const CODE_TTL_SECONDS = 60;
  * @returns The plaintext code (only ever returned here — only the hash is stored).
  */
 export async function createCode(discordId: string): Promise<string> {
-  const plain = randomBytes(24).toString('hex');
-  const hash = createHash('sha256').update(plain).digest('hex');
+  const { secret: plain, hash } = generateSecretAndHash(24);
   await getPool().execute(
     `INSERT INTO companion_oauth_codes (code_hash, discord_id, expires_at, used_at)
      VALUES (?, ?, DATE_ADD(NOW(), INTERVAL ? SECOND), NULL)`,

--- a/src/db/companionTokens.ts
+++ b/src/db/companionTokens.ts
@@ -1,7 +1,7 @@
-import { randomBytes, createHash } from 'crypto';
 import mysql from 'mysql2/promise';
 import { getPool } from './pool';
 import { hashesMatch } from './utils';
+import { generateSecretAndHash } from '../shared/crypto';
 
 export interface CompanionTokenStatus {
   hasToken: boolean;
@@ -24,8 +24,7 @@ export async function issueTokenOnConnection(
   executor: mysql.Pool | mysql.PoolConnection,
   discordId: string,
 ): Promise<string> {
-  const plain = randomBytes(32).toString('hex');
-  const hash = createHash('sha256').update(plain).digest('hex');
+  const { secret: plain, hash } = generateSecretAndHash();
   const now = new Date();
   await executor.execute(
     `INSERT INTO companion_app_tokens (discord_id, key_hash, created_at, revoked_at)

--- a/src/db/streamdeckKeys.ts
+++ b/src/db/streamdeckKeys.ts
@@ -1,8 +1,8 @@
-import { randomBytes, createHash } from 'crypto';
 import mysql from 'mysql2/promise';
 import { getPool, withTransaction } from './pool';
 import { AccessLevel } from './users';
 import { hashesMatch } from './utils';
+import { generateSecretAndHash } from '../shared/crypto';
 
 /** Per-guild approval state for a Streamdeck API key. */
 export interface StreamdeckKeyGuildStatusRow {
@@ -70,8 +70,7 @@ export async function createApiKeyAndRequestGuildAccess(
   accessLevel: number,
   guildId: string,
 ): Promise<{ plain: string; status: 'pending' | 'approved' }> {
-  const plain = randomBytes(32).toString('hex');
-  const hash = createHash('sha256').update(plain).digest('hex');
+  const { secret: plain, hash } = generateSecretAndHash();
   const status = initialStatus(accessLevel);
   const now = new Date();
 
@@ -144,8 +143,7 @@ export async function requestGuildAccessForExistingKey(
  * @returns The new plaintext key.
  */
 export async function rotateApiKey(discordId: string): Promise<{ plain: string }> {
-  const plain = randomBytes(32).toString('hex');
-  const hash = createHash('sha256').update(plain).digest('hex');
+  const { secret: plain, hash } = generateSecretAndHash();
   await getPool().execute(
     'UPDATE streamdeck_api_keys SET key_hash = ?, created_at = ? WHERE discord_id = ?',
     [hash, new Date(), discordId],

--- a/src/shared/crypto.test.ts
+++ b/src/shared/crypto.test.ts
@@ -3,7 +3,8 @@ import { mockLogger } from '../test-utils/loggerMock';
 
 vi.mock('./logger', () => ({ createLogger: mockLogger }));
 
-import { encryptToken, decryptToken } from './crypto';
+import { encryptToken, decryptToken, generateSecretAndHash } from './crypto';
+import { createHash } from 'node:crypto';
 
 const VALID_SECRET = 'a'.repeat(64); // 64 hex chars = 32 bytes
 
@@ -67,5 +68,29 @@ describe('decryptToken', () => {
     const parts = token.split('.');
     parts[2] = parts[2]!.split('').reverse().join('');
     expect(() => decryptToken(parts.join('.'), VALID_SECRET)).toThrow();
+  });
+});
+
+describe('generateSecretAndHash', () => {
+  it('returns a hex secret matching its SHA-256 hash', () => {
+    const { secret, hash } = generateSecretAndHash();
+    expect(secret).toMatch(/^[0-9a-f]+$/);
+    expect(hash).toBe(createHash('sha256').update(secret).digest('hex'));
+  });
+
+  it('defaults to 32 bytes (64 hex characters)', () => {
+    const { secret } = generateSecretAndHash();
+    expect(secret).toHaveLength(64);
+  });
+
+  it('honors a custom byte length', () => {
+    const { secret } = generateSecretAndHash(24);
+    expect(secret).toHaveLength(48);
+  });
+
+  it('produces different secrets on repeated calls', () => {
+    const a = generateSecretAndHash();
+    const b = generateSecretAndHash();
+    expect(a.secret).not.toBe(b.secret);
   });
 });

--- a/src/shared/crypto.ts
+++ b/src/shared/crypto.ts
@@ -1,4 +1,4 @@
-import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto';
 
 const ALGORITHM = 'aes-256-gcm';
 const ENC_PREFIX = 'enc:';
@@ -37,4 +37,17 @@ export function decryptToken(stored: string, secret: string): string {
   const decipher = createDecipheriv(ALGORITHM, key, Buffer.from(ivB64, 'base64'));
   decipher.setAuthTag(Buffer.from(tagB64, 'base64'));
   return Buffer.concat([decipher.update(Buffer.from(dataB64, 'base64')), decipher.final()]).toString('utf8');
+}
+
+/**
+ * Generates a random hex secret and its SHA-256 hash, for the "store only the hash,
+ * return the plaintext exactly once" pattern used by API keys, companion tokens, and
+ * companion OAuth codes.
+ * @param byteLength - Number of random bytes to generate before hex-encoding (default 32).
+ * @returns The plaintext secret (hex-encoded) and its SHA-256 hash (hex-encoded).
+ */
+export function generateSecretAndHash(byteLength = 32): { secret: string; hash: string } {
+  const secret = randomBytes(byteLength).toString('hex');
+  const hash = createHash('sha256').update(secret).digest('hex');
+  return { secret, hash };
 }

--- a/src/twitch/eventsub/twitchEventSubSubscriptionGroups.test.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptionGroups.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 vi.mock('../../shared/config', () => ({}));
 
 import { getAlertTypesCoveredBySubscriptionGroups } from './twitchEventSubSubscriptionGroups';
-import { ALERT_EVENT_TYPES } from '../../db/alertConfig';
+import { ALERT_EVENT_TYPES } from '../../db';
 
 // ---------------------------------------------------------------------------
 // Subscription-group alert-type coverage (exhaustiveness)


### PR DESCRIPTION
## Summary

First of three small maintainability PRs (see plan discussed with @danielm59). This one covers quick wins and DB/shared-layer dedup; no behavior changes.

- **Fixed stale `CLAUDE.md` doc**: the `customCommands.ts` cache-ownership bullet said write functions call `invalidateCustomCommandLookupCache()` internally, but `db.ts` has since become the sole owner of invalidation via `withInvalidation()`. Updated the doc to match reality so a future change doesn't reintroduce double-invalidation.
- **Fixed a stray direct `db/*` import** bypassing the `db.ts` facade invariant, in `twitchEventSubSubscriptionGroups.test.ts` (kept `rateLimits.test.ts`'s direct `db/users` import as-is — it deliberately avoids pulling in the full `db.ts` chain, which requires `DISCORD_TOKEN` at import time).
- **Deduplicated token-hash generation**: added `generateSecretAndHash()` to `shared/crypto.ts` and replaced three copy-pasted `randomBytes` + SHA-256 blocks in `streamdeckKeys.ts`, `companionTokens.ts`, and `companionOAuthCodes.ts`.
- **Unified the two near-identical deadlock-retry transaction loops**: extracted `runWithDeadlockRetry` into `commandLocks.ts`, used by both `runSerializedCommandWrite` (same file) and `withDeadlockRetryAndTriggerLock` (`commandConflicts.ts`), preserving each function's existing behavior on retry exhaustion (one rethrows the raw driver error, the other throws a synthesized message).

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 3193 tests passing)
- [x] `npm run lint` (no new errors/warnings)
- [x] `npm run check:circular` (no circular deps)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MTbKkGViHz5Er6tDxL76iD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of database writes by automatically retrying recoverable deadlocks and rolling back failed transactions safely.
  * Preserved original errors when retries are exhausted or failures are not deadlock-related.
* **Security**
  * Standardized generation and hashing of companion codes, tokens, and API keys using a shared secure process.
* **Tests**
  * Added coverage for deadlock retry behavior and secure secret generation, including custom lengths and hash validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->