### PR TITLE
Add bot health monitoring: dashboard, owner DM alerts, !health command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
         "mysql2": "^3.23.1",
         "openai": "^7.5.0",
         "winston": "^3.19.0",
-        "winston-daily-rotate-file": "^5.0.0"
+        "winston-daily-rotate-file": "^5.0.0",
+        "winston-transport": "^4.9.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "mysql2": "^3.23.1",
     "openai": "^7.5.0",
     "winston": "^3.19.0",
-    "winston-daily-rotate-file": "^5.0.0"
+    "winston-daily-rotate-file": "^5.0.0",
+    "winston-transport": "^4.9.0"
   },
   "overrides": {
     "ws": ">=8.21.1",

--- a/public/health.js
+++ b/public/health.js
@@ -23,11 +23,11 @@ function buildHealthRow(component, ok, lastEvent, lastError) {
   const tr = document.createElement('tr');
   const dot = ok ? '🟢' : '🔴';
   const state = ok ? 'OK' : 'Down';
-  tr.innerHTML =
-    '<td>' + component + '</td>' +
-    '<td>' + dot + ' ' + state + '</td>' +
-    '<td>' + (lastEvent || '—') + '</td>' +
-    '<td>' + (lastError || '—') + '</td>';
+  [component, dot + ' ' + state, lastEvent || '—', lastError || '—'].forEach(function (text) {
+    const td = document.createElement('td');
+    td.textContent = text;
+    tr.appendChild(td);
+  });
   return tr;
 }
 

--- a/public/health.js
+++ b/public/health.js
@@ -1,0 +1,100 @@
+/* ── Bot health dashboard ─────────────────────────────────────────────── */
+
+/**
+ * Formats an ISO/serialized date string for display, or '—' if absent.
+ * @param {string|null} value - A date value as serialized by `JSON.stringify` (an ISO string), or null.
+ * @returns {string} A locale-formatted date/time, or '—'.
+ */
+function formatHealthDate(value) {
+  if (!value) return '—';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? '—' : date.toLocaleString();
+}
+
+/**
+ * Builds one `<tr>` for the health table.
+ * @param {string} component - Display name of the component.
+ * @param {boolean} ok - Whether the component is currently healthy.
+ * @param {string|null} lastEvent - Formatted last-event timestamp text.
+ * @param {string|null} lastError - Last error message, or null/empty for none.
+ * @returns {HTMLTableRowElement} The built row.
+ */
+function buildHealthRow(component, ok, lastEvent, lastError) {
+  const tr = document.createElement('tr');
+  const dot = ok ? '🟢' : '🔴';
+  const state = ok ? 'OK' : 'Down';
+  tr.innerHTML =
+    '<td>' + component + '</td>' +
+    '<td>' + dot + ' ' + state + '</td>' +
+    '<td>' + (lastEvent || '—') + '</td>' +
+    '<td>' + (lastError || '—') + '</td>';
+  return tr;
+}
+
+/**
+ * Renders the full health table and recent-errors list from a health snapshot payload
+ * (shaped like `healthStore.getHealthSnapshot()`, JSON-serialized).
+ * @param {object} health - The health snapshot.
+ * @returns {void}
+ */
+function applyHealth(health) {
+  const body = document.getElementById('health-table-body');
+  if (!body) return;
+  body.innerHTML = '';
+
+  body.appendChild(buildHealthRow('Discord', health.discordConnected, null, null));
+  body.appendChild(buildHealthRow('Twitch chat', health.twitchChatConnected, null, null));
+  body.appendChild(buildHealthRow('Database', health.db.lastPingOk, formatHealthDate(health.db.lastPingAt), health.db.lastError));
+
+  Object.keys(health.eventsub || {}).forEach(function (streamer) {
+    const entry = health.eventsub[streamer];
+    body.appendChild(
+      buildHealthRow(
+        'EventSub: ' + streamer + ' (reconnects: ' + entry.reconnectAttempts + ')',
+        entry.connected,
+        formatHealthDate(entry.connected ? entry.lastConnectedAt : entry.lastDisconnectedAt),
+        entry.lastError,
+      ),
+    );
+  });
+
+  body.appendChild(buildHealthRow('Stream monitor', health.monitor.lastPollOk, formatHealthDate(health.monitor.lastPollAt), health.monitor.lastError));
+
+  Object.keys(health.schedulers || {}).forEach(function (name) {
+    const entry = health.schedulers[name];
+    if (!entry) return;
+    body.appendChild(buildHealthRow('Scheduler: ' + name, entry.lastRunOk, formatHealthDate(entry.lastRunAt), entry.lastError));
+  });
+
+  const errorsList = document.getElementById('health-errors-list');
+  const errorsEmpty = document.getElementById('health-errors-empty');
+  if (errorsList && errorsEmpty) {
+    errorsList.innerHTML = '';
+    const errors = (health.errors || []).slice().reverse();
+    errorsEmpty.style.display = errors.length === 0 ? '' : 'none';
+    errors.forEach(function (err) {
+      const li = document.createElement('li');
+      li.textContent = '[' + formatHealthDate(err.timestamp) + '] ' + err.module + ': ' + err.message;
+      errorsList.appendChild(li);
+    });
+  }
+}
+
+const initialHealthRaw = document.body && document.body.dataset ? document.body.dataset.initialHealth : null;
+if (initialHealthRaw) {
+  try {
+    applyHealth(JSON.parse(initialHealthRaw));
+  } catch (e) {
+    // Malformed initial payload — the SSE stream below will populate the page shortly.
+  }
+}
+
+// Live-push health updates over SSE; EventSource's own auto-reconnect handles transient drops.
+const healthSource = new EventSource('/admin/health/events');
+healthSource.onmessage = function (msg) {
+  try {
+    applyHealth(JSON.parse(msg.data));
+  } catch (e) {
+    // Ignore malformed payloads.
+  }
+};

--- a/src/commands/counterScheduler.test.ts
+++ b/src/commands/counterScheduler.test.ts
@@ -5,10 +5,12 @@ import { mockLogger } from '../test-utils/loggerMock';
 vi.mock('../shared/logger', () => ({ createLogger: mockLogger }));
 
 vi.mock('../db', () => ({ archiveAndResetYearlyCounters: vi.fn() }));
+vi.mock('../shared/healthStore', () => ({ recordSchedulerRun: vi.fn(), normalizeError: vi.fn((err: unknown) => (err instanceof Error ? err.message : String(err))) }));
 
 let startCounterScheduler: () => void;
 let stopCounterScheduler: () => void;
 let archiveAndResetYearlyCounters: ReturnType<typeof vi.fn>;
+let recordSchedulerRun: ReturnType<typeof vi.fn>;
 
 async function flushAsync(): Promise<void> {
   // Multiple rounds of microtask flushing to let async tick() complete
@@ -28,6 +30,9 @@ beforeEach(async () => {
   const db = await import('../db.js');
   archiveAndResetYearlyCounters = vi.mocked(db.archiveAndResetYearlyCounters);
   archiveAndResetYearlyCounters.mockResolvedValue(0);
+
+  const healthStore = await import('../shared/healthStore.js');
+  recordSchedulerRun = vi.mocked(healthStore.recordSchedulerRun);
 });
 
 afterEach(() => {
@@ -161,6 +166,31 @@ describe('counterScheduler', () => {
     // A single stopCounterScheduler() call should still fully stop everything.
     stopCounterScheduler();
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('records a successful scheduler run on the non-archive poll path', async () => {
+    vi.setSystemTime(new Date(2025, 1, 15)); // Feb 15, 2025 — not Jan 1
+    startCounterScheduler();
+    await flushAsync();
+
+    expect(recordSchedulerRun).toHaveBeenCalledWith('counter', true);
+  });
+
+  it('records a successful scheduler run when the yearly archive succeeds', async () => {
+    vi.setSystemTime(new Date(2025, 0, 1)); // Jan 1, 2025
+    startCounterScheduler();
+    await flushAsync();
+
+    expect(recordSchedulerRun).toHaveBeenCalledWith('counter', true);
+  });
+
+  it('records a failed scheduler run with the normalized error when the yearly archive throws', async () => {
+    vi.setSystemTime(new Date(2025, 0, 1)); // Jan 1, 2025
+    archiveAndResetYearlyCounters.mockRejectedValueOnce(new Error('DB down'));
+    startCounterScheduler();
+    await flushAsync();
+
+    expect(recordSchedulerRun).toHaveBeenCalledWith('counter', false, 'DB down');
   });
 
   it('stopCounterScheduler prevents further ticks', async () => {

--- a/src/commands/counterScheduler.ts
+++ b/src/commands/counterScheduler.ts
@@ -21,7 +21,13 @@ let started = false;
 // `started` check alone can't distinguish "still my run" from "a newer run began".
 let runGeneration = 0;
 
-/** Polls once for the yearly counter archive and reschedules itself hourly while its run is still active. */
+/**
+ * Polls once for the yearly counter archive and reschedules itself hourly while its run is
+ * still active, recording the outcome (archive attempted or skipped) into `healthStore`.
+ * @param myGeneration - This run's generation number (see {@link runGeneration}), used to detect
+ *   a stale reschedule from an earlier, since-stopped run.
+ * @returns Resolves once this tick (and its reschedule, if still the active run) completes.
+ */
 async function tick(myGeneration: number): Promise<void> {
   const now = new Date();
   const prevYear = now.getFullYear() - 1;

--- a/src/commands/counterScheduler.ts
+++ b/src/commands/counterScheduler.ts
@@ -1,5 +1,6 @@
 import { createLogger } from '../shared/logger';
 import { archiveAndResetYearlyCounters } from '../db';
+import { recordSchedulerRun, normalizeError } from '../shared/healthStore';
 
 const log = createLogger('CounterScheduler');
 
@@ -30,10 +31,14 @@ async function tick(myGeneration: number): Promise<void> {
       const count = await archiveAndResetYearlyCounters(prevYear);
       log.info(`Archived and reset ${count} counter(s) for year ${prevYear}.`);
       lastArchivedYear = prevYear;
+      recordSchedulerRun('counter', true);
     } catch (err) {
       log.error(`Failed to archive counters for year ${prevYear}:`, err);
+      recordSchedulerRun('counter', false, normalizeError(err));
       // lastArchivedYear is not set on failure, so the next hourly poll will retry.
     }
+  } else {
+    recordSchedulerRun('counter', true);
   }
 
   // Only reschedule while still the active run — guards both a stop() that raced this

--- a/src/commands/healthCommandHandler.test.ts
+++ b/src/commands/healthCommandHandler.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mockLogger } from '../test-utils/loggerMock';
+
+vi.mock('../shared/logger', () => ({ createLogger: mockLogger }));
+
+vi.mock('../db', () => ({
+  findOwnerUser: vi.fn(),
+}));
+
+vi.mock('../shared/healthStore', () => ({
+  getHealthSnapshot: vi.fn(),
+}));
+
+import { executeHealthCommandForDiscord } from './healthCommandHandler';
+import { findOwnerUser } from '../db';
+import { getHealthSnapshot } from '../shared/healthStore';
+
+const OWNER_ID = '111222333444555666';
+const OWNER_ROW = {
+  discord_id: OWNER_ID,
+  discord_name: 'Owner',
+  is_twitch_bot_enabled: false,
+  twitch_name: null,
+  access_level: 3,
+  is_owner: true,
+};
+
+const EMPTY_SNAPSHOT = {
+  discordConnected: true,
+  twitchChatConnected: true,
+  db: { lastPingOk: true, lastPingAt: new Date('2026-01-01T00:00:00Z'), lastError: null },
+  eventsub: {},
+  monitor: { lastPollOk: true, lastPollAt: new Date('2026-01-01T00:00:00Z'), lastError: null },
+  schedulers: {},
+  errors: [],
+};
+
+function makeMockMessage(content: string, authorId: string) {
+  return {
+    content,
+    author: { id: authorId },
+    reply: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('executeHealthCommandForDiscord', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getHealthSnapshot).mockReturnValue(EMPTY_SNAPSHOT as any);
+    vi.mocked(findOwnerUser).mockResolvedValue(OWNER_ROW as any);
+  });
+
+  it('does not reply for a message that is not !health', async () => {
+    const message = makeMockMessage('!other', OWNER_ID);
+    await executeHealthCommandForDiscord(message as any);
+    expect(message.reply).not.toHaveBeenCalled();
+    expect(findOwnerUser).not.toHaveBeenCalled();
+  });
+
+  it('does not reply when the author is not the owner', async () => {
+    const message = makeMockMessage('!health', 'not-the-owner');
+    await executeHealthCommandForDiscord(message as any);
+    expect(message.reply).not.toHaveBeenCalled();
+  });
+
+  it('does not reply when there is no owner row', async () => {
+    vi.mocked(findOwnerUser).mockResolvedValue(null);
+    const message = makeMockMessage('!health', OWNER_ID);
+    await executeHealthCommandForDiscord(message as any);
+    expect(message.reply).not.toHaveBeenCalled();
+  });
+
+  it('replies with a health summary for the owner', async () => {
+    const message = makeMockMessage('!health', OWNER_ID);
+    await executeHealthCommandForDiscord(message as any);
+    expect(message.reply).toHaveBeenCalledOnce();
+    const replyText = message.reply.mock.calls[0][0] as string;
+    expect(replyText).toContain('Bot Health');
+    expect(replyText).toContain('Discord');
+    expect(replyText).toContain('Twitch chat');
+    expect(replyText).toContain('DB');
+  });
+
+  it('matches !health only as the first word, not as a substring of another command', async () => {
+    const message = makeMockMessage('!healthcheck', OWNER_ID);
+    await executeHealthCommandForDiscord(message as any);
+    expect(message.reply).not.toHaveBeenCalled();
+  });
+
+  it('includes recent errors, newest first', async () => {
+    vi.mocked(getHealthSnapshot).mockReturnValue({
+      ...EMPTY_SNAPSHOT,
+      errors: [
+        { timestamp: new Date('2026-01-01T00:00:00Z'), module: 'Discord', message: 'first' },
+        { timestamp: new Date('2026-01-01T00:01:00Z'), module: 'Twitch', message: 'second' },
+      ],
+    } as any);
+    const message = makeMockMessage('!health', OWNER_ID);
+    await executeHealthCommandForDiscord(message as any);
+    const replyText = message.reply.mock.calls[0][0] as string;
+    const firstIndex = replyText.indexOf('first');
+    const secondIndex = replyText.indexOf('second');
+    expect(secondIndex).toBeGreaterThan(-1);
+    expect(firstIndex).toBeGreaterThan(secondIndex);
+  });
+
+  it('does not throw when findOwnerUser rejects', async () => {
+    vi.mocked(findOwnerUser).mockRejectedValue(new Error('db down'));
+    const message = makeMockMessage('!health', OWNER_ID);
+    await expect(executeHealthCommandForDiscord(message as any)).resolves.toBeUndefined();
+    expect(message.reply).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/healthCommandHandler.test.ts
+++ b/src/commands/healthCommandHandler.test.ts
@@ -35,10 +35,11 @@ const EMPTY_SNAPSHOT = {
   errors: [],
 };
 
-function makeMockMessage(content: string, authorId: string) {
+function makeMockMessage(content: string, authorId: string, opts: { guild?: unknown } = {}) {
   return {
     content,
-    author: { id: authorId },
+    author: { id: authorId, send: vi.fn().mockResolvedValue(undefined) },
+    guild: opts.guild ?? null,
     reply: vi.fn().mockResolvedValue(undefined),
   };
 }
@@ -50,40 +51,64 @@ describe('executeHealthCommandForDiscord', () => {
     vi.mocked(findOwnerUser).mockResolvedValue(OWNER_ROW as any);
   });
 
-  it('does not reply for a message that is not !health', async () => {
+  it('does not DM for a message that is not !health', async () => {
     const message = makeMockMessage('!other', OWNER_ID);
     await executeHealthCommandForDiscord(message as any);
+    expect(message.author.send).not.toHaveBeenCalled();
     expect(message.reply).not.toHaveBeenCalled();
     expect(findOwnerUser).not.toHaveBeenCalled();
   });
 
-  it('does not reply when the author is not the owner', async () => {
+  it('does not DM when the author is not the owner', async () => {
     const message = makeMockMessage('!health', 'not-the-owner');
     await executeHealthCommandForDiscord(message as any);
+    expect(message.author.send).not.toHaveBeenCalled();
     expect(message.reply).not.toHaveBeenCalled();
   });
 
-  it('does not reply when there is no owner row', async () => {
+  it('does not DM when there is no owner row', async () => {
     vi.mocked(findOwnerUser).mockResolvedValue(null);
     const message = makeMockMessage('!health', OWNER_ID);
     await executeHealthCommandForDiscord(message as any);
+    expect(message.author.send).not.toHaveBeenCalled();
     expect(message.reply).not.toHaveBeenCalled();
   });
 
-  it('replies with a health summary for the owner', async () => {
+  it('DMs the owner a health summary, and does not reply in-channel outside a guild', async () => {
     const message = makeMockMessage('!health', OWNER_ID);
     await executeHealthCommandForDiscord(message as any);
+    expect(message.author.send).toHaveBeenCalledOnce();
+    const dmText = message.author.send.mock.calls[0][0] as string;
+    expect(dmText).toContain('Bot Health');
+    expect(dmText).toContain('Discord');
+    expect(dmText).toContain('Twitch chat');
+    expect(dmText).toContain('DB');
+    expect(message.reply).not.toHaveBeenCalled();
+  });
+
+  it('DMs the owner and posts a non-sensitive channel ack when triggered from a guild', async () => {
+    const message = makeMockMessage('!health', OWNER_ID, { guild: { id: 'guild-1' } });
+    await executeHealthCommandForDiscord(message as any);
+    expect(message.author.send).toHaveBeenCalledOnce();
+    const dmText = message.author.send.mock.calls[0][0] as string;
+    expect(dmText).toContain('Bot Health');
     expect(message.reply).toHaveBeenCalledOnce();
     const replyText = message.reply.mock.calls[0][0] as string;
-    expect(replyText).toContain('Bot Health');
-    expect(replyText).toContain('Discord');
-    expect(replyText).toContain('Twitch chat');
-    expect(replyText).toContain('DB');
+    expect(replyText).not.toContain('Bot Health');
+    expect(replyText).not.toContain('DB');
+  });
+
+  it('logs and swallows a failed DM (e.g. DMs closed) instead of throwing, without posting a channel ack', async () => {
+    const message = makeMockMessage('!health', OWNER_ID, { guild: { id: 'guild-1' } });
+    message.author.send.mockRejectedValue(new Error('Cannot send messages to this user'));
+    await expect(executeHealthCommandForDiscord(message as any)).resolves.toBeUndefined();
+    expect(message.reply).not.toHaveBeenCalled();
   });
 
   it('matches !health only as the first word, not as a substring of another command', async () => {
     const message = makeMockMessage('!healthcheck', OWNER_ID);
     await executeHealthCommandForDiscord(message as any);
+    expect(message.author.send).not.toHaveBeenCalled();
     expect(message.reply).not.toHaveBeenCalled();
   });
 
@@ -97,11 +122,26 @@ describe('executeHealthCommandForDiscord', () => {
     } as any);
     const message = makeMockMessage('!health', OWNER_ID);
     await executeHealthCommandForDiscord(message as any);
-    const replyText = message.reply.mock.calls[0][0] as string;
-    const firstIndex = replyText.indexOf('first');
-    const secondIndex = replyText.indexOf('second');
+    const dmText = message.author.send.mock.calls[0][0] as string;
+    const firstIndex = dmText.indexOf('first');
+    const secondIndex = dmText.indexOf('second');
     expect(secondIndex).toBeGreaterThan(-1);
     expect(firstIndex).toBeGreaterThan(secondIndex);
+  });
+
+  it('truncates a summary that would otherwise exceed the Discord message limit', async () => {
+    const manyEventSubEntries = Object.fromEntries(
+      Array.from({ length: 100 }, (_, i) => [
+        `streamer-with-a-fairly-long-name-${i}`,
+        { connected: true, lastConnectedAt: null, lastDisconnectedAt: null, reconnectAttempts: 0, lastError: null },
+      ]),
+    );
+    vi.mocked(getHealthSnapshot).mockReturnValue({ ...EMPTY_SNAPSHOT, eventsub: manyEventSubEntries } as any);
+    const message = makeMockMessage('!health', OWNER_ID);
+    await executeHealthCommandForDiscord(message as any);
+    const dmText = message.author.send.mock.calls[0][0] as string;
+    expect(dmText.length).toBeLessThanOrEqual(2000);
+    expect(dmText.endsWith('\n… (truncated)')).toBe(true);
   });
 
   it('does not throw when findOwnerUser rejects', async () => {

--- a/src/commands/healthCommandHandler.test.ts
+++ b/src/commands/healthCommandHandler.test.ts
@@ -129,6 +129,27 @@ describe('executeHealthCommandForDiscord', () => {
     expect(firstIndex).toBeGreaterThan(secondIndex);
   });
 
+  it('includes an EventSub section and a Schedulers section when either is populated', async () => {
+    vi.mocked(getHealthSnapshot).mockReturnValue({
+      ...EMPTY_SNAPSHOT,
+      eventsub: {
+        streamerA: { connected: true, lastConnectedAt: null, lastDisconnectedAt: null, reconnectAttempts: 0, lastError: null },
+      },
+      schedulers: {
+        counter: { lastRunAt: new Date('2026-01-01T00:00:00Z'), lastRunOk: true, lastError: null },
+        timer: { lastRunAt: new Date('2026-01-01T00:00:00Z'), lastRunOk: false, lastError: 'boom' },
+      },
+    } as any);
+    const message = makeMockMessage('!health', OWNER_ID);
+    await executeHealthCommandForDiscord(message as any);
+    const dmText = message.author.send.mock.calls[0][0] as string;
+    expect(dmText).toContain('EventSub:');
+    expect(dmText).toContain('streamerA');
+    expect(dmText).toContain('Schedulers:');
+    expect(dmText).toContain('counter: 🟢 ok');
+    expect(dmText).toContain('timer: 🔴 failing');
+  });
+
   it('truncates a summary that would otherwise exceed the Discord message limit', async () => {
     const manyEventSubEntries = Object.fromEntries(
       Array.from({ length: 100 }, (_, i) => [

--- a/src/commands/healthCommandHandler.ts
+++ b/src/commands/healthCommandHandler.ts
@@ -11,6 +11,19 @@ const TRIGGER = '!health';
 /** Number of most-recent error entries shown in the `!health` summary (newest first). */
 const RECENT_ERROR_COUNT = 5;
 
+/**
+ * Discord's per-message character cap. {@link formatHealthSummary}'s output is truncated to
+ * stay comfortably under this, since both the owner DM and (if ever sent in-channel) a reply
+ * share the same limit.
+ */
+const DISCORD_MESSAGE_LIMIT = 2000;
+
+/** Length {@link formatHealthSummary}'s output is truncated to before appending the truncation marker, leaving headroom under {@link DISCORD_MESSAGE_LIMIT}. */
+const SUMMARY_TRUNCATE_LENGTH = 1900;
+
+/** Appended to a truncated `!health` summary (see {@link formatHealthSummary}). */
+const TRUNCATION_MARKER = '\n… (truncated)';
+
 /** Formats a `Date | null` for display, or `'—'` if absent. */
 function formatDate(date: Date | null): string {
   return date ? date.toLocaleString() : '—';
@@ -76,7 +89,7 @@ function formatRecentErrorLines(snapshot: HealthSnapshot): string[] {
  * @returns The formatted summary text.
  */
 function formatHealthSummary(snapshot: HealthSnapshot): string {
-  return [
+  const full = [
     '**Bot Health**',
     ...formatConnectivityLines(snapshot),
     ...formatEventSubLines(snapshot),
@@ -84,15 +97,21 @@ function formatHealthSummary(snapshot: HealthSnapshot): string {
     ...formatSchedulerLines(snapshot),
     ...formatRecentErrorLines(snapshot),
   ].join('\n');
+  if (full.length <= DISCORD_MESSAGE_LIMIT) return full;
+  return full.slice(0, SUMMARY_TRUNCATE_LENGTH) + TRUNCATION_MARKER;
 }
 
 /**
  * Handles the `!health` Discord command: matched as the literal first word of the message
  * (no prefix stripping — see `CLAUDE.md`'s command-matching convention), owner-only.
  * Silently no-ops for a non-match, a missing owner row, or an author who isn't the owner, so
- * the command's existence isn't revealed to anyone else. Owner match replies with a plain-text
- * summary of the current `healthStore` snapshot.
- * @param message - The Discord message to check and, if it's an owner-issued `!health`, reply to.
+ * the command's existence isn't revealed to anyone else. Owner match sends the full summary of
+ * the current `healthStore` snapshot via DM — never into the (possibly public) guild channel it
+ * was triggered from, since the summary includes DB/EventSub/scheduler/recent-error details.
+ * When triggered from a guild channel, also posts a minimal, non-sensitive acknowledgement reply
+ * there so the owner knows to check their DMs. If the DM itself fails (e.g. the owner has DMs
+ * closed), that's logged and swallowed rather than thrown.
+ * @param message - The Discord message to check and, if it's an owner-issued `!health`, respond to.
  */
 export async function executeHealthCommandForDiscord(message: Message): Promise<void> {
   if (extractCommand(message.content) !== TRIGGER) return;
@@ -106,5 +125,14 @@ export async function executeHealthCommandForDiscord(message: Message): Promise<
   }
   if (!owner || message.author.id !== owner.discord_id) return;
 
-  await message.reply(formatHealthSummary(getHealthSnapshot()));
+  try {
+    await message.author.send(formatHealthSummary(getHealthSnapshot()));
+  } catch (err) {
+    log.error('Failed to DM health summary to owner:', err);
+    return;
+  }
+
+  if (message.guild) {
+    await message.reply('📬 Sent you the health report via DM.');
+  }
 }

--- a/src/commands/healthCommandHandler.ts
+++ b/src/commands/healthCommandHandler.ts
@@ -112,6 +112,7 @@ function formatHealthSummary(snapshot: HealthSnapshot): string {
  * there so the owner knows to check their DMs. If the DM itself fails (e.g. the owner has DMs
  * closed), that's logged and swallowed rather than thrown.
  * @param message - The Discord message to check and, if it's an owner-issued `!health`, respond to.
+ * @returns Resolves once the command has been handled (or ignored as a non-match).
  */
 export async function executeHealthCommandForDiscord(message: Message): Promise<void> {
   if (extractCommand(message.content) !== TRIGGER) return;

--- a/src/commands/healthCommandHandler.ts
+++ b/src/commands/healthCommandHandler.ts
@@ -1,0 +1,95 @@
+import type { Message } from 'discord.js';
+import { createLogger } from '../shared/logger';
+import { extractCommand } from './commandUtils';
+import { findOwnerUser } from '../db';
+import { getHealthSnapshot, type HealthSnapshot } from '../shared/healthStore';
+
+const log = createLogger('HealthCommand');
+
+const TRIGGER = '!health';
+
+/** Number of most-recent error entries shown in the `!health` summary (newest first). */
+const RECENT_ERROR_COUNT = 5;
+
+/** Formats a `Date | null` for display, or `'—'` if absent. */
+function formatDate(date: Date | null): string {
+  return date ? date.toLocaleString() : '—';
+}
+
+/**
+ * Builds the plain-text `!health` summary from a health snapshot: Discord/Twitch chat
+ * connection state, the last DB ping, every tracked EventSub streamer's connection status,
+ * the last monitor poll, every tracked scheduler's last run, and the most recent errors
+ * (newest first, capped at {@link RECENT_ERROR_COUNT}).
+ * @param snapshot - The health snapshot to summarize (see `healthStore.getHealthSnapshot`).
+ * @returns The formatted summary text.
+ */
+function formatHealthSummary(snapshot: HealthSnapshot): string {
+  const lines: string[] = ['**Bot Health**'];
+
+  lines.push(`Discord: ${snapshot.discordConnected ? '🟢 connected' : '🔴 disconnected'}`);
+  lines.push(`Twitch chat: ${snapshot.twitchChatConnected ? '🟢 connected' : '🔴 disconnected'}`);
+  lines.push(
+    `DB: ${snapshot.db.lastPingOk ? '🟢 ok' : '🔴 failing'} (last ping ${formatDate(snapshot.db.lastPingAt)}${
+      snapshot.db.lastError ? `, last error: ${snapshot.db.lastError}` : ''
+    })`,
+  );
+
+  const eventsubEntries = Object.entries(snapshot.eventsub);
+  if (eventsubEntries.length > 0) {
+    lines.push('EventSub:');
+    for (const [streamer, health] of eventsubEntries) {
+      lines.push(
+        `  ${streamer}: ${health.connected ? '🟢 connected' : '🔴 disconnected'} (reconnect attempts: ${health.reconnectAttempts})`,
+      );
+    }
+  }
+
+  lines.push(
+    `Monitor: ${snapshot.monitor.lastPollOk ? '🟢 ok' : '🔴 failing'} (last poll ${formatDate(snapshot.monitor.lastPollAt)}${
+      snapshot.monitor.lastError ? `, last error: ${snapshot.monitor.lastError}` : ''
+    })`,
+  );
+
+  const schedulerEntries = Object.entries(snapshot.schedulers);
+  if (schedulerEntries.length > 0) {
+    lines.push('Schedulers:');
+    for (const [name, health] of schedulerEntries) {
+      if (!health) continue;
+      lines.push(`  ${name}: ${health.lastRunOk ? '🟢 ok' : '🔴 failing'} (last run ${formatDate(health.lastRunAt)})`);
+    }
+  }
+
+  if (snapshot.errors.length > 0) {
+    lines.push('Recent errors:');
+    const recent = snapshot.errors.slice(-RECENT_ERROR_COUNT).reverse();
+    for (const err of recent) {
+      lines.push(`  [${formatDate(err.timestamp)}] ${err.module}: ${err.message}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Handles the `!health` Discord command: matched as the literal first word of the message
+ * (no prefix stripping — see `CLAUDE.md`'s command-matching convention), owner-only.
+ * Silently no-ops for a non-match, a missing owner row, or an author who isn't the owner, so
+ * the command's existence isn't revealed to anyone else. Owner match replies with a plain-text
+ * summary of the current `healthStore` snapshot.
+ * @param message - The Discord message to check and, if it's an owner-issued `!health`, reply to.
+ */
+export async function executeHealthCommandForDiscord(message: Message): Promise<void> {
+  if (extractCommand(message.content) !== TRIGGER) return;
+
+  let owner;
+  try {
+    owner = await findOwnerUser();
+  } catch (err) {
+    log.error('Failed to resolve owner user for !health command:', err);
+    return;
+  }
+  if (!owner || message.author.id !== owner.discord_id) return;
+
+  await message.reply(formatHealthSummary(getHealthSnapshot()));
+}

--- a/src/commands/healthCommandHandler.ts
+++ b/src/commands/healthCommandHandler.ts
@@ -16,6 +16,57 @@ function formatDate(date: Date | null): string {
   return date ? date.toLocaleString() : '—';
 }
 
+/** Formats the Discord/Twitch-chat/DB connectivity lines for the `!health` summary. */
+function formatConnectivityLines(snapshot: HealthSnapshot): string[] {
+  return [
+    `Discord: ${snapshot.discordConnected ? '🟢 connected' : '🔴 disconnected'}`,
+    `Twitch chat: ${snapshot.twitchChatConnected ? '🟢 connected' : '🔴 disconnected'}`,
+    `DB: ${snapshot.db.lastPingOk ? '🟢 ok' : '🔴 failing'} (last ping ${formatDate(snapshot.db.lastPingAt)}${
+      snapshot.db.lastError ? `, last error: ${snapshot.db.lastError}` : ''
+    })`,
+  ];
+}
+
+/** Formats one line per tracked EventSub streamer, or `[]` if none are tracked yet. */
+function formatEventSubLines(snapshot: HealthSnapshot): string[] {
+  const entries = Object.entries(snapshot.eventsub);
+  if (entries.length === 0) return [];
+  return [
+    'EventSub:',
+    ...entries.map(
+      ([streamer, health]) =>
+        `  ${streamer}: ${health.connected ? '🟢 connected' : '🔴 disconnected'} (reconnect attempts: ${health.reconnectAttempts})`,
+    ),
+  ];
+}
+
+/** Formats the Twitch stream-monitor's last-poll line for the `!health` summary. */
+function formatMonitorLine(snapshot: HealthSnapshot): string {
+  return `Monitor: ${snapshot.monitor.lastPollOk ? '🟢 ok' : '🔴 failing'} (last poll ${formatDate(snapshot.monitor.lastPollAt)}${
+    snapshot.monitor.lastError ? `, last error: ${snapshot.monitor.lastError}` : ''
+  })`;
+}
+
+/** Formats one line per tracked scheduler, or `[]` if none are tracked yet. */
+function formatSchedulerLines(snapshot: HealthSnapshot): string[] {
+  const entries = Object.entries(snapshot.schedulers).filter(([, health]) => health !== undefined);
+  if (entries.length === 0) return [];
+  return [
+    'Schedulers:',
+    ...entries.map(
+      ([name, health]) =>
+        `  ${name}: ${health!.lastRunOk ? '🟢 ok' : '🔴 failing'} (last run ${formatDate(health!.lastRunAt)})`,
+    ),
+  ];
+}
+
+/** Formats the most recent errors (newest first, capped at {@link RECENT_ERROR_COUNT}), or `[]` if none. */
+function formatRecentErrorLines(snapshot: HealthSnapshot): string[] {
+  if (snapshot.errors.length === 0) return [];
+  const recent = snapshot.errors.slice(-RECENT_ERROR_COUNT).reverse();
+  return ['Recent errors:', ...recent.map((err) => `  [${formatDate(err.timestamp)}] ${err.module}: ${err.message}`)];
+}
+
 /**
  * Builds the plain-text `!health` summary from a health snapshot: Discord/Twitch chat
  * connection state, the last DB ping, every tracked EventSub streamer's connection status,
@@ -25,50 +76,14 @@ function formatDate(date: Date | null): string {
  * @returns The formatted summary text.
  */
 function formatHealthSummary(snapshot: HealthSnapshot): string {
-  const lines: string[] = ['**Bot Health**'];
-
-  lines.push(`Discord: ${snapshot.discordConnected ? '🟢 connected' : '🔴 disconnected'}`);
-  lines.push(`Twitch chat: ${snapshot.twitchChatConnected ? '🟢 connected' : '🔴 disconnected'}`);
-  lines.push(
-    `DB: ${snapshot.db.lastPingOk ? '🟢 ok' : '🔴 failing'} (last ping ${formatDate(snapshot.db.lastPingAt)}${
-      snapshot.db.lastError ? `, last error: ${snapshot.db.lastError}` : ''
-    })`,
-  );
-
-  const eventsubEntries = Object.entries(snapshot.eventsub);
-  if (eventsubEntries.length > 0) {
-    lines.push('EventSub:');
-    for (const [streamer, health] of eventsubEntries) {
-      lines.push(
-        `  ${streamer}: ${health.connected ? '🟢 connected' : '🔴 disconnected'} (reconnect attempts: ${health.reconnectAttempts})`,
-      );
-    }
-  }
-
-  lines.push(
-    `Monitor: ${snapshot.monitor.lastPollOk ? '🟢 ok' : '🔴 failing'} (last poll ${formatDate(snapshot.monitor.lastPollAt)}${
-      snapshot.monitor.lastError ? `, last error: ${snapshot.monitor.lastError}` : ''
-    })`,
-  );
-
-  const schedulerEntries = Object.entries(snapshot.schedulers);
-  if (schedulerEntries.length > 0) {
-    lines.push('Schedulers:');
-    for (const [name, health] of schedulerEntries) {
-      if (!health) continue;
-      lines.push(`  ${name}: ${health.lastRunOk ? '🟢 ok' : '🔴 failing'} (last run ${formatDate(health.lastRunAt)})`);
-    }
-  }
-
-  if (snapshot.errors.length > 0) {
-    lines.push('Recent errors:');
-    const recent = snapshot.errors.slice(-RECENT_ERROR_COUNT).reverse();
-    for (const err of recent) {
-      lines.push(`  [${formatDate(err.timestamp)}] ${err.module}: ${err.message}`);
-    }
-  }
-
-  return lines.join('\n');
+  return [
+    '**Bot Health**',
+    ...formatConnectivityLines(snapshot),
+    ...formatEventSubLines(snapshot),
+    formatMonitorLine(snapshot),
+    ...formatSchedulerLines(snapshot),
+    ...formatRecentErrorLines(snapshot),
+  ].join('\n');
 }
 
 /**

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -618,4 +618,11 @@ describe('pingDb', () => {
     vi.mocked(getPool).mockReturnValue({ getConnection: vi.fn().mockResolvedValue(conn) } as any);
     expect(await pingDb()).toBe(false);
   });
+
+  it('still releases the connection back to the pool when the ping rejects', async () => {
+    const conn = { ping: vi.fn().mockRejectedValue(new Error('timeout')), release: vi.fn() };
+    vi.mocked(getPool).mockReturnValue({ getConnection: vi.fn().mockResolvedValue(conn) } as any);
+    expect(await pingDb()).toBe(false);
+    expect(conn.release).toHaveBeenCalledOnce();
+  });
 });

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -14,6 +14,7 @@ vi.mock('./db/users', () => ({
   ACCESS_LEVEL_LABELS: {},
   findUser: vi.fn(),
   findUserByTwitchName: vi.fn(),
+  findOwnerUser: vi.fn(),
   getAllUsers: vi.fn(),
   updateDiscordName: vi.fn(),
   getTwitchEnabledChannels: vi.fn(),
@@ -219,7 +220,9 @@ import {
   initAlertConfigs, saveAlertConfig, setAlertImage, setAlertSound,
   createSfxTrigger, updateSfxTrigger, deleteSfxTrigger,
   addSfxFile, updateSfxFile, deleteSfxFile,
+  pingDb,
 } from './db';
+import { getPool } from './db/pool';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -593,5 +596,26 @@ describe('deleteSfxFile', () => {
     const result = await deleteSfxFile(999);
     expect(result).toBeNull();
     expect(invalidateSfxLookupCache).not.toHaveBeenCalled();
+  });
+});
+
+describe('pingDb', () => {
+  it('returns true when a connection can be acquired and pinged', async () => {
+    const conn = { ping: vi.fn().mockResolvedValue(undefined), release: vi.fn() };
+    vi.mocked(getPool).mockReturnValue({ getConnection: vi.fn().mockResolvedValue(conn) } as any);
+    expect(await pingDb()).toBe(true);
+    expect(conn.ping).toHaveBeenCalledOnce();
+    expect(conn.release).toHaveBeenCalledOnce();
+  });
+
+  it('returns false when acquiring a connection fails', async () => {
+    vi.mocked(getPool).mockReturnValue({ getConnection: vi.fn().mockRejectedValue(new Error('down')) } as any);
+    expect(await pingDb()).toBe(false);
+  });
+
+  it('returns false when the ping itself fails', async () => {
+    const conn = { ping: vi.fn().mockRejectedValue(new Error('timeout')), release: vi.fn() };
+    vi.mocked(getPool).mockReturnValue({ getConnection: vi.fn().mockResolvedValue(conn) } as any);
+    expect(await pingDb()).toBe(false);
   });
 });

--- a/src/db.ts
+++ b/src/db.ts
@@ -5,6 +5,25 @@ export {
   DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS,
 } from './db/lookupCache';
 export { getPool, closePool } from './db/pool';
+import { getPool as getDbPool } from './db/pool';
+
+/**
+ * Verifies DB connectivity by acquiring a pooled connection and pinging it, mirroring the
+ * check `index.ts`'s startup sequence already performs. Deliberately doesn't touch
+ * `healthStore` itself — callers (e.g. the periodic health-check interval in `index.ts`)
+ * record the outcome, keeping this module free of any dependency on `shared/healthStore`.
+ * @returns true if the ping succeeded, false if acquiring a connection or pinging it failed.
+ */
+export async function pingDb(): Promise<boolean> {
+  try {
+    const conn = await getDbPool().getConnection();
+    await conn.ping();
+    conn.release();
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 // ─── Guilds ──────────────────────────────────────────────────────────────────
 
@@ -72,7 +91,7 @@ export async function removeOverride(guildId: string, commandId: number): Promis
 
 export {
   AccessLevel, ACCESS_LEVEL_LABELS,
-  findUser, findUsersByIds, findUserByTwitchName, getAllUsers, getGuildMemberUsers,
+  findUser, findUsersByIds, findUserByTwitchName, findOwnerUser, getAllUsers, getGuildMemberUsers,
   updateDiscordName, getTwitchEnabledChannels, getAllTwitchLinkedUsers,
 } from './db/users';
 export type { AccessLevelValue, DbUser, TwitchLinkedUser } from './db/users';

--- a/src/db.ts
+++ b/src/db.ts
@@ -12,16 +12,24 @@ import { getPool as getDbPool } from './db/pool';
  * check `index.ts`'s startup sequence already performs. Deliberately doesn't touch
  * `healthStore` itself — callers (e.g. the periodic health-check interval in `index.ts`)
  * record the outcome, keeping this module free of any dependency on `shared/healthStore`.
+ * The connection is always released back to the pool once acquired, even if the ping itself
+ * throws — otherwise a failing ping would leak a pooled connection on every failure.
  * @returns true if the ping succeeded, false if acquiring a connection or pinging it failed.
  */
 export async function pingDb(): Promise<boolean> {
+  let conn;
   try {
-    const conn = await getDbPool().getConnection();
+    conn = await getDbPool().getConnection();
+  } catch {
+    return false;
+  }
+  try {
     await conn.ping();
-    conn.release();
     return true;
   } catch {
     return false;
+  } finally {
+    conn.release();
   }
 }
 

--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -24,6 +24,8 @@ vi.mock('../commands/counterHandler', () => ({
   forgetGuildCounterCooldown: vi.fn(),
 }));
 vi.mock('../shared/statusStore', () => ({ setDiscordReady: vi.fn(), clearVoiceStatus: vi.fn() }));
+vi.mock('../shared/healthStore', () => ({ recordDiscordConnected: vi.fn() }));
+vi.mock('../commands/healthCommandHandler', () => ({ executeHealthCommandForDiscord: vi.fn().mockResolvedValue(undefined) }));
 vi.mock('../audio/audioPlayer', () => ({ forgetGuild: vi.fn() }));
 vi.mock('./guildRefreshState', () => ({ forgetGuildRefreshState: vi.fn() }));
 vi.mock('./guildRegistry', () => ({
@@ -173,6 +175,14 @@ describe('startDiscordBot — messageCreate handler', () => {
     cb(msg);
     expect(vi.mocked(commands.handleCommand)).toHaveBeenCalledWith('!test', 'discord', 'guild-id');
     expect(vi.mocked(customCmds.executeCustomCommandForDiscord)).toHaveBeenCalledWith(msg, 'Alice', 'guild-id');
+  });
+
+  it('dispatches to the health command handler for registered guild messages', async () => {
+    const health = await import('../commands/healthCommandHandler.js');
+    const cb = getMessageCreateCb();
+    const msg = { author: { bot: false, username: 'Alice' }, guildId: 'guild-id', content: '!health', member: { displayName: 'Alice' } };
+    cb(msg);
+    expect(vi.mocked(health.executeHealthCommandForDiscord)).toHaveBeenCalledWith(msg);
   });
 });
 

--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -390,6 +390,14 @@ describe('startDiscordBot — clientReady ready state', () => {
     await readyCb(mockInstance);
     expect(vi.mocked(status.setDiscordReady)).toHaveBeenCalledWith('Bot#1234');
   });
+
+  it('records the Discord connection as up on clientReady success', async () => {
+    const healthStore = await import('../shared/healthStore.js');
+    mod.startDiscordBot();
+    const readyCb = mockInstance.once.mock.calls.find(([event]: string[]) => event === 'clientReady')?.[1];
+    await readyCb(mockInstance);
+    expect(vi.mocked(healthStore.recordDiscordConnected)).toHaveBeenCalledWith(true);
+  });
 });
 
 // ─── startDiscordBot — error event ───────────────────────────────────────────
@@ -437,6 +445,14 @@ describe('startDiscordBot — gateway watchdog', () => {
     expect(mockInstance.login).toHaveBeenCalledTimes(2);
     expect(mod.getDiscordClient()).toBeNull();
   });
+
+  it('records the Discord connection as down when a shard disconnects permanently', async () => {
+    const healthStore = await import('../shared/healthStore.js');
+    mod.startDiscordBot();
+    const handler = findHandler('shardDisconnect');
+    handler({ code: 4004 }, 0);
+    expect(vi.mocked(healthStore.recordDiscordConnected)).toHaveBeenCalledWith(false);
+  });
 });
 
 // ─── stopDiscordBot ───────────────────────────────────────────────────────────
@@ -445,6 +461,17 @@ describe('stopDiscordBot', () => {
   it('does not throw when called before startDiscordBot (existing?.destroy is safe)', () => {
     expect(() => mod.stopDiscordBot()).not.toThrow();
     expect(mod.getDiscordClient()).toBeNull();
+  });
+
+  it('records the Discord connection as down', async () => {
+    const healthStore = await import('../shared/healthStore.js');
+    mod.startDiscordBot();
+    const readyCb = mockInstance.once.mock.calls.find(([event]: string[]) => event === 'clientReady')?.[1];
+    await readyCb(mockInstance);
+
+    mod.stopDiscordBot();
+
+    expect(vi.mocked(healthStore.recordDiscordConnected)).toHaveBeenCalledWith(false);
   });
 
   it('calls destroy on the existing client and nulls the reference', async () => {

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -128,6 +128,9 @@ export function startDiscordBot(): void {
   });
   bootingClient = localClient;
 
+  // Dispatches every non-bot message from a registered guild to each command handler in turn
+  // (fire-and-forget — a failure in one handler must not block the others). `message` is the
+  // triggering Discord message; returns void.
   localClient.on('messageCreate', (message) => {
     if (message.author.bot) return;
     if (!message.guildId || !isRegisteredGuild(message.guildId)) return;

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -5,6 +5,8 @@ import { fireAndForget } from '../commands/commandUtils';
 import { executeCustomCommandForDiscord, forgetGuildCustomCommandCooldown } from '../commands/customCommandHandler';
 import { executeCounterCommandForDiscord, forgetGuildCounterCooldown } from '../commands/counterHandler';
 import { setDiscordReady, clearVoiceStatus } from '../shared/statusStore';
+import { recordDiscordConnected } from '../shared/healthStore';
+import { executeHealthCommandForDiscord } from '../commands/healthCommandHandler';
 import { forgetGuild as forgetGuildVoiceState } from '../audio/audioPlayer';
 import { forgetGuildRefreshState } from './guildRefreshState';
 import { isRegisteredGuild, reloadGuildRegistry } from './guildRegistry';
@@ -136,6 +138,7 @@ export function startDiscordBot(): void {
     fireAndForget(executeCustomCommandForDiscord(message, displayName, guildId), 'Custom command error', log);
     fireAndForget(executeCounterCommandForDiscord(message, displayName), 'Counter command error', log);
     fireAndForget(handleCommand(message.content, 'discord', guildId), 'Command handler error', log);
+    fireAndForget(executeHealthCommandForDiscord(message), 'Health command error', log);
   });
 
   // Bootstrap: when the bot is added to a server for the first time, record the
@@ -186,6 +189,7 @@ export function startDiscordBot(): void {
     setDiscordClient(c);
     log.info(`Logged in as ${c.user.tag}`);
     setDiscordReady(c.user.tag);
+    recordDiscordConnected(true);
   });
 
   localClient.on('error', (err) => {
@@ -212,6 +216,7 @@ export function startDiscordBot(): void {
   // of sitting alive-but-dead until someone notices and restarts it manually.
   localClient.on('shardDisconnect', (event, shardId) => {
     log.error(`Shard ${shardId} disconnected permanently (code ${event.code}) — reconnecting client.`);
+    recordDiscordConnected(false);
     stopDiscordBot();
     startDiscordBot();
   });
@@ -226,12 +231,14 @@ export function startDiscordBot(): void {
  * Disconnect and destroy the Discord client, including any client that is
  * still connecting. Idempotent — safe to call before {@link startDiscordBot}.
  * `destroy()` rejections are caught and logged rather than left unhandled.
+ * Records the Discord connection as down in `healthStore` before tearing down.
  */
 export function stopDiscordBot(): void {
   const existingReady = getDiscordClient();
   const existingBooting = bootingClient;
   setDiscordClient(null);
   bootingClient = null;
+  recordDiscordConnected(false);
   existingReady?.destroy().catch((err: unknown) => log.error('Error destroying client:', err));
   existingBooting?.destroy().catch((err: unknown) => log.error('Error destroying booting client:', err));
   log.info('Client destroyed.');

--- a/src/discord/ownerAlerts.test.ts
+++ b/src/discord/ownerAlerts.test.ts
@@ -121,6 +121,26 @@ describe('ownerAlerts', () => {
     expect(send).not.toHaveBeenCalled();
   });
 
+  it('treats a successful lookup that returns no owner as authoritative — does not fall back to a stale cached id', async () => {
+    // First alert resolves normally and populates the cache.
+    healthStore.recordDbPing(false, 'boom');
+    await flush();
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenLastCalledWith(OWNER_ID, expect.any(String));
+
+    // Recover, then fail again once findOwnerUser successfully resolves null (e.g. ownership
+    // was just removed) — the cached id must not be used.
+    healthStore.recordDbPing(true);
+    await flush();
+
+    vi.mocked(findOwnerUser).mockResolvedValue(null);
+    send.mockClear();
+    healthStore.recordDbPing(false, 'boom again');
+    await flush();
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
   it('never throws when the runtime send itself rejects', async () => {
     send.mockRejectedValue(new Error('DM failed — user has DMs disabled'));
     healthStore.recordDbPing(false, 'boom');

--- a/src/discord/ownerAlerts.test.ts
+++ b/src/discord/ownerAlerts.test.ts
@@ -202,4 +202,42 @@ describe('primeOwnerAlertBaseline', () => {
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenCalledWith(OWNER_ID, expect.stringContaining('connection refused'));
   });
+
+  it('seeds the baseline from the state as of when owner resolution finishes, not from a stale snapshot taken before it', async () => {
+    // Settle db healthy too — a prior test in this file may have left it failing, which would
+    // make this test's own recordDbPing(false, ...) transition a no-op (already-failing state)
+    // instead of the fresh ok→fail edge it's meant to exercise.
+    healthStore.recordDiscordConnected(false);
+    healthStore.recordDbPing(true);
+    await flush();
+    send.mockClear();
+
+    let resolveLookup!: () => void;
+    const lookupGate = new Promise<void>((resolve) => { resolveLookup = resolve; });
+    vi.mocked(findOwnerUser).mockImplementation(async () => {
+      await lookupGate;
+      return OWNER_ROW as any;
+    });
+
+    const primePromise = primeOwnerAlertBaseline();
+
+    // Discord finishes connecting while owner resolution is still pending — if the baseline
+    // snapshot were taken up front (before this await), it would capture the old
+    // discordConnected: false state and treat it as the primed baseline.
+    healthStore.recordDiscordConnected(true);
+    resolveLookup();
+    await primePromise;
+    startOwnerAlertWatcher();
+    await flush();
+    send.mockClear();
+
+    // An unrelated transition must not trigger a false "discord recovered" alert from a stale
+    // (pre-connect) baseline.
+    healthStore.recordDbPing(false, 'boom');
+    await flush();
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith(OWNER_ID, expect.stringContaining('db is down'));
+    expect(send).not.toHaveBeenCalledWith(OWNER_ID, expect.stringContaining('discord'));
+  });
 });

--- a/src/discord/ownerAlerts.test.ts
+++ b/src/discord/ownerAlerts.test.ts
@@ -163,6 +163,63 @@ describe('ownerAlerts', () => {
       await flush();
     }
   });
+
+  it('alerts on a scheduler run failing, naming the scheduler', async () => {
+    try {
+      healthStore.recordSchedulerRun('counter', false, 'archive failed');
+      await flush();
+
+      expect(send).toHaveBeenCalledWith(OWNER_ID, expect.stringContaining('scheduler:counter'));
+      expect(send).toHaveBeenCalledWith(OWNER_ID, expect.stringContaining('archive failed'));
+    } finally {
+      // healthStore's scheduler map has no removal operation (schedulers are always one of a
+      // fixed set of names, unlike EventSub streamers) — restore it to healthy so it doesn't
+      // linger as a permanently-failing component and pollute later tests' baselines.
+      healthStore.recordSchedulerRun('counter', true);
+      await flush();
+    }
+  });
+
+  it('re-alerts "still down" once the cooldown window has elapsed for a component that never recovered', async () => {
+    vi.useFakeTimers();
+    try {
+      healthStore.recordDbPing(false, 'boom');
+      await flush();
+      expect(send).toHaveBeenCalledTimes(1);
+
+      // Still failing, but re-notified with a distinct DB error — before the cooldown elapses
+      // this must NOT resend (covered by the existing "does not resend..." test); here we
+      // advance past the 30-minute cooldown so the "still down" branch fires instead.
+      await vi.advanceTimersByTimeAsync(31 * 60_000);
+      healthStore.recordDbPing(false, 'still boom');
+      await flush();
+
+      expect(send).toHaveBeenCalledTimes(2);
+      expect(send).toHaveBeenLastCalledWith(OWNER_ID, expect.stringContaining('is still down'));
+    } finally {
+      vi.useRealTimers();
+      healthStore.recordDbPing(true);
+      await flush();
+    }
+  });
+});
+
+describe('sendOwnerAlert with no runtime registered', () => {
+  it('logs and returns without throwing when no runtime has ever been registered', async () => {
+    // Uses a fresh module instance (via vi.resetModules() + dynamic import) rather than the
+    // file's shared/top-level-imported one, so this test can exercise the "never registered"
+    // path without needing to un-register the runtime the other describe blocks depend on —
+    // there's no unregister API, and runtimeRegistry has no reset hook of its own.
+    vi.resetModules();
+    const freshHealthStore = await import('../shared/healthStore.js');
+    const fresh = await import('./ownerAlerts.js');
+
+    await fresh.primeOwnerAlertBaseline();
+    fresh.startOwnerAlertWatcher();
+
+    expect(() => freshHealthStore.recordDbPing(false, 'boom')).not.toThrow();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
 });
 
 describe('primeOwnerAlertBaseline', () => {

--- a/src/discord/ownerAlerts.test.ts
+++ b/src/discord/ownerAlerts.test.ts
@@ -148,6 +148,35 @@ describe('ownerAlerts', () => {
     await expect(flush()).resolves.toBeUndefined();
   });
 
+  it('does not send a false recovery DM when the down DM itself failed to deliver', async () => {
+    send.mockRejectedValue(new Error('DM failed — user has DMs disabled'));
+    healthStore.recordDbPing(false, 'boom');
+    await flush();
+    expect(send).toHaveBeenCalledTimes(1); // the (failed) down DM attempt
+
+    send.mockClear();
+    send.mockResolvedValue(undefined);
+    healthStore.recordDbPing(true);
+    await flush();
+
+    // No down DM was ever actually delivered, so recovery must stay silent.
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('does not send a false recovery DM when the down DM was skipped (no owner to notify)', async () => {
+    // findOwnerUser resolves with no owner row, and no ID is cached yet — sendOwnerAlert must
+    // skip the down DM for lack of a resolvable owner, which must not count as delivered.
+    vi.mocked(findOwnerUser).mockResolvedValue(null);
+    healthStore.recordDbPing(false, 'boom');
+    await flush();
+    expect(send).not.toHaveBeenCalled();
+
+    healthStore.recordDbPing(true);
+    await flush();
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
   it('alerts on an EventSub streamer disconnecting, naming the streamer', async () => {
     try {
       healthStore.recordEventSubConnected('streamerX', false, 'socket closed');

--- a/src/discord/ownerAlerts.test.ts
+++ b/src/discord/ownerAlerts.test.ts
@@ -147,6 +147,22 @@ describe('ownerAlerts', () => {
     healthStore.recordDbPing(false, 'boom');
     await expect(flush()).resolves.toBeUndefined();
   });
+
+  it('alerts on an EventSub streamer disconnecting, naming the streamer', async () => {
+    try {
+      healthStore.recordEventSubConnected('streamerX', false, 'socket closed');
+      await flush();
+
+      expect(send).toHaveBeenCalledWith(OWNER_ID, expect.stringContaining('eventsub:streamerX'));
+      expect(send).toHaveBeenCalledWith(OWNER_ID, expect.stringContaining('socket closed'));
+    } finally {
+      // healthStore is a real, un-reset module singleton across this file's tests (see the
+      // beforeEach comment above) — remove this streamer's entry so it doesn't linger as a
+      // permanently-failing component and pollute later tests' baselines/assertions.
+      healthStore.removeEventSubHealth('streamerX');
+      await flush();
+    }
+  });
 });
 
 describe('primeOwnerAlertBaseline', () => {

--- a/src/discord/ownerAlerts.test.ts
+++ b/src/discord/ownerAlerts.test.ts
@@ -252,8 +252,21 @@ describe('primeOwnerAlertBaseline', () => {
     await flush();
     expect(send).not.toHaveBeenCalled();
 
-    // Later, once it actually connects, this is a real ok transition (a "recovered" message,
-    // not a false "down" alert during startup).
+    // Later, once it actually connects — since no "down" DM was ever sent for this
+    // startup-seeded failure (e.g. twitchChat, still connecting when the watcher started), this
+    // must NOT fire a false "recovered" DM either.
+    healthStore.recordTwitchChatConnected(true);
+    await flush();
+    expect(send).not.toHaveBeenCalled();
+
+    // A genuine later failure, though, must still alert normally.
+    healthStore.recordTwitchChatConnected(false);
+    await flush();
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith(OWNER_ID, expect.stringContaining('🔴'));
+
+    // ...and its recovery now alerts too, since a real "down" DM was sent this time.
+    send.mockClear();
     healthStore.recordTwitchChatConnected(true);
     await flush();
     expect(send).toHaveBeenCalledTimes(1);

--- a/src/discord/ownerAlerts.test.ts
+++ b/src/discord/ownerAlerts.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mockLogger } from '../test-utils/loggerMock';
+
+vi.mock('../shared/logger', () => ({ createLogger: mockLogger }));
+
+vi.mock('../db', () => ({
+  findOwnerUser: vi.fn(),
+}));
+
+import { findOwnerUser } from '../db';
+import * as healthStore from '../shared/healthStore';
+import {
+  registerOwnerAlertRuntime,
+  startOwnerAlertWatcher,
+  __resetOwnerAlertsForTests,
+} from './ownerAlerts';
+
+const OWNER_ID = '111222333444555666';
+const OWNER_ROW = {
+  discord_id: OWNER_ID,
+  discord_name: 'Owner',
+  is_twitch_bot_enabled: false,
+  twitch_name: null,
+  access_level: 3,
+  is_owner: true,
+};
+
+/**
+ * Waits enough microtask ticks for the fire-and-forget `sendOwnerAlert` promise chain
+ * (resolveOwnerDiscordId's own await chain, then `runtime.send`) to fully settle before
+ * assertions run.
+ */
+async function flush(): Promise<void> {
+  for (let i = 0; i < 10; i++) await Promise.resolve();
+}
+
+describe('ownerAlerts', () => {
+  let send: ReturnType<typeof vi.fn<(discordId: string, message: string) => Promise<void>>>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    __resetOwnerAlertsForTests();
+    send = vi.fn().mockResolvedValue(undefined);
+    registerOwnerAlertRuntime({ send });
+    vi.mocked(findOwnerUser).mockResolvedValue(OWNER_ROW as any);
+    // Baseline every other tracked component healthy first, so each test below can isolate
+    // a single component's ok→fail/fail→ok transition without discordConnected/
+    // twitchChatConnected's own false-by-default starting state (or `db`'s state left over
+    // from a previous test — healthStore itself is a real, un-reset module singleton here)
+    // also counting as a (never-seen-before or edge-triggering) transition that sends its
+    // own alert. `startOwnerAlertWatcher()`'s listener registration also persists across
+    // tests (healthStore.onHealthChanged has no "off"), so these baseline calls are already
+    // observed live once a prior test has started the watcher — `flush()` below drains any
+    // alert they trigger before `send.mockClear()`, so a late-resolving baseline alert can't
+    // land in the mock's call history after it's been cleared.
+    healthStore.recordDiscordConnected(true);
+    healthStore.recordTwitchChatConnected(true);
+    healthStore.recordDbPing(true);
+    await flush();
+    send.mockClear();
+    startOwnerAlertWatcher();
+  });
+
+  it('sends exactly one alert on an ok→fail transition', async () => {
+    healthStore.recordDbPing(false, 'connection refused');
+    await flush();
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith(OWNER_ID, expect.stringContaining('🔴'));
+    expect(send).toHaveBeenCalledWith(OWNER_ID, expect.stringContaining('connection refused'));
+  });
+
+  it('does not resend while still failing within the cooldown window', async () => {
+    healthStore.recordDbPing(false, 'boom');
+    await flush();
+    expect(send).toHaveBeenCalledTimes(1);
+
+    healthStore.recordDbPing(false, 'boom again');
+    await flush();
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends a recovery alert on a fail→ok transition', async () => {
+    healthStore.recordDbPing(false, 'boom');
+    await flush();
+    expect(send).toHaveBeenCalledTimes(1);
+
+    healthStore.recordDbPing(true);
+    await flush();
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send).toHaveBeenLastCalledWith(OWNER_ID, expect.stringContaining('✅'));
+  });
+
+  it('falls back to the last cached owner ID when findOwnerUser rejects', async () => {
+    // First alert resolves normally and populates the cache.
+    healthStore.recordDbPing(false, 'boom');
+    await flush();
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenLastCalledWith(OWNER_ID, expect.any(String));
+
+    // Recover, then fail again after findOwnerUser starts rejecting (e.g. DB is down).
+    healthStore.recordDbPing(true);
+    await flush();
+
+    vi.mocked(findOwnerUser).mockRejectedValue(new Error('db down'));
+    healthStore.recordDbPing(false, 'boom again');
+    await flush();
+
+    expect(send).toHaveBeenCalledTimes(3);
+    expect(send).toHaveBeenLastCalledWith(OWNER_ID, expect.any(String));
+  });
+
+  it('skips the alert (does not throw) when findOwnerUser rejects with no cached ID yet', async () => {
+    // A previous test's own db-recovery alert (during ITS baseline) can have already
+    // populated the module's owner-ID cache — reset it again here (componentStates too,
+    // harmlessly, since discord/twitchChat/db are all still healthy) so this test starts
+    // from a genuinely never-resolved cache, matching its name.
+    __resetOwnerAlertsForTests();
+    vi.mocked(findOwnerUser).mockRejectedValue(new Error('db down'));
+    healthStore.recordDbPing(false, 'boom');
+    await flush();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('never throws when the runtime send itself rejects', async () => {
+    send.mockRejectedValue(new Error('DM failed — user has DMs disabled'));
+    healthStore.recordDbPing(false, 'boom');
+    await expect(flush()).resolves.toBeUndefined();
+  });
+});

--- a/src/discord/ownerAlerts.test.ts
+++ b/src/discord/ownerAlerts.test.ts
@@ -11,6 +11,7 @@ import { findOwnerUser } from '../db';
 import * as healthStore from '../shared/healthStore';
 import {
   registerOwnerAlertRuntime,
+  primeOwnerAlertBaseline,
   startOwnerAlertWatcher,
   __resetOwnerAlertsForTests,
 } from './ownerAlerts';
@@ -145,5 +146,60 @@ describe('ownerAlerts', () => {
     send.mockRejectedValue(new Error('DM failed — user has DMs disabled'));
     healthStore.recordDbPing(false, 'boom');
     await expect(flush()).resolves.toBeUndefined();
+  });
+});
+
+describe('primeOwnerAlertBaseline', () => {
+  let send: ReturnType<typeof vi.fn<(discordId: string, message: string) => Promise<void>>>;
+
+  async function flush(): Promise<void> {
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetOwnerAlertsForTests();
+    send = vi.fn().mockResolvedValue(undefined);
+    registerOwnerAlertRuntime({ send });
+    vi.mocked(findOwnerUser).mockResolvedValue(OWNER_ROW as any);
+  });
+
+  it('seeds the baseline from a currently-unhealthy component without alerting', async () => {
+    // The watcher's listener is a single persistent function attached to the real, un-reset
+    // `healthStore` module for the lifetime of this test file (see the `ownerAlerts` describe
+    // block's beforeEach comment above) — so this setup mutation may itself be observed by a
+    // watcher instance left listening from an earlier test. Settle and clear it before
+    // asserting what THIS test cares about: that `primeOwnerAlertBaseline()` itself never alerts.
+    healthStore.recordTwitchChatConnected(false);
+    await flush();
+    send.mockClear();
+
+    await primeOwnerAlertBaseline();
+    startOwnerAlertWatcher();
+    await flush();
+    expect(send).not.toHaveBeenCalled();
+
+    // Later, once it actually connects, this is a real ok transition (a "recovered" message,
+    // not a false "down" alert during startup).
+    healthStore.recordTwitchChatConnected(true);
+    await flush();
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith(OWNER_ID, expect.stringContaining('✅'));
+  });
+
+  it('warms the cached owner id up front, so the first real failure can still alert even if findOwnerUser then rejects', async () => {
+    healthStore.recordDbPing(true);
+    await flush();
+    send.mockClear();
+
+    await primeOwnerAlertBaseline();
+    startOwnerAlertWatcher();
+
+    vi.mocked(findOwnerUser).mockRejectedValue(new Error('db down'));
+    healthStore.recordDbPing(false, 'connection refused');
+    await flush();
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith(OWNER_ID, expect.stringContaining('connection refused'));
   });
 });

--- a/src/discord/ownerAlerts.ts
+++ b/src/discord/ownerAlerts.ts
@@ -37,36 +37,40 @@ let cachedOwnerDiscordId: string | null = null;
 
 let watcherStarted = false;
 
-/**
- * Resolves the current ok/fail boolean and an optional error string for every component this
- * watcher tracks, from a health snapshot and the staleness constants. One entry per
- * Discord/Twitch-chat/DB/EventSub-streamer/monitor/scheduler component, keyed by a stable
- * component id used across ticks to track edge transitions.
- * @param snapshot - The health snapshot to derive component states from.
- * @returns A map from component id to `{ ok, error }`.
- */
-function deriveComponentOks(snapshot: HealthSnapshot): Map<string, { ok: boolean; error: string | null }> {
-  const now = Date.now();
-  const result = new Map<string, { ok: boolean; error: string | null }>();
+/** One component's derived ok/fail state, plus an error message when it's failing. */
+type ComponentOk = { ok: boolean; error: string | null };
 
+/** Sets the `discord`/`twitchChat`/`db` connectivity entries into `result`. */
+function addConnectivityOks(snapshot: HealthSnapshot, result: Map<string, ComponentOk>): void {
   result.set('discord', { ok: snapshot.discordConnected, error: snapshot.discordConnected ? null : 'Discord gateway disconnected' });
   result.set('twitchChat', { ok: snapshot.twitchChatConnected, error: snapshot.twitchChatConnected ? null : 'Twitch chat disconnected' });
   result.set('db', { ok: snapshot.db.lastPingOk, error: snapshot.db.lastPingOk ? null : (snapshot.db.lastError ?? 'DB ping failed') });
+}
 
+/** Sets one `eventsub:<streamer>` entry per tracked streamer into `result`. */
+function addEventSubOks(snapshot: HealthSnapshot, result: Map<string, ComponentOk>): void {
   for (const [streamer, health] of Object.entries(snapshot.eventsub)) {
     result.set(`eventsub:${streamer}`, {
       ok: health.connected,
       error: health.connected ? null : (health.lastError ?? `EventSub disconnected for ${streamer}`),
     });
   }
+}
 
-  const monitorStale = snapshot.monitor.lastPollAt !== null && now - snapshot.monitor.lastPollAt.getTime() > MONITOR_STALE_MS;
-  const monitorOk = snapshot.monitor.lastPollOk && !monitorStale;
+/** Sets the `monitor` entry into `result`, treating a poll older than {@link MONITOR_STALE_MS} as failing too. */
+function addMonitorOk(snapshot: HealthSnapshot, result: Map<string, ComponentOk>): void {
+  const now = Date.now();
+  const stale = snapshot.monitor.lastPollAt !== null && now - snapshot.monitor.lastPollAt.getTime() > MONITOR_STALE_MS;
+  const ok = snapshot.monitor.lastPollOk && !stale;
   result.set('monitor', {
-    ok: monitorOk,
-    error: monitorOk ? null : (snapshot.monitor.lastError ?? (monitorStale ? 'Stream monitor poll is stale' : 'Stream monitor poll failed')),
+    ok,
+    error: ok ? null : (snapshot.monitor.lastError ?? (stale ? 'Stream monitor poll is stale' : 'Stream monitor poll failed')),
   });
+}
 
+/** Sets one `scheduler:<name>` entry per tracked scheduler into `result`, treating a run older than {@link SCHEDULER_STALE_MS} as failing too. */
+function addSchedulerOks(snapshot: HealthSnapshot, result: Map<string, ComponentOk>): void {
+  const now = Date.now();
   for (const [name, health] of Object.entries(snapshot.schedulers)) {
     if (!health) continue;
     const stale = health.lastRunAt !== null && now - health.lastRunAt.getTime() > SCHEDULER_STALE_MS;
@@ -76,7 +80,22 @@ function deriveComponentOks(snapshot: HealthSnapshot): Map<string, { ok: boolean
       error: ok ? null : (health.lastError ?? (stale ? `${name} scheduler run is stale` : `${name} scheduler run failed`)),
     });
   }
+}
 
+/**
+ * Resolves the current ok/fail boolean and an optional error string for every component this
+ * watcher tracks, from a health snapshot and the staleness constants. One entry per
+ * Discord/Twitch-chat/DB/EventSub-streamer/monitor/scheduler component, keyed by a stable
+ * component id used across ticks to track edge transitions.
+ * @param snapshot - The health snapshot to derive component states from.
+ * @returns A map from component id to `{ ok, error }`.
+ */
+function deriveComponentOks(snapshot: HealthSnapshot): Map<string, ComponentOk> {
+  const result = new Map<string, ComponentOk>();
+  addConnectivityOks(snapshot, result);
+  addEventSubOks(snapshot, result);
+  addMonitorOk(snapshot, result);
+  addSchedulerOks(snapshot, result);
   return result;
 }
 

--- a/src/discord/ownerAlerts.ts
+++ b/src/discord/ownerAlerts.ts
@@ -199,15 +199,19 @@ function handleHealthChanged(): void {
  * `startTwitchBot()` has run). Also resolves and caches the owner's Discord ID up front (via
  * {@link resolveOwnerDiscordId}) so the very first real failure — e.g. a DB outage — doesn't skip
  * its alert because `cachedOwnerDiscordId` was never populated yet.
+ * Resolves the owner ID *before* taking the health snapshot — the watcher isn't listening yet
+ * at this point, so nothing here reacts to concurrent health changes, but a snapshot taken
+ * before that await could still go stale (e.g. Discord finishing its connect) by the time this
+ * function returns and the caller starts the watcher, seeding a baseline that's already wrong.
  */
 export async function primeOwnerAlertBaseline(): Promise<void> {
+  await resolveOwnerDiscordId();
   const snapshot = getHealthSnapshot();
   const componentOks = deriveComponentOks(snapshot);
   const now = Date.now();
   for (const [componentId, { ok }] of componentOks) {
     componentStates.set(componentId, { failing: !ok, lastAlertAt: now });
   }
-  await resolveOwnerDiscordId();
 }
 
 /**

--- a/src/discord/ownerAlerts.ts
+++ b/src/discord/ownerAlerts.ts
@@ -32,7 +32,12 @@ interface ComponentAlertState {
 
 const componentStates = new Map<string, ComponentAlertState>();
 
-/** Caches the last successfully resolved owner Discord ID, so a `findOwnerUser()` failure (e.g. the DB itself being down — the very case this watcher most needs to alert about) doesn't also prevent the alert from being sent. */
+/**
+ * Caches the last successfully resolved owner Discord ID, so a `findOwnerUser()` failure (e.g.
+ * the DB itself being down — the very case this watcher most needs to alert about) doesn't also
+ * prevent the alert from being sent. Cleared to `null` whenever a successful lookup confirms
+ * there's no owner row (rather than left stale) — see {@link resolveOwnerDiscordId}.
+ */
 let cachedOwnerDiscordId: string | null = null;
 
 let watcherStarted = false;
@@ -101,9 +106,12 @@ function deriveComponentOks(snapshot: HealthSnapshot): Map<string, ComponentOk> 
 
 /**
  * Resolves the Discord ID to DM: a fresh `findOwnerUser()` lookup when it succeeds (also
- * refreshing {@link cachedOwnerDiscordId}), falling back to the last cached ID if the lookup
- * itself throws (e.g. the DB is down — exactly the case this watcher needs to still be able to
- * alert about). Returns null (and logs) if there's no cached ID yet to fall back to.
+ * refreshing {@link cachedOwnerDiscordId}), falling back to the last cached ID only if the
+ * lookup itself throws (e.g. the DB is down — exactly the case this watcher needs to still be
+ * able to alert about). A successful lookup that finds no owner row is authoritative — it clears
+ * the cache and returns null, rather than falling back to a possibly-stale cached ID for an
+ * owner that may have just been removed. Returns null (and logs) if there's no cached ID yet to
+ * fall back to on a failed lookup.
  */
 async function resolveOwnerDiscordId(): Promise<string | null> {
   try {
@@ -112,7 +120,8 @@ async function resolveOwnerDiscordId(): Promise<string | null> {
       cachedOwnerDiscordId = owner.discord_id;
       return owner.discord_id;
     }
-    return cachedOwnerDiscordId;
+    cachedOwnerDiscordId = null;
+    return null;
   } catch (err) {
     log.error('Failed to resolve owner user — falling back to cached ID if any:', err);
     if (!cachedOwnerDiscordId) {

--- a/src/discord/ownerAlerts.ts
+++ b/src/discord/ownerAlerts.ts
@@ -160,48 +160,71 @@ async function sendOwnerAlert(message: string): Promise<void> {
 }
 
 /**
+ * Records a component seen for the first time: stored (not alerted on) if it starts out healthy,
+ * matching the "nothing was wrong before" baseline, or alerted immediately if it starts out
+ * failing.
+ * @param componentId - The component's stable id (see {@link deriveComponentOks}).
+ * @param ok - Whether the component is currently healthy.
+ * @param error - The component's current error message, if failing.
+ */
+function handleFirstSeenComponent(componentId: string, ok: boolean, error: string | null): void {
+  const now = Date.now();
+  componentStates.set(componentId, { failing: !ok, lastAlertAt: ok ? 0 : now, downAlertSent: !ok });
+  if (!ok) {
+    void sendOwnerAlert(`🔴 ${componentId} is down: ${error ?? 'unknown error'}`);
+  }
+}
+
+/**
+ * Reacts to one component's latest ok/fail state against its previously tracked state: sends an
+ * edge-triggered DM alert on a fail→ok or ok→fail transition, or a "still down" DM once the
+ * {@link REALERT_COOLDOWN_MS} cooldown has elapsed for a component that's stayed failing.
+ * @param componentId - The component's stable id (see {@link deriveComponentOks}).
+ * @param ok - Whether the component is currently healthy.
+ * @param error - The component's current error message, if failing.
+ * @param existing - The component's previously tracked alert state, mutated in place.
+ */
+function handleTrackedComponent(componentId: string, ok: boolean, error: string | null, existing: ComponentAlertState): void {
+  const now = Date.now();
+
+  if (ok && existing.failing) {
+    existing.failing = false;
+    existing.lastAlertAt = now;
+    // Only announce a recovery if a "down" DM actually went out for this failure — otherwise
+    // this is a component that was merely seeded as failing at startup (e.g. twitchChat, before
+    // startTwitchBot() has run) finishing its normal startup, not a real recovery.
+    const wasAlerted = existing.downAlertSent;
+    existing.downAlertSent = false;
+    if (wasAlerted) {
+      void sendOwnerAlert(`✅ ${componentId} recovered`);
+    }
+  } else if (!ok && !existing.failing) {
+    existing.failing = true;
+    existing.lastAlertAt = now;
+    existing.downAlertSent = true;
+    void sendOwnerAlert(`🔴 ${componentId} is down: ${error ?? 'unknown error'}`);
+  } else if (!ok && existing.failing && now - existing.lastAlertAt > REALERT_COOLDOWN_MS) {
+    existing.lastAlertAt = now;
+    existing.downAlertSent = true;
+    void sendOwnerAlert(`🔴 ${componentId} is still down: ${error ?? 'unknown error'}`);
+  }
+}
+
+/**
  * Reacts to one health-changed notification: derives every tracked component's ok/fail state
- * from the latest snapshot, and for each one whose state transitioned since the last check —
- * or that's still failing after the {@link REALERT_COOLDOWN_MS} cooldown has elapsed — sends an
- * edge-triggered DM alert to the owner. A component seen for the first time is only recorded
- * (not alerted on) if it starts out healthy, matching the "nothing was wrong before" baseline.
+ * from the latest snapshot and dispatches each one to {@link handleFirstSeenComponent} or
+ * {@link handleTrackedComponent} depending on whether it's been seen before.
  */
 function handleHealthChanged(): void {
   const snapshot = getHealthSnapshot();
   const componentOks = deriveComponentOks(snapshot);
-  const now = Date.now();
 
   for (const [componentId, { ok, error }] of componentOks) {
     const existing = componentStates.get(componentId);
-
-    if (!existing) {
-      componentStates.set(componentId, { failing: !ok, lastAlertAt: ok ? 0 : now, downAlertSent: !ok });
-      if (!ok) {
-        void sendOwnerAlert(`🔴 ${componentId} is down: ${error ?? 'unknown error'}`);
-      }
-      continue;
-    }
-
-    if (ok && existing.failing) {
-      existing.failing = false;
-      existing.lastAlertAt = now;
-      // Only announce a recovery if a "down" DM actually went out for this failure — otherwise
-      // this is a component that was merely seeded as failing at startup (e.g. twitchChat, before
-      // startTwitchBot() has run) finishing its normal startup, not a real recovery.
-      const wasAlerted = existing.downAlertSent;
-      existing.downAlertSent = false;
-      if (wasAlerted) {
-        void sendOwnerAlert(`✅ ${componentId} recovered`);
-      }
-    } else if (!ok && !existing.failing) {
-      existing.failing = true;
-      existing.lastAlertAt = now;
-      existing.downAlertSent = true;
-      void sendOwnerAlert(`🔴 ${componentId} is down: ${error ?? 'unknown error'}`);
-    } else if (!ok && existing.failing && now - existing.lastAlertAt > REALERT_COOLDOWN_MS) {
-      existing.lastAlertAt = now;
-      existing.downAlertSent = true;
-      void sendOwnerAlert(`🔴 ${componentId} is still down: ${error ?? 'unknown error'}`);
+    if (existing) {
+      handleTrackedComponent(componentId, ok, error, existing);
+    } else {
+      handleFirstSeenComponent(componentId, ok, error);
     }
   }
 }

--- a/src/discord/ownerAlerts.ts
+++ b/src/discord/ownerAlerts.ts
@@ -203,6 +203,7 @@ function handleHealthChanged(): void {
  * at this point, so nothing here reacts to concurrent health changes, but a snapshot taken
  * before that await could still go stale (e.g. Discord finishing its connect) by the time this
  * function returns and the caller starts the watcher, seeding a baseline that's already wrong.
+ * @returns Resolves once both owner-ID resolution and baseline seeding have completed.
  */
 export async function primeOwnerAlertBaseline(): Promise<void> {
   await resolveOwnerDiscordId();

--- a/src/discord/ownerAlerts.ts
+++ b/src/discord/ownerAlerts.ts
@@ -1,0 +1,181 @@
+import { createLogger } from '../shared/logger';
+import { createRuntimeRegistry } from '../commands/twitchRuntime';
+import { findOwnerUser } from '../db';
+import { getHealthSnapshot, onHealthChanged, MONITOR_STALE_MS, SCHEDULER_STALE_MS, type HealthSnapshot } from '../shared/healthStore';
+
+const log = createLogger('OwnerAlerts');
+
+/** Runtime hook injected from `index.ts`, mirroring every other `registerXRuntime` pattern in this codebase (see `twitchRuntime.ts`'s `createRuntimeRegistry`) — avoids a circular import back into `index.ts`/`discordBot.ts`. */
+interface OwnerAlertRuntime {
+  send: (discordId: string, message: string) => Promise<void>;
+}
+
+const runtimeRegistry = createRuntimeRegistry<OwnerAlertRuntime>();
+
+/**
+ * Registers the runtime used to DM the bot owner. Call once from `index.ts` after the
+ * Discord bot is ready.
+ * @param runtime - The {@link OwnerAlertRuntime} to store.
+ */
+export function registerOwnerAlertRuntime(runtime: OwnerAlertRuntime): void {
+  runtimeRegistry.register(runtime);
+}
+
+/** How long a component may keep re-alerting while it stays in the failing state, before this watcher sends another notification. */
+const REALERT_COOLDOWN_MS = 30 * 60_000;
+
+/** Per-component edge-trigger state tracked across health-changed notifications. */
+interface ComponentAlertState {
+  failing: boolean;
+  lastAlertAt: number;
+}
+
+const componentStates = new Map<string, ComponentAlertState>();
+
+/** Caches the last successfully resolved owner Discord ID, so a `findOwnerUser()` failure (e.g. the DB itself being down — the very case this watcher most needs to alert about) doesn't also prevent the alert from being sent. */
+let cachedOwnerDiscordId: string | null = null;
+
+let watcherStarted = false;
+
+/**
+ * Resolves the current ok/fail boolean and an optional error string for every component this
+ * watcher tracks, from a health snapshot and the staleness constants. One entry per
+ * Discord/Twitch-chat/DB/EventSub-streamer/monitor/scheduler component, keyed by a stable
+ * component id used across ticks to track edge transitions.
+ * @param snapshot - The health snapshot to derive component states from.
+ * @returns A map from component id to `{ ok, error }`.
+ */
+function deriveComponentOks(snapshot: HealthSnapshot): Map<string, { ok: boolean; error: string | null }> {
+  const now = Date.now();
+  const result = new Map<string, { ok: boolean; error: string | null }>();
+
+  result.set('discord', { ok: snapshot.discordConnected, error: snapshot.discordConnected ? null : 'Discord gateway disconnected' });
+  result.set('twitchChat', { ok: snapshot.twitchChatConnected, error: snapshot.twitchChatConnected ? null : 'Twitch chat disconnected' });
+  result.set('db', { ok: snapshot.db.lastPingOk, error: snapshot.db.lastPingOk ? null : (snapshot.db.lastError ?? 'DB ping failed') });
+
+  for (const [streamer, health] of Object.entries(snapshot.eventsub)) {
+    result.set(`eventsub:${streamer}`, {
+      ok: health.connected,
+      error: health.connected ? null : (health.lastError ?? `EventSub disconnected for ${streamer}`),
+    });
+  }
+
+  const monitorStale = snapshot.monitor.lastPollAt !== null && now - snapshot.monitor.lastPollAt.getTime() > MONITOR_STALE_MS;
+  const monitorOk = snapshot.monitor.lastPollOk && !monitorStale;
+  result.set('monitor', {
+    ok: monitorOk,
+    error: monitorOk ? null : (snapshot.monitor.lastError ?? (monitorStale ? 'Stream monitor poll is stale' : 'Stream monitor poll failed')),
+  });
+
+  for (const [name, health] of Object.entries(snapshot.schedulers)) {
+    if (!health) continue;
+    const stale = health.lastRunAt !== null && now - health.lastRunAt.getTime() > SCHEDULER_STALE_MS;
+    const ok = health.lastRunOk && !stale;
+    result.set(`scheduler:${name}`, {
+      ok,
+      error: ok ? null : (health.lastError ?? (stale ? `${name} scheduler run is stale` : `${name} scheduler run failed`)),
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Resolves the Discord ID to DM: a fresh `findOwnerUser()` lookup when it succeeds (also
+ * refreshing {@link cachedOwnerDiscordId}), falling back to the last cached ID if the lookup
+ * itself throws (e.g. the DB is down — exactly the case this watcher needs to still be able to
+ * alert about). Returns null (and logs) if there's no cached ID yet to fall back to.
+ */
+async function resolveOwnerDiscordId(): Promise<string | null> {
+  try {
+    const owner = await findOwnerUser();
+    if (owner) {
+      cachedOwnerDiscordId = owner.discord_id;
+      return owner.discord_id;
+    }
+    return cachedOwnerDiscordId;
+  } catch (err) {
+    log.error('Failed to resolve owner user — falling back to cached ID if any:', err);
+    if (!cachedOwnerDiscordId) {
+      log.warn('No cached owner ID available — skipping alert.');
+      return null;
+    }
+    return cachedOwnerDiscordId;
+  }
+}
+
+/**
+ * Sends a DM alert to the bot owner via the registered runtime. Never throws — a failed DM is
+ * logged and swallowed so it can never crash the process (see {@link registerOwnerAlertRuntime}).
+ * @param message - The alert text to send.
+ */
+async function sendOwnerAlert(message: string): Promise<void> {
+  const runtime = runtimeRegistry.get();
+  if (!runtime) {
+    log.warn('No owner-alert runtime registered — skipping alert:', message);
+    return;
+  }
+  const discordId = await resolveOwnerDiscordId();
+  if (!discordId) return;
+  try {
+    await runtime.send(discordId, message);
+  } catch (err) {
+    log.error('Failed to send owner alert DM:', err);
+  }
+}
+
+/**
+ * Reacts to one health-changed notification: derives every tracked component's ok/fail state
+ * from the latest snapshot, and for each one whose state transitioned since the last check —
+ * or that's still failing after the {@link REALERT_COOLDOWN_MS} cooldown has elapsed — sends an
+ * edge-triggered DM alert to the owner. A component seen for the first time is only recorded
+ * (not alerted on) if it starts out healthy, matching the "nothing was wrong before" baseline.
+ */
+function handleHealthChanged(): void {
+  const snapshot = getHealthSnapshot();
+  const componentOks = deriveComponentOks(snapshot);
+  const now = Date.now();
+
+  for (const [componentId, { ok, error }] of componentOks) {
+    const existing = componentStates.get(componentId);
+
+    if (!existing) {
+      componentStates.set(componentId, { failing: !ok, lastAlertAt: ok ? 0 : now });
+      if (!ok) {
+        void sendOwnerAlert(`🔴 ${componentId} is down: ${error ?? 'unknown error'}`);
+      }
+      continue;
+    }
+
+    if (ok && existing.failing) {
+      existing.failing = false;
+      existing.lastAlertAt = now;
+      void sendOwnerAlert(`✅ ${componentId} recovered`);
+    } else if (!ok && !existing.failing) {
+      existing.failing = true;
+      existing.lastAlertAt = now;
+      void sendOwnerAlert(`🔴 ${componentId} is down: ${error ?? 'unknown error'}`);
+    } else if (!ok && existing.failing && now - existing.lastAlertAt > REALERT_COOLDOWN_MS) {
+      existing.lastAlertAt = now;
+      void sendOwnerAlert(`🔴 ${componentId} is still down: ${error ?? 'unknown error'}`);
+    }
+  }
+}
+
+/**
+ * Subscribes to `healthStore.onHealthChanged` and starts sending owner DM alerts on
+ * component health transitions. Call once from `index.ts` after {@link registerOwnerAlertRuntime}.
+ * Idempotent — a second call is a no-op, so it can never register a duplicate listener.
+ */
+export function startOwnerAlertWatcher(): void {
+  if (watcherStarted) return;
+  watcherStarted = true;
+  onHealthChanged(handleHealthChanged);
+}
+
+/** Test-only: resets all module state so each test starts from a clean slate. */
+export function __resetOwnerAlertsForTests(): void {
+  componentStates.clear();
+  cachedOwnerDiscordId = null;
+  watcherStarted = false;
+}

--- a/src/discord/ownerAlerts.ts
+++ b/src/discord/ownerAlerts.ts
@@ -191,8 +191,28 @@ function handleHealthChanged(): void {
 }
 
 /**
+ * Seeds this watcher's baseline component state and owner-ID cache from the current health
+ * snapshot, without sending any alerts. Call once from `index.ts`, after
+ * {@link registerOwnerAlertRuntime} and before {@link startOwnerAlertWatcher} — otherwise the
+ * watcher's first health-changed notification would compare against an empty baseline and fire
+ * false "down" alerts for components still mid-startup (e.g. Twitch chat, before
+ * `startTwitchBot()` has run). Also resolves and caches the owner's Discord ID up front (via
+ * {@link resolveOwnerDiscordId}) so the very first real failure — e.g. a DB outage — doesn't skip
+ * its alert because `cachedOwnerDiscordId` was never populated yet.
+ */
+export async function primeOwnerAlertBaseline(): Promise<void> {
+  const snapshot = getHealthSnapshot();
+  const componentOks = deriveComponentOks(snapshot);
+  const now = Date.now();
+  for (const [componentId, { ok }] of componentOks) {
+    componentStates.set(componentId, { failing: !ok, lastAlertAt: now });
+  }
+  await resolveOwnerDiscordId();
+}
+
+/**
  * Subscribes to `healthStore.onHealthChanged` and starts sending owner DM alerts on
- * component health transitions. Call once from `index.ts` after {@link registerOwnerAlertRuntime}.
+ * component health transitions. Call once from `index.ts`, after {@link primeOwnerAlertBaseline}.
  * Idempotent — a second call is a no-op, so it can never register a duplicate listener.
  */
 export function startOwnerAlertWatcher(): void {

--- a/src/discord/ownerAlerts.ts
+++ b/src/discord/ownerAlerts.ts
@@ -7,6 +7,12 @@ const log = createLogger('OwnerAlerts');
 
 /** Runtime hook injected from `index.ts`, mirroring every other `registerXRuntime` pattern in this codebase (see `twitchRuntime.ts`'s `createRuntimeRegistry`) — avoids a circular import back into `index.ts`/`discordBot.ts`. */
 interface OwnerAlertRuntime {
+  /**
+   * Sends `message` to the bot owner as a Discord DM.
+   * @param discordId - The owner's Discord user id to DM.
+   * @param message - The alert text to send.
+   * @returns Resolves once the DM has been sent; rejects if delivery fails.
+   */
   send: (discordId: string, message: string) => Promise<void>;
 }
 
@@ -16,6 +22,7 @@ const runtimeRegistry = createRuntimeRegistry<OwnerAlertRuntime>();
  * Registers the runtime used to DM the bot owner. Call once from `index.ts` after the
  * Discord bot is ready.
  * @param runtime - The {@link OwnerAlertRuntime} to store.
+ * @returns void.
  */
 export function registerOwnerAlertRuntime(runtime: OwnerAlertRuntime): void {
   runtimeRegistry.register(runtime);
@@ -35,6 +42,14 @@ interface ComponentAlertState {
    * a "recovered" DM with no matching prior "down" DM.
    */
   downAlertSent: boolean;
+  /**
+   * Bumped on every failing-episode boundary — a fresh ok→fail transition (or first seen already
+   * failing), and a fail→ok recovery. Lets {@link dispatchDownAlert}'s delayed delivery result
+   * detect that the component has since moved past the episode it was sent for (recovered, or
+   * recovered and failed again) and skip marking {@link downAlertSent} for one that's no longer
+   * current.
+   */
+  generation: number;
 }
 
 const componentStates = new Map<string, ComponentAlertState>();
@@ -52,14 +67,24 @@ let watcherStarted = false;
 /** One component's derived ok/fail state, plus an error message when it's failing. */
 type ComponentOk = { ok: boolean; error: string | null };
 
-/** Sets the `discord`/`twitchChat`/`db` connectivity entries into `result`. */
+/**
+ * Sets the `discord`/`twitchChat`/`db` connectivity entries into `result`.
+ * @param snapshot - The health snapshot to read connectivity state from.
+ * @param result - The map to add entries to, mutated in place.
+ * @returns void.
+ */
 function addConnectivityOks(snapshot: HealthSnapshot, result: Map<string, ComponentOk>): void {
   result.set('discord', { ok: snapshot.discordConnected, error: snapshot.discordConnected ? null : 'Discord gateway disconnected' });
   result.set('twitchChat', { ok: snapshot.twitchChatConnected, error: snapshot.twitchChatConnected ? null : 'Twitch chat disconnected' });
   result.set('db', { ok: snapshot.db.lastPingOk, error: snapshot.db.lastPingOk ? null : (snapshot.db.lastError ?? 'DB ping failed') });
 }
 
-/** Sets one `eventsub:<streamer>` entry per tracked streamer into `result`. */
+/**
+ * Sets one `eventsub:<streamer>` entry per tracked streamer into `result`.
+ * @param snapshot - The health snapshot to read EventSub state from.
+ * @param result - The map to add entries to, mutated in place.
+ * @returns void.
+ */
 function addEventSubOks(snapshot: HealthSnapshot, result: Map<string, ComponentOk>): void {
   for (const [streamer, health] of Object.entries(snapshot.eventsub)) {
     result.set(`eventsub:${streamer}`, {
@@ -69,7 +94,12 @@ function addEventSubOks(snapshot: HealthSnapshot, result: Map<string, ComponentO
   }
 }
 
-/** Sets the `monitor` entry into `result`, treating a poll older than {@link MONITOR_STALE_MS} as failing too. */
+/**
+ * Sets the `monitor` entry into `result`, treating a poll older than {@link MONITOR_STALE_MS} as failing too.
+ * @param snapshot - The health snapshot to read monitor state from.
+ * @param result - The map to add the entry to, mutated in place.
+ * @returns void.
+ */
 function addMonitorOk(snapshot: HealthSnapshot, result: Map<string, ComponentOk>): void {
   const now = Date.now();
   const stale = snapshot.monitor.lastPollAt !== null && now - snapshot.monitor.lastPollAt.getTime() > MONITOR_STALE_MS;
@@ -80,7 +110,12 @@ function addMonitorOk(snapshot: HealthSnapshot, result: Map<string, ComponentOk>
   });
 }
 
-/** Sets one `scheduler:<name>` entry per tracked scheduler into `result`, treating a run older than {@link SCHEDULER_STALE_MS} as failing too. */
+/**
+ * Sets one `scheduler:<name>` entry per tracked scheduler into `result`, treating a run older than {@link SCHEDULER_STALE_MS} as failing too.
+ * @param snapshot - The health snapshot to read scheduler state from.
+ * @param result - The map to add entries to, mutated in place.
+ * @returns void.
+ */
 function addSchedulerOks(snapshot: HealthSnapshot, result: Map<string, ComponentOk>): void {
   const now = Date.now();
   for (const [name, health] of Object.entries(snapshot.schedulers)) {
@@ -119,6 +154,7 @@ function deriveComponentOks(snapshot: HealthSnapshot): Map<string, ComponentOk> 
  * the cache and returns null, rather than falling back to a possibly-stale cached ID for an
  * owner that may have just been removed. Returns null (and logs) if there's no cached ID yet to
  * fall back to on a failed lookup.
+ * @returns The Discord id to DM, or null if none is available.
  */
 async function resolveOwnerDiscordId(): Promise<string | null> {
   try {
@@ -143,20 +179,47 @@ async function resolveOwnerDiscordId(): Promise<string | null> {
  * Sends a DM alert to the bot owner via the registered runtime. Never throws — a failed DM is
  * logged and swallowed so it can never crash the process (see {@link registerOwnerAlertRuntime}).
  * @param message - The alert text to send.
+ * @returns Whether the DM was actually delivered — false if no runtime is registered, the owner
+ *   ID couldn't be resolved, or the send itself failed.
  */
-async function sendOwnerAlert(message: string): Promise<void> {
+async function sendOwnerAlert(message: string): Promise<boolean> {
   const runtime = runtimeRegistry.get();
   if (!runtime) {
     log.warn('No owner-alert runtime registered — skipping alert:', message);
-    return;
+    return false;
   }
   const discordId = await resolveOwnerDiscordId();
-  if (!discordId) return;
+  if (!discordId) return false;
   try {
     await runtime.send(discordId, message);
+    return true;
   } catch (err) {
     log.error('Failed to send owner alert DM:', err);
+    return false;
   }
+}
+
+/**
+ * Sends a "down" (or, for a cooldown re-notification, "still down") DM for a component and, only
+ * once delivery is confirmed, marks {@link ComponentAlertState.downAlertSent} — so a component
+ * whose down DM never reached the owner (no runtime, owner lookup failure, or a rejected send)
+ * doesn't later fire a false "recovered" DM. Guards against a delayed delivery result from an
+ * earlier failure episode incorrectly marking a newer one, via {@link ComponentAlertState.generation}.
+ * @param componentId - The component's stable id (see {@link deriveComponentOks}).
+ * @param error - The component's current error message, if any.
+ * @param state - The component's tracked alert state, mutated in place once delivery resolves.
+ * @param stillDown - Whether this is a cooldown re-notification for an already-failing component,
+ *   rather than the initial down transition.
+ * @returns void — the alert send and any resulting state update happen asynchronously.
+ */
+function dispatchDownAlert(componentId: string, error: string | null, state: ComponentAlertState, stillDown: boolean): void {
+  const generation = state.generation;
+  const label = stillDown ? 'is still down' : 'is down';
+  void sendOwnerAlert(`🔴 ${componentId} ${label}: ${error ?? 'unknown error'}`).then((delivered) => {
+    if (delivered && state.generation === generation) {
+      state.downAlertSent = true;
+    }
+  });
 }
 
 /**
@@ -166,12 +229,14 @@ async function sendOwnerAlert(message: string): Promise<void> {
  * @param componentId - The component's stable id (see {@link deriveComponentOks}).
  * @param ok - Whether the component is currently healthy.
  * @param error - The component's current error message, if failing.
+ * @returns void.
  */
 function handleFirstSeenComponent(componentId: string, ok: boolean, error: string | null): void {
   const now = Date.now();
-  componentStates.set(componentId, { failing: !ok, lastAlertAt: ok ? 0 : now, downAlertSent: !ok });
+  const state: ComponentAlertState = { failing: !ok, lastAlertAt: ok ? 0 : now, downAlertSent: false, generation: 0 };
+  componentStates.set(componentId, state);
   if (!ok) {
-    void sendOwnerAlert(`🔴 ${componentId} is down: ${error ?? 'unknown error'}`);
+    dispatchDownAlert(componentId, error, state, false);
   }
 }
 
@@ -183,6 +248,7 @@ function handleFirstSeenComponent(componentId: string, ok: boolean, error: strin
  * @param ok - Whether the component is currently healthy.
  * @param error - The component's current error message, if failing.
  * @param existing - The component's previously tracked alert state, mutated in place.
+ * @returns void.
  */
 function handleTrackedComponent(componentId: string, ok: boolean, error: string | null, existing: ComponentAlertState): void {
   const now = Date.now();
@@ -190,23 +256,27 @@ function handleTrackedComponent(componentId: string, ok: boolean, error: string 
   if (ok && existing.failing) {
     existing.failing = false;
     existing.lastAlertAt = now;
-    // Only announce a recovery if a "down" DM actually went out for this failure — otherwise
+    // Only announce a recovery if a "down" DM was actually delivered for this failure — otherwise
     // this is a component that was merely seeded as failing at startup (e.g. twitchChat, before
-    // startTwitchBot() has run) finishing its normal startup, not a real recovery.
+    // startTwitchBot() has run), or whose down DM never reached the owner, finishing its normal
+    // startup rather than undergoing a real recovery.
     const wasAlerted = existing.downAlertSent;
     existing.downAlertSent = false;
+    // Bump the generation so a still-in-flight down-DM delivery from this now-ended episode can't
+    // resurrect downAlertSent (via dispatchDownAlert's delayed .then()) after this recovery.
+    existing.generation += 1;
     if (wasAlerted) {
       void sendOwnerAlert(`✅ ${componentId} recovered`);
     }
   } else if (!ok && !existing.failing) {
     existing.failing = true;
     existing.lastAlertAt = now;
-    existing.downAlertSent = true;
-    void sendOwnerAlert(`🔴 ${componentId} is down: ${error ?? 'unknown error'}`);
+    existing.downAlertSent = false;
+    existing.generation += 1;
+    dispatchDownAlert(componentId, error, existing, false);
   } else if (!ok && existing.failing && now - existing.lastAlertAt > REALERT_COOLDOWN_MS) {
     existing.lastAlertAt = now;
-    existing.downAlertSent = true;
-    void sendOwnerAlert(`🔴 ${componentId} is still down: ${error ?? 'unknown error'}`);
+    dispatchDownAlert(componentId, error, existing, true);
   }
 }
 
@@ -214,6 +284,7 @@ function handleTrackedComponent(componentId: string, ok: boolean, error: string 
  * Reacts to one health-changed notification: derives every tracked component's ok/fail state
  * from the latest snapshot and dispatches each one to {@link handleFirstSeenComponent} or
  * {@link handleTrackedComponent} depending on whether it's been seen before.
+ * @returns void.
  */
 function handleHealthChanged(): void {
   const snapshot = getHealthSnapshot();
@@ -253,7 +324,7 @@ export async function primeOwnerAlertBaseline(): Promise<void> {
     // downAlertSent starts false even for a component seeded as already-failing (e.g. twitchChat,
     // before startTwitchBot() has run) — no "down" DM was actually sent for this baseline state,
     // so its later recovery must not fire a "recovered" DM either. See handleHealthChanged.
-    componentStates.set(componentId, { failing: !ok, lastAlertAt: now, downAlertSent: false });
+    componentStates.set(componentId, { failing: !ok, lastAlertAt: now, downAlertSent: false, generation: 0 });
   }
 }
 
@@ -261,6 +332,7 @@ export async function primeOwnerAlertBaseline(): Promise<void> {
  * Subscribes to `healthStore.onHealthChanged` and starts sending owner DM alerts on
  * component health transitions. Call once from `index.ts`, after {@link primeOwnerAlertBaseline}.
  * Idempotent — a second call is a no-op, so it can never register a duplicate listener.
+ * @returns void.
  */
 export function startOwnerAlertWatcher(): void {
   if (watcherStarted) return;

--- a/src/discord/ownerAlerts.ts
+++ b/src/discord/ownerAlerts.ts
@@ -28,6 +28,13 @@ const REALERT_COOLDOWN_MS = 30 * 60_000;
 interface ComponentAlertState {
   failing: boolean;
   lastAlertAt: number;
+  /**
+   * Whether a "down" DM has actually been sent for the current failure. A component seeded as
+   * failing at startup (e.g. `twitchChat`, before `startTwitchBot()` has run — see
+   * {@link primeOwnerAlertBaseline}) starts with this false, so its eventual recovery doesn't fire
+   * a "recovered" DM with no matching prior "down" DM.
+   */
+  downAlertSent: boolean;
 }
 
 const componentStates = new Map<string, ComponentAlertState>();
@@ -168,7 +175,7 @@ function handleHealthChanged(): void {
     const existing = componentStates.get(componentId);
 
     if (!existing) {
-      componentStates.set(componentId, { failing: !ok, lastAlertAt: ok ? 0 : now });
+      componentStates.set(componentId, { failing: !ok, lastAlertAt: ok ? 0 : now, downAlertSent: !ok });
       if (!ok) {
         void sendOwnerAlert(`🔴 ${componentId} is down: ${error ?? 'unknown error'}`);
       }
@@ -178,13 +185,22 @@ function handleHealthChanged(): void {
     if (ok && existing.failing) {
       existing.failing = false;
       existing.lastAlertAt = now;
-      void sendOwnerAlert(`✅ ${componentId} recovered`);
+      // Only announce a recovery if a "down" DM actually went out for this failure — otherwise
+      // this is a component that was merely seeded as failing at startup (e.g. twitchChat, before
+      // startTwitchBot() has run) finishing its normal startup, not a real recovery.
+      const wasAlerted = existing.downAlertSent;
+      existing.downAlertSent = false;
+      if (wasAlerted) {
+        void sendOwnerAlert(`✅ ${componentId} recovered`);
+      }
     } else if (!ok && !existing.failing) {
       existing.failing = true;
       existing.lastAlertAt = now;
+      existing.downAlertSent = true;
       void sendOwnerAlert(`🔴 ${componentId} is down: ${error ?? 'unknown error'}`);
     } else if (!ok && existing.failing && now - existing.lastAlertAt > REALERT_COOLDOWN_MS) {
       existing.lastAlertAt = now;
+      existing.downAlertSent = true;
       void sendOwnerAlert(`🔴 ${componentId} is still down: ${error ?? 'unknown error'}`);
     }
   }
@@ -211,7 +227,10 @@ export async function primeOwnerAlertBaseline(): Promise<void> {
   const componentOks = deriveComponentOks(snapshot);
   const now = Date.now();
   for (const [componentId, { ok }] of componentOks) {
-    componentStates.set(componentId, { failing: !ok, lastAlertAt: now });
+    // downAlertSent starts false even for a component seeded as already-failing (e.g. twitchChat,
+    // before startTwitchBot() has run) — no "down" DM was actually sent for this baseline state,
+    // so its later recovery must not fire a "recovered" DM either. See handleHealthChanged.
+    componentStates.set(componentId, { failing: !ok, lastAlertAt: now, downAlertSent: false });
   }
 }
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -310,6 +310,55 @@ describe('DB health check interval', () => {
     await vi.advanceTimersByTimeAsync(60_000);
     expect(vi.mocked(pingDb)).toHaveBeenCalledTimes(2);
   });
+
+  it('logs and recovers (does not get stuck in-flight) when pingDb itself rejects', async () => {
+    vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] });
+    const { pingDb } = await import('./db.js');
+    vi.mocked(pingDb).mockRejectedValueOnce(new Error('connection refused'));
+
+    await runMain();
+    vi.mocked(pingDb).mockClear();
+    lastBotLogger!.error.mockClear();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(lastBotLogger!.error).toHaveBeenCalledWith('Unexpected error during DB health check:', expect.any(Error));
+
+    // The in-flight guard must have been released in .finally() despite the rejection, or this
+    // next tick's probe would be silently skipped.
+    vi.mocked(pingDb).mockClear();
+    vi.mocked(pingDb).mockResolvedValueOnce(true);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(vi.mocked(pingDb)).toHaveBeenCalledOnce();
+  });
+});
+
+describe('owner-alert DM send callback', () => {
+  it('throws when the Discord client is not ready', async () => {
+    const { registerOwnerAlertRuntime } = await import('./discord/ownerAlerts.js');
+    const { getDiscordClient } = await import('./discord/discordBot.js');
+    vi.mocked(getDiscordClient).mockReturnValue(undefined as any);
+
+    await runMain();
+
+    const send = vi.mocked(registerOwnerAlertRuntime).mock.calls[0][0].send;
+    await expect(send('123', 'hi')).rejects.toThrow('Discord client is not ready');
+  });
+
+  it('fetches the user and DMs them when the client is ready', async () => {
+    const { registerOwnerAlertRuntime } = await import('./discord/ownerAlerts.js');
+    const { getDiscordClient } = await import('./discord/discordBot.js');
+    const userSend = vi.fn().mockResolvedValue(undefined);
+    const fetch = vi.fn().mockResolvedValue({ send: userSend });
+    vi.mocked(getDiscordClient).mockReturnValue({ users: { fetch } } as any);
+
+    await runMain();
+
+    const send = vi.mocked(registerOwnerAlertRuntime).mock.calls[0][0].send;
+    await send('123', 'hi');
+
+    expect(fetch).toHaveBeenCalledWith('123');
+    expect(userSend).toHaveBeenCalledWith('hi');
+  });
 });
 
 describe('shutdown', () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -272,6 +272,39 @@ describe('startup — reward pricing scheduler', () => {
   });
 });
 
+describe('DB health check interval', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not start a second probe while one is still in flight (overlap guard)', async () => {
+    // Only fake setInterval/clearInterval — runMain()'s own setImmediate-based settling wait
+    // (and anything else main() schedules) keeps running on real timers.
+    vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] });
+    const { pingDb } = await import('./db.js');
+    let resolvePing!: (ok: boolean) => void;
+    vi.mocked(pingDb).mockImplementation(() => new Promise((resolve) => { resolvePing = resolve; }));
+
+    await runMain();
+    vi.mocked(pingDb).mockClear();
+
+    // First interval tick starts a probe that never resolves during this window.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(vi.mocked(pingDb)).toHaveBeenCalledOnce();
+
+    // A second interval tick fires while the first probe is still pending — the guard
+    // should skip it rather than stacking a second call.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(vi.mocked(pingDb)).toHaveBeenCalledOnce();
+
+    // Once the in-flight probe resolves, the next tick is free to start a new one.
+    resolvePing(true);
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(vi.mocked(pingDb)).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe('shutdown', () => {
   it('stops the reward pricing scheduler on SIGINT', async () => {
     const { stopRewardPricingScheduler } = await import('./twitch/pricing/rewardPricingScheduler.js');

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -13,10 +13,19 @@ vi.mock('./db', () => ({
     }),
   })),
   closePool: vi.fn().mockResolvedValue(undefined),
+  pingDb: vi.fn().mockResolvedValue(true),
+}));
+vi.mock('./shared/healthStore', () => ({
+  recordDbPing: vi.fn(),
+}));
+vi.mock('./discord/ownerAlerts', () => ({
+  registerOwnerAlertRuntime: vi.fn(),
+  startOwnerAlertWatcher: vi.fn(),
 }));
 vi.mock('./discord/discordBot', () => ({
   startDiscordBot: vi.fn(),
   stopDiscordBot: vi.fn(),
+  getDiscordClient: vi.fn(),
 }));
 vi.mock('./discord/guildRegistry', () => ({
   reloadGuildRegistry: vi.fn().mockResolvedValue(undefined),
@@ -203,6 +212,17 @@ describe('startup — guild registry preload', () => {
 
     expect(exitSpy).toHaveBeenCalledWith(1);
     expect(vi.mocked(startDiscordBot)).not.toHaveBeenCalled();
+  });
+
+  it('records the startup DB ping and registers/starts the owner-alert runtime on a clean startup', async () => {
+    const { recordDbPing } = await import('./shared/healthStore.js');
+    const { registerOwnerAlertRuntime, startOwnerAlertWatcher } = await import('./discord/ownerAlerts.js');
+
+    await runMain();
+
+    expect(vi.mocked(recordDbPing)).toHaveBeenCalledWith(true);
+    expect(vi.mocked(registerOwnerAlertRuntime)).toHaveBeenCalledWith({ send: expect.any(Function) });
+    expect(vi.mocked(startOwnerAlertWatcher)).toHaveBeenCalledOnce();
   });
 
   it('calls process.exit(1) and does not start the bot when the DB connection ping fails', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -20,6 +20,7 @@ vi.mock('./shared/healthStore', () => ({
 }));
 vi.mock('./discord/ownerAlerts', () => ({
   registerOwnerAlertRuntime: vi.fn(),
+  primeOwnerAlertBaseline: vi.fn(),
   startOwnerAlertWatcher: vi.fn(),
 }));
 vi.mock('./discord/discordBot', () => ({
@@ -214,15 +215,21 @@ describe('startup — guild registry preload', () => {
     expect(vi.mocked(startDiscordBot)).not.toHaveBeenCalled();
   });
 
-  it('records the startup DB ping and registers/starts the owner-alert runtime on a clean startup', async () => {
+  it('records the startup DB ping and registers/primes/starts the owner-alert runtime, in order, on a clean startup', async () => {
     const { recordDbPing } = await import('./shared/healthStore.js');
-    const { registerOwnerAlertRuntime, startOwnerAlertWatcher } = await import('./discord/ownerAlerts.js');
+    const { registerOwnerAlertRuntime, primeOwnerAlertBaseline, startOwnerAlertWatcher } = await import('./discord/ownerAlerts.js');
 
     await runMain();
 
     expect(vi.mocked(recordDbPing)).toHaveBeenCalledWith(true);
     expect(vi.mocked(registerOwnerAlertRuntime)).toHaveBeenCalledWith({ send: expect.any(Function) });
+    expect(vi.mocked(primeOwnerAlertBaseline)).toHaveBeenCalledOnce();
     expect(vi.mocked(startOwnerAlertWatcher)).toHaveBeenCalledOnce();
+    // primeOwnerAlertBaseline must run before the watcher starts listening — otherwise its
+    // first health-changed notification compares against an empty baseline (see
+    // ownerAlerts.ts's primeOwnerAlertBaseline JSDoc for why that causes false "down" alerts).
+    expect(vi.mocked(primeOwnerAlertBaseline).mock.invocationCallOrder[0])
+      .toBeLessThan(vi.mocked(startOwnerAlertWatcher).mock.invocationCallOrder[0]);
   });
 
   it('calls process.exit(1) and does not start the bot when the DB connection ping fails', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ function startDbHealthCheck(): void {
   dbHealthCheckTimer = setInterval(() => {
     if (dbHealthCheckInFlight) return;
     dbHealthCheckInFlight = true;
-    pingDb()
+    void pingDb()
       .then((ok) => recordDbPing(ok, ok ? undefined : 'DB ping failed'))
       .catch((err: unknown) => log.error('Unexpected error during DB health check:', err))
       .finally(() => { dbHealthCheckInFlight = false; });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import 'mediaplex'; // Must be imported first to register as Opus provider
 import { getPool, closePool, pingDb } from './db';
 import { recordDbPing } from './shared/healthStore';
-import { registerOwnerAlertRuntime, startOwnerAlertWatcher } from './discord/ownerAlerts';
+import { registerOwnerAlertRuntime, primeOwnerAlertBaseline, startOwnerAlertWatcher } from './discord/ownerAlerts';
 import { startTwitchBot, stopTwitchBot, sayInChannel } from './twitch/twitchBot';
 import { getActiveChannels, getActiveChannelUserIds, setChannelJoinedHook } from './twitch/twitchChannelMembership';
 import { startChannelReconciliationPoll, stopChannelReconciliationPoll } from './twitch/twitchChannelReconciliationPoll';
@@ -188,6 +188,7 @@ async function main(): Promise<void> {
       await user.send(message);
     },
   });
+  await primeOwnerAlertBaseline();
   startOwnerAlertWatcher();
   await startTwitchBot();
   startWebPanel();

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,10 @@ const log = createLogger('Bot');
 const DB_HEALTH_CHECK_INTERVAL_MS = 60_000;
 
 let dbHealthCheckTimer: ReturnType<typeof setInterval> | null = null;
+// Guards against overlapping probes: pingDb()'s getConnection() has no timeout of its own, so
+// a pool that's exhausted/wedged could in principle keep a probe in flight past the next
+// interval tick — this flag makes an overlap a no-op instead of stacking probes.
+let dbHealthCheckInFlight = false;
 
 /**
  * Starts the periodic DB-connectivity health check: pings the pool every
@@ -50,9 +54,12 @@ let dbHealthCheckTimer: ReturnType<typeof setInterval> | null = null;
 function startDbHealthCheck(): void {
   if (dbHealthCheckTimer) return;
   dbHealthCheckTimer = setInterval(() => {
+    if (dbHealthCheckInFlight) return;
+    dbHealthCheckInFlight = true;
     pingDb()
       .then((ok) => recordDbPing(ok, ok ? undefined : 'DB ping failed'))
-      .catch((err: unknown) => log.error('Unexpected error during DB health check:', err));
+      .catch((err: unknown) => log.error('Unexpected error during DB health check:', err))
+      .finally(() => { dbHealthCheckInFlight = false; });
   }, DB_HEALTH_CHECK_INTERVAL_MS);
   // Doesn't keep the process alive on its own — same reasoning as this codebase's other
   // background-purge intervals (e.g. twitchEventSubConnection.ts's message-dedup sweep):

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,11 @@
 import 'mediaplex'; // Must be imported first to register as Opus provider
-import { getPool, closePool } from './db';
+import { getPool, closePool, pingDb } from './db';
+import { recordDbPing } from './shared/healthStore';
+import { registerOwnerAlertRuntime, startOwnerAlertWatcher } from './discord/ownerAlerts';
 import { startTwitchBot, stopTwitchBot, sayInChannel } from './twitch/twitchBot';
 import { getActiveChannels, getActiveChannelUserIds, setChannelJoinedHook } from './twitch/twitchChannelMembership';
 import { startChannelReconciliationPoll, stopChannelReconciliationPoll } from './twitch/twitchChannelReconciliationPoll';
-import { startDiscordBot, stopDiscordBot } from './discord/discordBot';
+import { startDiscordBot, stopDiscordBot, getDiscordClient } from './discord/discordBot';
 import { reloadGuildRegistry } from './discord/guildRegistry';
 import { resolveGuildIdForDiscordId } from './discord/voicePresence';
 import { registerTwitchGuildResolutionRuntime } from './twitch/twitchGuildResolutionRuntime';
@@ -34,12 +36,43 @@ import { createLogger } from './shared/logger';
 
 const log = createLogger('Bot');
 
+/** How often the DB-connectivity health check pings the pool (see {@link startDbHealthCheck}). */
+const DB_HEALTH_CHECK_INTERVAL_MS = 60_000;
+
+let dbHealthCheckTimer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Starts the periodic DB-connectivity health check: pings the pool every
+ * {@link DB_HEALTH_CHECK_INTERVAL_MS} and records the outcome in `healthStore`, so the owner
+ * health dashboard/`!health` command/owner-alert watcher reflect live DB reachability, not just
+ * the one-off ping `main()` already does at startup. No-ops if already started.
+ */
+function startDbHealthCheck(): void {
+  if (dbHealthCheckTimer) return;
+  dbHealthCheckTimer = setInterval(() => {
+    pingDb()
+      .then((ok) => recordDbPing(ok, ok ? undefined : 'DB ping failed'))
+      .catch((err: unknown) => log.error('Unexpected error during DB health check:', err));
+  }, DB_HEALTH_CHECK_INTERVAL_MS);
+  // Doesn't keep the process alive on its own — same reasoning as this codebase's other
+  // background-purge intervals (e.g. twitchEventSubConnection.ts's message-dedup sweep):
+  // shutdown() always clears it explicitly, so unref only matters for a process that would
+  // otherwise exit cleanly (e.g. a test importing this module) with this timer still pending.
+  dbHealthCheckTimer.unref();
+}
+
+/** Stops the periodic DB-connectivity health check, if running. */
+function stopDbHealthCheck(): void {
+  if (dbHealthCheckTimer) { clearInterval(dbHealthCheckTimer); dbHealthCheckTimer = null; }
+}
+
 /**
  * Gracefully stops schedulers and bot connections, closes the DB pool, and exits the process.
  * @param signal - The name of the signal that triggered shutdown (e.g. `SIGINT`).
  */
 async function shutdown(signal: string): Promise<void> {
   log.info(`${signal} received — disconnecting from voice and shutting down.`);
+  stopDbHealthCheck();
   stopCounterScheduler();
   stopChannelReconciliationPoll();
   await stopRewardPricingScheduler();
@@ -101,6 +134,7 @@ async function main(): Promise<void> {
     await conn.ping();
     conn.release();
     log.info('Database connection OK');
+    recordDbPing(true);
   } catch (err) {
     log.error('Cannot connect to database:', err);
     process.exit(1);
@@ -139,12 +173,22 @@ async function main(): Promise<void> {
 
   setChannelJoinedHook(() => reloadEventSubSubscriptions());
   startDiscordBot();
+  registerOwnerAlertRuntime({
+    send: async (discordId, message) => {
+      const client = getDiscordClient();
+      if (!client) throw new Error('Discord client is not ready');
+      const user = await client.users.fetch(discordId);
+      await user.send(message);
+    },
+  });
+  startOwnerAlertWatcher();
   await startTwitchBot();
   startWebPanel();
   startChannelReconciliationPoll();
   startCounterScheduler();
   startRewardPricingScheduler();
   startTimerCommandScheduler();
+  startDbHealthCheck();
 
   startTwitchMonitor().catch((err) => log.error('TwitchMonitor startup error:', err));
   startEventSub();

--- a/src/shared/healthStore.test.ts
+++ b/src/shared/healthStore.test.ts
@@ -102,6 +102,19 @@ describe('EventSub connections', () => {
     expect(snap.eventsub['streamerA'].connected).toBe(true);
     expect(snap.eventsub['streamerB'].connected).toBe(false);
   });
+
+  it('removeEventSubHealth deletes the record entirely, rather than leaving it reported as disconnected', () => {
+    mod.recordEventSubConnected('streamerA', true);
+    mod.removeEventSubHealth('streamerA');
+    expect(mod.getHealthSnapshot().eventsub['streamerA']).toBeUndefined();
+  });
+
+  it('removeEventSubHealth no-ops for a streamer with no recorded health', () => {
+    const listener = vi.fn();
+    mod.onHealthChanged(listener);
+    mod.removeEventSubHealth('never-seen');
+    expect(listener).not.toHaveBeenCalled();
+  });
 });
 
 describe('Monitor poll', () => {

--- a/src/shared/healthStore.test.ts
+++ b/src/shared/healthStore.test.ts
@@ -211,6 +211,15 @@ describe('getHealthSnapshot returns copies', () => {
     expect(mod.getHealthSnapshot().db.lastError).toBeNull();
   });
 
+  it('mutating a returned Date field (e.g. via setTime) does not affect internal state', () => {
+    mod.recordDbPing(true);
+    const snap = mod.getHealthSnapshot();
+    const originalTime = snap.db.lastPingAt!.getTime();
+    snap.db.lastPingAt!.setTime(0);
+    const refreshed = mod.getHealthSnapshot();
+    expect(refreshed.db.lastPingAt!.getTime()).toBe(originalTime);
+  });
+
   it('mutating a returned eventsub entry does not affect internal state', () => {
     mod.recordEventSubConnected('streamerA', true);
     const snap = mod.getHealthSnapshot();

--- a/src/shared/healthStore.test.ts
+++ b/src/shared/healthStore.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+let mod: Awaited<typeof import('./healthStore.js')>;
+
+beforeEach(async () => {
+  vi.resetModules();
+  mod = await import('./healthStore.js');
+});
+
+describe('Discord/Twitch chat connection state', () => {
+  it('starts disconnected', () => {
+    const snap = mod.getHealthSnapshot();
+    expect(snap.discordConnected).toBe(false);
+    expect(snap.twitchChatConnected).toBe(false);
+  });
+
+  it('recordDiscordConnected mutates state and notifies', () => {
+    const listener = vi.fn();
+    mod.onHealthChanged(listener);
+    mod.recordDiscordConnected(true);
+    expect(mod.getHealthSnapshot().discordConnected).toBe(true);
+    expect(listener).toHaveBeenCalledOnce();
+    mod.recordDiscordConnected(false);
+    expect(mod.getHealthSnapshot().discordConnected).toBe(false);
+  });
+
+  it('recordTwitchChatConnected mutates state and notifies', () => {
+    const listener = vi.fn();
+    mod.onHealthChanged(listener);
+    mod.recordTwitchChatConnected(true);
+    expect(mod.getHealthSnapshot().twitchChatConnected).toBe(true);
+    expect(listener).toHaveBeenCalledOnce();
+  });
+});
+
+describe('DB ping', () => {
+  it('starts with lastPingOk true and no history', () => {
+    const { db } = mod.getHealthSnapshot();
+    expect(db.lastPingOk).toBe(true);
+    expect(db.lastPingAt).toBeNull();
+    expect(db.lastError).toBeNull();
+  });
+
+  it('recordDbPing(true) stamps lastPingAt and clears no error', () => {
+    mod.recordDbPing(true);
+    const { db } = mod.getHealthSnapshot();
+    expect(db.lastPingOk).toBe(true);
+    expect(db.lastPingAt).toBeInstanceOf(Date);
+    expect(db.lastError).toBeNull();
+  });
+
+  it('recordDbPing(false, error) records the error', () => {
+    mod.recordDbPing(false, 'connection refused');
+    const { db } = mod.getHealthSnapshot();
+    expect(db.lastPingOk).toBe(false);
+    expect(db.lastError).toBe('connection refused');
+  });
+
+  it('a later ok ping leaves lastError from a previous failure intact', () => {
+    mod.recordDbPing(false, 'boom');
+    mod.recordDbPing(true);
+    const { db } = mod.getHealthSnapshot();
+    expect(db.lastPingOk).toBe(true);
+    expect(db.lastError).toBe('boom');
+  });
+});
+
+describe('EventSub connections', () => {
+  it('starts with no streamers tracked', () => {
+    expect(mod.getHealthSnapshot().eventsub).toEqual({});
+  });
+
+  it('recordEventSubConnected(true) creates a record, stamps lastConnectedAt, resets reconnectAttempts', () => {
+    mod.recordEventSubReconnectAttempt('streamerA');
+    mod.recordEventSubReconnectAttempt('streamerA');
+    mod.recordEventSubConnected('streamerA', true);
+    const entry = mod.getHealthSnapshot().eventsub['streamerA'];
+    expect(entry.connected).toBe(true);
+    expect(entry.lastConnectedAt).toBeInstanceOf(Date);
+    expect(entry.reconnectAttempts).toBe(0);
+  });
+
+  it('recordEventSubConnected(false, error) stamps lastDisconnectedAt and records the error', () => {
+    mod.recordEventSubConnected('streamerA', true);
+    mod.recordEventSubConnected('streamerA', false, 'socket closed');
+    const entry = mod.getHealthSnapshot().eventsub['streamerA'];
+    expect(entry.connected).toBe(false);
+    expect(entry.lastDisconnectedAt).toBeInstanceOf(Date);
+    expect(entry.lastError).toBe('socket closed');
+  });
+
+  it('recordEventSubReconnectAttempt increments the counter, creating a record on first use', () => {
+    mod.recordEventSubReconnectAttempt('streamerB');
+    mod.recordEventSubReconnectAttempt('streamerB');
+    expect(mod.getHealthSnapshot().eventsub['streamerB'].reconnectAttempts).toBe(2);
+  });
+
+  it('tracks multiple streamers independently', () => {
+    mod.recordEventSubConnected('streamerA', true);
+    mod.recordEventSubConnected('streamerB', false, 'err');
+    const snap = mod.getHealthSnapshot();
+    expect(snap.eventsub['streamerA'].connected).toBe(true);
+    expect(snap.eventsub['streamerB'].connected).toBe(false);
+  });
+});
+
+describe('Monitor poll', () => {
+  it('starts with lastPollOk true and no history', () => {
+    const { monitor } = mod.getHealthSnapshot();
+    expect(monitor.lastPollOk).toBe(true);
+    expect(monitor.lastPollAt).toBeNull();
+  });
+
+  it('recordMonitorPoll(true) stamps lastPollAt', () => {
+    mod.recordMonitorPoll(true);
+    const { monitor } = mod.getHealthSnapshot();
+    expect(monitor.lastPollOk).toBe(true);
+    expect(monitor.lastPollAt).toBeInstanceOf(Date);
+  });
+
+  it('recordMonitorPoll(false, error) records the error', () => {
+    mod.recordMonitorPoll(false, 'API down');
+    const { monitor } = mod.getHealthSnapshot();
+    expect(monitor.lastPollOk).toBe(false);
+    expect(monitor.lastError).toBe('API down');
+  });
+});
+
+describe('Scheduler runs', () => {
+  it('starts with no schedulers tracked', () => {
+    expect(mod.getHealthSnapshot().schedulers).toEqual({});
+  });
+
+  it('recordSchedulerRun creates a record and stamps lastRunAt', () => {
+    mod.recordSchedulerRun('counter', true);
+    const entry = mod.getHealthSnapshot().schedulers.counter!;
+    expect(entry.lastRunOk).toBe(true);
+    expect(entry.lastRunAt).toBeInstanceOf(Date);
+  });
+
+  it('recordSchedulerRun(false, error) records the error', () => {
+    mod.recordSchedulerRun('rewardPricing', false, 'DB shutdown');
+    const entry = mod.getHealthSnapshot().schedulers.rewardPricing!;
+    expect(entry.lastRunOk).toBe(false);
+    expect(entry.lastError).toBe('DB shutdown');
+  });
+
+  it('tracks each named scheduler independently', () => {
+    mod.recordSchedulerRun('counter', true);
+    mod.recordSchedulerRun('timer', false, 'oops');
+    const snap = mod.getHealthSnapshot();
+    expect(snap.schedulers.counter?.lastRunOk).toBe(true);
+    expect(snap.schedulers.timer?.lastRunOk).toBe(false);
+  });
+});
+
+describe('Error ring buffer', () => {
+  it('starts empty', () => {
+    expect(mod.getHealthSnapshot().errors).toEqual([]);
+  });
+
+  it('recordError appends an entry', () => {
+    mod.recordError('Discord', 'boom');
+    const { errors } = mod.getHealthSnapshot();
+    expect(errors).toHaveLength(1);
+    expect(errors[0].module).toBe('Discord');
+    expect(errors[0].message).toBe('boom');
+    expect(errors[0].timestamp).toBeInstanceOf(Date);
+  });
+
+  it('trims to the newest 50 entries, evicting the oldest first', () => {
+    for (let i = 0; i < 55; i++) mod.recordError('Mod', `err-${i}`);
+    const { errors } = mod.getHealthSnapshot();
+    expect(errors).toHaveLength(50);
+    expect(errors[0].message).toBe('err-5');
+    expect(errors[49].message).toBe('err-54');
+  });
+});
+
+describe('onHealthChanged', () => {
+  it('is not called before any mutator runs', () => {
+    const listener = vi.fn();
+    mod.onHealthChanged(listener);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('notifies every registered listener, not just the most recently registered one', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    mod.onHealthChanged(first);
+    mod.onHealthChanged(second);
+    mod.recordDiscordConnected(true);
+    expect(first).toHaveBeenCalledOnce();
+    expect(second).toHaveBeenCalledOnce();
+  });
+
+  it('does not register the same listener function twice', () => {
+    const listener = vi.fn();
+    mod.onHealthChanged(listener);
+    mod.onHealthChanged(listener);
+    mod.recordDiscordConnected(true);
+    expect(listener).toHaveBeenCalledOnce();
+  });
+});
+
+describe('getHealthSnapshot returns copies', () => {
+  it('mutating the returned db object does not affect internal state', () => {
+    mod.recordDbPing(true);
+    const snap = mod.getHealthSnapshot();
+    (snap.db as Record<string, unknown>).lastError = 'mutated';
+    expect(mod.getHealthSnapshot().db.lastError).toBeNull();
+  });
+
+  it('mutating a returned eventsub entry does not affect internal state', () => {
+    mod.recordEventSubConnected('streamerA', true);
+    const snap = mod.getHealthSnapshot();
+    (snap.eventsub['streamerA'] as unknown as Record<string, unknown>).connected = false;
+    expect(mod.getHealthSnapshot().eventsub['streamerA'].connected).toBe(true);
+  });
+
+  it('mutating the returned errors array does not affect internal state', () => {
+    mod.recordError('Mod', 'boom');
+    const snap = mod.getHealthSnapshot();
+    snap.errors.push({ timestamp: new Date(), module: 'Fake', message: 'injected' });
+    expect(mod.getHealthSnapshot().errors).toHaveLength(1);
+  });
+});

--- a/src/shared/healthStore.ts
+++ b/src/shared/healthStore.ts
@@ -1,0 +1,245 @@
+// Sibling to `statusStore.ts`: an in-memory, dependency-free store of live health/liveness
+// signals for the bot's various components (Discord gateway, Twitch chat, DB, per-streamer
+// EventSub connections, the Twitch stream monitor, and the schedulers), consumed by the owner
+// health dashboard (`src/web/routes/health.ts`), the `!health` Discord command
+// (`src/commands/healthCommandHandler.ts`), and the owner-alert watcher
+// (`src/discord/ownerAlerts.ts`). Zero imports from `db`/`discord`/`web` — same rationale as
+// `statusStore.ts` — so it can be imported from anywhere (including `shared/logger.ts`) without
+// creating import cycles.
+
+/**
+ * How stale `monitor.lastPollAt` may get before a consumer should treat the Twitch stream
+ * monitor as unhealthy. Set to 2x the monitor's own poll interval (60s, see
+ * `src/twitch/monitor/twitchMonitor.ts`'s `POLL_INTERVAL_MS`) so a single slow/skipped poll
+ * doesn't false-positive, but two in a row does.
+ */
+export const MONITOR_STALE_MS = 120_000;
+
+/**
+ * How stale a scheduler's `lastRunAt` may get before a consumer should treat it as unhealthy.
+ * Set to 2x the slowest scheduler's own tick interval (the counter-archive scheduler polls
+ * hourly — see `src/commands/counterScheduler.ts`'s `POLL_INTERVAL_MS` — the widest interval of
+ * the three schedulers tracked here) so a single missed tick of any tracked scheduler doesn't
+ * false-positive, but two in a row does.
+ */
+export const SCHEDULER_STALE_MS = 7_200_000;
+
+/** Max number of entries kept in the error ring buffer (see {@link recordError}). Oldest evicted first. */
+const MAX_ERRORS = 50;
+
+/** One entry in the health store's bounded error ring buffer. */
+export interface HealthErrorEntry {
+  timestamp: Date;
+  module: string;
+  message: string;
+}
+
+/** Live connection/reconnect status for a single streamer's EventSub WebSocket connection. */
+export interface EventSubHealth {
+  connected: boolean;
+  lastConnectedAt: Date | null;
+  lastDisconnectedAt: Date | null;
+  reconnectAttempts: number;
+  lastError: string | null;
+}
+
+/** Live run status for one of the periodic schedulers. */
+export interface SchedulerHealth {
+  lastRunAt: Date | null;
+  lastRunOk: boolean;
+  lastError: string | null;
+}
+
+/** The set of scheduler names tracked by {@link recordSchedulerRun}. */
+export type SchedulerName = 'counter' | 'rewardPricing' | 'timer';
+
+/** Returns a fresh, disconnected/no-history EventSub health record. */
+function defaultEventSubHealth(): EventSubHealth {
+  return { connected: false, lastConnectedAt: null, lastDisconnectedAt: null, reconnectAttempts: 0, lastError: null };
+}
+
+/** Returns a fresh, never-run scheduler health record. */
+function defaultSchedulerHealth(): SchedulerHealth {
+  return { lastRunAt: null, lastRunOk: true, lastError: null };
+}
+
+const state = {
+  discordConnected: false,
+  twitchChatConnected: false,
+  db: {
+    lastPingOk: true,
+    lastPingAt: null as Date | null,
+    lastError: null as string | null,
+  },
+  eventsub: new Map<string, EventSubHealth>(),
+  monitor: {
+    lastPollAt: null as Date | null,
+    lastPollOk: true,
+    lastError: null as string | null,
+  },
+  schedulers: new Map<SchedulerName, SchedulerHealth>(),
+  errors: [] as HealthErrorEntry[],
+};
+
+// Registered by the web layer (via onHealthChanged) and by the owner-alert watcher, mirroring
+// `statusStore.ts`'s `onStatusChanged` — a Set of listeners (not a single slot) since more than
+// one consumer subscribes independently.
+const healthChangeListeners = new Set<() => void>();
+
+/**
+ * Registers a callback invoked after every health mutation below, so the web layer and the
+ * owner-alert watcher can react without this module depending on either of them. Adds to the
+ * set of registered listeners — every registered listener is notified on each change; none are
+ * dropped by a later registration.
+ * @param listener - Called (with no arguments) after each health mutation.
+ */
+export function onHealthChanged(listener: () => void): void {
+  healthChangeListeners.add(listener);
+}
+
+/** Invokes every registered health-change listener (see {@link onHealthChanged}). */
+function notifyHealthChanged(): void {
+  for (const listener of healthChangeListeners) listener();
+}
+
+/** Returns a guarded copy of an error message: `err.message` for an `Error`, `undefined` otherwise. */
+function normalizeError(error: unknown): string | undefined {
+  if (error === undefined) return undefined;
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** Records the Discord gateway client's connected/disconnected state. Notifies registered listeners. */
+export function recordDiscordConnected(connected: boolean): void {
+  state.discordConnected = connected;
+  notifyHealthChanged();
+}
+
+/** Records the Twitch chat client's connected/disconnected state. Notifies registered listeners. */
+export function recordTwitchChatConnected(connected: boolean): void {
+  state.twitchChatConnected = connected;
+  notifyHealthChanged();
+}
+
+/**
+ * Records the outcome of a DB connectivity ping. Notifies registered listeners.
+ * @param ok - Whether the ping succeeded.
+ * @param error - Error message on failure; ignored (left as the previous value) when `ok` is true.
+ */
+export function recordDbPing(ok: boolean, error?: string): void {
+  state.db.lastPingOk = ok;
+  state.db.lastPingAt = new Date();
+  if (!ok) state.db.lastError = error ?? state.db.lastError;
+  notifyHealthChanged();
+}
+
+/**
+ * Records a streamer's EventSub WebSocket connecting or disconnecting, creating its health
+ * record on first use. On connect, resets `reconnectAttempts` to 0 and stamps
+ * `lastConnectedAt`; on disconnect, stamps `lastDisconnectedAt`. Notifies registered listeners.
+ * @param streamer - Streamer key (matches the name used elsewhere for this connection).
+ * @param connected - New connected state.
+ * @param error - Error message associated with a disconnect, if any.
+ */
+export function recordEventSubConnected(streamer: string, connected: boolean, error?: string): void {
+  const existing = state.eventsub.get(streamer) ?? defaultEventSubHealth();
+  existing.connected = connected;
+  if (connected) {
+    existing.reconnectAttempts = 0;
+    existing.lastConnectedAt = new Date();
+  } else {
+    existing.lastDisconnectedAt = new Date();
+    if (error !== undefined) existing.lastError = error;
+  }
+  state.eventsub.set(streamer, existing);
+  notifyHealthChanged();
+}
+
+/**
+ * Increments a streamer's EventSub reconnect-attempt counter, creating its health record on
+ * first use. Notifies registered listeners.
+ * @param streamer - Streamer key (matches the name used elsewhere for this connection).
+ */
+export function recordEventSubReconnectAttempt(streamer: string): void {
+  const existing = state.eventsub.get(streamer) ?? defaultEventSubHealth();
+  existing.reconnectAttempts += 1;
+  state.eventsub.set(streamer, existing);
+  notifyHealthChanged();
+}
+
+/**
+ * Records the outcome of a Twitch stream-monitor poll. Notifies registered listeners.
+ * @param ok - Whether the poll succeeded.
+ * @param error - Error message on failure; ignored (left as the previous value) when `ok` is true.
+ */
+export function recordMonitorPoll(ok: boolean, error?: string): void {
+  state.monitor.lastPollAt = new Date();
+  state.monitor.lastPollOk = ok;
+  if (!ok) state.monitor.lastError = error ?? state.monitor.lastError;
+  notifyHealthChanged();
+}
+
+/**
+ * Records the outcome of one scheduler's tick, creating its health record on first use.
+ * Notifies registered listeners.
+ * @param name - Which scheduler ran (see {@link SchedulerName}).
+ * @param ok - Whether the tick succeeded.
+ * @param error - Error message on failure; ignored (left as the previous value) when `ok` is true.
+ */
+export function recordSchedulerRun(name: SchedulerName, ok: boolean, error?: string): void {
+  const existing = state.schedulers.get(name) ?? defaultSchedulerHealth();
+  existing.lastRunAt = new Date();
+  existing.lastRunOk = ok;
+  if (!ok) existing.lastError = error ?? existing.lastError;
+  state.schedulers.set(name, existing);
+  notifyHealthChanged();
+}
+
+/**
+ * Appends an error to the bounded ring buffer (see {@link MAX_ERRORS}), evicting the oldest
+ * entry first once full. Notifies registered listeners. Intended primarily as the sink for
+ * `shared/logger.ts`'s error-capturing transport, but usable directly too.
+ * @param module - Log label identifying which module the error came from.
+ * @param message - The error message.
+ */
+export function recordError(module: string, message: string): void {
+  state.errors.push({ timestamp: new Date(), module, message });
+  if (state.errors.length > MAX_ERRORS) state.errors.shift();
+  notifyHealthChanged();
+}
+
+/** Plain-object snapshot shape returned by {@link getHealthSnapshot}. */
+export interface HealthSnapshot {
+  discordConnected: boolean;
+  twitchChatConnected: boolean;
+  db: { lastPingOk: boolean; lastPingAt: Date | null; lastError: string | null };
+  eventsub: Record<string, EventSubHealth>;
+  monitor: { lastPollAt: Date | null; lastPollOk: boolean; lastError: string | null };
+  schedulers: Partial<Record<SchedulerName, SchedulerHealth>>;
+  errors: HealthErrorEntry[];
+}
+
+/**
+ * Returns a snapshot of the current health state: a deep-ish copy (own top-level objects
+ * copied, Maps converted to plain records, the error list copied) so a caller mutating the
+ * returned object can never affect internal state — same spirit as `statusStore.ts`'s
+ * `getStatus()`.
+ */
+export function getHealthSnapshot(): HealthSnapshot {
+  return {
+    discordConnected: state.discordConnected,
+    twitchChatConnected: state.twitchChatConnected,
+    db: { ...state.db },
+    eventsub: Object.fromEntries(
+      Array.from(state.eventsub, ([key, value]) => [key, { ...value }]),
+    ) as Record<string, EventSubHealth>,
+    monitor: { ...state.monitor },
+    schedulers: Object.fromEntries(
+      Array.from(state.schedulers, ([key, value]) => [key, { ...value }]),
+    ) as Partial<Record<SchedulerName, SchedulerHealth>>,
+    errors: state.errors.map((e) => ({ ...e })),
+  };
+}
+
+// `normalizeError` is exported for reuse by call sites that want to pass a caught `unknown`
+// error straight into one of the `record*` functions above without duplicating this logic.
+export { normalizeError };

--- a/src/shared/healthStore.ts
+++ b/src/shared/healthStore.ts
@@ -160,6 +160,18 @@ export function recordEventSubConnected(streamer: string, connected: boolean, er
 }
 
 /**
+ * Removes a streamer's EventSub health record entirely, e.g. when its connection is stopped
+ * for good (no subscriptions left) rather than reconnecting — otherwise it would keep reporting
+ * as "disconnected" indefinitely for a streamer that was intentionally removed. No-ops if the
+ * streamer has no recorded health. Notifies registered listeners.
+ * @param streamer - Streamer key (matches the name used elsewhere for this connection).
+ */
+export function removeEventSubHealth(streamer: string): void {
+  if (!state.eventsub.delete(streamer)) return;
+  notifyHealthChanged();
+}
+
+/**
  * Increments a streamer's EventSub reconnect-attempt counter, creating its health record on
  * first use. Notifies registered listeners.
  * @param streamer - Streamer key (matches the name used elsewhere for this connection).

--- a/src/shared/healthStore.ts
+++ b/src/shared/healthStore.ts
@@ -53,6 +53,11 @@ export interface SchedulerHealth {
 /** The set of scheduler names tracked by {@link recordSchedulerRun}. */
 export type SchedulerName = 'counter' | 'rewardPricing' | 'timer';
 
+/** Clones a `Date | null` field so a snapshot's copy can never alias (and thus mutate) internal state. */
+function cloneDate(d: Date | null): Date | null {
+  return d ? new Date(d.getTime()) : null;
+}
+
 /** Returns a fresh, disconnected/no-history EventSub health record. */
 function defaultEventSubHealth(): EventSubHealth {
   return { connected: false, lastConnectedAt: null, lastDisconnectedAt: null, reconnectAttempts: 0, lastError: null };
@@ -220,23 +225,28 @@ export interface HealthSnapshot {
 
 /**
  * Returns a snapshot of the current health state: a deep-ish copy (own top-level objects
- * copied, Maps converted to plain records, the error list copied) so a caller mutating the
- * returned object can never affect internal state — same spirit as `statusStore.ts`'s
- * `getStatus()`.
+ * copied, Maps converted to plain records, the error list copied, and every `Date` field
+ * cloned via {@link cloneDate}) so a caller mutating the returned object — including calling a
+ * mutator method directly on one of its `Date` fields — can never affect internal state — same
+ * spirit as `statusStore.ts`'s `getStatus()`.
  */
 export function getHealthSnapshot(): HealthSnapshot {
   return {
     discordConnected: state.discordConnected,
     twitchChatConnected: state.twitchChatConnected,
-    db: { ...state.db },
+    db: { ...state.db, lastPingAt: cloneDate(state.db.lastPingAt) },
     eventsub: Object.fromEntries(
-      Array.from(state.eventsub, ([key, value]) => [key, { ...value }]),
+      Array.from(state.eventsub, ([key, value]) => [key, {
+        ...value,
+        lastConnectedAt: cloneDate(value.lastConnectedAt),
+        lastDisconnectedAt: cloneDate(value.lastDisconnectedAt),
+      }]),
     ) as Record<string, EventSubHealth>,
-    monitor: { ...state.monitor },
+    monitor: { ...state.monitor, lastPollAt: cloneDate(state.monitor.lastPollAt) },
     schedulers: Object.fromEntries(
-      Array.from(state.schedulers, ([key, value]) => [key, { ...value }]),
+      Array.from(state.schedulers, ([key, value]) => [key, { ...value, lastRunAt: cloneDate(value.lastRunAt) }]),
     ) as Partial<Record<SchedulerName, SchedulerHealth>>,
-    errors: state.errors.map((e) => ({ ...e })),
+    errors: state.errors.map((e) => ({ ...e, timestamp: cloneDate(e.timestamp) as Date })),
   };
 }
 

--- a/src/shared/logger.test.ts
+++ b/src/shared/logger.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('./healthStore', () => ({
+  recordError: vi.fn(),
+}));
+
+import { recordError } from './healthStore';
+import { HealthStoreErrorTransport, createLogger } from './logger';
+
+describe('HealthStoreErrorTransport', () => {
+  it('forwards the log entry to healthStore.recordError under its label, then signals completion', async () => {
+    const transport = new HealthStoreErrorTransport({ level: 'error' });
+    const callback = vi.fn();
+    const logged = new Promise<unknown>((resolve) => transport.once('logged', resolve));
+
+    transport.log({ label: 'SomeModule', message: 'boom' }, callback);
+
+    expect(recordError).toHaveBeenCalledWith('SomeModule', 'boom');
+    expect(callback).toHaveBeenCalledOnce();
+    await expect(logged).resolves.toEqual({ label: 'SomeModule', message: 'boom' });
+  });
+
+  it('falls back to "unknown"/empty string when label/message are absent', () => {
+    const transport = new HealthStoreErrorTransport({ level: 'error' });
+    transport.log({}, vi.fn());
+
+    expect(recordError).toHaveBeenCalledWith('unknown', '');
+  });
+});
+
+describe('createLogger', () => {
+  it('returns a logger usable at every level without throwing', () => {
+    const log = createLogger('TestModule');
+    expect(() => {
+      log.info('info message');
+      log.warn('warn message');
+      log.error('error message');
+      log.debug('debug message');
+    }).not.toThrow();
+  });
+});

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -1,9 +1,33 @@
 import { createLogger as winstonCreateLogger, format, transports } from 'winston';
+import Transport from 'winston-transport';
 import DailyRotateFile from 'winston-daily-rotate-file';
+import { recordError } from './healthStore';
 
 const LOG_LEVEL = process.env.LOG_LEVEL ?? (process.env.NODE_ENV === 'production' ? 'info' : 'debug');
 const LOG_DIR = 'logs';
 const IS_TEST = !!process.env.VITEST;
+
+/**
+ * Winston transport that forwards every `error`-level log entry into `healthStore`'s bounded
+ * error ring buffer, so the owner health dashboard/`!health` command surface the same
+ * failures that already show up in the logs, without every call site having to remember to
+ * call `recordError` itself. Only every level *at or above* the transport's configured
+ * `level` is forwarded — set to `'error'` below so warn/info/debug entries never reach it.
+ */
+class HealthStoreErrorTransport extends Transport {
+  /**
+   * Winston's transport contract: forwards `info.message` to `healthStore.recordError`
+   * under `info.label` (the module tag set via `createLogger(module)`), then signals
+   * completion via the `logged` event as required by every `winston-transport` subclass.
+   * @param info - The log entry; `label` is the module tag, `message` the formatted text.
+   * @param callback - Invoked once handling is done, per the `winston-transport` contract.
+   */
+  log(info: { label?: string; message?: string }, callback: () => void): void {
+    setImmediate(() => this.emit('logged', info));
+    recordError(info.label ?? 'unknown', info.message ?? '');
+    callback();
+  }
+}
 
 const fileFormat = format.combine(
   format.errors({ stack: true }),
@@ -53,6 +77,10 @@ const rootLogger = winstonCreateLogger({
     new transports.Console({
       format: consoleFormat,
     }),
+    // Error-capturing feeds healthStore's error ring buffer for the owner health
+    // dashboard/`!health` command — skipped in tests so a test asserting on error logs
+    // doesn't also mutate healthStore's shared module state as a side effect.
+    ...(!IS_TEST ? [new HealthStoreErrorTransport({ level: 'error' })] : []),
   ],
 });
 

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -14,7 +14,7 @@ const IS_TEST = !!process.env.VITEST;
  * call `recordError` itself. Only every level *at or above* the transport's configured
  * `level` is forwarded — set to `'error'` below so warn/info/debug entries never reach it.
  */
-class HealthStoreErrorTransport extends Transport {
+export class HealthStoreErrorTransport extends Transport {
   /**
    * Winston's transport contract: forwards `info.message` to `healthStore.recordError`
    * under `info.label` (the module tag set via `createLogger(module)`), then signals

--- a/src/twitch/eventsub/twitchEventSubConnection.test.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.test.ts
@@ -10,6 +10,7 @@ vi.mock('./twitchEventSubSubscriptions', () => ({
 vi.mock('../../shared/healthStore', () => ({
   recordEventSubConnected: vi.fn(),
   recordEventSubReconnectAttempt: vi.fn(),
+  removeEventSubHealth: vi.fn(),
 }));
 
 import {
@@ -26,7 +27,7 @@ import {
   handleRevocation,
   removeStreamerFromMap,
 } from './twitchEventSubSubscriptions';
-import { recordEventSubConnected } from '../../shared/healthStore';
+import { recordEventSubConnected, removeEventSubHealth } from '../../shared/healthStore';
 
 // ---------------------------------------------------------------------------
 // buildReconnectUrl
@@ -340,6 +341,15 @@ describe('StreamerConnection lifecycle', () => {
     expect(ws.close).toHaveBeenCalledWith(1000, 'shutdown');
     expect((conn as any).ws).toBeNull();
     expect(removeStreamerFromMap).toHaveBeenCalledWith('uid-123');
+  });
+
+  it('stop() removes the streamer\'s health record entirely, rather than leaving it reported as disconnected', () => {
+    const conn = new StreamerConnection(makeStreamerData());
+    conn.start();
+
+    conn.stop();
+
+    expect(removeEventSubHealth).toHaveBeenCalledWith('streamer');
   });
 
   it('does not reconnect after a close once stopped', () => {

--- a/src/twitch/eventsub/twitchEventSubConnection.test.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.test.ts
@@ -7,6 +7,10 @@ vi.mock('./twitchEventSubSubscriptions', () => ({
   dispatchNotification: vi.fn(),
   handleRevocation: vi.fn(),
 }));
+vi.mock('../../shared/healthStore', () => ({
+  recordEventSubConnected: vi.fn(),
+  recordEventSubReconnectAttempt: vi.fn(),
+}));
 
 import {
   buildReconnectUrl,
@@ -22,6 +26,7 @@ import {
   handleRevocation,
   removeStreamerFromMap,
 } from './twitchEventSubSubscriptions';
+import { recordEventSubConnected } from '../../shared/healthStore';
 
 // ---------------------------------------------------------------------------
 // buildReconnectUrl
@@ -445,6 +450,19 @@ describe('StreamerConnection lifecycle', () => {
     // a socket that's already open and working — this proves it can't, independent of the
     // keepalive timer (which is a separate 20s mechanism also armed by open()).
     expect((conn as any).connectTimer).toBeNull();
+  });
+
+  /** Verifies a watchdog-triggered (keepalive-timeout) forceReconnect records the connection as disconnected, not just the error/close handlers. */
+  it('records disconnected health state on a keepalive-timeout-triggered reconnect', () => {
+    const conn = new StreamerConnection(makeStreamerData());
+    conn.start();
+    const firstWs = (conn as any).ws as MockWebSocket;
+    firstWs.listeners.get('open')!();
+    vi.mocked(recordEventSubConnected).mockClear(); // clear the onOpen(true) call above
+
+    vi.advanceTimersByTime(20_000); // keepalive timeout fires, triggering forceReconnect directly
+
+    expect(recordEventSubConnected).toHaveBeenCalledWith('streamer', false);
   });
 
   /** Verifies the keepalive-timeout path force-reconnects without waiting on the socket's own 'close' event; returns void. */

--- a/src/twitch/eventsub/twitchEventSubConnection.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.ts
@@ -1,4 +1,5 @@
 import { createLogger } from '../../shared/logger';
+import { recordEventSubConnected, recordEventSubReconnectAttempt } from '../../shared/healthStore';
 import { subscribeForStreamer, removeStreamerFromMap, dispatchNotification, handleRevocation, StreamerEventSubData } from './twitchEventSubSubscriptions';
 
 const log = createLogger('EventSub');
@@ -109,6 +110,7 @@ export class StreamerConnection {
     if (this.reconnectTimer) { clearTimeout(this.reconnectTimer); this.reconnectTimer = null; }
     this.ws?.close(1000, 'shutdown');
     this.ws = null;
+    recordEventSubConnected(this.name, false, 'Stopped');
     removeStreamerFromMap(this.uid);
   }
 
@@ -212,6 +214,7 @@ export class StreamerConnection {
     this.clearConnectTimer();
     this.reconnectAttempts = 0;
     this.resetKeepaliveTimer();
+    recordEventSubConnected(this.name, true);
   }
 
   private onMessage(ev: MessageEvent): void {
@@ -233,6 +236,7 @@ export class StreamerConnection {
   private onClose(ev: CloseEvent, socket: WebSocket): void {
     if (this.ws !== socket) return; // old socket closed during session migration, or already force-reconnected — ignore
     log.warn(`[${this.name}] WebSocket closed: ${ev.code} ${ev.reason}`);
+    recordEventSubConnected(this.name, false, `Closed: ${ev.code} ${ev.reason}`);
     this.forceReconnect(socket);
   }
 
@@ -247,6 +251,7 @@ export class StreamerConnection {
   private onError(socket: WebSocket): void {
     if (this.ws !== socket) return;
     log.warn(`[${this.name}] WebSocket error`);
+    recordEventSubConnected(this.name, false, 'WebSocket error');
     this.forceReconnect(socket);
   }
 
@@ -354,6 +359,7 @@ export class StreamerConnection {
     const delay = Math.min(RECONNECT_BACKOFF_MAX_MS, 1_000 * Math.pow(2, this.reconnectAttempts));
     this.reconnectAttempts++;
     log.info(`[${this.name}] Reconnecting in ${delay}ms (attempt ${this.reconnectAttempts})`);
+    recordEventSubReconnectAttempt(this.name);
     this.reconnectTimer = setTimeout(() => { this.reconnectTimer = null; this.connect(); }, delay);
   }
 

--- a/src/twitch/eventsub/twitchEventSubConnection.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '../../shared/logger';
-import { recordEventSubConnected, recordEventSubReconnectAttempt } from '../../shared/healthStore';
+import { recordEventSubConnected, recordEventSubReconnectAttempt, removeEventSubHealth } from '../../shared/healthStore';
 import { subscribeForStreamer, removeStreamerFromMap, dispatchNotification, handleRevocation, StreamerEventSubData } from './twitchEventSubSubscriptions';
 
 const log = createLogger('EventSub');
@@ -110,7 +110,7 @@ export class StreamerConnection {
     if (this.reconnectTimer) { clearTimeout(this.reconnectTimer); this.reconnectTimer = null; }
     this.ws?.close(1000, 'shutdown');
     this.ws = null;
-    recordEventSubConnected(this.name, false, 'Stopped');
+    removeEventSubHealth(this.name);
     removeStreamerFromMap(this.uid);
   }
 

--- a/src/twitch/eventsub/twitchEventSubConnection.ts
+++ b/src/twitch/eventsub/twitchEventSubConnection.ts
@@ -269,11 +269,18 @@ export class StreamerConnection {
    * this connection's current socket any more (e.g. a session migration or an earlier
    * force-reconnect already superseded it) — including the case where `socket`'s real
    * `'close'` event does eventually land after this already ran.
+   * Always records this connection as disconnected in `healthStore` before doing any of the
+   * above — most callers here (`onClose`/`onError`) already record it themselves first, but a
+   * watchdog-triggered call (the connect-timeout and keepalive-timeout paths) does not, and
+   * without this, `healthStore` would keep reporting `connected: true` while the connection is
+   * actually being torn down and retried. A second `recordEventSubConnected(false)` call from
+   * an already-recording caller is harmless.
    * @param socket - The socket to tear down, or `null` (always a no-op in that case).
    * @returns Nothing.
    */
   private forceReconnect(socket: WebSocket | null): void {
     if (this.ws !== socket) return;
+    recordEventSubConnected(this.name, false);
     // Best-effort: request a close (harmless if already closing/closed) so Twitch has a
     // better chance of revoking this session's EventSub subscriptions promptly, rather than
     // leaving them "enabled" until Twitch's own delayed dead-connection detection catches up.
@@ -354,6 +361,11 @@ export class StreamerConnection {
     setTimeout(() => { oldSocket?.close(1000, 'reconnect'); }, SESSION_MIGRATION_CLOSE_DELAY_MS);
   }
 
+  /**
+   * Schedules a reconnect attempt after an exponential backoff delay (capped at
+   * {@link RECONNECT_BACKOFF_MAX_MS}), replacing any already-pending attempt. Records the
+   * attempt in `healthStore` before scheduling.
+   */
   private scheduleReconnect(): void {
     if (this.reconnectTimer) { clearTimeout(this.reconnectTimer); }
     const delay = Math.min(RECONNECT_BACKOFF_MAX_MS, 1_000 * Math.pow(2, this.reconnectAttempts));

--- a/src/twitch/monitor/twitchMonitor.ts
+++ b/src/twitch/monitor/twitchMonitor.ts
@@ -35,7 +35,12 @@ let currentPollPromise: Promise<void> = Promise.resolve();
 
 // ─── Polling ───────────────────────────────────────────────────────────────
 
-/** Polls the Twitch API for all monitored streamers' live status and dispatches the results. No-ops if a poll is already in flight or there are no streamers configured. */
+/**
+ * Polls the Twitch API for all monitored streamers' live status, dispatches the results, and
+ * records the poll's success/failure into `healthStore`. No-ops if a poll is already in flight
+ * or there are no streamers configured.
+ * @returns Resolves once the poll (and its dispatch) completes.
+ */
 async function pollStreams(): Promise<void> {
   if (pollRunning || streamersData.length === 0) return;
   pollRunning = true;

--- a/src/twitch/monitor/twitchMonitor.ts
+++ b/src/twitch/monitor/twitchMonitor.ts
@@ -16,6 +16,7 @@ import {
 import { deleteAnnouncement } from './twitchMonitorAnnouncements';
 import { performStartupLiveCheck } from './twitchMonitorStartup';
 import { handlePollStreamer, dispatchStreamerPolls, withLoginLock } from './twitchMonitorPoll';
+import { recordMonitorPoll, normalizeError } from '../../shared/healthStore';
 
 const log = createLogger('TwitchMonitor');
 
@@ -48,8 +49,10 @@ async function pollStreams(): Promise<void> {
         liveStreams.filter((s) => s.type === 'live').map((s) => [s.user_id, s]),
       );
       await dispatchStreamerPolls(liveStates, loginToUserId, streamersData, liveByUserId);
+      recordMonitorPoll(true);
     } catch (err) {
       log.error('Poll error:', err);
+      recordMonitorPoll(false, normalizeError(err));
     } finally {
       pollRunning = false;
     }

--- a/src/twitch/pricing/rewardPricingScheduler.ts
+++ b/src/twitch/pricing/rewardPricingScheduler.ts
@@ -1,6 +1,7 @@
 import { createLogger } from '../../shared/logger';
 import { getAllEnabledPricingRows, getPricingSettingsForStreamers, type StreamerPricingSettings } from '../../db';
 import { applyDecayTick } from './rewardPricingService';
+import { recordSchedulerRun, normalizeError } from '../../shared/healthStore';
 
 const log = createLogger('RewardPricingScheduler');
 
@@ -99,12 +100,15 @@ export async function runDecayTick(): Promise<void> {
           }),
         ),
       );
+      recordSchedulerRun('rewardPricing', true);
     } catch (err) {
       if (isServerShutdownError(err)) {
         log.warn('Database is shutting down — pausing decay tick polling until it recovers.');
+        recordSchedulerRun('rewardPricing', false, normalizeError(err));
         pauseForDbShutdown();
       } else {
         log.error('Failed to load enabled pricing rows:', err);
+        recordSchedulerRun('rewardPricing', false, normalizeError(err));
         // A recovery probe can fail with something other than the shutdown error it was
         // triggered by (e.g. a transient network blip) — without this, that probe's own
         // cleanup would already have cleared dbShutdownRetryTimer, leaving the scheduler

--- a/src/twitch/timers/timerCommandScheduler.test.ts
+++ b/src/twitch/timers/timerCommandScheduler.test.ts
@@ -7,11 +7,16 @@ vi.mock('../../db', () => ({ getAllEnabledTimerCommandsWithChannel: vi.fn() }));
 vi.mock('../twitchChatActivity', () => ({ getMessageCount: vi.fn() }));
 vi.mock('../monitor/twitchMonitor', () => ({ isChannelLive: vi.fn() }));
 vi.mock('../../commands/customCommandHandler', () => ({ resolveSharedChatSessionId: vi.fn() }));
+vi.mock('../../shared/healthStore', () => ({
+  recordSchedulerRun: vi.fn(),
+  normalizeError: vi.fn((err: unknown) => (err instanceof Error ? err.message : String(err))),
+}));
 
 import { getAllEnabledTimerCommandsWithChannel } from '../../db';
 import { getMessageCount } from '../twitchChatActivity';
 import { isChannelLive } from '../monitor/twitchMonitor';
 import { resolveSharedChatSessionId } from '../../commands/customCommandHandler';
+import { recordSchedulerRun } from '../../shared/healthStore';
 import {
   runTimerCommandTick, startTimerCommandScheduler, stopTimerCommandScheduler, registerTimerCommandsRuntime,
 } from './timerCommandScheduler';
@@ -182,6 +187,18 @@ describe('runTimerCommandTick', () => {
   it('does not throw when loading rows fails', async () => {
     vi.mocked(getAllEnabledTimerCommandsWithChannel).mockRejectedValue(new Error('db down'));
     await expect(runTimerCommandTick()).resolves.toBeUndefined();
+  });
+
+  it('records a successful scheduler run on a successful tick', async () => {
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockResolvedValue([timerRow()] as any);
+    await runTimerCommandTick();
+    expect(recordSchedulerRun).toHaveBeenCalledWith('timer', true);
+  });
+
+  it('records a failed scheduler run with the normalized error when the tick fails at the top level', async () => {
+    vi.mocked(getAllEnabledTimerCommandsWithChannel).mockRejectedValue(new Error('db down'));
+    await runTimerCommandTick();
+    expect(recordSchedulerRun).toHaveBeenCalledWith('timer', false, 'db down');
   });
 
   it('a reentrancy guard prevents overlapping ticks', async () => {

--- a/src/twitch/timers/timerCommandScheduler.ts
+++ b/src/twitch/timers/timerCommandScheduler.ts
@@ -5,6 +5,7 @@ import { resolveSharedChatSessionId } from '../../commands/customCommandHandler'
 import { createRuntimeRegistry, type TwitchSendRuntime } from '../../commands/twitchRuntime';
 import { shouldFire, type TimerRuntimeState } from './timerCommandFireGate';
 import { pickRowsToFire, releaseReservations, pruneStaleCooldowns, clearCooldowns } from './timerCommandCooldowns';
+import { recordSchedulerRun, normalizeError } from '../../shared/healthStore';
 
 const log = createLogger('TimerCommandScheduler');
 
@@ -148,8 +149,10 @@ export async function runTimerCommandTick(): Promise<void> {
       const toFire = pickRowsToFire(eligibleRows, sessionIdByChannel, now, lastFiredAtOf);
 
       await Promise.allSettled(toFire.map(({ row, sessionKey }) => sendTimerRow(row, now, sessionKey)));
+      recordSchedulerRun('timer', true);
     } catch (err) {
       log.error('Failed to load enabled timer commands:', err);
+      recordSchedulerRun('timer', false, normalizeError(err));
     } finally {
       tickRunning = false;
     }

--- a/src/twitch/twitchBot.test.ts
+++ b/src/twitch/twitchBot.test.ts
@@ -103,6 +103,10 @@ vi.mock('../shared/statusStore', () => ({
   setTwitchChannel: vi.fn(),
 }));
 
+vi.mock('../shared/healthStore', () => ({
+  recordTwitchChatConnected: vi.fn(),
+}));
+
 vi.mock('../commands/commandRouter', () => ({
   handleCommand: vi.fn(),
 }));
@@ -156,6 +160,7 @@ import { getTwitchEnabledChannels, getAllTwitchLinkedUsers, findUserByTwitchName
 import { resolveGuildIdForDiscordId } from './twitchGuildResolutionRuntime';
 import { getUsers } from './twitchApi';
 import { setTwitchChannel } from '../shared/statusStore';
+import { recordTwitchChatConnected } from '../shared/healthStore';
 import { executeCustomCommandForTwitch } from '../commands/customCommandHandler';
 import { executeCounterCommandForTwitch } from '../commands/counterHandler';
 import { executeMultiCommandForTwitch } from '../commands/multiCommandHandler';
@@ -898,6 +903,23 @@ describe('stopTwitchBot', () => {
     await stopTwitchBot();
 
     expect(mockClient.quit).toHaveBeenCalledOnce();
+  });
+
+  it('records the health store as disconnected immediately, even before quit() settles', async () => {
+    await connectBot();
+    vi.mocked(recordTwitchChatConnected).mockClear();
+    mockClient.quit.mockImplementation(() => {}); // never fires onDisconnect
+
+    try {
+      const stopped = stopTwitchBot();
+      expect(recordTwitchChatConnected).toHaveBeenCalledWith(false);
+      await vi.advanceTimersByTimeAsync(DISCONNECT_TIMEOUT_MS);
+      await stopped;
+    } finally {
+      mockClient.quit.mockImplementation(() => {
+        queueMicrotask(() => fireDisconnect(true));
+      });
+    }
   });
 
   it('is a no-op when the client was never started', async () => {

--- a/src/twitch/twitchBot.ts
+++ b/src/twitch/twitchBot.ts
@@ -10,6 +10,7 @@ import { executeCountdownForTwitch } from '../commands/countdownHandler';
 import { fireAndForget } from '../commands/commandUtils';
 import { recordChatMessage } from './twitchChatActivity';
 import { setTwitchChannel } from '../shared/statusStore';
+import { recordTwitchChatConnected } from '../shared/healthStore';
 import { normalizeTwitchChannelName } from './twitchChannelName';
 import { throttledTwitchSend, withTimeout } from './twitchSendQueue';
 import { createLogger } from '../shared/logger';
@@ -232,6 +233,7 @@ function handleTwitchMessage(channel: string, user: string, message: string, msg
 function onConnected(): void {
   connected = true;
   setConnected(true);
+  recordTwitchChatConnected(true);
   log.info('Connected to Twitch chat.');
   log.info(`Listening on: ${[...getActiveChannels()].join(', ') || '(none)'}`);
   // Reset every activeChannels entry via setTwitchChannel to a pessimistic
@@ -260,6 +262,7 @@ function onConnected(): void {
 function onDisconnected(manually: boolean, reason?: Error): void {
   connected = false;
   setConnected(false);
+  recordTwitchChatConnected(false);
   log.warn(`Disconnected${manually ? ' (manual)' : ''}: ${reason?.message ?? 'no reason given'}`);
   getActiveChannels().forEach((ch) => { setTwitchChannel(ch, false); });
   privilegedChannels.clear();

--- a/src/twitch/twitchBot.ts
+++ b/src/twitch/twitchBot.ts
@@ -477,6 +477,7 @@ function quitAndWait(c: ChatClient): Promise<void> {
 export async function stopTwitchBot(): Promise<void> {
   connected = false;
   setConnected(false);
+  recordTwitchChatConnected(false);
   if (client) {
     try {
       await withTimeout(quitAndWait(client), DISCONNECT_TIMEOUT_MS, 'Twitch disconnect');

--- a/src/web/routes/health.test.ts
+++ b/src/web/routes/health.test.ts
@@ -72,6 +72,11 @@ describe('GET /admin/health', () => {
     expect(body.locals.health).toEqual(SNAPSHOT);
   });
 
+  it('sets Cache-Control: no-store so browsers/proxies never cache the owner health data', async () => {
+    const res = await supertest(buildApp(OWNER_SESSION_USER)).get('/');
+    expect(res.headers['cache-control']).toBe('no-store');
+  });
+
   it('blocks a non-owner with a 403', async () => {
     const res = await supertest(buildApp(NON_OWNER_SESSION_USER)).get('/');
     expect(res.status).toBe(403);

--- a/src/web/routes/health.test.ts
+++ b/src/web/routes/health.test.ts
@@ -77,6 +77,19 @@ describe('GET /admin/health', () => {
     expect(res.headers['cache-control']).toBe('no-store');
   });
 
+  it('renders a 500 error page if building the health snapshot response throws', async () => {
+    vi.mocked(getHealthSnapshot).mockImplementation(() => {
+      throw new Error('snapshot boom');
+    });
+
+    const res = await supertest(buildApp(OWNER_SESSION_USER)).get('/');
+
+    expect(res.status).toBe(500);
+    const body = res.body as any;
+    expect(body.view).toBe('error');
+    expect(body.locals.message).toBe('Failed to load health dashboard.');
+  });
+
   it('blocks a non-owner with a 403', async () => {
     const res = await supertest(buildApp(NON_OWNER_SESSION_USER)).get('/');
     expect(res.status).toBe(403);

--- a/src/web/routes/health.test.ts
+++ b/src/web/routes/health.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mockLogger } from '../../test-utils/loggerMock';
+
+vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
+
+vi.mock('../../shared/healthStore', () => ({
+  getHealthSnapshot: vi.fn(),
+}));
+
+// viewHelpers.ts (used by health.ts for renderView/renderError) imports `getStreamerByDiscordId`
+// from '../../db' at module load — mocked here purely so that transitive import doesn't pull in
+// the real db/pool module, which requires DB_* env vars to be set.
+vi.mock('../../db', () => ({
+  getStreamerByDiscordId: vi.fn(),
+}));
+
+vi.mock('../csrf', () => ({
+  csrfProtection: (req: any, _res: any, next: any) => {
+    req.csrfToken = () => 'test-token';
+    next();
+  },
+}));
+
+vi.mock('../middleware', () => ({
+  requireOwner: (req: any, res: any, next: any) => {
+    if (req.session?.user?.isOwner) return next();
+    res.status(403).json({ error: 'forbidden' });
+  },
+}));
+
+import supertest from 'supertest';
+import router from './health';
+import { getHealthSnapshot } from '../../shared/healthStore';
+import { buildTestApp } from '../../test-utils/expressTestApp';
+
+const OWNER_SESSION_USER = {
+  discordId: '1',
+  discordName: 'Owner',
+  accessLevel: 3,
+  currentGuildId: null,
+  isOwner: true,
+  guilds: [],
+};
+
+const NON_OWNER_SESSION_USER = { ...OWNER_SESSION_USER, isOwner: false };
+
+const SNAPSHOT = {
+  discordConnected: true,
+  twitchChatConnected: true,
+  db: { lastPingOk: true, lastPingAt: null, lastError: null },
+  eventsub: {},
+  monitor: { lastPollOk: true, lastPollAt: null, lastError: null },
+  schedulers: {},
+  errors: [],
+};
+
+function buildApp(sessionUser: unknown) {
+  return buildTestApp({ router, sessionUser, mockRender: 'nested' });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getHealthSnapshot).mockReturnValue(SNAPSHOT as any);
+});
+
+describe('GET /admin/health', () => {
+  it('renders the health view with a snapshot for the owner', async () => {
+    const res = await supertest(buildApp(OWNER_SESSION_USER)).get('/');
+    expect(res.status).toBe(200);
+    const body = res.body as any;
+    expect(body.view).toBe('health');
+    expect(body.locals.health).toEqual(SNAPSHOT);
+  });
+
+  it('blocks a non-owner with a 403', async () => {
+    const res = await supertest(buildApp(NON_OWNER_SESSION_USER)).get('/');
+    expect(res.status).toBe(403);
+  });
+
+  it('blocks an unauthenticated request with a 403', async () => {
+    const res = await supertest(buildApp(undefined)).get('/');
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/web/routes/health.ts
+++ b/src/web/routes/health.ts
@@ -1,0 +1,33 @@
+import { createLogger } from '../../shared/logger';
+import { Router } from 'express';
+import { requireOwner } from '../middleware';
+import { csrfProtection } from '../csrf';
+import { getHealthSnapshot } from '../../shared/healthStore';
+import { renderView, renderError } from './viewHelpers';
+
+const log = createLogger('Web');
+const router = Router();
+
+/**
+ * GET /admin/health — renders the owner-only bot health dashboard, summarizing
+ * `healthStore.getHealthSnapshot()` (Discord/Twitch chat connection state, DB
+ * ping, per-streamer EventSub status, stream-monitor poll status, scheduler
+ * runs, and recent errors). Not guild-scoped — health isn't per-guild.
+ * @param req - Express request; reads `req.session.user`.
+ * @param res - Express response; renders the `health` view, or a 500 error
+ *   page if building the response somehow throws.
+ */
+router.get('/', requireOwner, csrfProtection, (req, res) => {
+  try {
+    renderView(res, 'health', {
+      user: req.session.user,
+      csrfToken: req.csrfToken(),
+      health: getHealthSnapshot(),
+    });
+  } catch (err) {
+    log.error('Failed to render health dashboard:', err);
+    renderError(res, 500, 'Failed to load health dashboard.', req.session.user);
+  }
+});
+
+export default router;

--- a/src/web/routes/health.ts
+++ b/src/web/routes/health.ts
@@ -18,6 +18,7 @@ const router = Router();
  *   page if building the response somehow throws.
  */
 router.get('/', requireOwner, csrfProtection, (req, res) => {
+  res.set('Cache-Control', 'no-store');
   try {
     renderView(res, 'health', {
       user: req.session.user,

--- a/src/web/routes/healthStatusEvents.test.ts
+++ b/src/web/routes/healthStatusEvents.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../shared/config', () => ({
+  SSE_MAX_TOTAL_CONNECTIONS: 1000,
+}));
+
+vi.mock('../../shared/healthStore', () => ({
+  onHealthChanged: vi.fn(),
+  getHealthSnapshot: vi.fn(),
+}));
+
+vi.mock('../../shared/logger', () => ({ createLogger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn() }) }));
+
+vi.mock('../middleware', () => ({
+  requireOwner: (req: any, res: any, next: any) => {
+    if (req.session?.user?.isOwner) return next();
+    res.status(403).json({ error: 'forbidden' });
+  },
+}));
+
+import supertest from 'supertest';
+import router from './healthStatusEvents';
+import { onHealthChanged, getHealthSnapshot } from '../../shared/healthStore';
+import { buildTestApp } from '../../test-utils/expressTestApp';
+
+const OWNER_SESSION_USER = {
+  discordId: '1',
+  discordName: 'Owner',
+  accessLevel: 3,
+  currentGuildId: null,
+  isOwner: true,
+  guilds: [],
+};
+
+const NON_OWNER_SESSION_USER = { ...OWNER_SESSION_USER, isOwner: false };
+
+// Captured once at module load, mirroring dashboardStatusEvents.test.ts's pattern — this
+// module registers its listener as a top-level side effect, not per-request.
+const registeredListener = vi.mocked(onHealthChanged).mock.calls[0]?.[0] as () => void;
+
+function buildApp(sessionUser: unknown) {
+  return buildTestApp({ router, sessionUser });
+}
+
+beforeEach(() => {
+  vi.mocked(getHealthSnapshot).mockReturnValue({ discordConnected: true } as any);
+});
+
+describe('GET /events — auth', () => {
+  it('blocks a non-owner with a 403', async () => {
+    const res = await supertest(buildApp(NON_OWNER_SESSION_USER)).get('/events');
+    expect(res.status).toBe(403);
+  });
+
+  it('blocks an unauthenticated request with a 403', async () => {
+    const res = await supertest(buildApp(undefined)).get('/events');
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('pushHealthUpdate (registered onHealthChanged listener)', () => {
+  it('registers a listener at module load', () => {
+    expect(registeredListener).toBeTypeOf('function');
+  });
+
+  it('does not throw when there are no connected clients', () => {
+    expect(() => registeredListener()).not.toThrow();
+  });
+});

--- a/src/web/routes/healthStatusEvents.test.ts
+++ b/src/web/routes/healthStatusEvents.test.ts
@@ -67,3 +67,38 @@ describe('pushHealthUpdate (registered onHealthChanged listener)', () => {
     expect(() => registeredListener()).not.toThrow();
   });
 });
+
+describe('GET /events — initial snapshot push', () => {
+  /**
+   * Opens an SSE connection and resolves once the first `data:` frame has been written,
+   * leaving the stream open.
+   * @returns The response status, the SSE body received so far, and a `close()` callback that
+   * emits `'close'` on the underlying request so the test can release the connection.
+   */
+  function connect(): Promise<{ status: number; body: string; close: () => void }> {
+    const req = supertest(buildApp(OWNER_SESSION_USER)).get('/events');
+    return new Promise((resolve) => {
+      let body = '';
+      req
+        .buffer(false)
+        .parse((res, _cb) => {
+          res.on('data', (chunk: Buffer) => {
+            body += chunk.toString();
+            if (body.includes('data:')) {
+              resolve({ status: res.statusCode ?? 0, body, close: () => (res as any).req.emit('close') });
+            }
+          });
+          (res as any).resume();
+        })
+        .end();
+    });
+  }
+
+  it('pushes the current snapshot immediately once a connection is accepted', async () => {
+    vi.mocked(getHealthSnapshot).mockReturnValue({ discordConnected: true, marker: 'initial-push' } as any);
+    const { status, body, close } = await connect();
+    expect(status).toBe(200);
+    expect(body).toContain('initial-push');
+    close();
+  });
+});

--- a/src/web/routes/healthStatusEvents.test.ts
+++ b/src/web/routes/healthStatusEvents.test.ts
@@ -109,8 +109,10 @@ describe('GET /events — initial snapshot push (direct handler invocation)', ()
 
     await handler(req, res, vi.fn());
 
-    expect(res.write).toHaveBeenCalledWith(`data: ${JSON.stringify({ discordConnected: true, marker: 'initial-push' })}\n\n`);
-
-    triggerClose(); // clears the keepalive interval so it doesn't leak into other tests
+    try {
+      expect(res.write).toHaveBeenCalledWith(`data: ${JSON.stringify({ discordConnected: true, marker: 'initial-push' })}\n\n`);
+    } finally {
+      triggerClose(); // clears the keepalive interval so it doesn't leak into other tests, even if the assertion above fails
+    }
   });
 });

--- a/src/web/routes/healthStatusEvents.test.ts
+++ b/src/web/routes/healthStatusEvents.test.ts
@@ -23,6 +23,38 @@ import router from './healthStatusEvents';
 import { onHealthChanged, getHealthSnapshot } from '../../shared/healthStore';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 
+/** Finds a route's handler function directly from the router's internal stack, bypassing HTTP entirely — mirrors `dashboardStatusEvents.test.ts`'s helper of the same name. */
+function getRouteHandler(routePath: string): (req: any, res: any, next: any) => void {
+  const layer = (router as any).stack.find((l: any) => l.route?.path === routePath);
+  return layer.route.stack[layer.route.stack.length - 1].handle;
+}
+
+/** Builds a fake Express `res` covering the SSE-specific methods used by `attachSseConnection`. */
+function makeSseRes() {
+  return {
+    setHeader: vi.fn(),
+    flushHeaders: vi.fn(),
+    write: vi.fn(),
+    status: vi.fn().mockReturnThis(),
+    end: vi.fn(),
+    on: vi.fn(),
+  };
+}
+
+/** Builds a fake Express `req` with an owner session and a `close`-event hook, plus a `triggerClose()` helper to simulate the client disconnecting. */
+function makeSseReq() {
+  let closeCb: (() => void) | undefined;
+  return {
+    req: {
+      session: { user: OWNER_SESSION_USER },
+      on: (event: string, cb: () => void) => {
+        if (event === 'close') closeCb = cb;
+      },
+    },
+    triggerClose: () => closeCb?.(),
+  };
+}
+
 const OWNER_SESSION_USER = {
   discordId: '1',
   discordName: 'Owner',
@@ -68,37 +100,17 @@ describe('pushHealthUpdate (registered onHealthChanged listener)', () => {
   });
 });
 
-describe('GET /events — initial snapshot push', () => {
-  /**
-   * Opens an SSE connection and resolves once the first `data:` frame has been written,
-   * leaving the stream open.
-   * @returns The response status, the SSE body received so far, and a `close()` callback that
-   * emits `'close'` on the underlying request so the test can release the connection.
-   */
-  function connect(): Promise<{ status: number; body: string; close: () => void }> {
-    const req = supertest(buildApp(OWNER_SESSION_USER)).get('/events');
-    return new Promise((resolve) => {
-      let body = '';
-      req
-        .buffer(false)
-        .parse((res, _cb) => {
-          res.on('data', (chunk: Buffer) => {
-            body += chunk.toString();
-            if (body.includes('data:')) {
-              resolve({ status: res.statusCode ?? 0, body, close: () => (res as any).req.emit('close') });
-            }
-          });
-          (res as any).resume();
-        })
-        .end();
-    });
-  }
-
+describe('GET /events — initial snapshot push (direct handler invocation)', () => {
   it('pushes the current snapshot immediately once a connection is accepted', async () => {
     vi.mocked(getHealthSnapshot).mockReturnValue({ discordConnected: true, marker: 'initial-push' } as any);
-    const { status, body, close } = await connect();
-    expect(status).toBe(200);
-    expect(body).toContain('initial-push');
-    close();
+    const handler = getRouteHandler('/events');
+    const res = makeSseRes();
+    const { req, triggerClose } = makeSseReq();
+
+    await handler(req, res, vi.fn());
+
+    expect(res.write).toHaveBeenCalledWith(`data: ${JSON.stringify({ discordConnected: true, marker: 'initial-push' })}\n\n`);
+
+    triggerClose(); // clears the keepalive interval so it doesn't leak into other tests
   });
 });

--- a/src/web/routes/healthStatusEvents.test.ts
+++ b/src/web/routes/healthStatusEvents.test.ts
@@ -9,7 +9,12 @@ vi.mock('../../shared/healthStore', () => ({
   getHealthSnapshot: vi.fn(),
 }));
 
-vi.mock('../../shared/logger', () => ({ createLogger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn() }) }));
+// Captures the single logger instance createLogger('Web') produces, so tests can assert on
+// log.error calls — the module under test keeps its own reference, otherwise unreachable here.
+// Built inside vi.hoisted() since vi.mock's factory can run before a plain top-level const
+// (referenced by closure) has initialized.
+const { webLogger } = vi.hoisted(() => ({ webLogger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() } }));
+vi.mock('../../shared/logger', () => ({ createLogger: () => webLogger }));
 
 vi.mock('../middleware', () => ({
   requireOwner: (req: any, res: any, next: any) => {
@@ -97,6 +102,16 @@ describe('pushHealthUpdate (registered onHealthChanged listener)', () => {
 
   it('does not throw when there are no connected clients', () => {
     expect(() => registeredListener()).not.toThrow();
+  });
+
+  it('logs and swallows an error instead of throwing if building/broadcasting the snapshot fails', () => {
+    vi.mocked(getHealthSnapshot).mockImplementationOnce(() => {
+      throw new Error('snapshot boom');
+    });
+    webLogger.error.mockClear();
+
+    expect(() => registeredListener()).not.toThrow();
+    expect(webLogger.error).toHaveBeenCalledWith('Failed to push health update:', expect.any(Error));
   });
 });
 

--- a/src/web/routes/healthStatusEvents.ts
+++ b/src/web/routes/healthStatusEvents.ts
@@ -32,12 +32,16 @@ onHealthChanged(pushHealthUpdate);
 
 /**
  * GET /admin/health/events — SSE endpoint streaming live `getHealthSnapshot()` updates for the
- * owner health dashboard. Owner-only; not guild-scoped.
+ * owner health dashboard. Owner-only; not guild-scoped. On a successfully accepted connection,
+ * immediately pushes the current snapshot so the dashboard doesn't sit blank until the next
+ * health-changed event.
  * @param req - Express request; listened to for the 'close' event by `attachSseConnection`.
  * @param res - Express response; upgraded to a `text/event-stream` connection.
  */
 router.get('/events', requireOwner, (req, res) => {
-  attachSseConnection(req, res, { connections, key: HEALTH_CHANNEL_KEY, maxPerChannel: MAX_HEALTH_SSE_CONNECTIONS });
+  if (attachSseConnection(req, res, { connections, key: HEALTH_CHANNEL_KEY, maxPerChannel: MAX_HEALTH_SSE_CONNECTIONS })) {
+    pushHealthUpdate();
+  }
 });
 
 export default router;

--- a/src/web/routes/healthStatusEvents.ts
+++ b/src/web/routes/healthStatusEvents.ts
@@ -1,0 +1,43 @@
+import { Router } from 'express';
+import { requireOwner } from '../middleware';
+import { onHealthChanged, getHealthSnapshot } from '../../shared/healthStore';
+import { attachSseConnection, broadcastToChannel } from './sseChannel';
+import { createLogger } from '../../shared/logger';
+
+const log = createLogger('Web');
+const router = Router();
+
+/** Maximum concurrent SSE connections for the (single, ungoverned-by-guild) health stream. */
+const MAX_HEALTH_SSE_CONNECTIONS = 10;
+
+// A single global set of connections, keyed by a constant — health isn't per-guild like
+// `dashboardStatusEvents.ts`'s status stream, so there's only ever one logical channel here.
+const HEALTH_CHANNEL_KEY = 'health';
+const connections = new Map<string, Set<import('express').Response>>();
+
+/**
+ * Pushes a fresh health snapshot to every connected owner health-dashboard client via
+ * {@link broadcastToChannel}. Registered once as the `onHealthChanged` listener below, so it
+ * fires after every `healthStore` mutation.
+ */
+function pushHealthUpdate(): void {
+  try {
+    broadcastToChannel(connections, HEALTH_CHANNEL_KEY, getHealthSnapshot());
+  } catch (err) {
+    log.error('Failed to push health update:', err);
+  }
+}
+
+onHealthChanged(pushHealthUpdate);
+
+/**
+ * GET /admin/health/events — SSE endpoint streaming live `getHealthSnapshot()` updates for the
+ * owner health dashboard. Owner-only; not guild-scoped.
+ * @param req - Express request; listened to for the 'close' event by `attachSseConnection`.
+ * @param res - Express response; upgraded to a `text/event-stream` connection.
+ */
+router.get('/events', requireOwner, (req, res) => {
+  attachSseConnection(req, res, { connections, key: HEALTH_CHANNEL_KEY, maxPerChannel: MAX_HEALTH_SSE_CONNECTIONS });
+});
+
+export default router;

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -41,6 +41,7 @@ vi.mock('./middleware', () => ({
   requireAuth: vi.fn((_req: unknown, _res: unknown, next: () => void) => next()),
   requireGuildContext: vi.fn((_req: unknown, _res: unknown, next: () => void) => next()),
   requireMod: vi.fn((_req: unknown, _res: unknown, next: () => void) => next()),
+  requireOwner: vi.fn((_req: unknown, _res: unknown, next: () => void) => next()),
 }));
 
 /** An empty router, standing in for a real route module whose internals aren't under test. */
@@ -112,6 +113,8 @@ vi.mock('./routes/companionEvents', () => ({ default: emptyRouter() }));
 vi.mock('./routes/companionRewards', () => ({ default: emptyRouter() }));
 vi.mock('./routes/companionKeys', () => ({ default: emptyRouter() }));
 vi.mock('./routes/serviceWorker', () => ({ default: emptyRouter() }));
+vi.mock('./routes/health', () => ({ default: markerRouter('health') }));
+vi.mock('./routes/healthStatusEvents', () => ({ default: emptyRouter() }));
 
 import { app, generalLimiter, sessionLimiter } from './server';
 import { requireAuth, requireGuildContext } from './middleware';
@@ -156,6 +159,14 @@ describe('server route wiring', () => {
     // we don't assert an exact call count that would depend on every earlier '/' mount.
     expect(requireAuth).toHaveBeenCalled();
     expect(requireGuildContext).toHaveBeenCalled();
+  });
+
+  it('mounts /admin/health behind requireAuth only, without requireGuildContext (health is not guild-scoped)', async () => {
+    const res = await request(app).get('/admin/health/__marker_health');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ label: 'health' });
+    expect(requireAuth).toHaveBeenCalled();
+    expect(requireGuildContext).not.toHaveBeenCalled();
   });
 
   it('mounts the dashboard root behind both requireAuth and requireGuildContext', async () => {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -43,6 +43,8 @@ import timersRouter from './routes/timers';
 import privacyRouter from './routes/privacy';
 import tosRouter from './routes/tos';
 import serviceWorkerRouter from './routes/serviceWorker';
+import healthRouter from './routes/health';
+import healthStatusEventsRouter from './routes/healthStatusEvents';
 import { requireAuth, requireGuildContext } from './middleware';
 import { ensureSessionCsrfToken } from './csrf';
 import { renderView } from './routes/viewHelpers';
@@ -193,6 +195,15 @@ app.use('/api/companion', companionEventsRouter);
 app.use('/api/companion', companionRewardsRouter);
 app.use('/guild', requireAuth, guildRouter);
 app.use('/api', requireAuth, apiRouter);
+
+// Health isn't guild-scoped (unlike the '/admin'-mounted routers below), so it's mounted here,
+// ahead of the '/'-mounted routers' requireGuildContext gate — matching '/guild'/'/api' above —
+// rather than falling through the '/admin' prefix's adminGuildRouter, which would otherwise run
+// requireGuildContext for every '/admin/*' path regardless of which route actually matches.
+// requireOwner is applied per-route inside healthRouter/healthStatusEventsRouter (matching
+// admin.ts's per-route convention) rather than router-level here.
+app.use('/admin/health', requireAuth, healthRouter);
+app.use('/admin/health', requireAuth, healthStatusEventsRouter);
 
 // All of the routers below share the same '/' mount point, so registering each one
 // behind its own app.use(path, ...middleware, router) call made requireAuth (and, for

--- a/views/health.ejs
+++ b/views/health.ejs
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BCUK Bot — Health</title>
+  <link rel="stylesheet" href="/style.css">
+  <%- include('partials/pwa-head') %>
+<%
+function htmlAttrJson(value) {
+  const replacements = { '&': '&amp;', '"': '&quot;', "'": '&#39;', '<': '&lt;', '>': '&gt;' };
+  return JSON.stringify(value).replace(/[&"'<>]/g, function(char) { return replacements[char] || char; });
+}
+%>
+</head>
+<body data-initial-health="<%- htmlAttrJson(health) %>">
+  <%- include('partials/nav') %>
+
+  <main class="container">
+    <section class="section">
+      <h2 class="section-title">Bot Health</h2>
+
+      <div class="table-scroll">
+        <table class="table" id="health-table" aria-label="Component health">
+          <thead>
+            <tr>
+              <th scope="col">Component</th>
+              <th scope="col">State</th>
+              <th scope="col">Last event</th>
+              <th scope="col">Last error</th>
+            </tr>
+          </thead>
+          <tbody id="health-table-body">
+            <!-- Populated by /health.js from the server-rendered snapshot and live SSE updates. -->
+          </tbody>
+        </table>
+      </div>
+
+      <div class="card card-spaced">
+        <div class="card-header">
+          <span class="card-icon">&#9888;</span>
+          <span class="card-label">Recent Errors</span>
+        </div>
+        <div id="health-errors">
+          <p class="muted" id="health-errors-empty">No recent errors.</p>
+          <ul class="list-unstyled" id="health-errors-list"></ul>
+        </div>
+      </div>
+    </section>
+  </main>
+  <%- include('partials/pwa-register') %>
+  <%- include('partials/footer') %>
+  <script src="/health.js"></script>
+</body>
+</html>

--- a/views/health.ejs
+++ b/views/health.ejs
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="/style.css">
   <%- include('partials/pwa-head') %>
 <%
+/** JSON-stringifies `value` and HTML-escapes the result so it's safe to embed inside a double-quoted HTML attribute; returns the escaped string. */
 function htmlAttrJson(value) {
   const replacements = { '&': '&amp;', '"': '&quot;', "'": '&#39;', '<': '&lt;', '>': '&gt;' };
   return JSON.stringify(value).replace(/[&"'<>]/g, function(char) { return replacements[char] || char; });

--- a/views/partials/nav.ejs
+++ b/views/partials/nav.ejs
@@ -31,6 +31,9 @@
           <% if (user.accessLevel >= 3) { %>
           <a href="/admin/streamdeck-keys" class="nav-item">Streamdeck Keys</a>
           <% } %>
+          <% if (user.isOwner) { %>
+          <a href="/admin/health" class="nav-item">Health</a>
+          <% } %>
         </div>
       </div>
       <% } %>


### PR DESCRIPTION
## Summary

The bot owner had no single place to confirm the bot is actually working — connection state was scattered, errors only ever reached a log file, and there was no owner-only way to check health or get warned when something breaks.

This adds a lightweight, in-memory health-tracking layer (`src/shared/healthStore.ts`, mirroring the existing `statusStore.ts`) covering:
- Discord gateway / Twitch chat connectivity
- DB reachability (a new 60s ping loop)
- Per-streamer EventSub connection/reconnect health
- The Twitch stream monitor's last poll
- The counter / reward-pricing / timer schedulers' last tick
- A bounded (50-entry) feed of recent errors, fed automatically from every `logger.error()` call via a custom winston transport

...and three owner-only consumer surfaces:
- **`GET /admin/health`** — a live-updating (SSE) dashboard page, gated by the existing `requireOwner` middleware (previously defined but unused anywhere)
- **`!health`** — an owner-only Discord command (silent no-op for anyone else)
- **Proactive Discord DMs** to the bot owner (`src/discord/ownerAlerts.ts`), edge-triggered on failure and recovery, with a 30-minute cooldown against repeat alerts for a component that stays down. Resolves the owner via the existing `findOwnerUser()`, with a cached fallback so a DB outage doesn't also block the DM about the DB outage.

## Notable implementation notes

- `/admin/health` and its SSE route are mounted early in `server.ts` (alongside `/guild`/`/api`), not near the other `/admin/*` routers, because those apply `requireGuildContext` to every path under their prefix and health is intentionally guild-agnostic.
- `db.ts`'s new `pingDb()` returns a plain boolean (swallowing the underlying error) per the health-store's simple ok/fail model; the DB ping loop in `index.ts` records a generic failure message rather than the raw driver error.
- Everything is in-memory only and resets on restart, matching `statusStore.ts`'s existing precedent — no new DB table.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (184 files / 3344 tests)
- [x] `npm run lint` (0 errors)
- [x] `npm run build`
- [x] `npm run check:circular`
- [ ] Manual: `GET /admin/health` as the owner account renders and live-updates; blocked for non-owners
- [ ] Manual: `!health` in Discord replies for the owner, silent for everyone else
- [ ] Manual: forcing a failure (e.g. stopping the DB) sends an owner DM, and recovery sends a second DM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKpVe248UutjX2J1uGM8YR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an owner-only Bot Health dashboard with live status updates and recent errors.
  * Added the Discord `!health` command with service and scheduler summaries.
  * Added owner notifications for service failures, recoveries, and ongoing outages.
  * Added database connectivity checks and monitoring for key services and scheduled tasks.

* **Bug Fixes**
  * Improved resilience so health alerts and checks do not interrupt normal operation.

* **Tests**
  * Added comprehensive coverage for health reporting, monitoring, alerts, and access controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->