### PR TITLE
Add cooldown gate to !multi broadcast command

### DIFF
--- a/src/commands/multiCommandHandler.test.ts
+++ b/src/commands/multiCommandHandler.test.ts
@@ -143,6 +143,28 @@ describe('multi cooldown', () => {
     expect(mockRuntime.send).toHaveBeenCalledTimes(2);
   });
 
+  it('allows the same source channel to broadcast again once the cooldown has elapsed', async () => {
+    vi.mocked(getMultiTwitchDataForChannel).mockReturnValue({
+      url: 'multitwitch.tv/a/b',
+      participants: ['#a', '#b'],
+    } as any);
+    mockRuntime.getActiveChannels.mockReturnValue(new Set(['#a', '#b']));
+
+    await executeMultiCommandForTwitch('#a', '!multi', 'user1');
+    expect(mockRuntime.send).toHaveBeenCalledTimes(2);
+
+    // Still on cooldown.
+    await executeMultiCommandForTwitch('#a', '!multi', 'user1');
+    expect(mockRuntime.send).toHaveBeenCalledTimes(2);
+
+    // Once the cooldown window has elapsed, the channel can claim again. Advance the shared
+    // `mockNow` (not just a local offset) so later tests' beforeEach still clears this claim.
+    mockNow += COOLDOWN_MS + 1;
+    vi.spyOn(Date, 'now').mockReturnValue(mockNow);
+    await executeMultiCommandForTwitch('#a', '!multi', 'user1');
+    expect(mockRuntime.send).toHaveBeenCalledTimes(4);
+  });
+
   it("does not apply one source channel's cooldown to another", async () => {
     vi.mocked(getMultiTwitchDataForChannel).mockReturnValue({
       url: 'multitwitch.tv/a/b',

--- a/src/commands/multiCommandHandler.test.ts
+++ b/src/commands/multiCommandHandler.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mockLogger } from '../test-utils/loggerMock';
 
 vi.mock('../shared/logger', () => ({ createLogger: mockLogger }));
+vi.mock('../shared/config', () => ({ GLOBAL_COOLDOWN_MS: 3_000 }));
 
 vi.mock('../twitch/monitor/twitchMonitor', () => ({
   getMultiTwitchDataForChannel: vi.fn(),
@@ -23,8 +24,16 @@ const mockRuntime = {
   getLoginUserIds: vi.fn(),
 };
 
+// Base time far in the future, advanced further each test so any cooldown claim left over
+// from a previous test (same channel key) has already expired — matches the pattern in
+// counterHandler.test.ts.
+const COOLDOWN_MS = 3_000;
+let mockNow = 1_000_000_000_000;
+
 beforeEach(() => {
+  mockNow += COOLDOWN_MS + 1_000;
   vi.clearAllMocks();
+  vi.spyOn(Date, 'now').mockReturnValue(mockNow);
   mockRuntime.send.mockResolvedValue(undefined);
   mockRuntime.getActiveChannels.mockReturnValue(new Set<string>());
   mockRuntime.getLoginUserIds.mockReturnValue(new Map<string, string>());
@@ -116,5 +125,35 @@ describe('executeMultiCommandForTwitch', () => {
 
     await expect(executeMultiCommandForTwitch('#a', '!multi', 'user1')).resolves.toBeUndefined();
     expect(mockRuntime.send).not.toHaveBeenCalled();
+  });
+});
+
+describe('multi cooldown', () => {
+  it('blocks a second !multi from the same source channel within the cooldown window', async () => {
+    vi.mocked(getMultiTwitchDataForChannel).mockReturnValue({
+      url: 'multitwitch.tv/a/b',
+      participants: ['#a', '#b'],
+    } as any);
+    mockRuntime.getActiveChannels.mockReturnValue(new Set(['#a', '#b']));
+
+    await executeMultiCommandForTwitch('#a', '!multi', 'user1');
+    expect(mockRuntime.send).toHaveBeenCalledTimes(2);
+
+    await executeMultiCommandForTwitch('#a', '!multi', 'user1');
+    expect(mockRuntime.send).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not apply one source channel's cooldown to another", async () => {
+    vi.mocked(getMultiTwitchDataForChannel).mockReturnValue({
+      url: 'multitwitch.tv/a/b',
+      participants: ['#a', '#b'],
+    } as any);
+    mockRuntime.getActiveChannels.mockReturnValue(new Set(['#a', '#b']));
+
+    await executeMultiCommandForTwitch('#a', '!multi', 'user1');
+    expect(mockRuntime.send).toHaveBeenCalledTimes(2);
+
+    await executeMultiCommandForTwitch('#b', '!multi', 'user1');
+    expect(mockRuntime.send).toHaveBeenCalledTimes(4);
   });
 });

--- a/src/commands/multiCommandHandler.ts
+++ b/src/commands/multiCommandHandler.ts
@@ -6,8 +6,18 @@ import { resolveSharedChatSessionId } from './customCommandHandler';
 import { extractCommand } from './commandUtils';
 import { sendDedupedBySession } from './twitchBroadcast';
 import { createRuntimeRegistry, type TwitchBroadcastRuntime } from './twitchRuntime';
+import { createCooldownGate } from './cooldownGate';
 
 const MULTI_COMMAND = '!multi';
+
+// ─── Cooldown ─────────────────────────────────────────────────────────────────
+//
+// Otherwise unthrottled: any chat member (no permission needed) can spam `!multi`
+// as fast as they can send it, and each spam broadcasts to every participant
+// channel in the shared-chat group — the cost scales with group size. Gated per
+// source channel, mirroring counterHandler.ts's per-channel cooldown.
+
+const multiCooldown = createCooldownGate();
 
 // ─── Twitch runtime (registered from index.ts before startTwitchBot) ─────────
 //
@@ -54,7 +64,9 @@ async function broadcastToGroupChannels(
 /**
  * Handles a Twitch chat `!multi` command: looks up the multitwitch group for
  * `channel` and — if the channel is part of an active group — broadcasts the
- * multitwitch URL to the group via {@link broadcastToGroupChannels}.
+ * multitwitch URL to the group via {@link broadcastToGroupChannels}. Throttled
+ * per source channel so repeated spam doesn't repeatedly broadcast to the whole
+ * group.
  *
  * @param channel - Twitch channel the command was sent in.
  * @param rawMessage - Raw chat message text.
@@ -75,6 +87,8 @@ export async function executeMultiCommandForTwitch(
 
   const runtime = multiTwitchRuntime.get();
   if (!runtime) return;
+
+  if (!multiCooldown.tryClaim(`twitch:${channel}`)) return;
 
   try {
     const sent = await broadcastToGroupChannels(channel, groupInfo.participants, groupInfo.url, runtime);


### PR DESCRIPTION
## Summary
- `!multi` had no cooldown/rate-limit, unlike the counter and custom-command triggers, which both explicitly gate spam.
- Any unprivileged chat member could spam `!multi` as fast as they could send messages, and each spam broadcasts one message per active participant channel in the shared-chat group — the cost scales with group size, worse amplification than a single-channel spam target.
- Gate it per source channel using the same `createCooldownGate()` pattern `counterHandler.ts` already uses.

Found during a full-codebase review; shipped as its own PR alongside a matching fix for `!321` (#553) and a couple of unrelated cleanups.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 3235 tests passing)
- [x] `npx eslint src/commands/multiCommandHandler.ts src/commands/multiCommandHandler.test.ts` — clean (one pre-existing, unrelated warning)
- [x] New tests cover: a rapid second `!multi` from the same source channel is blocked; the cooldown does not leak across channels

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fj4fSVr25DicATh5iF4FMH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cooldown protection for repeated Twitch `!multi` commands from the same channel.
  * Commands are blocked during the cooldown period and automatically allowed again afterward.
  * Cooldowns are isolated by channel, so activity in one channel does not affect another.

* **Tests**
  * Added coverage for cooldown enforcement, expiration, and channel isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->