### PR TITLE
Maintainability cleanup: dedupe repeated patterns, add missing JSDoc

### DIFF
--- a/src/audio/audioConnectionHandlers.ts
+++ b/src/audio/audioConnectionHandlers.ts
@@ -43,6 +43,8 @@ async function handleDisconnected(
   attemptId: number,
   deps: ConnectionHandlerDeps,
 ): Promise<void> {
+  // Stale once a newer connection attempt has started, or another handler already
+  // swapped in a different (or no) connection for this guild.
   const isStale = (): boolean => {
     const c = deps.getConnection();
     return attemptId !== deps.getAttemptId() || (c !== null && c !== joinedConnection);

--- a/src/audio/sfxPlayer.ts
+++ b/src/audio/sfxPlayer.ts
@@ -26,6 +26,7 @@ if (ffmpegPath) {
 const sfxRoot = path.posix.resolve(SFX_FOLDER);
 let realSfxRoot: string | null = null;
 
+/** Returns the SFX folder's canonical (symlink-resolved) real path, resolving and caching it on first call. */
 function getRealSfxRoot(): string {
   if (!realSfxRoot) {
     realSfxRoot = fs.realpathSync(sfxRoot);

--- a/src/commands/counterHandler.test.ts
+++ b/src/commands/counterHandler.test.ts
@@ -10,10 +10,22 @@ vi.mock('../db', () => ({
   incrementCounter: vi.fn(),
 }));
 
-vi.mock('../discord/discordUtils', () => ({
-  isDiscordNotFoundError: vi.fn().mockReturnValue(false),
-  NO_MENTIONS: { parse: [] },
-}));
+vi.mock('../discord/discordUtils', () => {
+  const isDiscordNotFoundError = vi.fn().mockReturnValue(false);
+  return {
+    isDiscordNotFoundError,
+    NO_MENTIONS: { parse: [] },
+    trySendDiscordReply: async (message: { reply: (payload: unknown) => Promise<unknown> }, payload: unknown, onError: (err: unknown) => void) => {
+      try {
+        await message.reply(payload);
+        return true;
+      } catch (err) {
+        if (!isDiscordNotFoundError(err)) onError(err);
+        return false;
+      }
+    },
+  };
+});
 
 import {
   executeCounterCommandForDiscord,

--- a/src/commands/counterHandler.ts
+++ b/src/commands/counterHandler.ts
@@ -76,7 +76,7 @@ interface CounterResult {
  * @param cooldownKey - Cooldown-gate key for the invoking guild/channel.
  * @returns The response text, display label, and whether it's safe to send it; null if no counter matches `command`, or if the match is on cooldown.
  */
-async function _buildCounterResponse(
+async function buildCounterResponse(
   command: string,
   errorPrefix: string,
   cooldownKey: string,
@@ -137,7 +137,7 @@ export async function executeCounterCommandForDiscord(
   const command = resolveCommand(message.content, precomputedCommand);
   if (!command) return;
 
-  const result = await _buildCounterResponse(command, '[Discord]', discordCooldownKey(message));
+  const result = await buildCounterResponse(command, '[Discord]', discordCooldownKey(message));
   if (!result) return;
 
   if (!result.canReply) return;
@@ -174,7 +174,7 @@ export async function executeCounterCommandForTwitch(
   const command = resolveCommand(rawMessage, precomputedCommand);
   if (!command) return;
 
-  const result = await _buildCounterResponse(command, `[Twitch:${channel}]`, `twitch:${channel}`);
+  const result = await buildCounterResponse(command, `[Twitch:${channel}]`, `twitch:${channel}`);
   if (!result) return;
 
   if (!result.canReply) return;

--- a/src/commands/counterHandler.ts
+++ b/src/commands/counterHandler.ts
@@ -4,7 +4,7 @@ import { findCounterByCommand, incrementCounter } from '../db';
 
 const log = createLogger('Counter');
 import { resolveCommand } from './commandUtils';
-import { isDiscordNotFoundError, NO_MENTIONS } from '../discord/discordUtils';
+import { NO_MENTIONS, trySendDiscordReply } from '../discord/discordUtils';
 import { createRuntimeRegistry, type TwitchSendRuntime } from './twitchRuntime';
 import { createCooldownGate } from './cooldownGate';
 
@@ -142,13 +142,13 @@ export async function executeCounterCommandForDiscord(
 
   if (!result.canReply) return;
 
-  try {
-    await message.reply({ content: result.response, allowedMentions: NO_MENTIONS });
+  const sent = await trySendDiscordReply(
+    message,
+    { content: result.response, allowedMentions: NO_MENTIONS },
+    (err) => log.error(`[Discord] Failed to reply to message ${message.id} for ${result.label} '${command}':`, err),
+  );
+  if (sent) {
     log.info(`[Discord] Sent ${result.label} '${command}'.`);
-  } catch (err) {
-    if (!isDiscordNotFoundError(err)) {
-      log.error(`[Discord] Failed to reply to message ${message.id} for ${result.label} '${command}':`, err);
-    }
   }
 }
 

--- a/src/commands/customCommandHandler.test.ts
+++ b/src/commands/customCommandHandler.test.ts
@@ -14,10 +14,22 @@ vi.mock('../twitch/twitchApi', () => ({
   getSharedChatSession: vi.fn().mockResolvedValue(null),
 }));
 
-vi.mock('../discord/discordUtils', () => ({
-  isDiscordNotFoundError: vi.fn().mockReturnValue(false),
-  NO_MENTIONS: { parse: [] },
-}));
+vi.mock('../discord/discordUtils', () => {
+  const isDiscordNotFoundError = vi.fn().mockReturnValue(false);
+  return {
+    isDiscordNotFoundError,
+    NO_MENTIONS: { parse: [] },
+    trySendDiscordReply: async (message: { reply: (payload: unknown) => Promise<unknown> }, payload: unknown, onError: (err: unknown) => void) => {
+      try {
+        await message.reply(payload);
+        return true;
+      } catch (err) {
+        if (!isDiscordNotFoundError(err)) onError(err);
+        return false;
+      }
+    },
+  };
+});
 
 import {
   executeCustomCommandForDiscord,

--- a/src/commands/customCommandHandler.ts
+++ b/src/commands/customCommandHandler.ts
@@ -5,7 +5,7 @@ import { getCustomCommandForDiscord, getCustomCommandForTwitchChannel } from '..
 const log = createLogger('CustomCmd');
 import { getSharedChatSession } from '../twitch/twitchApi';
 import { extractArgs, resolveCommand } from './commandUtils';
-import { isDiscordNotFoundError, NO_MENTIONS } from '../discord/discordUtils';
+import { NO_MENTIONS, trySendDiscordReply } from '../discord/discordUtils';
 import type { MultiTwitchGroupInfo } from '../twitch/monitor/twitchMonitorTypes';
 import { fillTemplate } from '../shared/textTemplate';
 import { sendDedupedBySession } from './twitchBroadcast';
@@ -239,13 +239,13 @@ export async function executeCustomCommandForDiscord(
 
   const filledResponse = buildFilledResponse(result.response, message.content, username);
 
-  try {
-    await message.reply({ content: filledResponse, allowedMentions: NO_MENTIONS });
+  const sent = await trySendDiscordReply(
+    message,
+    { content: filledResponse, allowedMentions: NO_MENTIONS },
+    (err) => log.error(`[Discord] Failed to reply to message ${message.id} for command '${command}':`, err),
+  );
+  if (sent) {
     log.info(`[Discord] Sent custom command '${command}'.`);
-  } catch (err) {
-    if (!isDiscordNotFoundError(err)) {
-      log.error(`[Discord] Failed to reply to message ${message.id} for command '${command}':`, err);
-    }
   }
 }
 

--- a/src/commands/healthCommandHandler.test.ts
+++ b/src/commands/healthCommandHandler.test.ts
@@ -16,9 +16,21 @@ vi.mock('../shared/healthStore', () => ({
   getHealthSnapshot: vi.fn(),
 }));
 
-vi.mock('../discord/discordUtils', () => ({
-  isDiscordNotFoundError: vi.fn().mockReturnValue(false),
-}));
+vi.mock('../discord/discordUtils', () => {
+  const isDiscordNotFoundError = vi.fn().mockReturnValue(false);
+  return {
+    isDiscordNotFoundError,
+    trySendDiscordReply: async (message: { reply: (payload: unknown) => Promise<unknown> }, payload: unknown, onError: (err: unknown) => void) => {
+      try {
+        await message.reply(payload);
+        return true;
+      } catch (err) {
+        if (!isDiscordNotFoundError(err)) onError(err);
+        return false;
+      }
+    },
+  };
+});
 
 import { executeHealthCommandForDiscord } from './healthCommandHandler';
 import { findOwnerUser } from '../db';

--- a/src/commands/healthCommandHandler.ts
+++ b/src/commands/healthCommandHandler.ts
@@ -3,7 +3,7 @@ import { createLogger } from '../shared/logger';
 import { resolveCommand } from './commandUtils';
 import { findOwnerUser } from '../db';
 import { getHealthSnapshot, type HealthSnapshot } from '../shared/healthStore';
-import { isDiscordNotFoundError } from '../discord/discordUtils';
+import { trySendDiscordReply } from '../discord/discordUtils';
 
 const log = createLogger('HealthCommand');
 
@@ -138,12 +138,10 @@ export async function executeHealthCommandForDiscord(message: Message, precomput
   }
 
   if (message.guild) {
-    try {
-      await message.reply('📬 Sent you the health report via DM.');
-    } catch (err) {
-      if (!isDiscordNotFoundError(err)) {
-        log.error('Failed to acknowledge !health command in channel:', err);
-      }
-    }
+    await trySendDiscordReply(
+      message,
+      '📬 Sent you the health report via DM.',
+      (err) => log.error('Failed to acknowledge !health command in channel:', err),
+    );
   }
 }

--- a/src/commands/soundSelector.ts
+++ b/src/commands/soundSelector.ts
@@ -1,5 +1,12 @@
 export interface WeightedFile { file: string; weight: number }
 
+/**
+ * Picks one file at random from `files`, weighted by each file's `weight` (non-positive
+ * weights are treated as 1).
+ * @param files Candidate files with their selection weights.
+ * @returns The chosen file's path.
+ * @throws If `files` is empty.
+ */
 export function pickWeightedRandom(files: WeightedFile[]): string {
   if (files.length === 0) throw new Error('No files to pick from');
   if (files.length === 1) return files[0].file;

--- a/src/db/alertConfig.ts
+++ b/src/db/alertConfig.ts
@@ -1,6 +1,7 @@
 import mysql from 'mysql2/promise';
 import { getPool, withTransaction } from './pool';
 import { fromBit } from './utils';
+import { getOrCreate } from '../shared/mapUtils';
 
 /** Twitch event types the alerts overlay can react to. */
 export type AlertEventType = 'follow' | 'sub' | 'resub' | 'giftsub' | 'raid';
@@ -87,8 +88,7 @@ export async function getEnabledAlertEventTypesBatch(streamerIds: number[]): Pro
     streamerIds,
   );
   for (const row of rows) {
-    if (!result.has(row.streamer_id)) result.set(row.streamer_id, new Set());
-    result.get(row.streamer_id)!.add(row.event_type);
+    getOrCreate(result, row.streamer_id, () => new Set<AlertEventType>()).add(row.event_type);
   }
   return result;
 }

--- a/src/db/alertConfigCache.ts
+++ b/src/db/alertConfigCache.ts
@@ -30,6 +30,9 @@ function createEmptyAlertConfigLookupCache(): AlertConfigLookupCache {
 
 /**
  * Builds an alert config lookup cache keyed by `streamerId:eventType` from every `alert_config` row.
+ * Unlike the custom-command/counter/SFX lookup caches, this doesn't need first-wins collision
+ * handling: `alert_config` has a DB-level `UNIQUE KEY (streamer_id, event_type)`, so two rows can
+ * never produce the same cache key.
  * @param rows Every alert config row across all streamers.
  * @returns The populated `AlertConfigLookupCache`.
  */

--- a/src/db/commandStringUtils.ts
+++ b/src/db/commandStringUtils.ts
@@ -62,6 +62,7 @@ export function buildInClausePlaceholders(count: number): string {
 
 // ─── Error types ─────────────────────────────────────────────────────────────
 
+/** Thrown when a custom-command lookup/mutation matches no row. */
 export class CommandNotFoundError extends Error {
   constructor(id: number) {
     super(`Command not found: ${id}`);
@@ -69,7 +70,9 @@ export class CommandNotFoundError extends Error {
   }
 }
 
+/** Thrown when one or more command strings are already taken by another command/counter. */
 export class CommandConflictError extends Error {
+  /** The command string(s) that caused the conflict. */
   readonly commands: string[];
 
   constructor(commands: string[]) {

--- a/src/db/counterCache.test.ts
+++ b/src/db/counterCache.test.ts
@@ -5,6 +5,9 @@ vi.mock('./lookupCache', () => ({
     getCache: () => loadCache(),
     invalidate: vi.fn(),
   })),
+  registerFirstWinsWithWarning: <K, V>(map: Map<K, V>, key: K, value: V) => {
+    if (!map.has(key)) map.set(key, value);
+  },
   DEFAULT_CACHE_TTL_MS: 300_000,
   DEFAULT_REFRESH_FAILURE_BACKOFF_MS: 5_000,
   DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS: 60_000,

--- a/src/db/counterCache.ts
+++ b/src/db/counterCache.ts
@@ -1,6 +1,6 @@
-import { createLogger } from '../shared/logger';
 import {
   createManagedLookupCache,
+  registerFirstWinsWithWarning,
   type RefreshingLookupCache,
   DEFAULT_CACHE_TTL_MS,
   DEFAULT_REFRESH_FAILURE_BACKOFF_MS,
@@ -9,8 +9,6 @@ import {
 import { normalizeCommandList, normalizeCommand } from './commandStringUtils';
 import { isAnyCommandTakenAcrossTables } from './commandLocks';
 import { getAllCounters, type DbCounter, type DbMatchedCounter, type CounterMatchType } from './counters';
-
-const log = createLogger('DB');
 
 // ─── Cache interface ──────────────────────────────────────────────────────────
 
@@ -52,13 +50,12 @@ function buildCounterLookupCache(counters: DbCounter[]): CounterLookupCache {
   ): void => {
     if (!normalizedCommand) return;
 
-    const existingCounter = byCommand.get(normalizedCommand);
-    if (existingCounter) {
-      log.warn(`Counter ${commandFieldLabel} collision: '${normalizedCommand}' is already registered (counter id=${existingCounter.id}); ignoring duplicate from counter id=${counter.id}.`);
-      return;
-    }
-
-    byCommand.set(normalizedCommand, { ...counter, matchType });
+    registerFirstWinsWithWarning(
+      byCommand,
+      normalizedCommand,
+      { ...counter, matchType },
+      (existingCounter) => `Counter ${commandFieldLabel} collision: '${normalizedCommand}' is already registered (counter id=${existingCounter.id}); ignoring duplicate from counter id=${counter.id}.`,
+    );
   };
 
   for (const counter of sortedCounters) {

--- a/src/db/counters.ts
+++ b/src/db/counters.ts
@@ -48,6 +48,7 @@ export interface UpdateCounterInput {
   resetYearly: boolean;
 }
 
+/** Thrown when a counter lookup/mutation matches no row. */
 export class CounterNotFoundError extends Error {
   constructor(id: number) {
     super(`Counter not found: ${id}`);

--- a/src/db/customCommandCache.test.ts
+++ b/src/db/customCommandCache.test.ts
@@ -9,6 +9,9 @@ vi.mock('./lookupCache', () => ({
     getCache: () => loadCache(),
     invalidate: vi.fn(),
   })),
+  registerFirstWinsWithWarning: <K, V>(map: Map<K, V>, key: K, value: V) => {
+    if (!map.has(key)) map.set(key, value);
+  },
   DEFAULT_CACHE_TTL_MS: 300_000,
   DEFAULT_REFRESH_FAILURE_BACKOFF_MS: 5_000,
   DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS: 60_000,

--- a/src/db/customCommandCache.ts
+++ b/src/db/customCommandCache.ts
@@ -2,6 +2,7 @@ import { createLogger } from '../shared/logger';
 import { normalizeTwitchChannelName } from '../twitch/twitchChannelName';
 import {
   createManagedLookupCache,
+  registerFirstWinsWithWarning,
   type RefreshingLookupCache,
   DEFAULT_CACHE_TTL_MS,
   DEFAULT_REFRESH_FAILURE_BACKOFF_MS,
@@ -144,16 +145,14 @@ function registerDiscordCommand(
     return;
   }
 
-  const existingCommand = discordByTrigger.get(triggerString);
-  if (existingCommand) {
-    log.warn(
+  registerFirstWinsWithWarning(
+    discordByTrigger,
+    triggerString,
+    command,
+    (existingCommand) =>
       `Custom command Discord trigger collision: '${triggerString}' is already registered ` +
       `(command_id=${existingCommand.command_id}); ignoring duplicate from command_id=${command.command_id}.`,
-    );
-    return;
-  }
-
-  discordByTrigger.set(triggerString, command);
+  );
 }
 
 /**

--- a/src/db/customCommands.test.ts
+++ b/src/db/customCommands.test.ts
@@ -3,7 +3,24 @@ import { mockLogger } from '../test-utils/loggerMock';
 
 /** Mocks the shared logger so this module's log calls don't produce real output during tests. */
 vi.mock('../shared/logger', () => ({ createLogger: mockLogger }));
-vi.mock('./pool', () => ({ getPool: vi.fn() }));
+// `runInTransaction` is reimplemented here (rather than via `importOriginal`) so this test
+// doesn't pull in pool.ts's real `../shared/config` import chain, which throws in a test
+// environment with no DISCORD_TOKEN etc. set. The logic mirrors pool.ts's real implementation
+// exactly, driven by the connection `removeCustomCommand` acquires from the mocked `getPool()`.
+vi.mock('./pool', () => ({
+  getPool: vi.fn(),
+  runInTransaction: async (conn: { beginTransaction: () => Promise<void>; commit: () => Promise<void>; rollback: () => Promise<void> }, work: () => Promise<unknown>) => {
+    try {
+      await conn.beginTransaction();
+      const result = await work();
+      await conn.commit();
+      return result;
+    } catch (err) {
+      await conn.rollback().catch(() => {});
+      throw err;
+    }
+  },
+}));
 vi.mock('mysql2/promise', () => ({ default: {} }));
 vi.mock('./commandLocks', () => ({
   acquireNamedLock: vi.fn().mockResolvedValue(undefined),

--- a/src/db/customCommands.ts
+++ b/src/db/customCommands.ts
@@ -1,6 +1,7 @@
 import mysql from 'mysql2/promise';
 import { getPool, runInTransaction } from './pool';
 import { fromBit, getRowCount } from './utils';
+import { getOrCreate } from '../shared/mapUtils';
 import { AccessLevel } from './users';
 import type { AccessLevelValue } from './users';
 import { assertNotReservedCommand } from './reservedCommands';
@@ -72,15 +73,13 @@ export async function getAllCustomCommandsWithAssignments(): Promise<DbCustomCom
   const commandMap = new Map<number, DbCustomCommandWithAssignments>();
 
   for (const row of rows) {
-    if (!commandMap.has(row.command_id)) {
-      commandMap.set(row.command_id, {
-        ...mapCustomCommand(row),
-        assigned_users: [],
-      });
-    }
+    const commandEntry = getOrCreate(commandMap, row.command_id, () => ({
+      ...mapCustomCommand(row),
+      assigned_users: [],
+    }));
 
     if (row.assigned_discord_id !== null && row.assigned_discord_id !== undefined) {
-      commandMap.get(row.command_id)!.assigned_users.push({
+      commandEntry.assigned_users.push({
         discord_id: String(row.assigned_discord_id),
         discord_name: row.discord_name ?? null,
         twitch_name: row.twitch_name ?? null,

--- a/src/db/customCommands.ts
+++ b/src/db/customCommands.ts
@@ -1,5 +1,5 @@
 import mysql from 'mysql2/promise';
-import { getPool } from './pool';
+import { getPool, runInTransaction } from './pool';
 import { fromBit, getRowCount } from './utils';
 import { AccessLevel } from './users';
 import type { AccessLevelValue } from './users';
@@ -207,24 +207,19 @@ export async function removeCustomCommand(commandId: number): Promise<void> {
 
   try {
     await acquireNamedLock(connection, lockName);
-    await connection.beginTransaction();
-    await connection.execute(
-      'DELETE FROM twitch_user_commands WHERE command_id = ?',
-      [commandId],
-    );
-    const [result] = await connection.execute<mysql.ResultSetHeader>(
-      'DELETE FROM custom_command WHERE command_id = ?',
-      [commandId],
-    );
-    if (result.affectedRows === 0) {
-      throw new CommandNotFoundError(commandId);
-    }
-    await connection.commit();
-  } catch (error) {
-    // Swallow a rollback failure so the original error still propagates (matches
-    // withTransaction in pool.ts).
-    await connection.rollback().catch(() => {});
-    throw error;
+    await runInTransaction(connection, async () => {
+      await connection.execute(
+        'DELETE FROM twitch_user_commands WHERE command_id = ?',
+        [commandId],
+      );
+      const [result] = await connection.execute<mysql.ResultSetHeader>(
+        'DELETE FROM custom_command WHERE command_id = ?',
+        [commandId],
+      );
+      if (result.affectedRows === 0) {
+        throw new CommandNotFoundError(commandId);
+      }
+    });
   } finally {
     await releaseNamedLock(connection, lockName);
     connection.release();

--- a/src/db/lookupCache.test.ts
+++ b/src/db/lookupCache.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   createManagedLookupCache,
+  registerFirstWinsWithWarning,
   DEFAULT_REFRESH_FAILURE_BACKOFF_MS,
   DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS,
 } from './lookupCache';
@@ -11,6 +12,29 @@ describe('default backoff constants', () => {
     expect(DEFAULT_REFRESH_FAILURE_BACKOFF_MS).toBe(5_000);
     expect(DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS).toBe(60_000);
     expect(DEFAULT_REFRESH_FAILURE_BACKOFF_MS).toBeLessThan(DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS);
+  });
+});
+
+describe('registerFirstWinsWithWarning', () => {
+  it('registers the value under the key when the key is not already taken', () => {
+    const map = new Map<string, number>();
+    const describeCollision = vi.fn();
+
+    registerFirstWinsWithWarning(map, 'a', 1, describeCollision);
+
+    expect(map.get('a')).toBe(1);
+    expect(describeCollision).not.toHaveBeenCalled();
+  });
+
+  it('keeps the existing entry and calls describeCollision on a key collision', () => {
+    const map = new Map<string, number>();
+    map.set('a', 1);
+    const describeCollision = vi.fn().mockReturnValue('collision message');
+
+    registerFirstWinsWithWarning(map, 'a', 2, describeCollision);
+
+    expect(map.get('a')).toBe(1);
+    expect(describeCollision).toHaveBeenCalledWith(1);
   });
 });
 

--- a/src/db/lookupCache.ts
+++ b/src/db/lookupCache.ts
@@ -15,6 +15,31 @@ export interface RefreshingLookupCache {
   loadedAt: number;
 }
 
+/**
+ * Registers `value` under `key` in `map`, unless `key` is already taken — in which case the
+ * existing entry is left in place and `describeCollision` (given that existing entry) is logged
+ * as a warning instead. Callers are expected to process their source rows in a fixed,
+ * deterministic order (e.g. ascending id) so which entry "wins" a collision stays stable across
+ * cache rebuilds.
+ * @param map The map being built.
+ * @param key The key to register `value` under.
+ * @param value The candidate value to register.
+ * @param describeCollision Builds the warning message from the entry already registered under `key`.
+ */
+export function registerFirstWinsWithWarning<K, V>(
+  map: Map<K, V>,
+  key: K,
+  value: V,
+  describeCollision: (existing: V) => string,
+): void {
+  const existing = map.get(key);
+  if (existing) {
+    log.warn(describeCollision(existing));
+    return;
+  }
+  map.set(key, value);
+}
+
 export interface ManagedLookupCacheOptions<TCache extends RefreshingLookupCache> {
   cacheName: string;
   ttlMs: number;

--- a/src/db/overlayVideos.test.ts
+++ b/src/db/overlayVideos.test.ts
@@ -1,28 +1,37 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// `withTransaction` is reimplemented here (rather than via `importOriginal`) so this
-// test doesn't pull in pool.ts's real `../shared/config` import chain, which throws
-// in a test environment with no DISCORD_TOKEN etc. set. The logic mirrors pool.ts's
-// real implementation exactly, driven by the same mocked `getPool()`.
+// `withTransaction`/`withTransactionOrNotFound` are reimplemented here (rather than via
+// `importOriginal`) so this test doesn't pull in pool.ts's real `../shared/config` import
+// chain, which throws in a test environment with no DISCORD_TOKEN etc. set. The logic
+// mirrors pool.ts's real implementation exactly, driven by the same mocked `getPool()`.
 vi.mock('./pool', () => {
   const getPool = vi.fn();
-  return {
-    getPool,
-    withTransaction: async (work: (conn: unknown) => Promise<unknown>) => {
-      const conn = await getPool().getConnection();
-      try {
-        await conn.beginTransaction();
-        const result = await work(conn);
-        await conn.commit();
-        return result;
-      } catch (err) {
-        await conn.rollback().catch(() => {});
-        throw err;
-      } finally {
-        conn.release();
-      }
-    },
+  const withTransaction = async (work: (conn: unknown) => Promise<unknown>) => {
+    const conn = await getPool().getConnection();
+    try {
+      await conn.beginTransaction();
+      const result = await work(conn);
+      await conn.commit();
+      return result;
+    } catch (err) {
+      await conn.rollback().catch(() => {});
+      throw err;
+    } finally {
+      conn.release();
+    }
   };
+  const withTransactionOrNotFound = async (
+    work: (conn: unknown, notFound: () => never) => Promise<unknown>,
+  ) => {
+    const notFoundSignal = new Error('withTransactionOrNotFound: not found');
+    try {
+      return await withTransaction((conn) => work(conn, () => { throw notFoundSignal; }));
+    } catch (err) {
+      if (err === notFoundSignal) return null;
+      throw err;
+    }
+  };
+  return { getPool, withTransaction, withTransactionOrNotFound };
 });
 vi.mock('mysql2/promise', () => ({ default: {} }));
 

--- a/src/db/overlayVideos.ts
+++ b/src/db/overlayVideos.ts
@@ -1,5 +1,5 @@
 import mysql from 'mysql2/promise';
-import { getPool, withTransaction } from './pool';
+import { getPool, withTransactionOrNotFound } from './pool';
 
 export interface OverlayVideo {
   id: number;
@@ -89,29 +89,23 @@ export async function getVideoById(videoId: number, streamerId: number): Promise
  * @returns The deleted row's filename (for filesystem cleanup), or null if no matching row existed.
  */
 export async function deleteVideo(videoId: number, streamerId: number): Promise<string | null> {
-  class VideoNotFoundError extends Error {}
-  try {
-    return await withTransaction(async (conn) => {
-      const [rows] = await conn.execute<mysql.RowDataPacket[]>(
-        `SELECT filename FROM overlay_video WHERE id = ? AND streamer_id = ?`,
-        [videoId, streamerId],
-      );
-      if (rows.length === 0) {
-        throw new VideoNotFoundError();
-      }
-      const filename: string = rows[0].filename;
-      const [del] = await conn.execute<mysql.ResultSetHeader>(
-        `DELETE FROM overlay_video WHERE id = ? AND streamer_id = ?`, [videoId, streamerId],
-      );
-      if (del.affectedRows === 0) {
-        throw new VideoNotFoundError();
-      }
-      return filename;
-    });
-  } catch (err) {
-    if (err instanceof VideoNotFoundError) return null;
-    throw err;
-  }
+  return withTransactionOrNotFound(async (conn, notFound) => {
+    const [rows] = await conn.execute<mysql.RowDataPacket[]>(
+      `SELECT filename FROM overlay_video WHERE id = ? AND streamer_id = ?`,
+      [videoId, streamerId],
+    );
+    if (rows.length === 0) {
+      notFound();
+    }
+    const filename: string = rows[0].filename;
+    const [del] = await conn.execute<mysql.ResultSetHeader>(
+      `DELETE FROM overlay_video WHERE id = ? AND streamer_id = ?`, [videoId, streamerId],
+    );
+    if (del.affectedRows === 0) {
+      notFound();
+    }
+    return filename;
+  });
 }
 
 /**
@@ -182,41 +176,35 @@ export async function setRewardVideos(
   streamerId: number,
   videos: Array<{ videoId: number; weight: number }>,
 ): Promise<void> {
-  class RewardNotFoundError extends Error {}
-  try {
-    await withTransaction(async (conn) => {
-      // Verify reward belongs to this streamer
-      const [check] = await conn.execute<mysql.RowDataPacket[]>(
-        `SELECT id FROM overlay_reward WHERE id = ? AND streamer_id = ?`,
-        [rewardId, streamerId],
-      );
-      if (check.length === 0) {
-        throw new RewardNotFoundError();
-      }
-      await conn.execute(`DELETE FROM overlay_reward_video WHERE reward_id = ?`, [rewardId]);
-      if (videos.length === 0) return;
+  await withTransactionOrNotFound(async (conn, notFound) => {
+    // Verify reward belongs to this streamer
+    const [check] = await conn.execute<mysql.RowDataPacket[]>(
+      `SELECT id FROM overlay_reward WHERE id = ? AND streamer_id = ?`,
+      [rewardId, streamerId],
+    );
+    if (check.length === 0) {
+      notFound();
+    }
+    await conn.execute(`DELETE FROM overlay_reward_video WHERE reward_id = ?`, [rewardId]);
+    if (videos.length === 0) return;
 
-      const [ownedRows] = await conn.execute<mysql.RowDataPacket[]>(
-        `SELECT id FROM overlay_video WHERE streamer_id = ? AND id IN (${videos.map(() => '?').join(', ')})`,
-        [streamerId, ...videos.map((v) => v.videoId)],
-      );
-      const ownedIds = new Set<number>(ownedRows.map((r) => r.id));
-      const invalid = videos.find((v) => !ownedIds.has(v.videoId));
-      if (invalid) {
-        throw new Error(`Video ${invalid.videoId} does not belong to streamer ${streamerId}`);
-      }
+    const [ownedRows] = await conn.execute<mysql.RowDataPacket[]>(
+      `SELECT id FROM overlay_video WHERE streamer_id = ? AND id IN (${videos.map(() => '?').join(', ')})`,
+      [streamerId, ...videos.map((v) => v.videoId)],
+    );
+    const ownedIds = new Set<number>(ownedRows.map((r) => r.id));
+    const invalid = videos.find((v) => !ownedIds.has(v.videoId));
+    if (invalid) {
+      throw new Error(`Video ${invalid.videoId} does not belong to streamer ${streamerId}`);
+    }
 
-      const placeholders = videos.map(() => '(?, ?, ?)').join(', ');
-      const params = videos.flatMap((v) => [rewardId, v.videoId, Math.max(1, v.weight)]);
-      await conn.execute(
-        `INSERT INTO overlay_reward_video (reward_id, video_id, weight) VALUES ${placeholders}`,
-        params,
-      );
-    });
-  } catch (err) {
-    if (err instanceof RewardNotFoundError) return;
-    throw err;
-  }
+    const placeholders = videos.map(() => '(?, ?, ?)').join(', ');
+    const params = videos.flatMap((v) => [rewardId, v.videoId, Math.max(1, v.weight)]);
+    await conn.execute(
+      `INSERT INTO overlay_reward_video (reward_id, video_id, weight) VALUES ${placeholders}`,
+      params,
+    );
+  });
 }
 
 /**

--- a/src/db/overlayVideos.ts
+++ b/src/db/overlayVideos.ts
@@ -1,5 +1,6 @@
 import mysql from 'mysql2/promise';
 import { getPool, withTransactionOrNotFound } from './pool';
+import { getOrCreate } from '../shared/mapUtils';
 
 export interface OverlayVideo {
   id: number;
@@ -127,16 +128,14 @@ export async function getRewardsForStreamer(streamerId: number): Promise<Overlay
 
   const rewardMap = new Map<number, OverlayRewardWithVideos>();
   for (const row of rewardRows) {
-    if (!rewardMap.has(row.id)) {
-      rewardMap.set(row.id, {
-        id: row.id,
-        streamer_id: row.streamer_id,
-        twitch_reward_id: row.twitch_reward_id,
-        videos: [],
-      });
-    }
+    const rewardEntry = getOrCreate(rewardMap, row.id, () => ({
+      id: row.id,
+      streamer_id: row.streamer_id,
+      twitch_reward_id: row.twitch_reward_id,
+      videos: [],
+    }));
     if (row.video_id != null) {
-      rewardMap.get(row.id)!.videos.push({
+      rewardEntry.videos.push({
         video_id: row.video_id,
         weight: row.weight,
         name: row.name,

--- a/src/db/pool.test.ts
+++ b/src/db/pool.test.ts
@@ -10,7 +10,7 @@ vi.mock('../shared/config', () => ({
   DB_NAME: 'test-db',
 }));
 
-import { getPool, closePool, withTransaction, withTransactionOrNotFound } from './pool';
+import { getPool, closePool, withTransaction, withTransactionOrNotFound, runInTransaction } from './pool';
 
 beforeEach(async () => {
   vi.clearAllMocks();
@@ -134,6 +134,51 @@ describe('withTransaction', () => {
 
     expect(conn.rollback).toHaveBeenCalledOnce();
     expect(conn.release).toHaveBeenCalledOnce();
+  });
+});
+
+describe('runInTransaction', () => {
+  /** Builds a fake pool connection whose lifecycle methods resolve successfully. */
+  function makeConn() {
+    return {
+      beginTransaction: vi.fn().mockResolvedValue(undefined),
+      commit: vi.fn().mockResolvedValue(undefined),
+      rollback: vi.fn().mockResolvedValue(undefined),
+      release: vi.fn(),
+    };
+  }
+
+  it('begins, runs work, commits, and returns the work result, without touching release', async () => {
+    const conn = makeConn();
+    const work = vi.fn().mockResolvedValue('the-result');
+
+    const result = await runInTransaction(conn as any, work);
+
+    expect(result).toBe('the-result');
+    expect(conn.beginTransaction).toHaveBeenCalledOnce();
+    expect(work).toHaveBeenCalledOnce();
+    expect(conn.commit).toHaveBeenCalledOnce();
+    expect(conn.rollback).not.toHaveBeenCalled();
+    expect(conn.release).not.toHaveBeenCalled();
+  });
+
+  it('rolls back and rethrows when work throws, without releasing the connection', async () => {
+    const conn = makeConn();
+    const boom = new Error('boom');
+
+    await expect(runInTransaction(conn as any, async () => { throw boom; })).rejects.toBe(boom);
+
+    expect(conn.rollback).toHaveBeenCalledOnce();
+    expect(conn.commit).not.toHaveBeenCalled();
+    expect(conn.release).not.toHaveBeenCalled();
+  });
+
+  it('swallows a rollback failure and still rethrows the original error', async () => {
+    const conn = makeConn();
+    conn.rollback.mockRejectedValue(new Error('rollback failed'));
+    const original = new Error('original failure');
+
+    await expect(runInTransaction(conn as any, async () => { throw original; })).rejects.toBe(original);
   });
 });
 

--- a/src/db/pool.test.ts
+++ b/src/db/pool.test.ts
@@ -10,7 +10,7 @@ vi.mock('../shared/config', () => ({
   DB_NAME: 'test-db',
 }));
 
-import { getPool, closePool, withTransaction } from './pool';
+import { getPool, closePool, withTransaction, withTransactionOrNotFound } from './pool';
 
 beforeEach(async () => {
   vi.clearAllMocks();
@@ -134,5 +134,68 @@ describe('withTransaction', () => {
 
     expect(conn.rollback).toHaveBeenCalledOnce();
     expect(conn.release).toHaveBeenCalledOnce();
+  });
+});
+
+describe('withTransactionOrNotFound', () => {
+  /** Builds a fake pool connection whose lifecycle methods resolve successfully. */
+  function makeConn() {
+    return {
+      beginTransaction: vi.fn().mockResolvedValue(undefined),
+      commit: vi.fn().mockResolvedValue(undefined),
+      rollback: vi.fn().mockResolvedValue(undefined),
+      release: vi.fn(),
+    };
+  }
+
+  it('returns the work result on success, committing like withTransaction', async () => {
+    const conn = makeConn();
+    createPool.mockReturnValue({ end: vi.fn(), getConnection: vi.fn().mockResolvedValue(conn) });
+
+    const result = await withTransactionOrNotFound(async () => 'the-result');
+
+    expect(result).toBe('the-result');
+    expect(conn.commit).toHaveBeenCalledOnce();
+    expect(conn.rollback).not.toHaveBeenCalled();
+  });
+
+  it('rolls back and resolves to null when work calls notFound()', async () => {
+    const conn = makeConn();
+    createPool.mockReturnValue({ end: vi.fn(), getConnection: vi.fn().mockResolvedValue(conn) });
+
+    const result = await withTransactionOrNotFound(async (_conn, notFound) => {
+      notFound();
+    });
+
+    expect(result).toBeNull();
+    expect(conn.rollback).toHaveBeenCalledOnce();
+    expect(conn.commit).not.toHaveBeenCalled();
+  });
+
+  it('rolls back and rethrows any other error, without treating it as not-found', async () => {
+    const conn = makeConn();
+    createPool.mockReturnValue({ end: vi.fn(), getConnection: vi.fn().mockResolvedValue(conn) });
+    const boom = new Error('boom');
+
+    await expect(withTransactionOrNotFound(async () => { throw boom; })).rejects.toBe(boom);
+
+    expect(conn.rollback).toHaveBeenCalledOnce();
+  });
+
+  it('does not confuse two concurrent calls not-found signals with each other', async () => {
+    const connA = makeConn();
+    const connB = makeConn();
+    const getConnection = vi.fn()
+      .mockResolvedValueOnce(connA)
+      .mockResolvedValueOnce(connB);
+    createPool.mockReturnValue({ end: vi.fn(), getConnection });
+
+    const [resultA, resultB] = await Promise.all([
+      withTransactionOrNotFound(async (_conn, notFound) => { notFound(); }),
+      withTransactionOrNotFound(async () => 'found-it'),
+    ]);
+
+    expect(resultA).toBeNull();
+    expect(resultB).toBe('found-it');
   });
 });

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -65,3 +65,25 @@ export async function withTransaction<T>(work: (conn: PoolConnection) => Promise
     conn.release();
   }
 }
+
+/**
+ * Like {@link withTransaction}, but for the common "load a row, maybe mutate it,
+ * bail out if it doesn't exist" shape: `work` is passed a `notFound()` function
+ * that rolls back the transaction and resolves this call to `null`, instead of
+ * every call site declaring its own throwaway sentinel error class to get the
+ * same effect. Any other thrown error still propagates and rejects as usual.
+ * @param work Callback that receives the transaction's connection and a
+ *   `notFound()` escape hatch to call (and `return`) when the target row is missing.
+ * @returns The value returned by `work`, or null if `work` called `notFound()`.
+ */
+export async function withTransactionOrNotFound<T>(
+  work: (conn: PoolConnection, notFound: () => never) => Promise<T>,
+): Promise<T | null> {
+  const notFoundSignal = new Error('withTransactionOrNotFound: not found');
+  try {
+    return await withTransaction((conn) => work(conn, () => { throw notFoundSignal; }));
+  } catch (err) {
+    if (err === notFoundSignal) return null;
+    throw err;
+  }
+}

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -41,6 +41,29 @@ export async function closePool(): Promise<void> {
 }
 
 /**
+ * Runs `work` inside a transaction on an already-acquired `conn`: begins the transaction,
+ * invokes `work`, and commits once it resolves. If `work` throws, the transaction is rolled
+ * back — rollback failures are swallowed so the original error still propagates — and the
+ * error is rethrown. Does not acquire or release `conn`; the caller owns its lifecycle, which
+ * is what lets a caller like `removeCustomCommand` (in `customCommands.ts`) hold the same
+ * connection across a named-lock acquire/release that must wrap the transaction.
+ * @param conn Pool connection to run the transaction on.
+ * @param work Callback that performs the transactional work.
+ * @returns The value returned by `work`, once the transaction has committed.
+ */
+export async function runInTransaction<T>(conn: PoolConnection, work: () => Promise<T>): Promise<T> {
+  try {
+    await conn.beginTransaction();
+    const result = await work();
+    await conn.commit();
+    return result;
+  } catch (err) {
+    await conn.rollback().catch(() => {});
+    throw err;
+  }
+}
+
+/**
  * Runs `work` inside a database transaction: acquires a connection, begins the
  * transaction, invokes `work(conn)`, and commits once it resolves. If `work`
  * throws (including a caller-defined sentinel error used to signal an early
@@ -54,13 +77,7 @@ export async function closePool(): Promise<void> {
 export async function withTransaction<T>(work: (conn: PoolConnection) => Promise<T>): Promise<T> {
   const conn = await getPool().getConnection();
   try {
-    await conn.beginTransaction();
-    const result = await work(conn);
-    await conn.commit();
-    return result;
-  } catch (err) {
-    await conn.rollback().catch(() => {});
-    throw err;
+    return await runInTransaction(conn, () => work(conn));
   } finally {
     conn.release();
   }

--- a/src/db/reservedCommands.ts
+++ b/src/db/reservedCommands.ts
@@ -17,6 +17,7 @@ export const BUILT_IN_COMMANDS: Readonly<Record<string, BuiltInCommandMeta>> = {
 
 export const RESERVED_BUILT_IN_COMMANDS: ReadonlySet<string> = new Set(Object.keys(BUILT_IN_COMMANDS));
 
+/** Thrown when a trigger string collides with a reserved built-in command (see {@link BUILT_IN_COMMANDS}). */
 export class ReservedCommandError extends Error {
   constructor(trigger: string) {
     super(`'${trigger}' is a reserved built-in command and cannot be used as a custom command trigger.`);

--- a/src/db/sfx.test.ts
+++ b/src/db/sfx.test.ts
@@ -1,28 +1,37 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// `withTransaction` is reimplemented here (rather than via `importOriginal`) so this
-// test doesn't pull in pool.ts's real `../shared/config` import chain, which throws
-// in a test environment with no DISCORD_TOKEN etc. set. The logic mirrors pool.ts's
-// real implementation exactly, driven by the same mocked `getPool()`.
+// `withTransaction`/`withTransactionOrNotFound` are reimplemented here (rather than via
+// `importOriginal`) so this test doesn't pull in pool.ts's real `../shared/config` import
+// chain, which throws in a test environment with no DISCORD_TOKEN etc. set. The logic
+// mirrors pool.ts's real implementation exactly, driven by the same mocked `getPool()`.
 vi.mock('./pool', () => {
   const getPool = vi.fn();
-  return {
-    getPool,
-    withTransaction: async (work: (conn: unknown) => Promise<unknown>) => {
-      const conn = await getPool().getConnection();
-      try {
-        await conn.beginTransaction();
-        const result = await work(conn);
-        await conn.commit();
-        return result;
-      } catch (err) {
-        await conn.rollback().catch(() => {});
-        throw err;
-      } finally {
-        conn.release();
-      }
-    },
+  const withTransaction = async (work: (conn: unknown) => Promise<unknown>) => {
+    const conn = await getPool().getConnection();
+    try {
+      await conn.beginTransaction();
+      const result = await work(conn);
+      await conn.commit();
+      return result;
+    } catch (err) {
+      await conn.rollback().catch(() => {});
+      throw err;
+    } finally {
+      conn.release();
+    }
   };
+  const withTransactionOrNotFound = async (
+    work: (conn: unknown, notFound: () => never) => Promise<unknown>,
+  ) => {
+    const notFoundSignal = new Error('withTransactionOrNotFound: not found');
+    try {
+      return await withTransaction((conn) => work(conn, () => { throw notFoundSignal; }));
+    } catch (err) {
+      if (err === notFoundSignal) return null;
+      throw err;
+    }
+  };
+  return { getPool, withTransaction, withTransactionOrNotFound };
 });
 vi.mock('mysql2/promise', () => ({ default: {} }));
 

--- a/src/db/sfx.ts
+++ b/src/db/sfx.ts
@@ -1,5 +1,5 @@
 import mysql from 'mysql2/promise';
-import { getPool, withTransaction } from './pool';
+import { getPool, withTransactionOrNotFound } from './pool';
 import { fromBit, affectedOrExists, rowExists, getRowCount } from './utils';
 
 export interface SfxTrigger {
@@ -221,30 +221,23 @@ export async function updateSfxTrigger(
  * @param id Trigger id.
  */
 export async function deleteSfxTrigger(id: bigint): Promise<{ files: string[] } | null> {
-  class TriggerNotFoundError extends Error {}
-  try {
-    const result = await withTransaction(async (conn) => {
-      const [triggerRows] = await conn.execute<mysql.RowDataPacket[]>(
-        `SELECT id FROM sfxtrigger WHERE id = ? FOR UPDATE`,
-        [id.toString()],
-      );
-      if (triggerRows.length === 0) {
-        throw new TriggerNotFoundError();
-      }
-      const [rows] = await conn.execute<mysql.RowDataPacket[]>(
-        `SELECT file FROM sfx WHERE trigger_id = ? FOR UPDATE`,
-        [id.toString()],
-      );
-      const files = rows.map((r) => r.file as string);
-      await conn.execute(`DELETE FROM sfx WHERE trigger_id = ?`, [id.toString()]);
-      await conn.execute(`DELETE FROM sfxtrigger WHERE id = ?`, [id.toString()]);
-      return { files };
-    });
-    return result;
-  } catch (err) {
-    if (err instanceof TriggerNotFoundError) return null;
-    throw err;
-  }
+  return withTransactionOrNotFound(async (conn, notFound) => {
+    const [triggerRows] = await conn.execute<mysql.RowDataPacket[]>(
+      `SELECT id FROM sfxtrigger WHERE id = ? FOR UPDATE`,
+      [id.toString()],
+    );
+    if (triggerRows.length === 0) {
+      notFound();
+    }
+    const [rows] = await conn.execute<mysql.RowDataPacket[]>(
+      `SELECT file FROM sfx WHERE trigger_id = ? FOR UPDATE`,
+      [id.toString()],
+    );
+    const files = rows.map((r) => r.file as string);
+    await conn.execute(`DELETE FROM sfx WHERE trigger_id = ?`, [id.toString()]);
+    await conn.execute(`DELETE FROM sfxtrigger WHERE id = ?`, [id.toString()]);
+    return { files };
+  });
 }
 
 /**
@@ -311,28 +304,21 @@ export async function updateSfxFile(id: number, weight: number, hidden: boolean)
  * @param id sfx row id.
  */
 export async function deleteSfxFile(id: number): Promise<string | null> {
-  class FileNotFoundError extends Error {}
-  try {
-    const file = await withTransaction(async (conn) => {
-      const [rows] = await conn.execute<mysql.RowDataPacket[]>(
-        `SELECT file FROM sfx WHERE id = ? FOR UPDATE`,
-        [id],
-      );
-      if (rows.length === 0) {
-        throw new FileNotFoundError();
-      }
-      const file: string = rows[0].file;
-      const [result] = await conn.execute<mysql.ResultSetHeader>(`DELETE FROM sfx WHERE id = ?`, [id]);
-      if (result.affectedRows === 0) {
-        throw new FileNotFoundError();
-      }
-      return file;
-    });
+  return withTransactionOrNotFound(async (conn, notFound) => {
+    const [rows] = await conn.execute<mysql.RowDataPacket[]>(
+      `SELECT file FROM sfx WHERE id = ? FOR UPDATE`,
+      [id],
+    );
+    if (rows.length === 0) {
+      notFound();
+    }
+    const file: string = rows[0].file;
+    const [result] = await conn.execute<mysql.ResultSetHeader>(`DELETE FROM sfx WHERE id = ?`, [id]);
+    if (result.affectedRows === 0) {
+      notFound();
+    }
     return file;
-  } catch (err) {
-    if (err instanceof FileNotFoundError) return null;
-    throw err;
-  }
+  });
 }
 
 /** Return all SFX triggers (including hidden) with their associated sound files, for the admin panel. */

--- a/src/db/sfx.ts
+++ b/src/db/sfx.ts
@@ -1,6 +1,7 @@
 import mysql from 'mysql2/promise';
 import { getPool, withTransactionOrNotFound } from './pool';
 import { fromBit, affectedOrExists, rowExists, getRowCount } from './utils';
+import { getOrCreate } from '../shared/mapUtils';
 
 export interface SfxTrigger {
   id: bigint;
@@ -343,19 +344,17 @@ export async function getAllSfxTriggers(): Promise<SfxTriggerRow[]> {
 
   const map = new Map<string, SfxTriggerRow>();
   for (const r of rows) {
-    if (!map.has(r.triggerId)) {
-      map.set(r.triggerId, {
-        triggerId: r.triggerId,
-        triggerCommand: r.triggerCommand,
-        description: r.description ?? null,
-        hidden: fromBit(r.triggerHidden),
-        categoryId: r.categoryId ?? null,
-        categoryName: r.categoryName ?? null,
-        files: [],
-      });
-    }
+    const triggerEntry = getOrCreate(map, r.triggerId, () => ({
+      triggerId: r.triggerId,
+      triggerCommand: r.triggerCommand,
+      description: r.description ?? null,
+      hidden: fromBit(r.triggerHidden),
+      categoryId: r.categoryId ?? null,
+      categoryName: r.categoryName ?? null,
+      files: [],
+    }));
     if (r.sfxId !== null) {
-      map.get(r.triggerId)!.files.push({
+      triggerEntry.files.push({
         id: r.sfxId,
         file: r.file,
         weight: r.weight,

--- a/src/db/sfxCache.test.ts
+++ b/src/db/sfxCache.test.ts
@@ -5,6 +5,9 @@ vi.mock('./lookupCache', () => ({
     getCache: () => loadCache(),
     invalidate: vi.fn(),
   })),
+  registerFirstWinsWithWarning: <K, V>(map: Map<K, V>, key: K, value: V) => {
+    if (!map.has(key)) map.set(key, value);
+  },
   DEFAULT_CACHE_TTL_MS: 300_000,
   DEFAULT_REFRESH_FAILURE_BACKOFF_MS: 5_000,
   DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS: 60_000,

--- a/src/db/sfxCache.ts
+++ b/src/db/sfxCache.ts
@@ -1,6 +1,6 @@
-import { createLogger } from '../shared/logger';
 import {
   createManagedLookupCache,
+  registerFirstWinsWithWarning,
   type RefreshingLookupCache,
   DEFAULT_CACHE_TTL_MS,
   DEFAULT_REFRESH_FAILURE_BACKOFF_MS,
@@ -8,8 +8,6 @@ import {
 } from './lookupCache';
 import { normalizeCommand } from './commandStringUtils';
 import { getAllSfxTriggers, type SfxTrigger, type SfxFile } from './sfx';
-
-const log = createLogger('DB');
 
 /** An SFX trigger paired with its playable sound files, as served from the lookup cache. */
 export interface SfxLookupResult {
@@ -57,12 +55,6 @@ function buildSfxLookupCache(triggers: Awaited<ReturnType<typeof getAllSfxTrigge
     const normalizedTriggerCommand = normalizeCommand(row.triggerCommand);
     if (!normalizedTriggerCommand) continue;
 
-    const existing = byTrigger.get(normalizedTriggerCommand);
-    if (existing) {
-      log.warn(`SFX trigger collision: '${normalizedTriggerCommand}' is already registered (trigger id=${existing.trigger.id}); ignoring duplicate from trigger id=${row.triggerId}.`);
-      continue;
-    }
-
     // Frozen once here (not copied per-lookup in findCachedSfxTrigger) since callers only ever
     // read these objects; freezing turns any future accidental mutation into a loud failure
     // instead of silently corrupting the shared cache entry. Cast back to the mutable interface
@@ -85,7 +77,13 @@ function buildSfxLookupCache(triggers: Awaited<ReturnType<typeof getAllSfxTrigge
         category_id: row.categoryId,
       }))) as SfxFile[],
     };
-    byTrigger.set(normalizedTriggerCommand, Object.freeze(result));
+
+    registerFirstWinsWithWarning(
+      byTrigger,
+      normalizedTriggerCommand,
+      Object.freeze(result),
+      (existing) => `SFX trigger collision: '${normalizedTriggerCommand}' is already registered (trigger id=${existing.trigger.id}); ignoring duplicate from trigger id=${row.triggerId}.`,
+    );
   }
 
   return { loadedAt: Date.now(), byTrigger };

--- a/src/db/timerCommands.ts
+++ b/src/db/timerCommands.ts
@@ -4,6 +4,7 @@ import { fromBit, affectedOrExists, rowExists } from './utils';
 import { AccessLevel } from './users';
 import type { AccessLevelValue } from './users';
 import { normalizeTwitchChannelName } from '../twitch/twitchChannelName';
+import { getOrCreate } from '../shared/mapUtils';
 
 /** A timer command row from the database. */
 export interface DbTimerCommand {
@@ -91,15 +92,13 @@ export async function getAllTimerCommandsWithAssignments(): Promise<DbTimerComma
   const timerMap = new Map<number, DbTimerCommandWithAssignments>();
 
   for (const row of rows) {
-    if (!timerMap.has(row.id)) {
-      timerMap.set(row.id, {
-        ...mapRow(row),
-        assigned_users: [],
-      });
-    }
+    const timerEntry = getOrCreate(timerMap, row.id, () => ({
+      ...mapRow(row),
+      assigned_users: [],
+    }));
 
     if (row.assigned_discord_id !== null && row.assigned_discord_id !== undefined) {
-      timerMap.get(row.id)!.assigned_users.push({
+      timerEntry.assigned_users.push({
         discord_id: String(row.assigned_discord_id),
         discord_name: row.discord_name ?? null,
         twitch_name: row.twitch_name ?? null,

--- a/src/discord/discordUtils.test.ts
+++ b/src/discord/discordUtils.test.ts
@@ -47,6 +47,7 @@ import {
   getAvailableVoiceChannels,
   getTextChannel,
   tryEditDiscordMessage,
+  trySendDiscordReply,
 } from './discordUtils';
 import { DiscordAPIError, HTTPError } from 'discord.js';
 import { getDiscordClient } from './discordClientStore';
@@ -295,6 +296,38 @@ describe('tryEditDiscordMessage', () => {
     const client = { channels: { fetch: channelsFetch } } as any;
 
     await expect(tryEditDiscordMessage(client, 'chan1', 'msg1', { content: 'hi' })).rejects.toThrow('network blip');
+  });
+});
+
+describe('trySendDiscordReply', () => {
+  it('replies with the given payload and returns true on success', async () => {
+    const reply = vi.fn().mockResolvedValue(undefined);
+    const message = { id: 'msg1', reply } as any;
+    const onError = vi.fn();
+
+    await expect(trySendDiscordReply(message, { content: 'hi' }, onError)).resolves.toBe(true);
+    expect(reply).toHaveBeenCalledWith({ content: 'hi' });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('returns false without calling onError on a not-found error', async () => {
+    const notFoundErr = new MockedDiscordAPIError({ code: UNKNOWN_MESSAGE, status: 200 });
+    const reply = vi.fn().mockRejectedValue(notFoundErr);
+    const message = { id: 'msg1', reply } as any;
+    const onError = vi.fn();
+
+    await expect(trySendDiscordReply(message, 'hi', onError)).resolves.toBe(false);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('calls onError and returns false, without throwing, on any other error', async () => {
+    const otherErr = new Error('network blip');
+    const reply = vi.fn().mockRejectedValue(otherErr);
+    const message = { id: 'msg1', reply } as any;
+    const onError = vi.fn();
+
+    await expect(trySendDiscordReply(message, 'hi', onError)).resolves.toBe(false);
+    expect(onError).toHaveBeenCalledWith(otherErr);
   });
 });
 

--- a/src/discord/discordUtils.ts
+++ b/src/discord/discordUtils.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '../shared/logger';
-import { DiscordAPIError, HTTPError, RESTJSONErrorCodes, ChannelType, type Client, type MessageEditOptions, type MessageMentionOptions, type TextBasedChannel } from 'discord.js';
+import { DiscordAPIError, HTTPError, RESTJSONErrorCodes, ChannelType, type Client, type Message, type MessageEditOptions, type MessageMentionOptions, type MessagePayload, type MessageReplyOptions, type TextBasedChannel } from 'discord.js';
 import { getDiscordClient } from './discordClientStore';
 
 const log = createLogger('Discord');
@@ -159,6 +159,34 @@ export async function tryEditDiscordMessage(
     if (isDiscordNotFoundError(err)) return false;
     log.error(`Failed to edit Discord message ${messageId} in channel ${channelId}:`, err);
     throw err;
+  }
+}
+
+/**
+ * Replies to `message`, swallowing a Discord not-found error (message/channel already gone
+ * by the time the reply is sent) rather than logging it — the same not-found handling as
+ * {@link tryDeleteDiscordMessage}/{@link tryEditDiscordMessage}. Any other error is passed to
+ * `onError` and swallowed, since a command handler's reply is best-effort and should never
+ * throw back into the message-handling loop.
+ *
+ * @param message - Discord message to reply to.
+ * @param payload - Reply content/options, forwarded to `message.reply` unchanged.
+ * @param onError - Called with the error when the reply fails for a reason other than not-found.
+ * @returns True if the reply was sent; false if it failed (not-found or otherwise).
+ */
+export async function trySendDiscordReply(
+  message: Message,
+  payload: string | MessagePayload | MessageReplyOptions,
+  onError: (err: unknown) => void,
+): Promise<boolean> {
+  try {
+    await message.reply(payload);
+    return true;
+  } catch (err) {
+    if (!isDiscordNotFoundError(err)) {
+      onError(err);
+    }
+    return false;
   }
 }
 

--- a/src/twitch/eventsub/twitchApiEventSub.ts
+++ b/src/twitch/eventsub/twitchApiEventSub.ts
@@ -7,6 +7,13 @@ import { saveStreamerToken, clearStreamerToken } from '../../db';
 const log = createLogger('TwitchToken');
 const TOKEN_BUFFER_MS = 5 * 60 * 1000;
 
+/**
+ * Returns a usable EventSub access token for `streamer`, refreshing it first if it's missing,
+ * expired, or within {@link TOKEN_BUFFER_MS} of expiring. Persists a successful refresh to the
+ * DB via `saveStreamerToken`.
+ * @param streamer Streamer row carrying the current EventSub token/refresh-token pair.
+ * @returns A valid access token, or null if none is available (no token stored, or refresh failed/impossible).
+ */
 export async function getValidToken(streamer: DbStreamerEventSub): Promise<string | null> {
   if (!streamer.eventsub_access_token) return null;
   // eventsub_token_expiry is BIGINT epoch ms — safe to coerce, won't exceed MAX_SAFE_INTEGER until year 275760.

--- a/src/twitch/eventsub/twitchEventSub.ts
+++ b/src/twitch/eventsub/twitchEventSub.ts
@@ -8,6 +8,11 @@ const connections = new Map<string, StreamerConnection>();
 let globalStopped = false;
 let topReloadChain: Promise<void> = Promise.resolve();
 
+/**
+ * Starts EventSub: loads every streamer configured for EventSub and opens a connection for
+ * each one not already connected. Queued behind {@link topReloadChain} so it never races a
+ * concurrent {@link reloadEventSubSubscriptions} call.
+ */
 export function startEventSub(): void {
   globalStopped = false;
   topReloadChain = topReloadChain
@@ -26,12 +31,19 @@ export function startEventSub(): void {
     .catch((err) => { log.error('EventSub start error:', err); });
 }
 
+/** Stops and discards every active EventSub connection, and blocks any queued/future reload from starting new ones. */
 export function stopEventSub(): void {
   globalStopped = true;
   for (const conn of connections.values()) conn.stop();
   connections.clear();
 }
 
+/**
+ * Re-syncs EventSub connections with the current streamer config: stops connections for
+ * streamers no longer configured, reloads existing ones whose config changed, and starts new
+ * connections for newly configured streamers. No-ops after {@link stopEventSub}. Queued behind
+ * {@link topReloadChain} so overlapping reloads run one at a time.
+ */
 export function reloadEventSubSubscriptions(): void {
   if (globalStopped) return;
   topReloadChain = topReloadChain

--- a/src/twitch/monitor/twitchMonitor.ts
+++ b/src/twitch/monitor/twitchMonitor.ts
@@ -112,6 +112,12 @@ async function teardown(): Promise<void> {
 
 // ─── Public API ───────────────────────────────────────────────────────────────
 
+/**
+ * Starts the Twitch live/offline poller: loads streamer/group config, resolves Twitch user
+ * IDs, reconciles live state against anything that changed while the bot was down, then
+ * begins the recurring poll loop.
+ * @returns Resolves once the initial state sync has completed and polling has started.
+ */
 export async function startTwitchMonitor(): Promise<void> {
   streamersData = await getAllStreamersWithGroups();
   if (streamersData.length === 0) {

--- a/src/twitch/monitor/twitchMonitorOffline.ts
+++ b/src/twitch/monitor/twitchMonitorOffline.ts
@@ -8,6 +8,12 @@ import { setTwitchChannelLive } from '../../shared/statusStore';
 
 const OFFLINE_GRACE_MS = 5 * 60 * 1000;
 
+/**
+ * Cancels and clears any pending offline-grace timers for every `liveStates` entry
+ * belonging to `loginKey` (e.g. because the streamer was confirmed live again).
+ * @param liveStates Live-state map keyed by group-scoped state key.
+ * @param loginKey Normalized Twitch login whose timers should be cancelled.
+ */
 export function cancelOfflineTimersForLogin(liveStates: Map<string, LiveState>, loginKey: string): void {
   for (const state of liveStates.values()) {
     if (state.login === loginKey && state.offlineTimer) {
@@ -23,6 +29,16 @@ export function cancelOfflineTimersForLogin(liveStates: Map<string, LiveState>, 
 // teardown() clears all offlineTimers on restart, so this is not restart
 // protection — it is a consistency guard. The finally block ensures
 // offlineTimer is nulled on every exit path, including early returns and errors.
+/**
+ * Fires at the end of a streamer's offline grace period: re-checks Helix directly, and if
+ * still offline, marks the channel offline and removes its live announcement.
+ * @param liveStates Live-state map keyed by group-scoped state key.
+ * @param loginToUserId Map of normalized login to Twitch user id.
+ * @param stateKey Group-scoped state key for the entry that scheduled this check.
+ * @param key Normalized Twitch login.
+ * @param login Original (non-normalized) login, used only for log messages.
+ * @returns Resolves once the check (and any resulting announcement cleanup) completes.
+ */
 export async function runOfflineCheck(
   liveStates: Map<string, LiveState>,
   loginToUserId: Map<string, string>,
@@ -47,6 +63,15 @@ export async function runOfflineCheck(
   }
 }
 
+/**
+ * Starts the offline grace period for every `liveStates` entry belonging to `login`: after
+ * {@link OFFLINE_GRACE_MS}, {@link runOfflineCheck} re-confirms the streamer is actually
+ * offline before tearing down its announcement.
+ * @param liveStates Live-state map keyed by group-scoped state key.
+ * @param loginToUserId Map of normalized login to Twitch user id.
+ * @param login Twitch login that went offline.
+ * @returns Resolves once the grace-period timers have been (re)scheduled.
+ */
 export async function handleStreamOffline(
   liveStates: Map<string, LiveState>,
   loginToUserId: Map<string, string>,

--- a/src/twitch/twitchApi.ts
+++ b/src/twitch/twitchApi.ts
@@ -5,6 +5,12 @@ const log = createLogger('TwitchAPI');
 
 const FETCH_TIMEOUT_MS = 10_000;
 
+/**
+ * Fetches `url`, aborting if the request takes longer than {@link FETCH_TIMEOUT_MS}.
+ * @param url URL to fetch.
+ * @param init Standard `fetch` options; its `signal` (if any) is overridden by the timeout signal.
+ * @returns The fetch response.
+ */
 export function twitchFetch(url: string, init?: RequestInit): Promise<Response> {
   return fetch(url, { ...init, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
 }
@@ -35,6 +41,12 @@ async function fetchNewAppToken(): Promise<string> {
   return cachedAppToken;
 }
 
+/**
+ * Returns a valid Twitch app access token, reusing the cached one if it hasn't expired yet.
+ * Concurrent calls during a refresh share the same in-flight request rather than each
+ * triggering their own token fetch.
+ * @returns A valid app access token.
+ */
 export async function getAppToken(): Promise<string> {
   if (cachedAppToken && Date.now() < appTokenExpiry) return cachedAppToken;
   if (!tokenRefreshPromise) {
@@ -43,6 +55,11 @@ export async function getAppToken(): Promise<string> {
   return tokenRefreshPromise;
 }
 
+/**
+ * Builds the standard Twitch Helix authorization headers for `token`.
+ * @param token Access token (app or user) to authenticate with.
+ * @returns The `Authorization`/`Client-Id` headers to attach to a Helix request.
+ */
 export function authHeaders(token: string): Record<string, string> {
   return {
     Authorization: `Bearer ${token}`,

--- a/src/twitch/twitchBot.ts
+++ b/src/twitch/twitchBot.ts
@@ -54,6 +54,23 @@ let disconnectListener: { unbind: () => void } | null = null;
 let userStateListenerId: string | null = null;
 
 /**
+ * Unbinds every listener {@link startTwitchBot} registered on `chatClient` and clears the
+ * module-level references, so a late event on a client we're abandoning (a failed connect, or
+ * a disconnect during {@link stopTwitchBot}) can never reach them.
+ * @param chatClient The client the listeners were registered on.
+ */
+function teardownTwitchListeners(chatClient: ChatClient): void {
+  messageListener?.unbind();
+  authSuccessListener?.unbind();
+  disconnectListener?.unbind();
+  if (userStateListenerId) { chatClient.irc.removeMessageListener(userStateListenerId); }
+  messageListener = null;
+  authSuccessListener = null;
+  disconnectListener = null;
+  userStateListenerId = null;
+}
+
+/**
  * Upper bound on how long {@link stopTwitchBot} waits for the `onDisconnect` event to fire after
  * calling `client.quit()`. `quit()` itself doesn't return a promise — bounding the wait here
  * guarantees shutdown always proceeds instead of hanging indefinitely if the event never arrives.
@@ -302,14 +319,7 @@ export async function startTwitchBot(): Promise<void> {
     // ones registered above) would otherwise stay live on `newClient` and could still update
     // module state (e.g. marking the bot connected) via a late event, even though startup already
     // reported failure to the caller.
-    messageListener.unbind();
-    authSuccessListener.unbind();
-    disconnectListener.unbind();
-    newClient.irc.removeMessageListener(userStateListenerId);
-    messageListener = null;
-    authSuccessListener = null;
-    disconnectListener = null;
-    userStateListenerId = null;
+    teardownTwitchListeners(newClient);
     try {
       newClient.quit();
     } catch (quitErr) {
@@ -456,16 +466,9 @@ export async function stopTwitchBot(): Promise<void> {
       unbind();
       getActiveChannels().forEach((ch) => { setTwitchChannel(ch, false); });
     }
-    // Unbind every listener startTwitchBot() registered on this client too — see their shared
-    // declaration for why a late event on this discarded client must not reach any of them.
-    messageListener?.unbind();
-    authSuccessListener?.unbind();
-    disconnectListener?.unbind();
-    if (userStateListenerId) { client.irc.removeMessageListener(userStateListenerId); }
-    messageListener = null;
-    authSuccessListener = null;
-    disconnectListener = null;
-    userStateListenerId = null;
+    // Unbind every listener startTwitchBot() registered on this client too — see
+    // teardownTwitchListeners for why a late event on this discarded client must not reach any of them.
+    teardownTwitchListeners(client);
     client = null;
     setChatClient(null);
   }

--- a/src/twitch/twitchChannelName.ts
+++ b/src/twitch/twitchChannelName.ts
@@ -1,5 +1,11 @@
 const TWITCH_CHANNEL_NAME_PATTERN = /^[a-z0-9_]{4,25}$/;
 
+/**
+ * Normalizes a Twitch channel/login name: trims whitespace, strips a leading `#`, and
+ * lowercases it, then validates it against Twitch's login name format.
+ * @param channel Raw channel name (e.g. from chat, config, or a Helix response).
+ * @returns The normalized name, or null if it doesn't match a valid Twitch login format.
+ */
 export function normalizeTwitchChannelName(channel: string): string | null {
   const normalized = channel.trim().replace(/^#/, '').toLowerCase();
   return TWITCH_CHANNEL_NAME_PATTERN.test(normalized) ? normalized : null;

--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -12,7 +12,8 @@ import { csrfProtection } from '../csrf';
 import { requireManager, requireAdmin } from '../middleware';
 import { getSessionUser, getCurrentGuildId } from '../session';
 import { trimField, filterQueryParam } from './validation';
-import { renderError, renderView } from './viewHelpers';
+import { renderView } from './viewHelpers';
+import { renderOrError } from './errorHandling';
 import { runUserMutation } from './adminUserMutationQueue';
 import adminRefreshRouter, { getRefreshState } from './adminRefresh';
 import {
@@ -51,7 +52,7 @@ const KNOWN_ERRORS = new Set([
  */
 router.get('/users', requireManager, csrfProtection, async (req, res) => {
   const guildId = getCurrentGuildId(req);
-  try {
+  await renderOrError({ res, log, logLabel: 'Admin users error:', sessionUser: req.session.user, errorMessage: 'Failed to load users.' }, async () => {
     const users = await getGuildMemberUsers(guildId);
     renderView(res, 'admin', {
       user: req.session.user,
@@ -61,10 +62,7 @@ router.get('/users', requireManager, csrfProtection, async (req, res) => {
       error: filterQueryParam(req.query.error, KNOWN_ERRORS),
       refreshState: getRefreshState(guildId),
     });
-  } catch (err) {
-    log.error('Admin users error:', err);
-    renderError(res, 500, 'Failed to load users.', req.session.user);
-  }
+  });
 });
 
 /** Refresh the guild registry after a membership change; log but never fail the request. */

--- a/src/web/routes/adminUserMutations.ts
+++ b/src/web/routes/adminUserMutations.ts
@@ -19,12 +19,22 @@ export class DuplicateTwitchNameError extends Error {
   }
 }
 
+/**
+ * Checks whether `error` is a MySQL lock-wait-timeout error (`ER_LOCK_WAIT_TIMEOUT` / errno 1205).
+ * @param error Value to check, typically a caught error.
+ * @returns True if `error` represents a lock-wait timeout.
+ */
 export function isLockWaitTimeoutDbError(error: unknown): boolean {
   if (!error || typeof error !== 'object') return false;
   const dbError = error as { errno?: number; code?: string };
   return dbError.errno === 1205 || dbError.code === 'ER_LOCK_WAIT_TIMEOUT';
 }
 
+/**
+ * Checks whether `error` is a MySQL duplicate-entry error on the `user.twitch_name` unique index.
+ * @param error Value to check, typically a caught error.
+ * @returns True if `error` represents a duplicate Twitch name.
+ */
 export function isDuplicateTwitchNameDbError(error: unknown): boolean {
   if (!error || typeof error !== 'object') {
     return false;
@@ -34,6 +44,17 @@ export function isDuplicateTwitchNameDbError(error: unknown): boolean {
     && (dbError.message?.includes('ux_user_twitch_name') ?? false);
 }
 
+/**
+ * Handles a user edit that clears their Twitch channel: disables the Twitch bot for them and
+ * parts the previous channel if no other enabled user still needs it. On failure, rolls the
+ * user's DB row and bot-enabled flag back to their pre-edit values.
+ * @param discordId Discord snowflake of the user being edited.
+ * @param discordName Discord display name to restore on rollback.
+ * @param level Access level to restore on rollback.
+ * @param previousChannel The user's Twitch channel before this edit, or null.
+ * @param wasBotEnabled Whether the Twitch bot was enabled for this user before this edit.
+ * @returns Resolves once the channel part (if any) completes; rejects (after best-effort rollback) if either step fails.
+ */
 async function handleClearTwitchChannel(
   discordId: string,
   discordName: string,
@@ -68,6 +89,14 @@ interface ChangeTwitchChannelParams {
   wasBotEnabled: boolean;
 }
 
+/**
+ * Handles a user edit that changes their Twitch channel: joins the new channel (if it should
+ * be joined) and parts the old one (if no other enabled user still needs it). On failure,
+ * rolls the user's DB row and bot-enabled flag back to their pre-edit values, then reconciles
+ * channel membership against that restored state.
+ * @param params Before/after channel and user state needed to perform and, if necessary, roll back the change.
+ * @returns Resolves once membership changes complete; rejects (after best-effort rollback) if either step fails.
+ */
 async function handleChangeTwitchChannel({
   discordId,
   discordName,
@@ -121,6 +150,14 @@ export interface AddOrUpdateParams {
   shouldClearTwitchName: boolean;
 }
 
+/**
+ * Creates or updates a user's DB row and reconciles their Twitch channel membership with the
+ * change: joins/parts channels as needed when their Twitch name is added, changed, or cleared.
+ * A no-op for channel membership if the bot wasn't enabled for them, or their channel didn't change.
+ * @param params The submitted user fields.
+ * @returns Resolves once the DB write and any channel membership changes complete.
+ * @throws {@link DuplicateTwitchNameError} if `normalizedTwitchName` is already assigned to another user.
+ */
 export async function addOrUpdateUserMutation({
   discordId,
   discordName,
@@ -162,6 +199,14 @@ export async function addOrUpdateUserMutation({
   await handleChangeTwitchChannel({ discordId, discordName, level, previousChannel, committedChannel, wasBotEnabled: existingUser?.is_twitch_bot_enabled ?? false });
 }
 
+/**
+ * Toggles a user's Twitch bot enabled flag and joins/parts their channel to match. On failure
+ * to join/part, rolls the enabled flag back to its previous value.
+ * @param discordId Discord snowflake of the user to toggle.
+ * @param nextEnabled The desired enabled state.
+ * @returns Resolves once the DB flag and channel membership are updated; a no-op if already in the desired state.
+ * @throws If the user doesn't exist, has no Twitch channel, or has an invalid Twitch channel name.
+ */
 export async function toggleTwitchMutation(discordId: string, nextEnabled: boolean): Promise<void> {
   const user = await findUser(discordId);
   if (!user || !user.twitch_name) {

--- a/src/web/routes/alertsAdmin.ts
+++ b/src/web/routes/alertsAdmin.ts
@@ -6,7 +6,8 @@ import { getSessionUser } from '../session';
 import { getStreamerByDiscordId, getAlertConfigsForStreamer, ALERT_EVENT_TYPES, ALERT_TEXT_ANIMATIONS } from '../../db';
 import { PUBLIC_URL, ALERT_STATUS_MAX_SSE_PER_STREAMER } from '../../shared/config';
 import { filterQueryParam } from './validation';
-import { renderError, renderView } from './viewHelpers';
+import { renderView } from './viewHelpers';
+import { renderOrError } from './errorHandling';
 import { router as mutationsRouter } from './alertsAdminMutations';
 import { router as assetMutationsRouter, MAX_IMAGE_MB, MAX_SOUND_MB } from './alertsAssetMutations';
 import { connections as alertsSourceConnections } from './alertsOverlaySource';
@@ -38,7 +39,7 @@ const KNOWN_SUCCESSES = new Set([
  *   loading settings fails.
  */
 router.get('/settings', requireAuth, csrfProtection, async (req, res) => {
-  try {
+  await renderOrError({ res, log, logLabel: 'Alerts settings page error:', sessionUser: req.session.user, errorMessage: 'Failed to load alerts settings.' }, async () => {
     const streamer = await getStreamerByDiscordId(getSessionUser(req).discordId);
     const configs = streamer ? await getAlertConfigsForStreamer(streamer.id) : [];
     const configByType = Object.fromEntries(configs.map((c) => [c.event_type, c]));
@@ -56,10 +57,7 @@ router.get('/settings', requireAuth, csrfProtection, async (req, res) => {
       error:   filterQueryParam(req.query.error,   KNOWN_ERRORS),
       success: filterQueryParam(req.query.success, KNOWN_SUCCESSES),
     });
-  } catch (err) {
-    log.error('Alerts settings page error:', err);
-    renderError(res, 500, 'Failed to load alerts settings.', req.session.user);
-  }
+  });
 });
 
 /**

--- a/src/web/routes/counters.ts
+++ b/src/web/routes/counters.ts
@@ -47,6 +47,12 @@ type CounterFormValidationResult =
       error: 'missing_fields' | 'same_commands';
     };
 
+/**
+ * Validates and normalizes a counter add/edit form submission.
+ * @param rawForm Raw `req.body` fields.
+ * @returns The normalized fields on success, or an `error` code (`missing_fields` if any
+ *   required field is blank, `same_commands` if the trigger and check commands match).
+ */
 function validateAndNormalizeCounterForm(
   rawForm: Record<string, string | undefined>,
 ): CounterFormValidationResult {

--- a/src/web/routes/counters.ts
+++ b/src/web/routes/counters.ts
@@ -12,8 +12,8 @@ import {
 import { csrfProtection } from '../csrf';
 import { requireAuth, requireGuildContext, requireMod, requireManager } from '../middleware';
 import { normalizeRequiredText, normalizeSingleTokenRequiredText, parsePositiveIntId, parseCheckboxField, filterQueryParam } from './validation';
-import { renderError, renderView } from './viewHelpers';
-import { logAndRedirectError, handleReservedOrConflictCommandError } from './errorHandling';
+import { renderView } from './viewHelpers';
+import { logAndRedirectError, handleReservedOrConflictCommandError, renderOrError } from './errorHandling';
 
 const log = createLogger('Web');
 const router = Router();
@@ -88,7 +88,7 @@ function validateAndNormalizeCounterForm(
  *   if loading counters fails.
  */
 router.get('/counters', requireAuth, csrfProtection, async (req, res) => {
-  try {
+  await renderOrError({ res, log, logLabel: 'Counters page error:', sessionUser: req.session.user, errorMessage: 'Failed to load counters page.' }, async () => {
     const counters = await getAllCounters();
 
     renderView(res, 'counters', {
@@ -98,10 +98,7 @@ router.get('/counters', requireAuth, csrfProtection, async (req, res) => {
       error: filterQueryParam(req.query.error, KNOWN_ERRORS),
       reset: req.query.reset === '1',
     });
-  } catch (err) {
-    log.error('Counters page error:', err);
-    renderError(res, 500, 'Failed to load counters page.', req.session.user);
-  }
+  });
 });
 
 /**

--- a/src/web/routes/dashboard.ts
+++ b/src/web/routes/dashboard.ts
@@ -4,7 +4,8 @@ import { getGuildScopedStatus } from '../guildScopedStatus';
 import { csrfProtection } from '../csrf';
 import { getStreamerByDiscordId, getSfxTriggerCount, getCustomCommandCount, getCounterCount, getRecentStreamerEvents } from '../../db';
 import { hasAuthFailedSubs } from '../../twitch/eventsub/twitchEventSubSubscriptions';
-import { renderError, renderView } from './viewHelpers';
+import { renderView } from './viewHelpers';
+import { renderOrError } from './errorHandling';
 import { RECENT_EVENTS_LIMIT, type DashboardEvent } from './dashboardEvents';
 
 const log = createLogger('Web');
@@ -20,7 +21,7 @@ const router = Router();
  *   500 error page if loading status/streamer data fails.
  */
 router.get('/', csrfProtection, async (req, res) => {
-  try {
+  await renderOrError({ res, log, logLabel: 'Dashboard error:', sessionUser: req.session.user, errorMessage: 'Failed to load dashboard data.' }, async () => {
     const [status, sfxCount, commandCount, counterCount, streamer] = await Promise.all([
       getGuildScopedStatus(req.session.user?.currentGuildId ?? null),
       getSfxTriggerCount(), getCustomCommandCount(), getCounterCount(),
@@ -46,10 +47,7 @@ router.get('/', csrfProtection, async (req, res) => {
       csrfToken: req.csrfToken(),
       needsReconnect,
     });
-  } catch (err) {
-    log.error('Dashboard error:', err);
-    renderError(res, 500, 'Failed to load dashboard data.', req.session.user);
-  }
+  });
 });
 
 export default router;

--- a/src/web/routes/errorHandling.test.ts
+++ b/src/web/routes/errorHandling.test.ts
@@ -12,7 +12,46 @@ vi.mock('../../db', () => {
 });
 
 import { ReservedCommandError, CommandConflictError, isMysqlDuplicateEntryError } from '../../db';
-import { logAndRedirectError, handleReservedOrConflictCommandError } from './errorHandling';
+import { logAndRedirectError, handleReservedOrConflictCommandError, renderOrError } from './errorHandling';
+
+describe('renderOrError', () => {
+  function mockRes() {
+    const render = vi.fn();
+    const status = vi.fn().mockReturnThis();
+    return { res: { render, status } as unknown as Response, render, status };
+  }
+
+  function mockLog() {
+    const error = vi.fn();
+    return { log: { error } as unknown as import('winston').Logger, error };
+  }
+
+  it('runs render and never touches the error path on success', async () => {
+    const { res, render, status } = mockRes();
+    const { log, error } = mockLog();
+    const doRender = vi.fn().mockResolvedValue(undefined);
+
+    await renderOrError({ res, log, logLabel: 'Widget page error:', sessionUser: undefined, errorMessage: 'Failed to load widgets.' }, doRender);
+
+    expect(doRender).toHaveBeenCalledOnce();
+    expect(error).not.toHaveBeenCalled();
+    expect(status).not.toHaveBeenCalled();
+    expect(render).not.toHaveBeenCalled();
+  });
+
+  it('logs the error and renders the error view with a 500 status when render throws', async () => {
+    const { res, render, status } = mockRes();
+    const { log, error } = mockLog();
+    const boom = new Error('boom');
+    const doRender = vi.fn().mockRejectedValue(boom);
+
+    await renderOrError({ res, log, logLabel: 'Widget page error:', sessionUser: undefined, errorMessage: 'Failed to load widgets.' }, doRender);
+
+    expect(error).toHaveBeenCalledWith('Widget page error:', boom);
+    expect(status).toHaveBeenCalledWith(500);
+    expect(render).toHaveBeenCalledWith('error', expect.objectContaining({ message: 'Failed to load widgets.' }));
+  });
+});
 
 describe('logAndRedirectError', () => {
   function mockRes() {

--- a/src/web/routes/errorHandling.ts
+++ b/src/web/routes/errorHandling.ts
@@ -1,10 +1,12 @@
 import type { Response } from 'express';
 import type { Logger } from 'winston';
+import type { SessionUser } from '../../types/express';
 import {
   ReservedCommandError,
   CommandConflictError,
   isMysqlDuplicateEntryError,
 } from '../../db';
+import { renderError } from './viewHelpers';
 
 /** Arguments for {@link logAndRedirectError}. */
 export interface LogAndRedirectErrorOptions {
@@ -38,6 +40,36 @@ export function logAndRedirectError({
 }: LogAndRedirectErrorOptions): void {
   log.error(logLabel, err);
   res.redirect(`${basePath}?error=${errorCode}`);
+}
+
+/** Arguments for {@link renderOrError}. */
+export interface RenderOrErrorOptions {
+  /** Express response object. */
+  res: Response;
+  /** Logger to record the error on (module-scoped `createLogger` instance). */
+  log: Logger;
+  /** Message prefix passed to `log.error`, matching the handler's existing wording. */
+  logLabel: string;
+  /** Current session user, forwarded to `renderError` so the error page still shows a logged-in nav. */
+  sessionUser: SessionUser | undefined;
+  /** Human-readable message shown on the 500 error page. */
+  errorMessage: string;
+}
+
+/**
+ * Runs `render`, and on failure logs the error and renders a generic 500 error page instead.
+ * Standardizes the generic `try { ...renderView(...) } catch (err) { log.error(...);
+ * renderError(...) }` tail repeated across GET route handlers.
+ * @param options - See {@link RenderOrErrorOptions}.
+ * @param render - Async work that loads data and calls `renderView` on success.
+ */
+export async function renderOrError(options: RenderOrErrorOptions, render: () => Promise<void>): Promise<void> {
+  try {
+    await render();
+  } catch (err) {
+    options.log.error(options.logLabel, err);
+    renderError(options.res, 500, options.errorMessage, options.sessionUser);
+  }
 }
 
 /** Arguments for {@link handleReservedOrConflictCommandError}. */

--- a/src/web/routes/overlayAdmin.ts
+++ b/src/web/routes/overlayAdmin.ts
@@ -34,6 +34,13 @@ const KNOWN_SUCCESSES = new Set([
   'video_uploaded', 'video_deleted', 'reward_saved', 'reward_deleted',
 ]);
 
+/**
+ * Fetches a streamer's live Twitch custom (channel-point) rewards, for display alongside the
+ * overlay reward-to-video assignment UI. Returns an empty list rather than throwing if the
+ * streamer has no linked Twitch account, no valid token, or the Helix call fails.
+ * @param streamer Streamer whose custom rewards to fetch.
+ * @returns The streamer's Twitch custom rewards, or an empty array if unavailable.
+ */
 async function fetchTwitchRewards(streamer: DbStreamerEventSub): Promise<TwitchCustomReward[]> {
   if (!streamer.twitch_user_id) return [];
   const token = await getValidToken(streamer);

--- a/src/web/routes/sfx.ts
+++ b/src/web/routes/sfx.ts
@@ -6,7 +6,8 @@ import { csrfProtection } from '../csrf';
 import { SFX_FOLDER, SFX_MAX_FILE_MB, OPENAI_API_KEY } from '../../shared/config';
 import { safeResolve } from '../../shared/pathUtils';
 import { filterQueryParam, parsePositiveIntId } from './validation';
-import { renderError, renderView } from './viewHelpers';
+import { renderView } from './viewHelpers';
+import { renderOrError } from './errorHandling';
 
 const log = createLogger('Web');
 const router = Router();
@@ -46,7 +47,7 @@ const KNOWN_SUCCESS = new Set([
  * matching the server-side requireOwnerJson guard on its route.
  */
 router.get('/sfx', csrfProtection, async (req, res) => {
-  try {
+  await renderOrError({ res, log, logLabel: 'SFX error:', sessionUser: req.session.user, errorMessage: 'Failed to load SFX data.' }, async () => {
     const [triggers, categories] = await Promise.all([getAllSfxTriggers(), getAllCategories()]);
     const canManage = (req.session.user?.accessLevel ?? 0) >= AccessLevel.MOD;
     const canSuggestDescriptions = !!req.session.user?.isOwner && OPENAI_API_KEY !== '';
@@ -61,10 +62,7 @@ router.get('/sfx', csrfProtection, async (req, res) => {
       error: filterQueryParam(req.query.error, KNOWN_ERRORS),
       success: filterQueryParam(req.query.success, KNOWN_SUCCESS),
     });
-  } catch (err) {
-    log.error('SFX error:', err);
-    renderError(res, 500, 'Failed to load SFX data.', req.session.user);
-  }
+  });
 });
 
 /**

--- a/src/web/routes/sfxPublic.ts
+++ b/src/web/routes/sfxPublic.ts
@@ -11,6 +11,12 @@ const CACHE_TTL_MS = 5 * 60 * 1000;
 let cache: { data: PublicSfxTrigger[]; expiresAt: number } | null = null;
 let inFlight: Promise<PublicSfxTrigger[]> | null = null;
 
+/**
+ * Returns the public SFX trigger list, served from a 5-minute in-memory cache. Concurrent
+ * calls while the cache is cold/expired share a single in-flight DB load rather than each
+ * triggering their own.
+ * @returns The public SFX triggers.
+ */
 async function getCachedData(): Promise<PublicSfxTrigger[]> {
   if (cache && Date.now() < cache.expiresAt) return cache.data;
   if (inFlight) return inFlight;

--- a/src/web/routes/streamdeckKeys.ts
+++ b/src/web/routes/streamdeckKeys.ts
@@ -28,24 +28,26 @@ const router = Router();
 /**
  * Renders the current user's Streamdeck key status page, shared by
  * GET /streamdeck-key and the success paths of the request/rotate POST
- * handlers below (they only differ in what `keyRow`/`newKey` they pass in).
+ * handlers below (they only differ in what `keyRow`/`newKey`/`error` they pass in).
  * @param req - Express request; reads `req.session.user` and `req.csrfToken()`.
  * @param res - Express response.
  * @param keyRow - The current (possibly just-created/rotated) guild-status row, or null.
  * @param newKey - Freshly generated plaintext key to display once, or null if none.
+ * @param error - Known `error` query-param code to show a banner for, or null.
  */
 function renderKeyStatus(
   req: Request,
   res: Response,
   keyRow: StreamdeckKeyGuildStatusRow | null,
   newKey: string | null,
+  error: string | null = null,
 ): void {
   renderView(res, 'streamdeck-keys', {
     user: req.session.user,
     csrfToken: req.csrfToken(),
     keyRow,
     newKey,
-    error: null,
+    error,
     webPort: WEB_PORT,
   });
 }
@@ -63,14 +65,7 @@ const USER_KNOWN_ERRORS = new Set(['request_failed', 'rotate_failed', 'revoke_fa
 router.get('/streamdeck-key', csrfProtection, async (req, res) => {
   try {
     const keyRow = await getGuildStatusForKey(getSessionUser(req).discordId, getCurrentGuildId(req));
-    renderView(res, 'streamdeck-keys', {
-      user: req.session.user,
-      csrfToken: req.csrfToken(),
-      keyRow,
-      newKey: null,
-      error: filterQueryParam(req.query.error, USER_KNOWN_ERRORS),
-      webPort: WEB_PORT,
-    });
+    renderKeyStatus(req, res, keyRow, null, filterQueryParam(req.query.error, USER_KNOWN_ERRORS));
   } catch (err) {
     log.error('Streamdeck key page error:', err);
     renderError(res, 500, 'Failed to load Streamdeck key status.', req.session.user);

--- a/src/web/routes/streams.ts
+++ b/src/web/routes/streams.ts
@@ -7,7 +7,7 @@ import { getCurrentGuildId } from '../session';
 import { getLiveStates } from '../../twitch/monitor/twitchMonitor';
 import { AccessLevel } from '../../db';
 import { filterQueryParam } from './validation';
-import { renderView, renderError } from './viewHelpers';
+import { renderView, renderError, getFriendlyErrorMessage } from './viewHelpers';
 import { STREAMS_ERROR_CODES, STREAMS_ERROR_MESSAGES, type StreamsErrorCode } from './streamsErrors';
 import groupsRouter from './streamGroups';
 import streamersRouter from './streamStreamers';
@@ -20,8 +20,9 @@ const KNOWN_SUCCESSES = new Set<string>([]);
 
 export const ERROR_MESSAGES = STREAMS_ERROR_MESSAGES;
 
+/** Looks up a `streams` page error code in {@link ERROR_MESSAGES}, for use as an EJS template helper. */
 function getFriendlyError(key: string): string {
-  return (ERROR_MESSAGES as Record<string, string>)[key] ?? `An error occurred (${key}).`;
+  return getFriendlyErrorMessage(ERROR_MESSAGES, key);
 }
 
 // ─── View ─────────────────────────────────────────────────────────────────────

--- a/src/web/routes/timers.ts
+++ b/src/web/routes/timers.ts
@@ -4,7 +4,8 @@ import { DbTimerCommandWithAssignments, DbUser, getAllTimerCommandsWithAssignmen
 import { csrfProtection } from '../csrf';
 import { requireGuildContext, requireManager } from '../middleware';
 import { filterQueryParam } from './validation';
-import { renderError, renderView } from './viewHelpers';
+import { renderView } from './viewHelpers';
+import { renderOrError } from './errorHandling';
 import timersMutationsRouter from './timersMutations';
 import timerAssignmentsRouter from './timerAssignments';
 
@@ -28,7 +29,7 @@ interface TimerViewModel extends DbTimerCommandWithAssignments {
  * assignments, so authentication alone isn't enough (mutations additionally require Mod+).
  */
 router.get('/timers', requireGuildContext, requireManager, csrfProtection, async (req, res) => {
-  try {
+  await renderOrError({ res, log, logLabel: 'Timers page error:', sessionUser: req.session.user, errorMessage: 'Failed to load timers page.' }, async () => {
     const [timers, users] = await Promise.all([
       getAllTimerCommandsWithAssignments(),
       getAllUsers(),
@@ -49,10 +50,7 @@ router.get('/timers', requireGuildContext, requireManager, csrfProtection, async
       csrfToken: req.csrfToken(),
       error: filterQueryParam(req.query.error, KNOWN_ERRORS),
     });
-  } catch (err) {
-    log.error('Timers page error:', err);
-    renderError(res, 500, 'Failed to load timers page.', req.session.user);
-  }
+  });
 });
 
 router.use(timersMutationsRouter);

--- a/src/web/routes/userSettings.ts
+++ b/src/web/routes/userSettings.ts
@@ -6,7 +6,7 @@ import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
 import { getSessionUser } from '../session';
 import { trimField, filterQueryParam } from './validation';
-import { renderError, renderView } from './viewHelpers';
+import { renderError, renderView, getFriendlyErrorMessage } from './viewHelpers';
 import { logAndRedirectError } from './errorHandling';
 import { reloadEventSubSubscriptions } from '../../twitch/eventsub/twitchEventSub';
 import { hasAuthFailedSubs } from '../../twitch/eventsub/twitchEventSubSubscriptions';
@@ -42,8 +42,9 @@ const ERROR_MESSAGES: Record<string, string> = {
   invalid_id:                    'Invalid request — please try again.',
 };
 
+/** Looks up a `userSettings` page error code in {@link ERROR_MESSAGES}, for use as an EJS template helper. */
 function getFriendlyError(key: string): string {
-  return ERROR_MESSAGES[key] ?? `An error occurred (${key}).`;
+  return getFriendlyErrorMessage(ERROR_MESSAGES, key);
 }
 
 // GET /user/settings

--- a/src/web/routes/viewHelpers.test.ts
+++ b/src/web/routes/viewHelpers.test.ts
@@ -9,7 +9,19 @@ vi.mock('../../db', () => ({
 }));
 
 import { AccessLevel, getStreamerByDiscordId } from '../../db';
-import { renderView, renderError, requireStreamer } from './viewHelpers';
+import { renderView, renderError, requireStreamer, getFriendlyErrorMessage } from './viewHelpers';
+
+describe('getFriendlyErrorMessage', () => {
+  const messages = { some_error: 'Something went wrong.' };
+
+  it('returns the mapped message for a known key', () => {
+    expect(getFriendlyErrorMessage(messages, 'some_error')).toBe('Something went wrong.');
+  });
+
+  it('returns a generic fallback for an unrecognized key', () => {
+    expect(getFriendlyErrorMessage(messages, 'unknown_key')).toBe('An error occurred (unknown_key).');
+  });
+});
 
 describe('renderView', () => {
   function mockRes() {

--- a/src/web/routes/viewHelpers.ts
+++ b/src/web/routes/viewHelpers.ts
@@ -107,6 +107,18 @@ export function renderError(
 }
 
 /**
+ * Looks up `key` in a page's `error`-code-to-message map, falling back to a generic
+ * "An error occurred (<key>)" message for an unrecognized code (e.g. a stale bookmark or a
+ * code from a since-removed error path) rather than showing nothing.
+ * @param messages The page's `error` query-param code-to-message map.
+ * @param key The `error` query-param value to look up.
+ * @returns The friendly message for `key`, or a generic fallback if `key` isn't in `messages`.
+ */
+export function getFriendlyErrorMessage(messages: Record<string, string>, key: string): string {
+  return messages[key] ?? `An error occurred (${key}).`;
+}
+
+/**
  * Loads the requesting user's streamer record, redirecting to `notAStreamerRedirectPath`
  * if they aren't one. Shared by every streamer-scoped admin page (channel points, overlay
  * settings), each of which passes its own not-a-streamer error redirect so the pages stay

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -329,6 +329,7 @@ export { app };
 // entire app to reach the 100/600 thresholds via every other mounted route.
 export { generalLimiter, sessionLimiter };
 
+/** Starts the Express app listening on {@link WEB_PORT}. */
 export function startWebPanel(): void {
   app.listen(WEB_PORT, () => {
     log.info(`Panel available at http://localhost:${WEB_PORT}`);


### PR DESCRIPTION
Closing in favor of a stack of focused, single-commit PRs — each one reviewable independently instead of one large 11-commit/57-file PR:

- #626 Extract withTransactionOrNotFound
- #627 Extract registerFirstWinsWithWarning
- #628 Extract runInTransaction (removeCustomCommand)
- #629 Add missing JSDoc
- #630 Dedupe getFriendlyError
- #631 Reuse renderKeyStatus
- #632 Add trySendDiscordReply
- #633 Extract teardownTwitchListeners
- #634 Use getOrCreate instead of non-null assertions
- #635 Rename _buildCounterResponse
- #636 Add renderOrError

Each is stacked on the previous (base = prior PR's branch) so its diff is exactly one commit; they merge in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
