### PR TITLE
Unref withTimeout's internal timer

### DIFF
--- a/src/shared/withTimeout.test.ts
+++ b/src/shared/withTimeout.test.ts
@@ -27,4 +27,17 @@ describe('withTimeout', () => {
     await vi.advanceTimersByTimeAsync(1_000);
     await assertion;
   });
+
+  it('unrefs its internal timer so a long-lived timeout cannot keep the event loop alive on its own', () => {
+    const unref = vi.fn();
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+      .mockReturnValue({ unref, ref: vi.fn() } as unknown as NodeJS.Timeout);
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout').mockImplementation(() => {});
+
+    void withTimeout(new Promise(() => {}), 1_000, 'test op').catch(() => {});
+    expect(unref).toHaveBeenCalledOnce();
+
+    setTimeoutSpy.mockRestore();
+    clearTimeoutSpy.mockRestore();
+  });
 });

--- a/src/shared/withTimeout.test.ts
+++ b/src/shared/withTimeout.test.ts
@@ -34,10 +34,12 @@ describe('withTimeout', () => {
       .mockReturnValue({ unref, ref: vi.fn() } as unknown as NodeJS.Timeout);
     const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout').mockImplementation(() => {});
 
-    void withTimeout(new Promise(() => {}), 1_000, 'test op').catch(() => {});
-    expect(unref).toHaveBeenCalledOnce();
-
-    setTimeoutSpy.mockRestore();
-    clearTimeoutSpy.mockRestore();
+    try {
+      void withTimeout(new Promise(() => {}), 1_000, 'test op').catch(() => {});
+      expect(unref).toHaveBeenCalledOnce();
+    } finally {
+      setTimeoutSpy.mockRestore();
+      clearTimeoutSpy.mockRestore();
+    }
   });
 });

--- a/src/shared/withTimeout.ts
+++ b/src/shared/withTimeout.ts
@@ -11,6 +11,9 @@
 export function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+    // Always cleared by promise settling above, but unref so a long-lived `ms` can't keep the
+    // event loop alive on its own if the process would otherwise be idle.
+    timer.unref();
     promise.then(
       (value) => { clearTimeout(timer); resolve(value); },
       (err) => { clearTimeout(timer); reject(err); },


### PR DESCRIPTION
## Summary
Part of a full-codebase review (see companion PRs for DB layer, Discord/Twitch, commands/audio, and web server). This one covers `src/index.ts` and `src/shared/`.

- `withTimeout.ts`'s internal `setTimeout` timer is now `unref()`'d. It was always cleared once the wrapped promise settled, but a caller awaiting a very long-lived `withTimeout()` call could keep the event loop alive for that duration even if the rest of the process would otherwise be idle. Matches the `unref()` discipline already used for `index.ts`'s DB health-check timer and `customCommandHandler.ts`'s session-cache purge interval.

`src/index.ts` and the rest of `src/shared/` (startup/shutdown sequence, `mutationQueue.ts`, `crypto.ts`, `config.ts`, `logger.ts`, etc.) were reviewed and found clean — no findings there.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 3415 tests passed)
- [x] `npx eslint src/shared` — clean
- [x] Added a test asserting the internal timer's `unref()` is called

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01TDtW3qZoB9mK7frNPgE34G

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDtW3qZoB9mK7frNPgE34G)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved timeout handling so pending timeouts no longer keep an otherwise idle Node.js process running.
  - Existing cleanup behavior remains intact when the associated promise settles.

- **Tests**
  - Added coverage verifying that timeout timers are detached from the event loop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->