### PR TITLE
Fix EventSub reconciliation cursor freezing on partial-tick failures

### DIFF
--- a/src/twitch/eventsub/twitchEventSubReconciliation.test.ts
+++ b/src/twitch/eventsub/twitchEventSubReconciliation.test.ts
@@ -178,10 +178,12 @@ describe('runReconciliationTick', () => {
     await runReconciliationTick();
     expect(handleRedemption).toHaveBeenCalledTimes(3);
 
-    // Next tick should only retry the failed redemption (r3), not the two that already succeeded.
+    // Next tick should only retry the failed redemption (r3), not the two that already succeeded —
+    // return the full page (as Twitch would) so this actually exercises the cursor's own cutoff
+    // filtering in fetchRedemptionsNewerThan, rather than passing merely because the mock omitted r1/r2.
     vi.mocked(handleRedemption).mockClear();
     vi.mocked(handleRedemption).mockResolvedValue(true);
-    mockFulfilledOnly({ redemptions: [redemption('r3', t3)], cursor: null });
+    mockFulfilledOnly({ redemptions: [redemption('r3', t3), redemption('r2', t2), redemption('r1', t1)], cursor: null });
 
     await runReconciliationTick();
 

--- a/src/twitch/eventsub/twitchEventSubReconciliation.test.ts
+++ b/src/twitch/eventsub/twitchEventSubReconciliation.test.ts
@@ -143,7 +143,7 @@ describe('runReconciliationTick', () => {
     expect(fulfilledCalls[1][4]).toBe('page-2-cursor'); // second call passed the first page's cursor as `after`
   });
 
-  it('does not advance the cursor when a redemption fails to handle, so it is retried on the next tick', async () => {
+  it('does not advance the cursor past a redemption that fails to handle, so it is retried on the next tick', async () => {
     vi.mocked(getAllStreamerInfo).mockReturnValue(new Map([['uid1', info]]));
     await runReconciliationTick(); // establishes the cursor at "now"
 
@@ -160,6 +160,33 @@ describe('runReconciliationTick', () => {
 
     expect(handleRedemption).toHaveBeenCalledTimes(2);
     expect(vi.mocked(handleRedemption).mock.calls[1][1]).toEqual(expect.objectContaining({ id: 'r1' }));
+  });
+
+  it('advances the cursor past redemptions that succeeded even when a later one in the same tick fails', async () => {
+    vi.mocked(getAllStreamerInfo).mockReturnValue(new Map([['uid1', info]]));
+    await runReconciliationTick(); // establishes the cursor at "now"
+
+    const t1 = new Date(Date.now() + 1_000).toISOString();
+    const t2 = new Date(Date.now() + 2_000).toISOString();
+    const t3 = new Date(Date.now() + 3_000).toISOString();
+    mockFulfilledOnly({ redemptions: [redemption('r3', t3), redemption('r2', t2), redemption('r1', t1)], cursor: null });
+    vi.mocked(handleRedemption).mockImplementation(async (_login, event: any) => {
+      if (event.id === 'r3') throw new Error('handler boom');
+      return true;
+    });
+
+    await runReconciliationTick();
+    expect(handleRedemption).toHaveBeenCalledTimes(3);
+
+    // Next tick should only retry the failed redemption (r3), not the two that already succeeded.
+    vi.mocked(handleRedemption).mockClear();
+    vi.mocked(handleRedemption).mockResolvedValue(true);
+    mockFulfilledOnly({ redemptions: [redemption('r3', t3)], cursor: null });
+
+    await runReconciliationTick();
+
+    expect(handleRedemption).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(handleRedemption).mock.calls[0][1]).toEqual(expect.objectContaining({ id: 'r3' }));
   });
 
   it('logs a "caught" warning only when handleRedemption reports it actually processed the redemption', async () => {

--- a/src/twitch/eventsub/twitchEventSubReconciliation.ts
+++ b/src/twitch/eventsub/twitchEventSubReconciliation.ts
@@ -78,12 +78,14 @@ async function fetchRedemptionsNewerThan(
  * since this poll's lookback window routinely re-fetches redemptions the WebSocket already
  * handled fine.
  *
- * The cursor only advances past a redemption once `handleRedemption` has actually succeeded for
- * it; if any redemption in this tick fails to handle, the cursor is left exactly where it was
- * before this tick, so every redemption fetched this tick (including ones that already
- * succeeded) is retried on the next tick. That reprocessing is safe: it lands well within
- * `handleRedemption`'s own redemption-id dedup TTL, so an already-handled redemption is a no-op
- * there rather than a real duplicate.
+ * The cursor advances independently per outcome: past every redemption that `handleRedemption`
+ * actually succeeded for, but never past a redemption that failed to handle. This matters when a
+ * tick has a mix of successes and failures (e.g. a transient failure partway through a batch) —
+ * only the failed (and anything newer) redemptions are retried on the next tick, rather than
+ * re-replaying already-succeeded ones. Re-replaying a success is not always a safe no-op: it's
+ * only deduped by `handleRedemption`'s redemption-id TTL, which a sustained run of failures could
+ * outlast, so keeping the cursor pinned in front of anything unhandled — instead of freezing it
+ * for the whole tick — bounds how far behind an already-succeeded redemption can fall.
  *
  * @param info - Dispatch info for the redemption's streamer (login/streamerId/config).
  * @param uid - Broadcaster's Twitch user ID.
@@ -109,8 +111,8 @@ async function reconcileReward(info: StreamerInfo, uid: string, token: string, r
     return;
   }
 
-  let maxSeen = cutoff;
-  let hadFailure = false;
+  let succeededMax: number | null = null;
+  let failedMin: number | null = null;
   for (const r of redemptions) {
     const redeemedAt = Date.parse(r.redeemed_at);
     if (!Number.isFinite(redeemedAt)) continue;
@@ -122,13 +124,16 @@ async function reconcileReward(info: StreamerInfo, uid: string, token: string, r
       if (processed) {
         log.warn(`Reconciliation caught a redemption missed by EventSub: "${r.reward.title}" (id=${r.id}) for ${info.login}`);
       }
-      if (redeemedAt > maxSeen) maxSeen = redeemedAt;
+      if (succeededMax === null || redeemedAt > succeededMax) succeededMax = redeemedAt;
     } catch (err) {
       log.error(`Reconciled-redemption handler error for redemption ${r.id} (${info.login}):`, err);
-      hadFailure = true;
+      if (failedMin === null || redeemedAt < failedMin) failedMin = redeemedAt;
     }
   }
-  if (!hadFailure) lastSeenRedeemedAt.set(key, maxSeen);
+  // Every redemption fetched this tick has redeemedAt > cutoff, so failedMin - 1 never moves the
+  // cursor backwards past where it already was.
+  const newCursor = failedMin !== null ? failedMin - 1 : (succeededMax ?? cutoff);
+  lastSeenRedeemedAt.set(key, newCursor);
 }
 
 /**


### PR DESCRIPTION
## Summary
- `reconcileReward()` in `twitchEventSubReconciliation.ts` used to freeze a reward's replay cursor for the *entire* tick if even one redemption failed to handle — including redemptions in the same tick that succeeded.
- If failures persisted longer than `handleRedemption`'s own redemption-id dedup TTL, recovery would replay those already-succeeded redemptions once their dedup entries expired, double-applying pricing increments and re-firing overlay/companion-app pushes.
- The cursor now advances independently per outcome: past every redemption that actually succeeded, and only holds back at the earliest one that failed — so retries on the next tick are scoped to what genuinely still needs handling.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx eslint src/twitch/eventsub`
- [x] `npm test` (full suite, 3284 tests passing)
- [x] New test: a tick with a mix of succeeded and failed redemptions only retries the failed one on the next tick, confirming already-succeeded redemptions are no longer replayed


---
_Generated by [Claude Code](https://claude.ai/code/session_01Re335bjZ54yY9LeouwbFiV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redemption reconciliation so successfully handled redemptions are not repeated when a later redemption fails.
  * Failed redemptions and newer items are retried on the next reconciliation cycle, while successful ones are skipped.
* **Tests**
  * Added coverage confirming correct retry behavior when successes and failures occur in the same cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->