### PR TITLE
Add getCurrentGuildId() helper, replace currentGuildId! assertions

### DIFF
--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -10,7 +10,7 @@ import {
 import { reloadGuildRegistry } from '../../discord/guildRegistry';
 import { csrfProtection } from '../csrf';
 import { requireManager, requireAdmin } from '../middleware';
-import { getSessionUser } from '../session';
+import { getSessionUser, getCurrentGuildId } from '../session';
 import { trimField, filterQueryParam } from './validation';
 import { renderError, renderView } from './viewHelpers';
 import { runUserMutation } from './adminUserMutationQueue';
@@ -44,13 +44,13 @@ const KNOWN_ERRORS = new Set([
 /**
  * GET /admin/users — renders the member-management page for the current guild,
  * listing every member with their access level and Twitch state.
- * @param req - Express request; reads `getSessionUser(req).currentGuildId` and the
+ * @param req - Express request; reads `getCurrentGuildId(req)` and the
  *   `error` query param.
  * @param res - Express response; renders the `admin` view, or a 500 error page if
  *   loading members fails.
  */
 router.get('/users', requireManager, csrfProtection, async (req, res) => {
-  const guildId = getSessionUser(req).currentGuildId!;
+  const guildId = getCurrentGuildId(req);
   try {
     const users = await getGuildMemberUsers(guildId);
     renderView(res, 'admin', {
@@ -94,7 +94,7 @@ async function reloadRegistrySafe(): Promise<void> {
  *   `duplicate_twitch_name`) or a DB failure (`add_failed`).
  */
 router.post('/users/add', requireManager, csrfProtection, async (req, res) => {
-  const guildId = getSessionUser(req).currentGuildId!;
+  const guildId = getCurrentGuildId(req);
 
   const { discord_id, discord_name, access_level, twitch_name, clear_twitch_name } = req.body as {
     discord_id?: string;
@@ -153,7 +153,7 @@ router.post('/users/add', requireManager, csrfProtection, async (req, res) => {
  *   failure (`update_failed`).
  */
 router.post('/users/update', requireManager, csrfProtection, async (req, res) => {
-  const guildId = getSessionUser(req).currentGuildId!;
+  const guildId = getCurrentGuildId(req);
 
   const { discord_id, access_level } = req.body as { discord_id?: string; access_level?: string };
   if (access_level === undefined) return res.redirect('/admin/users');
@@ -188,7 +188,7 @@ router.post('/users/update', requireManager, csrfProtection, async (req, res) =>
  *   (`remove_failed`).
  */
 router.post('/users/remove', requireAdmin, csrfProtection, async (req, res) => {
-  const guildId = getSessionUser(req).currentGuildId!;
+  const guildId = getCurrentGuildId(req);
 
   const { discord_id } = req.body as { discord_id?: string };
   const trimmedDiscordId = resolveValidDiscordId(res, discord_id);
@@ -219,7 +219,7 @@ router.post('/users/remove', requireAdmin, csrfProtection, async (req, res) => {
  *   `invalid_twitch_state`) or a DB failure (`toggle_failed`).
  */
 router.post('/users/toggle-twitch', requireManager, csrfProtection, async (req, res) => {
-  const guildId = getSessionUser(req).currentGuildId!;
+  const guildId = getCurrentGuildId(req);
 
   const { discord_id, is_twitch_bot_enabled } = req.body as {
     discord_id?: string;

--- a/src/web/routes/adminRefresh.ts
+++ b/src/web/routes/adminRefresh.ts
@@ -3,7 +3,7 @@ import { Router } from 'express';
 import { getGuildMemberUsers, updateDiscordName } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireManager, requireManagerJson } from '../middleware';
-import { getSessionUser } from '../session';
+import { getCurrentGuildId } from '../session';
 import { getDiscordClient, fetchMemberDisplayName } from '../../discord/discordBot';
 import { runUserMutation } from './adminUserMutationQueue';
 import {
@@ -81,24 +81,24 @@ const router = Router();
 /**
  * GET /admin/users/refresh-status — polling endpoint for the current guild's
  * in-progress (or most recent) Discord-name-refresh job.
- * @param req - Express request; reads `getSessionUser(req).currentGuildId`.
+ * @param req - Express request; reads `getCurrentGuildId(req)`.
  * @param res - Express response; always responds 200 with the guild's `RefreshState`
  *   as JSON.
  */
 router.get('/users/refresh-status', requireManagerJson, (req, res) => {
-  res.json(getRefreshState(getSessionUser(req).currentGuildId!));
+  res.json(getRefreshState(getCurrentGuildId(req)));
 });
 
 /**
  * POST /admin/users/refresh-names — kicks off a background job that re-fetches each
  * guild member's Discord display name and updates it if changed. No-ops if a refresh
  * is already running for the guild.
- * @param req - Express request; reads `getSessionUser(req).currentGuildId`.
+ * @param req - Express request; reads `getCurrentGuildId(req)`.
  * @param res - Express response; always redirects to `/admin/users` immediately —
  *   the refresh itself runs asynchronously and is polled via `/users/refresh-status`.
  */
 router.post('/users/refresh-names', requireManager, csrfProtection, async (req, res) => {
-  const guildId = getSessionUser(req).currentGuildId!;
+  const guildId = getCurrentGuildId(req);
   if (getRefreshState(guildId).outcome === 'running') {
     return res.redirect('/admin/users');
   }

--- a/src/web/routes/commandGuildOverrides.ts
+++ b/src/web/routes/commandGuildOverrides.ts
@@ -3,7 +3,7 @@ import { Router } from 'express';
 import { upsertOverride, removeOverride } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireMod, requireGuildContext } from '../middleware';
-import { getSessionUser } from '../session';
+import { getCurrentGuildId } from '../session';
 import { parsePositiveIntId, trimField } from './validation';
 import { logAndRedirectError } from './errorHandling';
 
@@ -19,7 +19,7 @@ const router = Router();
  * no custom output), the override row is removed instead of upserted.
  */
 router.post('/commands/guild-override', requireGuildContext, requireMod, csrfProtection, async (req, res) => {
-  const guildId = getSessionUser(req).currentGuildId!;
+  const guildId = getCurrentGuildId(req);
   const body = req.body as Record<string, unknown>;
   const commandId = parsePositiveIntId(body.command_id as string | string[] | undefined);
   if (!commandId) return res.redirect('/commands?error=invalid_id');
@@ -46,7 +46,7 @@ router.post('/commands/guild-override', requireGuildContext, requireMod, csrfPro
  * Accepts `command_id`. Guild ID is always taken from the session.
  */
 router.post('/commands/guild-override/reset', requireGuildContext, requireMod, csrfProtection, async (req, res) => {
-  const guildId = getSessionUser(req).currentGuildId!;
+  const guildId = getCurrentGuildId(req);
   const body = req.body as Record<string, unknown>;
   const commandId = parsePositiveIntId(body.command_id as string | string[] | undefined);
   if (!commandId) return res.redirect('/commands?error=invalid_id');

--- a/src/web/routes/eventsubAdmin.ts
+++ b/src/web/routes/eventsubAdmin.ts
@@ -3,7 +3,7 @@ import { Router } from 'express';
 import { clearStreamerToken } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireAdmin } from '../middleware';
-import { getSessionUser } from '../session';
+import { getCurrentGuildId } from '../session';
 import { reloadEventSubSubscriptions } from '../../twitch/eventsub/twitchEventSub';
 import { parsePositiveIntId } from './validation';
 import { redirectStreamsInvalid, redirectStreamsFailure } from './streamsErrors';
@@ -31,7 +31,7 @@ router.post('/streams/twitch-disconnect/:streamerId', requireAdmin, csrfProtecti
   if (streamerId === null) return redirectStreamsInvalid(res, 'invalid_id');
 
   try {
-    const cleared = await clearStreamerToken(streamerId, getSessionUser(req).currentGuildId!);
+    const cleared = await clearStreamerToken(streamerId, getCurrentGuildId(req));
     if (!cleared) return redirectStreamsInvalid(res, 'invalid_id');
     reloadEventSubSubscriptions();
   } catch (err) {

--- a/src/web/routes/streamGroups.ts
+++ b/src/web/routes/streamGroups.ts
@@ -3,7 +3,7 @@ import { Router } from 'express';
 import { addStreamGroup, updateStreamGroup, removeStreamGroupAndStreamers } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireManager } from '../middleware';
-import { getSessionUser } from '../session';
+import { getCurrentGuildId } from '../session';
 import { parsePositiveIntId, parseCheckboxField } from './validation';
 import { redirectStreamsInvalid, redirectStreamsFailure } from './streamsErrors';
 import { triggerRestart } from './streamRestart';
@@ -37,7 +37,7 @@ router.post('/streams/groups/add', requireManager, csrfProtection, async (req, r
 
   try {
     await addStreamGroup({
-      guildId: getSessionUser(req).currentGuildId!,
+      guildId: getCurrentGuildId(req),
       name: name!.trim().slice(0, 100),
       discordChannel: discord_channel!.trim().slice(0, 20),
       liveMessage: live_message!.trim().slice(0, 2000),
@@ -77,7 +77,7 @@ router.post('/streams/groups/update', requireManager, csrfProtection, async (req
   try {
     const updated = await updateStreamGroup({
       id: parsedGroupId,
-      guildId: getSessionUser(req).currentGuildId!,
+      guildId: getCurrentGuildId(req),
       name: name!.trim().slice(0, 100),
       discordChannel: discord_channel!.trim().slice(0, 20),
       liveMessage: live_message!.trim().slice(0, 2000),
@@ -108,7 +108,7 @@ router.post('/streams/groups/remove', requireManager, csrfProtection, async (req
   if (parsedGroupId === null) return redirectStreamsInvalid(res, 'invalid_id');
 
   try {
-    const guildId = getSessionUser(req).currentGuildId!;
+    const guildId = getCurrentGuildId(req);
     const removed = await removeStreamGroupAndStreamers(parsedGroupId, guildId);
     if (!removed) return redirectStreamsInvalid(res, 'remove_group_failed');
     triggerRestart();

--- a/src/web/routes/streamStreamers.ts
+++ b/src/web/routes/streamStreamers.ts
@@ -3,7 +3,7 @@ import { Router } from 'express';
 import { addStreamer, removeStreamer, findUser } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireManager } from '../middleware';
-import { getSessionUser } from '../session';
+import { getCurrentGuildId } from '../session';
 import { parsePositiveIntId, normalizeDiscordId } from './validation';
 import { redirectStreamsInvalid, redirectStreamsFailure } from './streamsErrors';
 import { triggerRestart } from './streamRestart';
@@ -33,7 +33,7 @@ router.post('/streams/streamers/add', requireManager, csrfProtection, async (req
   try {
     const user = await findUser(discordId);
     if (!user?.twitch_name) return redirectStreamsInvalid(res, 'missing_fields');
-    await addStreamer(discordId, parsedGroupId, getSessionUser(req).currentGuildId!);
+    await addStreamer(discordId, parsedGroupId, getCurrentGuildId(req));
     triggerRestart();
   } catch (err) {
     return redirectStreamsFailure(res, log, 'Add streamer error:', err, 'add_streamer_failed');
@@ -56,7 +56,7 @@ router.post('/streams/streamers/remove', requireManager, csrfProtection, async (
   if (parsedStreamerId === null) return redirectStreamsInvalid(res, 'invalid_id');
 
   try {
-    const removed = await removeStreamer(parsedStreamerId, getSessionUser(req).currentGuildId!);
+    const removed = await removeStreamer(parsedStreamerId, getCurrentGuildId(req));
     if (!removed) return redirectStreamsInvalid(res, 'remove_streamer_failed');
     triggerRestart();
   } catch (err) {

--- a/src/web/routes/streamdeckKeys.ts
+++ b/src/web/routes/streamdeckKeys.ts
@@ -15,7 +15,7 @@ import {
 } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireAdmin } from '../middleware';
-import { getSessionUser } from '../session';
+import { getSessionUser, getCurrentGuildId } from '../session';
 import { WEB_PORT } from '../../shared/config';
 import { normalizeDiscordId, filterQueryParam } from './validation';
 import { renderError, renderView } from './viewHelpers';
@@ -62,7 +62,7 @@ const USER_KNOWN_ERRORS = new Set(['request_failed', 'rotate_failed', 'revoke_fa
  */
 router.get('/streamdeck-key', csrfProtection, async (req, res) => {
   try {
-    const keyRow = await getGuildStatusForKey(getSessionUser(req).discordId, getSessionUser(req).currentGuildId!);
+    const keyRow = await getGuildStatusForKey(getSessionUser(req).discordId, getCurrentGuildId(req));
     renderView(res, 'streamdeck-keys', {
       user: req.session.user,
       csrfToken: req.csrfToken(),
@@ -103,7 +103,7 @@ router.get('/streamdeck-key', csrfProtection, async (req, res) => {
 router.post('/streamdeck-key/request', csrfProtection, async (req, res) => {
   const discordId = getSessionUser(req).discordId;
   const accessLevel = getSessionUser(req).accessLevel;
-  const guildId = getSessionUser(req).currentGuildId!;
+  const guildId = getCurrentGuildId(req);
   try {
     const { plain, keyRow } = await runUserMutation(discordId, async () => {
       const existingGuildStatus = await getGuildStatusForKey(discordId, guildId);
@@ -187,7 +187,7 @@ export function __resetRecentRotationsForTests(): void {
  */
 router.post('/streamdeck-key/rotate', csrfProtection, async (req, res) => {
   const discordId = getSessionUser(req).discordId;
-  const guildId = getSessionUser(req).currentGuildId!;
+  const guildId = getCurrentGuildId(req);
   try {
     const keyRow = await getGuildStatusForKey(discordId, guildId);
     const plain = await runUserMutation(discordId, async () => {
@@ -220,7 +220,7 @@ router.post('/streamdeck-key/rotate', csrfProtection, async (req, res) => {
  */
 router.post('/streamdeck-key/revoke', csrfProtection, async (req, res) => {
   try {
-    await revokeApiKey(getSessionUser(req).discordId, getSessionUser(req).currentGuildId!);
+    await revokeApiKey(getSessionUser(req).discordId, getCurrentGuildId(req));
     res.redirect('/streamdeck-key');
   } catch (err) {
     logAndRedirectError({ res, log, logLabel: 'Streamdeck key revoke error:', err, basePath: '/streamdeck-key', errorCode: 'revoke_failed' });
@@ -234,7 +234,7 @@ const ADMIN_KNOWN_ERRORS = new Set(['approve_failed', 'deny_failed', 'revoke_fai
 /** Renders the admin Streamdeck key management page, listing pending and all key requests for the admin's current guild. */
 router.get('/admin/streamdeck-keys', requireAdmin, csrfProtection, async (req, res) => {
   try {
-    const guildId = getSessionUser(req).currentGuildId!;
+    const guildId = getCurrentGuildId(req);
     const [pending, all] = await Promise.all([getPendingRequests(guildId), getAllApiKeys(guildId)]);
     renderView(res, 'streamdeck-keys-admin', {
       user: req.session.user,
@@ -254,7 +254,7 @@ router.post('/admin/streamdeck-keys/approve', requireAdmin, csrfProtection, asyn
   const validId = normalizeDiscordId((req.body as { discord_id?: string }).discord_id);
   if (!validId) return res.redirect('/admin/streamdeck-keys?error=invalid_discord_id');
   try {
-    await approveApiKey(validId, getSessionUser(req).discordId, getSessionUser(req).currentGuildId!);
+    await approveApiKey(validId, getSessionUser(req).discordId, getCurrentGuildId(req));
     res.redirect('/admin/streamdeck-keys');
   } catch (err) {
     logAndRedirectError({ res, log, logLabel: 'Streamdeck key approve error:', err, basePath: '/admin/streamdeck-keys', errorCode: 'approve_failed' });
@@ -266,7 +266,7 @@ router.post('/admin/streamdeck-keys/deny', requireAdmin, csrfProtection, async (
   const validId = normalizeDiscordId((req.body as { discord_id?: string }).discord_id);
   if (!validId) return res.redirect('/admin/streamdeck-keys?error=invalid_discord_id');
   try {
-    await denyApiKey(validId, getSessionUser(req).currentGuildId!);
+    await denyApiKey(validId, getCurrentGuildId(req));
     res.redirect('/admin/streamdeck-keys');
   } catch (err) {
     logAndRedirectError({ res, log, logLabel: 'Streamdeck key deny error:', err, basePath: '/admin/streamdeck-keys', errorCode: 'deny_failed' });
@@ -278,7 +278,7 @@ router.post('/admin/streamdeck-keys/revoke', requireAdmin, csrfProtection, async
   const validId = normalizeDiscordId((req.body as { discord_id?: string }).discord_id);
   if (!validId) return res.redirect('/admin/streamdeck-keys?error=invalid_discord_id');
   try {
-    await revokeApiKey(validId, getSessionUser(req).currentGuildId!);
+    await revokeApiKey(validId, getCurrentGuildId(req));
     res.redirect('/admin/streamdeck-keys');
   } catch (err) {
     logAndRedirectError({ res, log, logLabel: 'Streamdeck key admin revoke error:', err, basePath: '/admin/streamdeck-keys', errorCode: 'revoke_failed' });

--- a/src/web/routes/streams.ts
+++ b/src/web/routes/streams.ts
@@ -3,7 +3,7 @@ import { Router } from 'express';
 import { getStreamGroupsForGuild, getStreamersForGuild, getAllEventSubStreamers, getAllUsers } from '../../db';
 import { csrfProtection } from '../csrf';
 import { requireManager, requireManagerJson } from '../middleware';
-import { getSessionUser } from '../session';
+import { getCurrentGuildId } from '../session';
 import { getLiveStates } from '../../twitch/monitor/twitchMonitor';
 import { AccessLevel } from '../../db';
 import { filterQueryParam } from './validation';
@@ -37,7 +37,7 @@ function getFriendlyError(key: string): string {
 router.get('/streams', requireManager, csrfProtection, async (req, res) => {
   try {
     const isAdmin = (req.session.user?.accessLevel ?? 0) >= AccessLevel.ADMIN;
-    const guildId = getSessionUser(req).currentGuildId!;
+    const guildId = getCurrentGuildId(req);
     const [groups, streamers, eventSubStreamers, allUsers] = await Promise.all([
       getStreamGroupsForGuild(guildId),
       getStreamersForGuild(guildId),
@@ -82,7 +82,7 @@ router.get('/streams', requireManager, csrfProtection, async (req, res) => {
  * @param res - Express response; returns `{ streams }` from `getLiveStates(guildId)`.
  */
 router.get('/streams/live', requireManagerJson, (req, res) => {
-  res.json({ streams: getLiveStates(getSessionUser(req).currentGuildId!) });
+  res.json({ streams: getLiveStates(getCurrentGuildId(req)) });
 });
 
 router.use(groupsRouter);

--- a/src/web/session.test.ts
+++ b/src/web/session.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getSessionUser } from './session';
+import { getSessionUser, getCurrentGuildId } from './session';
 import { ACCESS_LEVEL_MOCK } from '../test-utils/accessLevelMock';
 
 /** Builds a minimal fake Express request for exercising `getSessionUser`. */
@@ -20,5 +20,24 @@ describe('getSessionUser', () => {
   it('throws when session.user is absent', () => {
     const req = makeReq({ session: {} });
     expect(() => getSessionUser(req)).toThrow(/authenticated session/);
+  });
+});
+
+describe('getCurrentGuildId', () => {
+  it('returns the selected guild id when present', () => {
+    const user = { discordId: '1', accessLevel: ACCESS_LEVEL_MOCK.USER, currentGuildId: 'g1' };
+    const req = makeReq({ session: { user } });
+    expect(getCurrentGuildId(req)).toBe('g1');
+  });
+
+  it('throws when currentGuildId is null', () => {
+    const user = { discordId: '1', accessLevel: ACCESS_LEVEL_MOCK.USER, currentGuildId: null };
+    const req = makeReq({ session: { user } });
+    expect(() => getCurrentGuildId(req)).toThrow(/selected guild/);
+  });
+
+  it('throws when session.user is absent', () => {
+    const req = makeReq({ session: {} });
+    expect(() => getCurrentGuildId(req)).toThrow(/authenticated session/);
   });
 });

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -19,3 +19,22 @@ export function getSessionUser(req: Request): SessionUser {
   }
   return user;
 }
+
+/**
+ * Reads the current session user's selected guild id, throwing if absent. Safe to call
+ * unconditionally in any route handler mounted behind `requireGuildContext` (which derives
+ * and sets `currentGuildId` on every request) — replaces the `getSessionUser(req).currentGuildId!`
+ * non-null assertion previously repeated at every call site with a single, compiler-checked
+ * invariant point.
+ * @param req - Express request.
+ * @returns The current session user's selected guild id.
+ * @throws If `currentGuildId` is not set, i.e. this was called from a route handler
+ *   that is missing its `requireGuildContext` middleware.
+ */
+export function getCurrentGuildId(req: Request): string {
+  const guildId = getSessionUser(req).currentGuildId;
+  if (!guildId) {
+    throw new Error('getCurrentGuildId called without a selected guild — route is missing requireGuildContext');
+  }
+  return guildId;
+}


### PR DESCRIPTION
## Summary
- Add `getCurrentGuildId(req)` to `src/web/session.ts`, mirroring the existing `getSessionUser(req)` throw-on-missing pattern.
- Replace the repeated `getSessionUser(req).currentGuildId!` non-null assertion (24 call sites across 8 route files) with `getCurrentGuildId(req)`, so a route handler missing its `requireGuildContext` middleware fails with a clear error instead of a silent `undefined`/type-unsafe assertion.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (3216 tests passing)
- [x] `npm run lint` (no new warnings/errors)
- [x] Added `getCurrentGuildId` test cases in `src/web/session.test.ts`

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDjsjtot8RAJYz6fugPbxS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when accessing guild-specific administration, streaming, Streamdeck, and Twitch settings.
  * Added clearer handling for unauthenticated sessions or sessions without a selected guild.

* **Tests**
  * Added coverage for valid guild selection and missing authentication or guild context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->