### PR TITLE
Add missing JSDoc to rewardPricing's mapRow helper

### DIFF
--- a/src/db/rewardPricing.ts
+++ b/src/db/rewardPricing.ts
@@ -57,6 +57,7 @@ const DEFAULT_STREAMER_PRICING_SETTINGS: StreamerPricingSettings = {
 /** Fallback cooldown (seconds) used for a reward's pricing math when it has no Twitch-enforced cooldown. */
 export const DEFAULT_PRICING_COOLDOWN_SECONDS = 60;
 
+/** Maps a raw `reward_pricing` row into a {@link RewardPricingRow}, coercing numeric/bit columns. */
 function mapRow(r: mysql.RowDataPacket): RewardPricingRow {
   return {
     id: r.id,


### PR DESCRIPTION
## Summary

Small follow-up to #566: CodeRabbit's review on that PR flagged `mapRow` in `src/db/rewardPricing.ts` as missing the JSDoc CLAUDE.md requires on every function (including internal helpers). The review landed just after #566 was already merged, so fixing it here.

- Adds a one-line JSDoc comment to `mapRow`.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 3264 tests passing)

---
_Generated by [Claude Code](https://claude.ai/code/session_013aHFgapL9R8zz8VDs9AkKG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation clarifying how reward pricing records are converted and how numeric and bit values are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->