### PR TITLE
Fix EventSub opening duplicate WebSocket connections on startup

### DIFF
--- a/src/twitch/eventsub/twitchEventSubConnection.test.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.test.ts
@@ -449,6 +449,38 @@ describe('StreamerConnection lifecycle', () => {
     return vi.waitFor(() => expect(connectSpy).toHaveBeenCalled());
   });
 
+  it('reload() does not open a second WebSocket when a connect() is already in flight (session_welcome not yet received)', async () => {
+    const conn = new StreamerConnection(makeStreamerData());
+    conn.start();
+    const firstWs = (conn as any).ws;
+    expect(firstWs).toBeTruthy();
+    // this.ws is set (start()'s connect() already ran) but this.sessionId is still null —
+    // session_welcome hasn't arrived yet. Without the fix, doReload() would call connect()
+    // again here, opening a second live WebSocket alongside the first.
+    expect((conn as any).sessionId).toBeNull();
+    const connectSpy = vi.spyOn(conn, 'connect');
+
+    const updatedData = { ...makeStreamerData(), name: 'updated-streamer' };
+    conn.reload(updatedData);
+
+    // Flush the reload chain's microtasks — doReload() must take its early-return branch
+    // rather than calling connect() a second time.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(connectSpy).not.toHaveBeenCalled();
+    expect((conn as any).ws).toBe(firstWs);
+
+    // The still-pending connect's own session_welcome now arrives — it must subscribe using
+    // reload()'s updated data (currentData was already reassigned synchronously), proving
+    // nothing was lost by not opening a second connection. The subscribe itself runs via
+    // reloadChain's own .then() (not awaited by handleMessage), so it settles a tick later.
+    await (conn as any).handleMessage(makeWelcomeMsg('sess-live'));
+    await vi.waitFor(() => {
+      expect(subscribeForStreamer).toHaveBeenCalledWith('sess-live', expect.objectContaining({ name: 'updated-streamer' }));
+    });
+  });
+
   it('reload() re-subscribes on the live session and stops when no subscriptions remain', async () => {
     const conn = new StreamerConnection(makeStreamerData());
     conn.start();

--- a/src/twitch/eventsub/twitchEventSubConnection.test.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.test.ts
@@ -387,6 +387,34 @@ describe('StreamerConnection lifecycle', () => {
     expect((conn as any).ws).toBe(secondWs);
   });
 
+  it('ignores a stale open event from a socket already superseded by a force-reconnect', () => {
+    const conn = new StreamerConnection(makeStreamerData());
+    conn.start();
+    const firstWs = (conn as any).ws as MockWebSocket;
+
+    // Socket A errors and forceReconnect() tears it down, scheduling a reconnect.
+    firstWs.listeners.get('error')!();
+    expect((conn as any).reconnectAttempts).toBe(1);
+
+    vi.advanceTimersByTime(1_000); // first reconnect attempt's backoff delay
+    const secondWs = (conn as any).ws as MockWebSocket;
+    expect(secondWs).not.toBe(firstWs);
+    expect((conn as any).connectTimer).not.toBeNull(); // B's own connect timeout is armed
+
+    // Socket A's 'open' now fires late — after it's already been superseded by B. Without the
+    // this.ws !== socket guard, this would incorrectly clear B's connect timer and reset
+    // reconnectAttempts/keepalive for a connection that hasn't actually opened yet.
+    firstWs.listeners.get('open')!();
+    expect((conn as any).reconnectAttempts).toBe(1);
+    expect((conn as any).connectTimer).not.toBeNull();
+    expect((conn as any).ws).toBe(secondWs);
+
+    // B's own open then arrives for real and correctly resets state.
+    secondWs.listeners.get('open')!();
+    expect((conn as any).reconnectAttempts).toBe(0);
+    expect((conn as any).connectTimer).toBeNull();
+  });
+
   it('reconnects if the WebSocket never leaves CONNECTING (no open/error/close ever fires)', () => {
     const conn = new StreamerConnection(makeStreamerData());
     conn.start();

--- a/src/twitch/eventsub/twitchEventSubConnection.test.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.test.ts
@@ -387,6 +387,38 @@ describe('StreamerConnection lifecycle', () => {
     expect((conn as any).ws).toBe(secondWs);
   });
 
+  it('reconnects if the WebSocket never leaves CONNECTING (no open/error/close ever fires)', () => {
+    const conn = new StreamerConnection(makeStreamerData());
+    conn.start();
+    const firstWs = (conn as any).ws as MockWebSocket;
+
+    // Simulates a TCP handshake that hangs silently (e.g. a firewall/NAT drop) rather than
+    // failing outright — none of 'open', 'error', or 'close' ever fires on their own.
+    vi.advanceTimersByTime(30_000); // CONNECT_TIMEOUT_MS
+    expect(firstWs.close).toHaveBeenCalled();
+    expect((conn as any).ws).toBeNull();
+    expect((conn as any).reconnectAttempts).toBe(1);
+
+    vi.advanceTimersByTime(1_000); // first reconnect attempt's backoff delay
+    const secondWs = (conn as any).ws as MockWebSocket;
+    expect(secondWs).not.toBeNull();
+    expect(secondWs).not.toBe(firstWs);
+  });
+
+  it('clears the connect timeout once the socket has already opened, so it cannot fire later', () => {
+    const conn = new StreamerConnection(makeStreamerData());
+    conn.start();
+    expect((conn as any).connectTimer).not.toBeNull();
+
+    const ws = (conn as any).ws as MockWebSocket;
+    ws.listeners.get('open')!();
+
+    // If the connect timeout weren't cleared here, it would fire at 30s and force-reconnect
+    // a socket that's already open and working — this proves it can't, independent of the
+    // keepalive timer (which is a separate 20s mechanism also armed by open()).
+    expect((conn as any).connectTimer).toBeNull();
+  });
+
   /** Verifies the keepalive-timeout path force-reconnects without waiting on the socket's own 'close' event; returns void. */
   it('reconnects on a keepalive timeout even if the socket never fires its own close event', () => {
     const conn = new StreamerConnection(makeStreamerData());

--- a/src/twitch/eventsub/twitchEventSubConnection.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.ts
@@ -6,6 +6,13 @@ const log = createLogger('EventSub');
 /** Default Twitch EventSub WebSocket URL. */
 export const EVENTSUB_WS_URL = 'wss://eventsub.wss.twitch.tv/ws';
 const RECONNECT_BACKOFF_MAX_MS = 30_000;
+/** Upper bound on how long a WebSocket may sit in CONNECTING before this connection gives up on
+ *  it and force-reconnects — see {@link StreamerConnection.connect}. Without this, a socket whose
+ *  underlying TCP handshake hangs (e.g. a connection silently dropped by a firewall/NAT) would
+ *  never fire 'open', 'error', or 'close', leaving this connection stuck with no live
+ *  subscription and nothing in the logs to explain why — unlike every other failure path here
+ *  (keepalive timeout, socket error, socket close), which already force-reconnects. */
+const CONNECT_TIMEOUT_MS = 30_000;
 /** How long a message ID is remembered for deduplication (ms). */
 export const MESSAGE_TTL_MS = 10 * 60 * 1000;
 /** Grace period before closing the old WebSocket during a session migration (Twitch-specified window). */
@@ -63,6 +70,7 @@ export class StreamerConnection {
   private sessionId: string | null = null;
   private keepaliveTimeoutSecs = 10;
   private keepaliveTimer: ReturnType<typeof setTimeout> | null = null;
+  private connectTimer: ReturnType<typeof setTimeout> | null = null;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private reconnectAttempts = 0;
   private isReconnecting = false;
@@ -97,6 +105,7 @@ export class StreamerConnection {
     this.reloadPendingAfterMigration = false;
     this.sessionId = null;
     this.clearKeepaliveTimer();
+    this.clearConnectTimer();
     if (this.reconnectTimer) { clearTimeout(this.reconnectTimer); this.reconnectTimer = null; }
     this.ws?.close(1000, 'shutdown');
     this.ws = null;
@@ -163,7 +172,11 @@ export class StreamerConnection {
     }
   }
 
-  /** Opens a new WebSocket to the given URL (defaults to the standard EventSub URL). */
+  /**
+   * Opens a new WebSocket to the given URL (defaults to the standard EventSub URL). Bounded by
+   * {@link CONNECT_TIMEOUT_MS} — see its doc for why a socket stuck in CONNECTING would otherwise
+   * never trigger a reconnect on its own.
+   */
   connect(url: string = EVENTSUB_WS_URL): void {
     if (this.stopped) return;
     const socket = new WebSocket(url);
@@ -172,10 +185,20 @@ export class StreamerConnection {
     socket.addEventListener('close', (ev: CloseEvent) => this.onClose(ev, socket));
     socket.addEventListener('error', () => this.onError(socket));
     this.ws = socket;
+    this.clearConnectTimer();
+    this.connectTimer = setTimeout(() => {
+      log.warn(`[${this.name}] Connect timeout — reconnecting`);
+      this.forceReconnect(socket);
+    }, CONNECT_TIMEOUT_MS);
+  }
+
+  private clearConnectTimer(): void {
+    if (this.connectTimer) { clearTimeout(this.connectTimer); this.connectTimer = null; }
   }
 
   private onOpen(): void {
     log.info(`[${this.name}] WebSocket connected`);
+    this.clearConnectTimer();
     this.reconnectAttempts = 0;
     this.resetKeepaliveTimer();
   }
@@ -220,11 +243,13 @@ export class StreamerConnection {
    * Tears down `socket` as this connection's active WebSocket and schedules a reconnect,
    * without depending on the socket ever emitting its own `'close'` event. Shared by
    * {@link onClose} (a real close event did arrive), {@link onError} (a socket error arrived
-   * but its `'close'` may never follow), and the keepalive-timeout path in
+   * but its `'close'` may never follow), the keepalive-timeout path in
    * {@link resetKeepaliveTimer} (a close was requested but might never actually fire — a
    * half-dead TCP connection, e.g. after a silent NAT/load-balancer drop, can leave `close()`
    * pending forever with no `'close'` event ever following it, which would otherwise strand
-   * this connection permanently until the whole process restarts). No-ops if `socket` isn't
+   * this connection permanently until the whole process restarts), and the connect-timeout path
+   * in {@link connect} (the socket never left CONNECTING at all, so none of 'open'/'error'/
+   * 'close' ever fired to begin with). No-ops if `socket` isn't
    * this connection's current socket any more (e.g. a session migration or an earlier
    * force-reconnect already superseded it) — including the case where `socket`'s real
    * `'close'` event does eventually land after this already ran.
@@ -239,6 +264,7 @@ export class StreamerConnection {
     // We don't wait on it — the next connect() proceeds immediately regardless.
     socket?.close();
     this.clearKeepaliveTimer();
+    this.clearConnectTimer();
     this.ws = null;
     this.sessionId = null;
     if (!this.stopped) {

--- a/src/twitch/eventsub/twitchEventSubConnection.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.ts
@@ -116,14 +116,28 @@ export class StreamerConnection {
    * is in flight, this.sessionId still refers to the old, soon-to-be-invalidated session —
    * subscribing now would silently fail against Twitch, so the reload is deferred and picked
    * up by onSessionWelcome() once the new session's id is known.
+   *
+   * Likewise, if `this.ws` is already set but `this.sessionId` is still null, a connect() is
+   * already in flight — its `session_welcome` just hasn't arrived yet. Calling connect() again
+   * here would open a *second* live WebSocket alongside the first (connect() never closes the
+   * socket it replaces), and both would end up subscribing independently, each treating the
+   * other's fresh subscription as "stale" and deleting it — observed in production as every
+   * subscription type being deleted and recreated within seconds of startup, with a real gap
+   * where nothing was subscribed. Reload only needs to fall through and do nothing: the pending
+   * connect's own onSessionWelcome() will subscribe once it lands, using this.currentData —
+   * already updated by reload() above — so nothing is lost by waiting for it instead of racing
+   * a second connection. A reconnect is only actually needed when there's no socket at all.
    */
   private async doReload(): Promise<void> {
     if (this.isReconnecting) {
       this.reloadPendingAfterMigration = true;
       return;
     }
-    if (!this.ws || !this.sessionId) {
+    if (!this.ws) {
       if (!this.stopped && !this.reconnectTimer) { this.connect(); }
+      return;
+    }
+    if (!this.sessionId) {
       return;
     }
     await this.subscribeAndHandleEmpty(this.sessionId, 'No subscriptions after reload — disconnecting');

--- a/src/twitch/eventsub/twitchEventSubConnection.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.ts
@@ -180,7 +180,7 @@ export class StreamerConnection {
   connect(url: string = EVENTSUB_WS_URL): void {
     if (this.stopped) return;
     const socket = new WebSocket(url);
-    socket.addEventListener('open', () => this.onOpen());
+    socket.addEventListener('open', () => this.onOpen(socket));
     socket.addEventListener('message', (ev: MessageEvent) => this.onMessage(ev));
     socket.addEventListener('close', (ev: CloseEvent) => this.onClose(ev, socket));
     socket.addEventListener('error', () => this.onError(socket));
@@ -192,11 +192,22 @@ export class StreamerConnection {
     }, CONNECT_TIMEOUT_MS);
   }
 
+  /** Clears the pending connect-timeout timer (see {@link CONNECT_TIMEOUT_MS}), if one is armed. */
   private clearConnectTimer(): void {
     if (this.connectTimer) { clearTimeout(this.connectTimer); this.connectTimer = null; }
   }
 
-  private onOpen(): void {
+  /**
+   * Handles the socket's `'open'` event: ignores it if `socket` is no longer this connection's
+   * active socket (a stale, late-arriving event from a socket already superseded by a
+   * force-reconnect — the same staleness this file already guards against in {@link onClose},
+   * {@link onError}, and {@link forceReconnect} itself). Without this guard, a delayed `open`
+   * from an old socket would incorrectly clear the *current* socket's connect timer and reset
+   * {@link reconnectAttempts}/the keepalive timer for a connection that may not have opened yet.
+   * @param socket - The socket that emitted the event.
+   */
+  private onOpen(socket: WebSocket): void {
+    if (this.ws !== socket) return;
     log.info(`[${this.name}] WebSocket connected`);
     this.clearConnectTimer();
     this.reconnectAttempts = 0;


### PR DESCRIPTION
## Summary

Root-caused from a production log report: `EventSubReconciliation` was recurrently catching redemptions missed by the live EventSub path (`Reconciliation caught a redemption missed by EventSub: ...`).

Startup logs showed the real bug: each streamer's `StreamerConnection` opens **two** live WebSocket connections at boot, each establishing its own separate Twitch session:

```
[EventSub] [StreamerA] WebSocket connected
[EventSub] [StreamerA] Session established: <session-1>
[EventSub] [StreamerB] WebSocket connected
[EventSub] [StreamerB] Session established: <session-1>
[EventSub] [StreamerA] WebSocket connected        ← second connect, same streamer
[EventSub] [StreamerB] WebSocket connected                 ← same for StreamerB
[EventSub] [StreamerA] Session established: <session-2>   ← second, different session
[EventSub] [StreamerB] Session established: <session-2>
```

followed immediately by every subscription type being deleted and recreated (`Deleting stale ... subscription — bound to a different session`), since the two sessions' independent subscribe passes each see the other's fresh subscription as stale.

**Root cause** (`src/twitch/eventsub/twitchEventSubConnection.ts`, `StreamerConnection.doReload()`): `index.ts` calls `startTwitchBot()` (which joins every configured Twitch chat channel) before `startEventSub()`. Each channel join fires the channel-joined hook → `reloadEventSubSubscriptions()`. The first reload creates a streamer's `StreamerConnection` and calls `.start()` (opens a WebSocket, `session_welcome` pending). If a *later* reload lands before that `session_welcome` arrives, it finds the connection already in the map and calls `.reload()` on it — hitting `doReload()`'s guard:

```ts
if (!this.ws || !this.sessionId) {
  if (!this.stopped && !this.reconnectTimer) { this.connect(); }
  return;
}
```

This treats "socket exists but `session_welcome` hasn't arrived yet" (`this.ws` set, `this.sessionId` still null) the same as "no connection at all," calling `connect()` a second time. `connect()` never closes the socket it replaces, so both stay open and both subscribe — leaving a real window where a redemption can land while no subscription is reliably live, and generally leaving the connection in a duplicated, unstable state.

## Fix

Only reconnect when there's truly no socket (`!this.ws`). If a connect is already in flight (`this.ws` set, `this.sessionId` still null), do nothing — the pending connect's own `session_welcome` will subscribe using `this.currentData`, which `reload()` already updated synchronously before calling `doReload()`, so nothing is lost.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 3277 tests passing)
- [x] `npm run lint` (0 errors)
- [x] `npm run check:circular`
- [x] Added a test reproducing the race: `reload()` while a connect is in flight must not call `connect()` again, and the pending connect's `session_welcome` must still subscribe using the reload's updated data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate WebSocket connections when reloading during initial connection.
  * Ensured pending connections use the latest streamer information once established.
  * Added a 30-second connection timeout to recover when a connection cannot be established.
  * Improved cleanup of connection timeouts after successful connections or reconnects.
* **Tests**
  * Added coverage for reload behavior, connection timeouts, reconnects, and session initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->