### PR TITLE
Forward all streamer events to the companion app

### DIFF
--- a/src/db/companionOAuthCodes.test.ts
+++ b/src/db/companionOAuthCodes.test.ts
@@ -88,7 +88,7 @@ describe('exchangeCodeForToken', () => {
     expect(conn.rollback).toHaveBeenCalledTimes(1);
   });
 
-  it('commits and returns a plaintext token when the code is valid', async () => {
+  it('commits and returns a plaintext token and its owning discord ID when the code is valid', async () => {
     const execute = vi
       .fn()
       .mockResolvedValueOnce([{ affectedRows: 1 }])
@@ -97,9 +97,10 @@ describe('exchangeCodeForToken', () => {
     const conn = buildConn({ execute });
     vi.mocked(getPool).mockReturnValue({ getConnection: vi.fn().mockResolvedValue(conn) } as any);
 
-    const token = await exchangeCodeForToken('good-code');
+    const result = await exchangeCodeForToken('good-code');
 
-    expect(token).toMatch(/^[0-9a-f]{64}$/); // 32 bytes as hex
+    expect(result?.token).toMatch(/^[0-9a-f]{64}$/); // 32 bytes as hex
+    expect(result?.discordId).toBe('42');
     expect(conn.commit).toHaveBeenCalledTimes(1);
     expect(conn.rollback).not.toHaveBeenCalled();
     expect(conn.release).toHaveBeenCalledTimes(1);

--- a/src/db/companionOAuthCodes.ts
+++ b/src/db/companionOAuthCodes.ts
@@ -53,6 +53,12 @@ async function consumeCodeOnConnection(executor: mysql.Pool | mysql.PoolConnecti
   return rows.length === 0 ? null : String(rows[0].discord_id);
 }
 
+/** A newly-issued companion app token, plaintext, plus who it belongs to. */
+export interface CompanionTokenExchange {
+  token: string;
+  discordId: string;
+}
+
 /**
  * Atomically exchanges a companion OAuth code for a companion app token: marks
  * the code used and issues the token in a single DB transaction, so a failure
@@ -61,9 +67,11 @@ async function consumeCodeOnConnection(executor: mysql.Pool | mysql.PoolConnecti
  * entire Discord OAuth login).
  *
  * @param code - Plaintext code presented by the companion app.
- * @returns The plaintext companion app token, or null if the code is invalid/expired/already used.
+ * @returns The plaintext companion app token and its owning Discord ID (the caller needs the
+ *   latter to disconnect any SSE connection still open under a token this issue just replaced),
+ *   or null if the code is invalid/expired/already used.
  */
-export async function exchangeCodeForToken(code: string): Promise<string | null> {
+export async function exchangeCodeForToken(code: string): Promise<CompanionTokenExchange | null> {
   const hash = createHash('sha256').update(code).digest('hex');
   class CodeNotFoundError extends Error {}
   try {
@@ -74,7 +82,8 @@ export async function exchangeCodeForToken(code: string): Promise<string | null>
       // edge case where the row vanishes between the UPDATE and the follow-up SELECT —
       // doesn't permanently burn the code with no token to show for it.
       if (!discordId) throw new CodeNotFoundError();
-      return issueTokenOnConnection(conn, discordId);
+      const token = await issueTokenOnConnection(conn, discordId);
+      return { token, discordId };
     });
   } catch (err) {
     if (err instanceof CodeNotFoundError) return null;

--- a/src/twitch/eventsub/twitchEventSubHandler.test.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.test.ts
@@ -515,6 +515,77 @@ describe('dashboard events push', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Companion app push — best-effort, mirrors the dashboard record for the same event
+// ---------------------------------------------------------------------------
+describe('companion events push', () => {
+  beforeEach(() => {
+    vi.mocked(getStreamerById).mockResolvedValue({ discord_id: '999888777' } as any);
+  });
+
+  it('handleFollow pushes a companion activity event keyed by the streamer discord_id', async () => {
+    await handleFollow('streamer', {
+      user_login: 'testuser', user_name: 'TestUser', broadcaster_user_login: 'streamer',
+    }, makeConfig({ follow_enabled: false }), STREAMER_ID);
+
+    expect(getStreamerById).toHaveBeenCalledWith(STREAMER_ID);
+    expect(mockPushCompanionEvent).toHaveBeenCalledWith('999888777', {
+      type: 'follow', displayName: 'TestUser', detail: null, occurredAt: expect.any(String),
+    });
+  });
+
+  it('handleRaid pushes a companion activity event with viewer count as detail', async () => {
+    await handleRaid('streamer', {
+      from_broadcaster_user_login: 'raider', from_broadcaster_user_name: 'RaiderDisplay',
+      to_broadcaster_user_login: 'streamer', viewers: 42,
+    }, makeConfig({ raid_enabled: false, raid_shoutout_enabled: false }), STREAMER_ID);
+
+    expect(mockPushCompanionEvent).toHaveBeenCalledWith('999888777', {
+      type: 'raid', displayName: 'RaiderDisplay', detail: '42 viewers', occurredAt: expect.any(String),
+    });
+  });
+
+  it('handleSub does not push a companion event for gift subs — handled by handleGiftSub instead', async () => {
+    await handleSub('streamer', {
+      user_login: 'subuser', user_name: 'SubUser', broadcaster_user_login: 'streamer', tier: '1000', is_gift: true,
+    }, makeConfig({ sub_enabled: true }), STREAMER_ID);
+    expect(mockPushCompanionEvent).not.toHaveBeenCalled();
+  });
+
+  it('does not push a companion event when the streamer cannot be found', async () => {
+    vi.mocked(getStreamerById).mockResolvedValue(null);
+    await handleFollow('streamer', {
+      user_login: 'testuser', user_name: 'TestUser', broadcaster_user_login: 'streamer',
+    }, makeConfig({ follow_enabled: false }), STREAMER_ID);
+    expect(mockPushCompanionEvent).not.toHaveBeenCalled();
+  });
+
+  it('still records and pushes the dashboard event when the companion lookup throws', async () => {
+    vi.mocked(getStreamerById).mockRejectedValue(new Error('db unavailable'));
+
+    await handleFollow('streamer', {
+      user_login: 'testuser', user_name: 'TestUser', broadcaster_user_login: 'streamer',
+    }, makeConfig({ follow_enabled: false }), STREAMER_ID);
+
+    expect(mockPushCompanionEvent).not.toHaveBeenCalled();
+    expect(mockPushDashboardEvent).toHaveBeenCalledWith(STREAMER_ID, {
+      eventType: 'follow', displayName: 'TestUser', detail: null, occurredAt: expect.any(String),
+    });
+  });
+
+  it('still records and pushes the dashboard event when the companion push itself throws', async () => {
+    mockPushCompanionEvent.mockImplementation(() => { throw new Error('sse write failed'); });
+
+    await handleFollow('streamer', {
+      user_login: 'testuser', user_name: 'TestUser', broadcaster_user_login: 'streamer',
+    }, makeConfig({ follow_enabled: false }), STREAMER_ID);
+
+    expect(mockPushDashboardEvent).toHaveBeenCalledWith(STREAMER_ID, {
+      eventType: 'follow', displayName: 'TestUser', detail: null, occurredAt: expect.any(String),
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // TEST_ALERT_VARS (alertsAdminMutations.ts's "Send Test Alert" preview) must stay in sync with
 // the real vars each handler below actually builds — otherwise a renamed/removed real variable
 // silently leaves a stale `{placeholder}` in the live preview while the real handler works fine.

--- a/src/twitch/eventsub/twitchEventSubHandler.ts
+++ b/src/twitch/eventsub/twitchEventSubHandler.ts
@@ -1,4 +1,5 @@
 import type { EventSubConfig, AlertEventType, StreamerEventType } from '../../db';
+import type { CompanionActivityEventType } from '../../web/routes/companionEvents';
 import { getVideosForReward, getStreamerById, findCachedAlertConfig, recordStreamerEvent } from '../../db';
 import { pickWeightedRandom } from '../../commands/soundSelector';
 import { buildShoutoutMessage } from '../../commands/shoutoutHandler';
@@ -163,6 +164,11 @@ async function maybePushAlert(
  * DB write or push is logged and swallowed rather than rejecting, so it can't surface as a
  * failure of the EventSub handler that called it.
  *
+ * Also best-effort forwards the event to the streamer's companion app (see
+ * {@link pushCompanionActivityEvent}) — this handler is only ever called with a non-redemption
+ * `eventType` (redemptions go through {@link recordAndPushDashboardEventOrThrow} instead), so
+ * every event it records is a valid {@link CompanionActivityEventType}.
+ *
  * @param streamerId - DB row ID of the streamer, used to scope the log entry and dashboard SSE channel.
  * @param eventType - Kind of activity that occurred.
  * @param displayName - The acting Twitch viewer's display name (follower, raider, redeemer, etc.).
@@ -177,11 +183,40 @@ async function recordAndPushDashboardEvent(
 ): Promise<void> {
   try {
     await recordStreamerEvent(streamerId, eventType, displayName, detail);
-    dashboardEventRuntimeRegistry.get()?.pushDashboardEvent(streamerId, {
-      eventType, displayName, detail, occurredAt: new Date().toISOString(),
-    });
+    const occurredAt = new Date().toISOString();
+    dashboardEventRuntimeRegistry.get()?.pushDashboardEvent(streamerId, { eventType, displayName, detail, occurredAt });
+    await pushCompanionActivityEvent(streamerId, eventType as CompanionActivityEventType, displayName, detail, occurredAt);
   } catch (err) {
     log.error(`Failed to record ${eventType} dashboard event for streamer ${streamerId}:`, err);
+  }
+}
+
+/**
+ * Best-effort forwards a follow/sub/resub/giftsub/raid activity event to the owning streamer's
+ * companion app, if any device is connected. Isolates its own errors (try/catch) so a
+ * companion-push failure can never affect the dashboard record/push that triggered it — mirrors
+ * the same best-effort isolation {@link handleRedemption} uses for its own companion push.
+ *
+ * @param streamerId - DB row ID of the streamer, used to resolve the owning Discord ID.
+ * @param eventType - Kind of activity that occurred.
+ * @param displayName - The acting Twitch viewer's display name.
+ * @param detail - Short additional context, or null if there's none.
+ * @param occurredAt - ISO timestamp of when the event was recorded.
+ */
+async function pushCompanionActivityEvent(
+  streamerId: number,
+  eventType: CompanionActivityEventType,
+  displayName: string,
+  detail: string | null,
+  occurredAt: string,
+): Promise<void> {
+  try {
+    const streamer = await getStreamerById(streamerId);
+    if (streamer) {
+      companionRuntimeRegistry.get()?.pushCompanionEvent(streamer.discord_id, { type: eventType, displayName, detail, occurredAt });
+    }
+  } catch (err) {
+    log.error(`Failed to push companion event for ${eventType}:`, err);
   }
 }
 

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -44,6 +44,10 @@ declare module 'express-serve-static-core' {
     apiKeyOwner?: string;
     /** Discord ID owning the companion app token, set by requireCompanionKey. */
     companionDiscordId?: string;
+    /** SHA-256 hex hash of the companion app bearer token presented in this request, set by
+     *  requireCompanionKey — lets a handler re-verify the exact credential later, not just
+     *  whether the Discord ID has some active token. */
+    companionTokenHash?: string;
   }
 }
 

--- a/src/web/middleware.test.ts
+++ b/src/web/middleware.test.ts
@@ -438,6 +438,13 @@ describe('requireCompanionKey', () => {
     expect(res.status).not.toHaveBeenCalled();
   });
 
+  it('also sets req.companionTokenHash to the hash of the presented token', async () => {
+    vi.mocked(findDiscordIdByTokenHash).mockResolvedValue('user42');
+    const req = makeReq({ headers: { authorization: 'Bearer validtoken' } });
+    await requireCompanionKey(req, makeRes(), next);
+    expect(req.companionTokenHash).toBe(createHash('sha256').update('validtoken').digest('hex'));
+  });
+
   it('hashes the token before looking it up', async () => {
     vi.mocked(findDiscordIdByTokenHash).mockResolvedValue('u1');
     const req = makeReq({ headers: { authorization: 'Bearer mytoken' } });

--- a/src/web/middleware.ts
+++ b/src/web/middleware.ts
@@ -146,12 +146,13 @@ export const requireManagerJson = requireAccessLevelJson(AccessLevel.MANAGER);
  * on success. Responds 401 when the header is missing/empty or `lookup` finds no match, and
  * 500 on any other lookup failure. Shared factory behind `requireApiKey`/`requireCompanionKey`.
  * @param lookup - Resolves a SHA-256 hex hash to the authenticated identity, or null if no match.
- * @param assign - Stores the resolved identity on `req` for downstream handlers.
+ * @param assign - Stores the resolved identity (and the token's own hash, for a caller that
+ *   needs to re-verify the exact presented credential later, not just the identity) on `req`.
  * @returns An Express middleware.
  */
 function authenticateBearerToken<T>(
   lookup: (hash: string) => Promise<T | null>,
-  assign: (req: Request, value: T) => void,
+  assign: (req: Request, value: T, hash: string) => void,
 ): (req: Request, res: Response, next: NextFunction) => Promise<void> {
   return async (req, res, next) => {
     const authHeader = req.headers['authorization'];
@@ -167,7 +168,7 @@ function authenticateBearerToken<T>(
         res.status(401).json({ ok: false, error: 'Unauthorized' });
         return;
       }
-      assign(req, value);
+      assign(req, value, hash);
       next();
     } catch {
       res.status(500).json({ ok: false, error: 'Internal server error' });
@@ -189,11 +190,17 @@ export const requireApiKey = authenticateBearerToken(
 /**
  * Authenticates a companion app request via a `Bearer` token, hashing it and looking it
  * up against active (non-revoked) companion tokens. On success, attaches the token
- * owner's Discord ID to the request.
+ * owner's Discord ID and the token's own hash to the request — the hash lets a long-lived
+ * handler (the SSE stream) re-verify this exact credential is still active later, rather than
+ * just whether the Discord ID has *some* active token (which a revoke-then-reissue could pass
+ * even for a connection authenticated by the now-dead token).
  */
 export const requireCompanionKey = authenticateBearerToken(
   findDiscordIdByTokenHash,
-  (req, discordId: string) => { req.companionDiscordId = discordId; },
+  (req, discordId: string, hash: string) => {
+    req.companionDiscordId = discordId;
+    req.companionTokenHash = hash;
+  },
 );
 
 /** Ensures the current-guild access level is Admin, otherwise renders a 403. */

--- a/src/web/routes/companionAuth.rateLimit.test.ts
+++ b/src/web/routes/companionAuth.rateLimit.test.ts
@@ -7,6 +7,7 @@ vi.mock('../../db', () => ({
 }));
 /** Mocks the shared logger so route handlers don't write real log output during tests. */
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
+vi.mock('./companionEvents', () => ({ disconnectCompanionConnections: vi.fn() }));
 
 import supertest from 'supertest';
 import router from './companionAuth';

--- a/src/web/routes/companionAuth.test.ts
+++ b/src/web/routes/companionAuth.test.ts
@@ -13,11 +13,13 @@ vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
 vi.mock('../rateLimits', () => ({
   authLimiter: (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
+vi.mock('./companionEvents', () => ({ disconnectCompanionConnections: vi.fn() }));
 
 import express from 'express';
 import supertest from 'supertest';
 import router from './companionAuth';
 import { exchangeCodeForToken } from '../../db';
+import { disconnectCompanionConnections } from './companionEvents';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 
 /** Builds a supertest-ready app: the companion-auth router with a customizable raw session and a render mock that returns the view/locals as JSON. */
@@ -108,11 +110,25 @@ describe('POST /api/companion/oauth/token', () => {
   });
 
   it('returns a token when the code is valid', async () => {
-    vi.mocked(exchangeCodeForToken).mockResolvedValue('plain-token-value');
+    vi.mocked(exchangeCodeForToken).mockResolvedValue({ token: 'plain-token-value', discordId: 'user1' });
     const res = await supertest(buildApp()).post('/api/companion/oauth/token').send({ code: 'good' });
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ token: 'plain-token-value' });
     expect(exchangeCodeForToken).toHaveBeenCalledWith('good');
+  });
+
+  it('ends any open companion SSE connections for the user after issuing a new token', async () => {
+    // A new token invalidates any prior one, so a connection still open under the old token
+    // must be disconnected — otherwise it would keep streaming under a now-replaced credential.
+    vi.mocked(exchangeCodeForToken).mockResolvedValue({ token: 'plain-token-value', discordId: 'user1' });
+    await supertest(buildApp()).post('/api/companion/oauth/token').send({ code: 'good' });
+    expect(disconnectCompanionConnections).toHaveBeenCalledWith('user1');
+  });
+
+  it('does not disconnect connections when the code is invalid/expired/used', async () => {
+    vi.mocked(exchangeCodeForToken).mockResolvedValue(null);
+    await supertest(buildApp()).post('/api/companion/oauth/token').send({ code: 'bad' });
+    expect(disconnectCompanionConnections).not.toHaveBeenCalled();
   });
 
   it('returns 500 when exchangeCodeForToken throws', async () => {

--- a/src/web/routes/companionAuth.ts
+++ b/src/web/routes/companionAuth.ts
@@ -4,6 +4,7 @@ import { exchangeCodeForToken } from '../../db';
 import { isLoopbackRedirectUri } from './validation';
 import { renderError } from './viewHelpers';
 import { authLimiter } from '../rateLimits';
+import { disconnectCompanionConnections } from './companionEvents';
 
 const log = createLogger('CompanionAuth');
 const router = Router();
@@ -38,7 +39,10 @@ router.get('/companion/login', authLimiter, (req, res) => {
  * POST /api/companion/oauth/token — exchanges a one-time authorization code (issued
  * by the /auth/discord/callback companion branch) for a long-lived companion token.
  * The exchange runs in a single DB transaction (see `exchangeCodeForToken`), so a
- * failure issuing the token doesn't permanently burn the one-time code.
+ * failure issuing the token doesn't permanently burn the one-time code. Since issuing
+ * a token replaces (invalidates) any prior one for the same Discord ID, this also ends
+ * any companion SSE connection still open under the token just replaced — otherwise it
+ * would keep streaming under a token that's no longer valid for new connections.
  * @param req.body.code - Plaintext one-time code from the loopback redirect.
  * @returns `{ token }` on success, or a 400/429/500 JSON error response —
  *   429 comes from `authLimiter` and short-circuits before this handler runs.
@@ -51,12 +55,13 @@ router.post('/api/companion/oauth/token', authLimiter, async (req, res) => {
   }
 
   try {
-    const token = await exchangeCodeForToken(code);
-    if (!token) {
+    const result = await exchangeCodeForToken(code);
+    if (!result) {
       res.status(400).json({ ok: false, error: 'Invalid or expired code' });
       return;
     }
-    res.json({ token });
+    disconnectCompanionConnections(result.discordId);
+    res.json({ token: result.token });
   } catch (err) {
     log.error('Companion token exchange failed:', err);
     res.status(500).json({ ok: false, error: 'Internal server error' });

--- a/src/web/routes/companionEvents.test.ts
+++ b/src/web/routes/companionEvents.test.ts
@@ -32,7 +32,9 @@ vi.mock('../../db', () => ({
 }));
 
 import supertest from 'supertest';
-import router, { pushCompanionEvent, MAX_SSE_CONNECTIONS_PER_TOKEN, connections, type CompanionEvent } from './companionEvents';
+import router, {
+  pushCompanionEvent, disconnectCompanionConnections, MAX_SSE_CONNECTIONS_PER_TOKEN, connections, type CompanionEvent,
+} from './companionEvents';
 import { RECENT_EVENTS_LIMIT } from './dashboardEvents';
 import { getStreamerByDiscordId, getRecentStreamerEvents } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
@@ -218,6 +220,46 @@ describe('pushCompanionEvent', () => {
 
   it('is a no-op when no clients are connected for the discord ID', () => {
     expect(() => pushCompanionEvent('nobody', sampleEvent)).not.toThrow();
+  });
+});
+
+describe('disconnectCompanionConnections', () => {
+  it('ends every open connection for the given discord ID', () => {
+    const resA = { end: vi.fn() } as any;
+    const resB = { end: vi.fn() } as any;
+    connections.set('user1', new Set([resA, resB]));
+
+    disconnectCompanionConnections('user1');
+
+    expect(resA.end).toHaveBeenCalled();
+    expect(resB.end).toHaveBeenCalled();
+  });
+
+  it('does not end connections for a different discord ID', () => {
+    const resA = { end: vi.fn() } as any;
+    const resB = { end: vi.fn() } as any;
+    connections.set('userA', new Set([resA]));
+    connections.set('userB', new Set([resB]));
+
+    disconnectCompanionConnections('userA');
+
+    expect(resA.end).toHaveBeenCalled();
+    expect(resB.end).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when no clients are connected for the discord ID', () => {
+    expect(() => disconnectCompanionConnections('nobody')).not.toThrow();
+  });
+
+  it('logs and continues when one connection throws on end()', () => {
+    const throwing = { end: vi.fn(() => { throw new Error('already destroyed'); }) } as any;
+    const live = { end: vi.fn() } as any;
+    connections.set('user1', new Set([throwing, live]));
+
+    expect(() => disconnectCompanionConnections('user1')).not.toThrow();
+
+    expect(throwing.end).toHaveBeenCalled();
+    expect(live.end).toHaveBeenCalled();
   });
 });
 

--- a/src/web/routes/companionEvents.test.ts
+++ b/src/web/routes/companionEvents.test.ts
@@ -235,6 +235,13 @@ describe('GET /events/recent', () => {
     expect(getRecentStreamerEvents).not.toHaveBeenCalled();
   });
 
+  it('sends Cache-Control: no-store, since the response is identity-scoped activity data', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue({ id: 123 } as any);
+    vi.mocked(getRecentStreamerEvents).mockResolvedValue([]);
+    const res = await supertest(buildApp()).get('/events/recent').set('x-test-discord-id', 'user1');
+    expect(res.headers['cache-control']).toBe('no-store');
+  });
+
   it('returns 500 (and logs) when getStreamerByDiscordId rejects', async () => {
     vi.mocked(getStreamerByDiscordId).mockRejectedValue(new Error('db down'));
     const res = await supertest(buildApp()).get('/events/recent').set('x-test-discord-id', 'user1');

--- a/src/web/routes/companionEvents.test.ts
+++ b/src/web/routes/companionEvents.test.ts
@@ -29,6 +29,7 @@ vi.mock('../middleware', () => ({
 vi.mock('../../db', () => ({
   getStreamerByDiscordId: vi.fn(),
   getRecentStreamerEvents: vi.fn(),
+  getTokenStatus: vi.fn(),
 }));
 
 import supertest from 'supertest';
@@ -36,7 +37,7 @@ import router, {
   pushCompanionEvent, disconnectCompanionConnections, MAX_SSE_CONNECTIONS_PER_TOKEN, connections, type CompanionEvent,
 } from './companionEvents';
 import { RECENT_EVENTS_LIMIT } from './dashboardEvents';
-import { getStreamerByDiscordId, getRecentStreamerEvents } from '../../db';
+import { getStreamerByDiscordId, getRecentStreamerEvents, getTokenStatus } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 
 /** Builds a supertest-ready app: the companion events router with no body parser or session stub (auth is driven via a test header, see requireCompanionKey mock above). */
@@ -57,6 +58,7 @@ const sampleEvent: CompanionEvent = {
 beforeEach(() => {
   connections.clear();
   vi.clearAllMocks();
+  vi.mocked(getTokenStatus).mockResolvedValue({ hasToken: true, createdAt: new Date() });
 });
 
 describe('GET /events — auth', () => {
@@ -173,6 +175,96 @@ describe('GET /events — keepalive ping and connection close cleanup', () => {
 
     expect(() => (res.req as any).emit('close')).not.toThrow();
     expect(connections.has('user1')).toBe(false);
+  });
+});
+
+describe('GET /events — post-connect token re-check', () => {
+  /**
+   * Extracts the `/events` route's actual handler (the last middleware in its stack, after
+   * `requireCompanionKey`) so it can be invoked directly with fully-controlled mock req/res —
+   * avoids real-socket timing around the async post-connect `getTokenStatus` re-check.
+   */
+  function getEventsHandler(): (req: any, res: any) => Promise<void> {
+    const layer = (router as any).stack.find((l: any) => l.route?.path === '/events');
+    const handlers = layer.route.stack;
+    return handlers[handlers.length - 1].handle;
+  }
+
+  /** Builds a fake Express `res` covering the SSE-specific methods the route handler uses. */
+  function makeSseRes() {
+    return {
+      setHeader: vi.fn(),
+      flushHeaders: vi.fn(),
+      write: vi.fn(),
+      end: vi.fn(),
+      status: vi.fn().mockReturnThis(),
+      on: vi.fn(),
+    };
+  }
+
+  /** Builds a fake Express `req` with a `close`-event hook, plus a `triggerClose()` helper. */
+  function makeSseReq(discordId: string) {
+    let closeCb: (() => void) | undefined;
+    return {
+      req: {
+        companionDiscordId: discordId,
+        on: (event: string, cb: () => void) => {
+          if (event === 'close') closeCb = cb;
+        },
+      },
+      triggerClose: () => closeCb?.(),
+    };
+  }
+
+  it('leaves the connection open when the token is still active', async () => {
+    vi.mocked(getTokenStatus).mockResolvedValue({ hasToken: true, createdAt: new Date() });
+    const handler = getEventsHandler();
+    const res = makeSseRes();
+    const { req, triggerClose } = makeSseReq('user1');
+
+    await handler(req, res);
+
+    expect(getTokenStatus).toHaveBeenCalledWith('user1');
+    expect(res.end).not.toHaveBeenCalled();
+    expect(connections.get('user1')?.has(res as any)).toBe(true);
+
+    triggerClose();
+  });
+
+  it('ends the connection when the token was revoked in the gap between auth and admission', async () => {
+    vi.mocked(getTokenStatus).mockResolvedValue({ hasToken: false, createdAt: new Date() });
+    const handler = getEventsHandler();
+    const res = makeSseRes();
+    const { req, triggerClose } = makeSseReq('user1');
+
+    await handler(req, res);
+
+    expect(res.end).toHaveBeenCalled();
+    triggerClose(); // clears the 25s keepalive interval so it doesn't leak into other tests — res.end() is mocked here, so it doesn't itself emit 'close'
+  });
+
+  it('ends the connection when the token has been deleted entirely', async () => {
+    vi.mocked(getTokenStatus).mockResolvedValue(null);
+    const handler = getEventsHandler();
+    const res = makeSseRes();
+    const { req, triggerClose } = makeSseReq('user1');
+
+    await handler(req, res);
+
+    expect(res.end).toHaveBeenCalled();
+    triggerClose();
+  });
+
+  it('leaves the connection open (logged, not fatal) when the re-check itself fails', async () => {
+    vi.mocked(getTokenStatus).mockRejectedValue(new Error('db down'));
+    const handler = getEventsHandler();
+    const res = makeSseRes();
+    const { req, triggerClose } = makeSseReq('user1');
+
+    await expect(handler(req, res)).resolves.toBeUndefined();
+
+    expect(res.end).not.toHaveBeenCalled();
+    triggerClose();
   });
 });
 

--- a/src/web/routes/companionEvents.test.ts
+++ b/src/web/routes/companionEvents.test.ts
@@ -9,6 +9,9 @@ vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
 vi.mock('../../shared/config', () => ({
   COMPANION_MAX_SSE_PER_TOKEN: 3,
   SSE_MAX_TOTAL_CONNECTIONS: 1000,
+  // dashboardEvents.ts (imported here only for its RECENT_EVENTS_LIMIT constant) reads this
+  // at module load time too.
+  DASHBOARD_EVENTS_MAX_SSE_PER_STREAMER: 5,
 }));
 
 vi.mock('../middleware', () => ({
@@ -23,8 +26,15 @@ vi.mock('../middleware', () => ({
   },
 }));
 
+vi.mock('../../db', () => ({
+  getStreamerByDiscordId: vi.fn(),
+  getRecentStreamerEvents: vi.fn(),
+}));
+
 import supertest from 'supertest';
 import router, { pushCompanionEvent, MAX_SSE_CONNECTIONS_PER_TOKEN, connections, type CompanionEvent } from './companionEvents';
+import { RECENT_EVENTS_LIMIT } from './dashboardEvents';
+import { getStreamerByDiscordId, getRecentStreamerEvents } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 
 /** Builds a supertest-ready app: the companion events router with no body parser or session stub (auth is driven via a test header, see requireCompanionKey mock above). */
@@ -208,5 +218,53 @@ describe('pushCompanionEvent', () => {
 
   it('is a no-op when no clients are connected for the discord ID', () => {
     expect(() => pushCompanionEvent('nobody', sampleEvent)).not.toThrow();
+  });
+});
+
+describe('GET /events/recent', () => {
+  it('returns 401 when no token-derived discord ID is present', async () => {
+    const res = await supertest(buildApp()).get('/events/recent');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns an empty events array when the discord ID has no linked streamer', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
+    const res = await supertest(buildApp()).get('/events/recent').set('x-test-discord-id', 'user1');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, events: [] });
+    expect(getRecentStreamerEvents).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 (and logs) when getStreamerByDiscordId rejects', async () => {
+    vi.mocked(getStreamerByDiscordId).mockRejectedValue(new Error('db down'));
+    const res = await supertest(buildApp()).get('/events/recent').set('x-test-discord-id', 'user1');
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ ok: false });
+  });
+
+  it('returns 500 (and logs) when getRecentStreamerEvents rejects', async () => {
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue({ id: 123 } as any);
+    vi.mocked(getRecentStreamerEvents).mockRejectedValue(new Error('db down'));
+    const res = await supertest(buildApp()).get('/events/recent').set('x-test-discord-id', 'user1');
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ ok: false });
+  });
+
+  it('returns activity events mapped to the companion shape, filtering out redemption rows', async () => {
+    const occurredAt = new Date('2026-07-17T12:00:00Z');
+    vi.mocked(getStreamerByDiscordId).mockResolvedValue({ id: 123 } as any);
+    vi.mocked(getRecentStreamerEvents).mockResolvedValue([
+      { eventType: 'raid', displayName: 'raider1', detail: '12 viewers', occurredAt },
+      { eventType: 'redemption', displayName: 'redeemer1', detail: 'Cool Reward', occurredAt },
+    ]);
+
+    const res = await supertest(buildApp()).get('/events/recent').set('x-test-discord-id', 'user1');
+
+    expect(res.status).toBe(200);
+    expect(getRecentStreamerEvents).toHaveBeenCalledWith(123, RECENT_EVENTS_LIMIT);
+    expect(res.body).toEqual({
+      ok: true,
+      events: [{ type: 'raid', displayName: 'raider1', detail: '12 viewers', occurredAt: occurredAt.toISOString() }],
+    });
   });
 });

--- a/src/web/routes/companionEvents.test.ts
+++ b/src/web/routes/companionEvents.test.ts
@@ -22,6 +22,7 @@ vi.mock('../middleware', () => ({
       return;
     }
     req.companionDiscordId = id;
+    req.companionTokenHash = `hash-${id}`;
     next();
   },
 }));
@@ -29,7 +30,7 @@ vi.mock('../middleware', () => ({
 vi.mock('../../db', () => ({
   getStreamerByDiscordId: vi.fn(),
   getRecentStreamerEvents: vi.fn(),
-  getTokenStatus: vi.fn(),
+  findDiscordIdByTokenHash: vi.fn(),
 }));
 
 import supertest from 'supertest';
@@ -37,7 +38,7 @@ import router, {
   pushCompanionEvent, disconnectCompanionConnections, MAX_SSE_CONNECTIONS_PER_TOKEN, connections, type CompanionEvent,
 } from './companionEvents';
 import { RECENT_EVENTS_LIMIT } from './dashboardEvents';
-import { getStreamerByDiscordId, getRecentStreamerEvents, getTokenStatus } from '../../db';
+import { getStreamerByDiscordId, getRecentStreamerEvents, findDiscordIdByTokenHash } from '../../db';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 
 /** Builds a supertest-ready app: the companion events router with no body parser or session stub (auth is driven via a test header, see requireCompanionKey mock above). */
@@ -58,7 +59,7 @@ const sampleEvent: CompanionEvent = {
 beforeEach(() => {
   connections.clear();
   vi.clearAllMocks();
-  vi.mocked(getTokenStatus).mockResolvedValue({ hasToken: true, createdAt: new Date() });
+  vi.mocked(findDiscordIdByTokenHash).mockResolvedValue('some-discord-id');
 });
 
 describe('GET /events — auth', () => {
@@ -182,7 +183,7 @@ describe('GET /events — post-connect token re-check', () => {
   /**
    * Extracts the `/events` route's actual handler (the last middleware in its stack, after
    * `requireCompanionKey`) so it can be invoked directly with fully-controlled mock req/res —
-   * avoids real-socket timing around the async post-connect `getTokenStatus` re-check.
+   * avoids real-socket timing around the async post-connect `findDiscordIdByTokenHash` re-check.
    */
   function getEventsHandler(): (req: any, res: any) => Promise<void> {
     const layer = (router as any).stack.find((l: any) => l.route?.path === '/events');
@@ -203,11 +204,12 @@ describe('GET /events — post-connect token re-check', () => {
   }
 
   /** Builds a fake Express `req` with a `close`-event hook, plus a `triggerClose()` helper. */
-  function makeSseReq(discordId: string) {
+  function makeSseReq(discordId: string, tokenHash: string) {
     let closeCb: (() => void) | undefined;
     return {
       req: {
         companionDiscordId: discordId,
+        companionTokenHash: tokenHash,
         on: (event: string, cb: () => void) => {
           if (event === 'close') closeCb = cb;
         },
@@ -216,15 +218,15 @@ describe('GET /events — post-connect token re-check', () => {
     };
   }
 
-  it('leaves the connection open when the token is still active', async () => {
-    vi.mocked(getTokenStatus).mockResolvedValue({ hasToken: true, createdAt: new Date() });
+  it('leaves the connection open when the exact presented token is still active', async () => {
+    vi.mocked(findDiscordIdByTokenHash).mockResolvedValue('user1');
     const handler = getEventsHandler();
     const res = makeSseRes();
-    const { req, triggerClose } = makeSseReq('user1');
+    const { req, triggerClose } = makeSseReq('user1', 'hash-a');
 
     await handler(req, res);
 
-    expect(getTokenStatus).toHaveBeenCalledWith('user1');
+    expect(findDiscordIdByTokenHash).toHaveBeenCalledWith('hash-a');
     expect(res.end).not.toHaveBeenCalled();
     expect(connections.get('user1')?.has(res as any)).toBe(true);
 
@@ -232,10 +234,10 @@ describe('GET /events — post-connect token re-check', () => {
   });
 
   it('ends the connection when the token was revoked in the gap between auth and admission', async () => {
-    vi.mocked(getTokenStatus).mockResolvedValue({ hasToken: false, createdAt: new Date() });
+    vi.mocked(findDiscordIdByTokenHash).mockResolvedValue(null);
     const handler = getEventsHandler();
     const res = makeSseRes();
-    const { req, triggerClose } = makeSseReq('user1');
+    const { req, triggerClose } = makeSseReq('user1', 'hash-a');
 
     await handler(req, res);
 
@@ -243,27 +245,32 @@ describe('GET /events — post-connect token re-check', () => {
     triggerClose(); // clears the 25s keepalive interval so it doesn't leak into other tests — res.end() is mocked here, so it doesn't itself emit 'close'
   });
 
-  it('ends the connection when the token has been deleted entirely', async () => {
-    vi.mocked(getTokenStatus).mockResolvedValue(null);
+  it('ends the connection when the old token was revoked even though the user has since issued a new one', async () => {
+    // The connection was authenticated with hash-old. By the time this re-check runs, hash-old
+    // has been revoked and a *different* token (hash-new) is now the user's active one —
+    // findDiscordIdByTokenHash('hash-old') correctly returns null rather than "yes, this
+    // discord ID has some active token."
+    vi.mocked(findDiscordIdByTokenHash).mockResolvedValue(null);
     const handler = getEventsHandler();
     const res = makeSseRes();
-    const { req, triggerClose } = makeSseReq('user1');
+    const { req, triggerClose } = makeSseReq('user1', 'hash-old');
 
     await handler(req, res);
 
+    expect(findDiscordIdByTokenHash).toHaveBeenCalledWith('hash-old');
     expect(res.end).toHaveBeenCalled();
     triggerClose();
   });
 
-  it('leaves the connection open (logged, not fatal) when the re-check itself fails', async () => {
-    vi.mocked(getTokenStatus).mockRejectedValue(new Error('db down'));
+  it('fails closed (ends the connection) when the re-check itself errors', async () => {
+    vi.mocked(findDiscordIdByTokenHash).mockRejectedValue(new Error('db down'));
     const handler = getEventsHandler();
     const res = makeSseRes();
-    const { req, triggerClose } = makeSseReq('user1');
+    const { req, triggerClose } = makeSseReq('user1', 'hash-a');
 
     await expect(handler(req, res)).resolves.toBeUndefined();
 
-    expect(res.end).not.toHaveBeenCalled();
+    expect(res.end).toHaveBeenCalled();
     triggerClose();
   });
 });

--- a/src/web/routes/companionEvents.ts
+++ b/src/web/routes/companionEvents.ts
@@ -68,11 +68,16 @@ router.get('/events', requireCompanionKey, (req, res) => {
  * them, not the richer fields (`rewardId`, `userInput`, etc.) the live
  * `channel_points_redemption` push carries, so replaying them would require a third, degraded
  * shape distinct from the live one.
+ * Always sends `Cache-Control: no-store`, since the response is identity-scoped activity data.
  * @param req - Express request; `req.companionDiscordId` is set by `requireCompanionKey`.
  * @param res - Express response; JSON `{ ok: true, events }` (empty if the Discord user has no
  *   linked streamer) on success, or 500 (logged) if the streamer or recent-events lookup fails.
  */
 router.get('/events/recent', requireCompanionKey, async (req, res) => {
+  // Identity-scoped activity data — never let a shared/browser cache reuse one user's response
+  // for another (or for the same user after they revoke/reissue their companion token).
+  res.set('Cache-Control', 'no-store');
+
   const discordId = req.companionDiscordId!;
   let streamer;
   try {

--- a/src/web/routes/companionEvents.ts
+++ b/src/web/routes/companionEvents.ts
@@ -2,13 +2,19 @@ import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import { requireCompanionKey } from '../middleware';
 import { COMPANION_MAX_SSE_PER_TOKEN } from '../../shared/config';
+import type { StreamerEventType } from '../../db';
+import { getStreamerByDiscordId, getRecentStreamerEvents } from '../../db';
+import { RECENT_EVENTS_LIMIT } from './dashboardEvents';
 import { attachSseConnection, broadcastToChannel } from './sseChannel';
 
 const log = createLogger('CompanionEvents');
 const router = Router();
 
+/** Non-redemption streamer activity types forwarded to the companion app. */
+export type CompanionActivityEventType = Exclude<StreamerEventType, 'redemption'>;
+
 /** A channel-point reward redemption forwarded to a user's companion app. */
-export interface CompanionEvent {
+export interface CompanionRedemptionEvent {
   type: 'channel_points_redemption';
   rewardId: string;
   rewardTitle: string;
@@ -17,6 +23,17 @@ export interface CompanionEvent {
   userInput: string;
   redeemedAt: string;
 }
+
+/** A follow/sub/resub/giftsub/raid activity event forwarded to a user's companion app. */
+export interface CompanionActivityEvent {
+  type: CompanionActivityEventType;
+  displayName: string;
+  detail: string | null;
+  occurredAt: string;
+}
+
+/** An event forwarded to a user's companion app over the `/api/companion/events` SSE stream. */
+export type CompanionEvent = CompanionRedemptionEvent | CompanionActivityEvent;
 
 // In-memory map of active SSE connections keyed by Discord ID.
 export const connections = new Map<string, Set<import('express').Response>>();
@@ -41,6 +58,47 @@ export function pushCompanionEvent(discordId: string, event: CompanionEvent): vo
 router.get('/events', requireCompanionKey, (req, res) => {
   const discordId = req.companionDiscordId!;
   attachSseConnection(req, res, { connections, key: discordId, maxPerChannel: MAX_SSE_CONNECTIONS_PER_TOKEN });
+});
+
+/**
+ * GET /api/companion/events/recent — JSON fallback used after an SSE reconnect to resync any
+ * activity events missed while disconnected (the SSE handshake itself sends no state, only a
+ * live push on the next new event). Bearer-token authenticated via `requireCompanionKey`.
+ * Redemptions are excluded: `streamer_event_log` only retains a plain display name/detail for
+ * them, not the richer fields (`rewardId`, `userInput`, etc.) the live
+ * `channel_points_redemption` push carries, so replaying them would require a third, degraded
+ * shape distinct from the live one.
+ * @param req - Express request; `req.companionDiscordId` is set by `requireCompanionKey`.
+ * @param res - Express response; JSON `{ ok: true, events }` (empty if the Discord user has no
+ *   linked streamer) on success, or 500 (logged) if the streamer or recent-events lookup fails.
+ */
+router.get('/events/recent', requireCompanionKey, async (req, res) => {
+  const discordId = req.companionDiscordId!;
+  let streamer;
+  try {
+    streamer = await getStreamerByDiscordId(discordId);
+  } catch (err) {
+    log.error('Failed to resolve streamer for companion recent events:', err);
+    res.status(500).json({ ok: false });
+    return;
+  }
+  if (!streamer) {
+    res.json({ ok: true, events: [] });
+    return;
+  }
+
+  try {
+    const events = await getRecentStreamerEvents(streamer.id, RECENT_EVENTS_LIMIT);
+    const companionEvents: CompanionActivityEvent[] = events
+      .filter((e) => e.eventType !== 'redemption')
+      .map((e) => ({
+        type: e.eventType as CompanionActivityEventType, displayName: e.displayName, detail: e.detail, occurredAt: e.occurredAt.toISOString(),
+      }));
+    res.json({ ok: true, events: companionEvents });
+  } catch (err) {
+    log.error('Failed to load recent companion events:', err);
+    res.status(500).json({ ok: false });
+  }
 });
 
 export default router;

--- a/src/web/routes/companionEvents.ts
+++ b/src/web/routes/companionEvents.ts
@@ -3,7 +3,7 @@ import { Router } from 'express';
 import { requireCompanionKey } from '../middleware';
 import { COMPANION_MAX_SSE_PER_TOKEN } from '../../shared/config';
 import type { StreamerEventType } from '../../db';
-import { getStreamerByDiscordId, getRecentStreamerEvents } from '../../db';
+import { getStreamerByDiscordId, getRecentStreamerEvents, getTokenStatus } from '../../db';
 import { RECENT_EVENTS_LIMIT } from './dashboardEvents';
 import { attachSseConnection, broadcastToChannel } from './sseChannel';
 
@@ -74,13 +74,29 @@ export function disconnectCompanionConnections(discordId: string): void {
  * `requireCompanionKey`. Streams companion events for the authenticated Discord
  * user until the client disconnects, sending a keepalive ping every 25s and
  * capping concurrent connections per user at `MAX_SSE_CONNECTIONS_PER_TOKEN`.
+ *
+ * `requireCompanionKey`'s token check and this handler's connection admission aren't atomic —
+ * a revoke landing in that gap (e.g. via `/companion-key/revoke`, which only closes connections
+ * already registered at the moment it runs) would otherwise leave a newly-admitted connection
+ * open indefinitely, since nothing re-checks the token afterward. Closes that race by
+ * re-verifying the token immediately after attaching, and ending the connection if it was
+ * revoked in that window; best-effort (a failed re-check is logged, not fatal to the connection),
+ * since it narrows an already-narrow race rather than guarding a required invariant.
  * @param req - Express request; `req.companionDiscordId` is set by `requireCompanionKey`.
  * @param res - Express response; upgraded to a `text/event-stream` connection by
  *   `attachSseConnection`, kept alive with periodic pings and torn down on client disconnect.
  */
-router.get('/events', requireCompanionKey, (req, res) => {
+router.get('/events', requireCompanionKey, async (req, res) => {
   const discordId = req.companionDiscordId!;
-  attachSseConnection(req, res, { connections, key: discordId, maxPerChannel: MAX_SSE_CONNECTIONS_PER_TOKEN });
+  const attached = attachSseConnection(req, res, { connections, key: discordId, maxPerChannel: MAX_SSE_CONNECTIONS_PER_TOKEN });
+  if (!attached) return;
+
+  try {
+    const status = await getTokenStatus(discordId);
+    if (!status?.hasToken) res.end();
+  } catch (err) {
+    log.error(`Failed to re-verify companion token for discord ${discordId} after connecting:`, err);
+  }
 });
 
 /**

--- a/src/web/routes/companionEvents.ts
+++ b/src/web/routes/companionEvents.ts
@@ -3,7 +3,7 @@ import { Router } from 'express';
 import { requireCompanionKey } from '../middleware';
 import { COMPANION_MAX_SSE_PER_TOKEN } from '../../shared/config';
 import type { StreamerEventType } from '../../db';
-import { getStreamerByDiscordId, getRecentStreamerEvents, getTokenStatus } from '../../db';
+import { getStreamerByDiscordId, getRecentStreamerEvents, findDiscordIdByTokenHash } from '../../db';
 import { RECENT_EVENTS_LIMIT } from './dashboardEvents';
 import { attachSseConnection, broadcastToChannel } from './sseChannel';
 
@@ -79,23 +79,30 @@ export function disconnectCompanionConnections(discordId: string): void {
  * a revoke landing in that gap (e.g. via `/companion-key/revoke`, which only closes connections
  * already registered at the moment it runs) would otherwise leave a newly-admitted connection
  * open indefinitely, since nothing re-checks the token afterward. Closes that race by
- * re-verifying the token immediately after attaching, and ending the connection if it was
- * revoked in that window; best-effort (a failed re-check is logged, not fatal to the connection),
- * since it narrows an already-narrow race rather than guarding a required invariant.
- * @param req - Express request; `req.companionDiscordId` is set by `requireCompanionKey`.
+ * re-verifying immediately after attaching that the *exact* presented token (`req.companionTokenHash`,
+ * not just "some active token for this Discord ID") is still active, and ending the connection if
+ * not — binding to the specific credential, rather than the Discord ID alone, also covers the
+ * revoke-then-reissue case: a connection authenticated by an old, now-dead token must not be
+ * allowed to keep streaming just because the same user has since issued a new one. Fails closed
+ * (ends the connection) if the re-check itself errors, since an unconfirmed credential shouldn't
+ * default to trusted for a security check.
+ * @param req - Express request; `req.companionDiscordId`/`req.companionTokenHash` are set by
+ *   `requireCompanionKey`.
  * @param res - Express response; upgraded to a `text/event-stream` connection by
  *   `attachSseConnection`, kept alive with periodic pings and torn down on client disconnect.
  */
 router.get('/events', requireCompanionKey, async (req, res) => {
   const discordId = req.companionDiscordId!;
+  const tokenHash = req.companionTokenHash!;
   const attached = attachSseConnection(req, res, { connections, key: discordId, maxPerChannel: MAX_SSE_CONNECTIONS_PER_TOKEN });
   if (!attached) return;
 
   try {
-    const status = await getTokenStatus(discordId);
-    if (!status?.hasToken) res.end();
+    const stillActive = await findDiscordIdByTokenHash(tokenHash);
+    if (stillActive === null) res.end();
   } catch (err) {
     log.error(`Failed to re-verify companion token for discord ${discordId} after connecting:`, err);
+    res.end();
   }
 });
 

--- a/src/web/routes/companionEvents.ts
+++ b/src/web/routes/companionEvents.ts
@@ -47,6 +47,29 @@ export function pushCompanionEvent(discordId: string, event: CompanionEvent): vo
 }
 
 /**
+ * Ends every open companion SSE connection for a Discord user, so a just-revoked token stops
+ * receiving events immediately instead of continuing to stream to a connection that was
+ * authenticated (via `requireCompanionKey`) before the revoke — auth is only checked once, at
+ * connect time, so without this an already-open stream would otherwise keep delivering events
+ * until the client happens to disconnect on its own. `res.end()` triggers the same `close`-event
+ * cleanup path `attachSseConnection` already wires up (clearing the keepalive, releasing the
+ * global connection slot, evicting the entry from `connections`), so no separate bookkeeping is
+ * needed here. Called from the `/companion-key/revoke` route after the DB revoke succeeds.
+ * @param discordId - Discord snowflake whose companion connections should be torn down.
+ */
+export function disconnectCompanionConnections(discordId: string): void {
+  const clients = connections.get(discordId);
+  if (!clients) return;
+  for (const res of Array.from(clients)) {
+    try {
+      res.end();
+    } catch (err) {
+      log.error(`Failed to close a companion connection for discord ${discordId}:`, err);
+    }
+  }
+}
+
+/**
  * GET /api/companion/events — SSE endpoint, bearer-token authenticated via
  * `requireCompanionKey`. Streams companion events for the authenticated Discord
  * user until the client disconnects, sending a keepalive ping every 25s and

--- a/src/web/routes/companionKeys.test.ts
+++ b/src/web/routes/companionKeys.test.ts
@@ -16,12 +16,14 @@ vi.mock('../csrf', () => ({
 }));
 vi.mock('../../shared/logger', () => ({ createLogger: mockLogger }));
 vi.mock('../../shared/config', () => ({ WEB_PORT: 3000 }));
+vi.mock('./companionEvents', () => ({ disconnectCompanionConnections: vi.fn() }));
 
 import express from 'express';
 import supertest from 'supertest';
 import router from './companionKeys';
 import { issueToken, getTokenStatus, revokeToken } from '../../db';
 import { AccessLevel } from '../../db';
+import { disconnectCompanionConnections } from './companionEvents';
 import { buildTestApp } from '../../test-utils/expressTestApp';
 
 const GUILD_ID = '900000000000000001';
@@ -104,9 +106,20 @@ describe('POST /companion-key/revoke', () => {
     expect(revokeToken).toHaveBeenCalledWith(SESSION_USER.discordId);
   });
 
+  it('ends any open companion SSE connections for the user after a successful revoke', async () => {
+    await supertest(buildApp()).post('/companion-key/revoke');
+    expect(disconnectCompanionConnections).toHaveBeenCalledWith(SESSION_USER.discordId);
+  });
+
   it('redirects to ?error=revoke_failed on error', async () => {
     vi.mocked(revokeToken).mockRejectedValueOnce(new Error('DB error'));
     const res = await supertest(buildApp()).post('/companion-key/revoke');
     expect(res.headers.location).toBe('/companion-key?error=revoke_failed');
+  });
+
+  it('does not disconnect connections when the revoke itself fails', async () => {
+    vi.mocked(revokeToken).mockRejectedValueOnce(new Error('DB error'));
+    await supertest(buildApp()).post('/companion-key/revoke');
+    expect(disconnectCompanionConnections).not.toHaveBeenCalled();
   });
 });

--- a/src/web/routes/companionKeys.test.ts
+++ b/src/web/routes/companionKeys.test.ts
@@ -95,6 +95,21 @@ describe('POST /companion-key/request', () => {
     const res = await supertest(buildApp()).post('/companion-key/request');
     expect(res.headers.location).toBe('/companion-key?error=request_failed');
   });
+
+  it('ends any open companion SSE connections for the user after issuing a new token', async () => {
+    vi.mocked(issueToken).mockResolvedValue('plain-token-value');
+    vi.mocked(getTokenStatus).mockResolvedValue({ hasToken: true, createdAt: new Date() } as any);
+    await supertest(buildApp()).post('/companion-key/request');
+    // A new token invalidates any prior one, so a connection still open under the old token
+    // must be disconnected — otherwise it would keep streaming under a now-replaced credential.
+    expect(disconnectCompanionConnections).toHaveBeenCalledWith(SESSION_USER.discordId);
+  });
+
+  it('does not disconnect connections when issuing the token itself fails', async () => {
+    vi.mocked(issueToken).mockRejectedValueOnce(new Error('denied'));
+    await supertest(buildApp()).post('/companion-key/request');
+    expect(disconnectCompanionConnections).not.toHaveBeenCalled();
+  });
 });
 
 // ─── POST /companion-key/revoke ───────────────────────────────────────────────

--- a/src/web/routes/companionKeys.ts
+++ b/src/web/routes/companionKeys.ts
@@ -35,12 +35,16 @@ router.get('/companion-key', csrfProtection, async (req, res) => {
  * to the OAuth login flow. Only this section's failure can burn the user's one
  * chance to see the new plaintext token, so the follow-up status refresh runs in
  * its own try/catch with a locally-derived fallback rather than risking the
- * already-issued token being lost behind a `request_failed` redirect.
+ * already-issued token being lost behind a `request_failed` redirect. Issuing a
+ * token replaces (invalidates) any prior one for this Discord ID, so this also ends
+ * any companion SSE connection still open under the token just replaced.
  */
 router.post('/companion-key/request', csrfProtection, async (req, res) => {
+  const discordId = getSessionUser(req).discordId;
   let plain: string;
   try {
-    plain = await issueToken(getSessionUser(req).discordId);
+    plain = await issueToken(discordId);
+    disconnectCompanionConnections(discordId);
   } catch (err) {
     logAndRedirectError({ res, log, logLabel: 'Companion key request error:', err, basePath: '/companion-key', errorCode: 'request_failed' });
     return;
@@ -48,7 +52,7 @@ router.post('/companion-key/request', csrfProtection, async (req, res) => {
 
   let tokenStatus;
   try {
-    tokenStatus = await getTokenStatus(getSessionUser(req).discordId);
+    tokenStatus = await getTokenStatus(discordId);
   } catch (err) {
     log.error('Companion key status refresh after issue failed:', err);
     tokenStatus = { hasToken: true, createdAt: new Date() };

--- a/src/web/routes/companionKeys.ts
+++ b/src/web/routes/companionKeys.ts
@@ -6,6 +6,7 @@ import { filterQueryParam } from './validation';
 import { renderError, renderView } from './viewHelpers';
 import { logAndRedirectError } from './errorHandling';
 import { getSessionUser } from '../session';
+import { disconnectCompanionConnections } from './companionEvents';
 
 const log = createLogger('Web');
 const router = Router();
@@ -62,10 +63,17 @@ router.post('/companion-key/request', csrfProtection, async (req, res) => {
   });
 });
 
-/** Revokes the current user's companion app token. */
+/**
+ * Revokes the current user's companion app token, and immediately ends any of their companion
+ * app's open SSE connections (see `disconnectCompanionConnections`) — otherwise a connection
+ * opened before the revoke would keep receiving events until it happened to disconnect on its
+ * own, since `requireCompanionKey` only checks the token once, at connect time.
+ */
 router.post('/companion-key/revoke', csrfProtection, async (req, res) => {
   try {
-    await revokeToken(getSessionUser(req).discordId);
+    const discordId = getSessionUser(req).discordId;
+    await revokeToken(discordId);
+    disconnectCompanionConnections(discordId);
     res.redirect('/companion-key');
   } catch (err) {
     logAndRedirectError({ res, log, logLabel: 'Companion key revoke error:', err, basePath: '/companion-key', errorCode: 'revoke_failed' });

--- a/views/companion-keys.ejs
+++ b/views/companion-keys.ejs
@@ -54,7 +54,7 @@
           <span class="badge badge-active">Active</span>
           <span class="text-muted-sm">Issued <%= tokenStatus.createdAt.toLocaleDateString() %></span>
         </div>
-        <p>Your companion app token is active. It is read-only — it can only receive your own channel-point redemption events.</p>
+        <p>Your companion app token is active. It is read-only — it can only receive activity events (follows, subs, resubs, gift subs, raids, and channel-point redemptions) for your own channel.</p>
         <p class="muted">If you have lost your device or believe the token has leaked, you can revoke it. The companion app can log in again afterwards to get a fresh token.</p>
         <div class="d-flex gap-05 flex-wrap mt-1">
           <form method="POST" action="/companion-key/request">
@@ -85,9 +85,14 @@
         <p class="muted">Only loopback redirect URIs (<code>http://127.0.0.1:*</code> or <code>http://localhost:*</code>) are accepted.</p>
 
         <p class="mt-1"><strong>Event feed:</strong></p>
-        <p>Connect to <code>GET /api/companion/events</code> with <code>Authorization: Bearer &lt;token&gt;</code>. This is a Server-Sent Events stream that delivers one event per line as it happens:</p>
+        <p>Connect to <code>GET /api/companion/events</code> with <code>Authorization: Bearer &lt;token&gt;</code>. This is a Server-Sent Events stream that delivers one event per line as it happens, for activity on your own channel only. A channel-point redemption has its own richer shape:</p>
         <pre class="mono event-feed-sample">data: {"type":"channel_points_redemption","rewardId":"...","rewardTitle":"...","userLogin":"...","userName":"...","userInput":"...","redeemedAt":"2026-01-01T00:00:00.000Z"}</pre>
-        <p class="muted">Events are only sent for redemptions on your own channel. What the companion app does with an event (play a sound, run a script, show a notification) is entirely up to it.</p>
+        <p>A follow, sub, resub, gift sub, or raid uses a shared, simpler shape instead:</p>
+        <pre class="mono event-feed-sample">data: {"type":"follow","displayName":"...","detail":null,"occurredAt":"2026-01-01T00:00:00.000Z"}</pre>
+        <p class="muted">What the companion app does with an event (play a sound, run a script, show a notification) is entirely up to it.</p>
+
+        <p class="mt-1"><strong>Missed-event replay:</strong></p>
+        <p><code>GET /api/companion/events/recent</code> (same bearer auth) returns <code>{ "ok": true, "events": [...] }</code> with your most recent follow/sub/resub/giftsub/raid activity, for catching up after a reconnect. Channel-point redemptions aren't included in this list — only the live event feed carries them.</p>
       </div>
     </section>
   </main>

--- a/views/privacy.ejs
+++ b/views/privacy.ejs
@@ -51,7 +51,8 @@
               redemption: the event type, the viewer's Twitch display name, and a short detail (for
               example a raid's viewer count, or a redeemed reward's name). This is shown on the dashboard's
               live "Recent Events" feed and is the only data we store about Twitch viewers who aren't
-              signed-in users of this site.</li>
+              signed-in users of this site. If you have an active companion app token, the same events for
+              your own channel are also delivered live to your companion app.</li>
           </ul>
           <p>We do not record or transcribe voice channel audio, and we do not store the content of Discord
             messages or chat logs. A short list of the most recent bot command executions is kept in

--- a/views/privacy.ejs
+++ b/views/privacy.ejs
@@ -47,12 +47,16 @@
               never stored in plain text.</li>
             <li>If you generate a Streamdeck API key: only a one-way hash of it, never the key itself.</li>
             <li>If you request a companion app token: only a one-way hash of it, never the token itself.</li>
-            <li>If a connected Twitch channel gets a follow, subscription, raid, or channel-point
-              redemption: the event type, the viewer's Twitch display name, and a short detail (for
-              example a raid's viewer count, or a redeemed reward's name). This is shown on the dashboard's
-              live "Recent Events" feed and is the only data we store about Twitch viewers who aren't
-              signed-in users of this site. If you have an active companion app token, the same events for
-              your own channel are also delivered live to your companion app.</li>
+            <li>If a connected Twitch channel gets a follow, subscription, resub, gift sub, raid, or
+              channel-point redemption: the event type, the viewer's Twitch display name, and a short
+              detail (for example a raid's viewer count, or a redeemed reward's name). This is shown on
+              the dashboard's live "Recent Events" feed and is the only data we store about Twitch viewers
+              who aren't signed-in users of this site. If you have an active companion app token, the same
+              events for your own channel are also delivered live to your companion app; a redemption's
+              live push additionally includes the reward ID, the redeemer's Twitch login, and any text
+              they entered, none of which we store. Your companion app can also fetch a short history of
+              recent follow/sub/resub/giftsub/raid activity (not redemptions) to catch up after
+              reconnecting, drawn from the same "Recent Events" data described above.</li>
           </ul>
           <p>We do not record or transcribe voice channel audio, and we do not store the content of Discord
             messages or chat logs. A short list of the most recent bot command executions is kept in


### PR DESCRIPTION
## Summary

- The companion app's `GET /api/companion/events` SSE stream previously only forwarded `channel_points_redemption` events. It now also forwards follow/sub/resub/giftsub/raid activity as a new `CompanionActivityEvent` type, pushed alongside the existing dashboard "Recent Events" record in `recordAndPushDashboardEvent` (`src/twitch/eventsub/twitchEventSubHandler.ts`), isolated in its own try/catch so a companion-push failure can never affect the dashboard record.
- Added `GET /api/companion/events/recent`, mirroring the dashboard's `/dashboard/events/recent` replay endpoint, so a companion client that reconnects after a gap can catch up on activity it missed (redemptions are excluded from replay since `streamer_event_log` only retains a plain display name/detail for them, not the richer fields the live redemption push carries).
- Stream online/offline/channel-update events are out of scope for this change — they aren't persisted to `streamer_event_log` today and would need separate plumbing.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, including new/updated tests in `companionEvents.test.ts` and `twitchEventSubHandler.test.ts`)
- [x] `npm run lint`
- [x] `npm run check:circular`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXVLtbQmjGLkjcTTEFHZMn

---
_Generated by [Claude Code](https://claude.ai/code/session_01DXVLtbQmjGLkjcTTEFHZMn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Companion apps now receive follow, raid, subscription, resubscription, and gifted-subscription activity updates.
  * Recent activity can be retrieved after reconnecting; channel-point redemptions are excluded.
  * Activity events include the event type, display name, details, and occurrence time.
  * Revoking or replacing a companion key immediately disconnects active sessions.
  * Companion connections re-check the exact token’s validity after connecting.

* **Reliability**
  * Dashboard recording continues when companion lookup or delivery fails.

* **Documentation**
  * Updated companion-app and privacy documentation for supported events, replay, and redemption details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->