### PR TITLE
Use constant-time comparison for EventSub OAuth state check

### DIFF
--- a/src/web/csrf.test.ts
+++ b/src/web/csrf.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import express from 'express';
 import supertest from 'supertest';
-import { csrfProtection } from './csrf';
+import { csrfProtection, oauthStateMatches } from './csrf';
 
 const SESSION_TOKEN = 'a'.repeat(64); // 32 hex bytes
 
@@ -133,5 +133,19 @@ describe('csrfProtection — query string token is ignored', () => {
       .post(`/test?_csrf=${SESSION_TOKEN}`);
     expect(res.status).toBe(403);
     expect(res.body.code).toBe('EBADCSRFTOKEN');
+  });
+});
+
+describe('oauthStateMatches', () => {
+  it('returns true when submitted equals stored', () => {
+    expect(oauthStateMatches('abc123', 'abc123')).toBe(true);
+  });
+
+  it('returns false when submitted differs from stored', () => {
+    expect(oauthStateMatches('abc123', 'xyz789')).toBe(false);
+  });
+
+  it('returns false without throwing when byte lengths differ (multi-byte input)', () => {
+    expect(oauthStateMatches('é', 'ee')).toBe(false);
   });
 });

--- a/src/web/csrf.test.ts
+++ b/src/web/csrf.test.ts
@@ -146,6 +146,6 @@ describe('oauthStateMatches', () => {
   });
 
   it('returns false without throwing when byte lengths differ (multi-byte input)', () => {
-    expect(oauthStateMatches('é', 'ee')).toBe(false);
+    expect(oauthStateMatches('é', 'e')).toBe(false);
   });
 });

--- a/src/web/csrf.ts
+++ b/src/web/csrf.ts
@@ -17,6 +17,24 @@ function csrfTokenBuffer(token: string): Buffer | null {
   return CSRF_TOKEN_HEX_PATTERN.test(token) ? Buffer.from(token, 'hex') : null;
 }
 
+/**
+ * Constant-time comparison of a submitted OAuth `state` against the session's stored value.
+ * Compares UTF-8 byte length rather than JS string length before calling `timingSafeEqual` — it
+ * requires equal-length buffers, and a submitted value containing multi-byte characters can have
+ * the same string length as `stored` while its UTF-8 byte length differs, which would otherwise
+ * throw instead of returning false. The length check up front doesn't leak anything — the
+ * expected length is public.
+ *
+ * Shared by the OAuth callback routes (`auth.ts`, `eventsubCallback.ts`) — import this rather
+ * than duplicating it.
+ */
+export function oauthStateMatches(submitted: string, stored: string): boolean {
+  const submittedBuf = Buffer.from(submitted, 'utf8');
+  const storedBuf = Buffer.from(stored, 'utf8');
+  if (submittedBuf.length !== storedBuf.length) return false;
+  return crypto.timingSafeEqual(submittedBuf, storedBuf);
+}
+
 function createCsrfError(): Error & { code: string } {
   const error = new Error('Invalid CSRF token') as Error & { code: string };
   error.code = 'EBADCSRFTOKEN';

--- a/src/web/routes/auth.test.ts
+++ b/src/web/routes/auth.test.ts
@@ -21,6 +21,7 @@ vi.mock('../../discord/discordBot', () => ({
 }));
 vi.mock('../csrf', () => ({
   csrfProtection: (_req: any, _res: any, next: any) => next(),
+  oauthStateMatches: (submitted: string, stored: string) => submitted === stored,
 }));
 vi.mock('../middleware', () => ({
   requireAuth: (_req: any, _res: any, next: any) => next(),

--- a/src/web/routes/auth.ts
+++ b/src/web/routes/auth.ts
@@ -14,7 +14,7 @@ import {
   type DbUser,
 } from '../../db';
 import { fetchMemberDisplayName } from '../../discord/discordBot';
-import { csrfProtection } from '../csrf';
+import { csrfProtection, oauthStateMatches } from '../csrf';
 import { requireAuth } from '../middleware';
 import { filterQueryParam, isLoopbackRedirectUri } from './validation';
 import { renderError, renderView } from './viewHelpers';
@@ -34,23 +34,6 @@ interface DiscordProfile {
 
 /** Error codes `GET /auth/login` accepts via `?error=`, both originating from `POST /guild/select`. */
 const LOGIN_KNOWN_ERRORS = new Set(['user_not_found', 'no_guilds']);
-
-/**
- * Constant-time comparison of the submitted OAuth `state` against the session's stored value
- * (see `GET /discord` below, which generates it as a fixed-length hex string), mirroring
- * `csrf.ts`'s `timingSafeEqual` comparison for CSRF tokens. Compares UTF-8 byte length rather
- * than JS string length before calling `timingSafeEqual` — it requires equal-length buffers,
- * and a submitted value containing multi-byte characters can have the same string length as
- * `stored` while its UTF-8 byte length differs, which would otherwise throw instead of
- * returning false. The length check up front doesn't leak anything — the expected length is
- * public.
- */
-function oauthStateMatches(submitted: string, stored: string): boolean {
-  const submittedBuf = Buffer.from(submitted, 'utf8');
-  const storedBuf = Buffer.from(stored, 'utf8');
-  if (submittedBuf.length !== storedBuf.length) return false;
-  return crypto.timingSafeEqual(submittedBuf, storedBuf);
-}
 
 // ─── Redirect to Discord OAuth2 ─────────────────────────────────────────────
 

--- a/src/web/routes/eventsubCallback.ts
+++ b/src/web/routes/eventsubCallback.ts
@@ -6,6 +6,7 @@ import { TWITCH_EVENTSUB_REDIRECT_URI } from '../../shared/config';
 import { reloadEventSubSubscriptions } from '../../twitch/eventsub/twitchEventSub';
 import { clearAuthFailedSubs } from '../../twitch/eventsub/twitchEventSubSubscriptions';
 import { logAndRedirectError } from './errorHandling';
+import { oauthStateMatches } from '../csrf';
 
 const log = createLogger('Web');
 const router = Router();
@@ -49,7 +50,7 @@ router.get('/twitch/eventsub/callback', async (req, res) => {
   if (!code || !state || !storedOAuth || !streamerId) {
     return res.redirect('/user/settings?error=eventsub_oauth_state_mismatch');
   }
-  if (state !== storedOAuth.value || Date.now() > storedOAuth.expiresAt) {
+  if (!oauthStateMatches(state, storedOAuth.value) || Date.now() > storedOAuth.expiresAt) {
     return res.redirect('/user/settings?error=eventsub_oauth_state_mismatch');
   }
 


### PR DESCRIPTION
## Summary
- Full code review of the repo turned up one minor finding: `eventsubCallback.ts` compared the Twitch EventSub OAuth `state` param with plain `!==` instead of the constant-time check `auth.ts` already used for the equivalent Discord OAuth flow.
- Moved the comparison logic into `src/web/csrf.ts` (the existing home for constant-time comparisons) as an exported `oauthStateMatches` helper, and had both `auth.ts` and `eventsubCallback.ts` import it instead of duplicating the logic.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run check:circular`
- [x] `npx vitest run` (3455 tests passing, including new direct unit tests for `oauthStateMatches` and existing route-level state-mismatch/expiry tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014o4YmBrJ3MdmQAFcEws44W)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Strengthened OAuth state validation across authentication and EventSub callbacks with constant-time comparison.
  * Improved handling of multi-byte values and mismatched inputs without errors.
* **Bug Fixes**
  * Standardized OAuth state checks to reduce risks from timing-based comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->