### PR TITLE
Guard voice-disconnect cleanup against a crash on unexpected throw

### DIFF
--- a/src/audio/audioConnectionHandlers.test.ts
+++ b/src/audio/audioConnectionHandlers.test.ts
@@ -161,6 +161,21 @@ describe('setupConnectionHandlers — disconnected handler', () => {
     expect(deps.scheduleReconnect).not.toHaveBeenCalled();
   });
 
+  it('logs and does not reject when cleanup (e.g. tearDown) throws', async () => {
+    vi.mocked(entersState).mockRejectedValue(new Error('timeout'));
+    const conn = makeConnection();
+    const tearDown = vi.fn(() => { throw new Error('listener blew up'); });
+    const deps = makeDeps({ getConnection: vi.fn(() => conn as any), tearDown });
+    setupConnectionHandlers(conn as any, 1, deps);
+
+    await expect(conn._handlers.get('disconnected')!()).resolves.toBeUndefined();
+
+    expect(mockLog.error).toHaveBeenCalledWith(
+      'Error while cleaning up a lost voice connection:',
+      expect.any(Error),
+    );
+  });
+
   it('re-checks staleness after the grace window before tearing down', async () => {
     vi.mocked(entersState).mockRejectedValue(new Error('timeout'));
     const conn = makeConnection();

--- a/src/audio/audioConnectionHandlers.test.ts
+++ b/src/audio/audioConnectionHandlers.test.ts
@@ -161,7 +161,7 @@ describe('setupConnectionHandlers — disconnected handler', () => {
     expect(deps.scheduleReconnect).not.toHaveBeenCalled();
   });
 
-  it('logs and does not reject when cleanup (e.g. tearDown) throws', async () => {
+  it('logs and does not reject when cleanup (e.g. tearDown) throws, but still schedules a reconnect', async () => {
     vi.mocked(entersState).mockRejectedValue(new Error('timeout'));
     const conn = makeConnection();
     const tearDown = vi.fn(() => { throw new Error('listener blew up'); });
@@ -172,6 +172,24 @@ describe('setupConnectionHandlers — disconnected handler', () => {
 
     expect(mockLog.error).toHaveBeenCalledWith(
       'Error while cleaning up a lost voice connection:',
+      expect.any(Error),
+    );
+    // A cleanup failure must not strand the guild with no reconnect attempt scheduled.
+    expect(deps.scheduleReconnect).toHaveBeenCalledWith('disconnected');
+  });
+
+  it('logs and does not reject when scheduleReconnect itself throws', async () => {
+    vi.mocked(entersState).mockRejectedValue(new Error('timeout'));
+    const conn = makeConnection();
+    const scheduleReconnect = vi.fn(() => { throw new Error('timer setup blew up'); });
+    const deps = makeDeps({ getConnection: vi.fn(() => conn as any), scheduleReconnect });
+    setupConnectionHandlers(conn as any, 1, deps);
+
+    await expect(conn._handlers.get('disconnected')!()).resolves.toBeUndefined();
+
+    expect(deps.tearDown).toHaveBeenCalled();
+    expect(mockLog.error).toHaveBeenCalledWith(
+      'Error while scheduling a voice reconnect:',
       expect.any(Error),
     );
   });

--- a/src/audio/audioConnectionHandlers.ts
+++ b/src/audio/audioConnectionHandlers.ts
@@ -66,15 +66,21 @@ async function handleDisconnected(
     // ESLint allows that only because it's expected to catch its own errors internally. A
     // throw here (e.g. from a future onStatusChanged listener called via deps.tearDown())
     // would otherwise become an unhandled rejection and crash the whole process over what
-    // should be an isolated per-guild voice hiccup.
+    // should be an isolated per-guild voice hiccup. scheduleReconnect runs in `finally` so a
+    // cleanup failure can't also strand the guild with no reconnect attempt scheduled.
     try {
       joinedConnection.destroy();
       if (deps.getConnection() === joinedConnection) deps.setConnection(null);
       deps.tearDown();
       log.warn('Voice connection lost.');
-      deps.scheduleReconnect('disconnected');
     } catch (cleanupErr) {
       log.error('Error while cleaning up a lost voice connection:', cleanupErr);
+    } finally {
+      try {
+        deps.scheduleReconnect('disconnected');
+      } catch (reconnectErr) {
+        log.error('Error while scheduling a voice reconnect:', reconnectErr);
+      }
     }
   }
 }

--- a/src/audio/audioConnectionHandlers.ts
+++ b/src/audio/audioConnectionHandlers.ts
@@ -62,11 +62,20 @@ async function handleDisconnected(
     // Guard against a concurrent handleDisconnected call that already destroyed this connection.
     if (joinedConnection.state.status === VoiceConnectionStatus.Destroyed) return;
 
-    joinedConnection.destroy();
-    if (deps.getConnection() === joinedConnection) deps.setConnection(null);
-    deps.tearDown();
-    log.warn('Voice connection lost.');
-    deps.scheduleReconnect('disconnected');
+    // This handler is attached as a bare `.on()` callback (see setupConnectionHandlers) —
+    // ESLint allows that only because it's expected to catch its own errors internally. A
+    // throw here (e.g. from a future onStatusChanged listener called via deps.tearDown())
+    // would otherwise become an unhandled rejection and crash the whole process over what
+    // should be an isolated per-guild voice hiccup.
+    try {
+      joinedConnection.destroy();
+      if (deps.getConnection() === joinedConnection) deps.setConnection(null);
+      deps.tearDown();
+      log.warn('Voice connection lost.');
+      deps.scheduleReconnect('disconnected');
+    } catch (cleanupErr) {
+      log.error('Error while cleaning up a lost voice connection:', cleanupErr);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
Found during a full codebase review. `setupConnectionHandlers` attaches `handleDisconnected` (an `async` function) as a bare `.on(VoiceConnectionStatus.Disconnected, ...)` callback with no `.catch`. ESLint's `no-misused-promises` rule allows this (`checksVoidReturn: { arguments: false }`) specifically because such handlers are expected to catch their own errors internally — but `handleDisconnected`'s cleanup path (`destroy`, `setConnection`, `tearDown`, `scheduleReconnect`) had no try/catch of its own. A throw anywhere in there would become an unhandled promise rejection, and `index.ts`'s global `unhandledRejection` handler calls `process.exit(1)`, crashing the whole bot process over what should be an isolated per-guild voice hiccup.

Traced the current call chain (`tearDown` → `tearDownGuild` → `setVoiceDisconnected` → `notifyStatusChanged`, which synchronously invokes every registered `onStatusChanged` listener) and confirmed the one currently-registered listener (`pushStatusUpdate`) is itself `async` and already catches its own errors, and `destroy()` is already guarded by a preceding `Destroyed`-status check — so this isn't an *active* bug today. But nothing enforces that invariant for a future listener or dependency, so this closes the gap defensively, matching the pattern other handlers in this file already document.

- Wraps the cleanup body in a try/catch, logging via the existing logger on failure instead of letting the rejection escape.
- Adds a regression test asserting the disconnected-handler promise resolves (doesn't reject) and logs when `tearDown` throws.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (3275 tests passed)
- [x] `npx eslint` on changed files


---
_Generated by [Claude Code](https://claude.ai/code/session_01GBvR11FcEXwtrwosMwn1Gz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved audio disconnect handling so cleanup errors are logged without causing unhandled failures.
  - Reconnection attempts are now scheduled reliably, even when cleanup encounters an error.
  - Errors occurring while scheduling reconnection are logged without interrupting disconnect handling.

- **Tests**
  - Added coverage confirming cleanup failures still trigger reconnection.
  - Added coverage verifying reconnection scheduling errors are logged and do not reject the disconnect handler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->