### PR TITLE
Suppress owner alerts and log noise for quick EventSub reconnects

### DIFF
--- a/src/discord/ownerAlerts.test.ts
+++ b/src/discord/ownerAlerts.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mockLogger } from '../test-utils/loggerMock';
 
 vi.mock('../shared/logger', () => ({ createLogger: mockLogger }));
@@ -14,6 +14,7 @@ import {
   primeOwnerAlertBaseline,
   startOwnerAlertWatcher,
   __resetOwnerAlertsForTests,
+  DOWN_ALERT_GRACE_MS,
 } from './ownerAlerts';
 
 const OWNER_ID = '111222333444555666';
@@ -35,10 +36,18 @@ async function flush(): Promise<void> {
   for (let i = 0; i < 10; i++) await Promise.resolve();
 }
 
+/** Advances the fake clock past the "down" DM's grace-period delay (see `DOWN_ALERT_GRACE_MS`
+ *  in `ownerAlerts.ts`) and flushes microtasks, so a pending down alert actually fires. */
+async function advanceGrace(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(DOWN_ALERT_GRACE_MS);
+  await flush();
+}
+
 describe('ownerAlerts', () => {
   let send: ReturnType<typeof vi.fn<(discordId: string, message: string) => Promise<void>>>;
 
   beforeEach(async () => {
+    vi.useFakeTimers();
     vi.clearAllMocks();
     __resetOwnerAlertsForTests();
     send = vi.fn().mockResolvedValue(undefined);
@@ -62,9 +71,28 @@ describe('ownerAlerts', () => {
     startOwnerAlertWatcher();
   });
 
-  it('sends exactly one alert on an ok→fail transition', async () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not alert at all on a quick reconnect that recovers within the grace period', async () => {
+    // Ensures 'db' is already a *tracked* component (as it always is in production, where
+    // primeOwnerAlertBaseline() seeds every component before the watcher ever starts) rather
+    // than one this call would see for the first time — a first-seen failing component alerts
+    // immediately (see handleFirstSeenComponent) and isn't subject to the grace period, which
+    // only debounces a transition on an already-tracked component.
+    await primeOwnerAlertBaseline();
+
     healthStore.recordDbPing(false, 'connection refused');
-    await flush();
+    await vi.advanceTimersByTimeAsync(DOWN_ALERT_GRACE_MS / 2);
+    healthStore.recordDbPing(true);
+    await advanceGrace();
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('sends exactly one alert on an ok→fail transition that outlasts the grace period', async () => {
+    healthStore.recordDbPing(false, 'connection refused');
+    await advanceGrace();
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenCalledWith(OWNER_ID, expect.stringContaining('🔴'));
     expect(send).toHaveBeenCalledWith(OWNER_ID, expect.stringContaining('connection refused'));
@@ -72,7 +100,7 @@ describe('ownerAlerts', () => {
 
   it('does not resend while still failing within the cooldown window', async () => {
     healthStore.recordDbPing(false, 'boom');
-    await flush();
+    await advanceGrace();
     expect(send).toHaveBeenCalledTimes(1);
 
     healthStore.recordDbPing(false, 'boom again');
@@ -82,7 +110,7 @@ describe('ownerAlerts', () => {
 
   it('sends a recovery alert on a fail→ok transition', async () => {
     healthStore.recordDbPing(false, 'boom');
-    await flush();
+    await advanceGrace();
     expect(send).toHaveBeenCalledTimes(1);
 
     healthStore.recordDbPing(true);
@@ -94,7 +122,7 @@ describe('ownerAlerts', () => {
   it('falls back to the last cached owner ID when findOwnerUser rejects', async () => {
     // First alert resolves normally and populates the cache.
     healthStore.recordDbPing(false, 'boom');
-    await flush();
+    await advanceGrace();
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenLastCalledWith(OWNER_ID, expect.any(String));
 
@@ -104,7 +132,7 @@ describe('ownerAlerts', () => {
 
     vi.mocked(findOwnerUser).mockRejectedValue(new Error('db down'));
     healthStore.recordDbPing(false, 'boom again');
-    await flush();
+    await advanceGrace();
 
     expect(send).toHaveBeenCalledTimes(3);
     expect(send).toHaveBeenLastCalledWith(OWNER_ID, expect.any(String));
@@ -118,14 +146,14 @@ describe('ownerAlerts', () => {
     __resetOwnerAlertsForTests();
     vi.mocked(findOwnerUser).mockRejectedValue(new Error('db down'));
     healthStore.recordDbPing(false, 'boom');
-    await flush();
+    await advanceGrace();
     expect(send).not.toHaveBeenCalled();
   });
 
   it('treats a successful lookup that returns no owner as authoritative — does not fall back to a stale cached id', async () => {
     // First alert resolves normally and populates the cache.
     healthStore.recordDbPing(false, 'boom');
-    await flush();
+    await advanceGrace();
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenLastCalledWith(OWNER_ID, expect.any(String));
 
@@ -137,7 +165,7 @@ describe('ownerAlerts', () => {
     vi.mocked(findOwnerUser).mockResolvedValue(null);
     send.mockClear();
     healthStore.recordDbPing(false, 'boom again');
-    await flush();
+    await advanceGrace();
 
     expect(send).not.toHaveBeenCalled();
   });
@@ -145,13 +173,13 @@ describe('ownerAlerts', () => {
   it('never throws when the runtime send itself rejects', async () => {
     send.mockRejectedValue(new Error('DM failed — user has DMs disabled'));
     healthStore.recordDbPing(false, 'boom');
-    await expect(flush()).resolves.toBeUndefined();
+    await expect(advanceGrace()).resolves.toBeUndefined();
   });
 
   it('does not send a false recovery DM when the down DM itself failed to deliver', async () => {
     send.mockRejectedValue(new Error('DM failed — user has DMs disabled'));
     healthStore.recordDbPing(false, 'boom');
-    await flush();
+    await advanceGrace();
     expect(send).toHaveBeenCalledTimes(1); // the (failed) down DM attempt
 
     send.mockClear();
@@ -168,7 +196,7 @@ describe('ownerAlerts', () => {
     // skip the down DM for lack of a resolvable owner, which must not count as delivered.
     vi.mocked(findOwnerUser).mockResolvedValue(null);
     healthStore.recordDbPing(false, 'boom');
-    await flush();
+    await advanceGrace();
     expect(send).not.toHaveBeenCalled();
 
     healthStore.recordDbPing(true);
@@ -180,7 +208,7 @@ describe('ownerAlerts', () => {
   it('alerts on an EventSub streamer disconnecting, naming the streamer', async () => {
     try {
       healthStore.recordEventSubConnected('streamerX', false, 'socket closed');
-      await flush();
+      await advanceGrace();
 
       expect(send).toHaveBeenCalledWith(OWNER_ID, expect.stringContaining('eventsub:streamerX'));
       expect(send).toHaveBeenCalledWith(OWNER_ID, expect.stringContaining('socket closed'));
@@ -196,7 +224,7 @@ describe('ownerAlerts', () => {
   it('alerts on a scheduler run failing, naming the scheduler', async () => {
     try {
       healthStore.recordSchedulerRun('counter', false, 'archive failed');
-      await flush();
+      await advanceGrace();
 
       expect(send).toHaveBeenCalledWith(OWNER_ID, expect.stringContaining('scheduler:counter'));
       expect(send).toHaveBeenCalledWith(OWNER_ID, expect.stringContaining('archive failed'));
@@ -210,10 +238,9 @@ describe('ownerAlerts', () => {
   });
 
   it('re-alerts "still down" once the cooldown window has elapsed for a component that never recovered', async () => {
-    vi.useFakeTimers();
     try {
       healthStore.recordDbPing(false, 'boom');
-      await flush();
+      await advanceGrace();
       expect(send).toHaveBeenCalledTimes(1);
 
       // Still failing, but re-notified with a distinct DB error — before the cooldown elapses
@@ -226,7 +253,6 @@ describe('ownerAlerts', () => {
       expect(send).toHaveBeenCalledTimes(2);
       expect(send).toHaveBeenLastCalledWith(OWNER_ID, expect.stringContaining('is still down'));
     } finally {
-      vi.useRealTimers();
       healthStore.recordDbPing(true);
       await flush();
     }
@@ -258,12 +284,22 @@ describe('primeOwnerAlertBaseline', () => {
     for (let i = 0; i < 10; i++) await Promise.resolve();
   }
 
+  async function advanceGrace(): Promise<void> {
+    await vi.advanceTimersByTimeAsync(DOWN_ALERT_GRACE_MS);
+    await flush();
+  }
+
   beforeEach(() => {
+    vi.useFakeTimers();
     vi.clearAllMocks();
     __resetOwnerAlertsForTests();
     send = vi.fn().mockResolvedValue(undefined);
     registerOwnerAlertRuntime({ send });
     vi.mocked(findOwnerUser).mockResolvedValue(OWNER_ROW as any);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('seeds the baseline from a currently-unhealthy component without alerting', async () => {
@@ -290,7 +326,7 @@ describe('primeOwnerAlertBaseline', () => {
 
     // A genuine later failure, though, must still alert normally.
     healthStore.recordTwitchChatConnected(false);
-    await flush();
+    await advanceGrace();
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenCalledWith(OWNER_ID, expect.stringContaining('🔴'));
 
@@ -312,7 +348,7 @@ describe('primeOwnerAlertBaseline', () => {
 
     vi.mocked(findOwnerUser).mockRejectedValue(new Error('db down'));
     healthStore.recordDbPing(false, 'connection refused');
-    await flush();
+    await advanceGrace();
 
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenCalledWith(OWNER_ID, expect.stringContaining('connection refused'));
@@ -349,7 +385,7 @@ describe('primeOwnerAlertBaseline', () => {
     // An unrelated transition must not trigger a false "discord recovered" alert from a stale
     // (pre-connect) baseline.
     healthStore.recordDbPing(false, 'boom');
-    await flush();
+    await advanceGrace();
 
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenCalledWith(OWNER_ID, expect.stringContaining('db is down'));

--- a/src/discord/ownerAlerts.ts
+++ b/src/discord/ownerAlerts.ts
@@ -31,6 +31,13 @@ export function registerOwnerAlertRuntime(runtime: OwnerAlertRuntime): void {
 /** How long a component may keep re-alerting while it stays in the failing state, before this watcher sends another notification. */
 const REALERT_COOLDOWN_MS = 30 * 60_000;
 
+/**
+ * How long a component must stay failing before this watcher sends a "down" DM at all — a
+ * quick reconnect (e.g. a brief EventSub WebSocket blip) that resolves within this window never
+ * generates a "down"/"recovered" DM pair.
+ */
+export const DOWN_ALERT_GRACE_MS = 60_000;
+
 /** Per-component edge-trigger state tracked across health-changed notifications. */
 interface ComponentAlertState {
   failing: boolean;
@@ -50,6 +57,13 @@ interface ComponentAlertState {
    * current.
    */
   generation: number;
+  /**
+   * Handle for the pending {@link DOWN_ALERT_GRACE_MS} grace-period timer started on an ok→fail
+   * transition, or null once it has fired or been cancelled by a recovery within the window. Kept
+   * so a fail→ok transition during the grace window can cancel it — suppressing the "down" DM
+   * entirely for a quick reconnect.
+   */
+  pendingDownTimer: NodeJS.Timeout | null;
 }
 
 const componentStates = new Map<string, ComponentAlertState>();
@@ -233,7 +247,13 @@ function dispatchDownAlert(componentId: string, error: string | null, state: Com
  */
 function handleFirstSeenComponent(componentId: string, ok: boolean, error: string | null): void {
   const now = Date.now();
-  const state: ComponentAlertState = { failing: !ok, lastAlertAt: ok ? 0 : now, downAlertSent: false, generation: 0 };
+  const state: ComponentAlertState = {
+    failing: !ok,
+    lastAlertAt: ok ? 0 : now,
+    downAlertSent: false,
+    generation: 0,
+    pendingDownTimer: null,
+  };
   componentStates.set(componentId, state);
   if (!ok) {
     dispatchDownAlert(componentId, error, state, false);
@@ -256,10 +276,16 @@ function handleTrackedComponent(componentId: string, ok: boolean, error: string 
   if (ok && existing.failing) {
     existing.failing = false;
     existing.lastAlertAt = now;
+    // Cancel a still-pending grace-period timer — the component recovered before it ever fired,
+    // so this was a quick reconnect: no "down" DM was sent, and none will be now.
+    if (existing.pendingDownTimer) {
+      clearTimeout(existing.pendingDownTimer);
+      existing.pendingDownTimer = null;
+    }
     // Only announce a recovery if a "down" DM was actually delivered for this failure — otherwise
     // this is a component that was merely seeded as failing at startup (e.g. twitchChat, before
-    // startTwitchBot() has run), or whose down DM never reached the owner, finishing its normal
-    // startup rather than undergoing a real recovery.
+    // startTwitchBot() has run), whose down DM never reached the owner, or that recovered within
+    // the grace period, finishing its normal startup/blip rather than undergoing a real recovery.
     const wasAlerted = existing.downAlertSent;
     existing.downAlertSent = false;
     // Bump the generation so a still-in-flight down-DM delivery from this now-ended episode can't
@@ -273,7 +299,17 @@ function handleTrackedComponent(componentId: string, ok: boolean, error: string 
     existing.lastAlertAt = now;
     existing.downAlertSent = false;
     existing.generation += 1;
-    dispatchDownAlert(componentId, error, existing, false);
+    const generation = existing.generation;
+    // Delay the "down" DM by the grace period rather than sending immediately — a component that
+    // recovers before this fires (see the `ok && existing.failing` branch above, which cancels
+    // this timer) was just a quick reconnect, and gets no DM at all.
+    existing.pendingDownTimer = setTimeout(() => {
+      const current = componentStates.get(componentId);
+      if (!current || current.generation !== generation) return;
+      current.pendingDownTimer = null;
+      const latestError = deriveComponentOks(getHealthSnapshot()).get(componentId)?.error ?? error;
+      dispatchDownAlert(componentId, latestError, current, false);
+    }, DOWN_ALERT_GRACE_MS);
   } else if (!ok && existing.failing && now - existing.lastAlertAt > REALERT_COOLDOWN_MS) {
     existing.lastAlertAt = now;
     dispatchDownAlert(componentId, error, existing, true);
@@ -324,7 +360,7 @@ export async function primeOwnerAlertBaseline(): Promise<void> {
     // downAlertSent starts false even for a component seeded as already-failing (e.g. twitchChat,
     // before startTwitchBot() has run) — no "down" DM was actually sent for this baseline state,
     // so its later recovery must not fire a "recovered" DM either. See handleHealthChanged.
-    componentStates.set(componentId, { failing: !ok, lastAlertAt: now, downAlertSent: false, generation: 0 });
+    componentStates.set(componentId, { failing: !ok, lastAlertAt: now, downAlertSent: false, generation: 0, pendingDownTimer: null });
   }
 }
 
@@ -342,6 +378,9 @@ export function startOwnerAlertWatcher(): void {
 
 /** Test-only: resets all module state so each test starts from a clean slate. */
 export function __resetOwnerAlertsForTests(): void {
+  for (const state of componentStates.values()) {
+    if (state.pendingDownTimer) clearTimeout(state.pendingDownTimer);
+  }
   componentStates.clear();
   cachedOwnerDiscordId = null;
   watcherStarted = false;

--- a/src/discord/ownerAlerts.ts
+++ b/src/discord/ownerAlerts.ts
@@ -309,13 +309,22 @@ function handleNewFailure(componentId: string, error: string | null, existing: C
   existing.downAlertSent = false;
   existing.generation += 1;
   const generation = existing.generation;
-  existing.pendingDownTimer = setTimeout(() => {
+  /**
+   * Fires once {@link DOWN_ALERT_GRACE_MS} elapses: no-ops if the component's tracked state is
+   * gone or has moved past this failure episode (recovered, or recovered and failed again — see
+   * {@link ComponentAlertState.generation}), otherwise re-derives the error from a fresh health
+   * snapshot (falling back to `error` as read at transition time, in case the snapshot no longer
+   * has one for this component) and dispatches the "down" DM via {@link dispatchDownAlert}.
+   * @returns void.
+   */
+  const dispatchDelayedDownAlert = (): void => {
     const current = componentStates.get(componentId);
     if (!current || current.generation !== generation) return;
     current.pendingDownTimer = null;
     const latestError = deriveComponentOks(getHealthSnapshot()).get(componentId)?.error ?? error;
     dispatchDownAlert(componentId, latestError, current, false);
-  }, DOWN_ALERT_GRACE_MS);
+  };
+  existing.pendingDownTimer = setTimeout(dispatchDelayedDownAlert, DOWN_ALERT_GRACE_MS);
 }
 
 /**

--- a/src/discord/ownerAlerts.ts
+++ b/src/discord/ownerAlerts.ts
@@ -261,9 +261,68 @@ function handleFirstSeenComponent(componentId: string, ok: boolean, error: strin
 }
 
 /**
+ * Handles a fail→ok transition: cancels a still-pending grace-period timer (the component
+ * recovered before it ever fired, so this was a quick reconnect — no "down" DM was sent, and
+ * none will be now), then announces the recovery only if a "down" DM was actually delivered for
+ * this failure — otherwise this is a component that was merely seeded as failing at startup
+ * (e.g. twitchChat, before startTwitchBot() has run), whose down DM never reached the owner, or
+ * that recovered within the grace period, finishing its normal startup/blip rather than
+ * undergoing a real recovery.
+ * @param componentId - The component's stable id (see {@link deriveComponentOks}).
+ * @param existing - The component's tracked alert state, mutated in place.
+ * @param now - The current timestamp, as already read by the caller.
+ * @returns void.
+ */
+function handleRecovery(componentId: string, existing: ComponentAlertState, now: number): void {
+  existing.failing = false;
+  existing.lastAlertAt = now;
+  if (existing.pendingDownTimer) {
+    clearTimeout(existing.pendingDownTimer);
+    existing.pendingDownTimer = null;
+  }
+  const wasAlerted = existing.downAlertSent;
+  existing.downAlertSent = false;
+  // Bump the generation so a still-in-flight down-DM delivery from this now-ended episode can't
+  // resurrect downAlertSent (via dispatchDownAlert's delayed .then()) after this recovery.
+  existing.generation += 1;
+  if (wasAlerted) {
+    void sendOwnerAlert(`✅ ${componentId} recovered`);
+  }
+}
+
+/**
+ * Handles an ok→fail transition: marks the component failing and schedules its "down" DM after
+ * {@link DOWN_ALERT_GRACE_MS} rather than sending immediately — a component that recovers before
+ * this timer fires (see {@link handleRecovery}, which cancels it) was just a quick reconnect, and
+ * gets no DM at all. Re-derives the error message from a fresh health snapshot when the timer
+ * fires, in case it changed during the grace window.
+ * @param componentId - The component's stable id (see {@link deriveComponentOks}).
+ * @param error - The component's error message as of this transition, used as a fallback if a
+ *   fresh snapshot read (once the timer fires) no longer has one for this component.
+ * @param existing - The component's tracked alert state, mutated in place.
+ * @param now - The current timestamp, as already read by the caller.
+ * @returns void.
+ */
+function handleNewFailure(componentId: string, error: string | null, existing: ComponentAlertState, now: number): void {
+  existing.failing = true;
+  existing.lastAlertAt = now;
+  existing.downAlertSent = false;
+  existing.generation += 1;
+  const generation = existing.generation;
+  existing.pendingDownTimer = setTimeout(() => {
+    const current = componentStates.get(componentId);
+    if (!current || current.generation !== generation) return;
+    current.pendingDownTimer = null;
+    const latestError = deriveComponentOks(getHealthSnapshot()).get(componentId)?.error ?? error;
+    dispatchDownAlert(componentId, latestError, current, false);
+  }, DOWN_ALERT_GRACE_MS);
+}
+
+/**
  * Reacts to one component's latest ok/fail state against its previously tracked state: sends an
- * edge-triggered DM alert on a fail→ok or ok→fail transition, or a "still down" DM once the
- * {@link REALERT_COOLDOWN_MS} cooldown has elapsed for a component that's stayed failing.
+ * edge-triggered DM alert on a fail→ok or ok→fail transition (see {@link handleRecovery} and
+ * {@link handleNewFailure}), or a "still down" DM once the {@link REALERT_COOLDOWN_MS} cooldown
+ * has elapsed for a component that's stayed failing.
  * @param componentId - The component's stable id (see {@link deriveComponentOks}).
  * @param ok - Whether the component is currently healthy.
  * @param error - The component's current error message, if failing.
@@ -274,42 +333,9 @@ function handleTrackedComponent(componentId: string, ok: boolean, error: string 
   const now = Date.now();
 
   if (ok && existing.failing) {
-    existing.failing = false;
-    existing.lastAlertAt = now;
-    // Cancel a still-pending grace-period timer — the component recovered before it ever fired,
-    // so this was a quick reconnect: no "down" DM was sent, and none will be now.
-    if (existing.pendingDownTimer) {
-      clearTimeout(existing.pendingDownTimer);
-      existing.pendingDownTimer = null;
-    }
-    // Only announce a recovery if a "down" DM was actually delivered for this failure — otherwise
-    // this is a component that was merely seeded as failing at startup (e.g. twitchChat, before
-    // startTwitchBot() has run), whose down DM never reached the owner, or that recovered within
-    // the grace period, finishing its normal startup/blip rather than undergoing a real recovery.
-    const wasAlerted = existing.downAlertSent;
-    existing.downAlertSent = false;
-    // Bump the generation so a still-in-flight down-DM delivery from this now-ended episode can't
-    // resurrect downAlertSent (via dispatchDownAlert's delayed .then()) after this recovery.
-    existing.generation += 1;
-    if (wasAlerted) {
-      void sendOwnerAlert(`✅ ${componentId} recovered`);
-    }
+    handleRecovery(componentId, existing, now);
   } else if (!ok && !existing.failing) {
-    existing.failing = true;
-    existing.lastAlertAt = now;
-    existing.downAlertSent = false;
-    existing.generation += 1;
-    const generation = existing.generation;
-    // Delay the "down" DM by the grace period rather than sending immediately — a component that
-    // recovers before this fires (see the `ok && existing.failing` branch above, which cancels
-    // this timer) was just a quick reconnect, and gets no DM at all.
-    existing.pendingDownTimer = setTimeout(() => {
-      const current = componentStates.get(componentId);
-      if (!current || current.generation !== generation) return;
-      current.pendingDownTimer = null;
-      const latestError = deriveComponentOks(getHealthSnapshot()).get(componentId)?.error ?? error;
-      dispatchDownAlert(componentId, latestError, current, false);
-    }, DOWN_ALERT_GRACE_MS);
+    handleNewFailure(componentId, error, existing, now);
   } else if (!ok && existing.failing && now - existing.lastAlertAt > REALERT_COOLDOWN_MS) {
     existing.lastAlertAt = now;
     dispatchDownAlert(componentId, error, existing, true);

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
@@ -473,6 +473,10 @@ describe('subscribeForStreamer', () => {
     // must exclude this id too (not just session-mismatch deletions), or it would be deleted twice.
     expect(deleteEventSubSubscription).toHaveBeenCalledTimes(1);
     expect(count).toBeGreaterThan(0);
+    // Still bound to the *live* session but not enabled — a genuine anomaly, not something a
+    // reconnect explains, so this must be logged at WARN rather than the routine-cleanup INFO.
+    expect(logMock.warn).toHaveBeenCalledWith(expect.stringContaining('sub-revoked-follow'));
+    expect(logMock.info).not.toHaveBeenCalledWith(expect.stringContaining('sub-revoked-follow'));
   });
 
   it('does not mistake a same-type, same-broadcaster subscription with a different condition for the desired one', async () => {
@@ -537,6 +541,9 @@ describe('subscribeForStreamer', () => {
     // Only deleted once — the reused own-subscriptions listing must not let the later stale-cleanup
     // pass attempt to delete the same id a second time (it was already removed above).
     expect(deleteEventSubSubscription).toHaveBeenCalledTimes(1);
+    // Bound to a different (prior) session — routine post-reconnect cleanup, not an anomaly.
+    expect(logMock.info).toHaveBeenCalledWith(expect.stringContaining('sub-dead-follow'));
+    expect(logMock.warn).not.toHaveBeenCalledWith(expect.stringContaining('sub-dead-follow'));
   });
 
   it('retries a stale-session delete in the same round if the recreation delete attempt failed', async () => {

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -211,7 +211,9 @@ async function listOwnSubscriptions(
  * to the live session yet not `enabled` (e.g. `authorization_revoked`, `notification_failures_exceeded`),
  * in which case it isn't actually receiving notifications and must not be counted as live — deletes
  * one that's stale (bound to a different session, or not enabled) before recreating it, or creates
- * fresh if none exists.
+ * fresh if none exists. Logs the deletion at WARN when it's still bound to the live session (a
+ * genuine anomaly), or at INFO when it's bound to a different session (routine post-reconnect
+ * cleanup — see {@link deleteStaleSubscriptions}).
  * @returns The live subscription's id (or null if creation failed — see {@link subscribe}), and
  *   whether a stale `existing` subscription was actually deleted here — `false` on a failed delete
  *   attempt, so the caller knows not to treat that id as already gone (it must remain eligible for
@@ -224,11 +226,17 @@ async function ensureSubscription(
   if (existing && existing.sessionId === sessionId && existing.status === 'enabled') return { id: existing.id, deleted: false };
   let deleted = false;
   if (existing) {
-    // INFO, not WARN: every non-graceful reconnect (see forceReconnect in
-    // twitchEventSubConnection.ts) starts a brand-new session, so *all* of the previous
-    // session's subscriptions are legitimately "stale" here — this fires routinely on every
-    // such reconnect, not just on an actual anomaly.
-    log.info(`Deleting stale ${spec.type} subscription (${existing.id}) for ${name} — bound to a different session or not enabled (status=${existing.status})`);
+    if (existing.sessionId === sessionId) {
+      // WARN: still bound to the *live* session yet not enabled (e.g. `authorization_revoked`,
+      // `notification_failures_exceeded`) — a genuine anomaly, not something a reconnect explains.
+      log.warn(`Deleting ${spec.type} subscription (${existing.id}) for ${name} — bound to the live session but not enabled (status=${existing.status})`);
+    } else {
+      // INFO, not WARN: every non-graceful reconnect (see forceReconnect in
+      // twitchEventSubConnection.ts) starts a brand-new session, so *all* of the previous
+      // session's subscriptions are legitimately "stale" here — this fires routinely on every
+      // such reconnect, not just on an actual anomaly.
+      log.info(`Deleting stale ${spec.type} subscription (${existing.id}) for ${name} — bound to a different session (status=${existing.status})`);
+    }
     try {
       await deleteEventSubSubscription(existing.id, token);
       deleted = true;

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -224,7 +224,11 @@ async function ensureSubscription(
   if (existing && existing.sessionId === sessionId && existing.status === 'enabled') return { id: existing.id, deleted: false };
   let deleted = false;
   if (existing) {
-    log.warn(`Deleting stale ${spec.type} subscription (${existing.id}) for ${name} — bound to a different session or not enabled (status=${existing.status})`);
+    // INFO, not WARN: every non-graceful reconnect (see forceReconnect in
+    // twitchEventSubConnection.ts) starts a brand-new session, so *all* of the previous
+    // session's subscriptions are legitimately "stale" here — this fires routinely on every
+    // such reconnect, not just on an actual anomaly.
+    log.info(`Deleting stale ${spec.type} subscription (${existing.id}) for ${name} — bound to a different session or not enabled (status=${existing.status})`);
     try {
       await deleteEventSubSubscription(existing.id, token);
       deleted = true;


### PR DESCRIPTION
## Summary
- `ownerAlerts`: a "down" DM for a tracked component is now delayed by a 60s grace period. A fail→ok transition within that window cancels the pending timer, so a quick reconnect (e.g. an EventSub WebSocket error that reconnects seconds later) no longer produces a "down"/"recovered" DM pair to the bot owner.
- `twitchEventSubSubscriptions`: downgraded the "Deleting stale ... subscription" log from WARN to INFO. Every non-graceful EventSub reconnect starts a brand-new session, so *all* prior subscriptions are legitimately stale and get recreated — this fires routinely on every such reconnect, not just on an actual anomaly, so it shouldn't read as a warning in the logs.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 3404 tests passing)
- [x] `npm run lint` (no new warnings/errors)
- [x] Added/updated Vitest coverage in `ownerAlerts.test.ts` for the new grace-period debounce (including a dedicated "quick reconnect within the grace period sends nothing" test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAKNC2FGGq1F2zjdErmo4o

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAKNC2FGGq1F2zjdErmo4o)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a 60-second grace period before sending component outage alerts.
  - Quick recoveries no longer trigger unnecessary outage and recovery notifications.
  - Alert errors are refreshed before delayed notifications are sent.

- **Bug Fixes**
  - Prevented false recovery notifications when sending an outage alert fails.
  - Improved handling and logging of routine stale subscription cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->