### PR TITLE
Remove dead barrel re-exports from twitchEventSubSubscriptions

### DIFF
--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -10,8 +10,7 @@ import { setStreamerInfo } from './twitchEventSubDispatch';
 
 const log = createLogger('EventSub');
 
-export { dispatchNotification, handleRevocation, removeStreamerFromMap, getAllStreamerInfo } from './twitchEventSubDispatch';
-export { getAlertTypesCoveredBySubscriptionGroups } from './twitchEventSubSubscriptionGroups';
+export { dispatchNotification, handleRevocation, removeStreamerFromMap } from './twitchEventSubDispatch';
 
 // Tracks "login:type:token" triples that failed with 403 — skipped until bot restarts or token changes
 const authFailedSubs = new Set<string>();


### PR DESCRIPTION
## Summary

- `src/twitch/eventsub/twitchEventSubSubscriptions.ts` re-exported `getAllStreamerInfo` (from `twitchEventSubDispatch.ts`) and `getAlertTypesCoveredBySubscriptionGroups` (from `twitchEventSubSubscriptionGroups.ts`), but every real consumer already imports both directly from their source modules — confirmed via grep across `src/` and the dedicated test suites for both source modules, neither of which touches this barrel.
- Removed both dead re-export lines. Kept `dispatchNotification`, `handleRevocation`, `removeStreamerFromMap`, which `twitchEventSubConnection.ts` genuinely consumes through this file.

Split out of [#602](https://github.com/Battle-Cattle/BCUK-Bot-4/pull/602), which now covers only the unrelated `discordBot.ts` refactor.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 186 test files / 3455 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RaxbgSZQgYT2gqoSBghnqc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the available EventSub exports by removing two previously exposed utilities.
  * No user-facing functionality or interface changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->