### PR TITLE
Reorder startup sequence to match documented order

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -236,6 +236,20 @@ describe('startup — reward pricing scheduler', () => {
     expect(vi.mocked(startChannelReconciliationPoll)).toHaveBeenCalledOnce();
     expect(exitSpy).not.toHaveBeenCalled();
   });
+
+  it('starts the web panel before the channel reconciliation poll, matching the documented startup sequence', async () => {
+    const { startWebPanel } = await import('./web/server.js');
+    const { startChannelReconciliationPoll } = await import('./twitch/twitchChannelReconciliationPoll.js');
+
+    await runMain();
+
+    expect(vi.mocked(startWebPanel)).toHaveBeenCalledOnce();
+    expect(vi.mocked(startChannelReconciliationPoll)).toHaveBeenCalledOnce();
+
+    const [webPanelCallOrder] = vi.mocked(startWebPanel).mock.invocationCallOrder;
+    const [reconciliationCallOrder] = vi.mocked(startChannelReconciliationPoll).mock.invocationCallOrder;
+    expect(webPanelCallOrder).toBeLessThan(reconciliationCallOrder);
+  });
 });
 
 describe('shutdown', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,8 +140,8 @@ async function main(): Promise<void> {
   setChannelJoinedHook(() => reloadEventSubSubscriptions());
   startDiscordBot();
   await startTwitchBot();
-  startChannelReconciliationPoll();
   startWebPanel();
+  startChannelReconciliationPoll();
   startCounterScheduler();
   startRewardPricingScheduler();
   startTimerCommandScheduler();


### PR DESCRIPTION
## Summary
Found during a full codebase review. `startChannelReconciliationPoll()` ran before `startWebPanel()` in `main()`, while CLAUDE.md's Startup Sequence section documents web panel start happening before the reconciliation/monitor schedulers. Functionally harmless either way — it's just a fire-and-forget interval starter, not itself async or order-dependent — but this fixes the drift so the code matches the documented sequence.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (3274 tests passed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GBvR11FcEXwtrwosMwn1Gz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The web panel now starts before channel reconciliation begins, improving startup sequencing and availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->