### PR TITLE
Add cooldown gate to !321 countdown command

### DIFF
--- a/src/commands/countdownHandler.test.ts
+++ b/src/commands/countdownHandler.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('./logger', () => ({ createLogger: () => ({ info: vi.fn(), error: vi.fn() }) }));
+vi.mock('../shared/config', () => ({ GLOBAL_COOLDOWN_MS: 3_000 }));
 
 import {
   executeCountdownForTwitch,
@@ -9,8 +10,16 @@ import {
 
 const mockRuntime = { send: vi.fn() };
 
+// Base time far in the future, advanced further each test so any cooldown claim left over
+// from a previous test (same channel key) has already expired — matches the pattern in
+// counterHandler.test.ts.
+const COOLDOWN_MS = 3_000;
+let mockNow = 1_000_000_000_000;
+
 beforeEach(() => {
+  mockNow += COOLDOWN_MS + 1_000;
   vi.useFakeTimers();
+  vi.setSystemTime(mockNow);
   vi.clearAllMocks();
   mockRuntime.send.mockResolvedValue(undefined);
   registerCountdownTwitchRuntime(mockRuntime);
@@ -66,5 +75,30 @@ describe('executeCountdownForTwitch', () => {
     registerCountdownTwitchRuntime(null as any);
     await executeCountdownForTwitch('#chan', '!321');
     expect(mockRuntime.send).not.toHaveBeenCalled();
+  });
+});
+
+describe('countdown cooldown', () => {
+  it('blocks a second !321 in the same channel within the cooldown window', async () => {
+    // Both calls claim/check the cooldown synchronously before their first await, so issuing
+    // them back-to-back deterministically exercises the claim vs. blocked-claim paths.
+    const first = executeCountdownForTwitch('#chan', '!321');
+    const second = executeCountdownForTwitch('#chan', '!321');
+
+    await vi.advanceTimersByTimeAsync(3000);
+    await Promise.all([first, second]);
+
+    // Only the first call's 4 steps were sent; the second was blocked by cooldown.
+    expect(mockRuntime.send).toHaveBeenCalledTimes(4);
+  });
+
+  it("does not apply one channel's cooldown to another channel", async () => {
+    const chanA = executeCountdownForTwitch('#chan-a', '!321');
+    const chanB = executeCountdownForTwitch('#chan-b', '!321');
+
+    await vi.advanceTimersByTimeAsync(3000);
+    await Promise.all([chanA, chanB]);
+
+    expect(mockRuntime.send).toHaveBeenCalledTimes(8);
   });
 });

--- a/src/commands/countdownHandler.test.ts
+++ b/src/commands/countdownHandler.test.ts
@@ -90,6 +90,13 @@ describe('countdown cooldown', () => {
 
     // Only the first call's 4 steps were sent; the second was blocked by cooldown.
     expect(mockRuntime.send).toHaveBeenCalledTimes(4);
+
+    // Once the cooldown window has elapsed, the channel can claim again.
+    await vi.advanceTimersByTimeAsync(COOLDOWN_MS + 1);
+    const retry = executeCountdownForTwitch('#chan', '!321');
+    await vi.advanceTimersByTimeAsync(3000);
+    await retry;
+    expect(mockRuntime.send).toHaveBeenCalledTimes(8);
   });
 
   it("does not apply one channel's cooldown to another channel", async () => {

--- a/src/commands/countdownHandler.ts
+++ b/src/commands/countdownHandler.ts
@@ -1,12 +1,22 @@
 import { createLogger } from '../shared/logger';
 import { extractCommand } from './commandUtils';
 import { createRuntimeRegistry, type TwitchSendRuntime } from './twitchRuntime';
+import { createCooldownGate } from './cooldownGate';
 
 const log = createLogger('Twitch');
 
 const COUNTDOWN_COMMAND = '!321';
 const STEPS = ['3', '2', '1', 'Go!'];
 const DELAY_MS = 1000;
+
+// ─── Cooldown ─────────────────────────────────────────────────────────────────
+//
+// Otherwise unthrottled: any chat member (no permission needed) can spam `!321`
+// as fast as they can send it, each spawning a 4-step countdown chain into the
+// shared global Twitch send queue. Gated per channel, mirroring
+// counterHandler.ts's per-channel cooldown.
+
+const countdownCooldown = createCooldownGate();
 
 /** Delays for `ms` milliseconds. */
 function sleep(ms: number): Promise<void> {
@@ -24,9 +34,10 @@ export function registerCountdownTwitchRuntime(runtime: CountdownTwitchRuntime):
 
 /**
  * Handles a `!321` countdown command by sending each step ("3", "2", "1", "Go!")
- * to `channel` with a one-second delay between steps. No-ops for other commands
- * or if no runtime has been registered. Aborts the remaining steps (without
- * throwing) if a send fails partway through.
+ * to `channel` with a one-second delay between steps. No-ops for other commands,
+ * if no runtime has been registered, or if `channel` is still on cooldown from a
+ * previous countdown. Aborts the remaining steps (without throwing) if a send
+ * fails partway through.
  *
  * @param channel - Twitch channel to send the countdown steps to.
  * @param rawMessage - Raw chat message text.
@@ -35,6 +46,7 @@ export async function executeCountdownForTwitch(channel: string, rawMessage: str
   if (extractCommand(rawMessage) !== COUNTDOWN_COMMAND) return;
   const runtime = countdownRuntime.get();
   if (!runtime) return;
+  if (!countdownCooldown.tryClaim(`twitch:${channel}`)) return;
   for (let i = 0; i < STEPS.length; i++) {
     if (i > 0) await sleep(DELAY_MS);
     try {


### PR DESCRIPTION
## Summary
- `!321` had no cooldown/rate-limit, unlike the `!clap`-style counter and custom-command triggers, which both explicitly gate spam.
- Any unprivileged chat member could spam `!321` as fast as they could send messages, each spawning an independent 4-step countdown chain that enqueues into the single global `throttledTwitchSend` queue shared account-wide across every channel and feature. A burst could starve unrelated bot output everywhere.
- Gate it per Twitch channel using the same `createCooldownGate()` pattern `counterHandler.ts` already uses.

Found during a full-codebase review; shipped as its own PR alongside a matching fix for `!multi` and a couple of unrelated cleanups.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 3235 tests passing)
- [x] `npx eslint src/commands/countdownHandler.ts src/commands/countdownHandler.test.ts` — clean
- [x] New tests cover: a rapid second `!321` in the same channel is blocked; the cooldown does not leak across channels

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fj4fSVr25DicATh5iF4FMH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated `!321` countdown commands from triggering multiple times within the same channel cooldown period.
  * Ensured countdown commands in different channels continue to operate independently.
  * Allowed countdown commands to be retried after the cooldown expires.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->