### PR TITLE
Make redemption dynamic-pricing increments idempotent across retries

### DIFF
--- a/DATABASE-SCHEMA.md
+++ b/DATABASE-SCHEMA.md
@@ -224,9 +224,10 @@ Dynamic Channel Point Pricing: per-reward config and demand state. Independent o
 | `demand` | `DECIMAL(9,6)` | Current demand, in `[0,1]` |
 | `demand_updated_at` | `BIGINT` | Epoch ms the `demand` value was last computed as of |
 | `last_pushed_cost` | `INT` NULL | Last cost actually pushed to Twitch; used to skip redundant Helix calls |
+| `last_redemption_id` | `VARCHAR(64)` NULL | Twitch's own id of the last redemption whose increment was applied to `demand` — the idempotency guard `syncRewardPrice` checks before applying another increment, so a retried redemption (see `handleRedemption`'s dedup pending/handled lifecycle) can't double-apply. Untouched by decay-only ticks. `NULL` until this reward's first redemption-driven sync |
 | `twitch_unsupported` | `TINYINT(1)` | Set (and `enabled` forced to 0) when Twitch returns 403 — the reward was created outside this app and can never be managed by it |
 
-Created by `migrations/reward_pricing.sql`. `round_to_nearest` added by `migrations/reward_pricing_round_to_nearest.sql`.
+Created by `migrations/reward_pricing.sql`. `round_to_nearest` added by `migrations/reward_pricing_round_to_nearest.sql`. `last_redemption_id` added by `migrations/reward_pricing_last_redemption_id.sql`.
 
 ## `reward_pricing_settings`
 

--- a/migrations/reward_pricing_last_redemption_id.sql
+++ b/migrations/reward_pricing_last_redemption_id.sql
@@ -1,0 +1,8 @@
+-- Idempotency guard for dynamic-pricing redemption increments: handleRedemption's retry-from-
+-- scratch recovery (see the twitchEventSubHandler.ts redemption-dedup lifecycle) can re-run
+-- applyRedemptionPricing for the same physical redemption after a later required effect (the
+-- getVideosForReward/overlay lookup) fails and the whole redemption is retried. Without tracking
+-- which redemption a reward's demand last accounted for, that retry would double-apply the
+-- redemption increment. NULL until a reward's first redemption-driven price sync.
+ALTER TABLE reward_pricing
+  ADD COLUMN last_redemption_id VARCHAR(64) NULL AFTER last_pushed_cost;

