### PR TITLE
Throttle shardError logging/owner alerts to stop log-file spam

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4247,6 +4247,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/filing-cabinet/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",

--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -28,6 +28,7 @@ vi.mock('../shared/healthStore', () => ({ recordDiscordConnected: vi.fn() }));
 vi.mock('../commands/healthCommandHandler', () => ({ executeHealthCommandForDiscord: vi.fn().mockResolvedValue(undefined) }));
 vi.mock('../audio/audioPlayer', () => ({ forgetGuild: vi.fn() }));
 vi.mock('./guildRefreshState', () => ({ forgetGuildRefreshState: vi.fn() }));
+vi.mock('./ownerAlerts', () => ({ sendOwnerAlert: vi.fn().mockResolvedValue(true) }));
 vi.mock('./guildRegistry', () => ({
   // Only the legacy configured guild is registered in these tests.
   isRegisteredGuild: vi.fn((id: string) => id === 'guild-id'),
@@ -474,12 +475,49 @@ describe('startDiscordBot — gateway watchdog', () => {
     expect(mockLog.warn).toHaveBeenCalledWith(expect.stringContaining('0'));
   });
 
-  it('logs a warning with the shard id and error when a shard reports a gateway connection error, without throwing', () => {
+  it('logs an error with the shard id and error the first time a shard reports a gateway connection error, and DMs the owner, without throwing', async () => {
+    const ownerAlerts = await import('./ownerAlerts.js');
     mod.startDiscordBot();
     const handler = findHandler('shardError');
     const gatewayError = new Error('gateway socket error');
     expect(() => handler(gatewayError, 0)).not.toThrow();
-    expect(mockLog.warn).toHaveBeenCalledWith(expect.stringContaining('0'), gatewayError);
+    expect(mockLog.error).toHaveBeenCalledWith(expect.stringContaining('0'), gatewayError);
+    expect(vi.mocked(ownerAlerts.sendOwnerAlert)).toHaveBeenCalledWith(expect.stringContaining('Shard 0'));
+  });
+
+  it('throttles repeated shardError logs/owner DMs for the same shard to one per interval, folding in a suppressed count', async () => {
+    const ownerAlerts = await import('./ownerAlerts.js');
+    vi.useFakeTimers();
+    try {
+      mod.startDiscordBot();
+      const handler = findHandler('shardError');
+      const gatewayError = new Error('gateway socket error');
+
+      handler(gatewayError, 0);
+      handler(gatewayError, 0);
+      handler(gatewayError, 0);
+      expect(mockLog.error).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(ownerAlerts.sendOwnerAlert)).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(60_000);
+      handler(gatewayError, 0);
+      expect(mockLog.error).toHaveBeenCalledTimes(2);
+      expect(mockLog.error).toHaveBeenLastCalledWith(expect.stringContaining('2 more suppressed'), gatewayError);
+      expect(vi.mocked(ownerAlerts.sendOwnerAlert)).toHaveBeenCalledTimes(2);
+      expect(vi.mocked(ownerAlerts.sendOwnerAlert)).toHaveBeenLastCalledWith(expect.stringContaining('2 more suppressed'));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('logs shardError independently per shard, without one shard throttling another', () => {
+    mod.startDiscordBot();
+    const handler = findHandler('shardError');
+    const gatewayError = new Error('gateway socket error');
+
+    handler(gatewayError, 0);
+    handler(gatewayError, 1);
+    expect(mockLog.error).toHaveBeenCalledTimes(2);
   });
 
   it('forces a fresh login when a shard disconnects permanently', () => {

--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -474,12 +474,12 @@ describe('startDiscordBot — gateway watchdog', () => {
     expect(mockLog.warn).toHaveBeenCalledWith(expect.stringContaining('0'));
   });
 
-  it('logs an error with the shard id and error when a shard reports a gateway connection error, without throwing', () => {
+  it('logs a warning with the shard id and error when a shard reports a gateway connection error, without throwing', () => {
     mod.startDiscordBot();
     const handler = findHandler('shardError');
     const gatewayError = new Error('gateway socket error');
     expect(() => handler(gatewayError, 0)).not.toThrow();
-    expect(mockLog.error).toHaveBeenCalledWith(expect.stringContaining('0'), gatewayError);
+    expect(mockLog.warn).toHaveBeenCalledWith(expect.stringContaining('0'), gatewayError);
   });
 
   it('forces a fresh login when a shard disconnects permanently', () => {

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -10,6 +10,7 @@ import { executeHealthCommandForDiscord } from '../commands/healthCommandHandler
 import { forgetGuild as forgetGuildVoiceState } from '../audio/audioPlayer';
 import { forgetGuildRefreshState } from './guildRefreshState';
 import { isRegisteredGuild, reloadGuildRegistry } from './guildRegistry';
+import { sendOwnerAlert } from './ownerAlerts';
 import { upsertGuild, getGuildById, findUser, upsertUser, setMemberAccessLevel, AccessLevel } from '../db';
 import { runUserMutation } from '../web/routes/adminUserMutationQueue';
 import { createLogger } from '../shared/logger';
@@ -20,6 +21,40 @@ const log = createLogger('Discord');
 let bootingClient: Client | null = null;
 
 export { getDiscordClient };
+
+/** How often a given shard's gateway connection errors are actually logged — see {@link logShardError}. */
+const SHARD_ERROR_LOG_INTERVAL_MS = 60_000;
+
+/** Per-shard state for {@link logShardError}: when it last actually logged, and how many errors it has swallowed since. */
+const shardErrorLogState = new Map<number, { lastLoggedAt: number; suppressedCount: number }>();
+
+/**
+ * Logs a `shardError` at `error` and DMs the owner, throttled to at most one line/DM per
+ * shard per {@link SHARD_ERROR_LOG_INTERVAL_MS}. During a Discord-side gateway hiccup (e.g.
+ * repeated `Unexpected server response: 503`), discord.js's automatic reconnect can retry —
+ * and this event can fire — many times a second; logging (and alerting on) every one of those
+ * verbatim has filled multiple log files in a single incident without adding any information
+ * discord.js's own retry wasn't already handling. Errors swallowed during the throttle window
+ * are counted and folded into the next line/DM that does get sent. Still worth surfacing as an
+ * error (unlike 'shardReconnecting') because a shard that keeps erroring is a real, ongoing
+ * connectivity problem worth a human looking at, even though discord.js itself will keep
+ * retrying without help.
+ * @param shardId - The shard that reported the error.
+ * @param err - The gateway connection error.
+ */
+function logShardError(shardId: number, err: Error): void {
+  const now = Date.now();
+  const state = shardErrorLogState.get(shardId);
+  if (state && now - state.lastLoggedAt < SHARD_ERROR_LOG_INTERVAL_MS) {
+    state.suppressedCount++;
+    return;
+  }
+  const suppressed = state?.suppressedCount ?? 0;
+  const suffix = suppressed > 0 ? ` (${suppressed} more suppressed in the last ${SHARD_ERROR_LOG_INTERVAL_MS / 1000}s)` : '';
+  log.error(`Shard ${shardId} gateway connection error:${suffix}`, err);
+  shardErrorLogState.set(shardId, { lastLoggedAt: now, suppressedCount: 0 });
+  void sendOwnerAlert(`🔴 Shard ${shardId} gateway connection error${suffix}: ${err.message}`);
+}
 
 /** Resolve callbacks awaiting the next `clientReady` — see {@link onceDiscordReady}. */
 let readyWaiters: Array<() => void> = [];
@@ -229,19 +264,15 @@ function registerClientReadyHandler(client: Client): void {
  * visibility logging — without them, a reconnect cycle produces zero log output,
  * making post-incident diagnosis impossible. 'shardError' is a connection-level
  * error on the gateway socket itself (distinct from the generic 'error' handler);
- * the manager keeps retrying after it, so it's also log-only.
+ * the manager keeps retrying after it, so it doesn't need any recovery action here —
+ * but it's still worth an error-level log and an owner DM, throttled (see
+ * {@link logShardError}) so a burst of retries during an outage doesn't flood either.
  *
  * 'shardDisconnect' fires only for an unrecoverable close code — the one case
  * where discord.js gives up and will *not* reconnect that shard on its own. With
  * this bot running a single (unsharded) client, that means every guild silently
  * stops receiving events. Force a fresh login so the process self-heals instead
  * of sitting alive-but-dead until someone notices and restarts it manually.
- *
- * 'shardError' is logged at `warn`, not `error`: Discord's gateway routinely
- * bounces connection attempts with transient failures (e.g. `Unexpected server
- * response: 503`) during its own hiccups, and discord.js's automatic retry
- * handles every one without our intervention. Logging those at `error` just
- * spams error-level logs/alerts for something that isn't actionable.
  * @param client - The Discord client to register the handlers on.
  */
 function registerConnectionHandlers(client: Client): void {
@@ -252,7 +283,7 @@ function registerConnectionHandlers(client: Client): void {
     log.warn(`Shard ${shardId} lost its connection and is reconnecting...`);
   });
   client.on('shardError', (err, shardId) => {
-    log.warn(`Shard ${shardId} gateway connection error:`, err);
+    logShardError(shardId, err);
   });
   client.on('shardDisconnect', (event, shardId) => {
     log.error(`Shard ${shardId} disconnected permanently (code ${event.code}) — reconnecting client.`);

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -236,6 +236,12 @@ function registerClientReadyHandler(client: Client): void {
  * this bot running a single (unsharded) client, that means every guild silently
  * stops receiving events. Force a fresh login so the process self-heals instead
  * of sitting alive-but-dead until someone notices and restarts it manually.
+ *
+ * 'shardError' is logged at `warn`, not `error`: Discord's gateway routinely
+ * bounces connection attempts with transient failures (e.g. `Unexpected server
+ * response: 503`) during its own hiccups, and discord.js's automatic retry
+ * handles every one without our intervention. Logging those at `error` just
+ * spams error-level logs/alerts for something that isn't actionable.
  * @param client - The Discord client to register the handlers on.
  */
 function registerConnectionHandlers(client: Client): void {
@@ -246,7 +252,7 @@ function registerConnectionHandlers(client: Client): void {
     log.warn(`Shard ${shardId} lost its connection and is reconnecting...`);
   });
   client.on('shardError', (err, shardId) => {
-    log.error(`Shard ${shardId} gateway connection error:`, err);
+    log.warn(`Shard ${shardId} gateway connection error:`, err);
   });
   client.on('shardDisconnect', (event, shardId) => {
     log.error(`Shard ${shardId} disconnected permanently (code ${event.code}) — reconnecting client.`);

--- a/src/discord/ownerAlerts.ts
+++ b/src/discord/ownerAlerts.ts
@@ -124,7 +124,7 @@ async function resolveOwnerDiscordId(): Promise<string | null> {
  * @returns Whether the DM was actually delivered — false if no runtime is registered, the owner
  *   ID couldn't be resolved, or the send itself failed.
  */
-async function sendOwnerAlert(message: string): Promise<boolean> {
+export async function sendOwnerAlert(message: string): Promise<boolean> {
   const runtime = runtimeRegistry.get();
   if (!runtime) {
     log.warn('No owner-alert runtime registered — skipping alert:', message);


### PR DESCRIPTION
## Summary

An incident log showed the Discord gateway repeatedly rejecting connection attempts with `Unexpected server response: 503`. discord.js's own `WebSocketManager` already retries automatically on `shardError`, but our handler logged every single occurrence verbatim — during a gateway hiccup this event can fire many times a second, which filled multiple log files in one incident.

- `shardError` is still logged at `error` (a shard that keeps erroring is a real, ongoing problem worth a human looking at) and now also DMs the bot owner, reusing the existing `ownerAlerts` DM channel.
- Both the log line and the owner DM are throttled to at most one per shard per 60 seconds; errors swallowed during that window are counted and folded into the message once the throttle window elapses (e.g. `... (12 more suppressed in the last 60s)`).
- Exported `sendOwnerAlert` from `ownerAlerts.ts` so `discordBot.ts` can reuse the existing owner-DM plumbing instead of duplicating it.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm test` (full suite, 3494 tests passing)
- [x] `npm run lint`
- [x] `npm run check:circular`
- [x] Added tests covering: first-occurrence log+DM, throttling of repeated errors for the same shard with suppressed-count folding, and independent throttling per shard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxT7aLphACfAzxNWjpshco

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxT7aLphACfAzxNWjpshco)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Discord shard error monitoring with owner alerts.
  - Repeated errors for the same shard are throttled to reduce notification noise, with suppressed error counts included in the next alert.
  - Errors from different shards continue to be tracked and reported independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->