### PR TITLE
Extract withTransactionOrNotFound to dedupe not-found sentinel pattern

### DIFF
--- a/src/db/overlayVideos.test.ts
+++ b/src/db/overlayVideos.test.ts
@@ -1,28 +1,37 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// `withTransaction` is reimplemented here (rather than via `importOriginal`) so this
-// test doesn't pull in pool.ts's real `../shared/config` import chain, which throws
-// in a test environment with no DISCORD_TOKEN etc. set. The logic mirrors pool.ts's
-// real implementation exactly, driven by the same mocked `getPool()`.
+// `withTransaction`/`withTransactionOrNotFound` are reimplemented here (rather than via
+// `importOriginal`) so this test doesn't pull in pool.ts's real `../shared/config` import
+// chain, which throws in a test environment with no DISCORD_TOKEN etc. set. The logic
+// mirrors pool.ts's real implementation exactly, driven by the same mocked `getPool()`.
 vi.mock('./pool', () => {
   const getPool = vi.fn();
-  return {
-    getPool,
-    withTransaction: async (work: (conn: unknown) => Promise<unknown>) => {
-      const conn = await getPool().getConnection();
-      try {
-        await conn.beginTransaction();
-        const result = await work(conn);
-        await conn.commit();
-        return result;
-      } catch (err) {
-        await conn.rollback().catch(() => {});
-        throw err;
-      } finally {
-        conn.release();
-      }
-    },
+  const withTransaction = async (work: (conn: unknown) => Promise<unknown>) => {
+    const conn = await getPool().getConnection();
+    try {
+      await conn.beginTransaction();
+      const result = await work(conn);
+      await conn.commit();
+      return result;
+    } catch (err) {
+      await conn.rollback().catch(() => {});
+      throw err;
+    } finally {
+      conn.release();
+    }
   };
+  const withTransactionOrNotFound = async (
+    work: (conn: unknown, notFound: () => never) => Promise<unknown>,
+  ) => {
+    const notFoundSignal = new Error('withTransactionOrNotFound: not found');
+    try {
+      return await withTransaction((conn) => work(conn, () => { throw notFoundSignal; }));
+    } catch (err) {
+      if (err === notFoundSignal) return null;
+      throw err;
+    }
+  };
+  return { getPool, withTransaction, withTransactionOrNotFound };
 });
 vi.mock('mysql2/promise', () => ({ default: {} }));
 

--- a/src/db/overlayVideos.ts
+++ b/src/db/overlayVideos.ts
@@ -1,5 +1,5 @@
 import mysql from 'mysql2/promise';
-import { getPool, withTransaction } from './pool';
+import { getPool, withTransactionOrNotFound } from './pool';
 
 export interface OverlayVideo {
   id: number;
@@ -89,29 +89,23 @@ export async function getVideoById(videoId: number, streamerId: number): Promise
  * @returns The deleted row's filename (for filesystem cleanup), or null if no matching row existed.
  */
 export async function deleteVideo(videoId: number, streamerId: number): Promise<string | null> {
-  class VideoNotFoundError extends Error {}
-  try {
-    return await withTransaction(async (conn) => {
-      const [rows] = await conn.execute<mysql.RowDataPacket[]>(
-        `SELECT filename FROM overlay_video WHERE id = ? AND streamer_id = ?`,
-        [videoId, streamerId],
-      );
-      if (rows.length === 0) {
-        throw new VideoNotFoundError();
-      }
-      const filename: string = rows[0].filename;
-      const [del] = await conn.execute<mysql.ResultSetHeader>(
-        `DELETE FROM overlay_video WHERE id = ? AND streamer_id = ?`, [videoId, streamerId],
-      );
-      if (del.affectedRows === 0) {
-        throw new VideoNotFoundError();
-      }
-      return filename;
-    });
-  } catch (err) {
-    if (err instanceof VideoNotFoundError) return null;
-    throw err;
-  }
+  return withTransactionOrNotFound(async (conn, notFound) => {
+    const [rows] = await conn.execute<mysql.RowDataPacket[]>(
+      `SELECT filename FROM overlay_video WHERE id = ? AND streamer_id = ?`,
+      [videoId, streamerId],
+    );
+    if (rows.length === 0) {
+      notFound();
+    }
+    const filename: string = rows[0].filename;
+    const [del] = await conn.execute<mysql.ResultSetHeader>(
+      `DELETE FROM overlay_video WHERE id = ? AND streamer_id = ?`, [videoId, streamerId],
+    );
+    if (del.affectedRows === 0) {
+      notFound();
+    }
+    return filename;
+  });
 }
 
 /**
@@ -182,41 +176,35 @@ export async function setRewardVideos(
   streamerId: number,
   videos: Array<{ videoId: number; weight: number }>,
 ): Promise<void> {
-  class RewardNotFoundError extends Error {}
-  try {
-    await withTransaction(async (conn) => {
-      // Verify reward belongs to this streamer
-      const [check] = await conn.execute<mysql.RowDataPacket[]>(
-        `SELECT id FROM overlay_reward WHERE id = ? AND streamer_id = ?`,
-        [rewardId, streamerId],
-      );
-      if (check.length === 0) {
-        throw new RewardNotFoundError();
-      }
-      await conn.execute(`DELETE FROM overlay_reward_video WHERE reward_id = ?`, [rewardId]);
-      if (videos.length === 0) return;
+  await withTransactionOrNotFound(async (conn, notFound) => {
+    // Verify reward belongs to this streamer
+    const [check] = await conn.execute<mysql.RowDataPacket[]>(
+      `SELECT id FROM overlay_reward WHERE id = ? AND streamer_id = ?`,
+      [rewardId, streamerId],
+    );
+    if (check.length === 0) {
+      notFound();
+    }
+    await conn.execute(`DELETE FROM overlay_reward_video WHERE reward_id = ?`, [rewardId]);
+    if (videos.length === 0) return;
 
-      const [ownedRows] = await conn.execute<mysql.RowDataPacket[]>(
-        `SELECT id FROM overlay_video WHERE streamer_id = ? AND id IN (${videos.map(() => '?').join(', ')})`,
-        [streamerId, ...videos.map((v) => v.videoId)],
-      );
-      const ownedIds = new Set<number>(ownedRows.map((r) => r.id));
-      const invalid = videos.find((v) => !ownedIds.has(v.videoId));
-      if (invalid) {
-        throw new Error(`Video ${invalid.videoId} does not belong to streamer ${streamerId}`);
-      }
+    const [ownedRows] = await conn.execute<mysql.RowDataPacket[]>(
+      `SELECT id FROM overlay_video WHERE streamer_id = ? AND id IN (${videos.map(() => '?').join(', ')})`,
+      [streamerId, ...videos.map((v) => v.videoId)],
+    );
+    const ownedIds = new Set<number>(ownedRows.map((r) => r.id));
+    const invalid = videos.find((v) => !ownedIds.has(v.videoId));
+    if (invalid) {
+      throw new Error(`Video ${invalid.videoId} does not belong to streamer ${streamerId}`);
+    }
 
-      const placeholders = videos.map(() => '(?, ?, ?)').join(', ');
-      const params = videos.flatMap((v) => [rewardId, v.videoId, Math.max(1, v.weight)]);
-      await conn.execute(
-        `INSERT INTO overlay_reward_video (reward_id, video_id, weight) VALUES ${placeholders}`,
-        params,
-      );
-    });
-  } catch (err) {
-    if (err instanceof RewardNotFoundError) return;
-    throw err;
-  }
+    const placeholders = videos.map(() => '(?, ?, ?)').join(', ');
+    const params = videos.flatMap((v) => [rewardId, v.videoId, Math.max(1, v.weight)]);
+    await conn.execute(
+      `INSERT INTO overlay_reward_video (reward_id, video_id, weight) VALUES ${placeholders}`,
+      params,
+    );
+  });
 }
 
 /**

--- a/src/db/pool.test.ts
+++ b/src/db/pool.test.ts
@@ -10,7 +10,7 @@ vi.mock('../shared/config', () => ({
   DB_NAME: 'test-db',
 }));
 
-import { getPool, closePool, withTransaction } from './pool';
+import { getPool, closePool, withTransaction, withTransactionOrNotFound } from './pool';
 
 beforeEach(async () => {
   vi.clearAllMocks();
@@ -134,5 +134,68 @@ describe('withTransaction', () => {
 
     expect(conn.rollback).toHaveBeenCalledOnce();
     expect(conn.release).toHaveBeenCalledOnce();
+  });
+});
+
+describe('withTransactionOrNotFound', () => {
+  /** Builds a fake pool connection whose lifecycle methods resolve successfully. */
+  function makeConn() {
+    return {
+      beginTransaction: vi.fn().mockResolvedValue(undefined),
+      commit: vi.fn().mockResolvedValue(undefined),
+      rollback: vi.fn().mockResolvedValue(undefined),
+      release: vi.fn(),
+    };
+  }
+
+  it('returns the work result on success, committing like withTransaction', async () => {
+    const conn = makeConn();
+    createPool.mockReturnValue({ end: vi.fn(), getConnection: vi.fn().mockResolvedValue(conn) });
+
+    const result = await withTransactionOrNotFound(async () => 'the-result');
+
+    expect(result).toBe('the-result');
+    expect(conn.commit).toHaveBeenCalledOnce();
+    expect(conn.rollback).not.toHaveBeenCalled();
+  });
+
+  it('rolls back and resolves to null when work calls notFound()', async () => {
+    const conn = makeConn();
+    createPool.mockReturnValue({ end: vi.fn(), getConnection: vi.fn().mockResolvedValue(conn) });
+
+    const result = await withTransactionOrNotFound(async (_conn, notFound) => {
+      notFound();
+    });
+
+    expect(result).toBeNull();
+    expect(conn.rollback).toHaveBeenCalledOnce();
+    expect(conn.commit).not.toHaveBeenCalled();
+  });
+
+  it('rolls back and rethrows any other error, without treating it as not-found', async () => {
+    const conn = makeConn();
+    createPool.mockReturnValue({ end: vi.fn(), getConnection: vi.fn().mockResolvedValue(conn) });
+    const boom = new Error('boom');
+
+    await expect(withTransactionOrNotFound(async () => { throw boom; })).rejects.toBe(boom);
+
+    expect(conn.rollback).toHaveBeenCalledOnce();
+  });
+
+  it('does not confuse two concurrent calls not-found signals with each other', async () => {
+    const connA = makeConn();
+    const connB = makeConn();
+    const getConnection = vi.fn()
+      .mockResolvedValueOnce(connA)
+      .mockResolvedValueOnce(connB);
+    createPool.mockReturnValue({ end: vi.fn(), getConnection });
+
+    const [resultA, resultB] = await Promise.all([
+      withTransactionOrNotFound(async (_conn, notFound) => { notFound(); }),
+      withTransactionOrNotFound(async () => 'found-it'),
+    ]);
+
+    expect(resultA).toBeNull();
+    expect(resultB).toBe('found-it');
   });
 });

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -65,3 +65,25 @@ export async function withTransaction<T>(work: (conn: PoolConnection) => Promise
     conn.release();
   }
 }
