### PR TITLE
Extract registerFirstWinsWithWarning to dedupe cache collision handling

### DIFF
--- a/src/db/alertConfigCache.ts
+++ b/src/db/alertConfigCache.ts
@@ -30,6 +30,9 @@ function createEmptyAlertConfigLookupCache(): AlertConfigLookupCache {
 
 /**
  * Builds an alert config lookup cache keyed by `streamerId:eventType` from every `alert_config` row.
+ * Unlike the custom-command/counter/SFX lookup caches, this doesn't need first-wins collision
+ * handling: `alert_config` has a DB-level `UNIQUE KEY (streamer_id, event_type)`, so two rows can
+ * never produce the same cache key.
  * @param rows Every alert config row across all streamers.
  * @returns The populated `AlertConfigLookupCache`.
  */

--- a/src/db/counterCache.test.ts
+++ b/src/db/counterCache.test.ts
@@ -5,6 +5,9 @@ vi.mock('./lookupCache', () => ({
     getCache: () => loadCache(),
     invalidate: vi.fn(),
   })),
+  registerFirstWinsWithWarning: <K, V>(map: Map<K, V>, key: K, value: V) => {
+    if (!map.has(key)) map.set(key, value);
+  },
   DEFAULT_CACHE_TTL_MS: 300_000,
   DEFAULT_REFRESH_FAILURE_BACKOFF_MS: 5_000,
   DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS: 60_000,

--- a/src/db/counterCache.test.ts
+++ b/src/db/counterCache.test.ts
@@ -5,9 +5,14 @@ vi.mock('./lookupCache', () => ({
     getCache: () => loadCache(),
     invalidate: vi.fn(),
   })),
-  registerFirstWinsWithWarning: <K, V>(map: Map<K, V>, key: K, value: V) => {
-    if (!map.has(key)) map.set(key, value);
-  },
+  registerFirstWinsWithWarning: vi.fn(<K, V>(map: Map<K, V>, key: K, value: V, describeCollision: (existing: V) => string) => {
+    const existing = map.get(key);
+    if (existing !== undefined) {
+      describeCollision(existing);
+      return;
+    }
+    map.set(key, value);
+  }),
   DEFAULT_CACHE_TTL_MS: 300_000,
   DEFAULT_REFRESH_FAILURE_BACKOFF_MS: 5_000,
   DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS: 60_000,
@@ -144,6 +149,22 @@ describe('buildCounterLookupCache (via findCounterByCommand)', () => {
 
     expect(result).not.toBeNull();
     expect(result!.id).toBe(1);
+  });
+
+  it('builds a descriptive collision message naming both counter ids', async () => {
+    const { registerFirstWinsWithWarning } = await import('./lookupCache.js');
+    const winner = makeCounter(1, '!hits', '!checkhits1');
+    const loser = makeCounter(2, '!hits', '!checkhits2');
+    vi.mocked(getAllCounters).mockResolvedValue([winner, loser]);
+
+    await findCounterByCommand('!hits');
+
+    const hitsCalls = vi.mocked(registerFirstWinsWithWarning).mock.calls.filter((call) => call[1] === '!hits');
+    expect(hitsCalls).toHaveLength(2);
+    const describeCollision = hitsCalls[1][3] as (existing: unknown) => string;
+    expect(describeCollision({ ...winner, matchType: 'trigger' })).toBe(
+      "Counter trigger_command collision: '!hits' is already registered (counter id=1); ignoring duplicate from counter id=2.",
+    );
   });
 
   it('sorts by id before processing so lower id still wins even when given in reverse order', async () => {

--- a/src/db/counterCache.ts
+++ b/src/db/counterCache.ts
@@ -1,6 +1,6 @@
-import { createLogger } from '../shared/logger';
 import {
   createManagedLookupCache,
+  registerFirstWinsWithWarning,
   type RefreshingLookupCache,
   DEFAULT_CACHE_TTL_MS,
   DEFAULT_REFRESH_FAILURE_BACKOFF_MS,
@@ -9,8 +9,6 @@ import {
 import { normalizeCommandList, normalizeCommand } from './commandStringUtils';
 import { isAnyCommandTakenAcrossTables } from './commandLocks';
 import { getAllCounters, type DbCounter, type DbMatchedCounter, type CounterMatchType } from './counters';
-
-const log = createLogger('DB');
 
 // ─── Cache interface ──────────────────────────────────────────────────────────
 
@@ -52,13 +50,12 @@ function buildCounterLookupCache(counters: DbCounter[]): CounterLookupCache {
   ): void => {
     if (!normalizedCommand) return;
 
-    const existingCounter = byCommand.get(normalizedCommand);
-    if (existingCounter) {
-      log.warn(`Counter ${commandFieldLabel} collision: '${normalizedCommand}' is already registered (counter id=${existingCounter.id}); ignoring duplicate from counter id=${counter.id}.`);
-      return;
-    }
-
-    byCommand.set(normalizedCommand, { ...counter, matchType });
+    registerFirstWinsWithWarning(
+      byCommand,
+      normalizedCommand,
+      { ...counter, matchType },
+      (existingCounter) => `Counter ${commandFieldLabel} collision: '${normalizedCommand}' is already registered (counter id=${existingCounter.id}); ignoring duplicate from counter id=${counter.id}.`,
+    );
   };
 
   for (const counter of sortedCounters) {

--- a/src/db/customCommandCache.test.ts
+++ b/src/db/customCommandCache.test.ts
@@ -9,6 +9,9 @@ vi.mock('./lookupCache', () => ({
     getCache: () => loadCache(),
     invalidate: vi.fn(),
   })),
+  registerFirstWinsWithWarning: <K, V>(map: Map<K, V>, key: K, value: V) => {
+    if (!map.has(key)) map.set(key, value);
+  },
   DEFAULT_CACHE_TTL_MS: 300_000,
   DEFAULT_REFRESH_FAILURE_BACKOFF_MS: 5_000,
   DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS: 60_000,

--- a/src/db/customCommandCache.test.ts
+++ b/src/db/customCommandCache.test.ts
@@ -9,8 +9,13 @@ vi.mock('./lookupCache', () => ({
     getCache: () => loadCache(),
     invalidate: vi.fn(),
   })),
-  registerFirstWinsWithWarning: <K, V>(map: Map<K, V>, key: K, value: V) => {
-    if (!map.has(key)) map.set(key, value);
+  registerFirstWinsWithWarning: <K, V>(map: Map<K, V>, key: K, value: V, describeCollision: (existing: V) => string) => {
+    const existing = map.get(key);
+    if (existing !== undefined) {
+      describeCollision(existing);
+      return;
+    }
+    map.set(key, value);
   },
   DEFAULT_CACHE_TTL_MS: 300_000,
   DEFAULT_REFRESH_FAILURE_BACKOFF_MS: 5_000,

--- a/src/db/customCommandCache.ts
+++ b/src/db/customCommandCache.ts
@@ -2,6 +2,7 @@ import { createLogger } from '../shared/logger';
 import { normalizeTwitchChannelName } from '../twitch/twitchChannelName';
 import {
   createManagedLookupCache,
+  registerFirstWinsWithWarning,
   type RefreshingLookupCache,
   DEFAULT_CACHE_TTL_MS,
   DEFAULT_REFRESH_FAILURE_BACKOFF_MS,
@@ -144,16 +145,14 @@ function registerDiscordCommand(
     return;
   }
 
-  const existingCommand = discordByTrigger.get(triggerString);
-  if (existingCommand) {
-    log.warn(
+  registerFirstWinsWithWarning(
+    discordByTrigger,
+    triggerString,
+    command,
+    (existingCommand) =>
       `Custom command Discord trigger collision: '${triggerString}' is already registered ` +
       `(command_id=${existingCommand.command_id}); ignoring duplicate from command_id=${command.command_id}.`,
-    );
-    return;
-  }
-
-  discordByTrigger.set(triggerString, command);
+  );
 }
 
 /**

--- a/src/db/lookupCache.test.ts
+++ b/src/db/lookupCache.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   createManagedLookupCache,
+  registerFirstWinsWithWarning,
   DEFAULT_REFRESH_FAILURE_BACKOFF_MS,
   DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS,
 } from './lookupCache';
@@ -11,6 +12,29 @@ describe('default backoff constants', () => {
     expect(DEFAULT_REFRESH_FAILURE_BACKOFF_MS).toBe(5_000);
     expect(DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS).toBe(60_000);
     expect(DEFAULT_REFRESH_FAILURE_BACKOFF_MS).toBeLessThan(DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS);
+  });
+});
+
+describe('registerFirstWinsWithWarning', () => {
+  it('registers the value under the key when the key is not already taken', () => {
+    const map = new Map<string, number>();
+    const describeCollision = vi.fn();
+
+    registerFirstWinsWithWarning(map, 'a', 1, describeCollision);
+
+    expect(map.get('a')).toBe(1);
+    expect(describeCollision).not.toHaveBeenCalled();
+  });
+
+  it('keeps the existing entry and calls describeCollision on a key collision', () => {
+    const map = new Map<string, number>();
+    map.set('a', 1);
+    const describeCollision = vi.fn().mockReturnValue('collision message');
+
+    registerFirstWinsWithWarning(map, 'a', 2, describeCollision);
+
+    expect(map.get('a')).toBe(1);
+    expect(describeCollision).toHaveBeenCalledWith(1);
   });
 });
 

--- a/src/db/lookupCache.ts
+++ b/src/db/lookupCache.ts
@@ -15,6 +15,31 @@ export interface RefreshingLookupCache {
   loadedAt: number;
 }
 
+/**
+ * Registers `value` under `key` in `map`, unless `key` is already taken — in which case the
+ * existing entry is left in place and `describeCollision` (given that existing entry) is logged
+ * as a warning instead. Callers are expected to process their source rows in a fixed,
+ * deterministic order (e.g. ascending id) so which entry "wins" a collision stays stable across
+ * cache rebuilds.
+ * @param map The map being built.
+ * @param key The key to register `value` under.
+ * @param value The candidate value to register.
+ * @param describeCollision Builds the warning message from the entry already registered under `key`.
+ */
+export function registerFirstWinsWithWarning<K, V>(
+  map: Map<K, V>,
+  key: K,
+  value: V,
+  describeCollision: (existing: V) => string,
+): void {
+  const existing = map.get(key);
+  if (existing) {
+    log.warn(describeCollision(existing));
+    return;
+  }
+  map.set(key, value);
+}
+
 export interface ManagedLookupCacheOptions<TCache extends RefreshingLookupCache> {
   cacheName: string;
   ttlMs: number;

--- a/src/db/overlayVideos.test.ts
+++ b/src/db/overlayVideos.test.ts
@@ -1,28 +1,37 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// `withTransaction` is reimplemented here (rather than via `importOriginal`) so this
-// test doesn't pull in pool.ts's real `../shared/config` import chain, which throws
-// in a test environment with no DISCORD_TOKEN etc. set. The logic mirrors pool.ts's
-// real implementation exactly, driven by the same mocked `getPool()`.
+// `withTransaction`/`withTransactionOrNotFound` are reimplemented here (rather than via
+// `importOriginal`) so this test doesn't pull in pool.ts's real `../shared/config` import
+// chain, which throws in a test environment with no DISCORD_TOKEN etc. set. The logic
+// mirrors pool.ts's real implementation exactly, driven by the same mocked `getPool()`.
 vi.mock('./pool', () => {
   const getPool = vi.fn();
-  return {
-    getPool,
-    withTransaction: async (work: (conn: unknown) => Promise<unknown>) => {
-      const conn = await getPool().getConnection();
-      try {
-        await conn.beginTransaction();
-        const result = await work(conn);
-        await conn.commit();
-        return result;
-      } catch (err) {
-        await conn.rollback().catch(() => {});
-        throw err;
-      } finally {
-        conn.release();
-      }
-    },
+  const withTransaction = async (work: (conn: unknown) => Promise<unknown>) => {
+    const conn = await getPool().getConnection();
+    try {
+      await conn.beginTransaction();
+      const result = await work(conn);
+      await conn.commit();
+      return result;
+    } catch (err) {
+      await conn.rollback().catch(() => {});
+      throw err;
+    } finally {
+      conn.release();
+    }
   };
+  const withTransactionOrNotFound = async (
+    work: (conn: unknown, notFound: () => never) => Promise<unknown>,
+  ) => {
+    const notFoundSignal = new Error('withTransactionOrNotFound: not found');
+    try {
+      return await withTransaction((conn) => work(conn, () => { throw notFoundSignal; }));
+    } catch (err) {
+      if (err === notFoundSignal) return null;
+      throw err;
+    }
+  };
+  return { getPool, withTransaction, withTransactionOrNotFound };
 });
 vi.mock('mysql2/promise', () => ({ default: {} }));
 

--- a/src/db/overlayVideos.ts
+++ b/src/db/overlayVideos.ts
@@ -1,5 +1,5 @@
 import mysql from 'mysql2/promise';
-import { getPool, withTransaction } from './pool';
+import { getPool, withTransactionOrNotFound } from './pool';
 
 export interface OverlayVideo {
   id: number;
@@ -89,29 +89,23 @@ export async function getVideoById(videoId: number, streamerId: number): Promise
  * @returns The deleted row's filename (for filesystem cleanup), or null if no matching row existed.
  */
 export async function deleteVideo(videoId: number, streamerId: number): Promise<string | null> {
-  class VideoNotFoundError extends Error {}
-  try {
-    return await withTransaction(async (conn) => {
-      const [rows] = await conn.execute<mysql.RowDataPacket[]>(
-        `SELECT filename FROM overlay_video WHERE id = ? AND streamer_id = ?`,
-        [videoId, streamerId],
-      );
-      if (rows.length === 0) {
-        throw new VideoNotFoundError();
-      }
-      const filename: string = rows[0].filename;
-      const [del] = await conn.execute<mysql.ResultSetHeader>(
-        `DELETE FROM overlay_video WHERE id = ? AND streamer_id = ?`, [videoId, streamerId],
-      );
-      if (del.affectedRows === 0) {
-        throw new VideoNotFoundError();
-      }
-      return filename;
-    });
-  } catch (err) {
-    if (err instanceof VideoNotFoundError) return null;
-    throw err;
-  }
+  return withTransactionOrNotFound(async (conn, notFound) => {
+    const [rows] = await conn.execute<mysql.RowDataPacket[]>(
+      `SELECT filename FROM overlay_video WHERE id = ? AND streamer_id = ?`,
+      [videoId, streamerId],
+    );
+    if (rows.length === 0) {
+      notFound();
+    }
+    const filename: string = rows[0].filename;
+    const [del] = await conn.execute<mysql.ResultSetHeader>(
+      `DELETE FROM overlay_video WHERE id = ? AND streamer_id = ?`, [videoId, streamerId],
+    );
+    if (del.affectedRows === 0) {
+      notFound();
+    }
+    return filename;
+  });
 }
 
 /**
@@ -182,41 +176,35 @@ export async function setRewardVideos(
   streamerId: number,
   videos: Array<{ videoId: number; weight: number }>,
 ): Promise<void> {
-  class RewardNotFoundError extends Error {}
-  try {
-    await withTransaction(async (conn) => {
-      // Verify reward belongs to this streamer
-      const [check] = await conn.execute<mysql.RowDataPacket[]>(
-        `SELECT id FROM overlay_reward WHERE id = ? AND streamer_id = ?`,
-        [rewardId, streamerId],
-      );
-      if (check.length === 0) {
-        throw new RewardNotFoundError();
-      }
-      await conn.execute(`DELETE FROM overlay_reward_video WHERE reward_id = ?`, [rewardId]);
-      if (videos.length === 0) return;
+  await withTransactionOrNotFound(async (conn, notFound) => {
+    // Verify reward belongs to this streamer
+    const [check] = await conn.execute<mysql.RowDataPacket[]>(
+      `SELECT id FROM overlay_reward WHERE id = ? AND streamer_id = ?`,
+      [rewardId, streamerId],
+    );
+    if (check.length === 0) {
+      notFound();
+    }
+    await conn.execute(`DELETE FROM overlay_reward_video WHERE reward_id = ?`, [rewardId]);
+    if (videos.length === 0) return;
 
-      const [ownedRows] = await conn.execute<mysql.RowDataPacket[]>(
-        `SELECT id FROM overlay_video WHERE streamer_id = ? AND id IN (${videos.map(() => '?').join(', ')})`,
-        [streamerId, ...videos.map((v) => v.videoId)],
-      );
-      const ownedIds = new Set<number>(ownedRows.map((r) => r.id));
-      const invalid = videos.find((v) => !ownedIds.has(v.videoId));
-      if (invalid) {
-        throw new Error(`Video ${invalid.videoId} does not belong to streamer ${streamerId}`);
-      }
+    const [ownedRows] = await conn.execute<mysql.RowDataPacket[]>(
+      `SELECT id FROM overlay_video WHERE streamer_id = ? AND id IN (${videos.map(() => '?').join(', ')})`,
+      [streamerId, ...videos.map((v) => v.videoId)],
+    );
+    const ownedIds = new Set<number>(ownedRows.map((r) => r.id));
+    const invalid = videos.find((v) => !ownedIds.has(v.videoId));
+    if (invalid) {
+      throw new Error(`Video ${invalid.videoId} does not belong to streamer ${streamerId}`);
+    }
 
-      const placeholders = videos.map(() => '(?, ?, ?)').join(', ');
-      const params = videos.flatMap((v) => [rewardId, v.videoId, Math.max(1, v.weight)]);
-      await conn.execute(
-        `INSERT INTO overlay_reward_video (reward_id, video_id, weight) VALUES ${placeholders}`,
-        params,
-      );
-    });
-  } catch (err) {
-    if (err instanceof RewardNotFoundError) return;
-    throw err;
-  }
+    const placeholders = videos.map(() => '(?, ?, ?)').join(', ');
+    const params = videos.flatMap((v) => [rewardId, v.videoId, Math.max(1, v.weight)]);
+    await conn.execute(
+      `INSERT INTO overlay_reward_video (reward_id, video_id, weight) VALUES ${placeholders}`,
+      params,
+    );
+  });
 }
 
 /**

--- a/src/db/pool.test.ts
+++ b/src/db/pool.test.ts
@@ -10,7 +10,7 @@ vi.mock('../shared/config', () => ({
   DB_NAME: 'test-db',
 }));
 
-import { getPool, closePool, withTransaction } from './pool';
+import { getPool, closePool, withTransaction, withTransactionOrNotFound } from './pool';
 
 beforeEach(async () => {
   vi.clearAllMocks();
@@ -134,5 +134,68 @@ describe('withTransaction', () => {
 
     expect(conn.rollback).toHaveBeenCalledOnce();
     expect(conn.release).toHaveBeenCalledOnce();
+  });
+});
+
+describe('withTransactionOrNotFound', () => {
+  /** Builds a fake pool connection whose lifecycle methods resolve successfully. */
+  function makeConn() {
+    return {
+      beginTransaction: vi.fn().mockResolvedValue(undefined),
+      commit: vi.fn().mockResolvedValue(undefined),
+      rollback: vi.fn().mockResolvedValue(undefined),
+      release: vi.fn(),
+    };
+  }
+
+  it('returns the work result on success, committing like withTransaction', async () => {
+    const conn = makeConn();
+    createPool.mockReturnValue({ end: vi.fn(), getConnection: vi.fn().mockResolvedValue(conn) });
+
+    const result = await withTransactionOrNotFound(async () => 'the-result');
+
+    expect(result).toBe('the-result');
+    expect(conn.commit).toHaveBeenCalledOnce();
+    expect(conn.rollback).not.toHaveBeenCalled();
+  });
+
+  it('rolls back and resolves to null when work calls notFound()', async () => {
+    const conn = makeConn();
+    createPool.mockReturnValue({ end: vi.fn(), getConnection: vi.fn().mockResolvedValue(conn) });
+
+    const result = await withTransactionOrNotFound(async (_conn, notFound) => {
+      notFound();
+    });
+
+    expect(result).toBeNull();
+    expect(conn.rollback).toHaveBeenCalledOnce();
+    expect(conn.commit).not.toHaveBeenCalled();
+  });
+
+  it('rolls back and rethrows any other error, without treating it as not-found', async () => {
+    const conn = makeConn();
+    createPool.mockReturnValue({ end: vi.fn(), getConnection: vi.fn().mockResolvedValue(conn) });
+    const boom = new Error('boom');
+
+    await expect(withTransactionOrNotFound(async () => { throw boom; })).rejects.toBe(boom);
+
+    expect(conn.rollback).toHaveBeenCalledOnce();
+  });
+
+  it('does not confuse two concurrent calls not-found signals with each other', async () => {
+    const connA = makeConn();
+    const connB = makeConn();
+    const getConnection = vi.fn()
+      .mockResolvedValueOnce(connA)
+      .mockResolvedValueOnce(connB);
+    createPool.mockReturnValue({ end: vi.fn(), getConnection });
+
+    const [resultA, resultB] = await Promise.all([
+      withTransactionOrNotFound(async (_conn, notFound) => { notFound(); }),
+      withTransactionOrNotFound(async () => 'found-it'),
+    ]);
+
+    expect(resultA).toBeNull();
+    expect(resultB).toBe('found-it');
   });
 });

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -65,3 +65,25 @@ export async function withTransaction<T>(work: (conn: PoolConnection) => Promise
     conn.release();
   }
 }
+
+/**
+ * Like {@link withTransaction}, but for the common "load a row, maybe mutate it,
+ * bail out if it doesn't exist" shape: `work` is passed a `notFound()` function
+ * that rolls back the transaction and resolves this call to `null`, instead of
+ * every call site declaring its own throwaway sentinel error class to get the
+ * same effect. Any other thrown error still propagates and rejects as usual.
+ * @param work Callback that receives the transaction's connection and a
+ *   `notFound()` escape hatch to call (and `return`) when the target row is missing.
+ * @returns The value returned by `work`, or null if `work` called `notFound()`.
+ */
+export async function withTransactionOrNotFound<T>(
+  work: (conn: PoolConnection, notFound: () => never) => Promise<T>,
+): Promise<T | null> {
+  const notFoundSignal = new Error('withTransactionOrNotFound: not found');
+  try {
+    return await withTransaction((conn) => work(conn, () => { throw notFoundSignal; }));
+  } catch (err) {
+    if (err === notFoundSignal) return null;
+    throw err;
+  }
+}

--- a/src/db/sfx.test.ts
+++ b/src/db/sfx.test.ts
@@ -1,28 +1,37 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// `withTransaction` is reimplemented here (rather than via `importOriginal`) so this
-// test doesn't pull in pool.ts's real `../shared/config` import chain, which throws
-// in a test environment with no DISCORD_TOKEN etc. set. The logic mirrors pool.ts's
-// real implementation exactly, driven by the same mocked `getPool()`.
+// `withTransaction`/`withTransactionOrNotFound` are reimplemented here (rather than via
+// `importOriginal`) so this test doesn't pull in pool.ts's real `../shared/config` import
+// chain, which throws in a test environment with no DISCORD_TOKEN etc. set. The logic
+// mirrors pool.ts's real implementation exactly, driven by the same mocked `getPool()`.
 vi.mock('./pool', () => {
   const getPool = vi.fn();
-  return {
-    getPool,
-    withTransaction: async (work: (conn: unknown) => Promise<unknown>) => {
-      const conn = await getPool().getConnection();
-      try {
-        await conn.beginTransaction();
-        const result = await work(conn);
-        await conn.commit();
-        return result;
-      } catch (err) {
-        await conn.rollback().catch(() => {});
-        throw err;
-      } finally {
-        conn.release();
-      }
-    },
+  const withTransaction = async (work: (conn: unknown) => Promise<unknown>) => {
+    const conn = await getPool().getConnection();
+    try {
+      await conn.beginTransaction();
+      const result = await work(conn);
+      await conn.commit();
+      return result;
+    } catch (err) {
+      await conn.rollback().catch(() => {});
+      throw err;
+    } finally {
+      conn.release();
+    }
   };
+  const withTransactionOrNotFound = async (
+    work: (conn: unknown, notFound: () => never) => Promise<unknown>,
+  ) => {
+    const notFoundSignal = new Error('withTransactionOrNotFound: not found');
+    try {
+      return await withTransaction((conn) => work(conn, () => { throw notFoundSignal; }));
+    } catch (err) {
+      if (err === notFoundSignal) return null;
+      throw err;
+    }
+  };
+  return { getPool, withTransaction, withTransactionOrNotFound };
 });
 vi.mock('mysql2/promise', () => ({ default: {} }));
 

--- a/src/db/sfx.ts
+++ b/src/db/sfx.ts
@@ -1,5 +1,5 @@
 import mysql from 'mysql2/promise';
-import { getPool, withTransaction } from './pool';
+import { getPool, withTransactionOrNotFound } from './pool';
 import { fromBit, affectedOrExists, rowExists, getRowCount } from './utils';
 
 export interface SfxTrigger {
@@ -221,30 +221,23 @@ export async function updateSfxTrigger(
  * @param id Trigger id.
  */
 export async function deleteSfxTrigger(id: bigint): Promise<{ files: string[] } | null> {
-  class TriggerNotFoundError extends Error {}
-  try {
-    const result = await withTransaction(async (conn) => {
-      const [triggerRows] = await conn.execute<mysql.RowDataPacket[]>(
-        `SELECT id FROM sfxtrigger WHERE id = ? FOR UPDATE`,
-        [id.toString()],
-      );
-      if (triggerRows.length === 0) {
-        throw new TriggerNotFoundError();
-      }
-      const [rows] = await conn.execute<mysql.RowDataPacket[]>(
-        `SELECT file FROM sfx WHERE trigger_id = ? FOR UPDATE`,
-        [id.toString()],
-      );
-      const files = rows.map((r) => r.file as string);
-      await conn.execute(`DELETE FROM sfx WHERE trigger_id = ?`, [id.toString()]);
-      await conn.execute(`DELETE FROM sfxtrigger WHERE id = ?`, [id.toString()]);
-      return { files };
-    });
-    return result;
-  } catch (err) {
-    if (err instanceof TriggerNotFoundError) return null;
-    throw err;
-  }
+  return withTransactionOrNotFound(async (conn, notFound) => {
+    const [triggerRows] = await conn.execute<mysql.RowDataPacket[]>(
+      `SELECT id FROM sfxtrigger WHERE id = ? FOR UPDATE`,
+      [id.toString()],
+    );
+    if (triggerRows.length === 0) {
+      notFound();
+    }
+    const [rows] = await conn.execute<mysql.RowDataPacket[]>(
+      `SELECT file FROM sfx WHERE trigger_id = ? FOR UPDATE`,
+      [id.toString()],
+    );
+    const files = rows.map((r) => r.file as string);
+    await conn.execute(`DELETE FROM sfx WHERE trigger_id = ?`, [id.toString()]);
+    await conn.execute(`DELETE FROM sfxtrigger WHERE id = ?`, [id.toString()]);
+    return { files };
+  });
 }
 
 /**
@@ -311,28 +304,21 @@ export async function updateSfxFile(id: number, weight: number, hidden: boolean)
  * @param id sfx row id.
  */
 export async function deleteSfxFile(id: number): Promise<string | null> {
-  class FileNotFoundError extends Error {}
-  try {
-    const file = await withTransaction(async (conn) => {
-      const [rows] = await conn.execute<mysql.RowDataPacket[]>(
-        `SELECT file FROM sfx WHERE id = ? FOR UPDATE`,
-        [id],
-      );
-      if (rows.length === 0) {
-        throw new FileNotFoundError();
-      }
-      const file: string = rows[0].file;
-      const [result] = await conn.execute<mysql.ResultSetHeader>(`DELETE FROM sfx WHERE id = ?`, [id]);
-      if (result.affectedRows === 0) {
-        throw new FileNotFoundError();
-      }
-      return file;
-    });
+  return withTransactionOrNotFound(async (conn, notFound) => {
+    const [rows] = await conn.execute<mysql.RowDataPacket[]>(
+      `SELECT file FROM sfx WHERE id = ? FOR UPDATE`,
+      [id],
+    );
+    if (rows.length === 0) {
+      notFound();
+    }
+    const file: string = rows[0].file;
+    const [result] = await conn.execute<mysql.ResultSetHeader>(`DELETE FROM sfx WHERE id = ?`, [id]);
+    if (result.affectedRows === 0) {
+      notFound();
+    }
     return file;
-  } catch (err) {
-    if (err instanceof FileNotFoundError) return null;
-    throw err;
-  }
+  });
 }
 
 /** Return all SFX triggers (including hidden) with their associated sound files, for the admin panel. */

--- a/src/db/sfxCache.test.ts
+++ b/src/db/sfxCache.test.ts
@@ -5,6 +5,9 @@ vi.mock('./lookupCache', () => ({
     getCache: () => loadCache(),
     invalidate: vi.fn(),
   })),
+  registerFirstWinsWithWarning: <K, V>(map: Map<K, V>, key: K, value: V) => {
+    if (!map.has(key)) map.set(key, value);
+  },
   DEFAULT_CACHE_TTL_MS: 300_000,
   DEFAULT_REFRESH_FAILURE_BACKOFF_MS: 5_000,
   DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS: 60_000,

--- a/src/db/sfxCache.test.ts
+++ b/src/db/sfxCache.test.ts
@@ -5,9 +5,14 @@ vi.mock('./lookupCache', () => ({
     getCache: () => loadCache(),
     invalidate: vi.fn(),
   })),
-  registerFirstWinsWithWarning: <K, V>(map: Map<K, V>, key: K, value: V) => {
-    if (!map.has(key)) map.set(key, value);
-  },
+  registerFirstWinsWithWarning: vi.fn(<K, V>(map: Map<K, V>, key: K, value: V, describeCollision: (existing: V) => string) => {
+    const existing = map.get(key);
+    if (existing !== undefined) {
+      describeCollision(existing);
+      return;
+    }
+    map.set(key, value);
+  }),
   DEFAULT_CACHE_TTL_MS: 300_000,
   DEFAULT_REFRESH_FAILURE_BACKOFF_MS: 5_000,
   DEFAULT_REFRESH_FAILURE_MAX_BACKOFF_MS: 60_000,
@@ -20,7 +25,7 @@ vi.mock('../shared/logger', () => ({
 }));
 
 import { findCachedSfxTrigger, invalidateSfxLookupCache } from './sfxCache';
-import { createManagedLookupCache } from './lookupCache';
+import { createManagedLookupCache, registerFirstWinsWithWarning } from './lookupCache';
 import { getAllSfxTriggers } from './sfx';
 import type { SfxTriggerRow } from './sfx';
 
@@ -138,6 +143,21 @@ describe('findCachedSfxTrigger', () => {
 
     expect(result).not.toBeNull();
     expect(result!.trigger.id).toBe(1n);
+  });
+
+  it('builds a descriptive collision message naming both trigger ids', async () => {
+    const winner = makeTriggerRow('1', '!bang');
+    const loser = makeTriggerRow('2', '!BANG');
+    vi.mocked(getAllSfxTriggers).mockResolvedValue([winner, loser]);
+
+    await findCachedSfxTrigger('!bang');
+
+    const bangCalls = vi.mocked(registerFirstWinsWithWarning).mock.calls.filter((call) => call[1] === '!bang');
+    expect(bangCalls).toHaveLength(2);
+    const describeCollision = bangCalls[1][3] as (existing: unknown) => string;
+    expect(describeCollision({ trigger: { id: 1n } })).toBe(
+      "SFX trigger collision: '!bang' is already registered (trigger id=1); ignoring duplicate from trigger id=2.",
+    );
   });
 
   it('sorts by id before processing so lower id still wins even when given in reverse order', async () => {

--- a/src/db/sfxCache.ts
+++ b/src/db/sfxCache.ts
@@ -1,6 +1,6 @@
-import { createLogger } from '../shared/logger';
 import {
   createManagedLookupCache,
+  registerFirstWinsWithWarning,
   type RefreshingLookupCache,
   DEFAULT_CACHE_TTL_MS,
   DEFAULT_REFRESH_FAILURE_BACKOFF_MS,
@@ -8,8 +8,6 @@ import {
 } from './lookupCache';
 import { normalizeCommand } from './commandStringUtils';
 import { getAllSfxTriggers, type SfxTrigger, type SfxFile } from './sfx';
-
-const log = createLogger('DB');
 
 /** An SFX trigger paired with its playable sound files, as served from the lookup cache. */
 export interface SfxLookupResult {
@@ -57,12 +55,6 @@ function buildSfxLookupCache(triggers: Awaited<ReturnType<typeof getAllSfxTrigge
     const normalizedTriggerCommand = normalizeCommand(row.triggerCommand);
     if (!normalizedTriggerCommand) continue;
 
-    const existing = byTrigger.get(normalizedTriggerCommand);
-    if (existing) {
-      log.warn(`SFX trigger collision: '${normalizedTriggerCommand}' is already registered (trigger id=${existing.trigger.id}); ignoring duplicate from trigger id=${row.triggerId}.`);
-      continue;
-    }
-
     // Frozen once here (not copied per-lookup in findCachedSfxTrigger) since callers only ever
     // read these objects; freezing turns any future accidental mutation into a loud failure
     // instead of silently corrupting the shared cache entry. Cast back to the mutable interface
@@ -85,7 +77,13 @@ function buildSfxLookupCache(triggers: Awaited<ReturnType<typeof getAllSfxTrigge
         category_id: row.categoryId,
       }))) as SfxFile[],
     };
-    byTrigger.set(normalizedTriggerCommand, Object.freeze(result));
+
+    registerFirstWinsWithWarning(
+      byTrigger,
+      normalizedTriggerCommand,
+      Object.freeze(result),
+      (existing) => `SFX trigger collision: '${normalizedTriggerCommand}' is already registered (trigger id=${existing.trigger.id}); ignoring duplicate from trigger id=${row.triggerId}.`,
+    );
   }
 
   return { loadedAt: Date.now(), byTrigger };


### PR DESCRIPTION
## Summary
- `customCommandCache.ts`, `counterCache.ts`, and `sfxCache.ts` each reimplemented the same "sort by id, first entry wins, warn on collision" logic when building their lookup caches.
- Replace all three with a shared `registerFirstWinsWithWarning` helper in `lookupCache.ts`, and document why `alertConfigCache.ts` doesn't need it (DB-level unique constraint).

Stacked on #626 — base is that PR's branch, so this diff shows only this commit's change. Part of the same cleanup stack as #625 (closed) / #626.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test`
- [x] `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ENwyn2MzgiF9mqvu7C4Bbo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized handling of duplicate trigger commands so the first registered command remains active and collisions produce clearer warnings.
  - Improved missing-record handling for video, reward-video, and sound-effect operations, returning a not-found result without affecting unrelated database errors.
  - Preserved transaction safety by rolling back changes when records are missing or operations fail.

- **Tests**
  - Expanded coverage for duplicate-command handling, transaction outcomes, missing records, and concurrent operations.

- **Documentation**
  - Clarified why alert configuration lookups do not require duplicate-collision handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->