### PR TITLE
Fix EventSub revocation cleanup and a stale reconciliation comment

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -62,6 +62,7 @@ vi.mock('./twitch/eventsub/twitchEventSubRuntime', () => ({
   registerEventSubCompanionRuntime: vi.fn(),
   registerEventSubAlertRuntime: vi.fn(),
   registerEventSubDashboardRuntime: vi.fn(),
+  registerEventSubReloadRuntime: vi.fn(),
 }));
 vi.mock('./web/routes/overlaySource', () => ({ pushOverlayEvent: vi.fn() }));
 vi.mock('./web/routes/companionEvents', () => ({ pushCompanionEvent: vi.fn() }));
@@ -182,6 +183,15 @@ describe('startup — guild registry preload', () => {
     await runMain();
 
     expect(vi.mocked(registerEventSubDashboardRuntime)).toHaveBeenCalledWith({ pushDashboardEvent });
+  });
+
+  it('registers the EventSub reload runtime with reloadEventSubSubscriptions on a clean startup', async () => {
+    const { registerEventSubReloadRuntime } = await import('./twitch/eventsub/twitchEventSubRuntime.js');
+    const { reloadEventSubSubscriptions } = await import('./twitch/eventsub/twitchEventSub.js');
+
+    await runMain();
+
+    expect(vi.mocked(registerEventSubReloadRuntime)).toHaveBeenCalledWith({ triggerReload: reloadEventSubSubscriptions });
   });
 
   it('calls process.exit(1) and does not start the bot when reloadGuildRegistry rejects', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import { registerShoutoutRuntime } from './commands/shoutoutHandler';
 import { registerCountdownTwitchRuntime } from './commands/countdownHandler';
 import {
   registerEventSubOverlayRuntime, registerEventSubTwitchRuntime, registerEventSubCompanionRuntime,
-  registerEventSubAlertRuntime, registerEventSubDashboardRuntime,
+  registerEventSubAlertRuntime, registerEventSubDashboardRuntime, registerEventSubReloadRuntime,
 } from './twitch/eventsub/twitchEventSubRuntime';
 import { pushOverlayEvent } from './web/routes/overlaySource';
 import { pushCompanionEvent } from './web/routes/companionEvents';
@@ -123,6 +123,7 @@ async function main(): Promise<void> {
   registerEventSubAlertRuntime({ pushAlertEvent });
   registerEventSubDashboardRuntime({ pushDashboardEvent });
   registerEventSubTwitchRuntime({ send: sayInChannel });
+  registerEventSubReloadRuntime({ triggerReload: reloadEventSubSubscriptions });
   registerRewardPricingRuntime({ pushPricingUpdate });
   registerTimerCommandsRuntime({ send: sayInChannel, getLoginUserIds: getActiveChannelUserIds });
   registerTwitchGuildResolutionRuntime({ resolveGuildIdForDiscordId });

--- a/src/twitch/eventsub/twitchEventSubDispatch.test.ts
+++ b/src/twitch/eventsub/twitchEventSubDispatch.test.ts
@@ -242,6 +242,16 @@ describe('handleRevocation', () => {
     expect(triggerReload).toHaveBeenCalledTimes(1);
   });
 
+  it('does not log a clear or trigger a reload when clearStreamerToken resolves false (no row matched)', async () => {
+    vi.mocked(clearStreamerToken).mockResolvedValueOnce(false);
+
+    handleRevocation({ type: 'channel.follow', status: 'authorization_revoked', condition: { broadcaster_user_id: 'uid-revoke' } });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(logMock.warn).not.toHaveBeenCalledWith('Cleared token for revokedStreamer (authorization_revoked)');
+    expect(triggerReload).not.toHaveBeenCalled();
+  });
+
   it('does not trigger a reload if clearing the token fails', async () => {
     vi.mocked(clearStreamerToken).mockRejectedValueOnce(new Error('db down'));
 

--- a/src/twitch/eventsub/twitchEventSubDispatch.test.ts
+++ b/src/twitch/eventsub/twitchEventSubDispatch.test.ts
@@ -37,6 +37,7 @@ import {
   handleStreamOnline, handleStreamOffline, handleChannelUpdate,
   handleFollow, handleSub, handleResub, handleGiftSub, handleRaid, handleRedemption,
 } from './twitchEventSubHandler';
+import { registerEventSubReloadRuntime } from './twitchEventSubRuntime';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -184,12 +185,16 @@ describe('removeStreamerFromMap', () => {
 // handleRevocation
 // ---------------------------------------------------------------------------
 describe('handleRevocation', () => {
+  const triggerReload = vi.fn();
+
   beforeEach(() => {
     vi.mocked(clearStreamerToken).mockResolvedValue(true as any);
     setStreamerInfo('uid-revoke', {
       login: 'revokedStreamer', streamerId: 100,
       config: { follow_enabled: false, sub_enabled: false, raid_enabled: false } as any,
     });
+    triggerReload.mockClear();
+    registerEventSubReloadRuntime({ triggerReload });
   });
 
   it('logs the revocation but does not clear a token for an unknown broadcaster', () => {
@@ -228,6 +233,34 @@ describe('handleRevocation', () => {
     await new Promise((resolve) => setImmediate(resolve));
 
     expect(logMock.error).toHaveBeenCalledWith('Clear token error:', expect.any(Error));
+  });
+
+  it('triggers an EventSub reload once the token is cleared, so the now-tokenless connection is torn down promptly', async () => {
+    handleRevocation({ type: 'channel.follow', status: 'authorization_revoked', condition: { broadcaster_user_id: 'uid-revoke' } });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(triggerReload).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not trigger a reload if clearing the token fails', async () => {
+    vi.mocked(clearStreamerToken).mockRejectedValueOnce(new Error('db down'));
+
+    handleRevocation({ type: 'channel.follow', status: 'authorization_revoked', condition: { broadcaster_user_id: 'uid-revoke' } });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(triggerReload).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when no reload runtime is registered', async () => {
+    // Simulates index.ts never having called registerEventSubReloadRuntime (e.g. app startup
+    // order) — eventSubReloadRuntimeRegistry.get() returns null and must be handled with
+    // optional chaining, not assumed non-null.
+    registerEventSubReloadRuntime(null as unknown as { triggerReload: () => void });
+
+    expect(() => {
+      handleRevocation({ type: 'channel.follow', status: 'authorization_revoked', condition: { broadcaster_user_id: 'uid-revoke' } });
+    }).not.toThrow();
+    await new Promise((resolve) => setImmediate(resolve));
   });
 });
 

--- a/src/twitch/eventsub/twitchEventSubDispatch.ts
+++ b/src/twitch/eventsub/twitchEventSubDispatch.ts
@@ -6,6 +6,7 @@ import {
   handleStreamOnline, handleStreamOffline, handleChannelUpdate,
   FollowEvent, SubEvent, ResubEvent, GiftSubEvent, RaidEvent, RedemptionEvent,
 } from './twitchEventSubHandler';
+import { eventSubReloadRuntimeRegistry } from './twitchEventSubRuntime';
 
 const log = createLogger('EventSub');
 
@@ -87,7 +88,14 @@ export function dispatchNotification(type: string, event: Record<string, unknown
     .catch((err) => log.error(`${type} handler error:`, err));
 }
 
-/** Handles a subscription revocation message, clearing the broadcaster's token if authorisation was revoked. */
+/**
+ * Handles a subscription revocation message, clearing the broadcaster's token if authorisation
+ * was revoked. Once the token is cleared, triggers a full EventSub reload (via
+ * {@link eventSubReloadRuntimeRegistry}) so the now-tokenless streamer's `StreamerConnection` is
+ * torn down promptly — `subscribeForStreamer` sees zero desired subscriptions without a token and
+ * self-stops the connection — rather than sitting open and idle until some unrelated admin action
+ * elsewhere happens to trigger the next reload.
+ */
 export function handleRevocation(sub: { type: string; status: string; condition: Record<string, string> }): void {
   log.warn(`Subscription revoked: type=${sub.type} status=${sub.status}`);
 
@@ -97,7 +105,10 @@ export function handleRevocation(sub: { type: string; status: string; condition:
       const info = streamerMap.get(broadcasterId);
       if (info) {
         clearStreamerToken(info.streamerId)
-          .then(() => log.warn(`Cleared token for ${info.login} (${sub.status})`))
+          .then(() => {
+            log.warn(`Cleared token for ${info.login} (${sub.status})`);
+            eventSubReloadRuntimeRegistry.get()?.triggerReload();
+          })
           .catch((err) => log.error('Clear token error:', err));
       }
     }

--- a/src/twitch/eventsub/twitchEventSubDispatch.ts
+++ b/src/twitch/eventsub/twitchEventSubDispatch.ts
@@ -105,7 +105,17 @@ export function handleRevocation(sub: { type: string; status: string; condition:
       const info = streamerMap.get(broadcasterId);
       if (info) {
         clearStreamerToken(info.streamerId)
-          .then(() => {
+          /**
+           * Handles a successful `clearStreamerToken` resolution: only when a row was actually
+           * updated (`cleared` true) does it log the clear and trigger a reload — a `false`
+           * resolution means no row matched `info.streamerId` (e.g. the streamer was deleted in
+           * the same race window), so there's nothing to log as cleared and no connection left to
+           * reload for.
+           * @param cleared - Whether `clearStreamerToken` actually updated a row.
+           * @returns void
+           */
+          .then((cleared) => {
+            if (!cleared) return;
             log.warn(`Cleared token for ${info.login} (${sub.status})`);
             eventSubReloadRuntimeRegistry.get()?.triggerReload();
           })

--- a/src/twitch/eventsub/twitchEventSubRuntime.test.ts
+++ b/src/twitch/eventsub/twitchEventSubRuntime.test.ts
@@ -5,6 +5,7 @@ import {
   registerEventSubAlertRuntime, alertRuntimeRegistry,
   registerEventSubDashboardRuntime, dashboardEventRuntimeRegistry,
   registerEventSubTwitchRuntime, twitchRuntimeRegistry,
+  registerEventSubReloadRuntime, eventSubReloadRuntimeRegistry,
 } from './twitchEventSubRuntime';
 
 // createRuntimeRegistry's own register/get contract is covered by
@@ -48,5 +49,13 @@ describe('registerEventSubTwitchRuntime', () => {
     const runtime = { send: vi.fn().mockResolvedValue(undefined) };
     registerEventSubTwitchRuntime(runtime);
     expect(twitchRuntimeRegistry.get()).toBe(runtime);
+  });
+});
+
+describe('registerEventSubReloadRuntime', () => {
+  it('stores the runtime on eventSubReloadRuntimeRegistry', () => {
+    const runtime = { triggerReload: vi.fn() };
+    registerEventSubReloadRuntime(runtime);
+    expect(eventSubReloadRuntimeRegistry.get()).toBe(runtime);
   });
 });

--- a/src/twitch/eventsub/twitchEventSubRuntime.ts
+++ b/src/twitch/eventsub/twitchEventSubRuntime.ts
@@ -148,3 +148,24 @@ export const twitchRuntimeRegistry = createRuntimeRegistry<EventSubTwitchRuntime
 export function registerEventSubTwitchRuntime(runtime: EventSubTwitchRuntime): void {
   twitchRuntimeRegistry.register(runtime);
 }
+
+// Runtime injection for triggering a full EventSub subscription reload — avoids a circular
+// import back into twitchEventSub.ts, which itself imports (transitively, via
+// twitchEventSubSubscriptions.ts) this module's own dispatch code. Registered from index.ts,
+// same as every other runtime above.
+interface EventSubReloadRuntime {
+  /** Reloads every streamer's EventSub subscriptions from the DB, tearing down and recreating
+   *  connections as needed — see `reloadEventSubSubscriptions` in `twitchEventSub.ts`. */
+  triggerReload: () => void;
+}
+
+export const eventSubReloadRuntimeRegistry = createRuntimeRegistry<EventSubReloadRuntime>();
+
+/**
+ * Register the EventSub reload trigger. Called from index.ts.
+ * @param runtime - The {@link EventSubReloadRuntime} to store.
+ * @returns void
+ */
+export function registerEventSubReloadRuntime(runtime: EventSubReloadRuntime): void {
+  eventSubReloadRuntimeRegistry.register(runtime);
+}

--- a/src/twitch/twitchChannelMembership.ts
+++ b/src/twitch/twitchChannelMembership.ts
@@ -297,7 +297,11 @@ export async function joinTwitchChannel(channel: string): Promise<void> {
     try {
       await throttledJoin(_client, normalized, (call) => compensateIfStale(membershipDeps(), normalized, call, 'join'));
     } catch (err) {
-      // Roll back local state; reconnect reconciliation will retry via activeChannels.
+      // Roll back the optimistic add above so a failed join doesn't linger in activeChannels
+      // as if it were still desired. This also means reconcileJoinedChannels() — which only
+      // iterates activeChannels — will NOT retry this channel on its own; the rejection below
+      // propagates to the caller, who owns retrying (e.g. the admin panel surfacing an error
+      // for the user to try again).
       activeChannels.delete(normalized);
       setTwitchChannel(normalized, false);
       log.error(`Failed to join channel ${normalized}:`, err);


### PR DESCRIPTION
## Summary

Follow-up from an in-depth review of the Twitch chat/EventSub code (which is otherwise very heavily hardened by recent fixes #525–#569). Two gaps found and fixed:

- **`handleRevocation` never cleaned up the affected `StreamerConnection`.** When Twitch revokes a streamer's authorization directly (`authorization_revoked`/`user_removed`), the DB token was correctly cleared but nothing tore down or reloaded that streamer's EventSub WebSocket connection — it stayed open and idle until some unrelated admin action elsewhere happened to trigger the next global reload (`reloadEventSubSubscriptions()` is otherwise only called from OAuth callback / config-save / channel-join routes; there's no periodic reload). Fixed by adding a `registerEventSubReloadRuntime` runtime-injection hook (same pattern as the other EventSub runtimes, to avoid a circular import into `twitchEventSub.ts`) and calling it from `handleRevocation` once the token is actually cleared — `subscribeForStreamer` already self-stops a connection with zero desired subscriptions once a reload picks it up with no token.
- **Stale/misleading comment in `joinTwitchChannel`'s failure path** (`twitchChannelMembership.ts`) claimed "reconnect reconciliation will retry via activeChannels," but the code right next to it removes the channel from `activeChannels` on failure, so reconciliation (which only iterates `activeChannels`) never retries it — the caller owns retrying. Not a functional bug, just corrected the comment to match actual behavior.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 3273 tests passing)
- [x] `npm run lint` (0 errors)
- [x] `npm run check:circular` (no circular deps introduced by the new runtime-injection hook)
- [x] Added tests covering: revocation triggers a reload once the token is cleared, does not trigger one if the token-clear fails, and doesn't throw when no reload runtime is registered; plus a registry-delegation test for `registerEventSubReloadRuntime` and a startup-wiring test in `index.test.ts`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BbUUaaj9EyJZmieNNKVyp6)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Twitch EventSub subscriptions now reload after successful authorization or user-removal revocations.
  * Tokenless subscriptions stop promptly, while unsuccessful or unmatched revocations no longer trigger unnecessary reloads.
  * Failed Twitch channel joins no longer trigger repeated automatic retries; errors remain available for explicit retry.
  * Revocation handling remains safe when subscription reload services are unavailable.

* **Reliability**
  * Improved startup and runtime recovery for Twitch EventSub subscriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->