### PR TITLE
Share one Helix subscriptions listing per subscribe pass

### DIFF
--- a/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
@@ -539,6 +539,34 @@ describe('subscribeForStreamer', () => {
     expect(deleteEventSubSubscription).toHaveBeenCalledTimes(1);
   });
 
+  it('retries a stale-session delete in the same round if the recreation delete attempt failed', async () => {
+    vi.mocked(getActiveChannels).mockReturnValue(new Set(['botinchannel']));
+    vi.mocked(createEventSubSubscription).mockResolvedValue('sub-fresh-follow-retry');
+    vi.mocked(listEventSubSubscriptions).mockResolvedValue([
+      {
+        id: 'sub-dead-follow-retry', type: 'channel.follow', sessionId: 'sess-old-dead', status: 'enabled',
+        condition: { broadcaster_user_id: 'uid-retry', moderator_user_id: 'uid-retry' },
+      },
+    ] as any);
+    // The delete attempted during recreation fails (e.g. a transient Twitch API error) — the
+    // subscription is still there, so it must remain eligible for deleteStaleSubscriptions to
+    // retry within this same round rather than being silently dropped from the snapshot.
+    vi.mocked(deleteEventSubSubscription).mockRejectedValueOnce(new Error('delete failed'));
+
+    await subscribeForStreamer('sess-new-live-retry', {
+      uid: 'uid-retry',
+      token: 'tok-retry',
+      name: 'botInChannel',
+      config: { follow_enabled: true, sub_enabled: false, raid_enabled: false } as any,
+      streamerId: 23,
+    });
+
+    // Retried: the failed attempt from ensureSubscription, then a second attempt from
+    // deleteStaleSubscriptions since the id was correctly kept in the reused snapshot.
+    expect(deleteEventSubSubscription).toHaveBeenCalledTimes(2);
+    expect(deleteEventSubSubscription).toHaveBeenCalledWith('sub-dead-follow-retry', 'tok-retry');
+  });
+
   it('ignores a same-type subscription belonging to a different broadcaster the streamer merely moderates, rather than keeping or deleting it', async () => {
     vi.mocked(getActiveChannels).mockReturnValue(new Set(['botinchannel']));
     vi.mocked(createEventSubSubscription).mockResolvedValue('sub-own-follow');

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
@@ -352,6 +352,25 @@ describe('subscribeForStreamer', () => {
     expect(deleteEventSubSubscription).toHaveBeenCalledWith('stale-sub', 'tok-z');
   });
 
+  it('lists existing EventSub subscriptions only once per round, reusing it for both matching and stale cleanup', async () => {
+    vi.mocked(getActiveChannels).mockReturnValue(new Set(['botinchannel']));
+    vi.mocked(createEventSubSubscription).mockResolvedValue('sub-new');
+    vi.mocked(listEventSubSubscriptions).mockResolvedValue([
+      { id: 'stale-sub', type: 'channel.subscribe', condition: { broadcaster_user_id: 'uid-once' } },
+    ] as any);
+
+    await subscribeForStreamer('sess-once', {
+      uid: 'uid-once',
+      token: 'tok-once',
+      name: 'botInChannel',
+      config: { follow_enabled: true, sub_enabled: false, raid_enabled: false } as any,
+      streamerId: 21,
+    });
+
+    expect(listEventSubSubscriptions).toHaveBeenCalledTimes(1);
+    expect(deleteEventSubSubscription).toHaveBeenCalledWith('stale-sub', 'tok-once');
+  });
+
   it('never deletes an undesired-type subscription belonging to a different broadcaster the streamer merely moderates', async () => {
     vi.mocked(getActiveChannels).mockReturnValue(new Set(['botinchannel']));
     vi.mocked(createEventSubSubscription).mockResolvedValue('sub-new');
@@ -450,6 +469,9 @@ describe('subscribeForStreamer', () => {
       'channel.follow', '2', { broadcaster_user_id: 'uid-revoked', moderator_user_id: 'uid-revoked' },
       'sess-revoked', 'tok-revoked',
     );
+    // Only deleted once — the shared own-subscriptions snapshot handed to the stale-cleanup pass
+    // must exclude this id too (not just session-mismatch deletions), or it would be deleted twice.
+    expect(deleteEventSubSubscription).toHaveBeenCalledTimes(1);
     expect(count).toBeGreaterThan(0);
   });
 
@@ -512,6 +534,9 @@ describe('subscribeForStreamer', () => {
       'channel.follow', '2', { broadcaster_user_id: 'uid-stale-session', moderator_user_id: 'uid-stale-session' },
       'sess-new-live', 'tok-stale-session',
     );
+    // Only deleted once — the reused own-subscriptions listing must not let the later stale-cleanup
+    // pass attempt to delete the same id a second time (it was already removed above).
+    expect(deleteEventSubSubscription).toHaveBeenCalledTimes(1);
   });
 
   it('ignores a same-type subscription belonging to a different broadcaster the streamer merely moderates, rather than keeping or deleting it', async () => {
@@ -788,12 +813,12 @@ describe('error handling in subscription setup', () => {
     expect(count).toBeGreaterThan(0);
   });
 
-  it('logs and continues when listing existing subscriptions fails during cleanup', async () => {
+  it('treats a failed listing as no existing subscriptions for both creation and cleanup, from a single fetch', async () => {
     vi.mocked(createEventSubSubscription).mockResolvedValue('sub-id');
-    // First call (pre-create lookup) succeeds; second call (deleteStaleSubscriptions) fails.
-    vi.mocked(listEventSubSubscriptions)
-      .mockResolvedValueOnce([])
-      .mockRejectedValueOnce(new Error('list failed'));
+    // Only one Helix listing call is made per subscribeForStreamer round (shared between the
+    // create-side match lookup and the cleanup step) — its failure means both treat it as if
+    // nothing exists: creation proceeds fresh, and cleanup has nothing to delete.
+    vi.mocked(listEventSubSubscriptions).mockRejectedValueOnce(new Error('list failed'));
 
     const count = await subscribeForStreamer('sess-err2', {
       uid: 'uid-err2',
@@ -803,7 +828,11 @@ describe('error handling in subscription setup', () => {
       streamerId: 70,
     });
 
-    expect(logMock.error).toHaveBeenCalledWith('Subscription cleanup failed for uid uid-err2:', expect.any(Error));
+    expect(listEventSubSubscriptions).toHaveBeenCalledTimes(1);
+    expect(logMock.error).toHaveBeenCalledWith(
+      'Failed to list existing EventSub subscriptions for errStreamer:', expect.any(Error),
+    );
+    expect(deleteEventSubSubscription).not.toHaveBeenCalled();
     expect(count).toBeGreaterThan(0);
   });
 

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -178,8 +178,8 @@ async function createSubscriptionsForStreamer(
       const match = ownSubscriptions.find(
         (sub) => sub.type === spec.type && conditionsEqual(sub.condition, spec.condition),
       );
-      if (match && (match.sessionId !== sessionId || match.status !== 'enabled')) deletedThisRound.add(match.id);
-      const id = await ensureSubscription(sessionId, spec, token, name, match);
+      const { id, deleted } = await ensureSubscription(sessionId, spec, token, name, match);
+      if (deleted && match) deletedThisRound.add(match.id);
       if (id !== null) created.set(spec.type, id);
     }
   }
@@ -212,20 +212,26 @@ async function listOwnSubscriptions(
  * in which case it isn't actually receiving notifications and must not be counted as live — deletes
  * one that's stale (bound to a different session, or not enabled) before recreating it, or creates
  * fresh if none exists.
- * @returns The live subscription's id, or null if creation failed (see {@link subscribe}).
+ * @returns The live subscription's id (or null if creation failed — see {@link subscribe}), and
+ *   whether a stale `existing` subscription was actually deleted here — `false` on a failed delete
+ *   attempt, so the caller knows not to treat that id as already gone (it must remain eligible for
+ *   {@link deleteStaleSubscriptions} to retry in the same round).
  */
 async function ensureSubscription(
   sessionId: string, spec: SubSpec, token: string, name: string,
   existing: { id: string; sessionId?: string; status?: string } | undefined,
-): Promise<string | null> {
-  if (existing && existing.sessionId === sessionId && existing.status === 'enabled') return existing.id;
+): Promise<{ id: string | null; deleted: boolean }> {
+  if (existing && existing.sessionId === sessionId && existing.status === 'enabled') return { id: existing.id, deleted: false };
+  let deleted = false;
   if (existing) {
     log.warn(`Deleting stale ${spec.type} subscription (${existing.id}) for ${name} — bound to a different session or not enabled (status=${existing.status})`);
-    await deleteEventSubSubscription(existing.id, token).catch((err) => {
+    deleted = await deleteEventSubSubscription(existing.id, token).then(() => true).catch((err) => {
       log.error(`Failed to delete stale ${spec.type} subscription for ${name}:`, err);
+      return false;
     });
   }
-  return subscribe(sessionId, spec, token, name);
+  const id = await subscribe(sessionId, spec, token, name);
+  return { id, deleted };
 }
 
 /**

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -225,10 +225,12 @@ async function ensureSubscription(
   let deleted = false;
   if (existing) {
     log.warn(`Deleting stale ${spec.type} subscription (${existing.id}) for ${name} — bound to a different session or not enabled (status=${existing.status})`);
-    deleted = await deleteEventSubSubscription(existing.id, token).then(() => true).catch((err) => {
+    try {
+      await deleteEventSubSubscription(existing.id, token);
+      deleted = true;
+    } catch (err) {
       log.error(`Failed to delete stale ${spec.type} subscription for ${name}:`, err);
-      return false;
-    });
+    }
   }
   const id = await subscribe(sessionId, spec, token, name);
   return { id, deleted };

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -55,32 +55,28 @@ function isOwnSubscription(condition: Record<string, string>, uid: string): bool
  * calls) — in that rare case it's left untouched, since we can't tell which one Twitch considers
  * the live one without risking deleting the subscription actually receiving events.
  *
- * @param uid - Broadcaster's Twitch user ID; also used to filter out another broadcaster's
- *   subscription that Twitch included only because this streamer moderates that channel (see
- *   {@link isOwnSubscription}) — never deleted, regardless of type or desired state.
+ * @param uid - Broadcaster's Twitch user ID; used only for logging here — `existing` is already
+ *   filtered down to this streamer's own subscriptions by {@link listOwnSubscriptions}.
  * @param desired - Subscription types that should exist after this call.
  * @param created - Type → subscription id for subscriptions freshly created this round (see
  *   {@link createSubscriptionsForStreamer}); a type present here has any other existing
  *   subscription of that type pruned as a stale duplicate.
  * @param userToken - Broadcaster's valid user token; no-ops if null (no token to authenticate with).
+ * @param existing - This streamer's own existing subscriptions, already fetched (and filtered via
+ *   {@link isOwnSubscription}) by {@link createSubscriptionsForStreamer} via
+ *   {@link listOwnSubscriptions} — reused here instead of re-fetching the same paginated Helix
+ *   listing a second time for this same subscribe pass.
  */
 async function deleteStaleSubscriptions(
   uid: string, desired: Set<string>, created: ReadonlyMap<string, string>, userToken: string | null,
+  existing: ReadonlyArray<{ id: string; type: string; condition: Record<string, string> }>,
 ): Promise<void> {
   if (!userToken) return;
-  let existing: Array<{ id: string; type: string; condition: Record<string, string> }>;
-  try {
-    existing = await listEventSubSubscriptions(userToken);
-  } catch (err) {
-    log.error(`Subscription cleanup failed for uid ${uid}:`, err);
-    return;
-  }
   // Each deletion is isolated (and run concurrently, since they target different
   // subscriptions) so one failure (e.g. a transient Twitch API error) doesn't abort the rest
   // of the cleanup — leaving a still-undeleted stale duplicate would keep delivering
   // notifications and double-firing the type's handler, the exact failure this cleanup targets.
   const staleSubs = existing.filter((sub) => {
-    if (!isOwnSubscription(sub.condition, uid)) return false;
     const keptId = created.get(sub.type);
     const isStaleDuplicate = keptId !== undefined && sub.id !== keptId;
     return !desired.has(sub.type) || isStaleDuplicate;
@@ -121,11 +117,13 @@ export interface StreamerEventSubData {
   enabledAlerts?: ReadonlySet<AlertEventType>;
 }
 
-/** Desired subscription types alongside the ones freshly created this round, keyed by type
- *  (see {@link createSubscriptionsForStreamer}). */
+/** Desired subscription types alongside the ones freshly created this round, keyed by type,
+ *  and this streamer's own existing subscriptions as already fetched (see
+ *  {@link createSubscriptionsForStreamer}). */
 interface SubscriptionResult {
   desired: Set<string>;
   created: Map<string, string>;
+  ownSubscriptions: Array<{ id: string; type: string; condition: Record<string, string> }>;
 }
 
 /** True if `a` and `b` have exactly the same keys and values — used to tell "the subscription
@@ -147,9 +145,11 @@ function conditionsEqual(a: Record<string, string>, b: Record<string, string>): 
  * Twitch hadn't yet revoked its subscriptions) or bound to the live session but not `enabled`
  * (e.g. `authorization_revoked`) — it's deleted first so the fresh create can't 409 against it and
  * leave the *new* session with no working subscription for that spec.
- * @returns The desired-types set alongside a type → id map of subscriptions actually created (or
+ * @returns The desired-types set, a type → id map of subscriptions actually created (or
  *   confirmed already-live on this session) this round (a type is absent from `created` only on a
- *   genuine race — see {@link deleteStaleSubscriptions}).
+ *   genuine race — see {@link deleteStaleSubscriptions}), and this streamer's own existing
+ *   subscriptions as fetched at the start of this call (with any id already deleted above removed)
+ *   — reused by {@link deleteStaleSubscriptions} instead of it re-fetching the same listing.
  */
 async function createSubscriptionsForStreamer(
   sessionId: string, data: StreamerEventSubData,
@@ -158,14 +158,18 @@ async function createSubscriptionsForStreamer(
   const normalizedName = normalizeTwitchChannelName(name) ?? name.toLowerCase();
   if (!getActiveChannels().has(normalizedName)) {
     log.info(`Skipping EventSub subscriptions for ${name} — bot not in channel`);
-    return { desired: new Set(), created: new Map() };
+    return { desired: new Set(), created: new Map(), ownSubscriptions: [] };
   }
 
   const desired = new Set<string>();
   const created = new Map<string, string>();
-  if (!token) return { desired, created };
+  if (!token) return { desired, created, ownSubscriptions: [] };
 
   const ownSubscriptions = await listOwnSubscriptions(token, uid, name);
+  // Tracks ids ensureSubscription already deleted this round (a stale-session duplicate deleted
+  // before recreating) — excluded from the ownSubscriptions snapshot handed to
+  // deleteStaleSubscriptions so it doesn't attempt to delete the same (already-gone) id again.
+  const deletedThisRound = new Set<string>();
 
   for (const group of SUBSCRIPTION_GROUPS) {
     if (!isGroupEnabled(group, config, enabledAlerts)) continue;
@@ -174,12 +178,13 @@ async function createSubscriptionsForStreamer(
       const match = ownSubscriptions.find(
         (sub) => sub.type === spec.type && conditionsEqual(sub.condition, spec.condition),
       );
+      if (match && (match.sessionId !== sessionId || match.status !== 'enabled')) deletedThisRound.add(match.id);
       const id = await ensureSubscription(sessionId, spec, token, name, match);
       if (id !== null) created.set(spec.type, id);
     }
   }
 
-  return { desired, created };
+  return { desired, created, ownSubscriptions: ownSubscriptions.filter((sub) => !deletedThisRound.has(sub.id)) };
 }
 
 /** Fetches existing EventSub subscriptions and filters out any that Twitch returned only because
@@ -257,8 +262,8 @@ export async function subscribeForStreamer(
 ): Promise<number> {
   const { uid, token, name, config, streamerId } = data;
   setStreamerInfo(uid, { login: name, streamerId, config });
-  const { desired, created } = await createSubscriptionsForStreamer(sessionId, data);
-  await deleteStaleSubscriptions(uid, desired, created, token);
+  const { desired, created, ownSubscriptions } = await createSubscriptionsForStreamer(sessionId, data);
+  await deleteStaleSubscriptions(uid, desired, created, token, ownSubscriptions);
   return created.size;
 }
 


### PR DESCRIPTION
## Summary
- `createSubscriptionsForStreamer` (via `listOwnSubscriptions`) and `deleteStaleSubscriptions` each independently paginated `GET /eventsub/subscriptions` for the same streamer on every subscribe pass (every `session_welcome`, reload, or config change), doubling avoidable Helix API calls on a hot path.
- `deleteStaleSubscriptions` now reuses the listing already fetched (and filtered) earlier in the same round instead of re-fetching it — one paginated Helix call per streamer per pass instead of two.
- Ids that `ensureSubscription` already deleted this round (a stale-session duplicate, or a same-session subscription that wasn't `enabled`) are excluded from the snapshot handed to `deleteStaleSubscriptions`, so the reused snapshot can't cause a duplicate delete attempt on the same id.

Replaces #577, which was stuck as a stacked PR on #576 and couldn't be retargeted to `main` after #576 landed (GitHub's stacked-PR base-branch restriction has no unstack action available to this session). Same branch, same diff, rebased onto current `main`.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx eslint src/twitch/eventsub`
- [x] `npm test` (full suite, 3288 tests passing)
- [x] Tests: exactly one `listEventSubSubscriptions` call per `subscribeForStreamer` round (covering both the normal and stale-cleanup paths), a failed listing gracefully affecting both creation and cleanup, and stale-session/not-enabled duplicates each being deleted only once rather than twice


---
_Generated by [Claude Code](https://claude.ai/code/session_01Re335bjZ54yY9LeouwbFiV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EventSub subscription management by reusing a consistent subscription snapshot.
  * Prevented duplicate deletion attempts during stale or inactive subscription cleanup.
  * Retried cleanup when a subscription deletion fails during recreation.
  * Improved handling of subscription listing failures to avoid unnecessary deletion requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->