### PR TITLE
Dedupe getFriendlyError lookup logic into viewHelpers.ts

### DIFF
--- a/src/web/routes/streams.ts
+++ b/src/web/routes/streams.ts
@@ -7,7 +7,7 @@ import { getCurrentGuildId } from '../session';
 import { getLiveStates } from '../../twitch/monitor/twitchMonitor';
 import { AccessLevel } from '../../db';
 import { filterQueryParam } from './validation';
-import { renderView, renderError } from './viewHelpers';
+import { renderView, renderError, getFriendlyErrorMessage } from './viewHelpers';
 import { STREAMS_ERROR_CODES, STREAMS_ERROR_MESSAGES, type StreamsErrorCode } from './streamsErrors';
 import groupsRouter from './streamGroups';
 import streamersRouter from './streamStreamers';
@@ -20,8 +20,9 @@ const KNOWN_SUCCESSES = new Set<string>([]);
 
 export const ERROR_MESSAGES = STREAMS_ERROR_MESSAGES;
 
+/** Looks up a `streams` page error code in {@link ERROR_MESSAGES}, for use as an EJS template helper. */
 function getFriendlyError(key: string): string {
-  return (ERROR_MESSAGES as Record<string, string>)[key] ?? `An error occurred (${key}).`;
+  return getFriendlyErrorMessage(ERROR_MESSAGES, key);
 }
 
 // ─── View ─────────────────────────────────────────────────────────────────────

--- a/src/web/routes/userSettings.ts
+++ b/src/web/routes/userSettings.ts
@@ -6,7 +6,7 @@ import { csrfProtection } from '../csrf';
 import { requireAuth } from '../middleware';
 import { getSessionUser } from '../session';
 import { trimField, filterQueryParam } from './validation';
-import { renderError, renderView } from './viewHelpers';
+import { renderError, renderView, getFriendlyErrorMessage } from './viewHelpers';
 import { logAndRedirectError } from './errorHandling';
 import { reloadEventSubSubscriptions } from '../../twitch/eventsub/twitchEventSub';
 import { hasAuthFailedSubs } from '../../twitch/eventsub/twitchEventSubSubscriptions';
@@ -42,8 +42,9 @@ const ERROR_MESSAGES: Record<string, string> = {
   invalid_id:                    'Invalid request — please try again.',
 };
 
+/** Looks up a `userSettings` page error code in {@link ERROR_MESSAGES}, for use as an EJS template helper. */
 function getFriendlyError(key: string): string {
-  return ERROR_MESSAGES[key] ?? `An error occurred (${key}).`;
+  return getFriendlyErrorMessage(ERROR_MESSAGES, key);
 }
 
 // GET /user/settings

--- a/src/web/routes/viewHelpers.test.ts
+++ b/src/web/routes/viewHelpers.test.ts
@@ -21,6 +21,13 @@ describe('getFriendlyErrorMessage', () => {
   it('returns a generic fallback for an unrecognized key', () => {
     expect(getFriendlyErrorMessage(messages, 'unknown_key')).toBe('An error occurred (unknown_key).');
   });
+
+  it.each(['toString', 'constructor', '__proto__', 'hasOwnProperty'])(
+    'returns the generic fallback for the inherited key %s rather than an Object.prototype value',
+    (key) => {
+      expect(getFriendlyErrorMessage(messages, key)).toBe(`An error occurred (${key}).`);
+    },
+  );
 });
 
 describe('renderView', () => {

--- a/src/web/routes/viewHelpers.test.ts
+++ b/src/web/routes/viewHelpers.test.ts
@@ -9,7 +9,19 @@ vi.mock('../../db', () => ({
 }));
 
 import { AccessLevel, getStreamerByDiscordId } from '../../db';
-import { renderView, renderError, requireStreamer } from './viewHelpers';
+import { renderView, renderError, requireStreamer, getFriendlyErrorMessage } from './viewHelpers';
+
+describe('getFriendlyErrorMessage', () => {
+  const messages = { some_error: 'Something went wrong.' };
+
+  it('returns the mapped message for a known key', () => {
+    expect(getFriendlyErrorMessage(messages, 'some_error')).toBe('Something went wrong.');
+  });
+
+  it('returns a generic fallback for an unrecognized key', () => {
+    expect(getFriendlyErrorMessage(messages, 'unknown_key')).toBe('An error occurred (unknown_key).');
+  });
+});
 
 describe('renderView', () => {
   function mockRes() {

--- a/src/web/routes/viewHelpers.ts
+++ b/src/web/routes/viewHelpers.ts
@@ -107,6 +107,18 @@ export function renderError(
 }
 
 /**
+ * Looks up `key` in a page's `error`-code-to-message map, falling back to a generic
+ * "An error occurred (<key>)" message for an unrecognized code (e.g. a stale bookmark or a
+ * code from a since-removed error path) rather than showing nothing.
+ * @param messages The page's `error` query-param code-to-message map.
+ * @param key The `error` query-param value to look up.
+ * @returns The friendly message for `key`, or a generic fallback if `key` isn't in `messages`.
+ */
+export function getFriendlyErrorMessage(messages: Record<string, string>, key: string): string {
+  return messages[key] ?? `An error occurred (${key}).`;
+}
+
+/**
  * Loads the requesting user's streamer record, redirecting to `notAStreamerRedirectPath`
  * if they aren't one. Shared by every streamer-scoped admin page (channel points, overlay
  * settings), each of which passes its own not-a-streamer error redirect so the pages stay

--- a/src/web/routes/viewHelpers.ts
+++ b/src/web/routes/viewHelpers.ts
@@ -115,7 +115,9 @@ export function renderError(
  * @returns The friendly message for `key`, or a generic fallback if `key` isn't in `messages`.
  */
 export function getFriendlyErrorMessage(messages: Record<string, string>, key: string): string {
-  return messages[key] ?? `An error occurred (${key}).`;
+  return Object.prototype.hasOwnProperty.call(messages, key)
+    ? messages[key]
+    : `An error occurred (${key}).`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- `streams.ts` and `userSettings.ts` each had an identical inline error-code-to-message lookup.
- Extract the shared lookup into `getFriendlyErrorMessage` in `viewHelpers.ts`; each route file keeps a thin single-arg wrapper bound to its own error-message map, since that's the shape their EJS templates call as a helper.

Stacked on #629. Part of the same cleanup stack as #625 (closed) / #626 / #627 / #628 / #629.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test`
- [x] `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ENwyn2MzgiF9mqvu7C4Bbo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error-message handling across the streams and user settings pages.
  * Unrecognized errors now display a consistent fallback message containing the relevant error code.
  * Known errors continue to show their appropriate, user-friendly descriptions.
  * Error keys that match built-in property names are now handled correctly.

* **Tests**
  * Added coverage for mapped messages, fallback behavior, and built-in property-name edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->