### PR TITLE
Guard !health channel ack reply against deleted-message errors

### DIFF
--- a/src/commands/healthCommandHandler.test.ts
+++ b/src/commands/healthCommandHandler.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { mockLogger } from '../test-utils/loggerMock';
 
-vi.mock('../shared/logger', () => ({ createLogger: mockLogger }));
+// A stable logger instance (unlike `mockLogger()`, which returns a fresh object per call) so
+// tests can assert on the same `log.error` spy the module-scoped `log` in healthCommandHandler.ts
+// was created with.
+const { log } = vi.hoisted(() => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+vi.mock('../shared/logger', () => ({ createLogger: () => log }));
 
 vi.mock('../db', () => ({
   findOwnerUser: vi.fn(),
@@ -110,6 +115,7 @@ describe('executeHealthCommandForDiscord', () => {
 
     await expect(executeHealthCommandForDiscord(message as any)).resolves.toBeUndefined();
     expect(message.author.send).toHaveBeenCalledOnce();
+    expect(log.error).not.toHaveBeenCalled();
   });
 
   it('logs (but does not throw) when the channel ack fails with a non-not-found error', async () => {
@@ -119,6 +125,7 @@ describe('executeHealthCommandForDiscord', () => {
 
     await expect(executeHealthCommandForDiscord(message as any)).resolves.toBeUndefined();
     expect(message.author.send).toHaveBeenCalledOnce();
+    expect(log.error).toHaveBeenCalledWith('Failed to acknowledge !health command in channel:', expect.any(Error));
   });
 
   it('logs and swallows a failed DM (e.g. DMs closed) instead of throwing, without posting a channel ack', async () => {

--- a/src/commands/healthCommandHandler.test.ts
+++ b/src/commands/healthCommandHandler.test.ts
@@ -11,9 +11,14 @@ vi.mock('../shared/healthStore', () => ({
   getHealthSnapshot: vi.fn(),
 }));
 
+vi.mock('../discord/discordUtils', () => ({
+  isDiscordNotFoundError: vi.fn().mockReturnValue(false),
+}));
+
 import { executeHealthCommandForDiscord } from './healthCommandHandler';
 import { findOwnerUser } from '../db';
 import { getHealthSnapshot } from '../shared/healthStore';
+import { isDiscordNotFoundError } from '../discord/discordUtils';
 
 const OWNER_ID = '111222333444555666';
 const OWNER_ROW = {
@@ -96,6 +101,15 @@ describe('executeHealthCommandForDiscord', () => {
     const replyText = message.reply.mock.calls[0][0] as string;
     expect(replyText).not.toContain('Bot Health');
     expect(replyText).not.toContain('DB');
+  });
+
+  it('swallows a Discord not-found error on the channel ack without throwing', async () => {
+    vi.mocked(isDiscordNotFoundError).mockReturnValue(true);
+    const message = makeMockMessage('!health', OWNER_ID, { guild: { id: 'guild-1' } });
+    message.reply.mockRejectedValue(new Error('Unknown message'));
+
+    await expect(executeHealthCommandForDiscord(message as any)).resolves.toBeUndefined();
+    expect(message.author.send).toHaveBeenCalledOnce();
   });
 
   it('logs and swallows a failed DM (e.g. DMs closed) instead of throwing, without posting a channel ack', async () => {

--- a/src/commands/healthCommandHandler.test.ts
+++ b/src/commands/healthCommandHandler.test.ts
@@ -112,6 +112,15 @@ describe('executeHealthCommandForDiscord', () => {
     expect(message.author.send).toHaveBeenCalledOnce();
   });
 
+  it('logs (but does not throw) when the channel ack fails with a non-not-found error', async () => {
+    vi.mocked(isDiscordNotFoundError).mockReturnValue(false);
+    const message = makeMockMessage('!health', OWNER_ID, { guild: { id: 'guild-1' } });
+    message.reply.mockRejectedValue(new Error('Missing Permissions'));
+
+    await expect(executeHealthCommandForDiscord(message as any)).resolves.toBeUndefined();
+    expect(message.author.send).toHaveBeenCalledOnce();
+  });
+
   it('logs and swallows a failed DM (e.g. DMs closed) instead of throwing, without posting a channel ack', async () => {
     const message = makeMockMessage('!health', OWNER_ID, { guild: { id: 'guild-1' } });
     message.author.send.mockRejectedValue(new Error('Cannot send messages to this user'));

--- a/src/commands/healthCommandHandler.ts
+++ b/src/commands/healthCommandHandler.ts
@@ -3,6 +3,7 @@ import { createLogger } from '../shared/logger';
 import { extractCommand } from './commandUtils';
 import { findOwnerUser } from '../db';
 import { getHealthSnapshot, type HealthSnapshot } from '../shared/healthStore';
+import { isDiscordNotFoundError } from '../discord/discordUtils';
 
 const log = createLogger('HealthCommand');
 
@@ -110,7 +111,8 @@ function formatHealthSummary(snapshot: HealthSnapshot): string {
  * was triggered from, since the summary includes DB/EventSub/scheduler/recent-error details.
  * When triggered from a guild channel, also posts a minimal, non-sensitive acknowledgement reply
  * there so the owner knows to check their DMs. If the DM itself fails (e.g. the owner has DMs
- * closed), that's logged and swallowed rather than thrown.
+ * closed), that's logged and swallowed rather than thrown. The acknowledgement reply is likewise
+ * swallowed on failure (e.g. the triggering message was deleted before it could be sent).
  * @param message - The Discord message to check and, if it's an owner-issued `!health`, respond to.
  * @returns Resolves once the command has been handled (or ignored as a non-match).
  */
@@ -134,6 +136,12 @@ export async function executeHealthCommandForDiscord(message: Message): Promise<
   }
 
   if (message.guild) {
-    await message.reply('📬 Sent you the health report via DM.');
+    try {
+      await message.reply('📬 Sent you the health report via DM.');
+    } catch (err) {
+      if (!isDiscordNotFoundError(err)) {
+        log.error('Failed to acknowledge !health command in channel:', err);
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
Part of a full-codebase review (see companion PRs for DB layer, Discord/Twitch, web server, and shared utils). This one covers `src/commands/` and `src/audio/`.

- `healthCommandHandler.ts`'s in-channel acknowledgement reply (sent after a successful `!health` DM) is now wrapped in the same try/catch + `isDiscordNotFoundError` filtering used by every other Discord reply in this codebase (e.g. `counterHandler.ts`). Previously, if the triggering message was deleted between the DM send and this reply, the failure surfaced as a raw, log-noisy error instead of being silently filtered like the equivalent case elsewhere.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 3415 tests passed)
- [x] `npx eslint src/commands src/audio` — clean (only pre-existing, unrelated warnings)
- [x] Added a test covering the swallowed not-found error on the channel ack reply

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01TDtW3qZoB9mK7frNPgE34G

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDtW3qZoB9mK7frNPgE34G)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the `!health` command’s resilience when its acknowledgement reply cannot be sent.
  * The health notification is still delivered to the owner even if the triggering message is unavailable or another reply error occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->