### PR TITLE
Pin qs to >=6.16.0 via overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "ws": ">=8.21.1",
     "undici": "^7.29.0",
     "mysql2": "^3.23.1",
+    "qs": ">=6.16.0",
     "madge": {
       "typescript": "$typescript"
     }


### PR DESCRIPTION
## Summary

Aikido flagged `qs` (CVE-2026-82417 / CVE-2026-82562, fixed in 6.16.0). Dependabot PR #615 already bumped `package-lock.json`'s resolved `qs` to `6.16.0`, and `npm audit` currently reports 0 vulnerabilities — so the alert was stale.

However, none of `qs`'s consumers (`body-parser` `^6.15.2`, `express` `^6.14.0`, `superagent` `^6.14.1`) actually enforce a 6.16.0+ floor on their own — they're satisfied by any 6.x within their range. Without an explicit pin, a future dependency bump or partial lockfile regeneration could re-resolve `qs` to an older, vulnerable version that still satisfies those ranges.

This adds `"qs": ">=6.16.0"` to the existing `overrides` block in `package.json` (alongside the existing `ws`/`undici`/`mysql2` security pins) so the fixed version is guaranteed going forward, not just incidentally resolved today.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test` (187 files / 3494 tests passed)
- [x] `npm audit` — 0 vulnerabilities
- [x] `npm ls qs` confirms single deduped `qs@6.16.0` across `express`, `body-parser`, `superagent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012HnD8M6Jbm3oBT8grxwaw9

---
_Generated by [Claude Code](https://claude.ai/code/session_012HnD8M6Jbm3oBT8grxwaw9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency resolution to require `qs` version 6.16.0 or newer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->