### PR TITLE
Efficiency review: dashboard, DB queries, and per-message parsing

### DIFF
--- a/src/commands/commandRouter.ts
+++ b/src/commands/commandRouter.ts
@@ -7,7 +7,7 @@ import { SFX_FOLDER, GLOBAL_COOLDOWN_MS } from '../shared/config';
 import { setVoicePlaying } from '../shared/statusStore';
 import { safeResolve } from '../shared/pathUtils';
 import { getOrCreate } from '../shared/mapUtils';
-import { extractCommand } from './commandUtils';
+import { resolveCommand } from './commandUtils';
 
 const log = createLogger('CommandRouter');
 
@@ -128,15 +128,18 @@ function tryClaimGuildSlot(
  *   connected to voice anywhere) — the command is skipped, with a warning
  *   logged only if the message actually matches a known trigger (most chat
  *   messages don't, and would otherwise spam this warning on every message).
+ * @param precomputedCommand - Already-parsed command token from the caller's single
+ *   `extractCommand` call for this message, or omit to parse `rawMessage` here.
  */
 export async function handleCommand(
   rawMessage: string,
   source: 'twitch' | 'discord',
   guildId: string | null,
+  precomputedCommand?: string | null,
 ): Promise<void> {
   // Extract the first word of the message — this is matched directly against
   // trigger_command in the DB, which already includes whatever prefix is used
-  const command = extractCommand(rawMessage);
+  const command = resolveCommand(rawMessage, precomputedCommand);
   if (!command) return;
 
   if (guildId === null) {

--- a/src/commands/commandUtils.test.ts
+++ b/src/commands/commandUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { extractCommand, extractArgs, fireAndForget } from './commandUtils';
+import { extractCommand, extractArgs, fireAndForget, resolveCommand } from './commandUtils';
 
 describe('extractCommand', () => {
   it('returns null for an empty string', () => {
@@ -24,6 +24,20 @@ describe('extractCommand', () => {
 
   it('returns the full string lowercased when there is only one token', () => {
     expect(extractCommand('!321')).toBe('!321');
+  });
+});
+
+describe('resolveCommand', () => {
+  it('parses rawMessage fresh when precomputed is undefined', () => {
+    expect(resolveCommand('!Ding extra')).toBe('!ding');
+  });
+
+  it('reuses a precomputed command without re-parsing rawMessage', () => {
+    expect(resolveCommand('!ignored raw text', '!precomputed')).toBe('!precomputed');
+  });
+
+  it('reuses a precomputed null instead of re-parsing rawMessage', () => {
+    expect(resolveCommand('!would-parse-to-something', null)).toBeNull();
   });
 });
 

--- a/src/commands/commandUtils.ts
+++ b/src/commands/commandUtils.ts
@@ -30,6 +30,22 @@ export function extractCommand(rawMessage: string): string | null {
 }
 
 /**
+ * Resolves the command token for a message, reusing an already-parsed value when the caller
+ * (`handleTwitchMessage`/Discord's `messageCreate`) parsed it once up front for every handler
+ * dispatched off the same message, instead of each handler re-parsing independently via
+ * {@link extractCommand}.
+ *
+ * @param rawMessage - Raw message text, used to parse the command if `precomputed` is `undefined`.
+ * @param precomputed - The already-parsed command (possibly `null`, if the message had none), or
+ *   `undefined` to parse `rawMessage` fresh — the latter keeps every direct/test call to a
+ *   handler working exactly as before, without having to pass this through.
+ * @returns The resolved command token, or null if there is none.
+ */
+export function resolveCommand(rawMessage: string, precomputed?: string | null): string | null {
+  return precomputed !== undefined ? precomputed : extractCommand(rawMessage);
+}
+
+/**
  * Extracts the argument text that follows the first token of a raw message.
  * Leading/trailing whitespace is trimmed; the result preserves the original
  * casing and internal spacing of the remaining text.

--- a/src/commands/countdownHandler.ts
+++ b/src/commands/countdownHandler.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '../shared/logger';
-import { extractCommand } from './commandUtils';
+import { resolveCommand } from './commandUtils';
 import { createRuntimeRegistry, type TwitchSendRuntime } from './twitchRuntime';
 import { createCooldownGate } from './cooldownGate';
 
@@ -41,9 +41,15 @@ export function registerCountdownTwitchRuntime(runtime: CountdownTwitchRuntime):
  *
  * @param channel - Twitch channel to send the countdown steps to.
  * @param rawMessage - Raw chat message text.
+ * @param precomputedCommand - Already-parsed command token from the caller's single
+ *   `extractCommand` call for this message, or omit to parse `rawMessage` here.
  */
-export async function executeCountdownForTwitch(channel: string, rawMessage: string): Promise<void> {
-  if (extractCommand(rawMessage) !== COUNTDOWN_COMMAND) return;
+export async function executeCountdownForTwitch(
+  channel: string,
+  rawMessage: string,
+  precomputedCommand?: string | null,
+): Promise<void> {
+  if (resolveCommand(rawMessage, precomputedCommand) !== COUNTDOWN_COMMAND) return;
   const runtime = countdownRuntime.get();
   if (!runtime) return;
   if (!countdownCooldown.tryClaim(`twitch:${channel}`)) return;

--- a/src/commands/counterHandler.ts
+++ b/src/commands/counterHandler.ts
@@ -3,7 +3,7 @@ import type { Message } from 'discord.js';
 import { findCounterByCommand, incrementCounter } from '../db';
 
 const log = createLogger('Counter');
-import { extractCommand } from './commandUtils';
+import { resolveCommand } from './commandUtils';
 import { isDiscordNotFoundError, NO_MENTIONS } from '../discord/discordUtils';
 import { createRuntimeRegistry, type TwitchSendRuntime } from './twitchRuntime';
 import { createCooldownGate } from './cooldownGate';
@@ -125,13 +125,16 @@ async function _buildCounterResponse(
  *
  * @param message - The Discord message to check for a counter command.
  * @param username - Display name of the sender (unused; kept for call-site symmetry with the Twitch handler).
+ * @param precomputedCommand - Already-parsed command token from the caller's single
+ *   `extractCommand` call for this message, or omit to parse `message.content` here.
  * @returns Resolves once the reply (or a no-op) has completed.
  */
 export async function executeCounterCommandForDiscord(
   message: Message,
   username?: string | null,
+  precomputedCommand?: string | null,
 ): Promise<void> {
-  const command = extractCommand(message.content);
+  const command = resolveCommand(message.content, precomputedCommand);
   if (!command) return;
 
   const result = await _buildCounterResponse(command, '[Discord]', discordCooldownKey(message));
@@ -158,14 +161,17 @@ export async function executeCounterCommandForDiscord(
  * @param channel - Twitch channel the message was sent in (also the send target).
  * @param rawMessage - Raw chat message text.
  * @param username - Twitch login of the sender (unused; kept for call-site symmetry with the Discord handler).
+ * @param precomputedCommand - Already-parsed command token from the caller's single
+ *   `extractCommand` call for this message, or omit to parse `rawMessage` here.
  * @returns Resolves once the send (or a no-op) has completed.
  */
 export async function executeCounterCommandForTwitch(
   channel: string,
   rawMessage: string,
   username?: string | null,
+  precomputedCommand?: string | null,
 ): Promise<void> {
-  const command = extractCommand(rawMessage);
+  const command = resolveCommand(rawMessage, precomputedCommand);
   if (!command) return;
 
   const result = await _buildCounterResponse(command, `[Twitch:${channel}]`, `twitch:${channel}`);

--- a/src/commands/customCommandHandler.ts
+++ b/src/commands/customCommandHandler.ts
@@ -4,7 +4,7 @@ import { getCustomCommandForDiscord, getCustomCommandForTwitchChannel } from '..
 
 const log = createLogger('CustomCmd');
 import { getSharedChatSession } from '../twitch/twitchApi';
-import { extractCommand, extractArgs } from './commandUtils';
+import { extractArgs, resolveCommand } from './commandUtils';
 import { isDiscordNotFoundError, NO_MENTIONS } from '../discord/discordUtils';
 import type { MultiTwitchGroupInfo } from '../twitch/monitor/twitchMonitorTypes';
 import { fillTemplate } from '../shared/textTemplate';
@@ -211,14 +211,17 @@ async function broadcastToActiveChannels(sourceChannel: string, command: string,
  * @param message - The Discord message to inspect and, if matched, reply to.
  * @param username - Display name for `{user}` substitution; null or omitted if unknown.
  * @param guildId - Explicit guild ID for override-aware lookup; falls back to message.guildId.
+ * @param precomputedCommand - Already-parsed command token from the caller's single
+ *   `extractCommand` call for this message, or omit to parse `message.content` here.
  * @returns Resolves when the command is handled (or skipped).
  */
 export async function executeCustomCommandForDiscord(
   message: Message,
   username?: string | null,
   guildId?: string,
+  precomputedCommand?: string | null,
 ): Promise<void> {
-  const command = extractCommand(message.content);
+  const command = resolveCommand(message.content, precomputedCommand);
   if (!command) return;
 
   // Prefer the explicitly threaded guildId; fall back to the message's own guild.
@@ -263,14 +266,17 @@ export async function executeCustomCommandForDiscord(
  * @param channel - Twitch channel login the message was received on.
  * @param rawMessage - Raw chat message text.
  * @param username - Display name for `{user}` substitution; null or omitted if unknown.
+ * @param precomputedCommand - Already-parsed command token from the caller's single
+ *   `extractCommand` call for this message, or omit to parse `rawMessage` here.
  * @returns Resolves when the command is handled (or skipped).
  */
 export async function executeCustomCommandForTwitch(
   channel: string,
   rawMessage: string,
   username?: string | null,
+  precomputedCommand?: string | null,
 ): Promise<void> {
-  const command = extractCommand(rawMessage);
+  const command = resolveCommand(rawMessage, precomputedCommand);
   if (!command) return;
 
   const result = await lookupCommand(command, (cmd) => getCustomCommandForTwitchChannel(channel, cmd));

--- a/src/commands/healthCommandHandler.ts
+++ b/src/commands/healthCommandHandler.ts
@@ -1,6 +1,6 @@
 import type { Message } from 'discord.js';
 import { createLogger } from '../shared/logger';
-import { extractCommand } from './commandUtils';
+import { resolveCommand } from './commandUtils';
 import { findOwnerUser } from '../db';
 import { getHealthSnapshot, type HealthSnapshot } from '../shared/healthStore';
 import { isDiscordNotFoundError } from '../discord/discordUtils';
@@ -114,10 +114,12 @@ function formatHealthSummary(snapshot: HealthSnapshot): string {
  * closed), that's logged and swallowed rather than thrown. The acknowledgement reply is likewise
  * swallowed on failure (e.g. the triggering message was deleted before it could be sent).
  * @param message - The Discord message to check and, if it's an owner-issued `!health`, respond to.
+ * @param precomputedCommand - Already-parsed command token from the caller's single
+ *   `extractCommand` call for this message, or omit to parse `message.content` here.
  * @returns Resolves once the command has been handled (or ignored as a non-match).
  */
-export async function executeHealthCommandForDiscord(message: Message): Promise<void> {
-  if (extractCommand(message.content) !== TRIGGER) return;
+export async function executeHealthCommandForDiscord(message: Message, precomputedCommand?: string | null): Promise<void> {
+  if (resolveCommand(message.content, precomputedCommand) !== TRIGGER) return;
 
   let owner;
   try {

--- a/src/commands/multiCommandHandler.ts
+++ b/src/commands/multiCommandHandler.ts
@@ -3,7 +3,7 @@ import { getMultiTwitchDataForChannel } from '../twitch/monitor/twitchMonitor';
 
 const log = createLogger('MultiCmd');
 import { resolveSharedChatSessionId } from './customCommandHandler';
-import { extractCommand } from './commandUtils';
+import { resolveCommand } from './commandUtils';
 import { sendDedupedBySession } from './twitchBroadcast';
 import { createRuntimeRegistry, type TwitchBroadcastRuntime } from './twitchRuntime';
 import { createCooldownGate } from './cooldownGate';
@@ -71,14 +71,17 @@ async function broadcastToGroupChannels(
  * @param channel - Twitch channel the command was sent in.
  * @param rawMessage - Raw chat message text.
  * @param username - Twitch login of the sender (unused).
+ * @param precomputedCommand - Already-parsed command token from the caller's single
+ *   `extractCommand` call for this message, or omit to parse `rawMessage` here.
  * @returns Resolves once the broadcast (or a no-op) has completed.
  */
 export async function executeMultiCommandForTwitch(
   channel: string,
   rawMessage: string,
   username?: string | null,
+  precomputedCommand?: string | null,
 ): Promise<void> {
-  const command = extractCommand(rawMessage);
+  const command = resolveCommand(rawMessage, precomputedCommand);
   if (command !== MULTI_COMMAND) return;
 
   const groupInfo = getMultiTwitchDataForChannel(channel);

--- a/src/commands/shoutoutHandler.ts
+++ b/src/commands/shoutoutHandler.ts
@@ -2,7 +2,7 @@ import { createLogger } from '../shared/logger';
 import { getUsers, getChannelInfo, getStreams, TwitchChannelInfo, TwitchStream } from '../twitch/twitchApi';
 
 const log = createLogger('Shoutout');
-import { extractCommand } from './commandUtils';
+import { resolveCommand } from './commandUtils';
 import { createRuntimeRegistry, type TwitchSendRuntime } from './twitchRuntime';
 
 const SO_COMMAND = '!so';
@@ -107,6 +107,8 @@ export async function buildShoutoutMessage(target: string): Promise<string | nul
  * @param rawMessage - Raw chat message text, e.g. `!so @someuser`.
  * @param username - Twitch login of the command invoker (unused).
  * @param isModerator - Whether the invoker has moderator privileges; required to run.
+ * @param precomputedCommand - Already-parsed command token from the caller's single
+ *   `extractCommand` call for this message, or omit to parse `rawMessage` here.
  * @returns Resolves once the shoutout (or no-op) has completed.
  */
 export async function executeShoutoutForTwitch(
@@ -114,8 +116,9 @@ export async function executeShoutoutForTwitch(
   rawMessage: string,
   username: string | null,
   isModerator: boolean,
+  precomputedCommand?: string | null,
 ): Promise<void> {
-  if (extractCommand(rawMessage) !== SO_COMMAND || !isModerator) return;
+  if (resolveCommand(rawMessage, precomputedCommand) !== SO_COMMAND || !isModerator) return;
 
   const rawTarget = rawMessage.trim().split(/\s+/)[1];
   const target = rawTarget?.replace(/^@/, '').toLowerCase();

--- a/src/db/commandConflicts.ts
+++ b/src/db/commandConflicts.ts
@@ -147,7 +147,7 @@ async function hasSingleTwitchAssignmentOverlap(
          OR (
            other_u.twitch_name IS NOT NULL
            AND other_u.is_twitch_bot_enabled = 1
-           AND LOWER(other_u.twitch_name) = LOWER(current_u.twitch_name)
+           AND other_u.twitch_name = current_u.twitch_name
          )
        )
      LIMIT 1`,
@@ -278,7 +278,7 @@ async function hasTwitchChannelTriggerConflict(
          OR (
            u.twitch_name IS NOT NULL
            AND u.is_twitch_bot_enabled = 1
-           AND LOWER(u.twitch_name) = ?
+           AND u.twitch_name = ?
          )
        )
      LIMIT 1`,
@@ -483,7 +483,7 @@ async function hasAnyTwitchChannelTriggerConflict(
          OR (
            u.twitch_name IS NOT NULL
            AND u.is_twitch_bot_enabled = 1
-           AND LOWER(u.twitch_name) IN (${buildInClausePlaceholders(normalizedTwitchNames.length)})
+           AND u.twitch_name IN (${buildInClausePlaceholders(normalizedTwitchNames.length)})
          )
        )
      LIMIT 1`,

--- a/src/db/eventLog.test.ts
+++ b/src/db/eventLog.test.ts
@@ -4,8 +4,11 @@ vi.mock('./pool', () => ({ getPool: vi.fn() }));
 vi.mock('mysql2/promise', () => ({ default: {} }));
 
 import { getPool } from './pool';
-import { recordStreamerEvent, getRecentStreamerEvents } from './eventLog';
+import { recordStreamerEvent, getRecentStreamerEvents, __resetEventLogPruneCountersForTests } from './eventLog';
 import { makeMockPool } from '../test-utils/mockMysqlPool';
+
+// Matches PRUNE_EVERY_N_INSERTS in eventLog.ts — the prune DELETE only runs on every Nth insert.
+const PRUNE_EVERY_N_INSERTS = 10;
 
 /** Builds a fake mysql pool whose `execute`/`query` resolve to the given rows/meta. */
 function makePool(rows: unknown[] = [], meta: unknown = {}) {
@@ -14,24 +17,53 @@ function makePool(rows: unknown[] = [], meta: unknown = {}) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  __resetEventLogPruneCountersForTests();
 });
 
 describe('recordStreamerEvent', () => {
-  it('inserts the event and prunes the streamer down to the retention cap', async () => {
+  it('inserts the event without pruning while under the prune-cadence threshold', async () => {
     const pool = makePool();
     vi.mocked(getPool).mockReturnValue(pool as any);
 
     await expect(recordStreamerEvent(5, 'follow', 'someviewer', null)).resolves.toBe(true);
 
-    expect(pool.execute).toHaveBeenCalledTimes(2);
+    expect(pool.execute).toHaveBeenCalledTimes(1);
     const [insertSql, insertParams] = pool.execute.mock.calls[0];
     expect(insertSql).toContain('INSERT INTO streamer_event_log');
     expect(insertParams).toEqual([5, 'follow', 'someviewer', null, null]);
+  });
 
+  it('prunes the streamer down to the retention cap once the prune-cadence threshold is reached', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+
+    for (let i = 0; i < PRUNE_EVERY_N_INSERTS - 1; i++) {
+      await recordStreamerEvent(5, 'follow', 'someviewer', null);
+    }
+    pool.execute.mockClear();
+
+    await expect(recordStreamerEvent(5, 'follow', 'someviewer', null)).resolves.toBe(true);
+
+    expect(pool.execute).toHaveBeenCalledTimes(2);
     const [deleteSql, deleteParams] = pool.execute.mock.calls[1];
     expect(deleteSql).toContain('DELETE FROM streamer_event_log');
     expect(deleteSql).toContain('LIMIT 200');
     expect(deleteParams).toEqual([5, 5]);
+  });
+
+  it('tracks the prune-cadence counter independently per streamer', async () => {
+    const pool = makePool();
+    vi.mocked(getPool).mockReturnValue(pool as any);
+
+    for (let i = 0; i < PRUNE_EVERY_N_INSERTS - 1; i++) {
+      await recordStreamerEvent(5, 'follow', 'someviewer', null);
+    }
+    pool.execute.mockClear();
+
+    // A different streamer's first insert should not inherit streamer 5's near-threshold count.
+    await recordStreamerEvent(7, 'follow', 'otherviewer', null);
+
+    expect(pool.execute).toHaveBeenCalledTimes(1);
   });
 
   it('passes through a non-null detail string', async () => {
@@ -83,16 +115,22 @@ describe('recordStreamerEvent', () => {
   });
 
   it('does not run the prune DELETE until the INSERT has resolved', async () => {
+    const pool = { execute: vi.fn().mockResolvedValue([{ affectedRows: 1 }, []]) };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+
+    // Bring streamer 5 to one insert short of the prune-cadence threshold.
+    for (let i = 0; i < PRUNE_EVERY_N_INSERTS - 1; i++) {
+      await recordStreamerEvent(5, 'follow', 'someviewer', null);
+    }
+    pool.execute.mockClear();
+
     let resolveInsert: (() => void) | undefined;
     const insertPromise = new Promise<[unknown, unknown]>((resolve) => {
       resolveInsert = () => resolve([{ affectedRows: 1 }, []]);
     });
-    const pool = {
-      execute: vi.fn()
-        .mockImplementationOnce(() => insertPromise)
-        .mockImplementationOnce(async () => [{ affectedRows: 0 }, []]),
-    };
-    vi.mocked(getPool).mockReturnValue(pool as any);
+    pool.execute
+      .mockImplementationOnce(() => insertPromise)
+      .mockImplementationOnce(async () => [{ affectedRows: 0 }, []]);
 
     const recordPromise = recordStreamerEvent(5, 'follow', 'someviewer', null);
 

--- a/src/db/eventLog.test.ts
+++ b/src/db/eventLog.test.ts
@@ -51,6 +51,33 @@ describe('recordStreamerEvent', () => {
     expect(deleteParams).toEqual([5, 5]);
   });
 
+  it('retries pruning on the very next insert when the prune DELETE fails, instead of waiting another full cadence', async () => {
+    const pool = { execute: vi.fn().mockResolvedValue([{ affectedRows: 1 }, []]) };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+
+    for (let i = 0; i < PRUNE_EVERY_N_INSERTS - 1; i++) {
+      await recordStreamerEvent(5, 'follow', 'someviewer', null);
+    }
+    pool.execute.mockClear();
+    // The threshold-reaching insert's DELETE fails.
+    pool.execute
+      .mockResolvedValueOnce([{ affectedRows: 1 }, []]) // INSERT
+      .mockRejectedValueOnce(new Error('DB down')); // DELETE
+
+    await expect(recordStreamerEvent(5, 'follow', 'someviewer', null)).rejects.toThrow('DB down');
+    pool.execute.mockClear();
+    pool.execute.mockResolvedValue([{ affectedRows: 1 }, []]);
+
+    // The counter must not have been cleared by the failed prune — this next insert (the first
+    // of a "quiet" streak) should retry the prune immediately rather than needing
+    // PRUNE_EVERY_N_INSERTS more successful inserts first.
+    await expect(recordStreamerEvent(5, 'follow', 'someviewer', null)).resolves.toBe(true);
+
+    expect(pool.execute).toHaveBeenCalledTimes(2);
+    const [deleteSql] = pool.execute.mock.calls[1];
+    expect(deleteSql).toContain('DELETE FROM streamer_event_log');
+  });
+
   it('tracks the prune-cadence counter independently per streamer', async () => {
     const pool = makePool();
     vi.mocked(getPool).mockReturnValue(pool as any);

--- a/src/db/eventLog.test.ts
+++ b/src/db/eventLog.test.ts
@@ -120,6 +120,49 @@ describe('recordStreamerEvent', () => {
     expect(deleteCalls).toHaveLength(1);
   });
 
+  it('counts inserts that land during an in-flight prune, and immediately runs a follow-up prune if they reach the threshold again', async () => {
+    let resolveDelete!: () => void;
+    const deletePromise = new Promise<[unknown, unknown]>((resolve) => {
+      resolveDelete = () => resolve([{ affectedRows: 5 }, []]);
+    });
+    const pool = { execute: vi.fn().mockResolvedValue([{ affectedRows: 1 }, []]) };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+
+    for (let i = 0; i < PRUNE_EVERY_N_INSERTS - 1; i++) {
+      await recordStreamerEvent(5, 'follow', 'someviewer', null);
+    }
+    pool.execute.mockClear();
+
+    // Call A's insert reaches the threshold; its DELETE is held pending.
+    pool.execute
+      .mockResolvedValueOnce([{ affectedRows: 1 }, []]) // A's INSERT
+      .mockImplementationOnce(() => deletePromise); // A's DELETE, held pending
+    const callA = recordStreamerEvent(5, 'follow', 'someviewer', null);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // A full batch of concurrent inserts lands while A's DELETE is still pending. Each must
+    // still be counted (not silently dropped just because it piggybacks on A's in-flight prune
+    // instead of starting its own) — otherwise a burst could push the table further over the
+    // retention cap than the documented bounded overshoot.
+    pool.execute.mockResolvedValue([{ affectedRows: 1 }, []]);
+    const concurrentCalls = Array.from(
+      { length: PRUNE_EVERY_N_INSERTS },
+      () => recordStreamerEvent(5, 'follow', 'someviewer', null),
+    );
+    for (let i = 0; i < 8; i++) await Promise.resolve();
+
+    resolveDelete();
+    await expect(Promise.all([callA, ...concurrentCalls])).resolves.toEqual(new Array(PRUNE_EVERY_N_INSERTS + 1).fill(true));
+
+    // A's INSERT + A's DELETE + 10 concurrent INSERTs + one follow-up DELETE. The follow-up
+    // DELETE runs automatically once the counted concurrent inserts reached the threshold
+    // again — without waiting for a further insert to trigger it.
+    expect(pool.execute).toHaveBeenCalledTimes(13);
+    const deleteCalls = pool.execute.mock.calls.filter(([sql]) => String(sql).includes('DELETE FROM streamer_event_log'));
+    expect(deleteCalls).toHaveLength(2);
+  });
+
   it('tracks the prune-cadence counter independently per streamer', async () => {
     const pool = makePool();
     vi.mocked(getPool).mockReturnValue(pool as any);

--- a/src/db/eventLog.test.ts
+++ b/src/db/eventLog.test.ts
@@ -78,6 +78,48 @@ describe('recordStreamerEvent', () => {
     expect(deleteSql).toContain('DELETE FROM streamer_event_log');
   });
 
+  it('shares one prune DELETE when a concurrent event lands for the same streamer while the first prune is still in flight', async () => {
+    let resolveDelete!: () => void;
+    const deletePromise = new Promise<[unknown, unknown]>((resolve) => {
+      resolveDelete = () => resolve([{ affectedRows: 5 }, []]);
+    });
+    const pool = { execute: vi.fn().mockResolvedValue([{ affectedRows: 1 }, []]) };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+
+    for (let i = 0; i < PRUNE_EVERY_N_INSERTS - 1; i++) {
+      await recordStreamerEvent(5, 'follow', 'someviewer', null);
+    }
+    pool.execute.mockClear();
+
+    // Call A's insert reaches the prune threshold; its DELETE is held pending.
+    pool.execute
+      .mockResolvedValueOnce([{ affectedRows: 1 }, []]) // call A's INSERT
+      .mockImplementationOnce(() => deletePromise); // call A's DELETE, held pending
+    const callA = recordStreamerEvent(5, 'follow', 'someviewer', null);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Since dispatchNotification fires EventSub handlers without awaiting them (see
+    // eventLog.ts's pruneInFlight doc comment), a second event for the same streamer can land
+    // while call A's DELETE is still pending — the in-memory counter isn't reset until that
+    // DELETE succeeds, so a naive implementation would compute a second threshold-reaching
+    // count and start its own redundant DELETE.
+    pool.execute.mockResolvedValueOnce([{ affectedRows: 1 }, []]); // call B's INSERT
+    const callB = recordStreamerEvent(5, 'follow', 'someviewer', null);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    resolveDelete();
+    await expect(callA).resolves.toBe(true);
+    await expect(callB).resolves.toBe(true);
+
+    // Only 3 execute calls total (A's INSERT, A's DELETE, B's INSERT) — B piggybacks on A's
+    // in-flight prune instead of issuing a second DELETE.
+    expect(pool.execute).toHaveBeenCalledTimes(3);
+    const deleteCalls = pool.execute.mock.calls.filter(([sql]) => String(sql).includes('DELETE FROM streamer_event_log'));
+    expect(deleteCalls).toHaveLength(1);
+  });
+
   it('tracks the prune-cadence counter independently per streamer', async () => {
     const pool = makePool();
     vi.mocked(getPool).mockReturnValue(pool as any);

--- a/src/db/eventLog.ts
+++ b/src/db/eventLog.ts
@@ -84,18 +84,38 @@ export async function recordStreamerEvent(
     throw err;
   }
 
+  // Recorded unconditionally, even while a prune for this streamer is already in flight (see
+  // ensurePruned's doc comment for why that matters): every successful insert must count, or a
+  // burst landing during one DELETE would go untracked and the next prune would wait a full
+  // PRUNE_EVERY_N_INSERTS longer than intended.
   const count = (insertsSincePrune.get(streamerId) ?? 0) + 1;
-  if (count < PRUNE_EVERY_N_INSERTS) {
-    insertsSincePrune.set(streamerId, count);
-    return true;
-  }
+  insertsSincePrune.set(streamerId, count);
+  if (count >= PRUNE_EVERY_N_INSERTS) await ensurePruned(streamerId);
+  return true;
+}
 
+/**
+ * Ensures `streamerId`'s rows are pruned once its `insertsSincePrune` counter has reached
+ * {@link PRUNE_EVERY_N_INSERTS}, coalescing concurrent callers onto a single in-flight `DELETE`
+ * per streamer instead of racing separate ones — `dispatchNotification` fires EventSub handlers
+ * without awaiting them, so multiple `recordStreamerEvent` calls for the same streamer can run
+ * concurrently (e.g. a redemption burst, or a follow and a raid landing together).
+ *
+ * A successful prune subtracts {@link PRUNE_EVERY_N_INSERTS} from the counter rather than
+ * resetting it to zero, so inserts that landed (and were counted) while this `DELETE` was
+ * in flight aren't lost. If enough of them accumulated to reach the threshold again, this loops
+ * immediately rather than waiting for a future insert that might not come for a while.
+ *
+ * @param streamerId - Primary key of the `streamer` row whose rows may need pruning.
+ * @returns Resolves once no further prune is currently needed for this streamer.
+ */
+async function ensurePruned(streamerId: number): Promise<void> {
   // Another concurrent call already reached the threshold and is pruning this streamer —
   // await that instead of racing it with a second DELETE (see pruneInFlight's doc comment).
   const existingPrune = pruneInFlight.get(streamerId);
   if (existingPrune) {
     await existingPrune;
-    return true;
+    return;
   }
 
   const prune = (async () => {
@@ -111,18 +131,22 @@ export async function recordStreamerEvent(
          )`,
         [streamerId, streamerId],
       );
-      // Only clear the counter once the prune actually succeeds — if the DELETE throws, the
+      // Only adjust the counter once the prune actually succeeds — if the DELETE throws, the
       // counter stays at/above the threshold, so the very next insert retries pruning instead
       // of waiting another PRUNE_EVERY_N_INSERTS (which could leave the table over cap
       // indefinitely for a streamer who goes quiet right after a failed prune).
-      insertsSincePrune.set(streamerId, 0);
+      const remaining = (insertsSincePrune.get(streamerId) ?? 0) - PRUNE_EVERY_N_INSERTS;
+      insertsSincePrune.set(streamerId, Math.max(remaining, 0));
     } finally {
       pruneInFlight.delete(streamerId);
     }
   })();
   pruneInFlight.set(streamerId, prune);
   await prune;
-  return true;
+
+  if ((insertsSincePrune.get(streamerId) ?? 0) >= PRUNE_EVERY_N_INSERTS) {
+    await ensurePruned(streamerId);
+  }
 }
 
 /**

--- a/src/db/eventLog.ts
+++ b/src/db/eventLog.ts
@@ -29,6 +29,16 @@ const PRUNE_EVERY_N_INSERTS = 10;
 const insertsSincePrune = new Map<number, number>();
 
 /**
+ * Per-streamer prune already in flight. `dispatchNotification` fires EventSub handlers without
+ * awaiting them, so multiple `recordStreamerEvent` calls for the same streamer can run
+ * concurrently — e.g. a redemption burst, or a follow and a raid landing together. Without this,
+ * every one of them that observes the threshold before the first prune's `insertsSincePrune`
+ * reset lands would start its own redundant `DELETE`. Concurrent callers that hit the threshold
+ * while a prune is already running piggyback on it instead.
+ */
+const pruneInFlight = new Map<number, Promise<void>>();
+
+/**
  * Records a streamer activity event, then — only once every {@link PRUNE_EVERY_N_INSERTS}
  * inserts for that streamer — prunes that streamer's rows down to the most recent
  * {@link EVENTS_RETAINED_PER_STREAMER}, so the table stays bounded (with a small, bounded
@@ -80,22 +90,38 @@ export async function recordStreamerEvent(
     return true;
   }
 
-  // mysql2's prepared statements (execute()) can't bind LIMIT as a placeholder, so the
-  // retention count — a fixed internal constant, never user input — is inlined directly.
-  await getPool().execute(
-    `DELETE FROM streamer_event_log WHERE streamer_id = ? AND id NOT IN (
-       SELECT id FROM (
-         SELECT id FROM streamer_event_log WHERE streamer_id = ?
-         ORDER BY occurred_at DESC, id DESC LIMIT ${EVENTS_RETAINED_PER_STREAMER}
-       ) AS keep
-     )`,
-    [streamerId, streamerId],
-  );
-  // Only clear the counter once the prune actually succeeds — if the DELETE throws, the
-  // counter stays at/above the threshold, so the very next insert retries pruning instead of
-  // waiting another PRUNE_EVERY_N_INSERTS (which could leave the table over cap indefinitely
-  // for a streamer who goes quiet right after a failed prune).
-  insertsSincePrune.set(streamerId, 0);
+  // Another concurrent call already reached the threshold and is pruning this streamer —
+  // await that instead of racing it with a second DELETE (see pruneInFlight's doc comment).
+  const existingPrune = pruneInFlight.get(streamerId);
+  if (existingPrune) {
+    await existingPrune;
+    return true;
+  }
+
+  const prune = (async () => {
+    try {
+      // mysql2's prepared statements (execute()) can't bind LIMIT as a placeholder, so the
+      // retention count — a fixed internal constant, never user input — is inlined directly.
+      await getPool().execute(
+        `DELETE FROM streamer_event_log WHERE streamer_id = ? AND id NOT IN (
+           SELECT id FROM (
+             SELECT id FROM streamer_event_log WHERE streamer_id = ?
+             ORDER BY occurred_at DESC, id DESC LIMIT ${EVENTS_RETAINED_PER_STREAMER}
+           ) AS keep
+         )`,
+        [streamerId, streamerId],
+      );
+      // Only clear the counter once the prune actually succeeds — if the DELETE throws, the
+      // counter stays at/above the threshold, so the very next insert retries pruning instead
+      // of waiting another PRUNE_EVERY_N_INSERTS (which could leave the table over cap
+      // indefinitely for a streamer who goes quiet right after a failed prune).
+      insertsSincePrune.set(streamerId, 0);
+    } finally {
+      pruneInFlight.delete(streamerId);
+    }
+  })();
+  pruneInFlight.set(streamerId, prune);
+  await prune;
   return true;
 }
 
@@ -128,4 +154,5 @@ export async function getRecentStreamerEvents(streamerId: number, limit: number)
 /** Test-only: clears the in-memory per-streamer prune-cadence counters so each test starts from a clean slate. */
 export function __resetEventLogPruneCountersForTests(): void {
   insertsSincePrune.clear();
+  pruneInFlight.clear();
 }

--- a/src/db/eventLog.ts
+++ b/src/db/eventLog.ts
@@ -17,13 +17,25 @@ export interface StreamerEvent {
 // keeps the table bounded regardless of how bursty follows/raids/redemptions get.
 const EVENTS_RETAINED_PER_STREAMER = 200;
 
+// Running the DELETE...ORDER BY...LIMIT prune query after every single insert doubles the
+// write cost of recording an event, even though the table is nowhere near its cap on most
+// inserts. Instead, prune only once every this-many inserts per streamer — a soft cap that
+// lets the table temporarily overshoot EVENTS_RETAINED_PER_STREAMER by at most this much
+// between prunes, which the dashboard's ~20-row "Recent Events" feed never notices.
+const PRUNE_EVERY_N_INSERTS = 10;
+
+/** In-memory count of inserts since the last prune, per streamer. Reset on process restart —
+ * worst case that just delays the next prune by up to {@link PRUNE_EVERY_N_INSERTS} inserts. */
+const insertsSincePrune = new Map<number, number>();
+
 /**
- * Records a streamer activity event, then prunes that streamer's rows down to the most
- * recent {@link EVENTS_RETAINED_PER_STREAMER}, so the table stays bounded regardless of
- * event rate. The prune runs only after the insert completes (not concurrently) so it always
- * sees the just-inserted row — two connections racing via `Promise.all` could otherwise let
- * the prune's snapshot miss the new row, leaving the table one row over the stated cap until
- * the next insert caught up.
+ * Records a streamer activity event, then — only once every {@link PRUNE_EVERY_N_INSERTS}
+ * inserts for that streamer — prunes that streamer's rows down to the most recent
+ * {@link EVENTS_RETAINED_PER_STREAMER}, so the table stays bounded (with a small, bounded
+ * overshoot between prunes) without paying a second round-trip on every insert. The prune, when
+ * it runs, always runs after the insert completes (not concurrently) so it sees the
+ * just-inserted row — two connections racing via `Promise.all` could otherwise let the prune's
+ * snapshot miss the new row.
  *
  * When `redemptionId` is given and collides with an existing row's `redemption_id` (the
  * `streamer_event_log` unique index), the insert is treated as already-done and silently
@@ -61,6 +73,13 @@ export async function recordStreamerEvent(
     if (redemptionId && isMysqlDuplicateEntryError(err)) return false;
     throw err;
   }
+
+  const count = (insertsSincePrune.get(streamerId) ?? 0) + 1;
+  if (count < PRUNE_EVERY_N_INSERTS) {
+    insertsSincePrune.set(streamerId, count);
+    return true;
+  }
+  insertsSincePrune.set(streamerId, 0);
 
   // mysql2's prepared statements (execute()) can't bind LIMIT as a placeholder, so the
   // retention count — a fixed internal constant, never user input — is inlined directly.
@@ -100,4 +119,9 @@ export async function getRecentStreamerEvents(streamerId: number, limit: number)
     detail: r.detail,
     occurredAt: r.occurred_at,
   }));
+}
+
+/** Test-only: clears the in-memory per-streamer prune-cadence counters so each test starts from a clean slate. */
+export function __resetEventLogPruneCountersForTests(): void {
+  insertsSincePrune.clear();
 }

--- a/src/db/eventLog.ts
+++ b/src/db/eventLog.ts
@@ -79,7 +79,6 @@ export async function recordStreamerEvent(
     insertsSincePrune.set(streamerId, count);
     return true;
   }
-  insertsSincePrune.set(streamerId, 0);
 
   // mysql2's prepared statements (execute()) can't bind LIMIT as a placeholder, so the
   // retention count — a fixed internal constant, never user input — is inlined directly.
@@ -92,6 +91,11 @@ export async function recordStreamerEvent(
      )`,
     [streamerId, streamerId],
   );
+  // Only clear the counter once the prune actually succeeds — if the DELETE throws, the
+  // counter stays at/above the threshold, so the very next insert retries pruning instead of
+  // waiting another PRUNE_EVERY_N_INSERTS (which could leave the table over cap indefinitely
+  // for a streamer who goes quiet right after a failed prune).
+  insertsSincePrune.set(streamerId, 0);
   return true;
 }
 

--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -222,8 +222,8 @@ describe('startDiscordBot — messageCreate handler', () => {
     const cb = getMessageCreateCb();
     const msg = { author: { bot: false, username: 'Alice' }, guildId: 'guild-id', content: '!test', member: { displayName: 'Alice' } };
     cb(msg);
-    expect(vi.mocked(commands.handleCommand)).toHaveBeenCalledWith('!test', 'discord', 'guild-id');
-    expect(vi.mocked(customCmds.executeCustomCommandForDiscord)).toHaveBeenCalledWith(msg, 'Alice', 'guild-id');
+    expect(vi.mocked(commands.handleCommand)).toHaveBeenCalledWith('!test', 'discord', 'guild-id', '!test');
+    expect(vi.mocked(customCmds.executeCustomCommandForDiscord)).toHaveBeenCalledWith(msg, 'Alice', 'guild-id', '!test');
   });
 
   it('dispatches to the health command handler for registered guild messages', async () => {
@@ -231,7 +231,7 @@ describe('startDiscordBot — messageCreate handler', () => {
     const cb = getMessageCreateCb();
     const msg = { author: { bot: false, username: 'Alice' }, guildId: 'guild-id', content: '!health', member: { displayName: 'Alice' } };
     cb(msg);
-    expect(vi.mocked(health.executeHealthCommandForDiscord)).toHaveBeenCalledWith(msg);
+    expect(vi.mocked(health.executeHealthCommandForDiscord)).toHaveBeenCalledWith(msg, '!health');
   });
 });
 

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -1,7 +1,7 @@
 import { Client, GatewayIntentBits, Guild, Partials } from 'discord.js';
 import { DISCORD_TOKEN } from '../shared/config';
 import { handleCommand, forgetGuildCommandState } from '../commands/commandRouter';
-import { fireAndForget } from '../commands/commandUtils';
+import { fireAndForget, extractCommand } from '../commands/commandUtils';
 import { executeCustomCommandForDiscord, forgetGuildCustomCommandCooldown } from '../commands/customCommandHandler';
 import { executeCounterCommandForDiscord, forgetGuildCounterCooldown } from '../commands/counterHandler';
 import { setDiscordReady, clearVoiceStatus } from '../shared/statusStore';
@@ -166,11 +166,14 @@ export function startDiscordBot(): void {
 
     const displayName = message.member?.displayName ?? message.author.username;
     const guildId = message.guildId;
+    // Parsed once and threaded into every handler below instead of each one re-parsing
+    // the same message independently.
+    const command = extractCommand(message.content);
 
-    fireAndForget(executeCustomCommandForDiscord(message, displayName, guildId), 'Custom command error', log);
-    fireAndForget(executeCounterCommandForDiscord(message, displayName), 'Counter command error', log);
-    fireAndForget(handleCommand(message.content, 'discord', guildId), 'Command handler error', log);
-    fireAndForget(executeHealthCommandForDiscord(message), 'Health command error', log);
+    fireAndForget(executeCustomCommandForDiscord(message, displayName, guildId, command), 'Custom command error', log);
+    fireAndForget(executeCounterCommandForDiscord(message, displayName, command), 'Counter command error', log);
+    fireAndForget(handleCommand(message.content, 'discord', guildId, command), 'Command handler error', log);
+    fireAndForget(executeHealthCommandForDiscord(message, command), 'Health command error', log);
   });
 
   // Bootstrap: when the bot is added to a server for the first time, record the

--- a/src/twitch/eventsub/twitchEventSubReconciliation.test.ts
+++ b/src/twitch/eventsub/twitchEventSubReconciliation.test.ts
@@ -108,6 +108,31 @@ describe('runReconciliationTick', () => {
     );
   });
 
+  it('drops the cursor for a streamer no longer returned by getAllStreamerInfo, so it re-establishes on reconnect', async () => {
+    vi.mocked(getAllStreamerInfo).mockReturnValue(new Map([['uid1', info]]));
+    await runReconciliationTick(); // establishes the cursor at "now"
+
+    // uid1 is absent this tick (e.g. streamer disconnected) — its cursor should be pruned.
+    vi.mocked(getAllStreamerInfo).mockReturnValue(new Map());
+    await runReconciliationTick();
+
+    // uid1 reconnects; a redemption just past the cursor established above would normally be
+    // skipped, but since the cursor was pruned this tick re-establishes a fresh one-poll-interval
+    // lookback instead, so a redemption within that fresh window is replayed.
+    vi.mocked(getAllStreamerInfo).mockReturnValue(new Map([['uid1', info]]));
+    const withinFreshLookback = new Date(Date.now() - 1_000).toISOString();
+    mockFulfilledOnly({ redemptions: [redemption('r1', withinFreshLookback)], cursor: null });
+    await runReconciliationTick();
+
+    expect(handleRedemption).toHaveBeenCalledTimes(1);
+    expect(handleRedemption).toHaveBeenCalledWith(
+      'streamerA',
+      expect.objectContaining({ id: 'r1' }),
+      config,
+      1,
+    );
+  });
+
   it('does not replay a redemption older than or equal to the cursor', async () => {
     vi.mocked(getAllStreamerInfo).mockReturnValue(new Map([['uid1', info]]));
     await runReconciliationTick(); // cursor lands at "now"

--- a/src/twitch/eventsub/twitchEventSubReconciliation.test.ts
+++ b/src/twitch/eventsub/twitchEventSubReconciliation.test.ts
@@ -109,19 +109,27 @@ describe('runReconciliationTick', () => {
   });
 
   it('drops the cursor for a streamer no longer returned by getAllStreamerInfo, so it re-establishes on reconnect', async () => {
+    // Seed tick 1 with a redemption so the cursor advances to ~"now" (not the initial
+    // one-poll-interval-ago default) — this is what makes the later assertion actually
+    // depend on pruning: without pruning, this recent cursor would still be in effect on
+    // tick 3 and would reject the older "reconnect" redemption below on its own.
     vi.mocked(getAllStreamerInfo).mockReturnValue(new Map([['uid1', info]]));
-    await runReconciliationTick(); // establishes the cursor at "now"
+    const seedRedeemedAt = new Date(Date.now() - 100).toISOString();
+    mockFulfilledOnly({ redemptions: [redemption('seed', seedRedeemedAt)], cursor: null });
+    await runReconciliationTick(); // cursor lands at seedRedeemedAt (~"now")
+    vi.mocked(handleRedemption).mockClear();
 
     // uid1 is absent this tick (e.g. streamer disconnected) — its cursor should be pruned.
     vi.mocked(getAllStreamerInfo).mockReturnValue(new Map());
     await runReconciliationTick();
 
-    // uid1 reconnects; a redemption just past the cursor established above would normally be
-    // skipped, but since the cursor was pruned this tick re-establishes a fresh one-poll-interval
-    // lookback instead, so a redemption within that fresh window is replayed.
+    // uid1 reconnects; this redemption is older than the tick-1 cursor (seedRedeemedAt) but
+    // within a fresh one-poll-interval lookback, so it's only replayed if the cursor was
+    // actually pruned in between — without pruning, the stale seedRedeemedAt cursor would
+    // still reject it as older-than-cutoff.
     vi.mocked(getAllStreamerInfo).mockReturnValue(new Map([['uid1', info]]));
-    const withinFreshLookback = new Date(Date.now() - 1_000).toISOString();
-    mockFulfilledOnly({ redemptions: [redemption('r1', withinFreshLookback)], cursor: null });
+    const reconnectRedeemedAt = new Date(Date.now() - 1_000).toISOString();
+    mockFulfilledOnly({ redemptions: [redemption('r1', reconnectRedeemedAt)], cursor: null });
     await runReconciliationTick();
 
     expect(handleRedemption).toHaveBeenCalledTimes(1);

--- a/src/twitch/eventsub/twitchEventSubReconciliation.ts
+++ b/src/twitch/eventsub/twitchEventSubReconciliation.ts
@@ -137,6 +137,20 @@ async function reconcileReward(info: StreamerInfo, uid: string, token: string, r
 }
 
 /**
+ * Drops `lastSeenRedeemedAt` entries whose broadcaster user id is no longer present in
+ * `currentUids` — e.g. a streamer removed from monitoring or disconnected since the last tick.
+ * Without this, the map grows by one entry per reward for every streamer that ever connected,
+ * even after they stop being reconciled.
+ * @param currentUids - Broadcaster user ids from this tick's {@link getAllStreamerInfo} snapshot.
+ */
+function pruneStaleReconciliationCursors(currentUids: ReadonlySet<string>): void {
+  for (const key of lastSeenRedeemedAt.keys()) {
+    const uid = key.slice(0, key.indexOf(':'));
+    if (!currentUids.has(uid)) lastSeenRedeemedAt.delete(key);
+  }
+}
+
+/**
  * Reconciles one streamer: resolves their broadcaster token, lists their custom rewards, and
  * reconciles each one via {@link reconcileReward}. No-ops silently if the streamer has no
  * usable token (nothing to authenticate the Helix calls with — the same condition that would
@@ -173,7 +187,9 @@ export async function runReconciliationTick(): Promise<void> {
   tickRunning = true;
   currentTickPromise = (async () => {
     try {
-      const entries = [...getAllStreamerInfo()].filter(([, info]) => info.config !== null);
+      const allStreamerInfo = [...getAllStreamerInfo()];
+      pruneStaleReconciliationCursors(new Set(allStreamerInfo.map(([uid]) => uid)));
+      const entries = allStreamerInfo.filter(([, info]) => info.config !== null);
       await Promise.allSettled(entries.map(([uid, info]) => reconcileStreamer(uid, info)));
     } finally {
       tickRunning = false;

--- a/src/twitch/eventsub/twitchEventSubReconciliation.ts
+++ b/src/twitch/eventsub/twitchEventSubReconciliation.ts
@@ -142,6 +142,7 @@ async function reconcileReward(info: StreamerInfo, uid: string, token: string, r
  * Without this, the map grows by one entry per reward for every streamer that ever connected,
  * even after they stop being reconciled.
  * @param currentUids - Broadcaster user ids from this tick's {@link getAllStreamerInfo} snapshot.
+ * @returns Nothing — mutates {@link lastSeenRedeemedAt} in place.
  */
 function pruneStaleReconciliationCursors(currentUids: ReadonlySet<string>): void {
   for (const key of lastSeenRedeemedAt.keys()) {

--- a/src/twitch/twitchBot.test.ts
+++ b/src/twitch/twitchBot.test.ts
@@ -343,15 +343,15 @@ describe('handleTwitchMessage', () => {
 
     sendMessage('#streamer', 'alice', '!cmd', { displayName: 'Alice' });
 
-    expect(executeCustomCommandForTwitch).toHaveBeenCalledOnce();
-    expect(executeCounterCommandForTwitch).toHaveBeenCalledOnce();
-    expect(executeMultiCommandForTwitch).toHaveBeenCalledOnce();
-    expect(executeShoutoutForTwitch).toHaveBeenCalledOnce();
+    expect(executeCustomCommandForTwitch).toHaveBeenCalledWith('streamer', '!cmd', 'Alice', '!cmd');
+    expect(executeCounterCommandForTwitch).toHaveBeenCalledWith('streamer', '!cmd', 'Alice', '!cmd');
+    expect(executeMultiCommandForTwitch).toHaveBeenCalledWith('streamer', '!cmd', 'Alice', '!cmd');
+    expect(executeShoutoutForTwitch).toHaveBeenCalledWith('streamer', '!cmd', 'Alice', false, '!cmd');
     // Guild resolution (Twitch-channel → discord_id → active voice guild) runs
     // asynchronously before handleCommand is invoked.
     await vi.waitFor(() => expect(handleCommand).toHaveBeenCalledOnce());
     expect(handleCommand).toHaveBeenCalledWith('!cmd', 'twitch', 'guild-A', '!cmd');
-    expect(executeCountdownForTwitch).toHaveBeenCalledOnce();
+    expect(executeCountdownForTwitch).toHaveBeenCalledWith('streamer', '!cmd', '!cmd');
   });
 
   it('resolves the target guild via the linked streamer\'s active voice presence', async () => {

--- a/src/twitch/twitchBot.test.ts
+++ b/src/twitch/twitchBot.test.ts
@@ -324,7 +324,7 @@ describe('handleTwitchMessage', () => {
   it('processes messages when sourceChannelId matches channelId', () => {
     vi.mocked(executeCustomCommandForTwitch).mockResolvedValue(undefined);
     sendMessage('#streamer', 'alice', 'hello', { channelId: '111', sourceChannelId: '111' });
-    expect(executeCustomCommandForTwitch).toHaveBeenCalledWith('streamer', 'hello', 'alice');
+    expect(executeCustomCommandForTwitch).toHaveBeenCalledWith('streamer', 'hello', 'alice', 'hello');
     expect(recordChatMessage).toHaveBeenCalledWith('streamer');
   });
 
@@ -350,7 +350,7 @@ describe('handleTwitchMessage', () => {
     // Guild resolution (Twitch-channel → discord_id → active voice guild) runs
     // asynchronously before handleCommand is invoked.
     await vi.waitFor(() => expect(handleCommand).toHaveBeenCalledOnce());
-    expect(handleCommand).toHaveBeenCalledWith('!cmd', 'twitch', 'guild-A');
+    expect(handleCommand).toHaveBeenCalledWith('!cmd', 'twitch', 'guild-A', '!cmd');
     expect(executeCountdownForTwitch).toHaveBeenCalledOnce();
   });
 
@@ -372,7 +372,7 @@ describe('handleTwitchMessage', () => {
     sendMessage('#streamer', 'alice', '!cmd');
 
     await vi.waitFor(() => expect(handleCommand).toHaveBeenCalledOnce());
-    expect(handleCommand).toHaveBeenCalledWith('!cmd', 'twitch', null);
+    expect(handleCommand).toHaveBeenCalledWith('!cmd', 'twitch', null, '!cmd');
     expect(resolveGuildIdForDiscordId).not.toHaveBeenCalled();
   });
 
@@ -425,31 +425,31 @@ describe('handleTwitchMessage', () => {
   it('passes the normalized channel and message to executors', () => {
     vi.mocked(executeCustomCommandForTwitch).mockResolvedValue(undefined);
     sendMessage('#STREAMER', 'alice', '!clap', { displayName: 'Alice' });
-    expect(executeCustomCommandForTwitch).toHaveBeenCalledWith('streamer', '!clap', 'Alice');
+    expect(executeCustomCommandForTwitch).toHaveBeenCalledWith('streamer', '!clap', 'Alice', '!clap');
   });
 
   it('falls back to the login username when userInfo.displayName is absent', () => {
     vi.mocked(executeCustomCommandForTwitch).mockResolvedValue(undefined);
     sendMessage('#streamer', 'alice', '!hi');
-    expect(executeCustomCommandForTwitch).toHaveBeenCalledWith('streamer', '!hi', 'alice');
+    expect(executeCustomCommandForTwitch).toHaveBeenCalledWith('streamer', '!hi', 'alice', '!hi');
   });
 
   it('detects isMod=true from userInfo.isMod', () => {
     vi.mocked(executeShoutoutForTwitch).mockResolvedValue(undefined);
     sendMessage('#streamer', 'alice', '!so alice', { isMod: true });
-    expect(executeShoutoutForTwitch).toHaveBeenCalledWith('streamer', '!so alice', 'alice', true);
+    expect(executeShoutoutForTwitch).toHaveBeenCalledWith('streamer', '!so alice', 'alice', true, '!so');
   });
 
   it('detects isMod=true from userInfo.isBroadcaster', () => {
     vi.mocked(executeShoutoutForTwitch).mockResolvedValue(undefined);
     sendMessage('#streamer', 'alice', '!so alice', { isBroadcaster: true });
-    expect(executeShoutoutForTwitch).toHaveBeenCalledWith('streamer', '!so alice', 'alice', true);
+    expect(executeShoutoutForTwitch).toHaveBeenCalledWith('streamer', '!so alice', 'alice', true, '!so');
   });
 
   it('passes isMod=false when neither isMod nor isBroadcaster is set', () => {
     vi.mocked(executeShoutoutForTwitch).mockResolvedValue(undefined);
     sendMessage('#streamer', 'alice', '!so alice');
-    expect(executeShoutoutForTwitch).toHaveBeenCalledWith('streamer', '!so alice', 'alice', false);
+    expect(executeShoutoutForTwitch).toHaveBeenCalledWith('streamer', '!so alice', 'alice', false, '!so');
   });
 });
 

--- a/src/twitch/twitchBot.ts
+++ b/src/twitch/twitchBot.ts
@@ -7,7 +7,7 @@ import { executeCounterCommandForTwitch } from '../commands/counterHandler';
 import { executeMultiCommandForTwitch } from '../commands/multiCommandHandler';
 import { executeShoutoutForTwitch } from '../commands/shoutoutHandler';
 import { executeCountdownForTwitch } from '../commands/countdownHandler';
-import { fireAndForget } from '../commands/commandUtils';
+import { fireAndForget, extractCommand } from '../commands/commandUtils';
 import { recordChatMessage } from './twitchChatActivity';
 import { setTwitchChannel } from '../shared/statusStore';
 import { recordTwitchChatConnected } from '../shared/healthStore';
@@ -222,17 +222,20 @@ function handleTwitchMessage(channel: string, user: string, message: string, msg
 
     const displayName = msg.userInfo.displayName ?? user ?? null;
     const isMod = msg.userInfo.isMod || msg.userInfo.isBroadcaster;
+    // Parsed once and threaded into every handler below instead of each one re-parsing
+    // the same message independently.
+    const command = extractCommand(message);
 
-    fireAndForget(executeCustomCommandForTwitch(normalizedChannel, message, displayName), 'Custom command error', log);
-    fireAndForget(executeCounterCommandForTwitch(normalizedChannel, message, displayName), 'Counter command error', log);
-    fireAndForget(executeMultiCommandForTwitch(normalizedChannel, message, displayName), 'Multi command error', log);
-    fireAndForget(executeShoutoutForTwitch(normalizedChannel, message, displayName, isMod), 'Shoutout error', log);
+    fireAndForget(executeCustomCommandForTwitch(normalizedChannel, message, displayName, command), 'Custom command error', log);
+    fireAndForget(executeCounterCommandForTwitch(normalizedChannel, message, displayName, command), 'Counter command error', log);
+    fireAndForget(executeMultiCommandForTwitch(normalizedChannel, message, displayName, command), 'Multi command error', log);
+    fireAndForget(executeShoutoutForTwitch(normalizedChannel, message, displayName, isMod, command), 'Shoutout error', log);
     fireAndForget(
-      resolveGuildIdForTwitchCommand(normalizedChannel).then((guildId) => handleCommand(message, 'twitch', guildId)),
+      resolveGuildIdForTwitchCommand(normalizedChannel).then((guildId) => handleCommand(message, 'twitch', guildId, command)),
       'Command handler error',
       log,
     );
-    fireAndForget(executeCountdownForTwitch(normalizedChannel, message), 'Countdown error', log);
+    fireAndForget(executeCountdownForTwitch(normalizedChannel, message, command), 'Countdown error', log);
   } catch (err) {
     log.error('Unexpected error in message handler:', err);
   }

--- a/src/web/middleware.test.ts
+++ b/src/web/middleware.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ACCESS_LEVEL_MOCK } from '../test-utils/accessLevelMock';
 
 vi.mock('../db', () => ({
@@ -15,7 +15,7 @@ vi.mock('./csrf', () => ({
 }));
 
 import { createHash } from 'crypto';
-import { requireAuth, requireManager, requireMod, requireAdmin, requireOwner, requireOwnerJson, requireModJson, requireManagerJson, requireAdminJson, requireApiKey, requireCompanionKey, requireGuildContext, clearGuildContextCache } from './middleware';
+import { requireAuth, requireManager, requireMod, requireAdmin, requireOwner, requireOwnerJson, requireModJson, requireManagerJson, requireAdminJson, requireApiKey, requireCompanionKey, requireGuildContext } from './middleware';
 import { findKeyByHash, findDiscordIdByTokenHash, getEffectiveAccessLevelForUser, findUser, getAllGuilds, getGuildsForMember, AccessLevel } from '../db';
 
 function makeReq(overrides: object = {}): any {
@@ -40,7 +40,6 @@ const next = vi.fn();
 
 beforeEach(() => {
   vi.clearAllMocks();
-  clearGuildContextCache();
 });
 
 // ─── requireAuth ─────────────────────────────────────────────────────────────
@@ -573,60 +572,5 @@ describe('requireGuildContext', () => {
     await requireGuildContext(req, res, next);
     expect(res.redirect).toHaveBeenCalledWith('/auth/login');
     expect(next).not.toHaveBeenCalled();
-  });
-});
-
-// ─── requireGuildContext — guild-context caching ──────────────────────────────
-
-describe('requireGuildContext — guild-context caching', () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-    vi.mocked(findUser).mockResolvedValue({ discord_id: 'u1', is_owner: false } as any);
-    vi.mocked(getGuildsForMember).mockResolvedValue([{ guild_id: 'g1', name: 'A', voice_channel_id: null, access_level: AccessLevel.ADMIN }] as any);
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  function makeUser() {
-    return { discordId: 'u1', currentGuildId: 'g1', accessLevel: AccessLevel.USER, guilds: [{ guildId: 'g1', name: 'A' }] };
-  }
-
-  it('reuses the cached findUser/fetchLiveGuildsForUser lookup for a second request within the TTL', async () => {
-    await requireGuildContext(makeReq({ session: { user: makeUser() } }), makeRes(), next);
-    await requireGuildContext(makeReq({ session: { user: makeUser() } }), makeRes(), next);
-    expect(findUser).toHaveBeenCalledTimes(1);
-    expect(getGuildsForMember).toHaveBeenCalledTimes(1);
-  });
-
-  it('re-fetches once the TTL has elapsed', async () => {
-    await requireGuildContext(makeReq({ session: { user: makeUser() } }), makeRes(), next);
-    vi.advanceTimersByTime(20_001);
-    await requireGuildContext(makeReq({ session: { user: makeUser() } }), makeRes(), next);
-    expect(findUser).toHaveBeenCalledTimes(2);
-    expect(getGuildsForMember).toHaveBeenCalledTimes(2);
-  });
-
-  it('caches independently per user', async () => {
-    await requireGuildContext(makeReq({ session: { user: makeUser() } }), makeRes(), next);
-    await requireGuildContext(makeReq({ session: { user: { ...makeUser(), discordId: 'u2' } } }), makeRes(), next);
-    expect(findUser).toHaveBeenCalledTimes(2);
-    expect(findUser).toHaveBeenNthCalledWith(1, 'u1');
-    expect(findUser).toHaveBeenNthCalledWith(2, 'u2');
-  });
-
-  it('coalesces concurrent cache misses for the same user onto a single DB fetch', async () => {
-    let resolveUser!: (value: { discord_id: string; is_owner: boolean }) => void;
-    vi.mocked(findUser).mockReturnValue(new Promise((resolve) => { resolveUser = resolve; }) as any);
-
-    const first = requireGuildContext(makeReq({ session: { user: makeUser() } }), makeRes(), next);
-    const second = requireGuildContext(makeReq({ session: { user: makeUser() } }), makeRes(), next);
-
-    resolveUser({ discord_id: 'u1', is_owner: false });
-    await Promise.all([first, second]);
-
-    expect(findUser).toHaveBeenCalledTimes(1);
-    expect(getGuildsForMember).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/web/middleware.test.ts
+++ b/src/web/middleware.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ACCESS_LEVEL_MOCK } from '../test-utils/accessLevelMock';
 
 vi.mock('../db', () => ({
@@ -15,7 +15,7 @@ vi.mock('./csrf', () => ({
 }));
 
 import { createHash } from 'crypto';
-import { requireAuth, requireManager, requireMod, requireAdmin, requireOwner, requireOwnerJson, requireModJson, requireManagerJson, requireAdminJson, requireApiKey, requireCompanionKey, requireGuildContext } from './middleware';
+import { requireAuth, requireManager, requireMod, requireAdmin, requireOwner, requireOwnerJson, requireModJson, requireManagerJson, requireAdminJson, requireApiKey, requireCompanionKey, requireGuildContext, clearGuildContextCache } from './middleware';
 import { findKeyByHash, findDiscordIdByTokenHash, getEffectiveAccessLevelForUser, findUser, getAllGuilds, getGuildsForMember, AccessLevel } from '../db';
 
 function makeReq(overrides: object = {}): any {
@@ -40,6 +40,7 @@ const next = vi.fn();
 
 beforeEach(() => {
   vi.clearAllMocks();
+  clearGuildContextCache();
 });
 
 // ─── requireAuth ─────────────────────────────────────────────────────────────
@@ -572,5 +573,60 @@ describe('requireGuildContext', () => {
     await requireGuildContext(req, res, next);
     expect(res.redirect).toHaveBeenCalledWith('/auth/login');
     expect(next).not.toHaveBeenCalled();
+  });
+});
+
+// ─── requireGuildContext — guild-context caching ──────────────────────────────
+
+describe('requireGuildContext — guild-context caching', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(findUser).mockResolvedValue({ discord_id: 'u1', is_owner: false } as any);
+    vi.mocked(getGuildsForMember).mockResolvedValue([{ guild_id: 'g1', name: 'A', voice_channel_id: null, access_level: AccessLevel.ADMIN }] as any);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function makeUser() {
+    return { discordId: 'u1', currentGuildId: 'g1', accessLevel: AccessLevel.USER, guilds: [{ guildId: 'g1', name: 'A' }] };
+  }
+
+  it('reuses the cached findUser/fetchLiveGuildsForUser lookup for a second request within the TTL', async () => {
+    await requireGuildContext(makeReq({ session: { user: makeUser() } }), makeRes(), next);
+    await requireGuildContext(makeReq({ session: { user: makeUser() } }), makeRes(), next);
+    expect(findUser).toHaveBeenCalledTimes(1);
+    expect(getGuildsForMember).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fetches once the TTL has elapsed', async () => {
+    await requireGuildContext(makeReq({ session: { user: makeUser() } }), makeRes(), next);
+    vi.advanceTimersByTime(20_001);
+    await requireGuildContext(makeReq({ session: { user: makeUser() } }), makeRes(), next);
+    expect(findUser).toHaveBeenCalledTimes(2);
+    expect(getGuildsForMember).toHaveBeenCalledTimes(2);
+  });
+
+  it('caches independently per user', async () => {
+    await requireGuildContext(makeReq({ session: { user: makeUser() } }), makeRes(), next);
+    await requireGuildContext(makeReq({ session: { user: { ...makeUser(), discordId: 'u2' } } }), makeRes(), next);
+    expect(findUser).toHaveBeenCalledTimes(2);
+    expect(findUser).toHaveBeenNthCalledWith(1, 'u1');
+    expect(findUser).toHaveBeenNthCalledWith(2, 'u2');
+  });
+
+  it('coalesces concurrent cache misses for the same user onto a single DB fetch', async () => {
+    let resolveUser!: (value: { discord_id: string; is_owner: boolean }) => void;
+    vi.mocked(findUser).mockReturnValue(new Promise((resolve) => { resolveUser = resolve; }) as any);
+
+    const first = requireGuildContext(makeReq({ session: { user: makeUser() } }), makeRes(), next);
+    const second = requireGuildContext(makeReq({ session: { user: makeUser() } }), makeRes(), next);
+
+    resolveUser({ discord_id: 'u1', is_owner: false });
+    await Promise.all([first, second]);
+
+    expect(findUser).toHaveBeenCalledTimes(1);
+    expect(getGuildsForMember).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/web/middleware.ts
+++ b/src/web/middleware.ts
@@ -6,78 +6,9 @@ import {
   findKeyByHash,
   findDiscordIdByTokenHash,
   findUser,
-  type DbUser,
 } from '../db';
 import { renderView } from './routes/viewHelpers';
-import { fetchLiveGuildsForUser, resolveAccessLevelForGuild, type LiveGuildsResult } from './guildAccess';
-
-/** How long a user's DB row + live guild/access-level list is cached before being re-fetched. */
-const GUILD_CONTEXT_CACHE_TTL_MS = 20_000;
-
-interface CachedGuildContext {
-  dbUser: DbUser | null;
-  liveGuilds: LiveGuildsResult;
-  fetchedAt: number;
-}
-
-/**
- * `requireGuildContext` runs on every guild-scoped request and always re-derives membership
- * and access level from the DB (see its doc comment for why), which costs a `findUser` plus a
- * `getAllGuilds`/`getGuildsForMember` round trip per request. Membership and owner status only
- * change on an admin action, so — mirroring `guildScopedStatus.ts`'s identical tradeoff — this
- * caches that pair per user for a short TTL instead of paying it on every request. Deliberately
- * TTL-only (not invalidated on every membership write): a few seconds of staleness before a
- * revoked membership takes effect is an acceptable tradeoff against touching every such write path.
- */
-const guildContextCache = new Map<string, CachedGuildContext>();
-
-/**
- * Users with a fetch already in flight — coalesces concurrent cache misses (e.g. several tabs
- * loading guild-scoped pages for the same user before the first fetch resolves) onto a single
- * `findUser`/`fetchLiveGuildsForUser` pair, instead of each request firing its own.
- */
-const guildContextInFlight = new Map<string, Promise<CachedGuildContext>>();
-
-/** Test-only: clears the guild-context cache so DB mocks aren't shadowed across test cases. */
-export function clearGuildContextCache(): void {
-  guildContextCache.clear();
-  guildContextInFlight.clear();
-}
-
-/**
- * Returns `discordId`'s cached DB user + live guild/access-level list, refreshing it (via
- * `findUser`/`fetchLiveGuildsForUser`) when missing or past `GUILD_CONTEXT_CACHE_TTL_MS`.
- * Concurrent calls for the same stale/missing user share one in-flight fetch instead of each
- * firing their own.
- * @param discordId - Discord snowflake of the session user to look up.
- * @returns The cached (or freshly fetched) DB user and live guild/access-level list.
- */
-async function getCachedGuildContext(discordId: string): Promise<CachedGuildContext> {
-  const cached = guildContextCache.get(discordId);
-  const now = Date.now();
-  if (cached && now - cached.fetchedAt < GUILD_CONTEXT_CACHE_TTL_MS) {
-    return cached;
-  }
-
-  const inFlight = guildContextInFlight.get(discordId);
-  if (inFlight) return inFlight;
-
-  const load = (async (): Promise<CachedGuildContext> => {
-    try {
-      const dbUser = await findUser(discordId);
-      const liveGuilds = dbUser
-        ? await fetchLiveGuildsForUser(dbUser)
-        : { guilds: [], accessLevelByGuildId: null };
-      const context: CachedGuildContext = { dbUser, liveGuilds, fetchedAt: Date.now() };
-      guildContextCache.set(discordId, context);
-      return context;
-    } finally {
-      guildContextInFlight.delete(discordId);
-    }
-  })();
-  guildContextInFlight.set(discordId, load);
-  return load;
-}
+import { fetchLiveGuildsForUser, resolveAccessLevelForGuild } from './guildAccess';
 
 /**
  * Ensures the request has a logged-in session user, redirecting to login otherwise.
@@ -121,12 +52,13 @@ export async function requireGuildContext(req: Request, res: Response, next: Nex
     return;
   }
 
-  const { dbUser, liveGuilds: { guilds: liveGuilds, accessLevelByGuildId } } = await getCachedGuildContext(user.discordId);
+  const dbUser = await findUser(user.discordId);
   if (!dbUser) {
     res.redirect('/auth/login');
     return;
   }
 
+  const { guilds: liveGuilds, accessLevelByGuildId } = await fetchLiveGuildsForUser(dbUser);
   user.isOwner = dbUser.is_owner;
   user.guilds = liveGuilds.map((g) => ({ guildId: g.guild_id, name: g.name }));
 

--- a/src/web/middleware.ts
+++ b/src/web/middleware.ts
@@ -6,9 +6,78 @@ import {
   findKeyByHash,
   findDiscordIdByTokenHash,
   findUser,
+  type DbUser,
 } from '../db';
 import { renderView } from './routes/viewHelpers';
-import { fetchLiveGuildsForUser, resolveAccessLevelForGuild } from './guildAccess';
+import { fetchLiveGuildsForUser, resolveAccessLevelForGuild, type LiveGuildsResult } from './guildAccess';
+
+/** How long a user's DB row + live guild/access-level list is cached before being re-fetched. */
+const GUILD_CONTEXT_CACHE_TTL_MS = 20_000;
+
+interface CachedGuildContext {
+  dbUser: DbUser | null;
+  liveGuilds: LiveGuildsResult;
+  fetchedAt: number;
+}
+
+/**
+ * `requireGuildContext` runs on every guild-scoped request and always re-derives membership
+ * and access level from the DB (see its doc comment for why), which costs a `findUser` plus a
+ * `getAllGuilds`/`getGuildsForMember` round trip per request. Membership and owner status only
+ * change on an admin action, so — mirroring `guildScopedStatus.ts`'s identical tradeoff — this
+ * caches that pair per user for a short TTL instead of paying it on every request. Deliberately
+ * TTL-only (not invalidated on every membership write): a few seconds of staleness before a
+ * revoked membership takes effect is an acceptable tradeoff against touching every such write path.
+ */
+const guildContextCache = new Map<string, CachedGuildContext>();
+
+/**
+ * Users with a fetch already in flight — coalesces concurrent cache misses (e.g. several tabs
+ * loading guild-scoped pages for the same user before the first fetch resolves) onto a single
+ * `findUser`/`fetchLiveGuildsForUser` pair, instead of each request firing its own.
+ */
+const guildContextInFlight = new Map<string, Promise<CachedGuildContext>>();
+
+/** Test-only: clears the guild-context cache so DB mocks aren't shadowed across test cases. */
+export function clearGuildContextCache(): void {
+  guildContextCache.clear();
+  guildContextInFlight.clear();
+}
+
+/**
+ * Returns `discordId`'s cached DB user + live guild/access-level list, refreshing it (via
+ * `findUser`/`fetchLiveGuildsForUser`) when missing or past `GUILD_CONTEXT_CACHE_TTL_MS`.
+ * Concurrent calls for the same stale/missing user share one in-flight fetch instead of each
+ * firing their own.
+ * @param discordId - Discord snowflake of the session user to look up.
+ * @returns The cached (or freshly fetched) DB user and live guild/access-level list.
+ */
+async function getCachedGuildContext(discordId: string): Promise<CachedGuildContext> {
+  const cached = guildContextCache.get(discordId);
+  const now = Date.now();
+  if (cached && now - cached.fetchedAt < GUILD_CONTEXT_CACHE_TTL_MS) {
+    return cached;
+  }
+
+  const inFlight = guildContextInFlight.get(discordId);
+  if (inFlight) return inFlight;
+
+  const load = (async (): Promise<CachedGuildContext> => {
+    try {
+      const dbUser = await findUser(discordId);
+      const liveGuilds = dbUser
+        ? await fetchLiveGuildsForUser(dbUser)
+        : { guilds: [], accessLevelByGuildId: null };
+      const context: CachedGuildContext = { dbUser, liveGuilds, fetchedAt: Date.now() };
+      guildContextCache.set(discordId, context);
+      return context;
+    } finally {
+      guildContextInFlight.delete(discordId);
+    }
+  })();
+  guildContextInFlight.set(discordId, load);
+  return load;
+}
 
 /**
  * Ensures the request has a logged-in session user, redirecting to login otherwise.
@@ -52,13 +121,12 @@ export async function requireGuildContext(req: Request, res: Response, next: Nex
     return;
   }
 
-  const dbUser = await findUser(user.discordId);
+  const { dbUser, liveGuilds: { guilds: liveGuilds, accessLevelByGuildId } } = await getCachedGuildContext(user.discordId);
   if (!dbUser) {
     res.redirect('/auth/login');
     return;
   }
 
-  const { guilds: liveGuilds, accessLevelByGuildId } = await fetchLiveGuildsForUser(dbUser);
   user.isOwner = dbUser.is_owner;
   user.guilds = liveGuilds.map((g) => ({ guildId: g.guild_id, name: g.name }));
 

--- a/src/web/routes/dashboard.test.ts
+++ b/src/web/routes/dashboard.test.ts
@@ -135,6 +135,33 @@ describe('GET /', () => {
     expect(res.status).toBe(500);
   });
 
+  it('starts getGuildScopedStatus concurrently with the usage-stat and streamer queries, not sequentially before them', async () => {
+    let resolveStatus!: (value: typeof STATUS) => void;
+    vi.mocked(getGuildScopedStatus).mockReturnValue(new Promise((resolve) => { resolveStatus = resolve; }) as any);
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
+
+    const responsePromise = supertest(buildApp({ discordId: '100' })).get('/');
+    // supertest's Test is a lazy thenable — the request isn't actually dispatched until it's
+    // awaited/`.then()`ed, so attach a no-op handler now to kick it off without consuming the
+    // promise this test still awaits below.
+    responsePromise.catch(() => {});
+
+    // If getGuildScopedStatus were awaited before the Promise.all batch (rather than inside
+    // it), these wouldn't have been called yet — they'd still be waiting on that await. Give
+    // the request time to reach the route handler and start every call in the batch, then
+    // assert they've all started even though getGuildScopedStatus's own promise is still
+    // unresolved.
+    await vi.waitFor(() => expect(getStreamerByDiscordId).toHaveBeenCalled());
+    expect(getSfxTriggerCount).toHaveBeenCalled();
+    expect(getCustomCommandCount).toHaveBeenCalled();
+    expect(getCounterCount).toHaveBeenCalled();
+
+    resolveStatus(STATUS);
+    const res = await responsePromise;
+    expect(res.status).toBe(200);
+    expect(res.body.status).toEqual(STATUS);
+  });
+
   it('loads and maps recent events when a streamer exists', async () => {
     vi.mocked(getStreamerByDiscordId).mockResolvedValue({ id: 42, eventsub_access_token: null, twitch_name: null } as any);
     const occurredAt = new Date('2026-07-17T12:00:00Z');

--- a/src/web/routes/dashboard.ts
+++ b/src/web/routes/dashboard.ts
@@ -21,8 +21,8 @@ const router = Router();
  */
 router.get('/', csrfProtection, async (req, res) => {
   try {
-    const status = await getGuildScopedStatus(req.session.user?.currentGuildId ?? null);
-    const [sfxCount, commandCount, counterCount, streamer] = await Promise.all([
+    const [status, sfxCount, commandCount, counterCount, streamer] = await Promise.all([
+      getGuildScopedStatus(req.session.user?.currentGuildId ?? null),
       getSfxTriggerCount(), getCustomCommandCount(), getCounterCount(),
       req.session.user ? getStreamerByDiscordId(req.session.user.discordId) : Promise.resolve(null),
     ]);


### PR DESCRIPTION
## Summary

A codebase-wide efficiency review (DB layer, Discord/Twitch bot runtime, web server) surfaced a handful of narrow, low-risk findings — the codebase is already well-optimized (batched Helix/DB calls, TTL caches with stale-while-revalidate, `Promise.all` fan-out, per-guild cleanup on `guildDelete`). This PR implements the actionable ones, each as its own commit:

- **`dashboard.ts`**: fold `getGuildScopedStatus` into the existing `Promise.all` batch instead of awaiting it sequentially first (was pure serialized latency on the most-visited page).
- **`commandConflicts.ts`**: drop redundant `LOWER(u.twitch_name)` wrappers — `twitch_name` is already normalized to lowercase at every write, so the function call was only defeating a potential index for no behavioral benefit.
- **`twitchEventSubReconciliation.ts`**: prune `lastSeenRedeemedAt` entries for streamers no longer returned by `getAllStreamerInfo()`, mirroring the existing `pruneStaleTimerState` pattern — the map previously grew unboundedly for disconnected/removed streamers.
- **`eventLog.ts`**: make `recordStreamerEvent`'s retention-prune query conditional (once every 10 inserts per streamer) instead of running it after every single insert, which doubled write cost during event bursts (e.g. redemption storms) for no benefit most of the time.
- **`middleware.ts`**: add a short-TTL cache (mirroring `guildScopedStatus.ts`'s existing 20s TTL + in-flight de-dup pattern) around `requireGuildContext`'s per-request `findUser`/`fetchLiveGuildsForUser` DB round trips, which ran unconditionally on every guild-scoped request.
- **`commands/*`**: parse each incoming chat message's command token once (`extractCommand`) instead of every one of the 4-6 dispatched handlers re-parsing the same message independently, via a new `resolveCommand` helper that's backward compatible with existing direct/test calls.

One deliberately excluded finding: `sfx.ts`'s `LOWER(trigger_command)` predicate was investigated but left as-is, since `trigger_command` casing is used for display in the public SFX listing (case-insensitive match, case-preserving display is intentional) and the query isn't on a hot path.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (186 files / 3450 tests)
- [x] Added/updated tests alongside each change: `dashboard.test.ts` (unchanged, already order-agnostic), `commandConflicts.test.ts` (no SQL-text assertions to update), `twitchEventSubReconciliation.test.ts` (new prune coverage), `eventLog.test.ts` (reworked prune-cadence coverage), `middleware.test.ts` (new caching coverage), `commandUtils.test.ts` + `twitchBot.test.ts` + `discordBot.test.ts` (updated call-arg assertions for the new precomputed-command parameter)


---
_Generated by [Claude Code](https://claude.ai/code/session_01K9GXkoQtJPvqTzganohhDK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved command processing by parsing incoming commands once across Twitch and Discord.
  - Dashboard status, usage, and streamer information now load concurrently for faster page responses.
  - Event history cleanup runs less frequently while maintaining retention limits.

- **Bug Fixes**
  - Improved Twitch channel conflict detection with exact channel-name matching.
  - Reconnected streamers now receive relevant recent redemption events.
  - Stale event-tracking data is cleared when streamers disconnect.
  - Failed event-history cleanup is retried on the next eligible update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->