--- a/src/db.ts
+++ b/src/db.ts
@@ -528,7 +528,7 @@ export {
 
 // ─── Channel point pricing ───────────────────────────────────────────────────
 
-export type { RewardPricingRow, RewardPricingInput, StreamerPricingSettings } from './db/rewardPricing';
+export type { RewardPricingRow, RewardPricingInput, PricingUpdateFields, StreamerPricingSettings } from './db/rewardPricing';
 export {
   getPricingForReward, getPricingConfigsForStreamer, getAllEnabledPricingRows,
   upsertPricingConfig, recordPricingUpdate, deletePricingConfig, markPricingUnsupported,

--- a/src/db/rewardPricing.test.ts
+++ b/src/db/rewardPricing.test.ts
@@ -42,6 +42,7 @@ const sampleRow = {
   demand: '0.500000',
   demand_updated_at: '1700000000000',
   last_pushed_cost: 400,
+  last_redemption_id: 'redemption-abc',
   twitch_unsupported: 0,
 };
 
@@ -67,8 +68,15 @@ describe('getPricingForReward', () => {
       demand: 0.5,
       demand_updated_at: '1700000000000',
       last_pushed_cost: 400,
+      last_redemption_id: 'redemption-abc',
       twitch_unsupported: false,
     });
+  });
+
+  it('maps a null last_redemption_id as null', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([{ ...sampleRow, last_redemption_id: null }]) as any);
+    const row = await getPricingForReward(7, 'rwd-abc');
+    expect(row!.last_redemption_id).toBeNull();
   });
 
   it('queries with streamerId and twitchRewardId', async () => {
@@ -181,20 +189,27 @@ describe('upsertPricingConfig', () => {
 });
 
 describe('recordPricingUpdate', () => {
-  it('updates exactly demand, demand_updated_at, and last_pushed_cost', async () => {
+  it('updates demand, demand_updated_at, last_pushed_cost, and last_redemption_id', async () => {
     const pool = makePool();
     vi.mocked(getPool).mockReturnValue(pool as any);
-    await recordPricingUpdate(7, 'rwd-abc', 0.75, 1700000000000, 350);
+    await recordPricingUpdate(7, 'rwd-abc', 0.75, 1700000000000, 350, 'redemption-abc');
     const sql: string = pool.execute.mock.calls[0][0];
-    expect(sql).toContain('SET demand = ?, demand_updated_at = ?, last_pushed_cost = ?');
-    expect(pool.execute.mock.calls[0][1]).toEqual([0.75, 1700000000000, 350, 7, 'rwd-abc']);
+    expect(sql).toContain('SET demand = ?, demand_updated_at = ?, last_pushed_cost = ?, last_redemption_id = ?');
+    expect(pool.execute.mock.calls[0][1]).toEqual([0.75, 1700000000000, 350, 'redemption-abc', 7, 'rwd-abc']);
   });
 
   it('accepts a null lastPushedCost', async () => {
     const pool = makePool();
     vi.mocked(getPool).mockReturnValue(pool as any);
-    await recordPricingUpdate(7, 'rwd-abc', 0.1, 1700000000000, null);
-    expect(pool.execute.mock.calls[0][1]).toEqual([0.1, 1700000000000, null, 7, 'rwd-abc']);
+    await recordPricingUpdate(7, 'rwd-abc', 0.1, 1700000000000, null, 'redemption-abc');
+    expect(pool.execute.mock.calls[0][1]).toEqual([0.1, 1700000000000, null, 'redemption-abc', 7, 'rwd-abc']);
+  });
+
+  it('accepts a null lastRedemptionId (a decay-only tick preserving the unchanged value)', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await recordPricingUpdate(7, 'rwd-abc', 0.1, 1700000000000, 350, null);
+    expect(pool.execute.mock.calls[0][1]).toEqual([0.1, 1700000000000, 350, null, 7, 'rwd-abc']);
   });
 });
 

--- a/src/db/rewardPricing.test.ts
+++ b/src/db/rewardPricing.test.ts
@@ -192,7 +192,7 @@ describe('recordPricingUpdate', () => {
   it('updates demand, demand_updated_at, last_pushed_cost, and last_redemption_id', async () => {
     const pool = makePool();
     vi.mocked(getPool).mockReturnValue(pool as any);
-    await recordPricingUpdate(7, 'rwd-abc', 0.75, 1700000000000, 350, 'redemption-abc');
+    await recordPricingUpdate(7, 'rwd-abc', { demand: 0.75, demandUpdatedAtMs: 1700000000000, lastPushedCost: 350, lastRedemptionId: 'redemption-abc' });
     const sql: string = pool.execute.mock.calls[0][0];
     expect(sql).toContain('SET demand = ?, demand_updated_at = ?, last_pushed_cost = ?, last_redemption_id = ?');
     expect(pool.execute.mock.calls[0][1]).toEqual([0.75, 1700000000000, 350, 'redemption-abc', 7, 'rwd-abc']);
@@ -201,14 +201,14 @@ describe('recordPricingUpdate', () => {
   it('accepts a null lastPushedCost', async () => {
     const pool = makePool();
     vi.mocked(getPool).mockReturnValue(pool as any);
-    await recordPricingUpdate(7, 'rwd-abc', 0.1, 1700000000000, null, 'redemption-abc');
+    await recordPricingUpdate(7, 'rwd-abc', { demand: 0.1, demandUpdatedAtMs: 1700000000000, lastPushedCost: null, lastRedemptionId: 'redemption-abc' });
     expect(pool.execute.mock.calls[0][1]).toEqual([0.1, 1700000000000, null, 'redemption-abc', 7, 'rwd-abc']);
   });
 
   it('accepts a null lastRedemptionId (a decay-only tick preserving the unchanged value)', async () => {
     const pool = makePool();
     vi.mocked(getPool).mockReturnValue(pool as any);
-    await recordPricingUpdate(7, 'rwd-abc', 0.1, 1700000000000, 350, null);
+    await recordPricingUpdate(7, 'rwd-abc', { demand: 0.1, demandUpdatedAtMs: 1700000000000, lastPushedCost: 350, lastRedemptionId: null });
     expect(pool.execute.mock.calls[0][1]).toEqual([0.1, 1700000000000, 350, null, 7, 'rwd-abc']);
   });
 });

--- a/src/db/rewardPricing.ts
+++ b/src/db/rewardPricing.ts
@@ -19,6 +19,13 @@ export interface RewardPricingRow {
   /** Epoch ms as a string — BIGINT column; never coerce with Number() at this layer. */
   demand_updated_at: string;
   last_pushed_cost: number | null;
+  /**
+   * Twitch's own id of the last redemption whose increment was applied to `demand` — the
+   * idempotency guard `syncRewardPrice` checks before applying another increment, so a retried
+   * redemption (see `handleRedemption`'s dedup pending/handled lifecycle) can't double-apply.
+   * Unaffected by decay-only ticks. NULL until this reward's first redemption-driven sync.
+   */
+  last_redemption_id: string | null;
   /** True once Twitch has returned 403 for this reward — it was created outside this app and can never be managed by it. */
   twitch_unsupported: boolean;
 }
@@ -64,13 +71,15 @@ function mapRow(r: mysql.RowDataPacket): RewardPricingRow {
     demand: Number(r.demand),
     demand_updated_at: String(r.demand_updated_at),
     last_pushed_cost: r.last_pushed_cost == null ? null : Number(r.last_pushed_cost),
+    last_redemption_id: r.last_redemption_id ?? null,
     twitch_unsupported: fromBit(r.twitch_unsupported),
   };
 }
 
 const REWARD_PRICING_SELECT = `
   id, streamer_id, twitch_reward_id, enabled, base_cost, cooldown_seconds,
-  max_multiplier, curve, round_to_nearest, demand, demand_updated_at, last_pushed_cost, twitch_unsupported`;
+  max_multiplier, curve, round_to_nearest, demand, demand_updated_at, last_pushed_cost,
+  last_redemption_id, twitch_unsupported`;
 
 /**
  * Look up a single reward's pricing config/demand row, or null if not configured.
@@ -182,6 +191,9 @@ export async function markPricingUnsupported(streamerId: number, twitchRewardId:
  * @param demand - The newly computed demand value.
  * @param demandUpdatedAtMs - Epoch ms this demand value was computed as of.
  * @param lastPushedCost - The cost last pushed to Twitch, or null if none has been pushed yet.
+ * @param lastRedemptionId - The redemption id to record as `last_redemption_id`: the new
+ *   redemption's id on a redemption-driven sync, or the row's existing (unchanged) value on a
+ *   decay-only tick — see `syncRewardPrice`, which is the only caller and decides which to pass.
  */
 export async function recordPricingUpdate(
   streamerId: number,
@@ -189,12 +201,13 @@ export async function recordPricingUpdate(
   demand: number,
   demandUpdatedAtMs: number,
   lastPushedCost: number | null,
+  lastRedemptionId: string | null,
 ): Promise<void> {
   await getPool().execute(
     `UPDATE reward_pricing
-     SET demand = ?, demand_updated_at = ?, last_pushed_cost = ?
+     SET demand = ?, demand_updated_at = ?, last_pushed_cost = ?, last_redemption_id = ?
      WHERE streamer_id = ? AND twitch_reward_id = ?`,
-    [demand, demandUpdatedAtMs, lastPushedCost, streamerId, twitchRewardId],
+    [demand, demandUpdatedAtMs, lastPushedCost, lastRedemptionId, streamerId, twitchRewardId],
   );
 }
 

--- a/src/db/rewardPricing.ts
+++ b/src/db/rewardPricing.ts
@@ -181,6 +181,22 @@ export async function markPricingUnsupported(streamerId: number, twitchRewardId:
   );
 }
 
+/** Fields persisted by {@link recordPricingUpdate}, bundled to keep its parameter count down. */
+export interface PricingUpdateFields {
+  /** The newly computed demand value. */
+  demand: number;
+  /** Epoch ms this demand value was computed as of. */
+  demandUpdatedAtMs: number;
+  /** The cost last pushed to Twitch, or null if none has been pushed yet. */
+  lastPushedCost: number | null;
+  /**
+   * The redemption id to record as `last_redemption_id`: the new redemption's id on a
+   * redemption-driven sync, or the row's existing (unchanged) value on a decay-only tick — see
+   * `syncRewardPrice`, which is the only caller and decides which to pass.
+   */
+  lastRedemptionId: string | null;
+}
+
 /**
  * Persist a recalculated demand value (and, if it changed, the last cost pushed to Twitch).
  * Shared by the redemption hook and the periodic decay scheduler — the only writer of
@@ -188,26 +204,18 @@ export async function markPricingUnsupported(streamerId: number, twitchRewardId:
  *
  * @param streamerId - DB row ID of the owning streamer.
  * @param twitchRewardId - Twitch reward UUID.
- * @param demand - The newly computed demand value.
- * @param demandUpdatedAtMs - Epoch ms this demand value was computed as of.
- * @param lastPushedCost - The cost last pushed to Twitch, or null if none has been pushed yet.
- * @param lastRedemptionId - The redemption id to record as `last_redemption_id`: the new
- *   redemption's id on a redemption-driven sync, or the row's existing (unchanged) value on a
- *   decay-only tick — see `syncRewardPrice`, which is the only caller and decides which to pass.
+ * @param fields - The demand/cost/redemption-id fields to persist; see {@link PricingUpdateFields}.
  */
 export async function recordPricingUpdate(
   streamerId: number,
   twitchRewardId: string,
-  demand: number,
-  demandUpdatedAtMs: number,
-  lastPushedCost: number | null,
-  lastRedemptionId: string | null,
+  fields: PricingUpdateFields,
 ): Promise<void> {
   await getPool().execute(
     `UPDATE reward_pricing
      SET demand = ?, demand_updated_at = ?, last_pushed_cost = ?, last_redemption_id = ?
      WHERE streamer_id = ? AND twitch_reward_id = ?`,
-    [demand, demandUpdatedAtMs, lastPushedCost, lastRedemptionId, streamerId, twitchRewardId],
+    [fields.demand, fields.demandUpdatedAtMs, fields.lastPushedCost, fields.lastRedemptionId, streamerId, twitchRewardId],
   );
 }
 

--- a/src/twitch/eventsub/twitchEventSubHandler.test.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.test.ts
@@ -819,7 +819,7 @@ describe('handleRedemption', () => {
 
     await handleRedemption('streamer', event, makeConfig(), streamerId);
 
-    expect(applyRedemptionPricing).toHaveBeenCalledWith(streamerId, 'reward-abc');
+    expect(applyRedemptionPricing).toHaveBeenCalledWith(streamerId, 'reward-abc', 'redemption-1');
   });
 
   it('records a dashboard event using the reward title as detail when there is no user input', async () => {

--- a/src/twitch/eventsub/twitchEventSubHandler.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.ts
@@ -423,7 +423,7 @@ export async function handleRedemption(
     // Awaited (unlike the other EventSub handlers' fire-and-forget pricing calls elsewhere):
     // a failed pricing update must propagate so the redemption is retried instead of silently
     // marked complete. See the doc comment above.
-    await applyRedemptionPricing(streamerId, event.reward.id);
+    await applyRedemptionPricing(streamerId, event.reward.id, event.id);
 
     const videos = await getVideosForReward(event.reward.id, streamerId);
     if (videos.length > 0) {

--- a/src/twitch/pricing/rewardPricingService.test.ts
+++ b/src/twitch/pricing/rewardPricingService.test.ts
@@ -50,6 +50,7 @@ function makeRow(overrides: Partial<Record<string, unknown>> = {}) {
     demand: 0,
     demand_updated_at: String(Date.now()),
     last_pushed_cost: null,
+    last_redemption_id: null,
     twitch_unsupported: false,
     ...overrides,
   };
@@ -76,29 +77,29 @@ beforeEach(() => {
 describe('applyRedemptionPricing', () => {
   it('no-ops (no DB write, no Twitch call) when no pricing config exists', async () => {
     vi.mocked(getPricingForReward).mockResolvedValue(null);
-    await applyRedemptionPricing(1, 'rwd1');
+    await applyRedemptionPricing(1, 'rwd1', 'redemption-1');
     expect(updateRewardCost).not.toHaveBeenCalled();
     expect(recordPricingUpdate).not.toHaveBeenCalled();
   });
 
   it('no-ops when pricing is disabled for the reward', async () => {
     vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ enabled: false }));
-    await applyRedemptionPricing(1, 'rwd1');
+    await applyRedemptionPricing(1, 'rwd1', 'redemption-1');
     expect(updateRewardCost).not.toHaveBeenCalled();
     expect(recordPricingUpdate).not.toHaveBeenCalled();
   });
 
   it('pushes the new cost to Twitch when it differs from last_pushed_cost', async () => {
     vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
-    await applyRedemptionPricing(1, 'rwd1');
+    await applyRedemptionPricing(1, 'rwd1', 'redemption-1');
     expect(updateRewardCost).toHaveBeenCalledWith('bc1', 'rwd1', expect.any(Number), 'user-token');
-    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), expect.any(Number));
+    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), expect.any(Number), 'redemption-1');
   });
 
   it('marks the reward unsupported and disables it on a 403, without recording demand or history', async () => {
     vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
     vi.mocked(updateRewardCost).mockRejectedValueOnce(new TwitchRewardUnsupportedError('403'));
-    await applyRedemptionPricing(1, 'rwd1');
+    await applyRedemptionPricing(1, 'rwd1', 'redemption-1');
     expect(markPricingUnsupported).toHaveBeenCalledWith(1, 'rwd1');
     expect(recordPricingUpdate).not.toHaveBeenCalled();
     expect(recordPricingHistory).not.toHaveBeenCalled();
@@ -106,23 +107,23 @@ describe('applyRedemptionPricing', () => {
 
   it('records a price history point using the row id, computed cost, and demand', async () => {
     vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ id: 42, demand: 0, last_pushed_cost: null }));
-    await applyRedemptionPricing(1, 'rwd1');
+    await applyRedemptionPricing(1, 'rwd1', 'redemption-1');
     expect(recordPricingHistory).toHaveBeenCalledWith(42, expect.any(Number), expect.any(Number), expect.any(Number));
   });
 
   it('does not fail the sync when recording history throws', async () => {
     vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
     vi.mocked(recordPricingHistory).mockRejectedValueOnce(new Error('history db down'));
-    await expect(applyRedemptionPricing(1, 'rwd1')).resolves.toBeUndefined();
+    await expect(applyRedemptionPricing(1, 'rwd1', 'redemption-1')).resolves.toBeUndefined();
     expect(recordPricingUpdate).toHaveBeenCalled();
   });
 
   it('on a 401, does not mark the reward unsupported but still persists the recalculated demand', async () => {
     vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
     vi.mocked(updateRewardCost).mockRejectedValueOnce(new TwitchRewardAuthError('401'));
-    await applyRedemptionPricing(1, 'rwd1');
+    await applyRedemptionPricing(1, 'rwd1', 'redemption-1');
     expect(markPricingUnsupported).not.toHaveBeenCalled();
-    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), null);
+    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), null, 'redemption-1');
   });
 
   it('skips the Twitch call when the recomputed price equals last_pushed_cost', async () => {
@@ -130,24 +131,24 @@ describe('applyRedemptionPricing', () => {
     // still saturates at demand=1, so price stays the same as last_pushed_cost.
     const maxPrice = Math.round(200 * (1 + Math.pow(1, 1.5) * 4)); // 1000
     vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 1, demand_updated_at: String(Date.now()), last_pushed_cost: maxPrice }));
-    await applyRedemptionPricing(1, 'rwd1');
+    await applyRedemptionPricing(1, 'rwd1', 'redemption-1');
     expect(updateRewardCost).not.toHaveBeenCalled();
-    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), maxPrice);
+    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), maxPrice, 'redemption-1');
   });
 
   it('swallows a Twitch push failure but still persists the recalculated demand', async () => {
     vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
     vi.mocked(updateRewardCost).mockRejectedValueOnce(new Error('Twitch down'));
-    await expect(applyRedemptionPricing(1, 'rwd1')).resolves.toBeUndefined();
-    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), null);
+    await expect(applyRedemptionPricing(1, 'rwd1', 'redemption-1')).resolves.toBeUndefined();
+    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), null, 'redemption-1');
   });
 
   it('skips the push (but still persists demand) when no valid token is available', async () => {
     vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
     vi.mocked(getValidToken).mockResolvedValue(null);
-    await applyRedemptionPricing(1, 'rwd1');
+    await applyRedemptionPricing(1, 'rwd1', 'redemption-1');
     expect(updateRewardCost).not.toHaveBeenCalled();
-    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), null);
+    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), null, 'redemption-1');
   });
 
   it('serializes two concurrent calls on the same reward key', async () => {
@@ -166,8 +167,8 @@ describe('applyRedemptionPricing', () => {
       order.push('write');
     });
 
-    const first = applyRedemptionPricing(1, 'rwd1');
-    const second = applyRedemptionPricing(1, 'rwd1'); // same key — must wait for first to finish
+    const first = applyRedemptionPricing(1, 'rwd1', 'redemption-1');
+    const second = applyRedemptionPricing(1, 'rwd1', 'redemption-1'); // same key — must wait for first to finish
 
     // Give the second call a chance to run if it were (incorrectly) not serialized.
     await Promise.resolve();
@@ -182,10 +183,57 @@ describe('applyRedemptionPricing', () => {
   it('does not serialize calls on different reward keys', async () => {
     vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
     await Promise.all([
-      applyRedemptionPricing(1, 'rwd1'),
-      applyRedemptionPricing(1, 'rwd2'),
+      applyRedemptionPricing(1, 'rwd1', 'redemption-1'),
+      applyRedemptionPricing(1, 'rwd2', 'redemption-2'),
     ]);
     expect(recordPricingUpdate).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('redemption idempotency', () => {
+  it('no-ops entirely (no Twitch call, no DB write) when the redemption id matches last_redemption_id', async () => {
+    vi.mocked(getPricingForReward).mockResolvedValue(makeRow({
+      demand: 0, last_pushed_cost: null, last_redemption_id: 'redemption-1',
+    }));
+
+    await applyRedemptionPricing(1, 'rwd1', 'redemption-1');
+
+    expect(updateRewardCost).not.toHaveBeenCalled();
+    expect(recordPricingUpdate).not.toHaveBeenCalled();
+    expect(recordPricingHistory).not.toHaveBeenCalled();
+  });
+
+  it('applies the increment normally when the redemption id differs from last_redemption_id', async () => {
+    vi.mocked(getPricingForReward).mockResolvedValue(makeRow({
+      demand: 0, last_pushed_cost: null, last_redemption_id: 'redemption-1',
+    }));
+
+    await applyRedemptionPricing(1, 'rwd1', 'redemption-2');
+
+    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), expect.any(Number), 'redemption-2');
+  });
+
+  it('retrying the same redemption id after a first attempt succeeded is a no-op', async () => {
+    let currentRow: any = makeRow({ demand: 0, last_pushed_cost: null });
+    vi.mocked(getPricingForReward).mockImplementation(async () => currentRow);
+    vi.mocked(recordPricingUpdate).mockImplementation(async (_streamerId, _rewardId, demand, demandUpdatedAtMs, lastPushedCost, lastRedemptionId) => {
+      currentRow = { ...currentRow, demand, demand_updated_at: String(demandUpdatedAtMs), last_pushed_cost: lastPushedCost, last_redemption_id: lastRedemptionId };
+    });
+
+    await applyRedemptionPricing(1, 'rwd1', 'redemption-1'); // first attempt succeeds
+    await applyRedemptionPricing(1, 'rwd1', 'redemption-1'); // retry of the same redemption
+
+    expect(recordPricingUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists a decay-only tick without touching an existing last_redemption_id', async () => {
+    vi.mocked(getPricingForReward).mockResolvedValue(makeRow({
+      demand: 0.5, demand_updated_at: String(Date.now() - 300_000), last_pushed_cost: null, last_redemption_id: 'redemption-1',
+    }));
+
+    await applyDecayTick(1, 'rwd1');
+
+    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), expect.any(Number), 'redemption-1');
   });
 });
 
@@ -235,7 +283,7 @@ describe('round_to_nearest', () => {
     // raw price at demand=0.5 (base_cost=200, max_multiplier=4, curve=1.5) is 482.84,
     // which rounds to 480 at round_to_nearest=10 (see rewardPricingMath.test.ts).
     expect(updateRewardCost).toHaveBeenCalledWith('bc1', 'rwd1', 480, 'user-token');
-    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), 480);
+    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), 480, null);
   });
 
   it('skips the Twitch push (but still persists demand) when the rounded price matches last_pushed_cost, even though the underlying demand has changed', async () => {
@@ -246,7 +294,7 @@ describe('round_to_nearest', () => {
     }));
     await applyDecayTick(1, 'rwd1');
     expect(updateRewardCost).not.toHaveBeenCalled();
-    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), 500);
+    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), 500, null);
   });
 });
 
@@ -364,7 +412,7 @@ describe('deleteRewardAndPricing', () => {
       order.push('delete');
     });
 
-    const redemption = applyRedemptionPricing(1, 'rwd1');
+    const redemption = applyRedemptionPricing(1, 'rwd1', 'redemption-1');
     const del = deleteRewardAndPricing(1, 'rwd1'); // same key — must wait for the redemption to finish
 
     await Promise.resolve();
@@ -381,8 +429,8 @@ describe('redemption push rate limiting', () => {
   it('does not push to Twitch again for the same reward within the rate-limit window, but still persists demand both times', async () => {
     vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
 
-    await applyRedemptionPricing(1, 'rwd1');
-    await applyRedemptionPricing(1, 'rwd1'); // same reward, moments later — within the 5s window
+    await applyRedemptionPricing(1, 'rwd1', 'redemption-1');
+    await applyRedemptionPricing(1, 'rwd1', 'redemption-1'); // same reward, moments later — within the 5s window
 
     expect(updateRewardCost).toHaveBeenCalledTimes(1);
     expect(recordPricingUpdate).toHaveBeenCalledTimes(2);
@@ -392,8 +440,8 @@ describe('redemption push rate limiting', () => {
     vi.mocked(getPricingForReward).mockImplementation(async (_streamerId, twitchRewardId) =>
       makeRow({ twitch_reward_id: twitchRewardId, demand: 0, last_pushed_cost: null }));
 
-    await applyRedemptionPricing(1, 'rwd1');
-    await applyRedemptionPricing(1, 'rwd2');
+    await applyRedemptionPricing(1, 'rwd1', 'redemption-1');
+    await applyRedemptionPricing(1, 'rwd2', 'redemption-2');
 
     expect(updateRewardCost).toHaveBeenCalledTimes(2);
   });
@@ -403,11 +451,11 @@ describe('redemption push rate limiting', () => {
     try {
       vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
 
-      await applyRedemptionPricing(1, 'rwd1');
+      await applyRedemptionPricing(1, 'rwd1', 'redemption-1');
       expect(updateRewardCost).toHaveBeenCalledTimes(1);
 
       await vi.advanceTimersByTimeAsync(5_000);
-      await applyRedemptionPricing(1, 'rwd1');
+      await applyRedemptionPricing(1, 'rwd1', 'redemption-1');
       expect(updateRewardCost).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
@@ -421,7 +469,7 @@ describe('live pricing update push', () => {
     registerRewardPricingRuntime({ pushPricingUpdate });
     vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
 
-    await applyRedemptionPricing(1, 'rwd1');
+    await applyRedemptionPricing(1, 'rwd1', 'redemption-1');
 
     expect(pushPricingUpdate).toHaveBeenCalledWith(1, {
       rewardId: 'rwd1', cost: expect.any(Number), demand: expect.any(Number), recordedAt: expect.any(Number),
@@ -434,7 +482,7 @@ describe('live pricing update push', () => {
     vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
     vi.mocked(recordPricingHistory).mockRejectedValueOnce(new Error('history db down'));
 
-    await applyRedemptionPricing(1, 'rwd1');
+    await applyRedemptionPricing(1, 'rwd1', 'redemption-1');
 
     expect(pushPricingUpdate).toHaveBeenCalled();
   });
@@ -444,7 +492,7 @@ describe('live pricing update push', () => {
     registerRewardPricingRuntime({ pushPricingUpdate });
     vi.mocked(getPricingForReward).mockResolvedValue(null);
 
-    await applyRedemptionPricing(1, 'rwd1');
+    await applyRedemptionPricing(1, 'rwd1', 'redemption-1');
 
     expect(pushPricingUpdate).not.toHaveBeenCalled();
   });
@@ -455,7 +503,7 @@ describe('live pricing update push', () => {
     });
     vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
 
-    await expect(applyRedemptionPricing(1, 'rwd1')).resolves.toBeUndefined();
+    await expect(applyRedemptionPricing(1, 'rwd1', 'redemption-1')).resolves.toBeUndefined();
     expect(recordPricingUpdate).toHaveBeenCalled();
   });
 });

--- a/src/twitch/pricing/rewardPricingService.test.ts
+++ b/src/twitch/pricing/rewardPricingService.test.ts
@@ -93,7 +93,10 @@ describe('applyRedemptionPricing', () => {
     vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
     await applyRedemptionPricing(1, 'rwd1', 'redemption-1');
     expect(updateRewardCost).toHaveBeenCalledWith('bc1', 'rwd1', expect.any(Number), 'user-token');
-    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), expect.any(Number), 'redemption-1');
+    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', {
+      demand: expect.any(Number), demandUpdatedAtMs: expect.any(Number),
+      lastPushedCost: expect.any(Number), lastRedemptionId: 'redemption-1',
+    });
   });
 
   it('marks the reward unsupported and disables it on a 403, without recording demand or history', async () => {
@@ -123,7 +126,10 @@ describe('applyRedemptionPricing', () => {
     vi.mocked(updateRewardCost).mockRejectedValueOnce(new TwitchRewardAuthError('401'));
     await applyRedemptionPricing(1, 'rwd1', 'redemption-1');
     expect(markPricingUnsupported).not.toHaveBeenCalled();
-    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), null, 'redemption-1');
+    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', {
+      demand: expect.any(Number), demandUpdatedAtMs: expect.any(Number),
+      lastPushedCost: null, lastRedemptionId: 'redemption-1',
+    });
   });
 
   it('skips the Twitch call when the recomputed price equals last_pushed_cost', async () => {
@@ -133,14 +139,20 @@ describe('applyRedemptionPricing', () => {
     vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 1, demand_updated_at: String(Date.now()), last_pushed_cost: maxPrice }));
     await applyRedemptionPricing(1, 'rwd1', 'redemption-1');
     expect(updateRewardCost).not.toHaveBeenCalled();
-    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), maxPrice, 'redemption-1');
+    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', {
+      demand: expect.any(Number), demandUpdatedAtMs: expect.any(Number),
+      lastPushedCost: maxPrice, lastRedemptionId: 'redemption-1',
+    });
   });
 
   it('swallows a Twitch push failure but still persists the recalculated demand', async () => {
     vi.mocked(getPricingForReward).mockResolvedValue(makeRow({ demand: 0, last_pushed_cost: null }));
     vi.mocked(updateRewardCost).mockRejectedValueOnce(new Error('Twitch down'));
     await expect(applyRedemptionPricing(1, 'rwd1', 'redemption-1')).resolves.toBeUndefined();
-    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), null, 'redemption-1');
+    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', {
+      demand: expect.any(Number), demandUpdatedAtMs: expect.any(Number),
+      lastPushedCost: null, lastRedemptionId: 'redemption-1',
+    });
   });
 
   it('skips the push (but still persists demand) when no valid token is available', async () => {
@@ -148,7 +160,10 @@ describe('applyRedemptionPricing', () => {
     vi.mocked(getValidToken).mockResolvedValue(null);
     await applyRedemptionPricing(1, 'rwd1', 'redemption-1');
     expect(updateRewardCost).not.toHaveBeenCalled();
-    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), null, 'redemption-1');
+    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', {
+      demand: expect.any(Number), demandUpdatedAtMs: expect.any(Number),
+      lastPushedCost: null, lastRedemptionId: 'redemption-1',
+    });
   });
 
   it('serializes two concurrent calls on the same reward key', async () => {
@@ -210,14 +225,23 @@ describe('redemption idempotency', () => {
 
     await applyRedemptionPricing(1, 'rwd1', 'redemption-2');
 
-    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), expect.any(Number), 'redemption-2');
+    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', {
+      demand: expect.any(Number), demandUpdatedAtMs: expect.any(Number),
+      lastPushedCost: expect.any(Number), lastRedemptionId: 'redemption-2',
+    });
   });
 
   it('retrying the same redemption id after a first attempt succeeded is a no-op', async () => {
     let currentRow: any = makeRow({ demand: 0, last_pushed_cost: null });
     vi.mocked(getPricingForReward).mockImplementation(async () => currentRow);
-    vi.mocked(recordPricingUpdate).mockImplementation(async (_streamerId, _rewardId, demand, demandUpdatedAtMs, lastPushedCost, lastRedemptionId) => {
-      currentRow = { ...currentRow, demand, demand_updated_at: String(demandUpdatedAtMs), last_pushed_cost: lastPushedCost, last_redemption_id: lastRedemptionId };
+    vi.mocked(recordPricingUpdate).mockImplementation(async (_streamerId, _rewardId, fields) => {
+      currentRow = {
+        ...currentRow,
+        demand: fields.demand,
+        demand_updated_at: String(fields.demandUpdatedAtMs),
+        last_pushed_cost: fields.lastPushedCost,
+        last_redemption_id: fields.lastRedemptionId,
+      };
     });
 
     await applyRedemptionPricing(1, 'rwd1', 'redemption-1'); // first attempt succeeds
@@ -233,7 +257,10 @@ describe('redemption idempotency', () => {
 
     await applyDecayTick(1, 'rwd1');
 
-    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), expect.any(Number), 'redemption-1');
+    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', {
+      demand: expect.any(Number), demandUpdatedAtMs: expect.any(Number),
+      lastPushedCost: expect.any(Number), lastRedemptionId: 'redemption-1',
+    });
   });
 });
 
@@ -245,7 +272,8 @@ describe('applyDecayTick', () => {
       last_pushed_cost: null,
     }));
     await applyDecayTick(1, 'rwd1');
-    const [, , demandArg] = vi.mocked(recordPricingUpdate).mock.calls[0];
+    const [, , fieldsArg] = vi.mocked(recordPricingUpdate).mock.calls[0];
+    const demandArg = fieldsArg.demand;
     // decay(0.5, ~300s elapsed, half_life=1800s) = 0.5 * 2^(-300/1800)
     expect(demandArg).toBeCloseTo(0.5 * Math.pow(2, -300 / 1800), 2);
   });
@@ -267,7 +295,8 @@ describe('applyDecayTick', () => {
     await applyDecayTick(1, 'rwd1', hintSettings);
 
     expect(getPricingSettingsForStreamer).not.toHaveBeenCalled();
-    const [, , demandArg] = vi.mocked(recordPricingUpdate).mock.calls[0];
+    const [, , fieldsArg] = vi.mocked(recordPricingUpdate).mock.calls[0];
+    const demandArg = fieldsArg.demand;
     // decay(0.5, ~300s elapsed, half_life=60s from the hint, not the default 1800s) ≈ 0
     expect(demandArg).toBeCloseTo(0.5 * Math.pow(2, -300 / 60), 4);
   });
@@ -283,7 +312,10 @@ describe('round_to_nearest', () => {
     // raw price at demand=0.5 (base_cost=200, max_multiplier=4, curve=1.5) is 482.84,
     // which rounds to 480 at round_to_nearest=10 (see rewardPricingMath.test.ts).
     expect(updateRewardCost).toHaveBeenCalledWith('bc1', 'rwd1', 480, 'user-token');
-    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), 480, null);
+    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', {
+      demand: expect.any(Number), demandUpdatedAtMs: expect.any(Number),
+      lastPushedCost: 480, lastRedemptionId: null,
+    });
   });
 
   it('skips the Twitch push (but still persists demand) when the rounded price matches last_pushed_cost, even though the underlying demand has changed', async () => {
@@ -294,7 +326,10 @@ describe('round_to_nearest', () => {
     }));
     await applyDecayTick(1, 'rwd1');
     expect(updateRewardCost).not.toHaveBeenCalled();
-    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', expect.any(Number), expect.any(Number), 500, null);
+    expect(recordPricingUpdate).toHaveBeenCalledWith(1, 'rwd1', {
+      demand: expect.any(Number), demandUpdatedAtMs: expect.any(Number),
+      lastPushedCost: 500, lastRedemptionId: null,
+    });
   });
 });
 

--- a/src/twitch/pricing/rewardPricingService.ts
+++ b/src/twitch/pricing/rewardPricingService.ts
@@ -190,10 +190,12 @@ async function syncRewardPrice(
     lastPushedCost = result.lastPushedCost;
   }
 
-  await recordPricingUpdate(
-    streamerId, twitchRewardId, newDemand, now, lastPushedCost,
-    applyIncrement ? redemptionId : row.last_redemption_id,
-  );
+  await recordPricingUpdate(streamerId, twitchRewardId, {
+    demand: newDemand,
+    demandUpdatedAtMs: now,
+    lastPushedCost,
+    lastRedemptionId: applyIncrement ? redemptionId : row.last_redemption_id,
+  });
 
   try {
     await recordPricingHistory(row.id, newCost, newDemand, now);

--- a/src/twitch/pricing/rewardPricingService.ts
+++ b/src/twitch/pricing/rewardPricingService.ts
@@ -148,15 +148,22 @@ async function pushRewardCostUpdate(
  * @param streamerId - DB row ID of the owning streamer.
  * @param twitchRewardId - Twitch reward UUID.
  * @param applyIncrement - True for a redemption (decay + increment); false for a decay-only tick.
+ * @param redemptionId - The redemption's own id when `applyIncrement` is true, so the idempotency
+ *   guard can detect (and no-op on) a retry of the same redemption; null for a decay-only tick,
+ *   which doesn't correspond to any single redemption.
  * @param settingsHint - Optional pre-fetched settings, passed by the decay scheduler when it has
  *   already loaded a streamer's settings once for this tick — avoids re-querying the same row for
  *   every one of that streamer's enabled rewards. Fetched fresh when omitted.
  */
 async function syncRewardPrice(
-  streamerId: number, twitchRewardId: string, applyIncrement: boolean, settingsHint?: StreamerPricingSettings,
+  streamerId: number, twitchRewardId: string, applyIncrement: boolean, redemptionId: string | null, settingsHint?: StreamerPricingSettings,
 ): Promise<void> {
   const row = await getPricingForReward(streamerId, twitchRewardId);
   if (!row || !row.enabled) return;
+
+  // Idempotency guard: a retried redemption (see handleRedemption's dedup pending/handled
+  // lifecycle) must not double-apply its increment if this reward already processed it.
+  if (applyIncrement && redemptionId && row.last_redemption_id === redemptionId) return;
 
   const settings = settingsHint ?? await getPricingSettingsForStreamer(streamerId);
   const now = Date.now();
@@ -183,7 +190,10 @@ async function syncRewardPrice(
     lastPushedCost = result.lastPushedCost;
   }
 
-  await recordPricingUpdate(streamerId, twitchRewardId, newDemand, now, lastPushedCost);
+  await recordPricingUpdate(
+    streamerId, twitchRewardId, newDemand, now, lastPushedCost,
+    applyIncrement ? redemptionId : row.last_redemption_id,
+  );
 
   try {
     await recordPricingHistory(row.id, newCost, newDemand, now);
@@ -201,13 +211,17 @@ async function syncRewardPrice(
 /**
  * Applies a single redemption to a reward's dynamic pricing: decays for elapsed time,
  * adds the global redemption increment, and pushes the new price to Twitch if it changed.
- * Called from the EventSub redemption handler.
+ * Called from the EventSub redemption handler. `redemptionId` is compared against the reward's
+ * `last_redemption_id` before doing anything else — a retry of the same redemption (e.g. after
+ * an unrelated later step in `handleRedemption` failed and the whole redemption was retried) is
+ * a no-op here, so it can't double-apply the increment.
  *
  * @param streamerId - DB row ID of the owning streamer.
  * @param twitchRewardId - Twitch reward UUID that was redeemed.
+ * @param redemptionId - Twitch's own id of the redemption being applied.
  */
-export async function applyRedemptionPricing(streamerId: number, twitchRewardId: string): Promise<void> {
-  await pricingQueue.run(queueKey(streamerId, twitchRewardId), () => syncRewardPrice(streamerId, twitchRewardId, true));
+export async function applyRedemptionPricing(streamerId: number, twitchRewardId: string, redemptionId: string): Promise<void> {
+  await pricingQueue.run(queueKey(streamerId, twitchRewardId), () => syncRewardPrice(streamerId, twitchRewardId, true, redemptionId));
 }
 
 /**
@@ -220,7 +234,7 @@ export async function applyRedemptionPricing(streamerId: number, twitchRewardId:
  * @param settingsHint - Optional pre-fetched settings for this streamer; see {@link syncRewardPrice}.
  */
 export async function applyDecayTick(streamerId: number, twitchRewardId: string, settingsHint?: StreamerPricingSettings): Promise<void> {
-  await pricingQueue.run(queueKey(streamerId, twitchRewardId), () => syncRewardPrice(streamerId, twitchRewardId, false, settingsHint));
+  await pricingQueue.run(queueKey(streamerId, twitchRewardId), () => syncRewardPrice(streamerId, twitchRewardId, false, null, settingsHint));
 }
 
 /**


### PR DESCRIPTION
## Summary

Completes #564 (the pricing half; the dashboard-recording half was #565). Since #563, `handleRedemption` retries a failed redemption from scratch: `clearPendingRedemption` releases the dedup claim and the whole function re-runs on the next attempt. `applyRedemptionPricing`/`syncRewardPrice` had no way to recognize "this redemption's increment was already applied" — if a later required effect (the `getVideosForReward`/overlay lookup) failed *after* pricing already succeeded, a retry would re-apply the redemption's demand increment a second time for the same physical redemption.

- Added a migration (`migrations/reward_pricing_last_redemption_id.sql`) adding a nullable `last_redemption_id` column to `reward_pricing`, tracking the Twitch redemption id whose increment was last applied. Documented it in `DATABASE-SCHEMA.md`.
- `syncRewardPrice` now checks `last_redemption_id` against the incoming redemption id (when this is a redemption-driven sync) before doing anything else, and no-ops entirely on a match — no Twitch Helix call, no DB write, no price-history point, no live SSE push.
- `recordPricingUpdate` now persists `last_redemption_id`: the new redemption's id on a redemption-driven sync, or the row's existing (unchanged) value on a decay-only tick — `applyDecayTick` never touches it.
- `applyRedemptionPricing` now requires the Twitch redemption id as a third parameter; `handleRedemption` passes `event.id` through.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 3264 tests passing)
- [x] `npm run lint` (no new errors/warnings)
- [x] `npm run check:circular` (no circular dependencies)
- [x] New tests in `rewardPricingService.test.ts`: a matching redemption id no-ops entirely (no Twitch call, no DB write, no history); a different redemption id applies the increment normally; a simulated retry of the same redemption (using a stateful mock that tracks the persisted row across calls) results in exactly one `recordPricingUpdate`; a decay-only tick leaves an existing `last_redemption_id` untouched.
- [x] New tests in `rewardPricing.test.ts` covering `recordPricingUpdate`'s new `lastRedemptionId` parameter and `mapRow`'s handling of a null `last_redemption_id`.
- [x] Existing `applyRedemptionPricing`/`applyDecayTick` tests updated for the new signature and parameter, unchanged in intent.

---
_Generated by [Claude Code](https://claude.ai/code/session_013aHFgapL9R8zz8VDs9AkKG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added redemption tracking for dynamic reward pricing.
  * Duplicate redemption events are now safely ignored, preventing repeated price adjustments.
  * Pricing updates retain the most recently processed redemption for reliable retry handling.

* **Bug Fixes**
  * Improved consistency when processing redemption retries and repeated events.
  * Preserved redemption history during pricing decay updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->