+
+/**
+ * Like {@link withTransaction}, but for the common "load a row, maybe mutate it,
+ * bail out if it doesn't exist" shape: `work` is passed a `notFound()` function
+ * that rolls back the transaction and resolves this call to `null`, instead of
+ * every call site declaring its own throwaway sentinel error class to get the
+ * same effect. Any other thrown error still propagates and rejects as usual.
+ * @param work Callback that receives the transaction's connection and a
+ *   `notFound()` escape hatch to call (and `return`) when the target row is missing.
+ * @returns The value returned by `work`, or null if `work` called `notFound()`.
+ */
+export async function withTransactionOrNotFound<T>(
+  work: (conn: PoolConnection, notFound: () => never) => Promise<T>,
+): Promise<T | null> {
+  const notFoundSignal = new Error('withTransactionOrNotFound: not found');
+  try {
+    return await withTransaction((conn) => work(conn, () => { throw notFoundSignal; }));
+  } catch (err) {
+    if (err === notFoundSignal) return null;
+    throw err;
+  }
+}

--- a/src/db/sfx.test.ts
+++ b/src/db/sfx.test.ts
@@ -1,28 +1,37 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// `withTransaction` is reimplemented here (rather than via `importOriginal`) so this
-// test doesn't pull in pool.ts's real `../shared/config` import chain, which throws
-// in a test environment with no DISCORD_TOKEN etc. set. The logic mirrors pool.ts's
-// real implementation exactly, driven by the same mocked `getPool()`.
+// `withTransaction`/`withTransactionOrNotFound` are reimplemented here (rather than via
+// `importOriginal`) so this test doesn't pull in pool.ts's real `../shared/config` import
+// chain, which throws in a test environment with no DISCORD_TOKEN etc. set. The logic
+// mirrors pool.ts's real implementation exactly, driven by the same mocked `getPool()`.
 vi.mock('./pool', () => {
   const getPool = vi.fn();
-  return {
-    getPool,
-    withTransaction: async (work: (conn: unknown) => Promise<unknown>) => {
-      const conn = await getPool().getConnection();
-      try {
-        await conn.beginTransaction();
-        const result = await work(conn);
-        await conn.commit();
-        return result;
-      } catch (err) {
-        await conn.rollback().catch(() => {});
-        throw err;
-      } finally {
-        conn.release();
-      }
-    },
+  const withTransaction = async (work: (conn: unknown) => Promise<unknown>) => {
+    const conn = await getPool().getConnection();
+    try {
+      await conn.beginTransaction();
+      const result = await work(conn);
+      await conn.commit();
+      return result;
+    } catch (err) {
+      await conn.rollback().catch(() => {});
+      throw err;
+    } finally {
+      conn.release();
+    }
   };
+  const withTransactionOrNotFound = async (
+    work: (conn: unknown, notFound: () => never) => Promise<unknown>,
+  ) => {
+    const notFoundSignal = new Error('withTransactionOrNotFound: not found');
+    try {
+      return await withTransaction((conn) => work(conn, () => { throw notFoundSignal; }));
+    } catch (err) {
+      if (err === notFoundSignal) return null;
+      throw err;
+    }
+  };
+  return { getPool, withTransaction, withTransactionOrNotFound };
 });
 vi.mock('mysql2/promise', () => ({ default: {} }));
 

--- a/src/db/sfx.ts
+++ b/src/db/sfx.ts
@@ -1,5 +1,5 @@
 import mysql from 'mysql2/promise';
-import { getPool, withTransaction } from './pool';
+import { getPool, withTransactionOrNotFound } from './pool';
 import { fromBit, affectedOrExists, rowExists, getRowCount } from './utils';
 
 export interface SfxTrigger {
@@ -221,30 +221,23 @@ export async function updateSfxTrigger(
  * @param id Trigger id.
  */
 export async function deleteSfxTrigger(id: bigint): Promise<{ files: string[] } | null> {
-  class TriggerNotFoundError extends Error {}
-  try {
-    const result = await withTransaction(async (conn) => {
-      const [triggerRows] = await conn.execute<mysql.RowDataPacket[]>(
-        `SELECT id FROM sfxtrigger WHERE id = ? FOR UPDATE`,
-        [id.toString()],
-      );
-      if (triggerRows.length === 0) {
-        throw new TriggerNotFoundError();
-      }
-      const [rows] = await conn.execute<mysql.RowDataPacket[]>(
-        `SELECT file FROM sfx WHERE trigger_id = ? FOR UPDATE`,
-        [id.toString()],
-      );
-      const files = rows.map((r) => r.file as string);
-      await conn.execute(`DELETE FROM sfx WHERE trigger_id = ?`, [id.toString()]);
-      await conn.execute(`DELETE FROM sfxtrigger WHERE id = ?`, [id.toString()]);
-      return { files };
-    });
-    return result;
-  } catch (err) {
-    if (err instanceof TriggerNotFoundError) return null;
-    throw err;
-  }
+  return withTransactionOrNotFound(async (conn, notFound) => {
+    const [triggerRows] = await conn.execute<mysql.RowDataPacket[]>(
+      `SELECT id FROM sfxtrigger WHERE id = ? FOR UPDATE`,
+      [id.toString()],
+    );
+    if (triggerRows.length === 0) {
+      notFound();
+    }
+    const [rows] = await conn.execute<mysql.RowDataPacket[]>(
+      `SELECT file FROM sfx WHERE trigger_id = ? FOR UPDATE`,
+      [id.toString()],
+    );
+    const files = rows.map((r) => r.file as string);
+    await conn.execute(`DELETE FROM sfx WHERE trigger_id = ?`, [id.toString()]);
+    await conn.execute(`DELETE FROM sfxtrigger WHERE id = ?`, [id.toString()]);
+    return { files };
+  });
 }
 
 /**
@@ -311,28 +304,21 @@ export async function updateSfxFile(id: number, weight: number, hidden: boolean)
  * @param id sfx row id.
  */
 export async function deleteSfxFile(id: number): Promise<string | null> {
-  class FileNotFoundError extends Error {}
-  try {
-    const file = await withTransaction(async (conn) => {
-      const [rows] = await conn.execute<mysql.RowDataPacket[]>(
-        `SELECT file FROM sfx WHERE id = ? FOR UPDATE`,
-        [id],
-      );
-      if (rows.length === 0) {
-        throw new FileNotFoundError();
-      }
-      const file: string = rows[0].file;
-      const [result] = await conn.execute<mysql.ResultSetHeader>(`DELETE FROM sfx WHERE id = ?`, [id]);
-      if (result.affectedRows === 0) {
-        throw new FileNotFoundError();
-      }
-      return file;
-    });
+  return withTransactionOrNotFound(async (conn, notFound) => {
+    const [rows] = await conn.execute<mysql.RowDataPacket[]>(
+      `SELECT file FROM sfx WHERE id = ? FOR UPDATE`,
+      [id],
+    );
+    if (rows.length === 0) {
+      notFound();
+    }
+    const file: string = rows[0].file;
+    const [result] = await conn.execute<mysql.ResultSetHeader>(`DELETE FROM sfx WHERE id = ?`, [id]);
+    if (result.affectedRows === 0) {
+      notFound();
+    }
     return file;
-  } catch (err) {
-    if (err instanceof FileNotFoundError) return null;
-    throw err;
-  }
+  });
 }
 
 /** Return all SFX triggers (including hidden) with their associated sound files, for the admin panel. */


### PR DESCRIPTION
## Summary
- `sfx.ts` and `overlayVideos.ts` each declared a throwaway local `Error` subclass per function to signal "row not found" out of a transaction.
- Replace all four copies with a shared `withTransactionOrNotFound` helper in `pool.ts` alongside `withTransaction`.

Part of a maintainability cleanup split into a stack of focused PRs (see #625 for the original combined change, now closed in favor of this stack). Base branch for the next PR in the stack is this one.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test`
- [x] `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ENwyn2MzgiF9mqvu7C4Bbo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent handling for database operations where a requested record is not found, returning `null` without treating it as an unexpected error.

- **Bug Fixes**
  - Improved deletion and reward-update operations to correctly distinguish missing records from other database errors.
  - Preserved rollback and error propagation behavior for unexpected failures.

- **Tests**
  - Added coverage for successful transactions, missing records, unexpected errors, and concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->