### PR TITLE
Retry transient network errors in reward-reconciliation Helix calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4083,6 +4083,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/filing-cabinet/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",

--- a/src/twitch/twitchApi.test.ts
+++ b/src/twitch/twitchApi.test.ts
@@ -185,6 +185,22 @@ describe('getCustomRewards', () => {
     vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(500, {}));
     await expect(getCustomRewards('bc1', 'user-token')).rejects.toThrow('getCustomRewards failed: 500');
   });
+
+  it('retries after a transient network error and returns the successful result', async () => {
+    vi.useFakeTimers();
+    const rewards = [{ id: 'rwd1', title: 'Cool Reward', cost: 500 }];
+    vi.mocked(globalThis.fetch)
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockResolvedValueOnce(mockResponse(200, { data: rewards }));
+
+    const promise = getCustomRewards('bc1', 'user-token');
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toEqual(rewards);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
 });
 
 describe('getRewardRedemptions', () => {
@@ -232,6 +248,22 @@ describe('getRewardRedemptions', () => {
   it('throws a generic error for other non-OK statuses', async () => {
     vi.mocked(globalThis.fetch).mockResolvedValueOnce(mockResponse(500, {}));
     await expect(getRewardRedemptions('bc1', 'rwd1', 'UNFULFILLED', 'user-token')).rejects.toThrow('getRewardRedemptions failed: 500');
+  });
+
+  it('retries after a transient network error and returns the successful result', async () => {
+    vi.useFakeTimers();
+    const redemptions = [{ id: 'redemp1', user_login: 'viewer1', status: 'UNFULFILLED' }];
+    vi.mocked(globalThis.fetch)
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockResolvedValueOnce(mockResponse(200, { data: redemptions }));
+
+    const promise = getRewardRedemptions('bc1', 'rwd1', 'UNFULFILLED', 'user-token');
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toEqual({ redemptions, cursor: null });
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
   });
 });
 

--- a/src/twitch/twitchApi.ts
+++ b/src/twitch/twitchApi.ts
@@ -251,14 +251,16 @@ function customRewardUrl(broadcasterId: string, rewardId?: string): string {
  * Lists a broadcaster's custom rewards via Helix. Unlike its create/update/delete siblings, a
  * 403 (the broadcaster is not a Twitch Partner or Affiliate, so channel points aren't available)
  * is treated as "no rewards" rather than a typed error, since listing is read-only and callers
- * generally just want to render whatever's available.
+ * generally just want to render whatever's available. Wrapped in fetchHelixWithRetry, unlike
+ * create/update/delete: this is a read used by the background reconciliation poll, not a
+ * synchronous admin action, so a transient network error is worth retrying rather than surfacing.
  * @param broadcasterId - Twitch user ID whose custom rewards to list.
  * @param userToken - Broadcaster OAuth user token with the channel:manage:redemptions scope.
  * @returns The broadcaster's custom rewards, or `[]` on a 403.
  * @throws If Twitch returns a non-OK, non-403 status.
  */
 export async function getCustomRewards(broadcasterId: string, userToken: string): Promise<TwitchCustomReward[]> {
-  const res = await twitchFetch(customRewardUrl(broadcasterId), { headers: authHeaders(userToken) });
+  const res = await fetchHelixWithRetry(customRewardUrl(broadcasterId), authHeaders(userToken));
   if (res.status === 403) return [];
   if (!res.ok) throw new Error(`[TwitchAPI] getCustomRewards failed: ${res.status}`);
   const data = await res.json() as { data: TwitchCustomReward[] };
@@ -288,7 +290,10 @@ export interface TwitchRewardRedemptionPage {
  * Lists one page (up to 50) of a broadcaster's redemptions for one custom reward and status, via
  * Helix, newest first. Used by the EventSub reconciliation poll to catch redemptions the
  * WebSocket connection missed (e.g. during a reconnect gap) — the live notification path is
- * driven entirely by EventSub and never calls this.
+ * driven entirely by EventSub and never calls this. Wrapped in fetchHelixWithRetry: this poll
+ * runs unattended in the background, so a transient network error should be retried rather than
+ * surfaced — unlike the reward create/update/delete calls, which are synchronous admin actions
+ * and leave retrying to the caller.
  *
  * @param broadcasterId - Twitch user ID whose reward redemptions to list.
  * @param rewardId - Twitch reward UUID to scope the query to.
@@ -307,7 +312,7 @@ export async function getRewardRedemptions(
 ): Promise<TwitchRewardRedemptionPage> {
   let url = `https://api.twitch.tv/helix/channel_points/custom_rewards/redemptions?broadcaster_id=${encodeURIComponent(broadcasterId)}&reward_id=${encodeURIComponent(rewardId)}&status=${status}&sort=NEWEST&first=50`;
   if (after) url += `&after=${encodeURIComponent(after)}`;
-  const res = await twitchFetch(url, { headers: authHeaders(userToken) });
+  const res = await fetchHelixWithRetry(url, authHeaders(userToken));
   if (res.status === 403) return { redemptions: [], cursor: null };
   if (!res.ok) throw new Error(`[TwitchAPI] getRewardRedemptions failed: ${res.status}`);
   const data = await res.json() as { data: TwitchRewardRedemption[]; pagination?: { cursor?: string } };


### PR DESCRIPTION
## Summary

Logs showed a burst of `[EventSubReconciliation] Failed to fetch redemptions ... TypeError: fetch failed` errors, one per reward, all at the same timestamp. `TypeError: fetch failed` is undici's generic wrapper for a transient network failure (DNS blip, connection reset, etc.) at the `fetch()` layer.

Root cause: `getCustomRewards` and `getRewardRedemptions` in `src/twitch/twitchApi.ts` called `twitchFetch` directly, bypassing `fetchHelixWithRetry` — the retry wrapper already used by the app-token-authed Helix calls (`getUsers`/`getStreams`/`getChannelInfo` via `fetchHelixPaged`). A single transient network error therefore failed the entire reconciliation tick immediately, with no retry, instead of being absorbed the way other Helix reads already are.

The reward create/update/delete calls intentionally stay unwrapped (documented in their JSDoc) since they're synchronous admin actions where the caller shows the error and the user retries manually. `getCustomRewards`/`getRewardRedemptions` are different: they're read-only calls driven by the unattended background reconciliation poll (`twitchEventSubReconciliation.ts`), so retrying transient network errors in place is the right behavior — the same reasoning already applied to the app-token Helix reads.

## Change

- `getCustomRewards` and `getRewardRedemptions` now go through `fetchHelixWithRetry` instead of `twitchFetch` directly, picking up its existing network-error retry (2 attempts, 2s/4s backoff) and 429 rate-limit retry.
- Added regression tests covering the network-error retry path for both functions.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 3213 tests passing)
- [x] `npm run lint` (no new warnings/errors)


---
_Generated by [Claude Code](https://claude.ai/code/session_01526pTeK9ctnbBrCQabLqUs)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of custom reward and reward redemption retrieval during temporary network failures or rate limits.
  * Background polling now automatically retries once before reporting an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->