### PR TITLE
Make redemption dashboard recording idempotent across retries

### DIFF
--- a/DATABASE-SCHEMA.md
+++ b/DATABASE-SCHEMA.md
@@ -190,6 +190,22 @@ Per-streamer EventSub notification message configuration. Applied once the strea
 
 Created by `migrations/twitch_eventsub.sql`. `raid_shoutout_enabled` added by `migrations/raid_shoutout.sql`.
 
+## `streamer_event_log`
+
+Live activity log for the dashboard's "Recent Events" feed: follows, subs, raids, and channel-point redemptions on a connected Twitch channel. Bounded to roughly the largest range the dashboard displays — `recordStreamerEvent()` prunes each streamer down to their most recent 200 rows on every insert, so this never grows unbounded.
+
+| Column | Type | Notes |
+| --- | --- | --- |
+| `id` | `INT` PK, auto-increment | |
+| `streamer_id` | `INT` | FK to `streamer.id` ON DELETE CASCADE |
+| `event_type` | `ENUM('follow','sub','resub','giftsub','raid','redemption')` | |
+| `display_name` | `VARCHAR(255)` | The acting Twitch viewer's display name |
+| `detail` | `VARCHAR(500)` NULL | Short additional context (e.g. raid viewer count, redeemed reward name) |
+| `redemption_id` | `VARCHAR(64)` NULL, UNIQUE | Twitch's own redemption id, set only for `redemption` rows. Lets a retried `INSERT` for the same physical redemption (see `handleRedemption`'s dedup pending/handled lifecycle) collide on the unique index instead of creating a duplicate row. `NULL` for the other five event types, which have no equivalent id — a `UNIQUE` index permits any number of `NULL`s |
+| `occurred_at` | `DATETIME` | Defaults to `CURRENT_TIMESTAMP` |
+
+Created by `migrations/streamer_event_log.sql`. `redemption_id` added by `migrations/streamer_event_log_redemption_id.sql`.
+
 ## `reward_pricing`
 
 Dynamic Channel Point Pricing: per-reward config and demand state. Independent of `overlay_reward` — a reward can have dynamic pricing without overlay videos and vice versa. Optional/opt-in per reward via `enabled`.

--- a/migrations/streamer_event_log_redemption_id.sql
+++ b/migrations/streamer_event_log_redemption_id.sql
@@ -1,0 +1,10 @@
+-- Idempotency key for redemption dashboard entries: handleRedemption's retry-from-scratch
+-- recovery (see the twitchEventSubHandler.ts redemption-dedup lifecycle) can re-run
+-- recordStreamerEvent for the same physical redemption after a later required effect (pricing)
+-- fails and the whole redemption is retried. redemption_id lets that retry's INSERT collide on
+-- the unique index instead of creating a second dashboard row for one redemption. NULL for the
+-- other five event types (follow/sub/resub/giftsub/raid), which have no equivalent natural id —
+-- a UNIQUE index permits any number of NULLs, so they're unaffected.
+ALTER TABLE streamer_event_log
+  ADD COLUMN redemption_id VARCHAR(64) NULL AFTER detail,
+  ADD UNIQUE KEY uq_streamer_event_log_redemption (redemption_id);

