### PR TITLE
Document intentional unescaped EJS output for data-initial-* attributes

### DIFF
--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -13,6 +13,7 @@ function htmlAttrJson(value) {
 }
 %>
 </head>
+<!-- Unescaped EJS output here is intentional: htmlAttrJson() already HTML-escapes its result via manual character replacement, so the escaping EJS tag would double-escape the attribute value. -->
 <body data-initial-status="<%- htmlAttrJson(status) %>" data-initial-events="<%- htmlAttrJson(recentEvents) %>" data-has-streamer="<%= hasStreamer %>" data-csrf-token="<%= csrfToken %>">
   <%- include('partials/nav') %>
 

--- a/views/health.ejs
+++ b/views/health.ejs
@@ -14,6 +14,7 @@ function htmlAttrJson(value) {
 }
 %>
 </head>
+<!-- Unescaped EJS output here is intentional: htmlAttrJson() already HTML-escapes its result via manual character replacement, so the escaping EJS tag would double-escape the attribute value. -->
 <body data-initial-health="<%- htmlAttrJson(health) %>">
   <%- include('partials/nav') %>
 


### PR DESCRIPTION
## Summary
- A security scanner flagged the `<%-` (unescaped) EJS output used to render `data-initial-health` in `views/health.ejs` and `data-initial-status`/`data-initial-events` in `views/dashboard.ejs` as potential unescaped-output XSS.
- This is a false positive: `htmlAttrJson()` already HTML-escapes its JSON output via manual character replacement (`&`, `"`, `'`, `<`, `>`) before the template renders it. Using EJS's escaping `<%=` tag on top of that would double-escape the value and break the JSON the client-side JS parses.
- Added a comment above each usage explaining why the unescaped tag is deliberate, so future scans/reviewers don't re-flag it.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (includes `ejsTemplates.test.ts`, which compiles both templates and would catch any EJS syntax error introduced by the comment)


---
_Generated by [Claude Code](https://claude.ai/code/session_012rsEvkKU9SZPhpcdh1FZCd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarifying comments to dashboard and health views explaining the intentional handling of pre-escaped HTML attribute data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->