### PR TITLE
Use constant-time comparison for OAuth state; fix middleware-order doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Boot order in `main()`: verify DB connectivity (ping, exit 1 on failure) → wir
 
 ## Web Server (`src/web/server.ts`)
 
-Middleware order: `helmet` (custom CSP) → EJS views → static → rate limiters (general/streamdeck/session) → body parsers → `trust proxy: 1` → session (`express-mysql-session`, backed by the `sessions` MySQL table) → `res.locals.user`/csrfToken.
+Middleware order: `helmet` (custom CSP) → EJS views → static → body parsers → `trust proxy: 1` → session (`express-mysql-session`, backed by the `sessions` MySQL table) → rate limiters (general/session; `streamdeckLimiter` is applied per-route instead) → `res.locals.user`/csrfToken. The general/session rate limiters run after session middleware deliberately — `sessionLimiter`'s key generator needs `req.session` populated.
 
 Auth middleware (`src/web/middleware.ts`), applied in this order:
 1. **`requireAuth`** — session check.

--- a/src/web/routes/auth.test.ts
+++ b/src/web/routes/auth.test.ts
@@ -125,6 +125,20 @@ describe('GET /discord/callback', () => {
     expect(res.status).toBe(400);
   });
 
+  it('renders error 400 (not a 500 crash) when state is tampered into an array', async () => {
+    const res = await supertest(buildApp({ oauthState: { value: 'abc', expiresAt: Date.now() + 60_000 } }))
+      .get('/discord/callback?code=code&state=abc&state=def');
+    expect(res.status).toBe(400);
+    expect((res.body as any).view).toBe('error');
+  });
+
+  it('renders error 400 (not a 500 crash) when code is tampered into an array', async () => {
+    const res = await supertest(buildApp({ oauthState: { value: 'state123', expiresAt: Date.now() + 60_000 } }))
+      .get('/discord/callback?code=a&code=b&state=state123');
+    expect(res.status).toBe(400);
+    expect((res.body as any).view).toBe('error');
+  });
+
   it('renders error 400 when OAuth state has expired', async () => {
     const res = await supertest(buildApp({ oauthState: { value: 'state123', expiresAt: Date.now() - 1 } }))
       .get('/discord/callback?code=code&state=state123');

--- a/src/web/routes/auth.test.ts
+++ b/src/web/routes/auth.test.ts
@@ -112,6 +112,13 @@ describe('GET /discord/callback', () => {
     expect((res.body as any).view).toBe('error');
   });
 
+  it('renders error 400 when state is the same length as the stored value but does not match', async () => {
+    const res = await supertest(buildApp({ oauthState: { value: 'state123', expiresAt: Date.now() + 60_000 } }))
+      .get('/discord/callback?code=abc&state=state999');
+    expect(res.status).toBe(400);
+    expect((res.body as any).view).toBe('error');
+  });
+
   it('renders error 400 when code is missing', async () => {
     const res = await supertest(buildApp({ oauthState: { value: 'abc', expiresAt: Date.now() + 60_000 } }))
       .get('/discord/callback?state=abc');

--- a/src/web/routes/auth.test.ts
+++ b/src/web/routes/auth.test.ts
@@ -119,6 +119,17 @@ describe('GET /discord/callback', () => {
     expect((res.body as any).view).toBe('error');
   });
 
+  it('renders error 400 (not a 500 crash) when state has the same JS string length as the stored value but a different UTF-8 byte length', async () => {
+    // 'staté123' has 8 UTF-16 code units (same as the 8-char stored value below), but 9 UTF-8
+    // bytes since 'é' is 2 bytes — this used to make timingSafeEqual throw instead of returning false.
+    const submitted = 'staté123';
+    const res = await supertest(buildApp({ oauthState: { value: 'state123', expiresAt: Date.now() + 60_000 } })).get(
+      `/discord/callback?code=abc&state=${encodeURIComponent(submitted)}`,
+    );
+    expect(res.status).toBe(400);
+    expect((res.body as any).view).toBe('error');
+  });
+
   it('renders error 400 when code is missing', async () => {
     const res = await supertest(buildApp({ oauthState: { value: 'abc', expiresAt: Date.now() + 60_000 } }))
       .get('/discord/callback?state=abc');

--- a/src/web/routes/auth.ts
+++ b/src/web/routes/auth.ts
@@ -26,6 +26,18 @@ const router = Router();
 /** Error codes `GET /auth/login` accepts via `?error=`, both originating from `POST /guild/select`. */
 const LOGIN_KNOWN_ERRORS = new Set(['user_not_found', 'no_guilds']);
 
+/**
+ * Constant-time comparison of the submitted OAuth `state` against the session's stored value
+ * (see `GET /discord` below, which generates it as a fixed-length hex string), mirroring
+ * `csrf.ts`'s `timingSafeEqual` comparison for CSRF tokens. The length check up front doesn't
+ * leak anything — the expected length is public — it just guarantees the buffers passed to
+ * `timingSafeEqual` are the same size, which it requires.
+ */
+function oauthStateMatches(submitted: string, stored: string): boolean {
+  if (submitted.length !== stored.length) return false;
+  return crypto.timingSafeEqual(Buffer.from(submitted, 'utf8'), Buffer.from(stored, 'utf8'));
+}
+
 // ─── Redirect to Discord OAuth2 ─────────────────────────────────────────────
 
 /**
@@ -81,7 +93,7 @@ router.get('/discord/callback', async (req, res) => {
 
   const storedOAuth = req.session.oauthState;
   delete req.session.oauthState;
-  const stateValid = !!storedOAuth && state === storedOAuth.value && Date.now() <= storedOAuth.expiresAt;
+  const stateValid = !!storedOAuth && !!state && oauthStateMatches(state, storedOAuth.value) && Date.now() <= storedOAuth.expiresAt;
   if (!code || !state || !stateValid) {
     return renderError(res, 400, 'Invalid OAuth2 state — please try logging in again.', undefined);
   }

--- a/src/web/routes/auth.ts
+++ b/src/web/routes/auth.ts
@@ -29,13 +29,18 @@ const LOGIN_KNOWN_ERRORS = new Set(['user_not_found', 'no_guilds']);
 /**
  * Constant-time comparison of the submitted OAuth `state` against the session's stored value
  * (see `GET /discord` below, which generates it as a fixed-length hex string), mirroring
- * `csrf.ts`'s `timingSafeEqual` comparison for CSRF tokens. The length check up front doesn't
- * leak anything — the expected length is public — it just guarantees the buffers passed to
- * `timingSafeEqual` are the same size, which it requires.
+ * `csrf.ts`'s `timingSafeEqual` comparison for CSRF tokens. Compares UTF-8 byte length rather
+ * than JS string length before calling `timingSafeEqual` — it requires equal-length buffers,
+ * and a submitted value containing multi-byte characters can have the same string length as
+ * `stored` while its UTF-8 byte length differs, which would otherwise throw instead of
+ * returning false. The length check up front doesn't leak anything — the expected length is
+ * public.
  */
 function oauthStateMatches(submitted: string, stored: string): boolean {
-  if (submitted.length !== stored.length) return false;
-  return crypto.timingSafeEqual(Buffer.from(submitted, 'utf8'), Buffer.from(stored, 'utf8'));
+  const submittedBuf = Buffer.from(submitted, 'utf8');
+  const storedBuf = Buffer.from(stored, 'utf8');
+  if (submittedBuf.length !== storedBuf.length) return false;
+  return crypto.timingSafeEqual(submittedBuf, storedBuf);
 }
 
 // ─── Redirect to Discord OAuth2 ─────────────────────────────────────────────

--- a/src/web/routes/auth.ts
+++ b/src/web/routes/auth.ts
@@ -89,12 +89,19 @@ router.get('/discord', (req, res) => {
  *   page if any step of the exchange/profile-fetch/session-save fails.
  */
 router.get('/discord/callback', async (req, res) => {
-  const { code, state } = req.query as { code?: string; state?: string };
+  // req.query values are `string | string[] | ParsedQs | ParsedQs[] | undefined` at runtime
+  // (e.g. `?state=a&state=b` parses to an array) — narrow with typeof rather than an unchecked
+  // `as` cast, so a tampered array/object param is rejected here instead of reaching
+  // oauthStateMatches (which requires a string) or the token-exchange request body below.
+  const { code, state } = req.query;
+  if (typeof code !== 'string' || typeof state !== 'string') {
+    return renderError(res, 400, 'Invalid OAuth2 state — please try logging in again.', undefined);
+  }
 
   const storedOAuth = req.session.oauthState;
   delete req.session.oauthState;
-  const stateValid = !!storedOAuth && !!state && oauthStateMatches(state, storedOAuth.value) && Date.now() <= storedOAuth.expiresAt;
-  if (!code || !state || !stateValid) {
+  const stateValid = !!storedOAuth && oauthStateMatches(state, storedOAuth.value) && Date.now() <= storedOAuth.expiresAt;
+  if (!code || !stateValid) {
     return renderError(res, 400, 'Invalid OAuth2 state — please try logging in again.', undefined);
   }
 


### PR DESCRIPTION
## Summary
Part of a full-codebase review (see companion PRs for DB layer, Discord/Twitch, commands/audio, and shared utils). This one covers `src/web/`.

- `auth.ts`'s Discord OAuth `state` check now compares the submitted value against the session's stored value with `crypto.timingSafeEqual` (via a new `oauthStateMatches` helper), matching the constant-time comparison `csrf.ts` already uses for CSRF tokens, instead of a plain `===`. Practical risk was low (the state is a single-use, high-entropy 32-char hex nonce, not a repeatedly-guessable secret), but it's now consistent with the rest of the codebase's own security posture.
- Corrected `CLAUDE.md`'s summary of `server.ts`'s middleware order — the general/session rate limiters actually run *after* body parsers and session middleware (an inline code comment explains `sessionLimiter`'s key generator needs `req.session` populated), not before as the doc previously stated. Code was already correct; only the doc was wrong.

No authorization bypasses were found in the wider web-layer review — every `requireAccessLevel` call site was traced back and confirmed to run after `requireGuildContext`, and all reviewed POST routes redirect on failure per the documented invariant (two deliberate, already-commented exceptions for one-time-secret display routes aside).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 3415 tests passed)
- [x] `npx eslint src/web src/types` — clean
- [x] Added a test for a same-length-but-mismatched OAuth state

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01TDtW3qZoB9mK7frNPgE34G

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDtW3qZoB9mK7frNPgE34G)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security Improvements**
  - Strengthened OAuth callback validation for state and authorization code parameters.
  - Added constant-time state comparison with UTF-8 byte-length validation.
  - Invalid, expired, tampered, or malformed query parameters now return a clear 400 error instead of causing a server error.

- **Tests**
  - Added coverage for mismatched, expired, missing, and array-form OAuth parameters.
  - Added coverage for state values with differing UTF-8 byte lengths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->