### PR TITLE
Remove unused DB helpers

### DIFF
--- a/src/db/companionOAuthCodes.test.ts
+++ b/src/db/companionOAuthCodes.test.ts
@@ -27,7 +27,7 @@ vi.mock('./pool', () => {
 vi.mock('mysql2/promise', () => ({ default: {} }));
 
 import { getPool } from './pool';
-import { createCode, consumeCode, exchangeCodeForToken } from './companionOAuthCodes';
+import { createCode, exchangeCodeForToken } from './companionOAuthCodes';
 import { createHash } from 'crypto';
 import { makeMockConnection } from '../test-utils/mockMysqlPool';
 
@@ -54,53 +54,6 @@ describe('createCode', () => {
     expect(params[0]).toBe(sha256hex(plain));
     expect(params[1]).toBe('123');
     expect(params[2]).toBe(60);
-  });
-});
-
-// ─── consumeCode ──────────────────────────────────────────────────────────────
-
-describe('consumeCode', () => {
-  it('returns null when the UPDATE affects no rows (invalid/expired/used code)', async () => {
-    const execute = vi.fn().mockResolvedValue([{ affectedRows: 0 }]);
-    vi.mocked(getPool).mockReturnValue({ execute } as any);
-    const result = await consumeCode('bad-code');
-    expect(result).toBeNull();
-    expect(execute).toHaveBeenCalledTimes(1); // no follow-up SELECT
-  });
-
-  it('returns the discord_id when the UPDATE succeeds and a row is found', async () => {
-    const execute = vi
-      .fn()
-      .mockResolvedValueOnce([{ affectedRows: 1 }])
-      .mockResolvedValueOnce([[{ discord_id: '42' }]]);
-    vi.mocked(getPool).mockReturnValue({ execute } as any);
-    const result = await consumeCode('good-code');
-    expect(result).toBe('42');
-    const [updateSql] = execute.mock.calls[0] as [string, unknown[]];
-    expect(updateSql).toContain('used_at IS NULL AND expires_at > NOW()');
-  });
-
-  it('returns null if the follow-up SELECT somehow finds no row', async () => {
-    const execute = vi
-      .fn()
-      .mockResolvedValueOnce([{ affectedRows: 1 }])
-      .mockResolvedValueOnce([[]]);
-    vi.mocked(getPool).mockReturnValue({ execute } as any);
-    const result = await consumeCode('good-code');
-    expect(result).toBeNull();
-  });
-
-  it('hashes the same code identically across calls, preventing double-spend via the affectedRows guard', async () => {
-    const execute = vi
-      .fn()
-      .mockResolvedValueOnce([{ affectedRows: 1 }])
-      .mockResolvedValueOnce([[{ discord_id: '1' }]])
-      .mockResolvedValueOnce([{ affectedRows: 0 }]); // second consume of the same code fails
-    vi.mocked(getPool).mockReturnValue({ execute } as any);
-    const first = await consumeCode('reused-code');
-    const second = await consumeCode('reused-code');
-    expect(first).toBe('1');
-    expect(second).toBeNull();
   });
 });
 

