### PR TITLE
Tighten a few any/non-null-assertion type-safety spots

### DIFF
--- a/src/audio/voiceAdapter.ts
+++ b/src/audio/voiceAdapter.ts
@@ -67,8 +67,7 @@ function getOrCreateDispatcher(client: Client): ClientDispatcher {
 function makeSendPayload(channel: VoiceBasedChannel): (payload: unknown) => boolean {
   return function sendPayload(payload: unknown): boolean {
     try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      channel.guild.shard.send(payload as any);
+      channel.guild.shard.send(payload);
       return true;
     } catch {
       return false;

--- a/src/shared/fetchWithRetry.ts
+++ b/src/shared/fetchWithRetry.ts
@@ -24,7 +24,7 @@ export async function fetchWithRetry(
   maxRetries = 2,
   retryDelayMs = 500,
 ): Promise<Response> {
-  let lastResponse: Response;
+  let lastResponse: Response | undefined;
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
     lastResponse = await fetch(input, init);
     if (lastResponse.ok || !TRANSIENT_STATUS_CODES.has(lastResponse.status)) {
@@ -39,5 +39,9 @@ export async function fetchWithRetry(
       await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
     }
   }
-  return lastResponse!;
+  // Unreachable in practice — the loop above always runs at least once (attempt 0
+  // <= maxRetries) since no caller passes a negative maxRetries — but this makes
+  // that invariant an explicit, type-checked throw instead of a bare `!` assertion.
+  if (!lastResponse) throw new Error('fetchWithRetry: no attempt was made');
+  return lastResponse;
 }

--- a/src/twitch/twitchBot.ts
+++ b/src/twitch/twitchBot.ts
@@ -32,6 +32,11 @@ import {
 
 const log = createLogger('Twitch');
 
+/** tmi.js's real internal shape for the confirmed-channel list, which isn't part of its public types. */
+interface TmiClientWithChannels {
+  channels: string[];
+}
+
 let client: tmi.Client | null = null;
 let connected = false;
 const TWITCH_CHAT_MESSAGE_PATTERN = /^\[#[^\]]+\] <[^>]+>: /;
@@ -186,7 +191,7 @@ function onDisconnected(reason: string): void {
   // disconnect, so without this reset the client would re-join every channel
   // twice on reconnect (once from its own queue, once from reconcileJoinedChannels).
   // `channels` is not part of the public type surface but is a real internal array.
-  (client as any).channels = [];
+  (client as unknown as TmiClientWithChannels).channels = [];
   log.warn(`Disconnected: ${reason}`);
   getActiveChannels().forEach((ch) => { setTwitchChannel(ch, false); });
 }


### PR DESCRIPTION
## Summary
Three small, unrelated type-safety fixes, one commit each:
- `src/shared/fetchWithRetry.ts` — replace the bare `lastResponse!` non-null assertion with an explicit, type-checked throw. Behavior is unchanged (the throw is unreachable today since `maxRetries` defaults to 2 and no caller passes negative), but the invariant is now checked rather than silently assumed.
- `src/twitch/twitchBot.ts` — replace `(client as any).channels = []` with a cast to a local `TmiClientWithChannels` interface describing tmi.js's actual internal shape, instead of `any`.
- `src/audio/voiceAdapter.ts` — drop the `payload as any` cast (and its `eslint-disable`) on `channel.guild.shard.send(...)`; discord.js's `WebSocketShard.send` already accepts `unknown`, so the cast was redundant.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (3213 tests passing)
- [x] `npm run lint` — the pre-existing `no-explicit-any` warning on `twitchBot.ts:189` is gone; only unrelated pre-existing warnings remain

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDjsjtot8RAJYz6fugPbxS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when sending audio-related messages.
  * Strengthened retry handling for network requests when no response is received.
  * Ensured disconnected Twitch connections properly clear tracked channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->