### PR TITLE
Allow !health to work in DMs

### DIFF
--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -44,7 +44,8 @@ vi.mock('../db', () => ({
 vi.mock('../shared/logger', () => ({ createLogger: vi.fn(mockLogger) }));
 vi.mock('discord.js', () => ({
   Client: vi.fn(),
-  GatewayIntentBits: { Guilds: 1, GuildMessages: 2, MessageContent: 4, GuildVoiceStates: 8 },
+  GatewayIntentBits: { Guilds: 1, GuildMessages: 2, MessageContent: 4, GuildVoiceStates: 8, DirectMessages: 16 },
+  Partials: { Channel: 1 },
 }));
 
 type DiscordBotModule = typeof import('./discordBot');
@@ -163,10 +164,19 @@ describe('startDiscordBot — messageCreate handler', () => {
     expect(vi.mocked(commands.handleCommand)).not.toHaveBeenCalled();
   });
 
-  it('skips DMs (no guildId)', () => {
+  it('skips guild-gated handlers for DMs (no guildId)', () => {
     const cb = getMessageCreateCb();
     cb({ author: { bot: false, username: 'Alice' }, guildId: null, content: '!test', member: null });
     expect(vi.mocked(commands.handleCommand)).not.toHaveBeenCalled();
+    expect(vi.mocked(customCmds.executeCustomCommandForDiscord)).not.toHaveBeenCalled();
+  });
+
+  it('still dispatches DMs to the health command handler', async () => {
+    const health = await import('../commands/healthCommandHandler.js');
+    const cb = getMessageCreateCb();
+    const msg = { author: { bot: false, username: 'Alice' }, guildId: null, content: '!health', member: null };
+    cb(msg);
+    expect(vi.mocked(health.executeHealthCommandForDiscord)).toHaveBeenCalledWith(msg);
   });
 
   it('dispatches to command handlers for registered guild messages', () => {

--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -164,11 +164,13 @@ describe('startDiscordBot — messageCreate handler', () => {
     expect(vi.mocked(commands.handleCommand)).not.toHaveBeenCalled();
   });
 
-  it('skips guild-gated handlers for DMs (no guildId)', () => {
+  it('skips guild-gated handlers for DMs (no guildId)', async () => {
+    const counters = await import('../commands/counterHandler.js');
     const cb = getMessageCreateCb();
     cb({ author: { bot: false, username: 'Alice' }, guildId: null, content: '!test', member: null });
     expect(vi.mocked(commands.handleCommand)).not.toHaveBeenCalled();
     expect(vi.mocked(customCmds.executeCustomCommandForDiscord)).not.toHaveBeenCalled();
+    expect(vi.mocked(counters.executeCounterCommandForDiscord)).not.toHaveBeenCalled();
   });
 
   it('still dispatches DMs to the health command handler', async () => {

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -130,11 +130,14 @@ export function startDiscordBot(): void {
   });
   bootingClient = localClient;
 
-  // Dispatches every non-bot message from a registered guild to each command handler in turn
-  // (fire-and-forget — a failure in one handler must not block the others). A DM (no guildId)
-  // skips the guild-gated handlers entirely and only reaches the owner-only `!health` command,
-  // which is designed to be triggered from a DM (see its own docstring). `message` is the
-  // triggering Discord message; returns void.
+  /**
+   * Dispatches every non-bot message from a registered guild to each command handler in turn
+   * (fire-and-forget — a failure in one handler must not block the others). A DM (no guildId)
+   * skips the guild-gated handlers entirely and only reaches the owner-only `!health` command,
+   * which is designed to be triggered from a DM (see its own docstring).
+   * @param message - The triggering Discord message.
+   * @returns void.
+   */
   localClient.on('messageCreate', (message) => {
     if (message.author.bot) return;
 

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -1,4 +1,4 @@
-import { Client, GatewayIntentBits, Guild } from 'discord.js';
+import { Client, GatewayIntentBits, Guild, Partials } from 'discord.js';
 import { DISCORD_TOKEN } from '../shared/config';
 import { handleCommand, forgetGuildCommandState } from '../commands/commandRouter';
 import { fireAndForget } from '../commands/commandUtils';
@@ -124,16 +124,25 @@ export function startDiscordBot(): void {
       GatewayIntentBits.GuildMessages,
       GatewayIntentBits.MessageContent,
       GatewayIntentBits.GuildVoiceStates,
+      GatewayIntentBits.DirectMessages,
     ],
+    partials: [Partials.Channel],
   });
   bootingClient = localClient;
 
   // Dispatches every non-bot message from a registered guild to each command handler in turn
-  // (fire-and-forget — a failure in one handler must not block the others). `message` is the
+  // (fire-and-forget — a failure in one handler must not block the others). A DM (no guildId)
+  // skips the guild-gated handlers entirely and only reaches the owner-only `!health` command,
+  // which is designed to be triggered from a DM (see its own docstring). `message` is the
   // triggering Discord message; returns void.
   localClient.on('messageCreate', (message) => {
     if (message.author.bot) return;
-    if (!message.guildId || !isRegisteredGuild(message.guildId)) return;
+
+    if (!message.guildId) {
+      fireAndForget(executeHealthCommandForDiscord(message), 'Health command error', log);
+      return;
+    }
+    if (!isRegisteredGuild(message.guildId)) return;
 
     const displayName = message.member?.displayName ?? message.author.username;
     const guildId = message.guildId;


### PR DESCRIPTION
## Summary

- The owner-only `!health` command was unreachable from a DM. `healthCommandHandler.ts` already branches on `message.guild` to decide whether to also post an in-channel ack (implying DM invocation was expected), but two things silently blocked it before the handler ever ran:
  - The Discord client never requested the `DirectMessages` gateway intent, so the gateway wouldn't deliver a `messageCreate` event for a DM at all.
  - The `messageCreate` listener's guild-registry gate (`if (!message.guildId || !isRegisteredGuild(message.guildId)) return;`) dropped every message with no `guildId`, including DMs, before any handler ran.
- Fix: added the `DirectMessages` intent (with the `Partials.Channel` needed for uncached DM channels), and split the gate so a DM now skips straight to `executeHealthCommandForDiscord` (the only handler that doesn't need a `guildId`) instead of being dropped outright. Guild-gated handlers (custom commands, counters, the general command router) are unaffected — they still require a registered `guildId`.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 3415 tests passing)
- [x] Updated `discordBot.test.ts`: reworded the DM-skip test to assert only the guild-gated handlers are skipped, and added a new test confirming a DM still dispatches to `executeHealthCommandForDiscord`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UsZmvrJ2zoccAhcuXd8DRz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for processing direct messages in Discord.
  * The owner-only `!health` command can now be used through direct messages.

* **Bug Fixes**
  * Guild-specific commands remain restricted to registered servers and are not triggered by direct messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->