### PR TITLE
Share one Helix subscriptions listing per subscribe pass

### DIFF
--- a/src/twitch/eventsub/twitchApiEventSub.test.ts
+++ b/src/twitch/eventsub/twitchApiEventSub.test.ts
@@ -311,6 +311,19 @@ describe('listEventSubSubscriptions', () => {
     ]);
   });
 
+  it('preserves each subscription\'s Twitch status in the mapped result', async () => {
+    const apiResponse = [
+      { id: 's1', type: 'channel.follow', condition: {}, status: 'enabled' },
+      { id: 's2', type: 'channel.follow', condition: {}, status: 'authorization_revoked' },
+    ];
+    vi.mocked(twitchFetch).mockResolvedValue(mockFetch(200, { data: apiResponse }));
+
+    const result = await listEventSubSubscriptions('token');
+
+    expect(result[0].status).toBe('enabled');
+    expect(result[1].status).toBe('authorization_revoked');
+  });
+
   it('paginates when a cursor is present', async () => {
     vi.mocked(twitchFetch)
       .mockResolvedValueOnce(mockFetch(200, { data: [{ id: 's1', type: 't1' }], pagination: { cursor: 'cursor1' } }))

--- a/src/twitch/eventsub/twitchApiEventSub.ts
+++ b/src/twitch/eventsub/twitchApiEventSub.ts
@@ -151,25 +151,28 @@ export async function createEventSubSubscription(
  *  returns subscriptions matching that user in any condition.
  *  `sessionId` is the WebSocket session (if any) the subscription is currently bound to — used
  *  to tell a subscription still live on the current connection apart from a stale duplicate
- *  left over from a prior (possibly dead) session. */
+ *  left over from a prior (possibly dead) session. `status` is Twitch's own subscription state
+ *  (e.g. `enabled`, `authorization_revoked`, `notification_failures_exceeded`) — a subscription
+ *  bound to the live session isn't necessarily receiving notifications; callers must check
+ *  `status === 'enabled'` before treating it as such. */
 export async function listEventSubSubscriptions(
   token: string,
   userId?: string,
-): Promise<Array<{ id: string; type: string; condition: Record<string, string>; sessionId?: string }>> {
+): Promise<Array<{ id: string; type: string; condition: Record<string, string>; sessionId?: string; status?: string }>> {
   const url = new URL('https://api.twitch.tv/helix/eventsub/subscriptions');
   if (userId) url.searchParams.set('user_id', userId);
-  const results: Array<{ id: string; type: string; condition: Record<string, string>; sessionId?: string }> = [];
+  const results: Array<{ id: string; type: string; condition: Record<string, string>; sessionId?: string; status?: string }> = [];
   let cursor: string | undefined;
   do {
     if (cursor) url.searchParams.set('after', cursor);
     const res = await twitchFetch(url.toString(), { headers: authHeaders(token) });
     if (!res.ok) throw new Error(`[TwitchAPI] listEventSubSubscriptions failed: ${res.status}`);
     const data = await res.json() as {
-      data: Array<{ id: string; type: string; condition: Record<string, string>; transport?: { session_id?: string } }>;
+      data: Array<{ id: string; type: string; condition: Record<string, string>; transport?: { session_id?: string }; status?: string }>;
       pagination?: { cursor?: string };
     };
     results.push(...data.data.map((sub) => (
-      { id: sub.id, type: sub.type, condition: sub.condition, sessionId: sub.transport?.session_id }
+      { id: sub.id, type: sub.type, condition: sub.condition, sessionId: sub.transport?.session_id, status: sub.status }
     )));
     cursor = data.pagination?.cursor;
   } while (cursor);

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
@@ -352,6 +352,25 @@ describe('subscribeForStreamer', () => {
     expect(deleteEventSubSubscription).toHaveBeenCalledWith('stale-sub', 'tok-z');
   });
 
+  it('lists existing EventSub subscriptions only once per round, reusing it for both matching and stale cleanup', async () => {
+    vi.mocked(getActiveChannels).mockReturnValue(new Set(['botinchannel']));
+    vi.mocked(createEventSubSubscription).mockResolvedValue('sub-new');
+    vi.mocked(listEventSubSubscriptions).mockResolvedValue([
+      { id: 'stale-sub', type: 'channel.subscribe', condition: { broadcaster_user_id: 'uid-once' } },
+    ] as any);
+
+    await subscribeForStreamer('sess-once', {
+      uid: 'uid-once',
+      token: 'tok-once',
+      name: 'botInChannel',
+      config: { follow_enabled: true, sub_enabled: false, raid_enabled: false } as any,
+      streamerId: 21,
+    });
+
+    expect(listEventSubSubscriptions).toHaveBeenCalledTimes(1);
+    expect(deleteEventSubSubscription).toHaveBeenCalledWith('stale-sub', 'tok-once');
+  });
+
   it('never deletes an undesired-type subscription belonging to a different broadcaster the streamer merely moderates', async () => {
     vi.mocked(getActiveChannels).mockReturnValue(new Set(['botinchannel']));
     vi.mocked(createEventSubSubscription).mockResolvedValue('sub-new');
@@ -450,6 +469,9 @@ describe('subscribeForStreamer', () => {
       'channel.follow', '2', { broadcaster_user_id: 'uid-revoked', moderator_user_id: 'uid-revoked' },
       'sess-revoked', 'tok-revoked',
     );
+    // Only deleted once — the shared own-subscriptions snapshot handed to the stale-cleanup pass
+    // must exclude this id too (not just session-mismatch deletions), or it would be deleted twice.
+    expect(deleteEventSubSubscription).toHaveBeenCalledTimes(1);
     expect(count).toBeGreaterThan(0);
   });
 
@@ -512,6 +534,9 @@ describe('subscribeForStreamer', () => {
       'channel.follow', '2', { broadcaster_user_id: 'uid-stale-session', moderator_user_id: 'uid-stale-session' },
       'sess-new-live', 'tok-stale-session',
     );
+    // Only deleted once — the reused own-subscriptions listing must not let the later stale-cleanup
+    // pass attempt to delete the same id a second time (it was already removed above).
+    expect(deleteEventSubSubscription).toHaveBeenCalledTimes(1);
   });
 
   it('ignores a same-type subscription belonging to a different broadcaster the streamer merely moderates, rather than keeping or deleting it', async () => {
@@ -788,12 +813,12 @@ describe('error handling in subscription setup', () => {
     expect(count).toBeGreaterThan(0);
   });
 
-  it('logs and continues when listing existing subscriptions fails during cleanup', async () => {
+  it('treats a failed listing as no existing subscriptions for both creation and cleanup, from a single fetch', async () => {
     vi.mocked(createEventSubSubscription).mockResolvedValue('sub-id');
-    // First call (pre-create lookup) succeeds; second call (deleteStaleSubscriptions) fails.
-    vi.mocked(listEventSubSubscriptions)
-      .mockResolvedValueOnce([])
-      .mockRejectedValueOnce(new Error('list failed'));
+    // Only one Helix listing call is made per subscribeForStreamer round (shared between the
+    // create-side match lookup and the cleanup step) — its failure means both treat it as if
+    // nothing exists: creation proceeds fresh, and cleanup has nothing to delete.
+    vi.mocked(listEventSubSubscriptions).mockRejectedValueOnce(new Error('list failed'));
 
     const count = await subscribeForStreamer('sess-err2', {
       uid: 'uid-err2',
@@ -803,7 +828,11 @@ describe('error handling in subscription setup', () => {
       streamerId: 70,
     });
 
-    expect(logMock.error).toHaveBeenCalledWith('Subscription cleanup failed for uid uid-err2:', expect.any(Error));
+    expect(listEventSubSubscriptions).toHaveBeenCalledTimes(1);
+    expect(logMock.error).toHaveBeenCalledWith(
+      'Failed to list existing EventSub subscriptions for errStreamer:', expect.any(Error),
+    );
+    expect(deleteEventSubSubscription).not.toHaveBeenCalled();
     expect(count).toBeGreaterThan(0);
   });
 

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
@@ -298,6 +298,25 @@ describe('subscribeForStreamer', () => {
     expect(createEventSubSubscription).not.toHaveBeenCalled();
   });
 
+  it('returns 0 when every subscribe attempt fails with a missing scope, even though subscriptions are desired', async () => {
+    vi.mocked(getActiveChannels).mockReturnValue(new Set(['botinchannel']));
+    vi.mocked(listEventSubSubscriptions).mockResolvedValue([]);
+    vi.mocked(createEventSubSubscription).mockRejectedValue(new TwitchAuthError('403'));
+
+    const count = await subscribeForStreamer('sess-noscope', {
+      uid: 'uid-noscope',
+      token: 'tok-noscope',
+      name: 'botInChannel',
+      config: { follow_enabled: true, sub_enabled: false, raid_enabled: false } as any,
+      streamerId: 20,
+    });
+
+    // Every desired type failed to subscribe (missing OAuth scope), so nothing is actually live —
+    // the count must reflect that, not the non-empty desired set, so a caller's zero-subscriptions
+    // self-stop check can detect this connection has no working subscriptions.
+    expect(count).toBe(0);
+  });
+
   it('calls createEventSubSubscription for enabled subscription types', async () => {
     vi.mocked(getActiveChannels).mockReturnValue(new Set(['botinchannel']));
     vi.mocked(createEventSubSubscription).mockResolvedValue('sub-new');
@@ -362,7 +381,7 @@ describe('subscribeForStreamer', () => {
     // "enabled" and shows up alongside the one already live on this round's session.
     vi.mocked(listEventSubSubscriptions).mockResolvedValue([
       {
-        id: 'sub-new-follow', type: 'channel.follow', sessionId: 'sess-dup',
+        id: 'sub-new-follow', type: 'channel.follow', sessionId: 'sess-dup', status: 'enabled',
         condition: { broadcaster_user_id: 'uid-dup', moderator_user_id: 'uid-dup' },
       },
       { id: 'sub-stale-follow', type: 'channel.follow', condition: { broadcaster_user_id: 'uid-dup', moderator_user_id: 'uid-dup' } },
@@ -384,7 +403,7 @@ describe('subscribeForStreamer', () => {
     vi.mocked(getActiveChannels).mockReturnValue(new Set(['botinchannel']));
     vi.mocked(listEventSubSubscriptions).mockResolvedValue([
       {
-        id: 'sub-live-follow', type: 'channel.follow', sessionId: 'sess-live-409',
+        id: 'sub-live-follow', type: 'channel.follow', sessionId: 'sess-live-409', status: 'enabled',
         condition: { broadcaster_user_id: 'uid-409', moderator_user_id: 'uid-409' },
       },
     ] as any);
@@ -402,6 +421,35 @@ describe('subscribeForStreamer', () => {
       'channel.follow', expect.anything(), expect.anything(), expect.anything(), expect.anything(),
     );
     expect(deleteEventSubSubscription).not.toHaveBeenCalledWith('sub-live-follow', 'tok-409');
+    expect(count).toBeGreaterThan(0);
+  });
+
+  it('recreates a subscription bound to the live session but not enabled, rather than counting it as live', async () => {
+    vi.mocked(getActiveChannels).mockReturnValue(new Set(['botinchannel']));
+    vi.mocked(createEventSubSubscription).mockResolvedValue('sub-fresh-follow-reenabled');
+    // Bound to our own live session, but Twitch has marked it non-enabled (e.g. the streamer
+    // briefly revoked and re-granted authorization) — it isn't actually receiving notifications,
+    // so it must not be mistaken for a working subscription just because the session id matches.
+    vi.mocked(listEventSubSubscriptions).mockResolvedValue([
+      {
+        id: 'sub-revoked-follow', type: 'channel.follow', sessionId: 'sess-revoked', status: 'authorization_revoked',
+        condition: { broadcaster_user_id: 'uid-revoked', moderator_user_id: 'uid-revoked' },
+      },
+    ] as any);
+
+    const count = await subscribeForStreamer('sess-revoked', {
+      uid: 'uid-revoked',
+      token: 'tok-revoked',
+      name: 'botInChannel',
+      config: { follow_enabled: true, sub_enabled: false, raid_enabled: false } as any,
+      streamerId: 23,
+    });
+
+    expect(deleteEventSubSubscription).toHaveBeenCalledWith('sub-revoked-follow', 'tok-revoked');
+    expect(createEventSubSubscription).toHaveBeenCalledWith(
+      'channel.follow', '2', { broadcaster_user_id: 'uid-revoked', moderator_user_id: 'uid-revoked' },
+      'sess-revoked', 'tok-revoked',
+    );
     expect(count).toBeGreaterThan(0);
   });
 
@@ -444,7 +492,7 @@ describe('subscribeForStreamer', () => {
     // a session id that's no longer the live one.
     vi.mocked(listEventSubSubscriptions).mockResolvedValue([
       {
-        id: 'sub-dead-follow', type: 'channel.follow', sessionId: 'sess-old-dead',
+        id: 'sub-dead-follow', type: 'channel.follow', sessionId: 'sess-old-dead', status: 'enabled',
         condition: { broadcaster_user_id: 'uid-stale-session', moderator_user_id: 'uid-stale-session' },
       },
     ] as any);

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -141,10 +141,11 @@ function conditionsEqual(a: Record<string, string>, b: Record<string, string>): 
 /**
  * Creates all desired EventSub subscriptions for a single streamer. Before creating each spec,
  * checks whether Twitch already has a subscription matching both its type *and* condition
- * exactly: if it's bound to the live `sessionId`, it's kept as-is (no redundant create call); if
- * it's bound to any other session id — a duplicate left over from a dead/prior connection (e.g.
- * after `onError`/`forceReconnect` tore down a socket without a clean close, so Twitch hadn't yet
- * revoked its subscriptions) — it's deleted first so the fresh create can't 409 against it and
+ * exactly: if it's bound to the live `sessionId` and `enabled`, it's kept as-is (no redundant
+ * create call); otherwise — bound to any other session id (a duplicate left over from a dead/prior
+ * connection, e.g. after `onError`/`forceReconnect` tore down a socket without a clean close, so
+ * Twitch hadn't yet revoked its subscriptions) or bound to the live session but not `enabled`
+ * (e.g. `authorization_revoked`) — it's deleted first so the fresh create can't 409 against it and
  * leave the *new* session with no working subscription for that spec.
  * @returns The desired-types set alongside a type → id map of subscriptions actually created (or
  *   confirmed already-live on this session) this round (a type is absent from `created` only on a
@@ -184,10 +185,12 @@ async function createSubscriptionsForStreamer(
 /** Fetches existing EventSub subscriptions and filters out any that Twitch returned only because
  *  this streamer moderates a different broadcaster's channel (see {@link isOwnSubscription}).
  *  Returns an empty array (and logs) on failure — callers treat that the same as "nothing exists
- *  yet" and create fresh. */
+ *  yet" and create fresh. Each returned subscription's `status` is Twitch's own subscription state
+ *  (see {@link ensureSubscription}) — callers must not assume a matching type/condition/session is
+ *  actually receiving notifications without also checking it. */
 async function listOwnSubscriptions(
   token: string, uid: string, name: string,
-): Promise<Array<{ id: string; type: string; condition: Record<string, string>; sessionId?: string }>> {
+): Promise<Array<{ id: string; type: string; condition: Record<string, string>; sessionId?: string; status?: string }>> {
   try {
     const existing = await listEventSubSubscriptions(token);
     return existing.filter((sub) => isOwnSubscription(sub.condition, uid));
@@ -199,17 +202,20 @@ async function listOwnSubscriptions(
 
 /**
  * Ensures a single subscription type is live on the given session: keeps an existing
- * subscription that's already bound to `sessionId`, deletes one bound to any other (stale/dead)
- * session before recreating it, or creates fresh if none exists.
+ * subscription that's already bound to `sessionId` *and* `enabled` — a subscription can be bound
+ * to the live session yet not `enabled` (e.g. `authorization_revoked`, `notification_failures_exceeded`),
+ * in which case it isn't actually receiving notifications and must not be counted as live — deletes
+ * one that's stale (bound to a different session, or not enabled) before recreating it, or creates
+ * fresh if none exists.
  * @returns The live subscription's id, or null if creation failed (see {@link subscribe}).
  */
 async function ensureSubscription(
   sessionId: string, spec: SubSpec, token: string, name: string,
-  existing: { id: string; sessionId?: string } | undefined,
+  existing: { id: string; sessionId?: string; status?: string } | undefined,
 ): Promise<string | null> {
-  if (existing && existing.sessionId === sessionId) return existing.id;
+  if (existing && existing.sessionId === sessionId && existing.status === 'enabled') return existing.id;
   if (existing) {
-    log.warn(`Deleting stale ${spec.type} subscription (${existing.id}) for ${name} — bound to a different session`);
+    log.warn(`Deleting stale ${spec.type} subscription (${existing.id}) for ${name} — bound to a different session or not enabled (status=${existing.status})`);
     await deleteEventSubSubscription(existing.id, token).catch((err) => {
       log.error(`Failed to delete stale ${spec.type} subscription for ${name}:`, err);
     });
@@ -241,7 +247,11 @@ export async function loadStreamersForEventSub(): Promise<StreamerEventSubData[]
 
 /** Creates all subscriptions for one streamer on their dedicated session, updates the
  *  dispatch-side streamer map, and cleans up stale subscriptions. Returns the count of
- *  desired subscriptions. */
+ *  subscriptions actually created or confirmed already-live this round — not merely desired —
+ *  since callers (e.g. `StreamerConnection`'s zero-subscriptions self-stop check) rely on this
+ *  to detect a connection with no working subscriptions, which `desired`'s count alone can't:
+ *  every desired type could still fail to subscribe (e.g. a missing OAuth scope) while `desired`
+ *  stays non-empty. */
 export async function subscribeForStreamer(
   sessionId: string, data: StreamerEventSubData,
 ): Promise<number> {
@@ -249,7 +259,7 @@ export async function subscribeForStreamer(
   setStreamerInfo(uid, { login: name, streamerId, config });
   const { desired, created } = await createSubscriptionsForStreamer(sessionId, data);
   await deleteStaleSubscriptions(uid, desired, created, token);
-  return desired.size;
+  return created.size;
 }
 
 /** Creates a single EventSub subscription. Returns the created subscription's id, or null if

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -55,32 +55,28 @@ function isOwnSubscription(condition: Record<string, string>, uid: string): bool
  * calls) — in that rare case it's left untouched, since we can't tell which one Twitch considers
  * the live one without risking deleting the subscription actually receiving events.
  *
- * @param uid - Broadcaster's Twitch user ID; also used to filter out another broadcaster's
- *   subscription that Twitch included only because this streamer moderates that channel (see
- *   {@link isOwnSubscription}) — never deleted, regardless of type or desired state.
+ * @param uid - Broadcaster's Twitch user ID; used only for logging here — `existing` is already
+ *   filtered down to this streamer's own subscriptions by {@link listOwnSubscriptions}.
  * @param desired - Subscription types that should exist after this call.
  * @param created - Type → subscription id for subscriptions freshly created this round (see
  *   {@link createSubscriptionsForStreamer}); a type present here has any other existing
  *   subscription of that type pruned as a stale duplicate.
  * @param userToken - Broadcaster's valid user token; no-ops if null (no token to authenticate with).
+ * @param existing - This streamer's own existing subscriptions, already fetched (and filtered via
+ *   {@link isOwnSubscription}) by {@link createSubscriptionsForStreamer} via
+ *   {@link listOwnSubscriptions} — reused here instead of re-fetching the same paginated Helix
+ *   listing a second time for this same subscribe pass.
  */
 async function deleteStaleSubscriptions(
   uid: string, desired: Set<string>, created: ReadonlyMap<string, string>, userToken: string | null,
+  existing: ReadonlyArray<{ id: string; type: string; condition: Record<string, string> }>,
 ): Promise<void> {
   if (!userToken) return;
-  let existing: Array<{ id: string; type: string; condition: Record<string, string> }>;
-  try {
-    existing = await listEventSubSubscriptions(userToken);
-  } catch (err) {
-    log.error(`Subscription cleanup failed for uid ${uid}:`, err);
-    return;
-  }
   // Each deletion is isolated (and run concurrently, since they target different
   // subscriptions) so one failure (e.g. a transient Twitch API error) doesn't abort the rest
   // of the cleanup — leaving a still-undeleted stale duplicate would keep delivering
   // notifications and double-firing the type's handler, the exact failure this cleanup targets.
   const staleSubs = existing.filter((sub) => {
-    if (!isOwnSubscription(sub.condition, uid)) return false;
     const keptId = created.get(sub.type);
     const isStaleDuplicate = keptId !== undefined && sub.id !== keptId;
     return !desired.has(sub.type) || isStaleDuplicate;
@@ -121,11 +117,13 @@ export interface StreamerEventSubData {
   enabledAlerts?: ReadonlySet<AlertEventType>;
 }
 
-/** Desired subscription types alongside the ones freshly created this round, keyed by type
- *  (see {@link createSubscriptionsForStreamer}). */
+/** Desired subscription types alongside the ones freshly created this round, keyed by type,
+ *  and this streamer's own existing subscriptions as already fetched (see
+ *  {@link createSubscriptionsForStreamer}). */
 interface SubscriptionResult {
   desired: Set<string>;
   created: Map<string, string>;
+  ownSubscriptions: Array<{ id: string; type: string; condition: Record<string, string> }>;
 }
 
 /** True if `a` and `b` have exactly the same keys and values — used to tell "the subscription
@@ -147,9 +145,11 @@ function conditionsEqual(a: Record<string, string>, b: Record<string, string>): 
  * Twitch hadn't yet revoked its subscriptions) or bound to the live session but not `enabled`
  * (e.g. `authorization_revoked`) — it's deleted first so the fresh create can't 409 against it and
  * leave the *new* session with no working subscription for that spec.
- * @returns The desired-types set alongside a type → id map of subscriptions actually created (or
+ * @returns The desired-types set, a type → id map of subscriptions actually created (or
  *   confirmed already-live on this session) this round (a type is absent from `created` only on a
- *   genuine race — see {@link deleteStaleSubscriptions}).
+ *   genuine race — see {@link deleteStaleSubscriptions}), and this streamer's own existing
+ *   subscriptions as fetched at the start of this call (with any id already deleted above removed)
+ *   — reused by {@link deleteStaleSubscriptions} instead of it re-fetching the same listing.
  */
 async function createSubscriptionsForStreamer(
   sessionId: string, data: StreamerEventSubData,
@@ -158,14 +158,18 @@ async function createSubscriptionsForStreamer(
   const normalizedName = normalizeTwitchChannelName(name) ?? name.toLowerCase();
   if (!getActiveChannels().has(normalizedName)) {
     log.info(`Skipping EventSub subscriptions for ${name} — bot not in channel`);
-    return { desired: new Set(), created: new Map() };
+    return { desired: new Set(), created: new Map(), ownSubscriptions: [] };
   }
 
   const desired = new Set<string>();
   const created = new Map<string, string>();
-  if (!token) return { desired, created };
+  if (!token) return { desired, created, ownSubscriptions: [] };
 
   const ownSubscriptions = await listOwnSubscriptions(token, uid, name);
+  // Tracks ids ensureSubscription already deleted this round (a stale-session duplicate deleted
+  // before recreating) — excluded from the ownSubscriptions snapshot handed to
+  // deleteStaleSubscriptions so it doesn't attempt to delete the same (already-gone) id again.
+  const deletedThisRound = new Set<string>();
 
   for (const group of SUBSCRIPTION_GROUPS) {
     if (!isGroupEnabled(group, config, enabledAlerts)) continue;
@@ -174,12 +178,13 @@ async function createSubscriptionsForStreamer(
       const match = ownSubscriptions.find(
         (sub) => sub.type === spec.type && conditionsEqual(sub.condition, spec.condition),
       );
+      if (match && (match.sessionId !== sessionId || match.status !== 'enabled')) deletedThisRound.add(match.id);
       const id = await ensureSubscription(sessionId, spec, token, name, match);
       if (id !== null) created.set(spec.type, id);
     }
   }
 
-  return { desired, created };
+  return { desired, created, ownSubscriptions: ownSubscriptions.filter((sub) => !deletedThisRound.has(sub.id)) };
 }
 
 /** Fetches existing EventSub subscriptions and filters out any that Twitch returned only because
@@ -257,8 +262,8 @@ export async function subscribeForStreamer(
 ): Promise<number> {
   const { uid, token, name, config, streamerId } = data;
   setStreamerInfo(uid, { login: name, streamerId, config });
-  const { desired, created } = await createSubscriptionsForStreamer(sessionId, data);
-  await deleteStaleSubscriptions(uid, desired, created, token);
+  const { desired, created, ownSubscriptions } = await createSubscriptionsForStreamer(sessionId, data);
+  await deleteStaleSubscriptions(uid, desired, created, token, ownSubscriptions);
   return created.size;
 }
 


### PR DESCRIPTION
## Summary
- `createSubscriptionsForStreamer` (via `listOwnSubscriptions`) and `deleteStaleSubscriptions` each independently paginated `GET /eventsub/subscriptions` for the same streamer on every subscribe pass (every `session_welcome`, reload, or config change), doubling avoidable Helix API calls on a hot path.
- `deleteStaleSubscriptions` now reuses the listing already fetched (and filtered) earlier in the same round instead of re-fetching it — one paginated Helix call per streamer per pass instead of two.
- Ids that `ensureSubscription` already deleted this round (a stale-session duplicate, or a same-session subscription that wasn't `enabled`) are excluded from the snapshot handed to `deleteStaleSubscriptions`, so the reused snapshot can't cause a duplicate delete attempt on the same id.

**Note:** this PR previously stacked on #576, which has since landed on `main` (its API-based merge was blocked by GitHub since a stacked PR depended on it, so it was merged via a direct squash push matching the PR's diff exactly — see #576 for the full history). This branch has been rebased onto the current `main` and retargeted here now that #576's changes are in.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx eslint src/twitch/eventsub`
- [x] `npm test` (full suite, 3288 tests passing)
- [x] Tests: exactly one `listEventSubSubscriptions` call per `subscribeForStreamer` round (covering both the normal and stale-cleanup paths), a failed listing gracefully affecting both creation and cleanup, and stale-session/not-enabled duplicates each being deleted only once rather than twice