--- a/src/db/companionOAuthCodes.ts
+++ b/src/db/companionOAuthCodes.ts
@@ -54,19 +54,6 @@ async function consumeCodeOnConnection(executor: mysql.Pool | mysql.PoolConnecti
 }
 
 /**
- * Atomically consumes a companion OAuth code: marks it used and returns the
- * Discord ID it was issued for, but only if it exists, hasn't expired, and
- * hasn't already been consumed.
- *
- * @param code - Plaintext code presented by the companion app.
- * @returns The Discord ID the code was issued for, or null if invalid/expired/already used.
- */
-export async function consumeCode(code: string): Promise<string | null> {
-  const hash = createHash('sha256').update(code).digest('hex');
-  return consumeCodeOnConnection(getPool(), hash);
-}
-
-/**
  * Atomically exchanges a companion OAuth code for a companion app token: marks
  * the code used and issues the token in a single DB transaction, so a failure
  * issuing the token rolls back the "used" mark instead of permanently burning

--- a/src/db/guildMembers.test.ts
+++ b/src/db/guildMembers.test.ts
@@ -11,7 +11,6 @@ vi.mock('./users', () => ({
 import { getPool } from './pool';
 import { findUser, AccessLevel } from './users';
 import {
-  getGuildMembers,
   getMemberAccessLevel,
   setMemberAccessLevel,
   removeGuildMember,
@@ -26,30 +25,6 @@ beforeEach(() => {
   vi.clearAllMocks();
   pool = makeMockPool();
   vi.mocked(getPool).mockReturnValue(pool as never);
-});
-
-describe('getGuildMembers', () => {
-  it('maps rows and preserves BIGINT snowflakes as strings without precision loss', async () => {
-    // These values exceed Number.MAX_SAFE_INTEGER; coercing to Number would corrupt them.
-    const GUILD  = 915557543463727107n;
-    const ALICE  = 799843684990877696n;
-    const BOB    = 799843684990877697n;
-
-    pool.execute.mockResolvedValueOnce([
-      [
-        { guild_id: GUILD, discord_id: ALICE, access_level: 3 },
-        { guild_id: GUILD, discord_id: BOB,   access_level: 1 },
-      ],
-      [],
-    ]);
-
-    const result = await getGuildMembers(String(GUILD));
-
-    expect(result).toEqual([
-      { guild_id: '915557543463727107', discord_id: '799843684990877696', access_level: 3 },
-      { guild_id: '915557543463727107', discord_id: '799843684990877697', access_level: 1 },
-    ]);
-  });
 });
 
 describe('getMemberAccessLevel', () => {

--- a/src/db/guildMembers.ts
+++ b/src/db/guildMembers.ts
@@ -11,32 +11,7 @@ export interface DbGuildMember {
   access_level: number;
 }
 
-function mapGuildMember(row: mysql.RowDataPacket): DbGuildMember {
-  return {
-    guild_id: String(row.guild_id),
-    discord_id: String(row.discord_id),
-    access_level: row.access_level,
-  };
-}
-
 // ─── Queries ─────────────────────────────────────────────────────────────────
-
-/**
- * Returns every membership row for a guild, ordered by access level descending.
- *
- * @param guildId - Guild snowflake ID.
- * @returns Array of guild member rows, highest access level first.
- */
-export async function getGuildMembers(guildId: string): Promise<DbGuildMember[]> {
-  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    `SELECT guild_id, discord_id, access_level
-     FROM guild_member
-     WHERE guild_id = ?
-     ORDER BY access_level DESC`,
-    [guildId],
-  );
-  return rows.map(mapGuildMember);
-}
 
 /**
  * Returns a user's access level within a specific guild, or null if they have no

--- a/src/db/guilds.test.ts
+++ b/src/db/guilds.test.ts
@@ -4,7 +4,7 @@ vi.mock('./pool', () => ({ getPool: vi.fn() }));
 vi.mock('mysql2/promise', () => ({ default: {} }));
 
 import { getPool } from './pool';
-import { getAllGuilds, getProvisionedGuilds, getGuildById, getGuildsForMember, upsertGuild, setGuildVoiceChannel } from './guilds';
+import { getAllGuilds, getProvisionedGuilds, getGuildById, getGuildsForMember, upsertGuild } from './guilds';
 import { makeMockPool, type MockPool } from '../test-utils/mockMysqlPool';
 
 let pool: MockPool;
@@ -110,20 +110,5 @@ describe('upsertGuild', () => {
     expect(sql).toContain('ON DUPLICATE KEY UPDATE name = new_guild.name');
     expect(sql).not.toContain('voice_channel_id =');
     expect(params).toEqual(['111', 'Alpha']);
-  });
-});
-
-describe('setGuildVoiceChannel', () => {
-  it('updates the voice channel for a guild', async () => {
-    await setGuildVoiceChannel('111', '222');
-    expect(pool.execute).toHaveBeenCalledWith(
-      expect.stringContaining('UPDATE guild SET voice_channel_id = ?'),
-      ['222', '111'],
-    );
-  });
-
-  it('clears the voice channel when passed null', async () => {
-    await setGuildVoiceChannel('111', null);
-    expect(pool.execute).toHaveBeenCalledWith(expect.any(String), [null, '111']);
   });
 });

--- a/src/db/guilds.ts
+++ b/src/db/guilds.ts
@@ -116,17 +116,3 @@ export async function upsertGuild(guildId: string, name: string): Promise<void> 
     [guildId, name],
   );
 }
-
-/**
- * Sets (or clears) the default voice channel for a guild.
- *
- * @param guildId BIGINT snowflake as a string.
- * @param voiceChannelId BIGINT snowflake as a string, or null to clear.
- * @returns Resolves when the update is complete.
- */
-export async function setGuildVoiceChannel(guildId: string, voiceChannelId: string | null): Promise<void> {
-  await getPool().execute(
-    'UPDATE guild SET voice_channel_id = ? WHERE guild_id = ?',
-    [voiceChannelId, guildId],
-  );
-}


### PR DESCRIPTION
## Summary
- Found during a full-codebase review: three DB-layer functions defined and tested, but never called from production code — only exercised by their own test suites, and none exported from the `src/db.ts` facade.
- `src/db/guilds.ts` `setGuildVoiceChannel`
- `src/db/guildMembers.ts` `getGuildMembers` (and its now-orphaned `mapGuildMember` row mapper)
- `src/db/companionOAuthCodes.ts` `consumeCode` — superseded by `exchangeCodeForToken`, which shares the same underlying `consumeCodeOnConnection` logic inside a transaction
- Removed each function plus its dedicated test cases. `consumeCodeOnConnection` itself is untouched and still fully covered by the `exchangeCodeForToken` tests.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 3226 tests passing)
- [x] `npx eslint` on all six touched files — clean
- [x] Confirmed via repo-wide grep that none of the three removed functions had any remaining production caller before deleting

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fj4fSVr25DicATh5iF4FMH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed support for retrieving all members of a guild.
  * Removed the ability to set or clear a guild’s voice channel configuration.
  * Consolidated one-time code consumption into the token exchange flow, preserving atomic use and double-spend protection.
* **Tests**
  * Removed tests covering the retired guild member lookup, voice channel configuration, and standalone code consumption functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->