### PR TITLE
Fix counterScheduler stop-during-tick race

### DIFF
--- a/src/commands/counterScheduler.test.ts
+++ b/src/commands/counterScheduler.test.ts
@@ -109,6 +109,31 @@ describe('counterScheduler', () => {
     expect(archiveAndResetYearlyCounters).toHaveBeenCalledTimes(1);
   });
 
+  it('stopping while a tick is still awaiting its archive call prevents the chain from resuming', async () => {
+    vi.setSystemTime(new Date(2025, 0, 1)); // Jan 1, 2025
+
+    // Keep the in-flight tick's archive call pending so stop() races it before
+    // schedulerTimer gets (re)assigned.
+    let resolveArchive!: (count: number) => void;
+    archiveAndResetYearlyCounters.mockImplementationOnce(
+      () => new Promise((resolve) => { resolveArchive = resolve; }),
+    );
+
+    startCounterScheduler();
+    await Promise.resolve(); // let tick() start and reach the pending archive await
+
+    stopCounterScheduler(); // schedulerTimer is still null here — nothing to clear
+
+    resolveArchive(0);
+    await flushAsync(); // let the in-flight tick() finish and (attempt to) reschedule
+
+    // Without the `started` guard, tick() would have re-armed schedulerTimer here anyway.
+    await vi.advanceTimersByTimeAsync(3_600_000);
+    await flushAsync();
+
+    expect(archiveAndResetYearlyCounters).toHaveBeenCalledTimes(1);
+  });
+
   it('stopCounterScheduler prevents further ticks', async () => {
     vi.setSystemTime(new Date(2025, 5, 15)); // June 15 — no archive expected
     startCounterScheduler();

--- a/src/commands/counterScheduler.test.ts
+++ b/src/commands/counterScheduler.test.ts
@@ -134,6 +134,35 @@ describe('counterScheduler', () => {
     expect(archiveAndResetYearlyCounters).toHaveBeenCalledTimes(1);
   });
 
+  it('a stop followed by a restart before the old tick resolves does not leak a duplicate chain', async () => {
+    vi.setSystemTime(new Date(2025, 0, 1)); // Jan 1, 2025
+
+    // Keep the first run's archive call pending so restart races it.
+    let resolveFirstArchive!: (count: number) => void;
+    archiveAndResetYearlyCounters.mockImplementationOnce(
+      () => new Promise((resolve) => { resolveFirstArchive = resolve; }),
+    );
+
+    startCounterScheduler();
+    await Promise.resolve(); // let the first tick() start and reach the pending archive await
+
+    stopCounterScheduler(); // schedulerTimer is still null here — nothing to clear
+    startCounterScheduler(); // flips `started` back to true for a new run; its own tick
+    await flushAsync(); // resolves immediately (default mock) and arms one timer
+
+    resolveFirstArchive(0); // let the stale first-run tick resolve and attempt to reschedule
+    await flushAsync();
+
+    // Without the generation guard, the stale first-run tick would arm a second,
+    // independent timer here (overwriting `schedulerTimer` and leaking the new run's own
+    // timer) — leaving two hourly chains running instead of one.
+    expect(vi.getTimerCount()).toBe(1);
+
+    // A single stopCounterScheduler() call should still fully stop everything.
+    stopCounterScheduler();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   it('stopCounterScheduler prevents further ticks', async () => {
     vi.setSystemTime(new Date(2025, 5, 15)); // June 15 — no archive expected
     startCounterScheduler();

--- a/src/commands/counterScheduler.ts
+++ b/src/commands/counterScheduler.ts
@@ -14,8 +14,14 @@ let lastArchivedYear: number | null = null;
 // used as the re-entrancy guard: two synchronous back-to-back start calls would both see it
 // as null and both kick off a tick() chain. This flag closes that gap.
 let started = false;
+// Incremented on every start, so a tick() begun by an earlier start (still awaiting
+// archiveAndResetYearlyCounters when that run was stopped) can tell it's no longer the
+// active run even after a subsequent start flips `started` back to true — a plain
+// `started` check alone can't distinguish "still my run" from "a newer run began".
+let runGeneration = 0;
 
-async function tick(): Promise<void> {
+/** Polls once for the yearly counter archive and reschedules itself hourly while its run is still active. */
+async function tick(myGeneration: number): Promise<void> {
   const now = new Date();
   const prevYear = now.getFullYear() - 1;
 
@@ -30,12 +36,13 @@ async function tick(): Promise<void> {
     }
   }
 
-  // Only reschedule while still started — otherwise a stop() that raced this tick's
-  // async work (schedulerTimer was still null when stop() ran, so it had nothing to
-  // clear) would have its cancellation silently undone here.
-  if (started) {
+  // Only reschedule while still the active run — guards both a stop() that raced this
+  // tick's async work (schedulerTimer was still null when stop() ran, so it had nothing
+  // to clear) and a stop()-then-start() that raced it (started is true again, but from a
+  // newer run than the one this tick belongs to).
+  if (started && myGeneration === runGeneration) {
     schedulerTimer = setTimeout(
-      () => tick().catch((err) => log.error('Unhandled error:', err)),
+      () => tick(myGeneration).catch((err) => log.error('Unhandled error:', err)),
       POLL_INTERVAL_MS,
     );
   }
@@ -49,7 +56,8 @@ async function tick(): Promise<void> {
 export function startCounterScheduler(): void {
   if (started) return;
   started = true;
-  tick().catch((err) => log.error('Startup error:', err));
+  runGeneration += 1;
+  tick(runGeneration).catch((err) => log.error('Startup error:', err));
   const hoursUntil = Math.round(msUntilNextJan1() / 3_600_000);
   log.info(`Started — polling hourly, next yearly archive in ~${hoursUntil}h.`);
 }

--- a/src/commands/counterScheduler.ts
+++ b/src/commands/counterScheduler.ts
@@ -30,10 +30,15 @@ async function tick(): Promise<void> {
     }
   }
 
-  schedulerTimer = setTimeout(
-    () => tick().catch((err) => log.error('Unhandled error:', err)),
-    POLL_INTERVAL_MS,
-  );
+  // Only reschedule while still started — otherwise a stop() that raced this tick's
+  // async work (schedulerTimer was still null when stop() ran, so it had nothing to
+  // clear) would have its cancellation silently undone here.
+  if (started) {
+    schedulerTimer = setTimeout(
+      () => tick().catch((err) => log.error('Unhandled error:', err)),
+      POLL_INTERVAL_MS,
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
Found during a full codebase review. `stopCounterScheduler()` only clears `schedulerTimer` if it's already set at the time it's called. If `stop` races an in-flight `tick()` call (e.g. `tick()` is awaiting `archiveAndResetYearlyCounters` and hasn't reached the point where it assigns `schedulerTimer` yet), the clear is a no-op, and the in-flight `tick()` then unconditionally re-arms the timer once it resolves — resurrecting the "stopped" polling chain. This contradicts the function's own doc comment about `started` guarding against a leaked duplicate chain.

- Guards the `setTimeout` reschedule in `tick()` with the `started` flag so a stop that lands mid-tick actually sticks.
- Adds a regression test (`stopping while a tick is still awaiting its archive call prevents the chain from resuming`) that reproduces the race with a manually-controlled pending promise.

Currently masked in production because `shutdown()` calls `process.exit(0)` shortly after `stopCounterScheduler()`, so this wasn't an active bug — but it's a real logic gap worth closing.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (3275 tests passed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GBvR11FcEXwtrwosMwn1Gz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where stopping the counter scheduler during an in-progress archive operation could unintentionally restart polling.
  - Scheduler shutdown now reliably prevents additional timers from being scheduled.
  - Fixed stop-and-restart race conditions that could create duplicate hourly timer chains.
  - Ensured stale background operations cannot resume scheduling after a newer scheduler session begins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->