### PR TITLE
Remove dead re-exports from db.ts facade

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -1,4 +1,4 @@
-export type { RefreshingLookupCache, ManagedLookupCacheOptions, ManagedLookupCache } from './db/lookupCache';
+export type { RefreshingLookupCache } from './db/lookupCache';
 export {
   createManagedLookupCache,
   DEFAULT_REFRESH_FAILURE_BACKOFF_MS,
@@ -38,15 +38,14 @@ export async function pingDb(): Promise<boolean> {
 export {
   getAllGuilds, getProvisionedGuilds, getGuildById, getGuildsForMember, upsertGuild,
 } from './db/guilds';
-export type { DbGuild, DbGuildMembership } from './db/guilds';
+export type { DbGuild } from './db/guilds';
 
 export {
   getMemberAccessLevel, setMemberAccessLevel,
   removeGuildMember, getEffectiveAccessLevelForUser,
 } from './db/guildMembers';
-export type { DbGuildMember } from './db/guildMembers';
 
-export { getOverridesForGuild, getAllOverrides } from './db/guildCommandOverrides';
+export { getOverridesForGuild } from './db/guildCommandOverrides';
 export type { DbGuildCommandOverride } from './db/guildCommandOverrides';
 
 import {
@@ -104,7 +103,7 @@ export {
   findUser, findUsersByIds, findUserByTwitchName, findOwnerUser, getAllUsers, getGuildMemberUsers,
   updateDiscordName, getTwitchEnabledChannels, getAllTwitchLinkedUsers,
 } from './db/users';
-export type { AccessLevelValue, DbUser, TwitchLinkedUser } from './db/users';
+export type { AccessLevelValue, DbUser } from './db/users';
 
 import { upsertUserRecord, setTwitchBotEnabledRecord } from './db/users';
 
@@ -249,14 +248,12 @@ export {
   CommandNotFoundError, CommandConflictError, isMysqlDuplicateEntryError,
   isCustomCommandTriggerTaken,
 } from './db/commandLocks';
-export { ReservedCommandError, RESERVED_BUILT_IN_COMMANDS } from './db/reservedCommands';
-export type { SqlExecutor } from './db/commandLocks';
+export { ReservedCommandError } from './db/reservedCommands';
 
 // ─── Counter commands ───────────────────────────────────────────────────────
 
 export { CounterNotFoundError, getAllCounters, getCounterCount, getCounterHistory } from './db/counters';
-export type { DbCounter, CounterMatchType, DbMatchedCounter, UpdateCounterInput, CounterHistoryEntry } from './db/counters';
-export { invalidateCounterLookupCache, findCounterByCommand, isCounterCommandTaken } from './db/counterCache';
+export { findCounterByCommand, isCounterCommandTaken } from './db/counterCache';
 
 import {
   addCounter as addCounterRecord,
@@ -360,7 +357,7 @@ export type { DbStreamerEventSub, EventSubConfig } from './db/eventSub';
 
 // ─── Alerts overlay ─────────────────────────────────────────────────────────
 
-export type { AlertConfig, AlertEventType, TextAnimation } from './db/alertConfig';
+export type { AlertEventType, TextAnimation } from './db/alertConfig';
 export { ALERT_EVENT_TYPES, ALERT_TEXT_ANIMATIONS } from './db/alertConfig';
 export { getAlertConfigsForStreamer, getAlertConfig, getEnabledAlertEventTypesBatch } from './db/alertConfig';
 export { findCachedAlertConfig } from './db/alertConfigCache';
@@ -445,7 +442,7 @@ export { recordStreamerEvent, getRecentStreamerEvents } from './db/eventLog';
 
 // ─── SFX ────────────────────────────────────────────────────────────────────
 
-export type { SfxTrigger, SfxFile, SfxTriggerRow, PublicSfxTrigger, SfxCategory } from './db/sfx';
+export type { SfxTrigger, SfxFile, PublicSfxTrigger } from './db/sfx';
 export {
   findTrigger, findSoundFiles, getAllSfxTriggers, getSfxTriggerCount, getPublicSfxTriggers,
   getAllCategories, createCategory, renameCategory, deleteCategory, getSfxFileById,
@@ -552,7 +549,6 @@ export async function deleteSfxFile(id: number): Promise<string | null> {
 
 // ─── Overlay videos ─────────────────────────────────────────────────────────
 
-export type { OverlayVideo, OverlayReward, OverlayRewardWithVideos, OverlayWeightedVideo } from './db/overlayVideos';
 export {
   getVideosForStreamer, addVideo, getVideoById, deleteVideo,
   getRewardsForStreamer, upsertReward, setRewardVideos, deleteReward,
@@ -561,7 +557,7 @@ export {
 
 // ─── Channel point pricing ───────────────────────────────────────────────────
 
-export type { RewardPricingRow, RewardPricingInput, PricingUpdateFields, StreamerPricingSettings } from './db/rewardPricing';
+export type { RewardPricingRow, StreamerPricingSettings } from './db/rewardPricing';
 export {
   getPricingForReward, getPricingConfigsForStreamer, getAllEnabledPricingRows,
   upsertPricingConfig, recordPricingUpdate, deletePricingConfig, markPricingUnsupported,
@@ -569,7 +565,6 @@ export {
   DEFAULT_PRICING_COOLDOWN_SECONDS,
 } from './db/rewardPricing';
 
-export type { RewardPricingHistoryPoint } from './db/rewardPricingHistory';
 export { recordPricingHistory, getPricingHistoryForRewards } from './db/rewardPricingHistory';
 
 // ─── Timer commands ─────────────────────────────────────────────────────────
@@ -606,7 +601,6 @@ export {
 
 // ─── Companion App ───────────────────────────────────────────────────────────
 
-export type { CompanionTokenStatus } from './db/companionTokens';
 export {
   issueToken,
   findDiscordIdByTokenHash,


### PR DESCRIPTION
## Summary

- Audited every `export { ... } from` / `export type { ... } from` statement in the repo (mainly the DB facade `src/db.ts`) and cross-checked each re-exported symbol against every import site.
- Removed 24 re-exported symbols across 12 lines in `src/db.ts` that were never consumed via the facade itself — only used internally within `src/db/*` modules, or by that module's own test file importing it directly (bypassing the facade). Some lines are removed entirely where every symbol on them was dead (`SqlExecutor`, `DbCounter`/`CounterMatchType`/`DbMatchedCounter`/`UpdateCounterInput`/`CounterHistoryEntry`, the four `Overlay*` types, `RewardPricingHistoryPoint`, `CompanionTokenStatus`, `DbGuildMember`).
- Neither `tsc` nor ESLint's `no-unused-vars` flags dead re-export statements (they create no local binding), so this was invisible to tooling and only surfaced by a manual grep audit.
- No behavior change — these were type/value re-exports with zero external consumers via the facade path.

Flagged but out of scope (not changed in this PR):
- `src/web/routes/auth.ts` has a private, non-exported `exchangeCodeForToken` (Discord OAuth) that shares a name with the *exported* `exchangeCodeForToken` in `src/db/companionOAuthCodes.ts` (re-exported via `db.ts`). Not a re-export bug since the `auth.ts` one isn't exported, just a naming collision that could warrant a rename separately.
- Facade "wrapper" duplicates (e.g. `updateCounter`, `addSfxFile` existing under the same name in both `db.ts` and `src/db/*.ts`) are intentional — `db.ts` wraps them with `withInvalidation()` cache-invalidation logic per the documented pattern.
- No direct (non-facade) production imports of `src/db/*` were found — the facade convention is already fully enforced elsewhere.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 187 test files / 3465 tests pass
- [x] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RDs4mC3qe5MtsqJsqwpyDj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the database module’s public interface by removing several internal type and utility exports.
  * Existing database values and functionality remain available through their supported interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->