--- a/src/db/eventLog.test.ts
+++ b/src/db/eventLog.test.ts
@@ -26,7 +26,7 @@ describe('recordStreamerEvent', () => {
     expect(pool.execute).toHaveBeenCalledTimes(2);
     const [insertSql, insertParams] = pool.execute.mock.calls[0];
     expect(insertSql).toContain('INSERT INTO streamer_event_log');
-    expect(insertParams).toEqual([5, 'follow', 'someviewer', null]);
+    expect(insertParams).toEqual([5, 'follow', 'someviewer', null, null]);
 
     const [deleteSql, deleteParams] = pool.execute.mock.calls[1];
     expect(deleteSql).toContain('DELETE FROM streamer_event_log');
@@ -41,7 +41,45 @@ describe('recordStreamerEvent', () => {
     await recordStreamerEvent(5, 'redemption', 'someviewer', 'Redeemed Hydrate: drink water!');
 
     const [, insertParams] = pool.execute.mock.calls[0];
-    expect(insertParams).toEqual([5, 'redemption', 'someviewer', 'Redeemed Hydrate: drink water!']);
+    expect(insertParams).toEqual([5, 'redemption', 'someviewer', 'Redeemed Hydrate: drink water!', null]);
+  });
+
+  it('passes a given redemptionId through as the fifth INSERT param', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+
+    await recordStreamerEvent(5, 'redemption', 'someviewer', 'Redeemed Hydrate', 'redemption-abc');
+
+    const [, insertParams] = pool.execute.mock.calls[0];
+    expect(insertParams).toEqual([5, 'redemption', 'someviewer', 'Redeemed Hydrate', 'redemption-abc']);
+  });
+
+  it('silently no-ops on a duplicate-key INSERT when a redemptionId was given (retry of an already-recorded redemption)', async () => {
+    const pool = {
+      execute: vi.fn().mockRejectedValueOnce(Object.assign(new Error('dup'), { code: 'ER_DUP_ENTRY' })),
+    };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+
+    await expect(recordStreamerEvent(5, 'redemption', 'someviewer', null, 'redemption-abc')).resolves.toBeUndefined();
+
+    // No prune DELETE either — nothing new was inserted.
+    expect(pool.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('rethrows a duplicate-key INSERT error when no redemptionId was given', async () => {
+    const dupError = Object.assign(new Error('dup'), { code: 'ER_DUP_ENTRY' });
+    const pool = { execute: vi.fn().mockRejectedValueOnce(dupError) };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+
+    await expect(recordStreamerEvent(5, 'follow', 'someviewer', null)).rejects.toThrow('dup');
+  });
+
+  it('rethrows a non-duplicate-key INSERT error even when a redemptionId was given', async () => {
+    const otherError = Object.assign(new Error('connection lost'), { code: 'PROTOCOL_CONNECTION_LOST' });
+    const pool = { execute: vi.fn().mockRejectedValueOnce(otherError) };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+
+    await expect(recordStreamerEvent(5, 'redemption', 'someviewer', null, 'redemption-abc')).rejects.toThrow('connection lost');
   });
 
   it('does not run the prune DELETE until the INSERT has resolved', async () => {

--- a/src/db/eventLog.test.ts
+++ b/src/db/eventLog.test.ts
@@ -21,7 +21,7 @@ describe('recordStreamerEvent', () => {
     const pool = makePool();
     vi.mocked(getPool).mockReturnValue(pool as any);
 
-    await recordStreamerEvent(5, 'follow', 'someviewer', null);
+    await expect(recordStreamerEvent(5, 'follow', 'someviewer', null)).resolves.toBe(true);
 
     expect(pool.execute).toHaveBeenCalledTimes(2);
     const [insertSql, insertParams] = pool.execute.mock.calls[0];
@@ -60,7 +60,7 @@ describe('recordStreamerEvent', () => {
     };
     vi.mocked(getPool).mockReturnValue(pool as any);
 
-    await expect(recordStreamerEvent(5, 'redemption', 'someviewer', null, 'redemption-abc')).resolves.toBeUndefined();
+    await expect(recordStreamerEvent(5, 'redemption', 'someviewer', null, 'redemption-abc')).resolves.toBe(false);
 
     // No prune DELETE either — nothing new was inserted.
     expect(pool.execute).toHaveBeenCalledTimes(1);

--- a/src/db/eventLog.ts
+++ b/src/db/eventLog.ts
@@ -40,6 +40,10 @@ const EVENTS_RETAINED_PER_STREAMER = 200;
  *   text the viewer entered), or null if there's none.
  * @param redemptionId - Twitch's own redemption id, for `eventType: 'redemption'` only; omit or
  *   pass null for every other event type.
+ * @returns True if this call actually inserted a new row; false if it collided with an
+ *   already-recorded `redemptionId` and was skipped. Callers that also push a live update (e.g.
+ *   the dashboard SSE feed) should only do so when this returns true, so a retry doesn't
+ *   re-deliver a live event for a redemption that was already recorded on an earlier attempt.
  */
 export async function recordStreamerEvent(
   streamerId: number,
@@ -47,14 +51,14 @@ export async function recordStreamerEvent(
   displayName: string,
   detail: string | null,
   redemptionId?: string | null,
-): Promise<void> {
+): Promise<boolean> {
   try {
     await getPool().execute(
       `INSERT INTO streamer_event_log (streamer_id, event_type, display_name, detail, redemption_id) VALUES (?, ?, ?, ?, ?)`,
       [streamerId, eventType, displayName, detail, redemptionId ?? null],
     );
   } catch (err) {
-    if (redemptionId && isMysqlDuplicateEntryError(err)) return;
+    if (redemptionId && isMysqlDuplicateEntryError(err)) return false;
     throw err;
   }
 
@@ -69,6 +73,7 @@ export async function recordStreamerEvent(
      )`,
     [streamerId, streamerId],
   );
+  return true;
 }
 
 /**

--- a/src/db/eventLog.ts
+++ b/src/db/eventLog.ts
@@ -1,5 +1,6 @@
 import mysql from 'mysql2/promise';
 import { getPool } from './pool';
+import { isMysqlDuplicateEntryError } from './commandStringUtils';
 
 /** Kind of streamer activity recorded in `streamer_event_log`. */
 export type StreamerEventType = 'follow' | 'sub' | 'resub' | 'giftsub' | 'raid' | 'redemption';
@@ -24,22 +25,38 @@ const EVENTS_RETAINED_PER_STREAMER = 200;
  * the prune's snapshot miss the new row, leaving the table one row over the stated cap until
  * the next insert caught up.
  *
+ * When `redemptionId` is given and collides with an existing row's `redemption_id` (the
+ * `streamer_event_log` unique index), the insert is treated as already-done and silently
+ * skipped (no error, no prune) rather than creating a duplicate row — this is what makes a
+ * retried redemption (see `handleRedemption`'s dedup pending/handled lifecycle) safe to record
+ * again after an earlier attempt already succeeded here but failed on a later required effect.
+ * Any other insert failure (including a genuine duplicate on an unrelated constraint) still
+ * propagates normally.
+ *
  * @param streamerId - Primary key of the `streamer` row this event belongs to.
  * @param eventType - Kind of activity that occurred.
  * @param displayName - The acting Twitch viewer's display name (follower, raider, redeemer, etc.).
  * @param detail - Short additional context (e.g. raid viewer count, redeemed reward name and any
  *   text the viewer entered), or null if there's none.
+ * @param redemptionId - Twitch's own redemption id, for `eventType: 'redemption'` only; omit or
+ *   pass null for every other event type.
  */
 export async function recordStreamerEvent(
   streamerId: number,
   eventType: StreamerEventType,
   displayName: string,
   detail: string | null,
+  redemptionId?: string | null,
 ): Promise<void> {
-  await getPool().execute(
-    `INSERT INTO streamer_event_log (streamer_id, event_type, display_name, detail) VALUES (?, ?, ?, ?)`,
-    [streamerId, eventType, displayName, detail],
-  );
+  try {
+    await getPool().execute(
+      `INSERT INTO streamer_event_log (streamer_id, event_type, display_name, detail, redemption_id) VALUES (?, ?, ?, ?, ?)`,
+      [streamerId, eventType, displayName, detail, redemptionId ?? null],
+    );
+  } catch (err) {
+    if (redemptionId && isMysqlDuplicateEntryError(err)) return;
+    throw err;
+  }
 
   // mysql2's prepared statements (execute()) can't bind LIMIT as a placeholder, so the
   // retention count — a fixed internal constant, never user input — is inlined directly.

--- a/src/twitch/eventsub/twitchEventSubHandler.test.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.test.ts
@@ -827,7 +827,7 @@ describe('handleRedemption', () => {
 
     await handleRedemption('streamer', event, makeConfig(), streamerId);
 
-    expect(recordStreamerEvent).toHaveBeenCalledWith(streamerId, 'redemption', 'Redeemer', 'Cool Reward');
+    expect(recordStreamerEvent).toHaveBeenCalledWith(streamerId, 'redemption', 'Redeemer', 'Cool Reward', 'redemption-1');
     expect(mockPushDashboardEvent).toHaveBeenCalledWith(streamerId, expect.objectContaining({
       eventType: 'redemption', displayName: 'Redeemer', detail: 'Cool Reward',
     }));
@@ -838,7 +838,15 @@ describe('handleRedemption', () => {
 
     await handleRedemption('streamer', { ...event, user_input: 'drink water!' }, makeConfig(), streamerId);
 
-    expect(recordStreamerEvent).toHaveBeenCalledWith(streamerId, 'redemption', 'Redeemer', 'Cool Reward: drink water!');
+    expect(recordStreamerEvent).toHaveBeenCalledWith(streamerId, 'redemption', 'Redeemer', 'Cool Reward: drink water!', 'redemption-1');
+  });
+
+  it('passes the Twitch redemption id through to recordStreamerEvent as the idempotency key', async () => {
+    vi.mocked(getVideosForReward).mockResolvedValue([]);
+
+    await handleRedemption('streamer', { ...event, id: 'redemption-xyz' }, makeConfig(), streamerId);
+
+    expect(recordStreamerEvent).toHaveBeenCalledWith(streamerId, 'redemption', 'Redeemer', 'Cool Reward', 'redemption-xyz');
   });
 
   it('rejects and skips the overlay lookup when applyRedemptionPricing throws, since pricing is a required effect', async () => {

--- a/src/twitch/eventsub/twitchEventSubHandler.test.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.test.ts
@@ -73,7 +73,7 @@ function makeConfig(overrides: Partial<{
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(findCachedAlertConfig).mockResolvedValue(null);
-  vi.mocked(recordStreamerEvent).mockResolvedValue(undefined);
+  vi.mocked(recordStreamerEvent).mockResolvedValue(true);
 });
 
 // ---------------------------------------------------------------------------
@@ -849,6 +849,15 @@ describe('handleRedemption', () => {
     expect(recordStreamerEvent).toHaveBeenCalledWith(streamerId, 'redemption', 'Redeemer', 'Cool Reward', 'redemption-xyz');
   });
 
+  it('does not push a live dashboard event when recordStreamerEvent reports the redemption was already recorded (a retry after collision)', async () => {
+    vi.mocked(recordStreamerEvent).mockResolvedValueOnce(false);
+    vi.mocked(getVideosForReward).mockResolvedValue([]);
+
+    await handleRedemption('streamer', event, makeConfig(), streamerId);
+
+    expect(mockPushDashboardEvent).not.toHaveBeenCalled();
+  });
+
   it('rejects and skips the overlay lookup when applyRedemptionPricing throws, since pricing is a required effect', async () => {
     vi.mocked(applyRedemptionPricing).mockRejectedValueOnce(new Error('pricing failed'));
     const videos = [{ file: 'clip1.mp4', weight: 1 }] as any[];
@@ -883,7 +892,7 @@ describe('handleRedemption', () => {
     expect(mockPushDashboardEvent).not.toHaveBeenCalled();
 
     // A retry with the same id must not be dropped as a duplicate.
-    vi.mocked(recordStreamerEvent).mockResolvedValue(undefined);
+    vi.mocked(recordStreamerEvent).mockResolvedValue(true);
     vi.mocked(getVideosForReward).mockResolvedValue([]);
     await expect(handleRedemption('streamer', event, makeConfig(), streamerId)).resolves.toBe(true);
   });

--- a/src/twitch/eventsub/twitchEventSubHandler.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.ts
@@ -192,10 +192,17 @@ async function recordAndPushDashboardEvent(
  * rather than being silently lost — unlike the other five EventSub handlers, which treat the
  * dashboard feed as best-effort and must never let its failure crash or reject them.
  *
+ * Passes `redemptionId` (Twitch's own redemption id) through to `recordStreamerEvent` as an
+ * idempotency key: if a retry re-runs this after an earlier attempt already recorded the event
+ * but failed on a later required effect, the duplicate `INSERT` collides on
+ * `streamer_event_log`'s unique index and is silently skipped instead of creating a second row
+ * — see `recordStreamerEvent`'s doc comment.
+ *
  * @param streamerId - DB row ID of the streamer, used to scope the log entry and dashboard SSE channel.
  * @param eventType - Kind of activity that occurred.
  * @param displayName - The acting Twitch viewer's display name.
  * @param detail - Short additional context, or null if there's none.
+ * @param redemptionId - Twitch's own redemption id, used as the idempotency key.
  * @returns A promise that resolves once the event is recorded and pushed to the dashboard.
  */
 async function recordAndPushDashboardEventOrThrow(
@@ -203,8 +210,9 @@ async function recordAndPushDashboardEventOrThrow(
   eventType: StreamerEventType,
   displayName: string,
   detail: string | null,
+  redemptionId: string,
 ): Promise<void> {
-  await recordStreamerEvent(streamerId, eventType, displayName, detail);
+  await recordStreamerEvent(streamerId, eventType, displayName, detail, redemptionId);
   dashboardEventRuntimeRegistry.get()?.pushDashboardEvent(streamerId, {
     eventType, displayName, detail, occurredAt: new Date().toISOString(),
   });
@@ -403,7 +411,7 @@ export async function handleRedemption(
   // redemption from scratch instead of being silently dropped as a duplicate.
   try {
     const detail = event.user_input ? `${event.reward.title}: ${event.user_input}` : event.reward.title;
-    await recordAndPushDashboardEventOrThrow(streamerId, 'redemption', event.user_name, detail);
+    await recordAndPushDashboardEventOrThrow(streamerId, 'redemption', event.user_name, detail, event.id);
 
     // Awaited (unlike the other EventSub handlers' fire-and-forget pricing calls elsewhere):
     // a failed pricing update must propagate so the redemption is retried instead of silently

--- a/src/twitch/eventsub/twitchEventSubHandler.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.ts
@@ -196,14 +196,17 @@ async function recordAndPushDashboardEvent(
  * idempotency key: if a retry re-runs this after an earlier attempt already recorded the event
  * but failed on a later required effect, the duplicate `INSERT` collides on
  * `streamer_event_log`'s unique index and is silently skipped instead of creating a second row
- * — see `recordStreamerEvent`'s doc comment.
+ * — see `recordStreamerEvent`'s doc comment. The live dashboard SSE push is skipped on that same
+ * retry path too, since `recordStreamerEvent` reports back whether it actually inserted a row —
+ * otherwise a retry would re-deliver a second live event for a redemption already shown once.
  *
  * @param streamerId - DB row ID of the streamer, used to scope the log entry and dashboard SSE channel.
  * @param eventType - Kind of activity that occurred.
  * @param displayName - The acting Twitch viewer's display name.
  * @param detail - Short additional context, or null if there's none.
  * @param redemptionId - Twitch's own redemption id, used as the idempotency key.
- * @returns A promise that resolves once the event is recorded and pushed to the dashboard.
+ * @returns A promise that resolves once the event is recorded, and pushed to the dashboard if
+ *   this call actually inserted a new row.
  */
 async function recordAndPushDashboardEventOrThrow(
   streamerId: number,
@@ -212,7 +215,11 @@ async function recordAndPushDashboardEventOrThrow(
   detail: string | null,
   redemptionId: string,
 ): Promise<void> {
-  await recordStreamerEvent(streamerId, eventType, displayName, detail, redemptionId);
+  const inserted = await recordStreamerEvent(streamerId, eventType, displayName, detail, redemptionId);
+  // Only push the live SSE update when a new row was actually inserted — if this redemption was
+  // already recorded on an earlier attempt (see recordStreamerEvent's doc comment), a retry must
+  // not re-deliver a second live dashboard event for the same physical redemption.
+  if (!inserted) return;
   dashboardEventRuntimeRegistry.get()?.pushDashboardEvent(streamerId, {
     eventType, displayName, detail, occurredAt: new Date().toISOString(),
   });


### PR DESCRIPTION
## Summary

Part of #564 (the dashboard half; pricing's double-application risk is intentionally split off — see below). Since #563, `handleRedemption` retries a failed redemption from scratch: `clearPendingRedemption` releases the dedup claim and the whole function re-runs on the next attempt. That's correct in general, but `recordAndPushDashboardEventOrThrow`'s `streamer_event_log` INSERT is not idempotent — if a later required effect (pricing, or the `getVideosForReward`/overlay lookup) fails *after* the dashboard write already succeeded, the retry re-inserts a second dashboard row for the same physical redemption.

- Added a migration (`migrations/streamer_event_log_redemption_id.sql`) adding a nullable, `UNIQUE` `redemption_id` column to `streamer_event_log`. `NULL` for the other five event types (follow/sub/resub/giftsub/raid), which have no equivalent natural id — a `UNIQUE` index permits any number of `NULL`s, so they're unaffected. Documented the (previously undocumented) table in `DATABASE-SCHEMA.md`.
- `recordStreamerEvent` (`src/db/eventLog.ts`) now accepts an optional `redemptionId` and treats a duplicate-key `INSERT` as an already-recorded no-op (using the existing `isMysqlDuplicateEntryError` helper) rather than an error, when a `redemptionId` was given. Any other insert failure — or a duplicate-key error when no `redemptionId` was passed — still propagates normally.
- `handleRedemption` passes `event.id` (Twitch's own redemption id) through via `recordAndPushDashboardEventOrThrow`, so a retry's duplicate insert collides on the unique index and is silently skipped instead of creating a second row.

Pricing's separate double-application risk (`applyRedemptionPricing`/`syncRewardPrice` has no per-redemption tracking today, and would need redemption-id awareness threaded through `reward_pricing` — a deeper, higher-risk change touching live Twitch price pushes) is intentionally left out of this PR for a follow-up, per #564's own scoping.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 3257 tests passing)
- [x] `npm run lint` (no new errors/warnings)
- [x] `npm run check:circular` (no circular dependencies)
- [x] New tests in `eventLog.test.ts`: a duplicate-key error is silently swallowed (no prune DELETE either) when a `redemptionId` was given; rethrown when no `redemptionId` was given; a non-duplicate-key error still propagates even with a `redemptionId`.
- [x] New/updated tests in `twitchEventSubHandler.test.ts`: `recordStreamerEvent` is called with the redemption id as its fifth argument.

---
_Generated by [Claude Code](https://claude.ai/code/session_013aHFgapL9R8zz8VDs9AkKG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redemption events now use a unique identifier to prevent duplicate dashboard entries when notifications are retried.
  * Redemption identifiers are stored with event records.

* **Bug Fixes**
  * Duplicate redemption notifications are safely ignored, preventing repeated live dashboard updates.
  * Other event-recording errors continue to be reported.

* **Documentation**
  * Documented event log fields, event types, redemption deduplication, timestamps, and data-pruning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->