### PR TITLE
Enforce db.ts-only DB imports via ESLint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -51,7 +51,10 @@ module.exports = tseslint.config(
     rules: {
       'no-restricted-imports': ['error', {
         patterns: [{
-          group: ['**/db/*'],
+          // Relative paths only (one or more leading ./ or ../ segments) — a glob group like
+          // '**/db/*' would also match an unrelated third-party package with its own "db"
+          // subpath (e.g. 'some-pkg/db/foo'), which isn't what this rule is meant to catch.
+          regex: '^(\\.\\.?/)+db/.+$',
           message: 'Import DB functions from src/db.ts only, not directly from src/db/* modules — see CLAUDE.md Critical Invariants.',
         }],
       }],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -41,6 +41,23 @@ module.exports = tseslint.config(
     },
   },
   {
+    // CLAUDE.md's "Import DB functions from src/db.ts only, never src/db/* directly" is
+    // otherwise enforced only by convention/comment — db.ts wraps some src/db/* write
+    // functions with withInvalidation() for cache-invalidation side effects, and a direct
+    // import bypasses that silently. src/db/** itself is exempt (submodules import each
+    // other internally) and test files keep their existing documented exception.
+    files: ['src/**/*.ts'],
+    ignores: ['src/db.ts', 'src/db/**', 'src/**/*.test.ts'],
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: [{
+          group: ['**/db/*'],
+          message: 'Import DB functions from src/db.ts only, not directly from src/db/* modules — see CLAUDE.md Critical Invariants.',
+        }],
+      }],
+    },
+  },
+  {
     // Not part of tsconfig.json's `include` (src/**/*), so lint it without type info.
     files: ['vitest.config.mts'],
     languageOptions: {


### PR DESCRIPTION
## Summary

- CLAUDE.md documents a critical invariant: DB functions must be imported from `src/db.ts` only, never `src/db/*` directly — `db.ts` wraps some write functions (e.g. `guildCommandOverrides.ts`, `users.ts`, `customCommands.ts`) with `withInvalidation()` for cache-invalidation side effects, and a direct import silently bypasses that.
- This rule was previously enforced only by convention/comment. Added a `no-restricted-imports` ESLint rule (`eslint.config.js`) that flags any `src/**/*.ts` file importing from a `**/db/*` path, excluding `src/db.ts` itself (the facade) and `src/db/**` (submodules importing each other internally is normal), plus the existing test-file exception.
- Config-only change; no production behavior changes.

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm run lint` — passes cleanly against the existing codebase (confirms no other production file currently imports a `db/*` submodule directly)
- [x] Verified the rule actually fires: temporarily added a direct `db/users` import in a scratch file, confirmed ESLint flagged it with the expected message, then removed the scratch file
- [x] `npm test` — all 3455 tests pass
- [x] `npm run check:circular` — no circular dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReM6U2ssMYAtvaGutuxLBC

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReM6U2ssMYAtvaGutuxLBC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added import-linting rules to enforce consistent access to database functionality.
  * Excluded database implementation files, the public database entry point, and tests from this restriction.
  * Refined the validation to target only local database imports, avoiding unnecessary restrictions on similarly named external packages.
  * These updates improve consistency and help prevent unintended access patterns without changing application behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->