### PR TITLE
Fix redemption dedup poisoning retries after a mid-processing failure

### DIFF
--- a/src/twitch/eventsub/twitchEventSubHandler.test.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.test.ts
@@ -14,7 +14,7 @@ import {
   handleFollow, handleSub, handleResub, handleGiftSub, handleRaid, handleRedemption,
   handleStreamOnline, handleStreamOffline, handleChannelUpdate,
 } from './twitchEventSubHandler';
-import { seenRedemptionIds } from './twitchEventSubRedemptionDedup';
+import { seenRedemptionIds, pendingRedemptionIds } from './twitchEventSubRedemptionDedup';
 import {
   registerEventSubOverlayRuntime, registerEventSubTwitchRuntime, registerEventSubCompanionRuntime,
   registerEventSubAlertRuntime, registerEventSubDashboardRuntime,
@@ -730,6 +730,7 @@ describe('handleRedemption', () => {
   beforeEach(() => {
     vi.mocked(getStreamerById).mockResolvedValue({ discord_id: '999888777' } as any);
     seenRedemptionIds.clear();
+    pendingRedemptionIds.clear();
   });
 
   it('does not call pushOverlayEvent when getVideosForReward returns an empty array', async () => {
@@ -851,6 +852,30 @@ describe('handleRedemption', () => {
     expect(applyRedemptionPricing).toHaveBeenCalledOnce();
     expect(getVideosForReward).toHaveBeenCalledOnce();
     expect(mockPushOverlayEvent).toHaveBeenCalledOnce();
+  });
+
+  it('retries and completes on a second attempt with the same redemption id after the first attempt throws', async () => {
+    const videos = [{ file: 'clip1.mp4', weight: 1 }] as any[];
+    vi.mocked(getVideosForReward).mockRejectedValueOnce(new Error('transient db error'));
+
+    await expect(handleRedemption('streamer', event, makeConfig(), streamerId)).rejects.toThrow('transient db error');
+
+    // The failed attempt must not be misclassified as "already handled" — none of its effects
+    // should have been left counted from a partial run, and a retry must be free to run again.
+    vi.mocked(getVideosForReward).mockResolvedValue(videos);
+    vi.mocked(pickWeightedRandom).mockReturnValue('clip1.mp4');
+
+    await expect(handleRedemption('streamer', event, makeConfig(), streamerId)).resolves.toBeUndefined();
+
+    // The dashboard/companion/pricing effects run ahead of the getVideosForReward call that
+    // failed the first time, so they fire once per attempt (twice total); the overlay trigger
+    // only ever completes on the successful second attempt.
+    expect(recordStreamerEvent).toHaveBeenCalledTimes(2);
+    expect(mockPushDashboardEvent).toHaveBeenCalledTimes(2);
+    expect(mockPushCompanionEvent).toHaveBeenCalledTimes(2);
+    expect(applyRedemptionPricing).toHaveBeenCalledTimes(2);
+    expect(mockPushOverlayEvent).toHaveBeenCalledOnce();
+    expect(mockPushOverlayEvent).toHaveBeenCalledWith('streamer', '/overlay/videos/7/clip1.mp4');
   });
 
   it('processes two notifications with different redemption ids normally', async () => {

--- a/src/twitch/eventsub/twitchEventSubHandler.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.ts
@@ -6,7 +6,7 @@ import { createLogger } from '../../shared/logger';
 import { triggerImmediateLiveCheck } from '../monitor/twitchMonitor';
 import { fillTemplate } from '../../shared/textTemplate';
 import { applyRedemptionPricing } from '../pricing/rewardPricingService';
-import { isDuplicateRedemption } from './twitchEventSubRedemptionDedup';
+import { isDuplicateRedemption, markRedemptionHandled, clearPendingRedemption } from './twitchEventSubRedemptionDedup';
 import {
   overlayRuntimeRegistry,
   companionRuntimeRegistry,
@@ -343,9 +343,12 @@ export async function handleRaid(login: string, event: RaidEvent, config: EventS
  * overlay-video logic below.
  *
  * Deduplicates on Twitch's own redemption id ({@link isDuplicateRedemption}) before doing
- * anything else — a duplicate is dropped silently, since every effect below (companion push,
- * dashboard record, pricing, overlay trigger) would otherwise double-fire for one physical
- * redemption.
+ * anything else — a duplicate (or an id already being processed by another in-flight call) is
+ * dropped silently, since every effect below (companion push, dashboard record, pricing, overlay
+ * trigger) would otherwise double-fire for one physical redemption. The id is only marked as
+ * successfully handled ({@link markRedemptionHandled}) once every effect below has run without
+ * throwing; a failure clears the in-flight claim ({@link clearPendingRedemption}) instead, so a
+ * retry of the same redemption id is not misclassified as a duplicate.
  *
  * @param login - Broadcaster login name.
  * @param event - Redemption event payload including reward ID and user details.
@@ -363,39 +366,49 @@ export async function handleRedemption(
     return;
   }
 
+  // Only mark the redemption as handled (via markRedemptionHandled) once every effect below has
+  // run without throwing. If anything throws, clearPendingRedemption releases the in-flight claim
+  // and the error is rethrown, so a retry (e.g. reconciliation's next poll tick) re-runs this
+  // redemption from scratch instead of being silently dropped as a duplicate.
   try {
-    const streamer = await getStreamerById(streamerId);
-    if (streamer) {
-      companionRuntimeRegistry.get()?.pushCompanionEvent(streamer.discord_id, {
-        type: 'channel_points_redemption',
-        rewardId: event.reward.id,
-        rewardTitle: event.reward.title,
-        userLogin: event.user_login,
-        userName: event.user_name,
-        userInput: event.user_input,
-        redeemedAt: new Date().toISOString(),
-      });
+    try {
+      const streamer = await getStreamerById(streamerId);
+      if (streamer) {
+        companionRuntimeRegistry.get()?.pushCompanionEvent(streamer.discord_id, {
+          type: 'channel_points_redemption',
+          rewardId: event.reward.id,
+          rewardTitle: event.reward.title,
+          userLogin: event.user_login,
+          userName: event.user_name,
+          userInput: event.user_input,
+          redeemedAt: new Date().toISOString(),
+        });
+      }
+    } catch (err) {
+      log.error('Failed to push companion event for redemption:', err);
     }
+
+    const detail = event.user_input ? `${event.reward.title}: ${event.user_input}` : event.reward.title;
+    await recordAndPushDashboardEvent(streamerId, 'redemption', event.user_name, detail);
+
+    // Not awaited: applyRedemptionPricing drives a queued Twitch Helix call, and there's no
+    // correctness reason to make the overlay-trigger path below wait on that network latency.
+    applyRedemptionPricing(streamerId, event.reward.id).catch((err) => {
+      log.error('Failed to apply dynamic pricing for redemption:', err);
+    });
+
+    const videos = await getVideosForReward(event.reward.id, streamerId);
+    if (videos.length > 0) {
+      const filename = pickWeightedRandom(videos);
+      const videoPath = `/overlay/videos/${streamerId}/${filename}`;
+      overlayRuntimeRegistry.get()?.pushOverlayEvent(login, videoPath);
+      log.info(`Overlay triggered for ${login}: reward="${event.reward.title}" video=${filename}`);
+    }
+    markRedemptionHandled(event.id);
   } catch (err) {
-    log.error('Failed to push companion event for redemption:', err);
+    clearPendingRedemption(event.id);
+    throw err;
   }
-
-  const detail = event.user_input ? `${event.reward.title}: ${event.user_input}` : event.reward.title;
-  await recordAndPushDashboardEvent(streamerId, 'redemption', event.user_name, detail);
-
-  // Not awaited: applyRedemptionPricing drives a queued Twitch Helix call, and there's no
-  // correctness reason to make the overlay-trigger path below wait on that network latency.
-  applyRedemptionPricing(streamerId, event.reward.id).catch((err) => {
-    log.error('Failed to apply dynamic pricing for redemption:', err);
-  });
-
-  const videos = await getVideosForReward(event.reward.id, streamerId);
-  if (videos.length === 0) return;
-
-  const filename = pickWeightedRandom(videos);
-  const videoPath = `/overlay/videos/${streamerId}/${filename}`;
-  overlayRuntimeRegistry.get()?.pushOverlayEvent(login, videoPath);
-  log.info(`Overlay triggered for ${login}: reward="${event.reward.title}" video=${filename}`);
 }
 
 /**

--- a/src/twitch/eventsub/twitchEventSubRedemptionDedup.test.ts
+++ b/src/twitch/eventsub/twitchEventSubRedemptionDedup.test.ts
@@ -1,8 +1,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { isDuplicateRedemption, purgeExpiredRedemptionIds, seenRedemptionIds, REDEMPTION_DEDUP_TTL_MS } from './twitchEventSubRedemptionDedup';
+import {
+  isDuplicateRedemption,
+  purgeExpiredRedemptionIds,
+  markRedemptionHandled,
+  clearPendingRedemption,
+  seenRedemptionIds,
+  pendingRedemptionIds,
+  REDEMPTION_DEDUP_TTL_MS,
+} from './twitchEventSubRedemptionDedup';
 
 beforeEach(() => {
   seenRedemptionIds.clear();
+  pendingRedemptionIds.clear();
 });
 
 // ---------------------------------------------------------------------------
@@ -21,13 +30,14 @@ describe('isDuplicateRedemption', () => {
     expect(isDuplicateRedemption('redemption-unique-1')).toBe(false);
   });
 
-  it('returns true on second call with the same redemption ID', () => {
+  it('returns true on second call with the same redemption ID while still pending', () => {
     isDuplicateRedemption('redemption-dup-1');
     expect(isDuplicateRedemption('redemption-dup-1')).toBe(true);
   });
 
-  it('returns false again after TTL has expired', () => {
+  it('returns false again after TTL has expired for a completed redemption', () => {
     isDuplicateRedemption('redemption-expired-1');
+    markRedemptionHandled('redemption-expired-1');
     vi.advanceTimersByTime(REDEMPTION_DEDUP_TTL_MS + 1);
     expect(isDuplicateRedemption('redemption-expired-1')).toBe(false);
   });
@@ -45,5 +55,38 @@ describe('purgeExpiredRedemptionIds', () => {
 
     expect(seenRedemptionIds.has('expired')).toBe(false);
     expect(seenRedemptionIds.has('live')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pending-vs-completed lifecycle (markRedemptionHandled / clearPendingRedemption)
+// ---------------------------------------------------------------------------
+describe('pending redemption lifecycle', () => {
+  it('treats an in-flight (pending) redemption id as a duplicate', () => {
+    expect(isDuplicateRedemption('redemption-pending-1')).toBe(false);
+    expect(isDuplicateRedemption('redemption-pending-1')).toBe(true);
+  });
+
+  it('lets a later attempt proceed after clearPendingRedemption releases a failed claim', () => {
+    isDuplicateRedemption('redemption-retry-1');
+    clearPendingRedemption('redemption-retry-1');
+
+    expect(isDuplicateRedemption('redemption-retry-1')).toBe(false);
+  });
+
+  it('marks a successfully handled redemption as a genuine duplicate within the TTL', () => {
+    vi.useFakeTimers();
+    try {
+      isDuplicateRedemption('redemption-success-1');
+      markRedemptionHandled('redemption-success-1');
+
+      expect(pendingRedemptionIds.has('redemption-success-1')).toBe(false);
+      expect(isDuplicateRedemption('redemption-success-1')).toBe(true);
+
+      vi.advanceTimersByTime(REDEMPTION_DEDUP_TTL_MS + 1);
+      expect(isDuplicateRedemption('redemption-success-1')).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/twitch/eventsub/twitchEventSubRedemptionDedup.ts
+++ b/src/twitch/eventsub/twitchEventSubRedemptionDedup.ts
@@ -11,6 +11,14 @@ export const REDEMPTION_DEDUP_TTL_MS = 10 * 60 * 1000;
 // TTL-map-plus-interval-purge shape so both dedup caches behave the same way operationally.
 export const seenRedemptionIds = new Map<string, number>();
 
+// Ids currently being processed by handleRedemption but not yet resolved or rejected. Kept
+// separate from seenRedemptionIds so that a redemption which fails partway through (e.g. a
+// transient DB error) is not permanently misclassified as "already handled" — only a redemption
+// that actually completes successfully (via markRedemptionHandled) earns a TTL'd entry in
+// seenRedemptionIds. This set still catches a genuine concurrent duplicate (e.g. the live
+// WebSocket delivery and a reconciliation replay racing on the same id).
+export const pendingRedemptionIds = new Set<string>();
+
 /** Removes all expired entries from the deduplication map. */
 export function purgeExpiredRedemptionIds(): void {
   const now = Date.now();
@@ -22,11 +30,28 @@ export function purgeExpiredRedemptionIds(): void {
 // Purge expired entries on a fixed interval so isDuplicateRedemption stays O(1).
 setInterval(purgeExpiredRedemptionIds, REDEMPTION_DEDUP_TTL_MS).unref();
 
-/** Returns true if redemptionId has been seen within REDEMPTION_DEDUP_TTL_MS; records it otherwise. */
+/**
+ * Returns true if redemptionId has already completed successfully within REDEMPTION_DEDUP_TTL_MS,
+ * or is currently being processed by another in-flight call. Otherwise claims the id as pending
+ * (via pendingRedemptionIds) and returns false — the caller must follow up with
+ * markRedemptionHandled on success or clearPendingRedemption on failure.
+ */
 export function isDuplicateRedemption(redemptionId: string): boolean {
   const now = Date.now();
   const expiry = seenRedemptionIds.get(redemptionId);
   if (expiry !== undefined && now <= expiry) return true;
-  seenRedemptionIds.set(redemptionId, now + REDEMPTION_DEDUP_TTL_MS);
+  if (pendingRedemptionIds.has(redemptionId)) return true;
+  pendingRedemptionIds.add(redemptionId);
   return false;
+}
+
+/** Marks a redemption as successfully processed: moves it from in-flight to the TTL'd completed set. */
+export function markRedemptionHandled(redemptionId: string): void {
+  pendingRedemptionIds.delete(redemptionId);
+  seenRedemptionIds.set(redemptionId, Date.now() + REDEMPTION_DEDUP_TTL_MS);
+}
+
+/** Clears an in-flight claim without marking it completed, so a later attempt is not treated as a duplicate. */
+export function clearPendingRedemption(redemptionId: string): void {
+  pendingRedemptionIds.delete(redemptionId);
 }


### PR DESCRIPTION
## Summary

- `handleRedemption` (`src/twitch/eventsub/twitchEventSubHandler.ts`) previously called `isDuplicateRedemption(event.id)` as its first step, which unconditionally marked the id "seen" (TTL'd) *before* any of the redemption's actual effects had run.
- If `getVideosForReward` threw partway through, the id was already poisoned, so a retry from reconciliation's next poll tick silently short-circuited as a "duplicate" instead of re-running the failed work — and reconciliation advanced its cursor as if the redemption had been handled, so it was never retried again.
- Split the dedup state in `src/twitch/eventsub/twitchEventSubRedemptionDedup.ts` into an in-flight `pendingRedemptionIds` set and the existing TTL'd `seenRedemptionIds` set. A redemption is only promoted to `seenRedemptionIds` (via `markRedemptionHandled`) once every effect in `handleRedemption` has completed without throwing; a failure clears the pending claim (`clearPendingRedemption`) so a retry is free to run again. Concurrent duplicate delivery while a redemption is still in flight is still caught via the pending set.

Fixes #559.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 3237 tests passing)
- [x] `npm run lint` (no new errors/warnings)
- [x] New regression test in `twitchEventSubHandler.test.ts`: a first attempt that throws (via `getVideosForReward` rejecting), followed by a successful retry with the same redemption id, verifying every effect (companion push, dashboard event, pricing, overlay) actually fires on the retry.
- [x] New unit tests in `twitchEventSubRedemptionDedup.test.ts` covering the pending-vs-completed lifecycle (`markRedemptionHandled`, `clearPendingRedemption`).
- [x] Existing "ignores a second notification carrying the same redemption id" test still passes unchanged, confirming genuine-duplicate protection is intact.

---
_Generated by [Claude Code](https://claude.ai/code/session_013aHFgapL9R8zz8VDs9AkKG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved redemption processing reliability when temporary errors occur.
  - Failed redemption attempts can now be retried instead of being incorrectly treated as duplicates.
  - Successfully completed redemptions remain protected from duplicate processing.
  - Redemption-related dashboard, companion, pricing, and overlay actions now execute consistently across retries.
  - Overlay triggers no longer stop processing solely because no videos are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->