### PR TITLE
Fully suppress owner-alert status reporting on shutdown, add explicit restart DMs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4247,6 +4247,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/filing-cabinet/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",

--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -117,6 +117,43 @@ describe('getDiscordClient', () => {
   });
 });
 
+// ─── onceDiscordReady ───────────────────────────────────────────────────────────
+
+describe('onceDiscordReady', () => {
+  it('resolves immediately when the client is already ready', async () => {
+    mod.startDiscordBot();
+    const readyCb = mockInstance.once.mock.calls.find(([event]: string[]) => event === 'clientReady')?.[1];
+    await readyCb(mockInstance);
+
+    await expect(mod.onceDiscordReady()).resolves.toBeUndefined();
+  });
+
+  it('resolves once clientReady fires, not before', async () => {
+    mod.startDiscordBot();
+    let resolved = false;
+    const waiter = mod.onceDiscordReady().then(() => { resolved = true; });
+
+    await flushMicrotasks();
+    expect(resolved).toBe(false);
+
+    const readyCb = mockInstance.once.mock.calls.find(([event]: string[]) => event === 'clientReady')?.[1];
+    await readyCb(mockInstance);
+    await waiter;
+    expect(resolved).toBe(true);
+  });
+
+  it('resolves every waiter registered before clientReady fires', async () => {
+    mod.startDiscordBot();
+    const waiterA = mod.onceDiscordReady();
+    const waiterB = mod.onceDiscordReady();
+
+    const readyCb = mockInstance.once.mock.calls.find(([event]: string[]) => event === 'clientReady')?.[1];
+    await readyCb(mockInstance);
+
+    await expect(Promise.all([waiterA, waiterB])).resolves.toEqual([undefined, undefined]);
+  });
+});
+
 // ─── fetchMemberDisplayName ───────────────────────────────────────────────────
 
 describe('fetchMemberDisplayName', () => {

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -21,6 +21,23 @@ let bootingClient: Client | null = null;
 
 export { getDiscordClient };
 
+/** Resolve callbacks awaiting the next `clientReady` — see {@link onceDiscordReady}. */
+let readyWaiters: Array<() => void> = [];
+
+/**
+ * Resolves once the Discord client has fired `clientReady` (immediately, if it already has by
+ * the time this is called). Lets a caller that needs the client to actually be usable — e.g.
+ * `index.ts`'s `announceStartup()`, which sends a DM through it — wait for that without
+ * `startDiscordBot()` itself becoming blocking (it stays fire-and-forget, matching the rest of
+ * the boot sequence). Never resolves if the client fails to connect and is never retried; pair
+ * with `withTimeout` at the call site if that matters there.
+ * @returns Resolves with no value once the client is ready.
+ */
+export function onceDiscordReady(): Promise<void> {
+  if (getDiscordClient()) return Promise.resolve();
+  return new Promise((resolve) => { readyWaiters.push(resolve); });
+}
+
 /**
  * Resolve a guild by ID from the discord.js cache, falling back to a fetch.
  * @throws if the client is not ready.
@@ -205,6 +222,9 @@ export function startDiscordBot(): void {
     log.info(`Logged in as ${c.user.tag}`);
     setDiscordReady(c.user.tag);
     recordDiscordConnected(true);
+    const waiters = readyWaiters;
+    readyWaiters = [];
+    waiters.forEach((resolve) => { resolve(); });
   });
 
   localClient.on('error', (err) => {

--- a/src/discord/ownerAlerts.test.ts
+++ b/src/discord/ownerAlerts.test.ts
@@ -13,6 +13,9 @@ import {
   registerOwnerAlertRuntime,
   primeOwnerAlertBaseline,
   startOwnerAlertWatcher,
+  stopOwnerAlertWatcher,
+  announceShutdown,
+  announceStartup,
   __resetOwnerAlertsForTests,
   DOWN_ALERT_GRACE_MS,
 } from './ownerAlerts';
@@ -276,6 +279,31 @@ describe('ownerAlerts', () => {
       await flush();
     }
   });
+
+  it('ignores every disconnect once stopOwnerAlertWatcher() is called, even outlasting the grace period', async () => {
+    try {
+      stopOwnerAlertWatcher();
+      healthStore.recordDbPing(false, 'shutting down');
+      await advanceGrace();
+      expect(send).not.toHaveBeenCalled();
+    } finally {
+      healthStore.recordDbPing(true);
+      await flush();
+    }
+  });
+
+  it('cancels a grace-period timer already pending when stopOwnerAlertWatcher() is called', async () => {
+    try {
+      healthStore.recordDbPing(false, 'boom');
+      await vi.advanceTimersByTimeAsync(DOWN_ALERT_GRACE_MS / 2);
+      stopOwnerAlertWatcher();
+      await advanceGrace();
+      expect(send).not.toHaveBeenCalled();
+    } finally {
+      healthStore.recordDbPing(true);
+      await flush();
+    }
+  });
 });
 
 describe('sendOwnerAlert with no runtime registered', () => {
@@ -409,5 +437,32 @@ describe('primeOwnerAlertBaseline', () => {
     expect(send).toHaveBeenCalledTimes(1);
     expect(send).toHaveBeenCalledWith(OWNER_ID, expect.stringContaining('db is down'));
     expect(send).not.toHaveBeenCalledWith(OWNER_ID, expect.stringContaining('discord'));
+  });
+});
+
+describe('announceShutdown / announceStartup', () => {
+  let send: ReturnType<typeof vi.fn<(discordId: string, message: string) => Promise<void>>>;
+
+  beforeEach(() => {
+    __resetOwnerAlertsForTests();
+    send = vi.fn().mockResolvedValue(undefined);
+    registerOwnerAlertRuntime({ send });
+    vi.mocked(findOwnerUser).mockResolvedValue(OWNER_ROW as any);
+  });
+
+  it('sends an explicit shutdown DM', async () => {
+    await announceShutdown();
+    expect(send).toHaveBeenCalledWith(OWNER_ID, expect.stringContaining('Shutting down'));
+  });
+
+  it('sends an explicit back-online DM', async () => {
+    await announceStartup();
+    expect(send).toHaveBeenCalledWith(OWNER_ID, expect.stringContaining('Back online'));
+  });
+
+  it('never throws when the runtime send itself rejects', async () => {
+    send.mockRejectedValue(new Error('DM failed — user has DMs disabled'));
+    await expect(announceShutdown()).resolves.toBeUndefined();
+    await expect(announceStartup()).resolves.toBeUndefined();
   });
 });

--- a/src/discord/ownerAlerts.ts
+++ b/src/discord/ownerAlerts.ts
@@ -80,6 +80,15 @@ let cachedOwnerDiscordId: string | null = null;
 let watcherStarted = false;
 
 /**
+ * Set by {@link stopOwnerAlertWatcher} once this process has started its own deliberate shutdown.
+ * Checked at the top of {@link handleHealthChanged} so the disconnects that shutdown itself
+ * causes (Twitch chat, Discord, EventSub, etc. all going down as components are stopped in turn)
+ * are never mistaken for real outages — there's nothing useful to alert the owner about "the bot
+ * is disconnecting because it's being restarted".
+ */
+let shuttingDown = false;
+
+/**
  * Resolves the Discord ID to DM: a fresh `findOwnerUser()` lookup when it succeeds (also
  * refreshing {@link cachedOwnerDiscordId}), falling back to the last cached ID only if the
  * lookup itself throws (e.g. the DB is down — exactly the case this watcher needs to still be
@@ -130,6 +139,29 @@ async function sendOwnerAlert(message: string): Promise<boolean> {
     log.error('Failed to send owner alert DM:', err);
     return false;
   }
+}
+
+/**
+ * Sends a "shutting down" DM to the owner. Call as the first thing `index.ts`'s `shutdown()`
+ * does once alerting itself has been turned off (see {@link stopOwnerAlertWatcher}) but before
+ * any component — including the Discord client this DM itself needs — actually disconnects.
+ * Pairs with {@link announceStartup}, sent once the next boot finishes: together they give an
+ * explicit before/after pair for a deliberate restart, rather than leaving the owner to
+ * reconstruct one from the edge-triggered component alerts above, which lose all memory of a
+ * "down" DM the instant the process that sent it exits.
+ * @returns Resolves once the DM attempt has settled, whether delivered or not — never throws.
+ */
+export async function announceShutdown(): Promise<void> {
+  await sendOwnerAlert('🟡 Shutting down for a restart.');
+}
+
+/**
+ * Sends a "back online" DM to the owner. Call once every step of `index.ts`'s `main()` has
+ * completed. Pairs with {@link announceShutdown}.
+ * @returns Resolves once the DM attempt has settled, whether delivered or not — never throws.
+ */
+export async function announceStartup(): Promise<void> {
+  await sendOwnerAlert('🟢 Back online.');
 }
 
 /**
@@ -279,6 +311,7 @@ function handleTrackedComponent(componentId: string, ok: boolean, error: string 
  * @returns void.
  */
 function handleHealthChanged(): void {
+  if (shuttingDown) return;
   const snapshot = getHealthSnapshot();
   const componentOks = deriveComponentOks(snapshot);
 
@@ -332,6 +365,29 @@ export function startOwnerAlertWatcher(): void {
   onHealthChanged(handleHealthChanged);
 }
 
+/**
+ * Marks this process as deliberately shutting down, so every disconnect that follows (Twitch
+ * chat, Discord, EventSub, etc. going down as `index.ts`'s `shutdown()` stops each component in
+ * turn) is ignored by {@link handleHealthChanged} instead of being treated as a real outage.
+ * Call once, as the very first step of `shutdown()` — before any component is actually stopped —
+ * so no disconnect it causes can start a grace-period timer (see {@link DOWN_ALERT_GRACE_MS})
+ * that might otherwise still be pending when the process exits, or (on a slow shutdown) fire
+ * before it does. There's no matching "resume" — a process that's shutting down never un-shuts-down;
+ * the next process boots with its own fresh module state instead.
+ * Also cancels any grace-period timer already pending for a component that failed moments before
+ * shutdown began, for the same reason — that alert is about to become moot.
+ * @returns void.
+ */
+export function stopOwnerAlertWatcher(): void {
+  shuttingDown = true;
+  for (const state of componentStates.values()) {
+    if (state.pendingDownTimer) {
+      clearTimeout(state.pendingDownTimer);
+      state.pendingDownTimer = null;
+    }
+  }
+}
+
 /** Test-only: resets all module state so each test starts from a clean slate. */
 export function __resetOwnerAlertsForTests(): void {
   for (const state of componentStates.values()) {
@@ -340,4 +396,5 @@ export function __resetOwnerAlertsForTests(): void {
   componentStates.clear();
   cachedOwnerDiscordId = null;
   watcherStarted = false;
+  shuttingDown = false;
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -30,6 +30,7 @@ vi.mock('./discord/discordBot', () => ({
   startDiscordBot: vi.fn(),
   stopDiscordBot: vi.fn(),
   getDiscordClient: vi.fn(),
+  onceDiscordReady: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock('./discord/guildRegistry', () => ({
   reloadGuildRegistry: vi.fn().mockResolvedValue(undefined),
@@ -279,6 +280,42 @@ describe('startup — reward pricing scheduler', () => {
     const [webPanelCallOrder] = vi.mocked(startWebPanel).mock.invocationCallOrder;
     const [reconciliationCallOrder] = vi.mocked(startChannelReconciliationPoll).mock.invocationCallOrder;
     expect(webPanelCallOrder).toBeLessThan(reconciliationCallOrder);
+  });
+});
+
+// ─── Owner "back online" startup DM ────────────────────────────────────────────
+
+describe('startup — owner back-online DM', () => {
+  it('waits for Discord readiness before sending the announceStartup DM', async () => {
+    const { onceDiscordReady } = await import('./discord/discordBot.js');
+    const { announceStartup } = await import('./discord/ownerAlerts.js');
+
+    await runMain();
+
+    expect(vi.mocked(onceDiscordReady)).toHaveBeenCalledOnce();
+    expect(vi.mocked(announceStartup)).toHaveBeenCalledOnce();
+    const [readyCallOrder] = vi.mocked(onceDiscordReady).mock.invocationCallOrder;
+    const [announceCallOrder] = vi.mocked(announceStartup).mock.invocationCallOrder;
+    expect(readyCallOrder).toBeLessThan(announceCallOrder);
+  });
+
+  it('skips the DM (without crashing the process) when Discord never becomes ready in time', async () => {
+    const { onceDiscordReady } = await import('./discord/discordBot.js');
+    const { announceStartup } = await import('./discord/ownerAlerts.js');
+    vi.mocked(onceDiscordReady).mockReturnValueOnce(new Promise(() => { /* never resolves */ }));
+
+    vi.useFakeTimers();
+    try {
+      const mainPromise = import('./index.js');
+      await vi.advanceTimersByTimeAsync(30_000);
+      await mainPromise;
+      await vi.advanceTimersByTimeAsync(0);
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(vi.mocked(announceStartup)).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -415,6 +415,30 @@ describe('shutdown', () => {
     expect(vi.mocked(stopEventSubReconciliation)).toHaveBeenCalledOnce();
     expect(vi.mocked(stopChannelReconciliationPoll)).toHaveBeenCalledOnce();
   });
+
+  it('turns off owner-alert reporting and announces the shutdown before any component disconnects', async () => {
+    const { stopOwnerAlertWatcher, announceShutdown } = await import('./discord/ownerAlerts.js');
+    const { stopDiscordBot } = await import('./discord/discordBot.js');
+    const { stopTwitchBot } = await import('./twitch/twitchBot.js');
+
+    await runMain();
+    process.emit('SIGINT');
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(vi.mocked(stopOwnerAlertWatcher)).toHaveBeenCalledOnce();
+    expect(vi.mocked(announceShutdown)).toHaveBeenCalledOnce();
+    expect(vi.mocked(stopDiscordBot)).toHaveBeenCalledOnce();
+    expect(vi.mocked(stopTwitchBot)).toHaveBeenCalledOnce();
+
+    const [stopWatcherOrder] = vi.mocked(stopOwnerAlertWatcher).mock.invocationCallOrder;
+    const [announceOrder] = vi.mocked(announceShutdown).mock.invocationCallOrder;
+    const [stopDiscordOrder] = vi.mocked(stopDiscordBot).mock.invocationCallOrder;
+    const [stopTwitchOrder] = vi.mocked(stopTwitchBot).mock.invocationCallOrder;
+
+    expect(stopWatcherOrder).toBeLessThan(announceOrder);
+    expect(announceOrder).toBeLessThan(stopDiscordOrder);
+    expect(announceOrder).toBeLessThan(stopTwitchOrder);
+  });
 });
 
 // ─── Global unhandled error handlers ──────────────────────────────────────────

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -22,6 +22,9 @@ vi.mock('./discord/ownerAlerts', () => ({
   registerOwnerAlertRuntime: vi.fn(),
   primeOwnerAlertBaseline: vi.fn(),
   startOwnerAlertWatcher: vi.fn(),
+  stopOwnerAlertWatcher: vi.fn(),
+  announceShutdown: vi.fn().mockResolvedValue(undefined),
+  announceStartup: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock('./discord/discordBot', () => ({
   startDiscordBot: vi.fn(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import 'mediaplex'; // Must be imported first to register as Opus provider
 import { getPool, closePool, pingDb } from './db';
 import { recordDbPing } from './shared/healthStore';
-import { registerOwnerAlertRuntime, primeOwnerAlertBaseline, startOwnerAlertWatcher } from './discord/ownerAlerts';
+import { registerOwnerAlertRuntime, primeOwnerAlertBaseline, startOwnerAlertWatcher, stopOwnerAlertWatcher, announceShutdown, announceStartup } from './discord/ownerAlerts';
 import { startTwitchBot, stopTwitchBot, sayInChannel } from './twitch/twitchBot';
 import { getActiveChannels, getActiveChannelUserIds, setChannelJoinedHook } from './twitch/twitchChannelMembership';
 import { startChannelReconciliationPoll, stopChannelReconciliationPoll } from './twitch/twitchChannelReconciliationPoll';
@@ -75,10 +75,19 @@ function stopDbHealthCheck(): void {
 
 /**
  * Gracefully stops schedulers and bot connections, closes the DB pool, and exits the process.
+ * Turns off owner-alert status reporting first and sends the owner a "shutting down" DM (see
+ * `ownerAlerts.ts`'s `stopOwnerAlertWatcher`/`announceShutdown`) before anything actually
+ * disconnects.
  * @param signal - The name of the signal that triggered shutdown (e.g. `SIGINT`).
  */
 async function shutdown(signal: string): Promise<void> {
   log.info(`${signal} received — disconnecting from voice and shutting down.`);
+  // Before anything else — every stop* call below disconnects a component (Twitch chat, EventSub,
+  // etc.), and none of that is a real outage the owner needs a DM about.
+  stopOwnerAlertWatcher();
+  // ...then announce the shutdown itself, while the Discord client this DM needs is still up —
+  // stopDiscordBot() below tears it down.
+  await announceShutdown();
   stopDbHealthCheck();
   stopCounterScheduler();
   stopChannelReconciliationPoll();
@@ -127,7 +136,9 @@ process.on('uncaughtException', (err) => {
 /**
  * Boots the bot: verifies DB connectivity, wires every Twitch/EventSub runtime callback,
  * loads the guild registry, then starts the Discord bot, Twitch bot, web panel, and
- * schedulers, in that order (see the Startup Sequence section of `CLAUDE.md`).
+ * schedulers, in that order (see the Startup Sequence section of `CLAUDE.md`), finishing with
+ * an owner DM (see `ownerAlerts.ts`'s `announceStartup`) confirming the bot is back online —
+ * paired with `shutdown()`'s `announceShutdown` DM.
  * @returns Resolves once every component has started; rejects (and exits the process,
  *   via the `.catch` below) if DB connectivity or the guild registry load fails.
  */
@@ -201,6 +212,7 @@ async function main(): Promise<void> {
   startTwitchMonitor().catch((err) => log.error('TwitchMonitor startup error:', err));
   startEventSub();
   startEventSubReconciliation();
+  await announceStartup();
 }
 
 main().catch((err) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { registerOwnerAlertRuntime, primeOwnerAlertBaseline, startOwnerAlertWatc
 import { startTwitchBot, stopTwitchBot, sayInChannel } from './twitch/twitchBot';
 import { getActiveChannels, getActiveChannelUserIds, setChannelJoinedHook } from './twitch/twitchChannelMembership';
 import { startChannelReconciliationPoll, stopChannelReconciliationPoll } from './twitch/twitchChannelReconciliationPoll';
-import { startDiscordBot, stopDiscordBot, getDiscordClient } from './discord/discordBot';
+import { startDiscordBot, stopDiscordBot, getDiscordClient, onceDiscordReady } from './discord/discordBot';
 import { reloadGuildRegistry } from './discord/guildRegistry';
 import { resolveGuildIdForDiscordId } from './discord/voicePresence';
 import { registerTwitchGuildResolutionRuntime } from './twitch/twitchGuildResolutionRuntime';
@@ -33,11 +33,21 @@ import { startRewardPricingScheduler, stopRewardPricingScheduler } from './twitc
 import { registerRewardPricingRuntime } from './twitch/pricing/rewardPricingService';
 import { startTimerCommandScheduler, stopTimerCommandScheduler, registerTimerCommandsRuntime } from './twitch/timers/timerCommandScheduler';
 import { createLogger } from './shared/logger';
+import { withTimeout } from './shared/withTimeout';
 
 const log = createLogger('Bot');
 
 /** How often the DB-connectivity health check pings the pool (see {@link startDbHealthCheck}). */
 const DB_HEALTH_CHECK_INTERVAL_MS = 60_000;
+
+/**
+ * How long `main()` waits for Discord to fire `clientReady` before giving up on sending the
+ * `announceStartup()` DM. `startDiscordBot()` is fire-and-forget — `getDiscordClient()` stays
+ * null until `clientReady` fires, which can still be pending by the time `main()` reaches its
+ * last line — so `announceStartup()` needs to wait for it explicitly rather than finding no
+ * client and silently failing to deliver (see `discordBot.ts`'s `onceDiscordReady`).
+ */
+const DISCORD_READY_FOR_STARTUP_DM_TIMEOUT_MS = 30_000;
 
 let dbHealthCheckTimer: ReturnType<typeof setInterval> | null = null;
 // Guards against overlapping probes: pingDb()'s getConnection() has no timeout of its own, so
@@ -138,7 +148,9 @@ process.on('uncaughtException', (err) => {
  * loads the guild registry, then starts the Discord bot, Twitch bot, web panel, and
  * schedulers, in that order (see the Startup Sequence section of `CLAUDE.md`), finishing with
  * an owner DM (see `ownerAlerts.ts`'s `announceStartup`) confirming the bot is back online —
- * paired with `shutdown()`'s `announceShutdown` DM.
+ * paired with `shutdown()`'s `announceShutdown` DM. Waits (up to
+ * {@link DISCORD_READY_FOR_STARTUP_DM_TIMEOUT_MS}) for Discord to actually be ready before that
+ * DM, since `startDiscordBot()` itself doesn't block on it.
  * @returns Resolves once every component has started; rejects (and exits the process,
  *   via the `.catch` below) if DB connectivity or the guild registry load fails.
  */
@@ -212,7 +224,13 @@ async function main(): Promise<void> {
   startTwitchMonitor().catch((err) => log.error('TwitchMonitor startup error:', err));
   startEventSub();
   startEventSubReconciliation();
-  await announceStartup();
+
+  try {
+    await withTimeout(onceDiscordReady(), DISCORD_READY_FOR_STARTUP_DM_TIMEOUT_MS, 'Discord ready for startup DM');
+    await announceStartup();
+  } catch (err) {
+    log.error('Discord never became ready — skipping the "back online" owner DM:', err);
+  }
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary

The owner used to occasionally get a one-sided `🔴 twitchChat is down: Twitch chat disconnected` DM around a restart, with no matching "recovered" DM ever following — because the process that sent the "down" DM exits, and the next process starts with no memory that it was ever sent, so it has no basis to send a "recovered" DM later.

Rather than trying to reconstruct that context across a restart, this PR:

- **Turns off owner-alert status reporting entirely during shutdown.** Every `stop*` call in `shutdown()` disconnects a component (Twitch chat, Discord, EventSub, etc.) — none of that is a real outage. `ownerAlerts.ts` now exports `stopOwnerAlertWatcher()`, which ignores every further health-changed event and cancels any already-pending grace-period timer. `index.ts`'s `shutdown()` calls it as the very first step, before anything actually disconnects.
- **Sends explicit restart DMs instead.** `ownerAlerts.ts` adds `announceShutdown()` (`🟡 Shutting down for a restart.`) and `announceStartup()` (`🟢 Back online.`). `shutdown()` sends the shutdown DM right after turning off status reporting (while the Discord client it needs is still up), and `main()` sends the startup DM as its last step, once every component has started.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (3434 tests passing, including new coverage for `stopOwnerAlertWatcher`, `announceShutdown`, `announceStartup`)
- [x] `npm run lint` (clean; 3 pre-existing unrelated warnings)


---
_Generated by [Claude Code](https://claude.ai/code/session_01YPchKphdX2tbAx2YjTJmN8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added owner notifications when the service shuts down and comes back online.
  * Startup notifications wait for Discord to become ready, with a 30-second timeout.
* **Bug Fixes**
  * Prevented misleading health alerts during deliberate shutdowns.
  * Cancelled pending outage alerts when shutdown begins.
  * Improved resilience when notifications cannot be delivered, ensuring notification failures do not interrupt shutdown or startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->