### PR TITLE
Add live connection-status indicator to overlay settings pages

### DIFF
--- a/public/overlayConnectionStatus.js
+++ b/public/overlayConnectionStatus.js
@@ -1,0 +1,15 @@
+(function () {
+  const script = document.currentScript;
+  const eventsUrl = script ? script.dataset.eventsUrl : '';
+  if (!eventsUrl) return;
+
+  const dot = document.getElementById('overlay-status-dot');
+  const text = document.getElementById('overlay-status-text');
+  if (!dot || !text) return;
+
+  connectSse(eventsUrl, function (data) {
+    if (!data || typeof data.connected !== 'boolean') return;
+    dot.className = data.connected ? 'dot dot--online' : 'dot dot--offline';
+    text.textContent = data.connected ? 'Connected' : 'Not connected';
+  });
+})();

--- a/public/style.css
+++ b/public/style.css
@@ -128,6 +128,7 @@ a:hover { text-decoration: underline; }
 .dot--offline { background: var(--danger); }
 .dot--playing { background: var(--warning); box-shadow: 0 0 6px var(--warning); animation: pulse 1s infinite; }
 @keyframes pulse { 0%,100% { opacity:1; } 50% { opacity:.5; } }
+.overlay-status { display: flex; align-items: center; gap: .5rem; margin-top: .5rem; font-size: .85rem; color: var(--muted); }
 
 /* ── Channel list (inside card-body) ──────────────────── */
 .channel-item { display: flex; justify-content: space-between; align-items: center; padding: .45rem 0; border-bottom: 1px solid var(--border); }

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -45,6 +45,8 @@ export const ALERT_MAX_SSE_PER_CHANNEL = parsePositiveIntEnv(process.env.ALERT_M
 export const CHANNEL_POINTS_MAX_SSE_PER_STREAMER = parsePositiveIntEnv(process.env.CHANNEL_POINTS_MAX_SSE_PER_STREAMER, 5);
 export const DASHBOARD_EVENTS_MAX_SSE_PER_STREAMER = parsePositiveIntEnv(process.env.DASHBOARD_EVENTS_MAX_SSE_PER_STREAMER, 5);
 export const DASHBOARD_STATUS_MAX_SSE_PER_GUILD = parsePositiveIntEnv(process.env.DASHBOARD_STATUS_MAX_SSE_PER_GUILD, 10);
+export const OVERLAY_STATUS_MAX_SSE_PER_STREAMER = parsePositiveIntEnv(process.env.OVERLAY_STATUS_MAX_SSE_PER_STREAMER, 3);
+export const ALERT_STATUS_MAX_SSE_PER_STREAMER = parsePositiveIntEnv(process.env.ALERT_STATUS_MAX_SSE_PER_STREAMER, 3);
 export const SSE_MAX_TOTAL_CONNECTIONS = parsePositiveIntEnv(process.env.SSE_MAX_TOTAL_CONNECTIONS, 500);
 const _COOLDOWN = parseInt(process.env.GLOBAL_COOLDOWN_MS ?? '3000', 10);
 if (Number.isNaN(_COOLDOWN)) throw new Error('Invalid GLOBAL_COOLDOWN_MS: must be a number');

--- a/src/web/routes/alertsAdmin.test.ts
+++ b/src/web/routes/alertsAdmin.test.ts
@@ -22,6 +22,10 @@ vi.mock('../middleware', () => ({
 
 vi.mock('../../shared/config', () => ({
   PUBLIC_URL: 'http://localhost:3000',
+  ALERT_STATUS_MAX_SSE_PER_STREAMER: 3,
+  ALERT_MAX_SSE_PER_CHANNEL: 10,
+  ALERT_ASSETS_FOLDER: './alert-assets',
+  SSE_MAX_TOTAL_CONNECTIONS: 1000,
 }));
 
 const { logMock } = vi.hoisted(() => ({
@@ -42,14 +46,47 @@ vi.mock('./alertsAssetMutations', async () => {
 });
 
 import supertest from 'supertest';
-import router from './alertsAdmin';
+import router, { statusConnections } from './alertsAdmin';
 import { getStreamerByDiscordId, getAlertConfigsForStreamer } from '../../db';
 import { AccessLevel } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 import { makeSessionUser, type SessionUserFixture } from '../../test-utils/fixtures';
+import { connections as alertsSourceConnections } from './alertsOverlaySource';
 
 type SessionUser = SessionUserFixture;
 const USER: SessionUser = makeSessionUser({ accessLevel: AccessLevel.MOD });
+
+/** Finds a route's handler function directly from the router's internal stack, bypassing HTTP entirely — needed to control the request's 'close' event deterministically and to await the async handler before assertions. */
+function getRouteHandler(routePath: string): (req: any, res: any, next: any) => Promise<void> | void {
+  const layer = (router as any).stack.find((l: any) => l.route?.path === routePath);
+  return layer.route.stack[layer.route.stack.length - 1].handle;
+}
+
+/** Builds a fake Express `res` covering the SSE-specific methods used by the events route handler. */
+function makeSseRes() {
+  return {
+    setHeader: vi.fn(),
+    flushHeaders: vi.fn(),
+    write: vi.fn(),
+    status: vi.fn().mockReturnThis(),
+    end: vi.fn(),
+    on: vi.fn(),
+  };
+}
+
+/** Builds a fake Express `req` with a session for `discordId`, and a `close`-event hook. */
+function makeSseReq(discordId: string) {
+  let closeCb: (() => void) | undefined;
+  return {
+    req: {
+      session: { user: { discordId } },
+      on: (event: string, cb: () => void) => {
+        if (event === 'close') closeCb = cb;
+      },
+    },
+    triggerClose: () => closeCb?.(),
+  };
+}
 
 /** Builds a supertest-ready app: the alerts admin router with a stubbed session and a render mock that flattens locals into the JSON body. */
 function buildApp(sessionUser: SessionUser = USER) {
@@ -60,6 +97,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
   vi.mocked(getAlertConfigsForStreamer).mockResolvedValue([]);
+  statusConnections.clear();
+  alertsSourceConnections.clear();
 });
 
 describe('GET /settings — query param filtering', () => {
@@ -134,5 +173,107 @@ describe('GET /settings — streamer and alert config loading', () => {
     const res = await supertest(buildApp()).get('/settings');
     expect(res.status).toBe(200);
     expect(res.body.textAnimations).toEqual(['none', 'wave', 'pulse', 'glitch', 'shake', 'rainbow', 'flicker', 'tilt', 'bounce-in', 'typewriter']);
+  });
+});
+
+describe('GET /settings/events', () => {
+  function makeStreamer(overrides: Record<string, unknown> = {}) {
+    return { id: 7, discord_id: 'discord1', twitch_name: 'somestreamer', ...overrides };
+  }
+
+  it('returns 403 when the user is not a monitored streamer', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
+    const res = await supertest(buildApp()).get('/settings/events');
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 when the streamer has no linked Twitch channel', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(makeStreamer({ twitch_name: null }) as any);
+    const res = await supertest(buildApp()).get('/settings/events');
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 500 when the streamer lookup throws', async () => {
+    vi.mocked(getStreamerByDiscordId).mockRejectedValue(new Error('DB down'));
+    const res = await supertest(buildApp()).get('/settings/events');
+    expect(res.status).toBe(500);
+  });
+
+  it('attaches the connection and reports disconnected when the overlay has no open connections', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(makeStreamer() as any);
+    const handler = getRouteHandler('/settings/events');
+    const res = makeSseRes();
+    const { req, triggerClose } = makeSseReq('discord1');
+
+    await handler(req, res, vi.fn());
+
+    expect(statusConnections.get(7)?.has(res as any)).toBe(true);
+    expect(res.write).toHaveBeenCalledWith(`data: ${JSON.stringify({ connected: false })}\n\n`);
+
+    triggerClose(); // clears the status-poll interval so it doesn't leak into other tests
+  });
+
+  it('reports connected when the overlay already has an open connection', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(makeStreamer() as any);
+    alertsSourceConnections.set('somestreamer', new Set([{} as any]));
+    const handler = getRouteHandler('/settings/events');
+    const res = makeSseRes();
+    const { req, triggerClose } = makeSseReq('discord1');
+
+    await handler(req, res, vi.fn());
+
+    expect(res.write).toHaveBeenCalledWith(`data: ${JSON.stringify({ connected: true })}\n\n`);
+
+    triggerClose();
+  });
+
+  it('pushes an update only when the overlay connection state actually changes on a poll tick', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.mocked(getStreamerByDiscordId).mockResolvedValue(makeStreamer() as any);
+      const handler = getRouteHandler('/settings/events');
+      const res = makeSseRes();
+      const { req, triggerClose } = makeSseReq('discord1');
+
+      await handler(req, res, vi.fn());
+      expect(res.write).toHaveBeenCalledTimes(2); // handshake + initial disconnected state
+      res.write.mockClear();
+
+      vi.advanceTimersByTime(3000); // no change yet — still disconnected
+      expect(res.write).not.toHaveBeenCalled();
+
+      alertsSourceConnections.set('somestreamer', new Set([{} as any]));
+      vi.advanceTimersByTime(3000);
+      expect(res.write).toHaveBeenCalledWith(`data: ${JSON.stringify({ connected: true })}\n\n`);
+      res.write.mockClear();
+
+      vi.advanceTimersByTime(3000); // still connected — no repeat push
+      expect(res.write).not.toHaveBeenCalled();
+
+      triggerClose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops polling once the request closes', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.mocked(getStreamerByDiscordId).mockResolvedValue(makeStreamer() as any);
+      const handler = getRouteHandler('/settings/events');
+      const res = makeSseRes();
+      const { req, triggerClose } = makeSseReq('discord1');
+
+      await handler(req, res, vi.fn());
+      triggerClose();
+      res.write.mockClear();
+
+      alertsSourceConnections.set('somestreamer', new Set([{} as any]));
+      vi.advanceTimersByTime(10_000);
+
+      expect(res.write).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/web/routes/alertsAdmin.ts
+++ b/src/web/routes/alertsAdmin.ts
@@ -4,14 +4,13 @@ import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
 import { getSessionUser } from '../session';
 import { getStreamerByDiscordId, getAlertConfigsForStreamer, ALERT_EVENT_TYPES, ALERT_TEXT_ANIMATIONS } from '../../db';
-import type { DbStreamerEventSub } from '../../db';
 import { PUBLIC_URL, ALERT_STATUS_MAX_SSE_PER_STREAMER } from '../../shared/config';
 import { filterQueryParam } from './validation';
 import { renderError, renderView } from './viewHelpers';
 import { router as mutationsRouter } from './alertsAdminMutations';
 import { router as assetMutationsRouter, MAX_IMAGE_MB, MAX_SOUND_MB } from './alertsAssetMutations';
 import { connections as alertsSourceConnections } from './alertsOverlaySource';
-import { attachSseConnection, broadcastToChannel } from './sseChannel';
+import { createOverlayStatusEventsHandler } from './sseChannel';
 
 const log = createLogger('AlertsAdmin');
 const router = Router();
@@ -67,51 +66,22 @@ router.get('/settings', requireAuth, csrfProtection, async (req, res) => {
  * GET /alerts/settings/events — SSE endpoint streaming `{ connected: boolean }` snapshots of
  * whether the logged-in user's own alerts browser source currently has an open connection, so the
  * settings page can show a live status dot instead of the user only finding out something's wrong
- * when an alert never fires. Polls the shared `alertsOverlaySource` connections map on an interval
- * rather than reacting to a push event, since opening/closing that overlay's SSE connection has no
- * existing event to subscribe to.
+ * when an alert never fires. Connection lifecycle and status-polling logic (streamer resolution,
+ * SSE handshake, poll-and-broadcast-on-change, and interval cleanup) is shared with the
+ * reward-video overlay via `createOverlayStatusEventsHandler`.
  * @param req - Express request; reads `req.session.user`.
  * @param res - Express response; upgrades to a `text/event-stream` connection kept alive with
  *   periodic pings and torn down (including the status-poll interval) on client disconnect;
  *   replies 403 if the user isn't a monitored streamer with a linked Twitch channel, 500 (logged)
  *   if the streamer lookup fails, or 429 if the connection limit is exceeded.
  */
-router.get('/settings/events', requireAuth, async (req, res) => {
-  let streamer: DbStreamerEventSub | null;
-  try {
-    streamer = await getStreamerByDiscordId(getSessionUser(req).discordId);
-  } catch (err) {
-    log.error('Failed to resolve streamer for alerts status SSE:', err);
-    res.status(500).end();
-    return;
-  }
-  if (!streamer || !streamer.twitch_name) {
-    res.status(403).end();
-    return;
-  }
-
-  const attached = attachSseConnection(req, res, {
-    connections: statusConnections,
-    key: streamer.id,
-    maxPerChannel: ALERT_STATUS_MAX_SSE_PER_STREAMER,
-  });
-  if (!attached) return;
-
-  const streamerId = streamer.id;
-  const login = streamer.twitch_name.toLowerCase();
-  let lastConnected: boolean | null = null;
-
-  const check = (): void => {
-    const isConnected = (alertsSourceConnections.get(login)?.size ?? 0) > 0;
-    if (isConnected === lastConnected) return;
-    lastConnected = isConnected;
-    broadcastToChannel(statusConnections, streamerId, { connected: isConnected });
-  };
-
-  check();
-  const interval = setInterval(check, STATUS_POLL_INTERVAL_MS);
-  req.on('close', () => clearInterval(interval));
-});
+router.get('/settings/events', requireAuth, createOverlayStatusEventsHandler({
+  statusConnections,
+  overlayConnections: alertsSourceConnections,
+  maxPerChannel: ALERT_STATUS_MAX_SSE_PER_STREAMER,
+  pollIntervalMs: STATUS_POLL_INTERVAL_MS,
+  log,
+}));
 
 router.use(mutationsRouter);
 router.use(assetMutationsRouter);

--- a/src/web/routes/alertsAdmin.ts
+++ b/src/web/routes/alertsAdmin.ts
@@ -1,17 +1,26 @@
 import { createLogger } from '../../shared/logger';
-import { Router } from 'express';
+import { Router, type Response } from 'express';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
 import { getSessionUser } from '../session';
 import { getStreamerByDiscordId, getAlertConfigsForStreamer, ALERT_EVENT_TYPES, ALERT_TEXT_ANIMATIONS } from '../../db';
-import { PUBLIC_URL } from '../../shared/config';
+import type { DbStreamerEventSub } from '../../db';
+import { PUBLIC_URL, ALERT_STATUS_MAX_SSE_PER_STREAMER } from '../../shared/config';
 import { filterQueryParam } from './validation';
 import { renderError, renderView } from './viewHelpers';
 import { router as mutationsRouter } from './alertsAdminMutations';
 import { router as assetMutationsRouter, MAX_IMAGE_MB, MAX_SOUND_MB } from './alertsAssetMutations';
+import { connections as alertsSourceConnections } from './alertsOverlaySource';
+import { attachSseConnection, broadcastToChannel } from './sseChannel';
 
 const log = createLogger('AlertsAdmin');
 const router = Router();
+
+// How often the settings-page SSE stream re-checks whether the overlay browser source is open.
+const STATUS_POLL_INTERVAL_MS = 3000;
+
+// In-memory map of active `/settings/events` SSE connections, keyed by streamer ID.
+export const statusConnections = new Map<number, Set<Response>>();
 
 const KNOWN_ERRORS = new Set([
   'not_a_streamer', 'invalid_event_type', 'invalid_file', 'invalid_message',
@@ -52,6 +61,56 @@ router.get('/settings', requireAuth, csrfProtection, async (req, res) => {
     log.error('Alerts settings page error:', err);
     renderError(res, 500, 'Failed to load alerts settings.', req.session.user);
   }
+});
+
+/**
+ * GET /alerts/settings/events — SSE endpoint streaming `{ connected: boolean }` snapshots of
+ * whether the logged-in user's own alerts browser source currently has an open connection, so the
+ * settings page can show a live status dot instead of the user only finding out something's wrong
+ * when an alert never fires. Polls the shared `alertsOverlaySource` connections map on an interval
+ * rather than reacting to a push event, since opening/closing that overlay's SSE connection has no
+ * existing event to subscribe to.
+ * @param req - Express request; reads `req.session.user`.
+ * @param res - Express response; upgrades to a `text/event-stream` connection kept alive with
+ *   periodic pings and torn down (including the status-poll interval) on client disconnect;
+ *   replies 403 if the user isn't a monitored streamer with a linked Twitch channel, 500 (logged)
+ *   if the streamer lookup fails, or 429 if the connection limit is exceeded.
+ */
+router.get('/settings/events', requireAuth, async (req, res) => {
+  let streamer: DbStreamerEventSub | null;
+  try {
+    streamer = await getStreamerByDiscordId(getSessionUser(req).discordId);
+  } catch (err) {
+    log.error('Failed to resolve streamer for alerts status SSE:', err);
+    res.status(500).end();
+    return;
+  }
+  if (!streamer || !streamer.twitch_name) {
+    res.status(403).end();
+    return;
+  }
+
+  const attached = attachSseConnection(req, res, {
+    connections: statusConnections,
+    key: streamer.id,
+    maxPerChannel: ALERT_STATUS_MAX_SSE_PER_STREAMER,
+  });
+  if (!attached) return;
+
+  const streamerId = streamer.id;
+  const login = streamer.twitch_name.toLowerCase();
+  let lastConnected: boolean | null = null;
+
+  const check = (): void => {
+    const isConnected = (alertsSourceConnections.get(login)?.size ?? 0) > 0;
+    if (isConnected === lastConnected) return;
+    lastConnected = isConnected;
+    broadcastToChannel(statusConnections, streamerId, { connected: isConnected });
+  };
+
+  check();
+  const interval = setInterval(check, STATUS_POLL_INTERVAL_MS);
+  req.on('close', () => clearInterval(interval));
 });
 
 router.use(mutationsRouter);

--- a/src/web/routes/overlayAdmin.test.ts
+++ b/src/web/routes/overlayAdmin.test.ts
@@ -29,6 +29,10 @@ vi.mock('../../twitch/eventsub/twitchApiEventSub', () => ({
 
 vi.mock('../../shared/config', () => ({
   PUBLIC_URL: 'http://localhost:3000',
+  OVERLAY_STATUS_MAX_SSE_PER_STREAMER: 3,
+  OVERLAY_MAX_SSE_PER_CHANNEL: 10,
+  OVERLAY_FOLDER: './overlay-videos',
+  SSE_MAX_TOTAL_CONNECTIONS: 1000,
 }));
 
 const { logMock } = vi.hoisted(() => ({
@@ -44,16 +48,49 @@ vi.mock('./overlayAdminMutations', async () => {
 });
 
 import supertest from 'supertest';
-import router from './overlayAdmin';
+import router, { statusConnections } from './overlayAdmin';
 import { getStreamerByDiscordId, getVideosForStreamer, getRewardsForStreamer } from '../../db';
 import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
 import { getCustomRewards } from '../../twitch/twitchApi';
 import { AccessLevel } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 import { makeSessionUser, type SessionUserFixture } from '../../test-utils/fixtures';
+import { connections as overlaySourceConnections } from './overlaySource';
 
 type SessionUser = SessionUserFixture;
 const USER: SessionUser = makeSessionUser({ accessLevel: AccessLevel.MOD });
+
+/** Finds a route's handler function directly from the router's internal stack, bypassing HTTP entirely — needed to control the request's 'close' event deterministically and to await the async handler before assertions. */
+function getRouteHandler(routePath: string): (req: any, res: any, next: any) => Promise<void> | void {
+  const layer = (router as any).stack.find((l: any) => l.route?.path === routePath);
+  return layer.route.stack[layer.route.stack.length - 1].handle;
+}
+
+/** Builds a fake Express `res` covering the SSE-specific methods used by the events route handler. */
+function makeSseRes() {
+  return {
+    setHeader: vi.fn(),
+    flushHeaders: vi.fn(),
+    write: vi.fn(),
+    status: vi.fn().mockReturnThis(),
+    end: vi.fn(),
+    on: vi.fn(),
+  };
+}
+
+/** Builds a fake Express `req` with a session for `discordId`, and a `close`-event hook. */
+function makeSseReq(discordId: string) {
+  let closeCb: (() => void) | undefined;
+  return {
+    req: {
+      session: { user: { discordId } },
+      on: (event: string, cb: () => void) => {
+        if (event === 'close') closeCb = cb;
+      },
+    },
+    triggerClose: () => closeCb?.(),
+  };
+}
 
 /** Builds a supertest-ready app: the overlay admin router with a stubbed session and a render mock that flattens locals into the JSON body. */
 function buildApp(sessionUser: SessionUser = USER) {
@@ -63,6 +100,8 @@ function buildApp(sessionUser: SessionUser = USER) {
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
+  statusConnections.clear();
+  overlaySourceConnections.clear();
 });
 
 describe('GET /settings — query param filtering', () => {
@@ -167,5 +206,107 @@ describe('GET /settings — fetchTwitchRewards', () => {
     expect(res.status).toBe(200);
     expect(res.body.twitchRewards).toEqual([]);
     expect(logMock.warn).toHaveBeenCalledWith('Failed to fetch Twitch custom rewards:', expect.any(Error));
+  });
+});
+
+describe('GET /settings/events', () => {
+  function makeStreamer(overrides: Record<string, unknown> = {}) {
+    return { id: 7, discord_id: 'discord1', twitch_name: 'somestreamer', ...overrides };
+  }
+
+  it('returns 403 when the user is not a monitored streamer', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
+    const res = await supertest(buildApp()).get('/settings/events');
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 when the streamer has no linked Twitch channel', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(makeStreamer({ twitch_name: null }) as any);
+    const res = await supertest(buildApp()).get('/settings/events');
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 500 when the streamer lookup throws', async () => {
+    vi.mocked(getStreamerByDiscordId).mockRejectedValue(new Error('DB down'));
+    const res = await supertest(buildApp()).get('/settings/events');
+    expect(res.status).toBe(500);
+  });
+
+  it('attaches the connection and reports disconnected when the overlay has no open connections', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(makeStreamer() as any);
+    const handler = getRouteHandler('/settings/events');
+    const res = makeSseRes();
+    const { req, triggerClose } = makeSseReq('discord1');
+
+    await handler(req, res, vi.fn());
+
+    expect(statusConnections.get(7)?.has(res as any)).toBe(true);
+    expect(res.write).toHaveBeenCalledWith(`data: ${JSON.stringify({ connected: false })}\n\n`);
+
+    triggerClose(); // clears the status-poll interval so it doesn't leak into other tests
+  });
+
+  it('reports connected when the overlay already has an open connection', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(makeStreamer() as any);
+    overlaySourceConnections.set('somestreamer', new Set([{} as any]));
+    const handler = getRouteHandler('/settings/events');
+    const res = makeSseRes();
+    const { req, triggerClose } = makeSseReq('discord1');
+
+    await handler(req, res, vi.fn());
+
+    expect(res.write).toHaveBeenCalledWith(`data: ${JSON.stringify({ connected: true })}\n\n`);
+
+    triggerClose();
+  });
+
+  it('pushes an update only when the overlay connection state actually changes on a poll tick', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.mocked(getStreamerByDiscordId).mockResolvedValue(makeStreamer() as any);
+      const handler = getRouteHandler('/settings/events');
+      const res = makeSseRes();
+      const { req, triggerClose } = makeSseReq('discord1');
+
+      await handler(req, res, vi.fn());
+      expect(res.write).toHaveBeenCalledTimes(2); // handshake + initial disconnected state
+      res.write.mockClear();
+
+      vi.advanceTimersByTime(3000); // no change yet — still disconnected
+      expect(res.write).not.toHaveBeenCalled();
+
+      overlaySourceConnections.set('somestreamer', new Set([{} as any]));
+      vi.advanceTimersByTime(3000);
+      expect(res.write).toHaveBeenCalledWith(`data: ${JSON.stringify({ connected: true })}\n\n`);
+      res.write.mockClear();
+
+      vi.advanceTimersByTime(3000); // still connected — no repeat push
+      expect(res.write).not.toHaveBeenCalled();
+
+      triggerClose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops polling once the request closes', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.mocked(getStreamerByDiscordId).mockResolvedValue(makeStreamer() as any);
+      const handler = getRouteHandler('/settings/events');
+      const res = makeSseRes();
+      const { req, triggerClose } = makeSseReq('discord1');
+
+      await handler(req, res, vi.fn());
+      triggerClose();
+      res.write.mockClear();
+
+      overlaySourceConnections.set('somestreamer', new Set([{} as any]));
+      vi.advanceTimersByTime(10_000);
+
+      expect(res.write).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/web/routes/overlayAdmin.ts
+++ b/src/web/routes/overlayAdmin.ts
@@ -14,7 +14,7 @@ import { renderError, renderView } from './viewHelpers';
 import { router as mutationsRouter, MAX_UPLOAD_MB } from './overlayAdminMutations';
 import { router as rewardMutationsRouter } from './overlayAdminRewardMutations';
 import { connections as overlaySourceConnections } from './overlaySource';
-import { attachSseConnection, broadcastToChannel } from './sseChannel';
+import { createOverlayStatusEventsHandler } from './sseChannel';
 
 const log = createLogger('OverlayAdmin');
 const router = Router();
@@ -102,51 +102,22 @@ router.get('/controller/settings', requireAuth, csrfProtection, (req, res) => {
  * GET /overlay/settings/events — SSE endpoint streaming `{ connected: boolean }` snapshots of
  * whether the logged-in user's own reward-video browser source currently has an open connection,
  * so the settings page can show a live status dot instead of the user only finding out something's
- * wrong when a reward video never plays. Polls the shared `overlaySource` connections map on an
- * interval rather than reacting to a push event, since opening/closing that overlay's SSE
- * connection has no existing event to subscribe to.
+ * wrong when a reward video never plays. Connection lifecycle and status-polling logic (streamer
+ * resolution, SSE handshake, poll-and-broadcast-on-change, and interval cleanup) is shared with
+ * the alerts overlay via `createOverlayStatusEventsHandler`.
  * @param req - Express request; reads `req.session.user`.
  * @param res - Express response; upgrades to a `text/event-stream` connection kept alive with
  *   periodic pings and torn down (including the status-poll interval) on client disconnect;
  *   replies 403 if the user isn't a monitored streamer with a linked Twitch channel, 500 (logged)
  *   if the streamer lookup fails, or 429 if the connection limit is exceeded.
  */
-router.get('/settings/events', requireAuth, async (req, res) => {
-  let streamer: DbStreamerEventSub | null;
-  try {
-    streamer = await getStreamerByDiscordId(getSessionUser(req).discordId);
-  } catch (err) {
-    log.error('Failed to resolve streamer for overlay status SSE:', err);
-    res.status(500).end();
-    return;
-  }
-  if (!streamer || !streamer.twitch_name) {
-    res.status(403).end();
-    return;
-  }
-
-  const attached = attachSseConnection(req, res, {
-    connections: statusConnections,
-    key: streamer.id,
-    maxPerChannel: OVERLAY_STATUS_MAX_SSE_PER_STREAMER,
-  });
-  if (!attached) return;
-
-  const streamerId = streamer.id;
-  const login = streamer.twitch_name.toLowerCase();
-  let lastConnected: boolean | null = null;
-
-  const check = (): void => {
-    const isConnected = (overlaySourceConnections.get(login)?.size ?? 0) > 0;
-    if (isConnected === lastConnected) return;
-    lastConnected = isConnected;
-    broadcastToChannel(statusConnections, streamerId, { connected: isConnected });
-  };
-
-  check();
-  const interval = setInterval(check, STATUS_POLL_INTERVAL_MS);
-  req.on('close', () => clearInterval(interval));
-});
+router.get('/settings/events', requireAuth, createOverlayStatusEventsHandler({
+  statusConnections,
+  overlayConnections: overlaySourceConnections,
+  maxPerChannel: OVERLAY_STATUS_MAX_SSE_PER_STREAMER,
+  pollIntervalMs: STATUS_POLL_INTERVAL_MS,
+  log,
+}));
 
 router.use(mutationsRouter);
 router.use(rewardMutationsRouter);

--- a/src/web/routes/overlayAdmin.ts
+++ b/src/web/routes/overlayAdmin.ts
@@ -1,21 +1,29 @@
 import { createLogger } from '../../shared/logger';
-import { Router } from 'express';
+import { Router, type Response } from 'express';
 import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
 import { getSessionUser } from '../session';
 import { getStreamerByDiscordId } from '../../db';
 import type { DbStreamerEventSub } from '../../db';
 import { getVideosForStreamer, getRewardsForStreamer } from '../../db';
-import { PUBLIC_URL } from '../../shared/config';
+import { PUBLIC_URL, OVERLAY_STATUS_MAX_SSE_PER_STREAMER } from '../../shared/config';
 import { getCustomRewards, TwitchCustomReward } from '../../twitch/twitchApi';
 import { getValidToken } from '../../twitch/eventsub/twitchApiEventSub';
 import { filterQueryParam } from './validation';
 import { renderError, renderView } from './viewHelpers';
 import { router as mutationsRouter, MAX_UPLOAD_MB } from './overlayAdminMutations';
 import { router as rewardMutationsRouter } from './overlayAdminRewardMutations';
+import { connections as overlaySourceConnections } from './overlaySource';
+import { attachSseConnection, broadcastToChannel } from './sseChannel';
 
 const log = createLogger('OverlayAdmin');
 const router = Router();
+
+// How often the settings-page SSE stream re-checks whether the overlay browser source is open.
+const STATUS_POLL_INTERVAL_MS = 3000;
+
+// In-memory map of active `/settings/events` SSE connections, keyed by streamer ID.
+export const statusConnections = new Map<number, Set<Response>>();
 
 const KNOWN_ERRORS = new Set([
   'not_a_streamer', 'invalid_file', 'upload_failed', 'delete_failed',
@@ -88,6 +96,56 @@ router.get('/controller/settings', requireAuth, csrfProtection, (req, res) => {
     csrfToken: req.csrfToken(),
     baseUrl: PUBLIC_URL,
   });
+});
+
+/**
+ * GET /overlay/settings/events — SSE endpoint streaming `{ connected: boolean }` snapshots of
+ * whether the logged-in user's own reward-video browser source currently has an open connection,
+ * so the settings page can show a live status dot instead of the user only finding out something's
+ * wrong when a reward video never plays. Polls the shared `overlaySource` connections map on an
+ * interval rather than reacting to a push event, since opening/closing that overlay's SSE
+ * connection has no existing event to subscribe to.
+ * @param req - Express request; reads `req.session.user`.
+ * @param res - Express response; upgrades to a `text/event-stream` connection kept alive with
+ *   periodic pings and torn down (including the status-poll interval) on client disconnect;
+ *   replies 403 if the user isn't a monitored streamer with a linked Twitch channel, 500 (logged)
+ *   if the streamer lookup fails, or 429 if the connection limit is exceeded.
+ */
+router.get('/settings/events', requireAuth, async (req, res) => {
+  let streamer: DbStreamerEventSub | null;
+  try {
+    streamer = await getStreamerByDiscordId(getSessionUser(req).discordId);
+  } catch (err) {
+    log.error('Failed to resolve streamer for overlay status SSE:', err);
+    res.status(500).end();
+    return;
+  }
+  if (!streamer || !streamer.twitch_name) {
+    res.status(403).end();
+    return;
+  }
+
+  const attached = attachSseConnection(req, res, {
+    connections: statusConnections,
+    key: streamer.id,
+    maxPerChannel: OVERLAY_STATUS_MAX_SSE_PER_STREAMER,
+  });
+  if (!attached) return;
+
+  const streamerId = streamer.id;
+  const login = streamer.twitch_name.toLowerCase();
+  let lastConnected: boolean | null = null;
+
+  const check = (): void => {
+    const isConnected = (overlaySourceConnections.get(login)?.size ?? 0) > 0;
+    if (isConnected === lastConnected) return;
+    lastConnected = isConnected;
+    broadcastToChannel(statusConnections, streamerId, { connected: isConnected });
+  };
+
+  check();
+  const interval = setInterval(check, STATUS_POLL_INTERVAL_MS);
+  req.on('close', () => clearInterval(interval));
 });
 
 router.use(mutationsRouter);

--- a/src/web/routes/sseChannel.test.ts
+++ b/src/web/routes/sseChannel.test.ts
@@ -412,6 +412,35 @@ describe('createOverlayStatusEventsHandler', () => {
     }
   });
 
+  it('clears the poll interval when the very first status write fails, before any state change', async () => {
+    vi.useFakeTimers();
+    try {
+      const handler = buildOverlayStatusHandler();
+      const res = makeRes();
+      let writeCount = 0;
+      res.write.mockImplementation(() => {
+        writeCount++;
+        // 1st write is the SSE handshake (': connected\n\n'); 2nd is the initial check()'s
+        // broadcast, fired synchronously inside the handler before the interval/wrapper race
+        // could otherwise leave nothing owning this interval's cleanup.
+        if (writeCount === 2) throw new Error('write failed');
+      });
+      const { req } = makeReq('unused');
+
+      await handler(req as any, res as any);
+
+      expect(statusConnections.has(7)).toBe(false);
+
+      res.write.mockClear();
+      overlayConnections.set('somestreamer', new Set([{} as any]));
+      vi.advanceTimersByTime(10_000);
+
+      expect(res.write).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('clears the poll interval when a broadcast write fails, with no close/error event ever emitted', async () => {
     vi.useFakeTimers();
     try {

--- a/src/web/routes/sseChannel.test.ts
+++ b/src/web/routes/sseChannel.test.ts
@@ -412,6 +412,34 @@ describe('createOverlayStatusEventsHandler', () => {
     }
   });
 
+  it('clears the poll interval when a broadcast write fails, with no close/error event ever emitted', async () => {
+    vi.useFakeTimers();
+    try {
+      const handler = buildOverlayStatusHandler();
+      const res = makeRes();
+      const { req } = makeReq('unused');
+
+      await handler(req as any, res as any);
+      expect(statusConnections.get(7)?.has(res as any)).toBe(true);
+
+      // Simulate broadcastToChannel's write failing on the next state-change push — this evicts
+      // the response via attachSseConnection's own cleanup, without ever firing 'close'/'error'.
+      res.write.mockImplementationOnce(() => { throw new Error('write failed'); });
+      overlayConnections.set('somestreamer', new Set([{} as any]));
+      vi.advanceTimersByTime(3000);
+
+      expect(statusConnections.has(7)).toBe(false);
+
+      res.write.mockClear();
+      overlayConnections.delete('somestreamer');
+      vi.advanceTimersByTime(10_000);
+
+      expect(res.write).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('clears the poll interval when the response errors without the request ever closing', async () => {
     vi.useFakeTimers();
     try {

--- a/src/web/routes/sseChannel.test.ts
+++ b/src/web/routes/sseChannel.test.ts
@@ -7,7 +7,7 @@ vi.mock('../session', () => ({ getSessionUser: vi.fn() }));
 
 import {
   createSseEventsHandler, createLoginValidator, attachSseConnection, broadcastToChannel,
-  createStreamerSseEventsHandler,
+  createStreamerSseEventsHandler, createOverlayStatusEventsHandler,
 } from './sseChannel';
 import { getStreamerByDiscordId } from '../../db';
 import { getSessionUser } from '../session';
@@ -17,30 +17,34 @@ const log = mockLogger() as any;
 const LOGIN_RE = /^[a-zA-Z0-9_]{1,25}$/;
 const RESERVED_LOGINS = new Set(['settings']);
 
+// Mirrors real EventEmitter semantics (multiple listeners per event, all fired in registration
+// order) rather than keeping only the last one — attachSseConnection and a caller built on top of
+// it (e.g. createOverlayStatusEventsHandler) can each register their own 'close'/'error' listener
+// on the same req/res, and both must still fire.
 function makeRes() {
-  const handlers: Record<string, () => void> = {};
+  const handlers: Record<string, Array<() => void>> = {};
   return {
     setHeader: vi.fn(),
     flushHeaders: vi.fn(),
     write: vi.fn(),
     status: vi.fn().mockReturnThis(),
     end: vi.fn(),
-    on: vi.fn((event: string, cb: () => void) => { handlers[event] = cb; }),
-    triggerResClose: () => handlers['close']?.(),
-    triggerResError: () => handlers['error']?.(),
+    on: vi.fn((event: string, cb: () => void) => { (handlers[event] ??= []).push(cb); }),
+    triggerResClose: () => handlers['close']?.forEach((cb) => cb()),
+    triggerResError: () => handlers['error']?.forEach((cb) => cb()),
   };
 }
 
 function makeReq(login: string) {
-  let closeCb: (() => void) | undefined;
+  const closeCbs: Array<() => void> = [];
   return {
     req: {
       params: { login },
       on: (event: string, cb: () => void) => {
-        if (event === 'close') closeCb = cb;
+        if (event === 'close') closeCbs.push(cb);
       },
     },
-    triggerClose: () => closeCb?.(),
+    triggerClose: () => closeCbs.forEach((cb) => cb()),
   };
 }
 
@@ -98,6 +102,7 @@ describe('createSseEventsHandler', () => {
 
     expect(connections.get('freshchannel')?.has(res as any)).toBe(true);
     expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/event-stream');
+    expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
     expect(res.write).toHaveBeenCalledWith(': connected\n\n');
 
     triggerClose();
@@ -353,6 +358,78 @@ describe('createStreamerSseEventsHandler', () => {
     await handler(req as any, res as any);
 
     expect(res.status).toHaveBeenCalledWith(429);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createOverlayStatusEventsHandler
+// ---------------------------------------------------------------------------
+describe('createOverlayStatusEventsHandler', () => {
+  const statusConnections = new Map<number, Set<any>>();
+  const overlayConnections = new Map<string, Set<any>>();
+
+  beforeEach(() => {
+    statusConnections.clear();
+    overlayConnections.clear();
+    vi.mocked(getSessionUser).mockReturnValue({ discordId: 'discord1' } as any);
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue({ id: 7, twitch_name: 'somestreamer' } as any);
+  });
+
+  function buildOverlayStatusHandler(pollIntervalMs = 3000, maxPerChannel = 10) {
+    return createOverlayStatusEventsHandler({
+      statusConnections, overlayConnections, maxPerChannel, pollIntervalMs, log,
+    });
+  }
+
+  it('returns 403 when the streamer has no linked Twitch channel', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue({ id: 7, twitch_name: null } as any);
+    const handler = buildOverlayStatusHandler();
+    const res = makeRes();
+    const { req } = makeReq('unused');
+
+    await handler(req as any, res as any);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('clears the poll interval when the response closes without the request ever closing', async () => {
+    vi.useFakeTimers();
+    try {
+      const handler = buildOverlayStatusHandler();
+      const res = makeRes();
+      const { req } = makeReq('unused');
+
+      await handler(req as any, res as any);
+      res.write.mockClear();
+      res.triggerResClose(); // an abrupt socket failure — req never fires 'close'
+
+      overlayConnections.set('somestreamer', new Set([{} as any]));
+      vi.advanceTimersByTime(10_000);
+
+      expect(res.write).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears the poll interval when the response errors without the request ever closing', async () => {
+    vi.useFakeTimers();
+    try {
+      const handler = buildOverlayStatusHandler();
+      const res = makeRes();
+      const { req } = makeReq('unused');
+
+      await handler(req as any, res as any);
+      res.write.mockClear();
+      res.triggerResError();
+
+      overlayConnections.set('somestreamer', new Set([{} as any]));
+      vi.advanceTimersByTime(10_000);
+
+      expect(res.write).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/src/web/routes/sseChannel.ts
+++ b/src/web/routes/sseChannel.ts
@@ -269,3 +269,76 @@ export function createStreamerSseEventsHandler<K>(
     attachSseConnection(req, res, { connections, key: resolveKey(streamer), maxPerChannel });
   };
 }
+
+/** Options for {@link createOverlayStatusEventsHandler}. */
+export interface OverlayStatusEventsHandlerOptions {
+  /** In-memory map of active status-stream SSE connections, keyed by streamer ID. */
+  statusConnections: Map<number, Set<Response>>;
+  /** The overlay's own connections map (e.g. from `overlaySource.ts`/`alertsOverlaySource.ts`), keyed by lowercased Twitch login — polled to derive `connected`. */
+  overlayConnections: Map<string, Set<Response>>;
+  /** Maximum concurrent status-stream connections permitted per streamer. */
+  maxPerChannel: number;
+  /** How often (ms) to re-check `overlayConnections` for a state change. */
+  pollIntervalMs: number;
+  /** Logger used to report an unexpected streamer lookup failure. */
+  log: ReturnType<typeof createLogger>;
+}
+
+/**
+ * Builds a `/settings/events`-style SSE route handler streaming `{ connected: boolean }`
+ * snapshots of whether the logged-in user's own browser-source overlay currently has an open
+ * connection, so a settings page can show a live status dot instead of the user only finding out
+ * something's wrong when an overlay never fires. Shared by the reward-video and alerts overlay
+ * settings pages (`overlayAdmin.ts`/`alertsAdmin.ts`) — each keeps its own `statusConnections` and
+ * `overlayConnections` maps, since those differ, but the "resolve the session's streamer, then
+ * poll for a connection-count change" lifecycle is identical. Polls on an interval rather than
+ * reacting to a push event, since opening/closing an overlay's own SSE connection has no existing
+ * event to subscribe to.
+ * @param options - See {@link OverlayStatusEventsHandlerOptions}.
+ * @returns An Express route handler: replies 403 if the user isn't a monitored streamer with a
+ *   linked Twitch channel, 500 (logged) if the streamer lookup fails, 429 if `maxPerChannel` is
+ *   exceeded, otherwise upgrades to `text/event-stream` and tears down the poll interval (along
+ *   with the connection itself) on client disconnect.
+ */
+export function createOverlayStatusEventsHandler(
+  options: OverlayStatusEventsHandlerOptions,
+): (req: Request, res: Response) => Promise<void> {
+  const { statusConnections, overlayConnections, maxPerChannel, pollIntervalMs, log } = options;
+
+  return async (req, res) => {
+    let streamer: DbStreamerEventSub | null;
+    try {
+      streamer = await getStreamerByDiscordId(getSessionUser(req).discordId);
+    } catch (err) {
+      log.error('Failed to resolve streamer for overlay status SSE:', err);
+      res.status(500).end();
+      return;
+    }
+    if (!streamer || !streamer.twitch_name) {
+      res.status(403).end();
+      return;
+    }
+
+    const attached = attachSseConnection(req, res, {
+      connections: statusConnections,
+      key: streamer.id,
+      maxPerChannel,
+    });
+    if (!attached) return;
+
+    const streamerId = streamer.id;
+    const login = streamer.twitch_name.toLowerCase();
+    let lastConnected: boolean | null = null;
+
+    const check = (): void => {
+      const isConnected = (overlayConnections.get(login)?.size ?? 0) > 0;
+      if (isConnected === lastConnected) return;
+      lastConnected = isConnected;
+      broadcastToChannel(statusConnections, streamerId, { connected: isConnected });
+    };
+
+    check();
+    const interval = setInterval(check, pollIntervalMs);
+    req.on('close', () => clearInterval(interval));
+  };
+}

--- a/src/web/routes/sseChannel.ts
+++ b/src/web/routes/sseChannel.ts
@@ -346,7 +346,6 @@ export function createOverlayStatusEventsHandler(
       broadcastToChannel(statusConnections, streamerId, { connected: isConnected });
     };
 
-    check();
     const interval = setInterval(check, pollIntervalMs);
     // attachSseConnection's own cleanup can be triggered by 'close'/'error' on either req or res
     // (an abrupt socket failure can fire res's events without req ever emitting 'close') — mirror
@@ -357,16 +356,25 @@ export function createOverlayStatusEventsHandler(
     res.on('close', clearStatusInterval);
     res.on('error', clearStatusInterval);
 
-    // A failed res.write() inside broadcastToChannel's own `check()` call above evicts this
-    // response via the same connectionCleanups entry attachSseConnection just registered for it —
-    // without emitting 'close'/'error' on either req or res, so the listeners above never fire for
-    // that path. Wrap that cleanup so it also stops this interval.
+    // A failed res.write() inside broadcastToChannel's own `check()` call evicts this response via
+    // the same connectionCleanups entry attachSseConnection just registered for it — without
+    // emitting 'close'/'error' on either req or res, so the listeners above never fire for that
+    // path. Wrap that cleanup so it also stops this interval; this must happen BEFORE the first
+    // check() below runs, otherwise a failure on that very first write would find no cleanup
+    // entry left to wrap (attachSseConnection's own cleanup already deleted it) and leak the
+    // interval with nothing left to own its teardown.
     const attachCleanup = connectionCleanups.get(res);
-    if (attachCleanup) {
-      connectionCleanups.set(res, () => {
-        attachCleanup();
-        clearStatusInterval();
-      });
+    if (!attachCleanup) {
+      // attachSseConnection's connection was already torn down before we got here — nothing left
+      // to poll for.
+      clearInterval(interval);
+      return;
     }
+    connectionCleanups.set(res, () => {
+      attachCleanup();
+      clearStatusInterval();
+    });
+
+    check();
   };
 }

--- a/src/web/routes/sseChannel.ts
+++ b/src/web/routes/sseChannel.ts
@@ -64,7 +64,9 @@ export function broadcastToChannel<K>(connections: Map<K, Set<Response>>, key: K
 /** Writes the SSE handshake headers and the initial `: connected` comment. */
 function sendSseHandshake(res: Response): void {
   res.setHeader('Content-Type', 'text/event-stream');
-  res.setHeader('Cache-Control', 'no-cache');
+  // no-store (not the weaker no-cache) so no intermediary ever stores or replays a stream —
+  // several of these carry per-streamer status that must not be cached or reused across clients.
+  res.setHeader('Cache-Control', 'no-store');
   res.setHeader('Connection', 'keep-alive');
   res.setHeader('X-Accel-Buffering', 'no'); // disable Nginx buffering if behind proxy
   res.flushHeaders();
@@ -305,6 +307,12 @@ export function createOverlayStatusEventsHandler(
 ): (req: Request, res: Response) => Promise<void> {
   const { statusConnections, overlayConnections, maxPerChannel, pollIntervalMs, log } = options;
 
+  /**
+   * Route handler for one settings page's status stream: resolves the session's streamer, attaches
+   * the SSE connection, then polls `overlayConnections` for that streamer's login on an interval.
+   * @param req - Express request; reads `req.session.user`.
+   * @param res - Express response; see {@link createOverlayStatusEventsHandler}'s `@returns`.
+   */
   return async (req, res) => {
     let streamer: DbStreamerEventSub | null;
     try {
@@ -330,6 +338,7 @@ export function createOverlayStatusEventsHandler(
     const login = streamer.twitch_name.toLowerCase();
     let lastConnected: boolean | null = null;
 
+    /** Re-checks whether `login`'s overlay has any open connection, broadcasting only on a change. */
     const check = (): void => {
       const isConnected = (overlayConnections.get(login)?.size ?? 0) > 0;
       if (isConnected === lastConnected) return;
@@ -339,6 +348,12 @@ export function createOverlayStatusEventsHandler(
 
     check();
     const interval = setInterval(check, pollIntervalMs);
-    req.on('close', () => clearInterval(interval));
+    // attachSseConnection's own cleanup can be triggered by 'close'/'error' on either req or res
+    // (an abrupt socket failure can fire res's events without req ever emitting 'close') — mirror
+    // that here so this interval doesn't outlive the connection under those same paths.
+    const clearStatusInterval = (): void => clearInterval(interval);
+    req.on('close', clearStatusInterval);
+    res.on('close', clearStatusInterval);
+    res.on('error', clearStatusInterval);
   };
 }

--- a/src/web/routes/sseChannel.ts
+++ b/src/web/routes/sseChannel.ts
@@ -351,9 +351,22 @@ export function createOverlayStatusEventsHandler(
     // attachSseConnection's own cleanup can be triggered by 'close'/'error' on either req or res
     // (an abrupt socket failure can fire res's events without req ever emitting 'close') — mirror
     // that here so this interval doesn't outlive the connection under those same paths.
+    /** Idempotent teardown for this handler's poll interval, wired to every path that can end the connection below. */
     const clearStatusInterval = (): void => clearInterval(interval);
     req.on('close', clearStatusInterval);
     res.on('close', clearStatusInterval);
     res.on('error', clearStatusInterval);
+
+    // A failed res.write() inside broadcastToChannel's own `check()` call above evicts this
+    // response via the same connectionCleanups entry attachSseConnection just registered for it —
+    // without emitting 'close'/'error' on either req or res, so the listeners above never fire for
+    // that path. Wrap that cleanup so it also stops this interval.
+    const attachCleanup = connectionCleanups.get(res);
+    if (attachCleanup) {
+      connectionCleanups.set(res, () => {
+        attachCleanup();
+        clearStatusInterval();
+      });
+    }
   };
 }

--- a/views/alertsAdmin.ejs
+++ b/views/alertsAdmin.ejs
@@ -64,14 +64,16 @@
           <p class="hint mt-05">In OBS: Sources → Add → Browser → check "Local file" OFF, paste the URL above.</p>
           <div class="overlay-status">
             <span class="dot dot--offline" id="overlay-status-dot"></span>
-            <span id="overlay-status-text">Checking…</span>
+            <span id="overlay-status-text"><%= login ? 'Checking…' : 'Not connected' %></span>
           </div>
         </div>
       </div>
     </section>
 
+    <% if (login) { %>
     <script src="/sseClient.js"></script>
     <script src="/overlayConnectionStatus.js" data-events-url="/alerts/settings/events"></script>
+    <% } %>
 
     <!-- ── Per-event-type alert configuration ─────────────────────── -->
     <% const labels = { follow: 'Follow', sub: 'Sub', resub: 'Resub', giftsub: 'Gift Sub', raid: 'Raid' };

--- a/views/alertsAdmin.ejs
+++ b/views/alertsAdmin.ejs
@@ -62,9 +62,16 @@
           <% const login = streamer.twitch_name ? streamer.twitch_name.toLowerCase() : ''; %>
           <code class="mono overlay-url-display"><%= baseUrl %>/alerts/<%= login %></code>
           <p class="hint mt-05">In OBS: Sources → Add → Browser → check "Local file" OFF, paste the URL above.</p>
+          <div class="overlay-status">
+            <span class="dot dot--offline" id="overlay-status-dot"></span>
+            <span id="overlay-status-text">Checking…</span>
+          </div>
         </div>
       </div>
     </section>
+
+    <script src="/sseClient.js"></script>
+    <script src="/overlayConnectionStatus.js" data-events-url="/alerts/settings/events"></script>
 
     <!-- ── Per-event-type alert configuration ─────────────────────── -->
     <% const labels = { follow: 'Follow', sub: 'Sub', resub: 'Resub', giftsub: 'Gift Sub', raid: 'Raid' };

--- a/views/overlayAdmin.ejs
+++ b/views/overlayAdmin.ejs
@@ -62,14 +62,16 @@
           <p class="hint mt-05">In OBS: Sources → Add → Browser → check "Local file" OFF, paste the URL above.</p>
           <div class="overlay-status">
             <span class="dot dot--offline" id="overlay-status-dot"></span>
-            <span id="overlay-status-text">Checking…</span>
+            <span id="overlay-status-text"><%= login ? 'Checking…' : 'Not connected' %></span>
           </div>
         </div>
       </div>
     </section>
 
+    <% if (login) { %>
     <script src="/sseClient.js"></script>
     <script src="/overlayConnectionStatus.js" data-events-url="/overlay/settings/events"></script>
+    <% } %>
 
     <!-- ── Video Library ──────────────────────────────────────────── -->
     <section class="section">

--- a/views/overlayAdmin.ejs
+++ b/views/overlayAdmin.ejs
@@ -60,9 +60,16 @@
           <% const login = streamer.twitch_name ? streamer.twitch_name.toLowerCase() : ''; %>
           <code class="mono overlay-url-display"><%= baseUrl %>/overlay/<%= login %></code>
           <p class="hint mt-05">In OBS: Sources → Add → Browser → check "Local file" OFF, paste the URL above.</p>
+          <div class="overlay-status">
+            <span class="dot dot--offline" id="overlay-status-dot"></span>
+            <span id="overlay-status-text">Checking…</span>
+          </div>
         </div>
       </div>
     </section>
+
+    <script src="/sseClient.js"></script>
+    <script src="/overlayConnectionStatus.js" data-events-url="/overlay/settings/events"></script>
 
     <!-- ── Video Library ──────────────────────────────────────────── -->
     <section class="section">


### PR DESCRIPTION
## Summary

- Streamers previously had no way to tell from `/overlay/settings` or `/alerts/settings` whether the corresponding OBS browser source was actually loaded/connected — they'd only notice when a reward video or alert never appeared on stream.
- Adds a small live "Connected"/"Not connected" status dot to both settings pages (mirroring the existing `.dot`/`.dot--online`/`.dot--offline` convention used on the dashboard), driven by a new `GET /overlay/settings/events` and `GET /alerts/settings/events` SSE endpoint on each admin router.
- Each endpoint resolves the logged-in user's own streamer/login from the session, then polls the existing `overlaySource.ts`/`alertsOverlaySource.ts` connections maps (already populated by `attachSseConnection`) every 3s and pushes `{ connected }` only when the state actually changes.
- Scope is the reward-video overlay and alerts overlay only — the controller/gamepad overlay has no server connection to report on (it's driven by the browser Gamepad API).
- New shared client script `public/overlayConnectionStatus.js` subscribes via the existing `sseClient.js` `connectSse()` helper and toggles the dot/text.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 3398 tests passing)
- [x] `npm run lint`
- [x] `npm run check:circular`
- [ ] Manual: open `/overlay/settings` and `/alerts/settings`, confirm the dot starts "Not connected", flips to "Connected" within ~3s of opening the corresponding `/overlay/<login>` / `/alerts/<login>` browser-source URL, and flips back after closing it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MaxEDGDS5jRNXWt7N5BZyN)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live connection status indicators to overlay settings pages.
  * Status updates show “Connected” or “Not connected” in real time.
  * Added connection limits for reliable status monitoring.

* **Bug Fixes**
  * Status polling now stops when the settings page is closed or disconnected.
  * Updates are sent only when the connection state changes.
  * Improved handling of unavailable or unconfigured connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->