### PR TITLE
Add JSON error variants for access-level middleware

### DIFF
--- a/src/web/middleware.test.ts
+++ b/src/web/middleware.test.ts
@@ -15,7 +15,7 @@ vi.mock('./csrf', () => ({
 }));
 
 import { createHash } from 'crypto';
-import { requireAuth, requireManager, requireMod, requireAdmin, requireOwner, requireOwnerJson, requireApiKey, requireCompanionKey, requireGuildContext } from './middleware';
+import { requireAuth, requireManager, requireMod, requireAdmin, requireOwner, requireOwnerJson, requireModJson, requireManagerJson, requireAdminJson, requireApiKey, requireCompanionKey, requireGuildContext } from './middleware';
 import { findKeyByHash, findDiscordIdByTokenHash, getEffectiveAccessLevelForUser, findUser, getAllGuilds, getGuildsForMember, AccessLevel } from '../db';
 
 function makeReq(overrides: object = {}): any {
@@ -246,6 +246,93 @@ describe('requireOwnerJson', () => {
     const req = makeReq({ session: {} });
     const res = makeRes();
     requireOwnerJson(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: 'forbidden' });
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+// ─── requireModJson ────────────────────────────────────────────────────────────
+
+describe('requireModJson', () => {
+  it('calls next() when access level is MOD (1)', () => {
+    const req = makeReq({ session: { user: { accessLevel: AccessLevel.MOD } } });
+    requireModJson(req, makeRes(), next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('returns a JSON 403 when access level is USER (0)', () => {
+    const req = makeReq({ session: { user: { accessLevel: AccessLevel.USER } } });
+    const res = makeRes();
+    requireModJson(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: 'forbidden' });
+    expect(res.render).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns a JSON 403 when session.user is absent', () => {
+    const req = makeReq({ session: {} });
+    const res = makeRes();
+    requireModJson(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: 'forbidden' });
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+// ─── requireManagerJson ────────────────────────────────────────────────────────
+
+describe('requireManagerJson', () => {
+  it('calls next() when access level is MANAGER (2)', () => {
+    const req = makeReq({ session: { user: { accessLevel: AccessLevel.MANAGER } } });
+    requireManagerJson(req, makeRes(), next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('returns a JSON 403 when access level is MOD (1)', () => {
+    const req = makeReq({ session: { user: { accessLevel: AccessLevel.MOD } } });
+    const res = makeRes();
+    requireManagerJson(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: 'forbidden' });
+    expect(res.render).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns a JSON 403 when no session user', () => {
+    const req = makeReq({ session: {} });
+    const res = makeRes();
+    requireManagerJson(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: 'forbidden' });
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+// ─── requireAdminJson ──────────────────────────────────────────────────────────
+
+describe('requireAdminJson', () => {
+  it('calls next() when access level is ADMIN (3)', () => {
+    const req = makeReq({ session: { user: { accessLevel: AccessLevel.ADMIN } } });
+    requireAdminJson(req, makeRes(), next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('returns a JSON 403 when access level is MANAGER (2)', () => {
+    const req = makeReq({ session: { user: { accessLevel: AccessLevel.MANAGER } } });
+    const res = makeRes();
+    requireAdminJson(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: 'forbidden' });
+    expect(res.render).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns a JSON 403 when no session user', () => {
+    const req = makeReq({ session: {} });
+    const res = makeRes();
+    requireAdminJson(req, res, next);
     expect(res.status).toHaveBeenCalledWith(403);
     expect(res.json).toHaveBeenCalledWith({ error: 'forbidden' });
     expect(next).not.toHaveBeenCalled();

--- a/src/web/middleware.ts
+++ b/src/web/middleware.ts
@@ -116,6 +116,31 @@ export const requireMod = requireAccessLevel(AccessLevel.MOD, 'Mod or above');
 export const requireManager = requireAccessLevel(AccessLevel.MANAGER, 'Manager or above');
 
 /**
+ * Creates a middleware that ensures the current-guild access level is at least `level`,
+ * otherwise responds `403 { error: 'forbidden' }`. JSON counterpart to
+ * {@link requireAccessLevel}, for routes whose handlers respond with `res.json(...)`
+ * rather than rendering a view.
+ * @param level - Minimum required `AccessLevel` value.
+ * @returns An Express middleware: calls `next()` when the session user meets `level`,
+ *   otherwise sends a 403 JSON response.
+ */
+function requireAccessLevelJson(level: number): (req: Request, res: Response, next: NextFunction) => void {
+  return (req, res, next) => {
+    if (req.session.user && req.session.user.accessLevel >= level) {
+      next();
+    } else {
+      res.status(403).json({ error: 'forbidden' });
+    }
+  };
+}
+
+/** Ensures the current-guild access level is Mod or above, otherwise sends a 403 JSON response. */
+export const requireModJson = requireAccessLevelJson(AccessLevel.MOD);
+
+/** Ensures the current-guild access level is Manager or above, otherwise sends a 403 JSON response. */
+export const requireManagerJson = requireAccessLevelJson(AccessLevel.MANAGER);
+
+/**
  * Creates a middleware that authenticates a request via a `Bearer` token: hashes it with
  * SHA-256, resolves the hash to an identity via `lookup`, and stores it on `req` via `assign`
  * on success. Responds 401 when the header is missing/empty or `lookup` finds no match, and
@@ -174,6 +199,9 @@ export const requireCompanionKey = authenticateBearerToken(
 /** Ensures the current-guild access level is Admin, otherwise renders a 403. */
 export const requireAdmin = requireAccessLevel(AccessLevel.ADMIN, 'Admin');
 
+/** Ensures the current-guild access level is Admin, otherwise sends a 403 JSON response. */
+export const requireAdminJson = requireAccessLevelJson(AccessLevel.ADMIN);
+
 /**
  * Ensures the session user is the bot owner (`user.is_owner`), otherwise renders a
  * 403. Distinct from {@link requireAdmin}: `isOwner` is a global super-admin flag set
@@ -202,10 +230,10 @@ export function requireOwner(req: Request, res: Response, next: NextFunction): v
  * Same check as {@link requireOwner}, for JSON-only routes: responds
  * `403 { error: 'forbidden' }` instead of rendering an HTML error page, so a
  * denied `fetch` call gets a real error payload instead of falling back to a
- * generic parse-failure message. See issue #451 — this is intentionally a
- * one-off next to `requireOwner` rather than a generic render-vs-json option
- * on `requireAccessLevel`; extract a shared factory once a second JSON-over-session
- * guard is needed.
+ * generic parse-failure message. See issue #451. Kept separate from
+ * {@link requireAccessLevelJson} (the generalized JSON variant for the
+ * `AccessLevel` ladder) since owner status is a global `isOwner` flag, not
+ * a per-guild access level.
  * @param req - Express request; checked for `req.session.user?.isOwner`.
  * @param res - Express response; used to send a 403 JSON body when denied.
  * @param next - Called when the session user is the owner.

--- a/src/web/routes/adminRefresh.test.ts
+++ b/src/web/routes/adminRefresh.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mockLogger } from '../../test-utils/loggerMock';
 
+const { middlewareCallOrder } = vi.hoisted(() => ({ middlewareCallOrder: [] as string[] }));
 vi.mock('../../db', () => ({
   getGuildMemberUsers: vi.fn(),
   updateDiscordName: vi.fn(),
@@ -10,8 +11,8 @@ vi.mock('../../discord/discordBot', () => ({
   fetchMemberDisplayName: vi.fn(),
 }));
 vi.mock('../middleware', () => ({
-  requireManager: (_req: any, _res: any, next: any) => next(),
-  requireManagerJson: (_req: any, _res: any, next: any) => next(),
+  requireManager: (_req: any, _res: any, next: any) => { middlewareCallOrder.push('requireManager'); next(); },
+  requireManagerJson: (_req: any, _res: any, next: any) => { middlewareCallOrder.push('requireManagerJson'); next(); },
 }));
 vi.mock('../csrf', () => ({
   csrfProtection: (_req: any, _res: any, next: any) => next(),
@@ -55,6 +56,7 @@ async function waitForRefreshComplete(guildId: string = GUILD_ID, timeoutMs = 20
 
 beforeEach(() => {
   vi.clearAllMocks();
+  middlewareCallOrder.length = 0;
   refreshStates.clear();
   vi.useFakeTimers();
 });
@@ -69,6 +71,11 @@ afterEach(() => {
 // ─── GET /users/refresh-status ────────────────────────────────────────────────
 
 describe('GET /users/refresh-status', () => {
+  it('gates the route behind requireManagerJson, not requireManager, so a denial returns JSON', async () => {
+    await buildApp().get('/users/refresh-status');
+    expect(middlewareCallOrder).toEqual(['requireManagerJson']);
+  });
+
   it('returns the current guild refresh state as JSON', async () => {
     const app = buildApp();
     const res = await app.get('/users/refresh-status');

--- a/src/web/routes/adminRefresh.test.ts
+++ b/src/web/routes/adminRefresh.test.ts
@@ -11,6 +11,7 @@ vi.mock('../../discord/discordBot', () => ({
 }));
 vi.mock('../middleware', () => ({
   requireManager: (_req: any, _res: any, next: any) => next(),
+  requireManagerJson: (_req: any, _res: any, next: any) => next(),
 }));
 vi.mock('../csrf', () => ({
   csrfProtection: (_req: any, _res: any, next: any) => next(),

--- a/src/web/routes/adminRefresh.ts
+++ b/src/web/routes/adminRefresh.ts
@@ -2,7 +2,7 @@ import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import { getGuildMemberUsers, updateDiscordName } from '../../db';
 import { csrfProtection } from '../csrf';
-import { requireManager } from '../middleware';
+import { requireManager, requireManagerJson } from '../middleware';
 import { getSessionUser } from '../session';
 import { getDiscordClient, fetchMemberDisplayName } from '../../discord/discordBot';
 import { runUserMutation } from './adminUserMutationQueue';
@@ -85,7 +85,7 @@ const router = Router();
  * @param res - Express response; always responds 200 with the guild's `RefreshState`
  *   as JSON.
  */
-router.get('/users/refresh-status', requireManager, (req, res) => {
+router.get('/users/refresh-status', requireManagerJson, (req, res) => {
   res.json(getRefreshState(getSessionUser(req).currentGuildId!));
 });
 

--- a/src/web/routes/api.test.ts
+++ b/src/web/routes/api.test.ts
@@ -5,7 +5,7 @@ const { middlewareCallOrder } = vi.hoisted(() => ({ middlewareCallOrder: [] as s
 vi.mock('../middleware', () => ({
   requireAuth: (_req: any, _res: any, next: any) => next(),
   requireGuildContext: (_req: any, _res: any, next: any) => { middlewareCallOrder.push('requireGuildContext'); next(); },
-  requireMod: (_req: any, _res: any, next: any) => { middlewareCallOrder.push('requireMod'); next(); },
+  requireModJson: (_req: any, _res: any, next: any) => { middlewareCallOrder.push('requireModJson'); next(); },
 }));
 
 vi.mock('../csrf', () => ({
@@ -88,9 +88,9 @@ describe('GET /status', () => {
 });
 
 describe('GET /voice/channels', () => {
-  it('runs requireGuildContext before requireMod, so a demoted session is re-checked with a fresh access level', async () => {
+  it('runs requireGuildContext before requireModJson, so a demoted session is re-checked with a fresh access level', async () => {
     await supertest(buildApp()).get('/voice/channels');
-    expect(middlewareCallOrder).toEqual(['requireGuildContext', 'requireMod']);
+    expect(middlewareCallOrder).toEqual(['requireGuildContext', 'requireModJson']);
   });
 
   it('reports the current channel and DB default for the session guild', async () => {
@@ -123,9 +123,9 @@ describe('GET /voice/channels', () => {
 });
 
 describe('POST /voice/join', () => {
-  it('runs requireGuildContext before requireMod, so a demoted session is re-checked with a fresh access level', async () => {
+  it('runs requireGuildContext before requireModJson, so a demoted session is re-checked with a fresh access level', async () => {
     await supertest(buildApp()).post('/voice/join').send({ channelId: '123456789012345678' });
-    expect(middlewareCallOrder).toEqual(['requireGuildContext', 'requireMod']);
+    expect(middlewareCallOrder).toEqual(['requireGuildContext', 'requireModJson']);
   });
 
   it('disconnects then joins the requested channel for the session guild', async () => {
@@ -183,9 +183,9 @@ describe('POST /voice/join', () => {
 });
 
 describe('POST /voice/leave', () => {
-  it('runs requireGuildContext before requireMod, so a demoted session is re-checked with a fresh access level', async () => {
+  it('runs requireGuildContext before requireModJson, so a demoted session is re-checked with a fresh access level', async () => {
     await supertest(buildApp()).post('/voice/leave');
-    expect(middlewareCallOrder).toEqual(['requireGuildContext', 'requireMod']);
+    expect(middlewareCallOrder).toEqual(['requireGuildContext', 'requireModJson']);
   });
 
   it('disconnects the session guild and returns ok', async () => {

--- a/src/web/routes/api.ts
+++ b/src/web/routes/api.ts
@@ -1,7 +1,7 @@
 import { createLogger } from '../../shared/logger';
 import { Router, type Request, type Response } from 'express';
 import { getGuildScopedStatus } from '../guildScopedStatus';
-import { requireAuth, requireGuildContext, requireMod } from '../middleware';
+import { requireAuth, requireGuildContext, requireModJson } from '../middleware';
 import { connect, disconnect, getCurrentChannelId } from '../../audio/audioPlayer';
 import { csrfProtection } from '../csrf';
 import { getAvailableVoiceChannels } from '../../discord/discordUtils';
@@ -65,7 +65,7 @@ router.get('/status', requireAuth, async (req, res) => {
  *   away otherwise), so `getSessionGuildId`'s 400 branch is a defensive
  *   fallback here, not the normal path.
  */
-router.get('/voice/channels', requireGuildContext, requireMod, async (req, res) => {
+router.get('/voice/channels', requireGuildContext, requireModJson, async (req, res) => {
   const guildId = getSessionGuildId(req, res);
   if (!guildId) return;
   try {
@@ -97,7 +97,7 @@ router.get('/voice/channels', requireGuildContext, requireMod, async (req, res) 
  *   otherwise), so `getSessionGuildId`'s "no guild selected" 400 is a
  *   defensive fallback here, not the normal path.
  */
-router.post('/voice/join', requireGuildContext, requireMod, csrfProtection, async (req, res) => {
+router.post('/voice/join', requireGuildContext, requireModJson, csrfProtection, async (req, res) => {
   const guildId = getSessionGuildId(req, res);
   if (!guildId) return;
 
@@ -139,7 +139,7 @@ router.post('/voice/join', requireGuildContext, requireMod, csrfProtection, asyn
  *   handler runs (or redirects away otherwise), so `getSessionGuildId`'s 400
  *   branch is a defensive fallback here, not the normal path.
  */
-router.post('/voice/leave', requireGuildContext, requireMod, csrfProtection, (req, res) => {
+router.post('/voice/leave', requireGuildContext, requireModJson, csrfProtection, (req, res) => {
   const guildId = getSessionGuildId(req, res);
   if (!guildId) return;
   disconnect(guildId);

--- a/src/web/routes/streams.test.ts
+++ b/src/web/routes/streams.test.ts
@@ -25,6 +25,7 @@ vi.mock('../csrf', () => ({
 
 vi.mock('../middleware', () => ({
   requireManager: (_req: any, _res: any, next: any) => next(),
+  requireManagerJson: (_req: any, _res: any, next: any) => next(),
 }));
 
 vi.mock('../../twitch/monitor/twitchMonitor', () => ({

--- a/src/web/routes/streams.test.ts
+++ b/src/web/routes/streams.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mockLogger } from '../../test-utils/loggerMock';
 import { ACCESS_LEVEL_MOCK } from '../../test-utils/accessLevelMock';
 
+const { middlewareCallOrder } = vi.hoisted(() => ({ middlewareCallOrder: [] as string[] }));
 vi.mock('../../db', () => ({
   getStreamGroupsForGuild: vi.fn(),
   getStreamersForGuild: vi.fn(),
@@ -24,8 +25,8 @@ vi.mock('../csrf', () => ({
 }));
 
 vi.mock('../middleware', () => ({
-  requireManager: (_req: any, _res: any, next: any) => next(),
-  requireManagerJson: (_req: any, _res: any, next: any) => next(),
+  requireManager: (_req: any, _res: any, next: any) => { middlewareCallOrder.push('requireManager'); next(); },
+  requireManagerJson: (_req: any, _res: any, next: any) => { middlewareCallOrder.push('requireManagerJson'); next(); },
 }));
 
 vi.mock('../../twitch/monitor/twitchMonitor', () => ({
@@ -57,6 +58,7 @@ function buildApp(sessionUser: SessionUser = MANAGER) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  middlewareCallOrder.length = 0;
   vi.mocked(getStreamGroupsForGuild).mockResolvedValue([]);
   vi.mocked(getStreamersForGuild).mockResolvedValue([]);
   vi.mocked(getAllUsers).mockResolvedValue([]);
@@ -94,6 +96,11 @@ describe('GET /streams — query param filtering', () => {
 });
 
 describe('GET /streams/live', () => {
+  it('gates the route behind requireManagerJson, not requireManager, so a denial returns JSON', async () => {
+    await supertest(buildApp()).get('/streams/live');
+    expect(middlewareCallOrder).toEqual(['requireManagerJson']);
+  });
+
   it('returns the current live states as JSON', async () => {
     vi.mocked(getLiveStates).mockReturnValue([{ login: 'streamera' } as any]);
     const res = await supertest(buildApp()).get('/streams/live');

--- a/src/web/routes/streams.ts
+++ b/src/web/routes/streams.ts
@@ -2,7 +2,7 @@ import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import { getStreamGroupsForGuild, getStreamersForGuild, getAllEventSubStreamers, getAllUsers } from '../../db';
 import { csrfProtection } from '../csrf';
-import { requireManager } from '../middleware';
+import { requireManager, requireManagerJson } from '../middleware';
 import { getSessionUser } from '../session';
 import { getLiveStates } from '../../twitch/monitor/twitchMonitor';
 import { AccessLevel } from '../../db';
@@ -80,7 +80,7 @@ router.get('/streams', requireManager, csrfProtection, async (req, res) => {
  * @param req - Express request; reads `req.session.user.currentGuildId`.
  * @param res - Express response; returns `{ streams }` from `getLiveStates(guildId)`.
  */
-router.get('/streams/live', requireManager, (req, res) => {
+router.get('/streams/live', requireManagerJson, (req, res) => {
   res.json({ streams: getLiveStates(getSessionUser(req).currentGuildId!) });
 });
 


### PR DESCRIPTION
## Summary

- `requireMod`/`requireManager`/`requireAdmin` always denied with an HTML error-page render, even for routes whose handlers respond exclusively with `res.json(...)`. A denied `fetch()` call against one of these JSON endpoints got back an HTML document instead of a parseable error body.
- Generalizes the existing `requireOwnerJson` pattern (next to `requireOwner`) into a `requireAccessLevelJson` factory, exporting `requireModJson`/`requireManagerJson`/`requireAdminJson`.
- Switches the 5 routes that are JSON-only under `requireMod`/`requireManager` to the new JSON variants: `GET /voice/channels`, `POST /voice/join`, `POST /voice/leave` (`src/web/routes/api.ts`), `GET /users/refresh-status` (`src/web/routes/adminRefresh.ts`), and `GET /streams/live` (`src/web/routes/streams.ts`). No route currently gates a JSON endpoint with `requireAdmin`, but `requireAdminJson` is added for symmetry.
- All other routes using these three middlewares respond via `res.redirect(...)` or view rendering and are left on the HTML variants.

Follows up on #451: that issue added `requireOwnerJson` as a deliberate one-off next to `requireOwner`, explicitly deferring the general abstraction until "a second or third JSON-over-session route shows up." This PR is that follow-through — it extracts `requireAccessLevelJson` now that real repetition (the 5 routes above) exists.

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm test` — all 3209 tests pass (177 files), including new `requireModJson`/`requireManagerJson`/`requireAdminJson` unit tests in `middleware.test.ts` and updated route tests in `api.test.ts`, `adminRefresh.test.ts`, `streams.test.ts`
- [x] `npm run lint` — no new errors (pre-existing unrelated warnings only)
- [ ] Manual check: log in as a non-Mod user and hit `GET /voice/channels` via `fetch` — expect `403` with JSON body `{"error":"forbidden"}` instead of an HTML page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added JSON-specific authorization checks for moderator, manager, and administrator access.
  - Protected voice, live stream, and refresh-status endpoints now return a consistent `403 { error: "forbidden" }` response when access is denied.

- **Bug Fixes**
  - Unauthorized requests to JSON endpoints no longer receive HTML error pages.
  - Updated access handling ensures insufficient or missing authorization is rejected without executing the requested action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->