### PR TITLE
Refactor: split startDiscordBot event registration into named handlers

### DIFF
--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -121,6 +121,142 @@ async function provisionGuildOwner(guild: Guild): Promise<void> {
 }
 
 /**
+ * Dispatches every non-bot message from a registered guild to each command handler in turn
+ * (fire-and-forget — a failure in one handler must not block the others). A DM (no guildId)
+ * skips the guild-gated handlers entirely and only reaches the owner-only `!health` command,
+ * which is designed to be triggered from a DM (see its own docstring).
+ * @param client - The Discord client to register the handler on.
+ */
+function registerMessageCreateHandler(client: Client): void {
+  client.on('messageCreate', (message) => {
+    if (message.author.bot) return;
+
+    if (!message.guildId) {
+      fireAndForget(executeHealthCommandForDiscord(message), 'Health command error', log);
+      return;
+    }
+    if (!isRegisteredGuild(message.guildId)) return;
+
+    const displayName = message.member?.displayName ?? message.author.username;
+    const guildId = message.guildId;
+    // Parsed once and threaded into every handler below instead of each one re-parsing
+    // the same message independently.
+    const command = extractCommand(message.content);
+
+    fireAndForget(executeCustomCommandForDiscord(message, displayName, guildId, command), 'Custom command error', log);
+    fireAndForget(executeCounterCommandForDiscord(message, displayName, command), 'Counter command error', log);
+    fireAndForget(handleCommand(message.content, 'discord', guildId, command), 'Command handler error', log);
+    fireAndForget(executeHealthCommandForDiscord(message, command), 'Health command error', log);
+  });
+}
+
+/**
+ * Bootstrap: when the bot is added to a server for the first time, record the
+ * guild row and auto-grant the Discord server's owner Admin access to it, so
+ * they can self-serve the panel without the bot owner manually provisioning the
+ * first member. guildCreate also fires on reconnect, and `guild` rows are never
+ * deleted on leave, so the owner grant runs only the first time a guild_id is
+ * ever seen (detected via getGuildById returning null beforehand) — never on a
+ * reconnect or a kick-then-reinvite. This preserves the existing invariant that
+ * a deliberately de-provisioned guild (all members removed) stays inert until
+ * someone manually re-provisions it; upsertGuild itself is insert-if-not-exists
+ * and never wipes existing per-guild config.
+ * @param client - The Discord client to register the handler on.
+ */
+function registerGuildCreateHandler(client: Client): void {
+  client.on('guildCreate', (guild) => {
+    (async () => {
+      const isNewGuild = (await getGuildById(guild.id)) === null;
+      await upsertGuild(guild.id, guild.name);
+      if (isNewGuild) {
+        await provisionGuildOwner(guild);
+      }
+      await reloadGuildRegistry();
+      log.info(`Registered guild '${guild.name}' (${guild.id}).`);
+    })().catch((err) => log.error(`Failed to register guild ${guild.id}:`, err));
+  });
+}
+
+/**
+ * The bot's per-guild in-memory state (voice connections, command cooldowns,
+ * dashboard voice status, admin name-refresh progress) is populated lazily
+ * and never expires on its own. Without this, a guild the bot is kicked
+ * from — or that deletes itself — leaves its entry behind forever in a
+ * long-running process. None of this touches the `guild` DB row, which
+ * (like guildCreate) is intentionally never deleted on leave.
+ * @param client - The Discord client to register the handler on.
+ */
+function registerGuildDeleteHandler(client: Client): void {
+  client.on('guildDelete', (guild) => {
+    forgetGuildVoiceState(guild.id);
+    forgetGuildCommandState(guild.id);
+    forgetGuildCustomCommandCooldown(guild.id);
+    forgetGuildCounterCooldown(guild.id);
+    clearVoiceStatus(guild.id);
+    forgetGuildRefreshState(guild.id);
+    log.info(`Forgot in-memory state for guild '${guild.name}' (${guild.id}) — bot removed.`);
+  });
+}
+
+/**
+ * Registers the one-shot `clientReady` handler that promotes `client` from `bootingClient` to
+ * the module-level ready client, unless {@link stopDiscordBot} discarded it mid-boot.
+ * @param client - The booting Discord client to register the handler on.
+ */
+function registerClientReadyHandler(client: Client): void {
+  client.once('clientReady', async (c) => {
+    if (bootingClient !== client) {
+      // stopDiscordBot() ran during boot — discard this ready client
+      await c.destroy().catch(() => { /* ignore */ });
+      return;
+    }
+    bootingClient = null;
+    setDiscordClient(c);
+    log.info(`Logged in as ${c.user.tag}`);
+    setDiscordReady(c.user.tag);
+    recordDiscordConnected(true);
+    const waiters = readyWaiters;
+    readyWaiters = [];
+    waiters.forEach((resolve) => { resolve(); });
+  });
+}
+
+/**
+ * Registers gateway-connection visibility/self-healing handlers.
+ *
+ * discord.js's own WebSocketManager already retries every recoverable gateway
+ * disconnect on its own (reflected by 'shardReconnecting'), so most of these are purely
+ * visibility logging — without them, a reconnect cycle produces zero log output,
+ * making post-incident diagnosis impossible. 'shardError' is a connection-level
+ * error on the gateway socket itself (distinct from the generic 'error' handler);
+ * the manager keeps retrying after it, so it's also log-only.
+ *
+ * 'shardDisconnect' fires only for an unrecoverable close code — the one case
+ * where discord.js gives up and will *not* reconnect that shard on its own. With
+ * this bot running a single (unsharded) client, that means every guild silently
+ * stops receiving events. Force a fresh login so the process self-heals instead
+ * of sitting alive-but-dead until someone notices and restarts it manually.
+ * @param client - The Discord client to register the handlers on.
+ */
+function registerConnectionHandlers(client: Client): void {
+  client.on('error', (err) => {
+    log.error('Client error:', err);
+  });
+  client.on('shardReconnecting', (shardId) => {
+    log.warn(`Shard ${shardId} lost its connection and is reconnecting...`);
+  });
+  client.on('shardError', (err, shardId) => {
+    log.error(`Shard ${shardId} gateway connection error:`, err);
+  });
+  client.on('shardDisconnect', (event, shardId) => {
+    log.error(`Shard ${shardId} disconnected permanently (code ${event.code}) — reconnecting client.`);
+    recordDiscordConnected(false);
+    stopDiscordBot();
+    startDiscordBot();
+  });
+}
+
+/**
  * Create and connect a Discord client. No-op if a client is already running or
  * booting — call {@link stopDiscordBot} first to replace it.
  *
@@ -147,117 +283,11 @@ export function startDiscordBot(): void {
   });
   bootingClient = localClient;
 
-  /**
-   * Dispatches every non-bot message from a registered guild to each command handler in turn
-   * (fire-and-forget — a failure in one handler must not block the others). A DM (no guildId)
-   * skips the guild-gated handlers entirely and only reaches the owner-only `!health` command,
-   * which is designed to be triggered from a DM (see its own docstring).
-   * @param message - The triggering Discord message.
-   * @returns void.
-   */
-  localClient.on('messageCreate', (message) => {
-    if (message.author.bot) return;
-
-    if (!message.guildId) {
-      fireAndForget(executeHealthCommandForDiscord(message), 'Health command error', log);
-      return;
-    }
-    if (!isRegisteredGuild(message.guildId)) return;
-
-    const displayName = message.member?.displayName ?? message.author.username;
-    const guildId = message.guildId;
-    // Parsed once and threaded into every handler below instead of each one re-parsing
-    // the same message independently.
-    const command = extractCommand(message.content);
-
-    fireAndForget(executeCustomCommandForDiscord(message, displayName, guildId, command), 'Custom command error', log);
-    fireAndForget(executeCounterCommandForDiscord(message, displayName, command), 'Counter command error', log);
-    fireAndForget(handleCommand(message.content, 'discord', guildId, command), 'Command handler error', log);
-    fireAndForget(executeHealthCommandForDiscord(message, command), 'Health command error', log);
-  });
-
-  // Bootstrap: when the bot is added to a server for the first time, record the
-  // guild row and auto-grant the Discord server's owner Admin access to it, so
-  // they can self-serve the panel without the bot owner manually provisioning the
-  // first member. guildCreate also fires on reconnect, and `guild` rows are never
-  // deleted on leave, so the owner grant runs only the first time a guild_id is
-  // ever seen (detected via getGuildById returning null beforehand) — never on a
-  // reconnect or a kick-then-reinvite. This preserves the existing invariant that
-  // a deliberately de-provisioned guild (all members removed) stays inert until
-  // someone manually re-provisions it; upsertGuild itself is insert-if-not-exists
-  // and never wipes existing per-guild config.
-  localClient.on('guildCreate', (guild) => {
-    (async () => {
-      const isNewGuild = (await getGuildById(guild.id)) === null;
-      await upsertGuild(guild.id, guild.name);
-      if (isNewGuild) {
-        await provisionGuildOwner(guild);
-      }
-      await reloadGuildRegistry();
-      log.info(`Registered guild '${guild.name}' (${guild.id}).`);
-    })().catch((err) => log.error(`Failed to register guild ${guild.id}:`, err));
-  });
-
-  // The bot's per-guild in-memory state (voice connections, command cooldowns,
-  // dashboard voice status, admin name-refresh progress) is populated lazily
-  // and never expires on its own. Without this, a guild the bot is kicked
-  // from — or that deletes itself — leaves its entry behind forever in a
-  // long-running process. None of this touches the `guild` DB row, which
-  // (like guildCreate) is intentionally never deleted on leave.
-  localClient.on('guildDelete', (guild) => {
-    forgetGuildVoiceState(guild.id);
-    forgetGuildCommandState(guild.id);
-    forgetGuildCustomCommandCooldown(guild.id);
-    forgetGuildCounterCooldown(guild.id);
-    clearVoiceStatus(guild.id);
-    forgetGuildRefreshState(guild.id);
-    log.info(`Forgot in-memory state for guild '${guild.name}' (${guild.id}) — bot removed.`);
-  });
-
-  localClient.once('clientReady', async (c) => {
-    if (bootingClient !== localClient) {
-      // stopDiscordBot() ran during boot — discard this ready client
-      await c.destroy().catch(() => { /* ignore */ });
-      return;
-    }
-    bootingClient = null;
-    setDiscordClient(c);
-    log.info(`Logged in as ${c.user.tag}`);
-    setDiscordReady(c.user.tag);
-    recordDiscordConnected(true);
-    const waiters = readyWaiters;
-    readyWaiters = [];
-    waiters.forEach((resolve) => { resolve(); });
-  });
-
-  localClient.on('error', (err) => {
-    log.error('Client error:', err);
-  });
-
-  // discord.js's own WebSocketManager already retries every recoverable gateway
-  // disconnect on its own (reflected by 'shardReconnecting'), so these are purely
-  // visibility logging — without them, a reconnect cycle produces zero log output,
-  // making post-incident diagnosis impossible. 'shardError' is a connection-level
-  // error on the gateway socket itself (distinct from the generic 'error' handler
-  // above); the manager keeps retrying after it, so it's also log-only.
-  localClient.on('shardReconnecting', (shardId) => {
-    log.warn(`Shard ${shardId} lost its connection and is reconnecting...`);
-  });
-  localClient.on('shardError', (err, shardId) => {
-    log.error(`Shard ${shardId} gateway connection error:`, err);
-  });
-
-  // 'shardDisconnect' fires only for an unrecoverable close code — the one case
-  // where discord.js gives up and will *not* reconnect that shard on its own. With
-  // this bot running a single (unsharded) client, that means every guild silently
-  // stops receiving events. Force a fresh login so the process self-heals instead
-  // of sitting alive-but-dead until someone notices and restarts it manually.
-  localClient.on('shardDisconnect', (event, shardId) => {
-    log.error(`Shard ${shardId} disconnected permanently (code ${event.code}) — reconnecting client.`);
-    recordDiscordConnected(false);
-    stopDiscordBot();
-    startDiscordBot();
-  });
+  registerMessageCreateHandler(localClient);
+  registerGuildCreateHandler(localClient);
+  registerGuildDeleteHandler(localClient);
+  registerClientReadyHandler(localClient);
+  registerConnectionHandlers(localClient);
 
   localClient.login(DISCORD_TOKEN).catch((err) => {
     log.error('Login failed:', err);

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -10,7 +10,8 @@ import { setStreamerInfo } from './twitchEventSubDispatch';
 
 const log = createLogger('EventSub');
 
-export { dispatchNotification, handleRevocation, removeStreamerFromMap } from './twitchEventSubDispatch';
+export { dispatchNotification, handleRevocation, removeStreamerFromMap, getAllStreamerInfo } from './twitchEventSubDispatch';
+export { getAlertTypesCoveredBySubscriptionGroups } from './twitchEventSubSubscriptionGroups';
 
 // Tracks "login:type:token" triples that failed with 403 — skipped until bot restarts or token changes
 const authFailedSubs = new Set<string>();

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -10,8 +10,7 @@ import { setStreamerInfo } from './twitchEventSubDispatch';
 
 const log = createLogger('EventSub');
 
-export { dispatchNotification, handleRevocation, removeStreamerFromMap, getAllStreamerInfo } from './twitchEventSubDispatch';
-export { getAlertTypesCoveredBySubscriptionGroups } from './twitchEventSubSubscriptionGroups';
+export { dispatchNotification, handleRevocation, removeStreamerFromMap } from './twitchEventSubDispatch';
 
 // Tracks "login:type:token" triples that failed with 403 — skipped until bot restarts or token changes
 const authFailedSubs = new Set<string>();


### PR DESCRIPTION
## Summary

`startDiscordBot()` (`src/discord/discordBot.ts`) was the longest function in the codebase (130 lines), mixing client construction, five distinct `localClient.on(...)` event-handler registrations, and login in one function. Extracted each registration into a named `registerXHandler(client)` helper (`registerMessageCreateHandler`, `registerGuildCreateHandler`, `registerGuildDeleteHandler`, `registerClientReadyHandler`, `registerConnectionHandlers`), mirroring the extraction pattern already used for `auth.ts` in #597. `startDiscordBot` is now a thin orchestrator. No behavior change — same handlers, same closures over module state.

An unrelated dead-re-export cleanup that was originally bundled into this PR has been split out into [#603](https://github.com/Battle-Cattle/BCUK-Bot-4/pull/603).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 186 test files / 3455 tests passed
- [x] `npm run check:circular` — no circular dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal organization of Discord bot event handling.
  * Existing bot behavior and public functionality remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->