### PR TITLE
Fix EventSub redemption subscriptions silently orphaned on reconnect

### DIFF
--- a/src/twitch/eventsub/twitchApiEventSub.test.ts
+++ b/src/twitch/eventsub/twitchApiEventSub.test.ts
@@ -287,6 +287,30 @@ describe('listEventSubSubscriptions', () => {
     expect(result).toEqual(subs);
   });
 
+  it('preserves each subscription\'s condition and transport session id in the mapped result', async () => {
+    const apiResponse = [
+      {
+        id: 's1', type: 'channel.follow',
+        condition: { broadcaster_user_id: 'uid-1', moderator_user_id: 'uid-1' },
+        transport: { method: 'websocket', session_id: 'sess-1' },
+      },
+      {
+        id: 's2', type: 'channel.raid',
+        condition: { to_broadcaster_user_id: 'uid-1' },
+        // No transport.session_id (e.g. webhook transport, or the field simply absent).
+        transport: { method: 'websocket' },
+      },
+    ];
+    vi.mocked(twitchFetch).mockResolvedValue(mockFetch(200, { data: apiResponse }));
+
+    const result = await listEventSubSubscriptions('token');
+
+    expect(result).toEqual([
+      { id: 's1', type: 'channel.follow', condition: { broadcaster_user_id: 'uid-1', moderator_user_id: 'uid-1' }, sessionId: 'sess-1' },
+      { id: 's2', type: 'channel.raid', condition: { to_broadcaster_user_id: 'uid-1' }, sessionId: undefined },
+    ]);
+  });
+
   it('paginates when a cursor is present', async () => {
     vi.mocked(twitchFetch)
       .mockResolvedValueOnce(mockFetch(200, { data: [{ id: 's1', type: 't1' }], pagination: { cursor: 'cursor1' } }))

--- a/src/twitch/eventsub/twitchApiEventSub.ts
+++ b/src/twitch/eventsub/twitchApiEventSub.ts
@@ -144,21 +144,27 @@ export async function createEventSubSubscription(
 }
 
 /** Lists EventSub subscriptions. With a user token returns the broadcaster's subscriptions;
- *  with an app token and userId returns subscriptions matching that user in any condition. */
+ *  with an app token and userId returns subscriptions matching that user in any condition.
+ *  `sessionId` is the WebSocket session (if any) the subscription is currently bound to —
+ *  used to tell a subscription still live on the current connection apart from a stale
+ *  duplicate left over from a prior (possibly dead) session. */
 export async function listEventSubSubscriptions(
   token: string,
   userId?: string,
-): Promise<Array<{ id: string; type: string }>> {
+): Promise<Array<{ id: string; type: string; sessionId?: string }>> {
   const url = new URL('https://api.twitch.tv/helix/eventsub/subscriptions');
   if (userId) url.searchParams.set('user_id', userId);
-  const results: Array<{ id: string; type: string }> = [];
+  const results: Array<{ id: string; type: string; sessionId?: string }> = [];
   let cursor: string | undefined;
   do {
     if (cursor) url.searchParams.set('after', cursor);
     const res = await twitchFetch(url.toString(), { headers: authHeaders(token) });
     if (!res.ok) throw new Error(`[TwitchAPI] listEventSubSubscriptions failed: ${res.status}`);
-    const data = await res.json() as { data: Array<{ id: string; type: string }>; pagination?: { cursor?: string } };
-    results.push(...data.data);
+    const data = await res.json() as {
+      data: Array<{ id: string; type: string; transport?: { session_id?: string } }>;
+      pagination?: { cursor?: string };
+    };
+    results.push(...data.data.map((sub) => ({ id: sub.id, type: sub.type, sessionId: sub.transport?.session_id })));
     cursor = data.pagination?.cursor;
   } while (cursor);
   return results;

--- a/src/twitch/eventsub/twitchApiEventSub.ts
+++ b/src/twitch/eventsub/twitchApiEventSub.ts
@@ -143,28 +143,34 @@ export async function createEventSubSubscription(
   return data.data[0].id;
 }
 
-/** Lists EventSub subscriptions. With a user token returns the broadcaster's subscriptions;
- *  with an app token and userId returns subscriptions matching that user in any condition.
- *  `sessionId` is the WebSocket session (if any) the subscription is currently bound to —
- *  used to tell a subscription still live on the current connection apart from a stale
- *  duplicate left over from a prior (possibly dead) session. */
+/** Lists EventSub subscriptions. With a user token returns the broadcaster's subscriptions —
+ *  note this also includes any subscription where the token's user is a *moderator* in the
+ *  condition (e.g. `channel.follow`'s `moderator_user_id`), so the result can include another
+ *  broadcaster's subscription entirely; callers must match on `condition`, not just `type`, to
+ *  avoid acting on a subscription that isn't actually theirs. With an app token and userId
+ *  returns subscriptions matching that user in any condition.
+ *  `sessionId` is the WebSocket session (if any) the subscription is currently bound to — used
+ *  to tell a subscription still live on the current connection apart from a stale duplicate
+ *  left over from a prior (possibly dead) session. */
 export async function listEventSubSubscriptions(
   token: string,
   userId?: string,
-): Promise<Array<{ id: string; type: string; sessionId?: string }>> {
+): Promise<Array<{ id: string; type: string; condition: Record<string, string>; sessionId?: string }>> {
   const url = new URL('https://api.twitch.tv/helix/eventsub/subscriptions');
   if (userId) url.searchParams.set('user_id', userId);
-  const results: Array<{ id: string; type: string; sessionId?: string }> = [];
+  const results: Array<{ id: string; type: string; condition: Record<string, string>; sessionId?: string }> = [];
   let cursor: string | undefined;
   do {
     if (cursor) url.searchParams.set('after', cursor);
     const res = await twitchFetch(url.toString(), { headers: authHeaders(token) });
     if (!res.ok) throw new Error(`[TwitchAPI] listEventSubSubscriptions failed: ${res.status}`);
     const data = await res.json() as {
-      data: Array<{ id: string; type: string; transport?: { session_id?: string } }>;
+      data: Array<{ id: string; type: string; condition: Record<string, string>; transport?: { session_id?: string } }>;
       pagination?: { cursor?: string };
     };
-    results.push(...data.data.map((sub) => ({ id: sub.id, type: sub.type, sessionId: sub.transport?.session_id })));
+    results.push(...data.data.map((sub) => (
+      { id: sub.id, type: sub.type, condition: sub.condition, sessionId: sub.transport?.session_id }
+    )));
     cursor = data.pagination?.cursor;
   } while (cursor);
   return results;

--- a/src/twitch/eventsub/twitchEventSubConnection.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.ts
@@ -219,6 +219,11 @@ export class StreamerConnection {
    */
   private forceReconnect(socket: WebSocket | null): void {
     if (this.ws !== socket) return;
+    // Best-effort: request a close (harmless if already closing/closed) so Twitch has a
+    // better chance of revoking this session's EventSub subscriptions promptly, rather than
+    // leaving them "enabled" until Twitch's own delayed dead-connection detection catches up.
+    // We don't wait on it — the next connect() proceeds immediately regardless.
+    socket?.close();
     this.clearKeepaliveTimer();
     this.ws = null;
     this.sessionId = null;

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
@@ -355,15 +355,13 @@ describe('subscribeForStreamer', () => {
     expect(deleteEventSubSubscription).not.toHaveBeenCalledWith('sub-new-follow', 'tok-dup');
   });
 
-  it('does not prune any existing subscription of a type when creating it hit a 409 (already exists)', async () => {
+  it('keeps an existing subscription already bound to the live session without recreating it', async () => {
     vi.mocked(getActiveChannels).mockReturnValue(new Set(['botinchannel']));
-    // 409 -> createEventSubSubscription resolves null, so subscribe() has no fresh id for this type.
-    vi.mocked(createEventSubSubscription).mockResolvedValue(null);
     vi.mocked(listEventSubSubscriptions).mockResolvedValue([
-      { id: 'sub-existing-follow', type: 'channel.follow' },
+      { id: 'sub-live-follow', type: 'channel.follow', sessionId: 'sess-live-409' },
     ] as any);
 
-    await subscribeForStreamer('sess-409', {
+    const count = await subscribeForStreamer('sess-live-409', {
       uid: 'uid-409',
       token: 'tok-409',
       name: 'botInChannel',
@@ -371,7 +369,39 @@ describe('subscribeForStreamer', () => {
       streamerId: 23,
     });
 
-    expect(deleteEventSubSubscription).not.toHaveBeenCalledWith('sub-existing-follow', 'tok-409');
+    // Already correctly bound to this session — no redundant create call, and definitely not deleted.
+    expect(createEventSubSubscription).not.toHaveBeenCalledWith(
+      'channel.follow', expect.anything(), expect.anything(), expect.anything(), expect.anything(),
+    );
+    expect(deleteEventSubSubscription).not.toHaveBeenCalledWith('sub-live-follow', 'tok-409');
+    expect(count).toBeGreaterThan(0);
+  });
+
+  it('deletes an existing subscription bound to a different (stale/dead) session before recreating it', async () => {
+    vi.mocked(getActiveChannels).mockReturnValue(new Set(['botinchannel']));
+    vi.mocked(createEventSubSubscription).mockResolvedValue('sub-fresh-follow');
+    // Left over from a prior session that died without a clean close (e.g. onError/forceReconnect
+    // tearing down the socket) — Twitch hasn't revoked it yet, so it still shows up here bound to
+    // a session id that's no longer the live one.
+    vi.mocked(listEventSubSubscriptions).mockResolvedValue([
+      { id: 'sub-dead-follow', type: 'channel.follow', sessionId: 'sess-old-dead' },
+    ] as any);
+
+    await subscribeForStreamer('sess-new-live', {
+      uid: 'uid-stale-session',
+      token: 'tok-stale-session',
+      name: 'botInChannel',
+      config: { follow_enabled: true, sub_enabled: false, raid_enabled: false } as any,
+      streamerId: 23,
+    });
+
+    // Deleted before the fresh create, so Twitch's 409 (identical type+condition still "enabled")
+    // can never leave the new session without a working subscription for this type.
+    expect(deleteEventSubSubscription).toHaveBeenCalledWith('sub-dead-follow', 'tok-stale-session');
+    expect(createEventSubSubscription).toHaveBeenCalledWith(
+      'channel.follow', '2', { broadcaster_user_id: 'uid-stale-session', moderator_user_id: 'uid-stale-session' },
+      'sess-new-live', 'tok-stale-session',
+    );
   });
 
   it('subscribes to stream.online and stream.offline whenever config and token are present', async () => {
@@ -598,7 +628,7 @@ describe('error handling in subscription setup', () => {
     vi.mocked(getActiveChannels).mockReturnValue(new Set(['errstreamer']));
   });
 
-  it('logs and continues when listing existing subscriptions fails during cleanup', async () => {
+  it('logs and continues (treating no subscription as existing) when listing existing subscriptions fails before creation', async () => {
     vi.mocked(createEventSubSubscription).mockResolvedValue('sub-id');
     vi.mocked(listEventSubSubscriptions).mockRejectedValueOnce(new Error('list failed'));
 
@@ -610,7 +640,29 @@ describe('error handling in subscription setup', () => {
       streamerId: 70,
     });
 
-    expect(logMock.error).toHaveBeenCalledWith('Subscription cleanup failed for uid uid-err:', expect.any(Error));
+    expect(logMock.error).toHaveBeenCalledWith(
+      'Failed to list existing EventSub subscriptions for errStreamer:', expect.any(Error),
+    );
+    expect(createEventSubSubscription).toHaveBeenCalled();
+    expect(count).toBeGreaterThan(0);
+  });
+
+  it('logs and continues when listing existing subscriptions fails during cleanup', async () => {
+    vi.mocked(createEventSubSubscription).mockResolvedValue('sub-id');
+    // First call (pre-create lookup) succeeds; second call (deleteStaleSubscriptions) fails.
+    vi.mocked(listEventSubSubscriptions)
+      .mockResolvedValueOnce([])
+      .mockRejectedValueOnce(new Error('list failed'));
+
+    const count = await subscribeForStreamer('sess-err2', {
+      uid: 'uid-err2',
+      token: 'tok-err2',
+      name: 'errStreamer',
+      config: { follow_enabled: true, sub_enabled: false, raid_enabled: false } as any,
+      streamerId: 70,
+    });
+
+    expect(logMock.error).toHaveBeenCalledWith('Subscription cleanup failed for uid uid-err2:', expect.any(Error));
     expect(count).toBeGreaterThan(0);
   });
 

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
@@ -359,9 +359,12 @@ describe('subscribeForStreamer', () => {
     vi.mocked(getActiveChannels).mockReturnValue(new Set(['botinchannel']));
     vi.mocked(createEventSubSubscription).mockResolvedValue('sub-new-follow');
     // The old, orphaned subscription (e.g. from a process that died without stop()) is still
-    // "enabled" and shows up alongside the one just created this round.
+    // "enabled" and shows up alongside the one already live on this round's session.
     vi.mocked(listEventSubSubscriptions).mockResolvedValue([
-      { id: 'sub-new-follow', type: 'channel.follow', condition: { broadcaster_user_id: 'uid-dup', moderator_user_id: 'uid-dup' } },
+      {
+        id: 'sub-new-follow', type: 'channel.follow', sessionId: 'sess-dup',
+        condition: { broadcaster_user_id: 'uid-dup', moderator_user_id: 'uid-dup' },
+      },
       { id: 'sub-stale-follow', type: 'channel.follow', condition: { broadcaster_user_id: 'uid-dup', moderator_user_id: 'uid-dup' } },
     ] as any);
 
@@ -400,6 +403,37 @@ describe('subscribeForStreamer', () => {
     );
     expect(deleteEventSubSubscription).not.toHaveBeenCalledWith('sub-live-follow', 'tok-409');
     expect(count).toBeGreaterThan(0);
+  });
+
+  it('does not mistake a same-type, same-broadcaster subscription with a different condition for the desired one', async () => {
+    vi.mocked(getActiveChannels).mockReturnValue(new Set(['botinchannel']));
+    vi.mocked(createEventSubSubscription).mockResolvedValue('sub-fresh-follow-v2');
+    // Same broadcaster, same type, but missing moderator_user_id — e.g. a leftover channel.follow
+    // v1 subscription (broadcaster_user_id only) from before the app moved to v2's two-key
+    // condition. Bound to the live session, so type-only matching would wrongly treat this as
+    // already satisfying the v2 spec and skip creating it.
+    vi.mocked(listEventSubSubscriptions).mockResolvedValue([
+      {
+        id: 'sub-v1-follow', type: 'channel.follow', sessionId: 'sess-condition-mismatch',
+        condition: { broadcaster_user_id: 'uid-condition-mismatch' },
+      },
+    ] as any);
+
+    await subscribeForStreamer('sess-condition-mismatch', {
+      uid: 'uid-condition-mismatch',
+      token: 'tok-condition-mismatch',
+      name: 'botInChannel',
+      config: { follow_enabled: true, sub_enabled: false, raid_enabled: false } as any,
+      streamerId: 23,
+    });
+
+    // Not recognized as satisfying the v2 spec — a fresh (correctly conditioned) subscription is
+    // created rather than being silently skipped.
+    expect(createEventSubSubscription).toHaveBeenCalledWith(
+      'channel.follow', '2',
+      { broadcaster_user_id: 'uid-condition-mismatch', moderator_user_id: 'uid-condition-mismatch' },
+      'sess-condition-mismatch', 'tok-condition-mismatch',
+    );
   });
 
   it('deletes an existing subscription bound to a different (stale/dead) session before recreating it', async () => {

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
@@ -319,7 +319,7 @@ describe('subscribeForStreamer', () => {
     vi.mocked(getActiveChannels).mockReturnValue(new Set(['botinchannel']));
     vi.mocked(createEventSubSubscription).mockResolvedValue('sub-new');
     vi.mocked(listEventSubSubscriptions).mockResolvedValue([
-      { id: 'stale-sub', type: 'channel.subscribe' }, // not in desired set
+      { id: 'stale-sub', type: 'channel.subscribe', condition: { broadcaster_user_id: 'uid-z' } }, // not in desired set
     ] as any);
 
     await subscribeForStreamer('sess-z', {
@@ -333,14 +333,36 @@ describe('subscribeForStreamer', () => {
     expect(deleteEventSubSubscription).toHaveBeenCalledWith('stale-sub', 'tok-z');
   });
 
+  it('never deletes an undesired-type subscription belonging to a different broadcaster the streamer merely moderates', async () => {
+    vi.mocked(getActiveChannels).mockReturnValue(new Set(['botinchannel']));
+    vi.mocked(createEventSubSubscription).mockResolvedValue('sub-new');
+    // Same reasoning as the create-side test above, but for the deleteStaleSubscriptions cleanup
+    // path: a type this streamer doesn't want (channel.subscribe, sub_enabled: false) must never
+    // be pruned just because it showed up in the list — it belongs to a broadcaster this streamer
+    // only moderates, not to this streamer's own channel.
+    vi.mocked(listEventSubSubscriptions).mockResolvedValue([
+      { id: 'other-broadcaster-sub', type: 'channel.subscribe', condition: { broadcaster_user_id: 'uid-OTHER' } },
+    ] as any);
+
+    await subscribeForStreamer('sess-foreign', {
+      uid: 'uid-foreign',
+      token: 'tok-foreign',
+      name: 'botInChannel',
+      config: { follow_enabled: true, sub_enabled: false, raid_enabled: false } as any,
+      streamerId: 21,
+    });
+
+    expect(deleteEventSubSubscription).not.toHaveBeenCalledWith('other-broadcaster-sub', 'tok-foreign');
+  });
+
   it('prunes a duplicate subscription of a still-desired type left over from a prior session', async () => {
     vi.mocked(getActiveChannels).mockReturnValue(new Set(['botinchannel']));
     vi.mocked(createEventSubSubscription).mockResolvedValue('sub-new-follow');
     // The old, orphaned subscription (e.g. from a process that died without stop()) is still
     // "enabled" and shows up alongside the one just created this round.
     vi.mocked(listEventSubSubscriptions).mockResolvedValue([
-      { id: 'sub-new-follow', type: 'channel.follow' },
-      { id: 'sub-stale-follow', type: 'channel.follow' },
+      { id: 'sub-new-follow', type: 'channel.follow', condition: { broadcaster_user_id: 'uid-dup', moderator_user_id: 'uid-dup' } },
+      { id: 'sub-stale-follow', type: 'channel.follow', condition: { broadcaster_user_id: 'uid-dup', moderator_user_id: 'uid-dup' } },
     ] as any);
 
     await subscribeForStreamer('sess-dup', {
@@ -358,7 +380,10 @@ describe('subscribeForStreamer', () => {
   it('keeps an existing subscription already bound to the live session without recreating it', async () => {
     vi.mocked(getActiveChannels).mockReturnValue(new Set(['botinchannel']));
     vi.mocked(listEventSubSubscriptions).mockResolvedValue([
-      { id: 'sub-live-follow', type: 'channel.follow', sessionId: 'sess-live-409' },
+      {
+        id: 'sub-live-follow', type: 'channel.follow', sessionId: 'sess-live-409',
+        condition: { broadcaster_user_id: 'uid-409', moderator_user_id: 'uid-409' },
+      },
     ] as any);
 
     const count = await subscribeForStreamer('sess-live-409', {
@@ -384,7 +409,10 @@ describe('subscribeForStreamer', () => {
     // tearing down the socket) — Twitch hasn't revoked it yet, so it still shows up here bound to
     // a session id that's no longer the live one.
     vi.mocked(listEventSubSubscriptions).mockResolvedValue([
-      { id: 'sub-dead-follow', type: 'channel.follow', sessionId: 'sess-old-dead' },
+      {
+        id: 'sub-dead-follow', type: 'channel.follow', sessionId: 'sess-old-dead',
+        condition: { broadcaster_user_id: 'uid-stale-session', moderator_user_id: 'uid-stale-session' },
+      },
     ] as any);
 
     await subscribeForStreamer('sess-new-live', {
@@ -401,6 +429,37 @@ describe('subscribeForStreamer', () => {
     expect(createEventSubSubscription).toHaveBeenCalledWith(
       'channel.follow', '2', { broadcaster_user_id: 'uid-stale-session', moderator_user_id: 'uid-stale-session' },
       'sess-new-live', 'tok-stale-session',
+    );
+  });
+
+  it('ignores a same-type subscription belonging to a different broadcaster the streamer merely moderates, rather than keeping or deleting it', async () => {
+    vi.mocked(getActiveChannels).mockReturnValue(new Set(['botinchannel']));
+    vi.mocked(createEventSubSubscription).mockResolvedValue('sub-own-follow');
+    // listEventSubSubscriptions is scoped by this streamer's own user token, but Twitch also
+    // matches subscriptions where that user is the *moderator* rather than the broadcaster — so
+    // another broadcaster's channel.follow subscription (this streamer is just a mod there) can
+    // show up here too, with the same type but a condition that doesn't reference this uid at all.
+    vi.mocked(listEventSubSubscriptions).mockResolvedValue([
+      {
+        id: 'sub-other-broadcaster-follow', type: 'channel.follow', sessionId: 'sess-new-mod',
+        condition: { broadcaster_user_id: 'uid-OTHER-broadcaster', moderator_user_id: 'uid-mod' },
+      },
+    ] as any);
+
+    await subscribeForStreamer('sess-new-mod', {
+      uid: 'uid-mod',
+      token: 'tok-mod',
+      name: 'botInChannel',
+      config: { follow_enabled: true, sub_enabled: false, raid_enabled: false } as any,
+      streamerId: 23,
+    });
+
+    // Not recognized as "this streamer's own" — never deleted, and a fresh subscription is
+    // created for this streamer's own channel.follow rather than being skipped as already-live.
+    expect(deleteEventSubSubscription).not.toHaveBeenCalledWith('sub-other-broadcaster-follow', 'tok-mod');
+    expect(createEventSubSubscription).toHaveBeenCalledWith(
+      'channel.follow', '2', { broadcaster_user_id: 'uid-mod', moderator_user_id: 'uid-mod' },
+      'sess-new-mod', 'tok-mod',
     );
   });
 
@@ -669,8 +728,8 @@ describe('error handling in subscription setup', () => {
   it('continues deleting remaining stale subscriptions after one deletion fails', async () => {
     vi.mocked(createEventSubSubscription).mockResolvedValue('sub-id');
     vi.mocked(listEventSubSubscriptions).mockResolvedValue([
-      { id: 'stale-1', type: 'channel.subscribe' },
-      { id: 'stale-2', type: 'channel.raid' },
+      { id: 'stale-1', type: 'channel.subscribe', condition: { broadcaster_user_id: 'uid-delete-err' } },
+      { id: 'stale-2', type: 'channel.raid', condition: { to_broadcaster_user_id: 'uid-delete-err' } },
     ] as any);
     vi.mocked(deleteEventSubSubscription)
       .mockRejectedValueOnce(new Error('delete failed'))
@@ -694,8 +753,8 @@ describe('error handling in subscription setup', () => {
   it('deletes stale subscriptions concurrently, isolating one deletion failure from the other', async () => {
     vi.mocked(createEventSubSubscription).mockResolvedValue('sub-id');
     vi.mocked(listEventSubSubscriptions).mockResolvedValue([
-      { id: 'stale-1', type: 'channel.subscribe' },
-      { id: 'stale-2', type: 'channel.raid' },
+      { id: 'stale-1', type: 'channel.subscribe', condition: { broadcaster_user_id: 'uid-concurrent-delete' } },
+      { id: 'stale-2', type: 'channel.raid', condition: { to_broadcaster_user_id: 'uid-concurrent-delete' } },
     ] as any);
 
     let rejectFirst!: (err: Error) => void;

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -140,35 +140,52 @@ async function createSubscriptionsForStreamer(
   const created = new Map<string, string>();
   if (!token) return { desired, created };
 
-  let existingByType = new Map<string, { id: string; sessionId?: string }>();
-  try {
-    const existing = await listEventSubSubscriptions(token);
-    existingByType = new Map(existing.map((sub) => [sub.type, { id: sub.id, sessionId: sub.sessionId }]));
-  } catch (err) {
-    log.error(`Failed to list existing EventSub subscriptions for ${name}:`, err);
-  }
+  const existingByType = await listExistingSubscriptionsByType(token, name);
 
   for (const group of SUBSCRIPTION_GROUPS) {
     if (!isGroupEnabled(group, config, enabledAlerts)) continue;
     for (const spec of group.specs(uid)) {
       desired.add(spec.type);
-      const existing = existingByType.get(spec.type);
-      if (existing && existing.sessionId === sessionId) {
-        created.set(spec.type, existing.id);
-        continue;
-      }
-      if (existing) {
-        log.warn(`Deleting stale ${spec.type} subscription (${existing.id}) for ${name} — bound to a different session`);
-        await deleteEventSubSubscription(existing.id, token).catch((err) => {
-          log.error(`Failed to delete stale ${spec.type} subscription for ${name}:`, err);
-        });
-      }
-      const id = await subscribe(sessionId, spec, token, name);
+      const id = await ensureSubscription(sessionId, spec, token, name, existingByType.get(spec.type));
       if (id !== null) created.set(spec.type, id);
     }
   }
 
   return { desired, created };
+}
+
+/** Fetches existing EventSub subscriptions and indexes them by type. Returns an empty map (and
+ *  logs) on failure — callers treat that the same as "nothing exists yet" and create fresh. */
+async function listExistingSubscriptionsByType(
+  token: string, name: string,
+): Promise<Map<string, { id: string; sessionId?: string }>> {
+  try {
+    const existing = await listEventSubSubscriptions(token);
+    return new Map(existing.map((sub) => [sub.type, { id: sub.id, sessionId: sub.sessionId }]));
+  } catch (err) {
+    log.error(`Failed to list existing EventSub subscriptions for ${name}:`, err);
+    return new Map();
+  }
+}
+
+/**
+ * Ensures a single subscription type is live on the given session: keeps an existing
+ * subscription that's already bound to `sessionId`, deletes one bound to any other (stale/dead)
+ * session before recreating it, or creates fresh if none exists.
+ * @returns The live subscription's id, or null if creation failed (see {@link subscribe}).
+ */
+async function ensureSubscription(
+  sessionId: string, spec: SubSpec, token: string, name: string,
+  existing: { id: string; sessionId?: string } | undefined,
+): Promise<string | null> {
+  if (existing && existing.sessionId === sessionId) return existing.id;
+  if (existing) {
+    log.warn(`Deleting stale ${spec.type} subscription (${existing.id}) for ${name} — bound to a different session`);
+    await deleteEventSubSubscription(existing.id, token).catch((err) => {
+      log.error(`Failed to delete stale ${spec.type} subscription for ${name}:`, err);
+    });
+  }
+  return subscribe(sessionId, spec, token, name);
 }
 
 /**

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -29,6 +29,17 @@ export function clearAuthFailedSubs(login: string): void {
   for (const key of authFailedSubs) if (key.startsWith(prefix)) authFailedSubs.delete(key);
 }
 
+/** True if `condition` identifies `uid` as the broadcaster — every {@link SubSpec} in
+ *  `SUBSCRIPTION_GROUPS` sets one of these two fields to the target streamer's uid. Used to
+ *  filter `listEventSubSubscriptions`' result down to this streamer's own subscriptions: that
+ *  call is scoped by the streamer's *user token*, which Twitch also matches against subscriptions
+ *  where the token's user is a moderator (e.g. `channel.follow`'s `moderator_user_id`) rather than
+ *  the broadcaster — so without this filter, another broadcaster's subscription (on a channel this
+ *  streamer moderates) could be mistaken for this streamer's own and wrongly kept or deleted. */
+function isOwnSubscription(condition: Record<string, string>, uid: string): boolean {
+  return condition.broadcaster_user_id === uid || condition.to_broadcaster_user_id === uid;
+}
+
 /**
  * Deletes subscriptions that shouldn't be active any more: those whose type isn't in
  * `desired` at all (e.g. the streamer turned off raid alerts), and — for types that were
@@ -44,7 +55,9 @@ export function clearAuthFailedSubs(login: string): void {
  * calls) — in that rare case it's left untouched, since we can't tell which one Twitch considers
  * the live one without risking deleting the subscription actually receiving events.
  *
- * @param uid - Broadcaster's Twitch user ID, used only for error logging.
+ * @param uid - Broadcaster's Twitch user ID; also used to filter out another broadcaster's
+ *   subscription that Twitch included only because this streamer moderates that channel (see
+ *   {@link isOwnSubscription}) — never deleted, regardless of type or desired state.
  * @param desired - Subscription types that should exist after this call.
  * @param created - Type → subscription id for subscriptions freshly created this round (see
  *   {@link createSubscriptionsForStreamer}); a type present here has any other existing
@@ -55,7 +68,7 @@ async function deleteStaleSubscriptions(
   uid: string, desired: Set<string>, created: ReadonlyMap<string, string>, userToken: string | null,
 ): Promise<void> {
   if (!userToken) return;
-  let existing: Array<{ id: string; type: string }>;
+  let existing: Array<{ id: string; type: string; condition: Record<string, string> }>;
   try {
     existing = await listEventSubSubscriptions(userToken);
   } catch (err) {
@@ -67,6 +80,7 @@ async function deleteStaleSubscriptions(
   // of the cleanup — leaving a still-undeleted stale duplicate would keep delivering
   // notifications and double-firing the type's handler, the exact failure this cleanup targets.
   const staleSubs = existing.filter((sub) => {
+    if (!isOwnSubscription(sub.condition, uid)) return false;
     const keptId = created.get(sub.type);
     const isStaleDuplicate = keptId !== undefined && sub.id !== keptId;
     return !desired.has(sub.type) || isStaleDuplicate;
@@ -140,7 +154,7 @@ async function createSubscriptionsForStreamer(
   const created = new Map<string, string>();
   if (!token) return { desired, created };
 
-  const existingByType = await listExistingSubscriptionsByType(token, name);
+  const existingByType = await listExistingSubscriptionsByType(token, uid, name);
 
   for (const group of SUBSCRIPTION_GROUPS) {
     if (!isGroupEnabled(group, config, enabledAlerts)) continue;
@@ -154,14 +168,20 @@ async function createSubscriptionsForStreamer(
   return { desired, created };
 }
 
-/** Fetches existing EventSub subscriptions and indexes them by type. Returns an empty map (and
- *  logs) on failure — callers treat that the same as "nothing exists yet" and create fresh. */
+/** Fetches existing EventSub subscriptions, filters out any that Twitch returned only because
+ *  this streamer moderates a different broadcaster's channel (see {@link isOwnSubscription}), and
+ *  indexes the rest by type. Returns an empty map (and logs) on failure — callers treat that the
+ *  same as "nothing exists yet" and create fresh. */
 async function listExistingSubscriptionsByType(
-  token: string, name: string,
+  token: string, uid: string, name: string,
 ): Promise<Map<string, { id: string; sessionId?: string }>> {
   try {
     const existing = await listEventSubSubscriptions(token);
-    return new Map(existing.map((sub) => [sub.type, { id: sub.id, sessionId: sub.sessionId }]));
+    return new Map(
+      existing
+        .filter((sub) => isOwnSubscription(sub.condition, uid))
+        .map((sub) => [sub.type, { id: sub.id, sessionId: sub.sessionId }]),
+    );
   } catch (err) {
     log.error(`Failed to list existing EventSub subscriptions for ${name}:`, err);
     return new Map();

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -128,14 +128,24 @@ interface SubscriptionResult {
   created: Map<string, string>;
 }
 
+/** True if `a` and `b` have exactly the same keys and values — used to tell "the subscription
+ *  this spec wants" apart from a same-type subscription with a different condition (e.g. a
+ *  leftover from an older API version whose condition shape has since changed), which type-only
+ *  matching would otherwise mistake for it. */
+function conditionsEqual(a: Record<string, string>, b: Record<string, string>): boolean {
+  const aKeys = Object.keys(a);
+  if (aKeys.length !== Object.keys(b).length) return false;
+  return aKeys.every((key) => a[key] === b[key]);
+}
+
 /**
- * Creates all desired EventSub subscriptions for a single streamer. Before creating each type,
- * checks whether Twitch already has a subscription of that type: if it's bound to the live
- * `sessionId`, it's kept as-is (no redundant create call); if it's bound to any other session id
- * — a duplicate left over from a dead/prior connection (e.g. after `onError`/`forceReconnect`
- * tore down a socket without a clean close, so Twitch hadn't yet revoked its subscriptions) —
- * it's deleted first so the fresh create can't 409 against it and leave the *new* session with no
- * working subscription of that type.
+ * Creates all desired EventSub subscriptions for a single streamer. Before creating each spec,
+ * checks whether Twitch already has a subscription matching both its type *and* condition
+ * exactly: if it's bound to the live `sessionId`, it's kept as-is (no redundant create call); if
+ * it's bound to any other session id — a duplicate left over from a dead/prior connection (e.g.
+ * after `onError`/`forceReconnect` tore down a socket without a clean close, so Twitch hadn't yet
+ * revoked its subscriptions) — it's deleted first so the fresh create can't 409 against it and
+ * leave the *new* session with no working subscription for that spec.
  * @returns The desired-types set alongside a type → id map of subscriptions actually created (or
  *   confirmed already-live on this session) this round (a type is absent from `created` only on a
  *   genuine race — see {@link deleteStaleSubscriptions}).
@@ -154,13 +164,16 @@ async function createSubscriptionsForStreamer(
   const created = new Map<string, string>();
   if (!token) return { desired, created };
 
-  const existingByType = await listExistingSubscriptionsByType(token, uid, name);
+  const ownSubscriptions = await listOwnSubscriptions(token, uid, name);
 
   for (const group of SUBSCRIPTION_GROUPS) {
     if (!isGroupEnabled(group, config, enabledAlerts)) continue;
     for (const spec of group.specs(uid)) {
       desired.add(spec.type);
-      const id = await ensureSubscription(sessionId, spec, token, name, existingByType.get(spec.type));
+      const match = ownSubscriptions.find(
+        (sub) => sub.type === spec.type && conditionsEqual(sub.condition, spec.condition),
+      );
+      const id = await ensureSubscription(sessionId, spec, token, name, match);
       if (id !== null) created.set(spec.type, id);
     }
   }
@@ -168,23 +181,19 @@ async function createSubscriptionsForStreamer(
   return { desired, created };
 }
 
-/** Fetches existing EventSub subscriptions, filters out any that Twitch returned only because
- *  this streamer moderates a different broadcaster's channel (see {@link isOwnSubscription}), and
- *  indexes the rest by type. Returns an empty map (and logs) on failure — callers treat that the
- *  same as "nothing exists yet" and create fresh. */
-async function listExistingSubscriptionsByType(
+/** Fetches existing EventSub subscriptions and filters out any that Twitch returned only because
+ *  this streamer moderates a different broadcaster's channel (see {@link isOwnSubscription}).
+ *  Returns an empty array (and logs) on failure — callers treat that the same as "nothing exists
+ *  yet" and create fresh. */
+async function listOwnSubscriptions(
   token: string, uid: string, name: string,
-): Promise<Map<string, { id: string; sessionId?: string }>> {
+): Promise<Array<{ id: string; type: string; condition: Record<string, string>; sessionId?: string }>> {
   try {
     const existing = await listEventSubSubscriptions(token);
-    return new Map(
-      existing
-        .filter((sub) => isOwnSubscription(sub.condition, uid))
-        .map((sub) => [sub.type, { id: sub.id, sessionId: sub.sessionId }]),
-    );
+    return existing.filter((sub) => isOwnSubscription(sub.condition, uid));
   } catch (err) {
     log.error(`Failed to list existing EventSub subscriptions for ${name}:`, err);
-    return new Map();
+    return [];
   }
 }
 

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -38,10 +38,11 @@ export function clearAuthFailedSubs(login: string): void {
  * an orphaned WebSocket subscription on its own, but not instantaneously — until then it stays
  * "enabled" and delivers notifications alongside the new one, double-firing the type's handler
  * for every event (e.g. `handleRedemption` recording two dashboard entries for one redemption).
- * A type whose subscribe() returned null this round (409 — Twitch says an identical
- * type+condition subscription already exists) is left untouched: `created` has no entry for
- * it, so none of its existing subscriptions get pruned, since we can't tell which one Twitch
- * considers the live one without risking deleting the subscription actually receiving events.
+ * `createSubscriptionsForStreamer` now proactively deletes a stale subscription (bound to a
+ * session id other than the live one) before recreating it, so a type only ends up missing from
+ * `created` here on a genuine race (another process/tab recreated it between our list and create
+ * calls) — in that rare case it's left untouched, since we can't tell which one Twitch considers
+ * the live one without risking deleting the subscription actually receiving events.
  *
  * @param uid - Broadcaster's Twitch user ID, used only for error logging.
  * @param desired - Subscription types that should exist after this call.
@@ -114,11 +115,16 @@ interface SubscriptionResult {
 }
 
 /**
- * Creates all desired EventSub subscriptions for a single streamer.
- * @returns The desired-types set alongside a type → id map of subscriptions actually created
- *   this round (a type is absent from `created` if `subscribe` hit a 409 — Twitch already has
- *   an identical type+condition subscription active — so the caller has no id to prefer over
- *   whatever else `listEventSubSubscriptions` later reports for that type).
+ * Creates all desired EventSub subscriptions for a single streamer. Before creating each type,
+ * checks whether Twitch already has a subscription of that type: if it's bound to the live
+ * `sessionId`, it's kept as-is (no redundant create call); if it's bound to any other session id
+ * — a duplicate left over from a dead/prior connection (e.g. after `onError`/`forceReconnect`
+ * tore down a socket without a clean close, so Twitch hadn't yet revoked its subscriptions) —
+ * it's deleted first so the fresh create can't 409 against it and leave the *new* session with no
+ * working subscription of that type.
+ * @returns The desired-types set alongside a type → id map of subscriptions actually created (or
+ *   confirmed already-live on this session) this round (a type is absent from `created` only on a
+ *   genuine race — see {@link deleteStaleSubscriptions}).
  */
 async function createSubscriptionsForStreamer(
   sessionId: string, data: StreamerEventSubData,
@@ -134,10 +140,29 @@ async function createSubscriptionsForStreamer(
   const created = new Map<string, string>();
   if (!token) return { desired, created };
 
+  let existingByType = new Map<string, { id: string; sessionId?: string }>();
+  try {
+    const existing = await listEventSubSubscriptions(token);
+    existingByType = new Map(existing.map((sub) => [sub.type, { id: sub.id, sessionId: sub.sessionId }]));
+  } catch (err) {
+    log.error(`Failed to list existing EventSub subscriptions for ${name}:`, err);
+  }
+
   for (const group of SUBSCRIPTION_GROUPS) {
     if (!isGroupEnabled(group, config, enabledAlerts)) continue;
     for (const spec of group.specs(uid)) {
       desired.add(spec.type);
+      const existing = existingByType.get(spec.type);
+      if (existing && existing.sessionId === sessionId) {
+        created.set(spec.type, existing.id);
+        continue;
+      }
+      if (existing) {
+        log.warn(`Deleting stale ${spec.type} subscription (${existing.id}) for ${name} — bound to a different session`);
+        await deleteEventSubSubscription(existing.id, token).catch((err) => {
+          log.error(`Failed to delete stale ${spec.type} subscription for ${name}:`, err);
+        });
+      }
       const id = await subscribe(sessionId, spec, token, name);
       if (id !== null) created.set(spec.type, id);
     }


### PR DESCRIPTION
## Summary

Live channel-point redemption (and other) EventSub events were being missed entirely, always caught only by the 60s `EventSubReconciliation` poller instead. Root cause:

- `StreamerConnection.onError()`/`forceReconnect()` tears down a dead WebSocket without calling `socket.close()`, so a socket that dies without a clean TCP close (observed in production) isn't promptly reported to Twitch as gone — its EventSub subscriptions stay "enabled" on Twitch's side.
- The reconnect immediately opens a new socket/session and re-subscribes every type (including `channel.channel_points_custom_reward_redemption.add`) against the new session.
- Twitch responds 409 (identical type+condition subscription already exists — the still-live orphan from the dead session). `subscribe()` silently swallowed this: no error logged, no recreation attempted.
- `deleteStaleSubscriptions` explicitly declines to prune a type whose create returned `null` this round, since it can't tell which of the (now two) subscriptions of that type Twitch considers live — so the orphan is left in place indefinitely, bound to a session nobody is listening on any more.
- Net effect: the new, healthy session has no working subscription for that type, so live notifications go nowhere; only the reconciliation poller ever surfaces the redemption.

## Changes

- `twitchApiEventSub.ts`: `listEventSubSubscriptions` now also returns each subscription's `transport.session_id` (as `sessionId`).
- `twitchEventSubSubscriptions.ts`: `createSubscriptionsForStreamer` looks up each desired type's existing subscription before creating it:
  - Already bound to the live session → kept as-is, no redundant create call.
  - Bound to any other (stale/dead) session → deleted first, then a fresh subscription is created — so the 409-and-silently-give-up path is avoided rather than relied on.
- `twitchEventSubConnection.ts`: `forceReconnect` now best-effort calls `socket.close()` on the dying socket (without waiting on it) so Twitch has a better chance of revoking that session's subscriptions promptly, rather than relying solely on its own delayed dead-connection detection.
- Updated/added tests in `twitchEventSubSubscriptions.test.ts` covering: keeping a same-session subscription untouched, deleting a stale cross-session duplicate before recreating, and the updated error-logging paths around the new pre-create lookup.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (3266 tests passing)
- [x] `npm run lint` (0 errors; pre-existing unrelated warnings only)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01B4qUbzsqsPfcdVsCTGpLND

---
_Generated by [Claude Code](https://claude.ai/code/session_01B4qUbzsqsPfcdVsCTGpLND)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented Twitch EventSub subscriptions from other channels you moderate from being incorrectly retained, deleted, or recreated.
  * Improved matching of subscriptions by broadcaster and subscription conditions.
  * Improved reconnection handling by closing active connections before reconnecting.
  * Continued to prevent duplicate and stale subscriptions during session changes.
  * Improved resilience when subscription listing or cleanup encounters errors.

* **Improvements**
  * EventSub subscription details now include broadcaster conditions and the associated WebSocket session when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->