### PR TITLE
Add trySendDiscordReply to dedupe the reply-swallow-not-found pattern

### DIFF
--- a/src/commands/counterHandler.test.ts
+++ b/src/commands/counterHandler.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { mockLogger } from '../test-utils/loggerMock';
 
-vi.mock('../shared/logger', () => ({ createLogger: mockLogger }));
+// A stable logger instance (unlike `mockLogger()`, which returns a fresh object per call) so
+// tests can assert on the same `log.error` spy the module-scoped `log` in counterHandler.ts
+// was created with.
+const { log } = vi.hoisted(() => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+vi.mock('../shared/logger', () => ({ createLogger: () => log }));
 
 vi.mock('../shared/config', () => ({ GLOBAL_COOLDOWN_MS: 3_000 }));
 
@@ -146,6 +151,22 @@ describe('executeCounterCommandForDiscord', () => {
     msg.reply.mockRejectedValue(new Error('Unknown message'));
 
     await expect(executeCounterCommandForDiscord(msg as any)).resolves.toBeUndefined();
+    expect(log.error).not.toHaveBeenCalled();
+  });
+
+  it('logs (but does not throw) when the Discord reply fails with a non-not-found error', async () => {
+    const { isDiscordNotFoundError } = await import('../discord/discordUtils.js');
+    vi.mocked(isDiscordNotFoundError).mockReturnValue(false);
+    vi.mocked(findCounterByCommand).mockResolvedValue(CHECK_COUNTER as any);
+    const msg = makeMockMessage('!count');
+    const boom = new Error('Missing Permissions');
+    msg.reply.mockRejectedValue(boom);
+
+    await expect(executeCounterCommandForDiscord(msg as any)).resolves.toBeUndefined();
+    expect(log.error).toHaveBeenCalledWith(
+      `[Discord] Failed to reply to message ${msg.id} for counter check '!count':`,
+      boom,
+    );
   });
 });
 

--- a/src/commands/counterHandler.test.ts
+++ b/src/commands/counterHandler.test.ts
@@ -10,10 +10,22 @@ vi.mock('../db', () => ({
   incrementCounter: vi.fn(),
 }));
 
