### PR TITLE
Fix Twitch bot never rejoining channels after an automatic reconnect

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -30,6 +30,8 @@ vi.mock('./twitch/twitchChannelMembership', () => ({
   getActiveChannels: vi.fn(),
   getActiveChannelUserIds: vi.fn(),
   setChannelJoinedHook: vi.fn(),
+}));
+vi.mock('./twitch/twitchChannelReconciliationPoll', () => ({
   startChannelReconciliationPoll: vi.fn(),
   stopChannelReconciliationPoll: vi.fn(),
 }));
@@ -214,7 +216,7 @@ describe('startup — reward pricing scheduler', () => {
     const { startRewardPricingScheduler } = await import('./twitch/pricing/rewardPricingScheduler.js');
     const { startEventSub } = await import('./twitch/eventsub/twitchEventSub.js');
     const { startEventSubReconciliation } = await import('./twitch/eventsub/twitchEventSubReconciliation.js');
-    const { startChannelReconciliationPoll } = await import('./twitch/twitchChannelMembership.js');
+    const { startChannelReconciliationPoll } = await import('./twitch/twitchChannelReconciliationPoll.js');
 
     await runMain();
 
@@ -230,7 +232,7 @@ describe('shutdown', () => {
   it('stops the reward pricing scheduler on SIGINT', async () => {
     const { stopRewardPricingScheduler } = await import('./twitch/pricing/rewardPricingScheduler.js');
     const { stopEventSubReconciliation } = await import('./twitch/eventsub/twitchEventSubReconciliation.js');
-    const { stopChannelReconciliationPoll } = await import('./twitch/twitchChannelMembership.js');
+    const { stopChannelReconciliationPoll } = await import('./twitch/twitchChannelReconciliationPoll.js');
 
     await runMain();
     process.emit('SIGINT');

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -30,6 +30,8 @@ vi.mock('./twitch/twitchChannelMembership', () => ({
   getActiveChannels: vi.fn(),
   getActiveChannelUserIds: vi.fn(),
   setChannelJoinedHook: vi.fn(),
+  startChannelReconciliationPoll: vi.fn(),
+  stopChannelReconciliationPoll: vi.fn(),
 }));
 vi.mock('./twitch/monitor/twitchMonitor', () => ({
   startTwitchMonitor: vi.fn().mockResolvedValue(undefined),
@@ -212,12 +214,14 @@ describe('startup — reward pricing scheduler', () => {
     const { startRewardPricingScheduler } = await import('./twitch/pricing/rewardPricingScheduler.js');
     const { startEventSub } = await import('./twitch/eventsub/twitchEventSub.js');
     const { startEventSubReconciliation } = await import('./twitch/eventsub/twitchEventSubReconciliation.js');
+    const { startChannelReconciliationPoll } = await import('./twitch/twitchChannelMembership.js');
 
     await runMain();
 
     expect(vi.mocked(startRewardPricingScheduler)).toHaveBeenCalledOnce();
     expect(vi.mocked(startEventSub)).toHaveBeenCalledOnce();
     expect(vi.mocked(startEventSubReconciliation)).toHaveBeenCalledOnce();
+    expect(vi.mocked(startChannelReconciliationPoll)).toHaveBeenCalledOnce();
     expect(exitSpy).not.toHaveBeenCalled();
   });
 });
@@ -226,6 +230,7 @@ describe('shutdown', () => {
   it('stops the reward pricing scheduler on SIGINT', async () => {
     const { stopRewardPricingScheduler } = await import('./twitch/pricing/rewardPricingScheduler.js');
     const { stopEventSubReconciliation } = await import('./twitch/eventsub/twitchEventSubReconciliation.js');
+    const { stopChannelReconciliationPoll } = await import('./twitch/twitchChannelMembership.js');
 
     await runMain();
     process.emit('SIGINT');
@@ -233,6 +238,7 @@ describe('shutdown', () => {
 
     expect(vi.mocked(stopRewardPricingScheduler)).toHaveBeenCalledOnce();
     expect(vi.mocked(stopEventSubReconciliation)).toHaveBeenCalledOnce();
+    expect(vi.mocked(stopChannelReconciliationPoll)).toHaveBeenCalledOnce();
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,8 @@
 import 'mediaplex'; // Must be imported first to register as Opus provider
 import { getPool, closePool } from './db';
 import { startTwitchBot, stopTwitchBot, sayInChannel } from './twitch/twitchBot';
-import {
-  getActiveChannels, getActiveChannelUserIds, setChannelJoinedHook,
-  startChannelReconciliationPoll, stopChannelReconciliationPoll,
-} from './twitch/twitchChannelMembership';
+import { getActiveChannels, getActiveChannelUserIds, setChannelJoinedHook } from './twitch/twitchChannelMembership';
+import { startChannelReconciliationPoll, stopChannelReconciliationPoll } from './twitch/twitchChannelReconciliationPoll';
 import { startDiscordBot, stopDiscordBot } from './discord/discordBot';
 import { reloadGuildRegistry } from './discord/guildRegistry';
 import { resolveGuildIdForDiscordId } from './discord/voicePresence';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,10 @@
 import 'mediaplex'; // Must be imported first to register as Opus provider
 import { getPool, closePool } from './db';
 import { startTwitchBot, stopTwitchBot, sayInChannel } from './twitch/twitchBot';
-import { getActiveChannels, getActiveChannelUserIds, setChannelJoinedHook } from './twitch/twitchChannelMembership';
+import {
+  getActiveChannels, getActiveChannelUserIds, setChannelJoinedHook,
+  startChannelReconciliationPoll, stopChannelReconciliationPoll,
+} from './twitch/twitchChannelMembership';
 import { startDiscordBot, stopDiscordBot } from './discord/discordBot';
 import { reloadGuildRegistry } from './discord/guildRegistry';
 import { resolveGuildIdForDiscordId } from './discord/voicePresence';
@@ -40,6 +43,7 @@ const log = createLogger('Bot');
 async function shutdown(signal: string): Promise<void> {
   log.info(`${signal} received — disconnecting from voice and shutting down.`);
   stopCounterScheduler();
+  stopChannelReconciliationPoll();
   await stopRewardPricingScheduler();
   await stopTimerCommandScheduler();
   await stopEventSubReconciliation();
@@ -137,6 +141,7 @@ async function main(): Promise<void> {
   setChannelJoinedHook(() => reloadEventSubSubscriptions());
   startDiscordBot();
   await startTwitchBot();
+  startChannelReconciliationPoll();
   startWebPanel();
   startCounterScheduler();
   startRewardPricingScheduler();

--- a/src/twitch/twitchBot.test.ts
+++ b/src/twitch/twitchBot.test.ts
@@ -149,6 +149,7 @@ import {
   getActiveChannels,
   getActiveChannelUserIds,
   setChannelJoinedHook,
+  __setConfirmedJoinedChannelsForTests,
 } from './twitchChannelMembership';
 import * as twitchChannelMembership from './twitchChannelMembership';
 import { getTwitchEnabledChannels, getAllTwitchLinkedUsers, findUserByTwitchName } from '../db';
@@ -471,7 +472,7 @@ describe('joinTwitchChannel', () => {
 
   it('syncs state without calling client.join when already joined', async () => {
     await connectBot();
-    mockClient.currentChannels = ['streamer'];
+    __setConfirmedJoinedChannelsForTests(['streamer']);
 
     await joinTwitchChannel('streamer');
 
@@ -534,7 +535,7 @@ describe('joinTwitchChannel', () => {
     await connectBot();
     const hook = vi.fn();
     setChannelJoinedHook(hook);
-    mockClient.currentChannels = ['streamer'];
+    __setConfirmedJoinedChannelsForTests(['streamer']);
 
     await joinTwitchChannel('streamer');
 
@@ -544,7 +545,7 @@ describe('joinTwitchChannel', () => {
   it('caches the user ID when already joined', async () => {
     await connectBot();
     vi.mocked(getUsers).mockResolvedValue([{ login: 'streamer', id: 'uid99' } as any]);
-    mockClient.currentChannels = ['streamer'];
+    __setConfirmedJoinedChannelsForTests(['streamer']);
 
     await joinTwitchChannel('streamer');
     await Promise.resolve(); // flush cacheChannelUserId
@@ -594,8 +595,7 @@ describe('partTwitchChannel', () => {
   it('calls client.part when the channel is active and already joined', async () => {
     await connectBot();
     vi.mocked(getUsers).mockResolvedValue([]);
-    await joinTwitchChannel('streamer');
-    mockClient.currentChannels = ['streamer'];
+    await joinTwitchChannel('streamer'); // real join — confirms 'streamer' joined
 
     await partTwitchChannel('streamer');
 
@@ -608,7 +608,7 @@ describe('partTwitchChannel', () => {
     await connectBot();
     vi.mocked(getUsers).mockResolvedValue([]);
     await joinTwitchChannel('streamer');
-    mockClient.currentChannels = []; // client reports no joined channels
+    __setConfirmedJoinedChannelsForTests([]); // simulate the channel no longer being joined
 
     await partTwitchChannel('streamer');
 
@@ -620,7 +620,6 @@ describe('partTwitchChannel', () => {
     await connectBot();
     vi.mocked(getUsers).mockResolvedValue([]);
     await joinTwitchChannel('streamer');
-    mockClient.currentChannels = ['streamer'];
     mockClient.part.mockImplementation(() => { throw new Error('part failed'); });
 
     await expect(partTwitchChannel('streamer')).rejects.toThrow('part failed');
@@ -632,7 +631,6 @@ describe('partTwitchChannel', () => {
     vi.mocked(getUsers).mockResolvedValue([{ login: 'streamer', id: 'uid42' } as any]);
     await joinTwitchChannel('streamer');
     await Promise.resolve(); // flush cacheChannelUserId
-    mockClient.currentChannels = ['streamer'];
 
     await partTwitchChannel('streamer');
 
@@ -646,7 +644,6 @@ describe('partTwitchChannel', () => {
       () => new Promise((resolve) => { resolveGetUsers = resolve; }),
     );
     await joinTwitchChannel('streamer'); // cacheChannelUserId fires but getUsers is pending
-    mockClient.currentChannels = ['streamer'];
     await partTwitchChannel('streamer'); // removes from activeChannels before getUsers resolves
 
     resolveGetUsers([{ login: 'streamer', id: 'uid-stale' }]);
@@ -964,16 +961,18 @@ describe('stopTwitchBot', () => {
 // ─── reconcileJoinedChannels (via onConnected) ────────────────────────────────
 //
 // startTwitchBot() itself only resolves once onAuthenticationSuccess fires (see connectAndWait),
-// and that same event triggers onConnected's fire-and-forget reconcileJoinedChannels() call — so by the
-// time `await startTwitchBot()` returns, the initial reconciliation has already been *kicked off*
-// against whatever mockClient.currentChannels was at that moment. These tests set currentChannels
-// up front, before starting the bot, rather than firing a separate synthetic reconnect afterward.
+// and that same event triggers onConnected's fire-and-forget reconcileJoinedChannels() call — so by
+// the time `await startTwitchBot()` returns, the initial reconciliation has already been *kicked
+// off*. These tests seed confirmedJoinedChannels (via __setConfirmedJoinedChannelsForTests) up
+// front, before starting the bot, rather than firing a separate synthetic reconnect afterward —
+// deliberately not mockClient.currentChannels, which reconcileJoinedChannels no longer trusts (see
+// confirmedJoinedChannels's doc in twitchChannelMembership.ts for why).
 
 describe('reconcileJoinedChannels', () => {
   it('parts a joined channel that is not in activeChannels', async () => {
     vi.mocked(getTwitchEnabledChannels).mockResolvedValue([]);
     vi.mocked(getUsers).mockResolvedValue([]);
-    mockClient.currentChannels = ['stale'];
+    __setConfirmedJoinedChannelsForTests(['stale']);
 
     await startTwitchBot();
     await vi.runAllTimersAsync();
@@ -985,7 +984,6 @@ describe('reconcileJoinedChannels', () => {
   it('joins an activeChannels channel that the client is not yet joined to', async () => {
     vi.mocked(getTwitchEnabledChannels).mockResolvedValue(['streamer']);
     vi.mocked(getUsers).mockResolvedValue([]);
-    mockClient.currentChannels = [];
 
     await startTwitchBot();
     await vi.runAllTimersAsync(); // advance JOIN_THROTTLE_MS
@@ -994,10 +992,22 @@ describe('reconcileJoinedChannels', () => {
     expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('streamer', true);
   });
 
-  it('marks a channel online when it is in both activeChannels and the client', async () => {
+  it('rejoins an active channel even when the client still reports it as previously joined (a reconnect leaves currentChannels stale)', async () => {
     vi.mocked(getTwitchEnabledChannels).mockResolvedValue(['streamer']);
     vi.mocked(getUsers).mockResolvedValue([]);
-    mockClient.currentChannels = ['streamer'];
+    mockClient.currentChannels = ['streamer']; // stale Twurple bookkeeping — must not be trusted
+
+    await startTwitchBot();
+    await vi.runAllTimersAsync();
+
+    expect(mockClient.join).toHaveBeenCalledWith('streamer');
+    expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('streamer', true);
+  });
+
+  it('marks a channel online when it is in both activeChannels and confirmed joined', async () => {
+    vi.mocked(getTwitchEnabledChannels).mockResolvedValue(['streamer']);
+    vi.mocked(getUsers).mockResolvedValue([]);
+    __setConfirmedJoinedChannelsForTests(['streamer']);
 
     await startTwitchBot();
     await vi.runAllTimersAsync();
@@ -1012,7 +1022,7 @@ describe('reconcileJoinedChannels', () => {
     vi.mocked(getUsers)
       .mockResolvedValueOnce([]) // initializeActiveChannels — simulate failed startup cache
       .mockResolvedValue([{ login: 'streamer', id: 'uid-reconcile' } as any]);
-    mockClient.currentChannels = ['streamer']; // already joined
+    __setConfirmedJoinedChannelsForTests(['streamer']); // already joined
 
     await startTwitchBot();
     await vi.runAllTimersAsync();
@@ -1026,7 +1036,6 @@ describe('reconcileJoinedChannels', () => {
     vi.mocked(getUsers)
       .mockResolvedValueOnce([]) // initializeActiveChannels
       .mockResolvedValue([{ login: 'streamer', id: 'uid-join' } as any]);
-    mockClient.currentChannels = []; // not yet joined
 
     await startTwitchBot();
     await vi.runAllTimersAsync(); // advance JOIN_THROTTLE_MS

--- a/src/twitch/twitchBot.ts
+++ b/src/twitch/twitchBot.ts
@@ -244,14 +244,16 @@ function onConnected(): void {
 }
 
 /**
- * Twurple `onDisconnect` event handler: marks the bot disconnected, marks every active channel's
- * status as disconnected, and clears {@link privilegedChannels}. Unlike tmi.js, Twurple's
- * underlying IRC client resets its own joined-channel list on every (re)connect, so there's no
- * equivalent of tmi.js's manual internal-state reset to avoid double-joining on reconnect. Clearing
- * privilege state matters because Twurple reconnects within the same `ChatClient` instance (this
- * handler doesn't imply a new client, unlike {@link stopTwitchBot}) — without this, a channel that
- * revoked the bot's mod/VIP status while disconnected would keep the stale privileged rate-limit
- * ceiling until its next `USERSTATE`, rather than reverting to the conservative default immediately.
+ * Twurple `onDisconnect` event handler: marks the bot disconnected (via {@link setConnected},
+ * which also clears `twitchChannelMembership.ts`'s own `confirmedJoinedChannels` tracking — see
+ * its doc for why: Twurple's `ChatClient#currentChannels` is *not* reset by an automatic
+ * reconnect, only by this process's own one-time `connect()` call, so it can't be trusted as
+ * "still joined" across one), marks every active channel's status as disconnected, and clears
+ * {@link privilegedChannels}. Clearing privilege state matters because Twurple reconnects within
+ * the same `ChatClient` instance (this handler doesn't imply a new client, unlike
+ * {@link stopTwitchBot}) — without this, a channel that revoked the bot's mod/VIP status while
+ * disconnected would keep the stale privileged rate-limit ceiling until its next `USERSTATE`,
+ * rather than reverting to the conservative default immediately.
  * @param manually - Whether the disconnect was requested by this process (e.g. via {@link stopTwitchBot}).
  * @param reason - The error that caused the disconnect, if any.
  */

--- a/src/twitch/twitchChannelMembership.test.ts
+++ b/src/twitch/twitchChannelMembership.test.ts
@@ -22,6 +22,8 @@ import {
   getActiveChannels,
   getActiveChannelUserIds,
   clearMembershipState,
+  startChannelReconciliationPoll,
+  stopChannelReconciliationPoll,
 } from './twitchChannelMembership';
 import { getTwitchEnabledChannels } from '../db';
 import { getUsers } from './twitchApi';
@@ -463,6 +465,70 @@ describe('reconcileJoinedChannels', () => {
     expect(client.join).toHaveBeenCalledWith('carol');
     expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('carol', true);
     expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('alice', false);
+  });
+});
+
+// ─── startChannelReconciliationPoll / stopChannelReconciliationPoll ────────
+
+describe('startChannelReconciliationPoll', () => {
+  it('re-runs reconciliation on an interval, retrying a channel a prior pass failed to join', async () => {
+    const client = makeMockClient([]);
+    setChatClient(client as any);
+    setConnected(false);
+    await joinTwitchChannel('alice'); // queues into activeChannels without calling client.join
+    setConnected(true);
+
+    // Simulate the connect-time reconciliation pass (onConnected's own call) failing to join —
+    // unlike joinTwitchChannel's own failure path, this leaves 'alice' in activeChannels (still
+    // desired) but not actually joined, exactly the case the periodic poll exists to retry.
+    client.join.mockRejectedValueOnce(new Error('join failed'));
+    await reconcileJoinedChannels();
+    expect(client.join).toHaveBeenCalledWith('alice');
+    expect(getActiveChannels().has('alice')).toBe(true);
+    vi.mocked(setTwitchChannel).mockClear();
+    client.join.mockClear();
+
+    startChannelReconciliationPoll();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(client.join).toHaveBeenCalledWith('alice');
+    expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('alice', true);
+  });
+
+  it('does not register a second interval when called again while already running', async () => {
+    const client = makeMockClient(['alice']);
+    setChatClient(client as any);
+    setConnected(true);
+    await joinTwitchChannel('alice');
+    vi.mocked(setTwitchChannel).mockClear();
+
+    startChannelReconciliationPoll();
+    startChannelReconciliationPoll();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // A duplicate interval would have run reconcileJoinedChannels twice in this window,
+    // marking the already-joined channel online twice instead of once.
+    expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('stopChannelReconciliationPoll', () => {
+  it('stops further reconciliation passes', async () => {
+    const client = makeMockClient(['alice']);
+    setChatClient(client as any);
+    setConnected(true);
+    await joinTwitchChannel('alice');
+    vi.mocked(setTwitchChannel).mockClear();
+
+    startChannelReconciliationPoll();
+    stopChannelReconciliationPoll();
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    expect(vi.mocked(setTwitchChannel)).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the poll was never started', () => {
+    expect(() => stopChannelReconciliationPoll()).not.toThrow();
   });
 });
 

--- a/src/twitch/twitchChannelMembership.test.ts
+++ b/src/twitch/twitchChannelMembership.test.ts
@@ -130,6 +130,36 @@ describe('joinTwitchChannel', () => {
     expect(getActiveChannelUserIds().get('alice')).toBe('uid-alice');
   });
 
+  it('does not record a join as confirmed if the connection cycled while it was in flight, so a later reconcile still rejoins it', async () => {
+    const client = makeMockClient();
+    setChatClient(client as any);
+    setConnected(true);
+    const { promise: gate, resolve: openGate } = deferred();
+    client.join.mockImplementation(() => gate);
+
+    const joinPromise = joinTwitchChannel('alice');
+    await flushMicrotasks();
+    expect(client.join).toHaveBeenCalledWith('alice');
+
+    // The connection drops and comes back — a new connection generation — while the join above
+    // is still pending. Its eventual success belongs to the old, now-superseded connection.
+    setConnected(false);
+    setConnected(true);
+    openGate();
+    await joinPromise;
+
+    // Still desired (queued for retry) but not confirmed joined — otherwise reconcile would
+    // believe it's already there and silently skip rejoining it on the current connection.
+    expect(getActiveChannels().has('alice')).toBe(true);
+    client.join.mockClear();
+    client.join.mockResolvedValue(undefined);
+    await vi.advanceTimersByTimeAsync(600); // release the first join's JOIN_THROTTLE_MS gate
+
+    await reconcileJoinedChannels();
+
+    expect(client.join).toHaveBeenCalledWith('alice');
+  });
+
   it('logs and does not throw when the joined-channel hook itself throws', async () => {
     const client = makeMockClient();
     setChatClient(client as any);
@@ -346,6 +376,31 @@ describe('stale join/part compensation', () => {
     // Actual membership no longer matches desired state (not active) — compensateIfStale must
     // notice and part the channel again rather than leaving a stale, unwanted join in place.
     expect(client.part).toHaveBeenCalledWith('alice');
+  });
+
+  it('does not mark a stale join confirmed — and so does not attempt to revert it — if the connection cycled before it settled', async () => {
+    const client = makeMockClient();
+    setChatClient(client as any);
+    setConnected(true);
+    let resolveJoin!: () => void;
+    client.join.mockImplementation(() => new Promise<void>((resolve) => { resolveJoin = resolve; }));
+
+    const joinPromise = joinTwitchChannel('alice');
+    const assertion = expect(joinPromise).rejects.toThrow('Twitch join timed out after 10000ms');
+    await vi.advanceTimersByTimeAsync(10_000); // JOIN_PART_TIMEOUT_MS — the caller gives up and rolls back
+    await assertion;
+    expect(getActiveChannels().has('alice')).toBe(false);
+
+    // Unlike the "lands late" test above, the connection also cycles before the dangling join
+    // settles — its eventual success belongs to a now-superseded connection generation.
+    setConnected(false);
+    setConnected(true);
+    resolveJoin();
+    await flushMicrotasks();
+
+    // compensateIfStale's markJoined is generation-guarded, so this must not be recorded as
+    // confirmed joined — and therefore must not trigger a (wrong) revert-part on the new connection.
+    expect(client.part).not.toHaveBeenCalled();
   });
 
   // No equivalent "stale part lands late" scenario exists for Twurple: partAsync() wraps

--- a/src/twitch/twitchChannelMembership.test.ts
+++ b/src/twitch/twitchChannelMembership.test.ts
@@ -22,8 +22,6 @@ import {
   getActiveChannels,
   getActiveChannelUserIds,
   clearMembershipState,
-  startChannelReconciliationPoll,
-  stopChannelReconciliationPoll,
   __setConfirmedJoinedChannelsForTests,
 } from './twitchChannelMembership';
 import { getTwitchEnabledChannels } from '../db';
@@ -471,70 +469,6 @@ describe('reconcileJoinedChannels', () => {
     expect(client.join).toHaveBeenCalledWith('carol');
     expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('carol', true);
     expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('alice', false);
-  });
-});
-
-// ─── startChannelReconciliationPoll / stopChannelReconciliationPoll ────────
-
-describe('startChannelReconciliationPoll', () => {
-  it('re-runs reconciliation on an interval, retrying a channel a prior pass failed to join', async () => {
-    const client = makeMockClient([]);
-    setChatClient(client as any);
-    setConnected(false);
-    await joinTwitchChannel('alice'); // queues into activeChannels without calling client.join
-    setConnected(true);
-
-    // Simulate the connect-time reconciliation pass (onConnected's own call) failing to join —
-    // unlike joinTwitchChannel's own failure path, this leaves 'alice' in activeChannels (still
-    // desired) but not actually joined, exactly the case the periodic poll exists to retry.
-    client.join.mockRejectedValueOnce(new Error('join failed'));
-    await reconcileJoinedChannels();
-    expect(client.join).toHaveBeenCalledWith('alice');
-    expect(getActiveChannels().has('alice')).toBe(true);
-    vi.mocked(setTwitchChannel).mockClear();
-    client.join.mockClear();
-
-    startChannelReconciliationPoll();
-    await vi.advanceTimersByTimeAsync(60_000);
-
-    expect(client.join).toHaveBeenCalledWith('alice');
-    expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledWith('alice', true);
-  });
-
-  it('does not register a second interval when called again while already running', async () => {
-    const client = makeMockClient(['alice']);
-    setChatClient(client as any);
-    setConnected(true);
-    await joinTwitchChannel('alice');
-    vi.mocked(setTwitchChannel).mockClear();
-
-    startChannelReconciliationPoll();
-    startChannelReconciliationPoll();
-    await vi.advanceTimersByTimeAsync(60_000);
-
-    // A duplicate interval would have run reconcileJoinedChannels twice in this window,
-    // marking the already-joined channel online twice instead of once.
-    expect(vi.mocked(setTwitchChannel)).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe('stopChannelReconciliationPoll', () => {
-  it('stops further reconciliation passes', async () => {
-    const client = makeMockClient(['alice']);
-    setChatClient(client as any);
-    setConnected(true);
-    await joinTwitchChannel('alice');
-    vi.mocked(setTwitchChannel).mockClear();
-
-    startChannelReconciliationPoll();
-    stopChannelReconciliationPoll();
-    await vi.advanceTimersByTimeAsync(120_000);
-
-    expect(vi.mocked(setTwitchChannel)).not.toHaveBeenCalled();
-  });
-
-  it('is a no-op when the poll was never started', () => {
-    expect(() => stopChannelReconciliationPoll()).not.toThrow();
   });
 });
 

--- a/src/twitch/twitchChannelMembership.test.ts
+++ b/src/twitch/twitchChannelMembership.test.ts
@@ -24,13 +24,20 @@ import {
   clearMembershipState,
   startChannelReconciliationPoll,
   stopChannelReconciliationPoll,
+  __setConfirmedJoinedChannelsForTests,
 } from './twitchChannelMembership';
 import { getTwitchEnabledChannels } from '../db';
 import { getUsers } from './twitchApi';
 import { setTwitchChannel } from '../shared/statusStore';
 
-/** Builds a minimal fake Twurple chat client, pre-seeded with the given already-joined channels. */
+/**
+ * Builds a minimal fake Twurple chat client, pre-seeded with the given already-joined channels.
+ * Also seeds {@link __setConfirmedJoinedChannelsForTests} with the same list — that's what
+ * `isChannelJoined` actually reads (see its doc for why `client.currentChannels` isn't trusted).
+ * `currentChannels` is kept on the mock only for shape-compatibility with the real `ChatClient`.
+ */
 function makeMockClient(channels: string[] = []) {
+  __setConfirmedJoinedChannelsForTests(channels);
   return {
     currentChannels: channels,
     join: vi.fn().mockResolvedValue(undefined),
@@ -202,10 +209,9 @@ describe('membershipMutationQueue serialization', () => {
     setConnected(true);
     const order: string[] = [];
     const { promise: gate, resolve: openGate } = deferred();
-    client.join.mockImplementation(async (channel: string) => {
+    client.join.mockImplementation(async () => {
       order.push('join-start');
       await gate;
-      client.currentChannels = [channel]; // simulate the join taking effect
       order.push('join-end');
     });
     client.part.mockImplementation(async () => { order.push('part'); });
@@ -334,8 +340,8 @@ describe('stale join/part compensation', () => {
     await assertion;
     expect(getActiveChannels().has('alice')).toBe(false);
 
-    // The real join now actually lands, out of band, well after the caller stopped waiting.
-    client.currentChannels = ['alice'];
+    // The real join now actually lands, out of band, well after the caller stopped waiting —
+    // compensateIfStale's own markJoined callback (not client.currentChannels) is what records it.
     resolveJoin();
     await flushMicrotasks();
 

--- a/src/twitch/twitchChannelMembership.ts
+++ b/src/twitch/twitchChannelMembership.ts
@@ -42,21 +42,54 @@ let _onChannelJoined: ((channel: string) => void) | null = null;
 const confirmedJoinedChannels = new Set<string>();
 
 /**
+ * Increments every time {@link setConnected} transitions to disconnected — i.e. once per
+ * connection episode. Exists so a join/part call issued on one episode can't have its eventual
+ * outcome (however late) applied to {@link confirmedJoinedChannels} after a *later* episode has
+ * already started: `_connected` alone can't distinguish "still on the episode this call was
+ * issued during" from "reconnected since, coincidentally connected again" — only a monotonically
+ * increasing counter can. See {@link markJoinedIfCurrent}/{@link markPartedIfCurrent}.
+ */
+let connectionGeneration = 0;
+
+/**
+ * Records `channel` as confirmed joined, but only if `generation` still matches the current
+ * {@link connectionGeneration} — i.e. no disconnect has happened since the caller captured it.
+ * Without this, a join issued before a disconnect that only *settles* (successfully) after a
+ * subsequent reconnect would re-poison {@link confirmedJoinedChannels} with a join that actually
+ * happened (if at all) on the old, now-dead connection — reintroducing the exact "reconcile
+ * believes it's already joined and skips rejoining" bug {@link confirmedJoinedChannels} exists to
+ * prevent, just via this race instead of via Twurple's stale `currentChannels`.
+ * @param channel - The channel a join call resolved for.
+ * @param generation - The {@link connectionGeneration} captured when that join call was issued.
+ */
+function markJoinedIfCurrent(channel: string, generation: number): void {
+  if (generation === connectionGeneration) confirmedJoinedChannels.add(channel);
+}
+
+/** See {@link markJoinedIfCurrent} — the corresponding part-side update. */
+function markPartedIfCurrent(channel: string, generation: number): void {
+  if (generation === connectionGeneration) confirmedJoinedChannels.delete(channel);
+}
+
+/**
  * Bundles this module's live client/membership state for {@link compensateIfStale} — see
  * `twitchChannelNetworkOps.ts`'s {@link MembershipDeps}. Built fresh at each join/part call site
- * so `runExclusive` closes over the current `channel`, but its accessor functions still read
+ * so `runExclusive` closes over the current `channel`, and so `markJoined`/`markParted` close over
+ * the {@link connectionGeneration} at the moment the call was issued (see
+ * {@link markJoinedIfCurrent}) — but its other accessor functions still read
  * `_client`/`_connected`/`activeChannels` live, not a snapshot, since reconciliation can run long
  * after this bundle was built.
  */
 function membershipDeps(): MembershipDeps {
+  const generation = connectionGeneration;
   return {
     getClient: () => _client,
     isConnected: () => _connected,
     isChannelJoined,
     isDesiredJoined: (channel) => activeChannels.has(channel),
     runExclusive: (channel, op) => membershipMutationQueue.run(channel, op),
-    markJoined: (channel) => confirmedJoinedChannels.add(channel),
-    markParted: (channel) => confirmedJoinedChannels.delete(channel),
+    markJoined: (channel) => markJoinedIfCurrent(channel, generation),
+    markParted: (channel) => markPartedIfCurrent(channel, generation),
   };
 }
 
@@ -71,12 +104,17 @@ export function setChatClient(c: ChatClient | null): void {
 
 /**
  * Updates the connected flag (called from twitchBot on connect/disconnect events). Going
- * disconnected also clears {@link confirmedJoinedChannels} — see its doc for why nothing can be
- * trusted as still-joined across a reconnect.
+ * disconnected also clears {@link confirmedJoinedChannels} and advances
+ * {@link connectionGeneration} — see their docs for why nothing can be trusted as still-joined
+ * across a reconnect, including a join/part call issued before this disconnect that only settles
+ * afterward.
  */
 export function setConnected(v: boolean): void {
   _connected = v;
-  if (!v) confirmedJoinedChannels.clear();
+  if (!v) {
+    confirmedJoinedChannels.clear();
+    connectionGeneration++;
+  }
 }
 
 /** Registers a callback fired each time the bot successfully joins a channel. */
@@ -84,6 +122,11 @@ export function setChannelJoinedHook(fn: (channel: string) => void): void {
   _onChannelJoined = fn;
 }
 
+/**
+ * Whether `channel` is currently joined: connected, and present in {@link confirmedJoinedChannels}.
+ * @param channel - The already-normalized channel name to check.
+ * @returns True if the client is connected and this module has itself confirmed `channel` joined.
+ */
 function isChannelJoined(channel: string): boolean {
   if (!_client || !_connected) return false;
   return confirmedJoinedChannels.has(channel);
@@ -119,14 +162,24 @@ async function partStaleChannel(channel: string): Promise<void> {
     setTwitchChannel(channel, false);
     return;
   }
+  const generation = connectionGeneration;
   const partCall = partAsync(_client, channel);
   compensateIfStale(membershipDeps(), channel, partCall, 'part');
   await withTimeout(partCall, JOIN_PART_TIMEOUT_MS, 'Twitch part');
-  confirmedJoinedChannels.delete(channel);
+  markPartedIfCurrent(channel, generation);
   setTwitchChannel(channel, false);
   log.info(`Parted stale channel after reconnect: ${channel}`);
 }
 
+/**
+ * Joins `channel` if it's still desired (in `activeChannels`) but not yet confirmed joined —
+ * called from {@link reconcileJoinedChannels} for a channel that needs (re)joining on the current
+ * connection. A no-op if the channel is no longer desired, the client isn't connected, or it's
+ * already confirmed joined.
+ * @param channel - The already-normalized channel name to join if needed.
+ * @returns Resolves once the join has been attempted (or skipped) and local state synced.
+ *   Rejects if the underlying join call fails or times out.
+ */
 async function joinMissingChannel(channel: string): Promise<void> {
   if (!activeChannels.has(channel)) return;
   if (!_client || !_connected) {
@@ -138,7 +191,16 @@ async function joinMissingChannel(channel: string): Promise<void> {
     cacheChannelUserId(channel);
     return;
   }
+  const generation = connectionGeneration;
   await throttledJoin(_client, channel, (call) => compensateIfStale(membershipDeps(), channel, call, 'join'));
+  if (generation !== connectionGeneration) {
+    // The connection cycled while this join was in flight — its success no longer reflects the
+    // current connection's real membership. Applying it here (status/hook/cache) would be
+    // misleading; reconcileJoinedChannels() will retry this channel on its own on the current
+    // connection. compensateIfStale's own markJoined (also generation-guarded) already skips
+    // recording it in confirmedJoinedChannels.
+    return;
+  }
   confirmedJoinedChannels.add(channel);
   setTwitchChannel(channel, true);
   cacheChannelUserId(channel);
@@ -231,11 +293,9 @@ export async function joinTwitchChannel(channel: string): Promise<void> {
 
     activeChannels.add(normalized);
     setTwitchChannel(normalized, false);
+    const generation = connectionGeneration;
     try {
       await throttledJoin(_client, normalized, (call) => compensateIfStale(membershipDeps(), normalized, call, 'join'));
-      confirmedJoinedChannels.add(normalized);
-      setTwitchChannel(normalized, true);
-      cacheChannelUserId(normalized);
     } catch (err) {
       // Roll back local state; reconnect reconciliation will retry via activeChannels.
       activeChannels.delete(normalized);
@@ -243,6 +303,15 @@ export async function joinTwitchChannel(channel: string): Promise<void> {
       log.error(`Failed to join channel ${normalized}:`, err);
       throw err;
     }
+    if (generation !== connectionGeneration) {
+      // The connection cycled while this join was in flight — see joinMissingChannel's identical
+      // guard for why applying it here would be misleading; reconcileJoinedChannels() will retry
+      // this still-desired channel on the current connection.
+      return;
+    }
+    confirmedJoinedChannels.add(normalized);
+    setTwitchChannel(normalized, true);
+    cacheChannelUserId(normalized);
     fireChannelJoinedHook(normalized);
   });
 }
@@ -276,10 +345,14 @@ export async function partTwitchChannel(channel: string): Promise<void> {
       activeChannelUserIds.delete(normalized);
       setTwitchChannel(normalized, false);
       if (isChannelJoined(normalized)) {
+        const generation = connectionGeneration;
         const partCall = partAsync(_client, normalized);
         compensateIfStale(membershipDeps(), normalized, partCall, 'part');
         await withTimeout(partCall, JOIN_PART_TIMEOUT_MS, 'Twitch part');
-        confirmedJoinedChannels.delete(normalized);
+        // Guarded, not an unconditional delete: if the connection cycled while this part was in
+        // flight and the channel has since been genuinely rejoined on the new connection, this
+        // stale part settling must not undo that real join.
+        markPartedIfCurrent(normalized, generation);
       }
     } catch (err) {
       // Keep desired membership removed so later reconciliation can retry

--- a/src/twitch/twitchChannelMembership.ts
+++ b/src/twitch/twitchChannelMembership.ts
@@ -19,6 +19,29 @@ const membershipMutationQueue = createMutationQueue();
 let _onChannelJoined: ((channel: string) => void) | null = null;
 
 /**
+ * Channels this module has itself confirmed joined (a `client.join()` call actually succeeded)
+ * for the *current* connection. This is the source of truth for "is this channel actually joined
+ * right now" — {@link isChannelJoined} reads it instead of Twurple's own `ChatClient#currentChannels`.
+ *
+ * That's deliberate, not a style choice: `currentChannels` is backed by `ircv3`'s `IrcClient`,
+ * which only clears its internal joined-channel set from `IrcClient#connect()` — called once, at
+ * this bot's startup. An automatic reconnect (the common case: a dropped socket, e.g. a `1006`)
+ * happens entirely inside Twurple's `PersistentConnection`, which reconnects the underlying
+ * transport without ever calling `IrcClient#connect()` again — so `currentChannels` is never
+ * cleared by a reconnect and keeps reporting the *previous* connection's joined channels forever,
+ * even though the new connection isn't actually joined to any of them yet server-side. Trusting it
+ * after a reconnect made {@link reconcileJoinedChannels} believe every previously-joined channel
+ * was still joined and skip rejoining all of them — silently, with no join call and no error to
+ * log — leaving the bot's actual per-channel membership up to whatever Twitch's IRC servers
+ * happened to do with the old session (observed in production as some channels going dead after a
+ * reconnect and others not, with nothing in the logs to explain why).
+ *
+ * Cleared entirely on every disconnect (see {@link setConnected}), so a reconnect always starts
+ * from "nothing confirmed joined" and {@link reconcileJoinedChannels} actually rejoins everything.
+ */
+const confirmedJoinedChannels = new Set<string>();
+
+/**
  * How often {@link startChannelReconciliationPoll} re-runs {@link reconcileJoinedChannels} in the
  * background. {@link reconcileJoinedChannels} otherwise only runs once, from `onConnected` after a
  * successful (re)connect — if a channel's join in that pass fails (e.g. a timeout, or racing the
@@ -45,6 +68,8 @@ function membershipDeps(): MembershipDeps {
     isChannelJoined,
     isDesiredJoined: (channel) => activeChannels.has(channel),
     runExclusive: (channel, op) => membershipMutationQueue.run(channel, op),
+    markJoined: (channel) => confirmedJoinedChannels.add(channel),
+    markParted: (channel) => confirmedJoinedChannels.delete(channel),
   };
 }
 
@@ -57,9 +82,14 @@ export function setChatClient(c: ChatClient | null): void {
   _client = c;
 }
 
-/** Updates the connected flag (called from twitchBot on connect/disconnect events). */
+/**
+ * Updates the connected flag (called from twitchBot on connect/disconnect events). Going
+ * disconnected also clears {@link confirmedJoinedChannels} — see its doc for why nothing can be
+ * trusted as still-joined across a reconnect.
+ */
 export function setConnected(v: boolean): void {
   _connected = v;
+  if (!v) confirmedJoinedChannels.clear();
 }
 
 /** Registers a callback fired each time the bot successfully joins a channel. */
@@ -69,7 +99,7 @@ export function setChannelJoinedHook(fn: (channel: string) => void): void {
 
 function isChannelJoined(channel: string): boolean {
   if (!_client || !_connected) return false;
-  return _client.currentChannels.some((ch) => normalizeTwitchChannelName(ch) === channel);
+  return confirmedJoinedChannels.has(channel);
 }
 
 function cacheChannelUserId(channel: string): void {
@@ -98,12 +128,14 @@ async function partStaleChannel(channel: string): Promise<void> {
     return;
   }
   if (!_client || !_connected || !isChannelJoined(channel)) {
+    confirmedJoinedChannels.delete(channel);
     setTwitchChannel(channel, false);
     return;
   }
   const partCall = partAsync(_client, channel);
   compensateIfStale(membershipDeps(), channel, partCall, 'part');
   await withTimeout(partCall, JOIN_PART_TIMEOUT_MS, 'Twitch part');
+  confirmedJoinedChannels.delete(channel);
   setTwitchChannel(channel, false);
   log.info(`Parted stale channel after reconnect: ${channel}`);
 }
@@ -120,22 +152,23 @@ async function joinMissingChannel(channel: string): Promise<void> {
     return;
   }
   await throttledJoin(_client, channel, (call) => compensateIfStale(membershipDeps(), channel, call, 'join'));
+  confirmedJoinedChannels.add(channel);
   setTwitchChannel(channel, true);
   cacheChannelUserId(channel);
   fireChannelJoinedHook(channel);
   log.info(`Joined queued channel after reconnect: ${channel}`);
 }
 
-/** Parts channels no longer in activeChannels and joins any queued but unjoined channels. */
+/**
+ * Parts channels no longer in activeChannels and (re)joins any active channel not currently in
+ * {@link confirmedJoinedChannels} — which, right after a reconnect, is *every* active channel,
+ * since {@link setConnected} clears it on every disconnect. See {@link confirmedJoinedChannels}'s
+ * doc for why this can't be driven off Twurple's own `currentChannels` instead.
+ */
 export async function reconcileJoinedChannels(): Promise<void> {
   if (!_client || !_connected) return;
 
-  const joinedChannels = _client.currentChannels
-    .map((channel) => normalizeTwitchChannelName(channel))
-    .filter((channel): channel is string => channel !== null);
-  const joinedChannelSet = new Set(joinedChannels);
-
-  for (const channel of joinedChannels) {
+  for (const channel of [...confirmedJoinedChannels]) {
     try {
       await membershipMutationQueue.run(channel, () => partStaleChannel(channel));
     } catch (err) {
@@ -144,7 +177,7 @@ export async function reconcileJoinedChannels(): Promise<void> {
   }
 
   for (const channel of activeChannels) {
-    if (joinedChannelSet.has(channel)) continue;
+    if (confirmedJoinedChannels.has(channel)) continue;
     try {
       await membershipMutationQueue.run(channel, () => joinMissingChannel(channel));
     } catch (err) {
@@ -231,6 +264,7 @@ export async function joinTwitchChannel(channel: string): Promise<void> {
     setTwitchChannel(normalized, false);
     try {
       await throttledJoin(_client, normalized, (call) => compensateIfStale(membershipDeps(), normalized, call, 'join'));
+      confirmedJoinedChannels.add(normalized);
       setTwitchChannel(normalized, true);
       cacheChannelUserId(normalized);
     } catch (err) {
@@ -276,6 +310,7 @@ export async function partTwitchChannel(channel: string): Promise<void> {
         const partCall = partAsync(_client, normalized);
         compensateIfStale(membershipDeps(), normalized, partCall, 'part');
         await withTimeout(partCall, JOIN_PART_TIMEOUT_MS, 'Twitch part');
+        confirmedJoinedChannels.delete(normalized);
       }
     } catch (err) {
       // Keep desired membership removed so later reconciliation can retry
@@ -300,6 +335,17 @@ export function getActiveChannelUserIds(): ReadonlyMap<string, string> {
 export function clearMembershipState(): void {
   activeChannels.clear();
   activeChannelUserIds.clear();
+  confirmedJoinedChannels.clear();
   resetJoinGate();
   stopChannelReconciliationPoll();
+}
+
+/**
+ * Test-only: seeds {@link confirmedJoinedChannels} directly, standing in for a real `client.join()`
+ * having already succeeded — since it's no longer driven off the mock client's `currentChannels`
+ * (see {@link confirmedJoinedChannels}'s doc for why production code doesn't trust that either).
+ */
+export function __setConfirmedJoinedChannelsForTests(channels: Iterable<string>): void {
+  confirmedJoinedChannels.clear();
+  for (const c of channels) confirmedJoinedChannels.add(c);
 }

--- a/src/twitch/twitchChannelMembership.ts
+++ b/src/twitch/twitchChannelMembership.ts
@@ -42,19 +42,6 @@ let _onChannelJoined: ((channel: string) => void) | null = null;
 const confirmedJoinedChannels = new Set<string>();
 
 /**
- * How often {@link startChannelReconciliationPoll} re-runs {@link reconcileJoinedChannels} in the
- * background. {@link reconcileJoinedChannels} otherwise only runs once, from `onConnected` after a
- * successful (re)connect — if a channel's join in that pass fails (e.g. a timeout, or racing the
- * underlying Twurple client's own join-rate-limiter being paused/cleared by a near-simultaneous
- * disconnect), nothing else ever retries it: the channel is left parted, silently, until the next
- * full reconnect. This poll exists purely to catch and self-heal that case (mirrors the
- * `twitchEventSubReconciliation.ts` periodic-poll pattern for the same class of problem).
- */
-const RECONCILE_POLL_INTERVAL_MS = 60_000;
-
-let reconcileTickTimer: ReturnType<typeof setInterval> | null = null;
-
-/**
  * Bundles this module's live client/membership state for {@link compensateIfStale} — see
  * `twitchChannelNetworkOps.ts`'s {@link MembershipDeps}. Built fresh at each join/part call site
  * so `runExclusive` closes over the current `channel`, but its accessor functions still read
@@ -185,24 +172,6 @@ export async function reconcileJoinedChannels(): Promise<void> {
       log.error(`Failed to join queued channel ${channel}:`, err);
     }
   }
-}
-
-/**
- * Starts the periodic channel-membership reconciliation interval (see
- * {@link RECONCILE_POLL_INTERVAL_MS}). Call once at bot startup, after {@link initializeActiveChannels}.
- * No-ops if already started, so a second call can't leak the original interval handle.
- */
-export function startChannelReconciliationPoll(): void {
-  if (reconcileTickTimer) return;
-  reconcileTickTimer = setInterval(() => {
-    reconcileJoinedChannels().catch((err) => log.error('Periodic channel reconciliation error:', err));
-  }, RECONCILE_POLL_INTERVAL_MS);
-  log.info(`Started periodic channel-membership reconciliation every ${RECONCILE_POLL_INTERVAL_MS / 1000}s`);
-}
-
-/** Stops the periodic channel-membership reconciliation interval. */
-export function stopChannelReconciliationPoll(): void {
-  if (reconcileTickTimer) { clearInterval(reconcileTickTimer); reconcileTickTimer = null; }
 }
 
 /** Loads enabled channels from the DB, populates activeChannels, and pre-resolves user IDs. */
@@ -337,7 +306,6 @@ export function clearMembershipState(): void {
   activeChannelUserIds.clear();
   confirmedJoinedChannels.clear();
   resetJoinGate();
-  stopChannelReconciliationPoll();
 }
 
 /**

--- a/src/twitch/twitchChannelMembership.ts
+++ b/src/twitch/twitchChannelMembership.ts
@@ -19,6 +19,19 @@ const membershipMutationQueue = createMutationQueue();
 let _onChannelJoined: ((channel: string) => void) | null = null;
 
 /**
+ * How often {@link startChannelReconciliationPoll} re-runs {@link reconcileJoinedChannels} in the
+ * background. {@link reconcileJoinedChannels} otherwise only runs once, from `onConnected` after a
+ * successful (re)connect — if a channel's join in that pass fails (e.g. a timeout, or racing the
+ * underlying Twurple client's own join-rate-limiter being paused/cleared by a near-simultaneous
+ * disconnect), nothing else ever retries it: the channel is left parted, silently, until the next
+ * full reconnect. This poll exists purely to catch and self-heal that case (mirrors the
+ * `twitchEventSubReconciliation.ts` periodic-poll pattern for the same class of problem).
+ */
+const RECONCILE_POLL_INTERVAL_MS = 60_000;
+
+let reconcileTickTimer: ReturnType<typeof setInterval> | null = null;
+
+/**
  * Bundles this module's live client/membership state for {@link compensateIfStale} — see
  * `twitchChannelNetworkOps.ts`'s {@link MembershipDeps}. Built fresh at each join/part call site
  * so `runExclusive` closes over the current `channel`, but its accessor functions still read
@@ -139,6 +152,24 @@ export async function reconcileJoinedChannels(): Promise<void> {
       log.error(`Failed to join queued channel ${channel}:`, err);
     }
   }
+}
+
+/**
+ * Starts the periodic channel-membership reconciliation interval (see
+ * {@link RECONCILE_POLL_INTERVAL_MS}). Call once at bot startup, after {@link initializeActiveChannels}.
+ * No-ops if already started, so a second call can't leak the original interval handle.
+ */
+export function startChannelReconciliationPoll(): void {
+  if (reconcileTickTimer) return;
+  reconcileTickTimer = setInterval(() => {
+    reconcileJoinedChannels().catch((err) => log.error('Periodic channel reconciliation error:', err));
+  }, RECONCILE_POLL_INTERVAL_MS);
+  log.info(`Started periodic channel-membership reconciliation every ${RECONCILE_POLL_INTERVAL_MS / 1000}s`);
+}
+
+/** Stops the periodic channel-membership reconciliation interval. */
+export function stopChannelReconciliationPoll(): void {
+  if (reconcileTickTimer) { clearInterval(reconcileTickTimer); reconcileTickTimer = null; }
 }
 
 /** Loads enabled channels from the DB, populates activeChannels, and pre-resolves user IDs. */
@@ -270,4 +301,5 @@ export function clearMembershipState(): void {
   activeChannels.clear();
   activeChannelUserIds.clear();
   resetJoinGate();
+  stopChannelReconciliationPoll();
 }

--- a/src/twitch/twitchChannelNetworkOps.test.ts
+++ b/src/twitch/twitchChannelNetworkOps.test.ts
@@ -22,6 +22,8 @@ function makeDeps(overrides: Partial<MembershipDeps> = {}): MembershipDeps & { s
     isChannelJoined: (channel) => (client as any)?.getChannels().includes(channel) ?? false,
     isDesiredJoined: (channel) => desired.has(channel),
     runExclusive: (_channel, op) => op(),
+    markJoined: vi.fn(),
+    markParted: vi.fn(),
     ...overrides,
   };
   return {

--- a/src/twitch/twitchChannelNetworkOps.ts
+++ b/src/twitch/twitchChannelNetworkOps.ts
@@ -56,6 +56,17 @@ export interface MembershipDeps {
   isDesiredJoined: (channel: string) => boolean;
   /** Runs `op` serialized per-channel, so it can't interleave with a concurrent operation on `channel`. */
   runExclusive: (channel: string, op: () => Promise<unknown>) => Promise<unknown>;
+  /**
+   * Records that `channel`'s membership actually changed (a `join()`/`part()` call genuinely
+   * settled), independent of whether the caller that issued it already gave up via a timeout.
+   * Needed because {@link isChannelJoined} is backed by the caller's own bookkeeping rather than
+   * a live query — without this, a call that lands late (after its caller's `withTimeout` already
+   * moved on without recording the outcome) would leave that bookkeeping never learning the real
+   * result.
+   */
+  markJoined: (channel: string) => void;
+  /** See {@link markJoined} — the corresponding part-side update. */
+  markParted: (channel: string) => void;
 }
 
 /**
@@ -83,8 +94,12 @@ export interface MembershipDeps {
 export function compensateIfStale(deps: MembershipDeps, channel: string, call: Promise<unknown>, kind: 'join' | 'part'): void {
   const startedAt = Date.now();
   call.then(() => {
+    // The call actually succeeded — sync bookkeeping to that real outcome regardless of whether
+    // the caller's own withTimeout already gave up on it (see markJoined/markParted's doc).
+    if (kind === 'join') deps.markJoined(channel); else deps.markParted(channel);
+
     // Settled within the normal window — the caller's own withTimeout race never gave up on
-    // this call, so there's nothing to reconcile.
+    // this call, so there's nothing further to reconcile.
     if (Date.now() - startedAt < JOIN_PART_TIMEOUT_MS) return;
     void deps.runExclusive(channel, async () => {
       const client = deps.getClient();

--- a/src/twitch/twitchChannelNetworkOps.ts
+++ b/src/twitch/twitchChannelNetworkOps.ts
@@ -50,7 +50,11 @@ export interface MembershipDeps {
   getClient: () => ChatClient | null;
   /** Whether the client is currently connected. */
   isConnected: () => boolean;
-  /** Whether `channel` is currently joined per the live Twurple client's own channel list. */
+  /**
+   * Whether `channel` is currently joined, per the caller's own application-owned bookkeeping
+   * (not Twurple's `ChatClient#currentChannels` — see `twitchChannelMembership.ts`'s
+   * `confirmedJoinedChannels` doc for why that can't be trusted across a reconnect).
+   */
   isChannelJoined: (channel: string) => boolean;
   /** Whether `channel` is currently desired to be joined (the source of truth for intent). */
   isDesiredJoined: (channel: string) => boolean;

--- a/src/twitch/twitchChannelReconciliationPoll.test.ts
+++ b/src/twitch/twitchChannelReconciliationPoll.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockLog = vi.hoisted(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }));
+vi.mock('../shared/logger', () => ({ createLogger: () => mockLog }));
+vi.mock('./twitchChannelMembership', () => ({ reconcileJoinedChannels: vi.fn() }));
+
+import { startChannelReconciliationPoll, stopChannelReconciliationPoll } from './twitchChannelReconciliationPoll';
+import { reconcileJoinedChannels } from './twitchChannelMembership';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  vi.mocked(reconcileJoinedChannels).mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  stopChannelReconciliationPoll();
+  vi.useRealTimers();
+});
+
+describe('startChannelReconciliationPoll / stopChannelReconciliationPoll', () => {
+  it('fires reconcileJoinedChannels on the configured interval and stops on request', async () => {
+    startChannelReconciliationPoll();
+
+    expect(reconcileJoinedChannels).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(reconcileJoinedChannels).toHaveBeenCalledTimes(1);
+
+    stopChannelReconciliationPoll();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(reconcileJoinedChannels).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not leak the interval when started twice without stopping', async () => {
+    startChannelReconciliationPoll();
+    startChannelReconciliationPoll();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // A duplicate interval would have fired reconcileJoinedChannels twice in this window.
+    expect(reconcileJoinedChannels).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs and does not throw when reconcileJoinedChannels rejects', async () => {
+    vi.mocked(reconcileJoinedChannels).mockRejectedValueOnce(new Error('reconcile boom'));
+    startChannelReconciliationPoll();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(mockLog.error).toHaveBeenCalledWith('Periodic channel reconciliation error:', expect.any(Error));
+  });
+
+  it('is a no-op when the poll was never started', () => {
+    expect(() => stopChannelReconciliationPoll()).not.toThrow();
+  });
+});

--- a/src/twitch/twitchChannelReconciliationPoll.ts
+++ b/src/twitch/twitchChannelReconciliationPoll.ts
@@ -1,0 +1,35 @@
+import { createLogger } from '../shared/logger';
+import { reconcileJoinedChannels } from './twitchChannelMembership';
+
+const log = createLogger('Twitch');
+
+/**
+ * How often {@link startChannelReconciliationPoll} re-runs `reconcileJoinedChannels()` in the
+ * background. It otherwise only runs once, from `onConnected` after a successful (re)connect — if
+ * a channel's join in that pass fails (e.g. a timeout, or racing the underlying Twurple client's
+ * own join-rate-limiter being paused/cleared by a near-simultaneous disconnect), nothing else ever
+ * retries it: the channel is left parted, silently, until the next full reconnect. This poll exists
+ * purely to catch and self-heal that case (mirrors `twitchEventSubReconciliation.ts`'s periodic-poll
+ * pattern for the same class of problem).
+ */
+const RECONCILE_POLL_INTERVAL_MS = 60_000;
+
+let reconcileTickTimer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Starts the periodic channel-membership reconciliation interval (see
+ * {@link RECONCILE_POLL_INTERVAL_MS}). Call once at bot startup, after Twitch chat has connected.
+ * No-ops if already started, so a second call can't leak the original interval handle.
+ */
+export function startChannelReconciliationPoll(): void {
+  if (reconcileTickTimer) return;
+  reconcileTickTimer = setInterval(() => {
+    reconcileJoinedChannels().catch((err) => log.error('Periodic channel reconciliation error:', err));
+  }, RECONCILE_POLL_INTERVAL_MS);
+  log.info(`Started periodic channel-membership reconciliation every ${RECONCILE_POLL_INTERVAL_MS / 1000}s`);
+}
+
+/** Stops the periodic channel-membership reconciliation interval. */
+export function stopChannelReconciliationPoll(): void {
+  if (reconcileTickTimer) { clearInterval(reconcileTickTimer); reconcileTickTimer = null; }
+}


### PR DESCRIPTION
## Summary

Investigated a report of Twitch commands stopping working right after a `Disconnected: [1006]` → `Connected to Twitch chat.` reconnect, with no further relevant log activity afterward. The fuller log confirmed: exactly **one** `1006` disconnect, all six channels listed in "Listening on:", and no join/error log lines at all after the reconnect — yet only some of those channels kept working afterward.

**Root cause**, found by tracing `@twurple/chat` and `ircv3`'s source: `ChatClient#currentChannels` (backed by `ircv3`'s `IrcClient`) is only cleared by `IrcClient#connect()` — called once, at this bot's own startup. An automatic reconnect (a dropped socket, e.g. the `1006` here) happens entirely inside Twurple's `PersistentConnection`, which reconnects the underlying transport **without ever calling `IrcClient#connect()` again** — so `currentChannels` keeps reporting the *previous* connection's joined channels forever, even though the new connection isn't actually joined to any of them yet server-side.

`reconcileJoinedChannels()` (the logic that's supposed to rejoin the bot's active channels after a reconnect) trusted that stale `currentChannels` as ground truth. So after any reconnect it believed every previously-joined channel was still joined and **skipped rejoining all of them — silently, with no join call and no error to log.** From there, whether a given channel kept receiving chat is entirely up to what Twitch's IRC servers did with the old session — explaining why some channels broke and others didn't, with nothing in the logs to explain why.

(An earlier commit on this branch added a periodic reconciliation poll as a general safety net for a *different*, narrower gap — a single failed join never being retried. That's still a real, worthwhile improvement, but it doesn't fix this: the poll calls the same `reconcileJoinedChannels()`, which would have kept trusting the same stale `currentChannels` forever.)

## Fix

- `src/twitch/twitchChannelMembership.ts`: replace the `currentChannels`-based "is this channel joined" check with a locally-owned `confirmedJoinedChannels` set — populated only by an actual successful `client.join()`, and cleared on every disconnect (via `setConnected`). `reconcileJoinedChannels()` now reads that instead of `client.currentChannels`, so a reconnect always starts from "nothing confirmed joined" and actually rejoins every active channel.
- `src/twitch/twitchChannelNetworkOps.ts`: `MembershipDeps` gains `markJoined`/`markParted` so `compensateIfStale` keeps `confirmedJoinedChannels` in sync even for a join/part that lands *late* (after its caller already gave up via `JOIN_PART_TIMEOUT_MS`) — matching what the old `currentChannels`-based check gave for free.
- `src/twitch/twitchBot.ts`: corrected a docstring that had asserted (incorrectly) that Twurple resets its joined-channel list on every reconnect — that wrong assumption is what the old code was built on.
- Added a regression test reproducing the exact bug: an active channel the mock client still reports in `currentChannels` (simulating the stale post-reconnect state) is rejoined anyway. Updated the rest of the affected tests in `twitchChannelMembership.test.ts`, `twitchChannelNetworkOps.test.ts`, and `twitchBot.test.ts` to seed the new `confirmedJoinedChannels` tracking (via a new test-only `__setConfirmedJoinedChannelsForTests`) instead of `client.currentChannels`, which production code no longer trusts.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (3238 tests passing)
- [x] `npm run lint` (0 errors, pre-existing unrelated warnings only)
- [x] `npm run check:circular` (no circular dependencies)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic Twitch channel-membership reconciliation every 60 seconds.
  - Channels can be rejoined when connection state becomes stale or inconsistent.
- **Bug Fixes**
  - Improved membership tracking across automatic reconnects.
  - Ensured delayed join and leave operations cannot overwrite current connection state.
- **Reliability**
  - Reconciliation starts with the Twitch connection and stops during shutdown.
  - Prevented duplicate reconciliation processes and handled errors without interrupting the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->