-vi.mock('../discord/discordUtils', () => ({
-  isDiscordNotFoundError: vi.fn().mockReturnValue(false),
-  NO_MENTIONS: { parse: [] },
-}));
+vi.mock('../discord/discordUtils', () => {
+  const isDiscordNotFoundError = vi.fn().mockReturnValue(false);
+  return {
+    isDiscordNotFoundError,
+    NO_MENTIONS: { parse: [] },
+    trySendDiscordReply: async (message: { reply: (payload: unknown) => Promise<unknown> }, payload: unknown, onError: (err: unknown) => void) => {
+      try {
+        await message.reply(payload);
+        return true;
+      } catch (err) {
+        if (!isDiscordNotFoundError(err)) onError(err);
+        return false;
+      }
+    },
+  };
+});
 
 import {
   executeCounterCommandForDiscord,

--- a/src/commands/counterHandler.ts
+++ b/src/commands/counterHandler.ts
@@ -4,7 +4,7 @@ import { findCounterByCommand, incrementCounter } from '../db';
 
 const log = createLogger('Counter');
 import { resolveCommand } from './commandUtils';
-import { isDiscordNotFoundError, NO_MENTIONS } from '../discord/discordUtils';
+import { NO_MENTIONS, trySendDiscordReply } from '../discord/discordUtils';
 import { createRuntimeRegistry, type TwitchSendRuntime } from './twitchRuntime';
 import { createCooldownGate } from './cooldownGate';
 
@@ -142,13 +142,13 @@ export async function executeCounterCommandForDiscord(
 
   if (!result.canReply) return;
 
-  try {
-    await message.reply({ content: result.response, allowedMentions: NO_MENTIONS });
+  const sent = await trySendDiscordReply(
+    message,
+    { content: result.response, allowedMentions: NO_MENTIONS },
+    (err) => log.error(`[Discord] Failed to reply to message ${message.id} for ${result.label} '${command}':`, err),
+  );
+  if (sent) {
     log.info(`[Discord] Sent ${result.label} '${command}'.`);
-  } catch (err) {
-    if (!isDiscordNotFoundError(err)) {
-      log.error(`[Discord] Failed to reply to message ${message.id} for ${result.label} '${command}':`, err);
-    }
   }
 }
 

--- a/src/commands/customCommandHandler.test.ts
+++ b/src/commands/customCommandHandler.test.ts
@@ -14,10 +14,22 @@ vi.mock('../twitch/twitchApi', () => ({
   getSharedChatSession: vi.fn().mockResolvedValue(null),
 }));
 
-vi.mock('../discord/discordUtils', () => ({
-  isDiscordNotFoundError: vi.fn().mockReturnValue(false),
-  NO_MENTIONS: { parse: [] },
-}));
+vi.mock('../discord/discordUtils', () => {
+  const isDiscordNotFoundError = vi.fn().mockReturnValue(false);
+  return {
+    isDiscordNotFoundError,
+    NO_MENTIONS: { parse: [] },
+    trySendDiscordReply: async (message: { reply: (payload: unknown) => Promise<unknown> }, payload: unknown, onError: (err: unknown) => void) => {
+      try {
+        await message.reply(payload);
+        return true;
+      } catch (err) {
+        if (!isDiscordNotFoundError(err)) onError(err);
+        return false;
+      }
+    },
+  };
+});
 
 import {
   executeCustomCommandForDiscord,

--- a/src/commands/customCommandHandler.test.ts
+++ b/src/commands/customCommandHandler.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { mockLogger } from '../test-utils/loggerMock';
 
-vi.mock('../shared/logger', () => ({ createLogger: mockLogger }));
+// A stable logger instance (unlike `mockLogger()`, which returns a fresh object per call) so
+// tests can assert on the same `log.error` spy the module-scoped `log` in customCommandHandler.ts
+// was created with.
+const { log } = vi.hoisted(() => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+vi.mock('../shared/logger', () => ({ createLogger: () => log }));
 
 vi.mock('../shared/config', () => ({ GLOBAL_COOLDOWN_MS: 3_000 }));
 
@@ -115,6 +120,24 @@ describe('executeCustomCommandForDiscord', () => {
     msg.reply.mockRejectedValue(new Error('Unknown message'));
 
     await expect(executeCustomCommandForDiscord(msg as any)).resolves.toBeUndefined();
+    expect(log.error).not.toHaveBeenCalled();
+  });
+
+  it('logs (but does not throw) when the Discord reply fails with a non-not-found error', async () => {
+    vi.mocked(getCustomCommandForDiscord).mockResolvedValue({
+      output: 'Hi!',
+      is_multi_twitch: false,
+    } as any);
+    vi.mocked(isDiscordNotFoundError).mockReturnValue(false);
+    const msg = mockMsg('!hi');
+    const boom = new Error('Missing Permissions');
+    msg.reply.mockRejectedValue(boom);
+
+    await expect(executeCustomCommandForDiscord(msg as any)).resolves.toBeUndefined();
+    expect(log.error).toHaveBeenCalledWith(
+      `[Discord] Failed to reply to message ${msg.id} for command '!hi':`,
+      boom,
+    );
   });
 
   it('threads an explicit guildId into the override-aware lookup', async () => {

--- a/src/commands/customCommandHandler.ts
+++ b/src/commands/customCommandHandler.ts
@@ -5,7 +5,7 @@ import { getCustomCommandForDiscord, getCustomCommandForTwitchChannel } from '..
 const log = createLogger('CustomCmd');
 import { getSharedChatSession } from '../twitch/twitchApi';
 import { extractArgs, resolveCommand } from './commandUtils';
-import { isDiscordNotFoundError, NO_MENTIONS } from '../discord/discordUtils';
+import { NO_MENTIONS, trySendDiscordReply } from '../discord/discordUtils';
 import type { MultiTwitchGroupInfo } from '../twitch/monitor/twitchMonitorTypes';
 import { fillTemplate } from '../shared/textTemplate';
 import { sendDedupedBySession } from './twitchBroadcast';
@@ -239,13 +239,13 @@ export async function executeCustomCommandForDiscord(
 
   const filledResponse = buildFilledResponse(result.response, message.content, username);
 
-  try {
-    await message.reply({ content: filledResponse, allowedMentions: NO_MENTIONS });
+  const sent = await trySendDiscordReply(
+    message,
+    { content: filledResponse, allowedMentions: NO_MENTIONS },
+    (err) => log.error(`[Discord] Failed to reply to message ${message.id} for command '${command}':`, err),
+  );
+  if (sent) {
     log.info(`[Discord] Sent custom command '${command}'.`);
-  } catch (err) {
-    if (!isDiscordNotFoundError(err)) {
-      log.error(`[Discord] Failed to reply to message ${message.id} for command '${command}':`, err);
-    }
   }
 }
 

--- a/src/commands/healthCommandHandler.test.ts
+++ b/src/commands/healthCommandHandler.test.ts
@@ -16,9 +16,21 @@ vi.mock('../shared/healthStore', () => ({
   getHealthSnapshot: vi.fn(),
 }));
 
-vi.mock('../discord/discordUtils', () => ({
-  isDiscordNotFoundError: vi.fn().mockReturnValue(false),
-}));
+vi.mock('../discord/discordUtils', () => {
+  const isDiscordNotFoundError = vi.fn().mockReturnValue(false);
+  return {
+    isDiscordNotFoundError,
+    trySendDiscordReply: async (message: { reply: (payload: unknown) => Promise<unknown> }, payload: unknown, onError: (err: unknown) => void) => {
+      try {
+        await message.reply(payload);
+        return true;
+      } catch (err) {
+        if (!isDiscordNotFoundError(err)) onError(err);
+        return false;
+      }
+    },
+  };
+});
 
 import { executeHealthCommandForDiscord } from './healthCommandHandler';
 import { findOwnerUser } from '../db';

--- a/src/commands/healthCommandHandler.ts
+++ b/src/commands/healthCommandHandler.ts
@@ -3,7 +3,7 @@ import { createLogger } from '../shared/logger';
 import { resolveCommand } from './commandUtils';
 import { findOwnerUser } from '../db';
 import { getHealthSnapshot, type HealthSnapshot } from '../shared/healthStore';
-import { isDiscordNotFoundError } from '../discord/discordUtils';
+import { trySendDiscordReply } from '../discord/discordUtils';
 
 const log = createLogger('HealthCommand');
 
@@ -138,12 +138,10 @@ export async function executeHealthCommandForDiscord(message: Message, precomput
   }
 
   if (message.guild) {
-    try {
-      await message.reply('📬 Sent you the health report via DM.');
-    } catch (err) {
-      if (!isDiscordNotFoundError(err)) {
-        log.error('Failed to acknowledge !health command in channel:', err);
-      }
-    }
+    await trySendDiscordReply(
+      message,
+      '📬 Sent you the health report via DM.',
+      (err) => log.error('Failed to acknowledge !health command in channel:', err),
+    );
   }
 }

--- a/src/discord/discordUtils.test.ts
+++ b/src/discord/discordUtils.test.ts
@@ -47,6 +47,7 @@ import {
   getAvailableVoiceChannels,
   getTextChannel,
   tryEditDiscordMessage,
+  trySendDiscordReply,
 } from './discordUtils';
 import { DiscordAPIError, HTTPError } from 'discord.js';
 import { getDiscordClient } from './discordClientStore';
@@ -295,6 +296,38 @@ describe('tryEditDiscordMessage', () => {
     const client = { channels: { fetch: channelsFetch } } as any;
 
     await expect(tryEditDiscordMessage(client, 'chan1', 'msg1', { content: 'hi' })).rejects.toThrow('network blip');
+  });
+});
+
+describe('trySendDiscordReply', () => {
+  it('replies with the given payload and returns true on success', async () => {
+    const reply = vi.fn().mockResolvedValue(undefined);
+    const message = { id: 'msg1', reply } as any;
+    const onError = vi.fn();
+
+    await expect(trySendDiscordReply(message, { content: 'hi' }, onError)).resolves.toBe(true);
+    expect(reply).toHaveBeenCalledWith({ content: 'hi' });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('returns false without calling onError on a not-found error', async () => {
+    const notFoundErr = new MockedDiscordAPIError({ code: UNKNOWN_MESSAGE, status: 200 });
+    const reply = vi.fn().mockRejectedValue(notFoundErr);
+    const message = { id: 'msg1', reply } as any;
+    const onError = vi.fn();
+
+    await expect(trySendDiscordReply(message, 'hi', onError)).resolves.toBe(false);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('calls onError and returns false, without throwing, on any other error', async () => {
+    const otherErr = new Error('network blip');
+    const reply = vi.fn().mockRejectedValue(otherErr);
+    const message = { id: 'msg1', reply } as any;
+    const onError = vi.fn();
+
+    await expect(trySendDiscordReply(message, 'hi', onError)).resolves.toBe(false);
+    expect(onError).toHaveBeenCalledWith(otherErr);
   });
 });
 

--- a/src/discord/discordUtils.ts
+++ b/src/discord/discordUtils.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '../shared/logger';
-import { DiscordAPIError, HTTPError, RESTJSONErrorCodes, ChannelType, type Client, type MessageEditOptions, type MessageMentionOptions, type TextBasedChannel } from 'discord.js';
+import { DiscordAPIError, HTTPError, RESTJSONErrorCodes, ChannelType, type Client, type Message, type MessageEditOptions, type MessageMentionOptions, type MessagePayload, type MessageReplyOptions, type TextBasedChannel } from 'discord.js';
 import { getDiscordClient } from './discordClientStore';
 
 const log = createLogger('Discord');
@@ -159,6 +159,34 @@ export async function tryEditDiscordMessage(
     if (isDiscordNotFoundError(err)) return false;
     log.error(`Failed to edit Discord message ${messageId} in channel ${channelId}:`, err);
     throw err;
+  }
+}
+
+/**
+ * Replies to `message`, swallowing a Discord not-found error (message/channel already gone
+ * by the time the reply is sent) rather than logging it — the same not-found handling as
+ * {@link tryDeleteDiscordMessage}/{@link tryEditDiscordMessage}. Any other error is passed to
+ * `onError` and swallowed, since a command handler's reply is best-effort and should never
+ * throw back into the message-handling loop.
+ *
+ * @param message - Discord message to reply to.
+ * @param payload - Reply content/options, forwarded to `message.reply` unchanged.
+ * @param onError - Called with the error when the reply fails for a reason other than not-found.
+ * @returns True if the reply was sent; false if it failed (not-found or otherwise).
+ */
+export async function trySendDiscordReply(
+  message: Message,
+  payload: string | MessagePayload | MessageReplyOptions,
+  onError: (err: unknown) => void,
+): Promise<boolean> {
+  try {
+    await message.reply(payload);
+    return true;
+  } catch (err) {
+    if (!isDiscordNotFoundError(err)) {
+      onError(err);
+    }
+    return false;
   }
 }
 


### PR DESCRIPTION
## Summary
`counterHandler.ts`, `customCommandHandler.ts`, and `healthCommandHandler.ts` each inlined the same try/reply/catch-swallow-on-not-found block. Mirror `tryEditDiscordMessage`/`tryDeleteDiscordMessage`'s existing shape with a new `trySendDiscordReply` in `discordUtils.ts` and use it at all three call sites.

Stacked on #631. Part of the same cleanup stack as #625 (closed) / #626–#631.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test`
- [x] `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ENwyn2MzgiF9mqvu7C4Bbo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Discord reply handling across commands.
  * Prevented expected “not found” reply failures from generating errors.
  * Logged unexpected Discord reply failures without interrupting command execution.
  * Success logging now occurs only when a reply is sent successfully.

* **Tests**
  * Added coverage for successful replies, expected failures, and unexpected errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->