### PR TITLE
Use getOrCreate instead of non-null assertions in row-grouping loops

### DIFF
--- a/src/db/alertConfig.ts
+++ b/src/db/alertConfig.ts
@@ -1,6 +1,7 @@
 import mysql from 'mysql2/promise';
 import { getPool, withTransaction } from './pool';
 import { fromBit } from './utils';
+import { getOrCreate } from '../shared/mapUtils';
 
 /** Twitch event types the alerts overlay can react to. */
 export type AlertEventType = 'follow' | 'sub' | 'resub' | 'giftsub' | 'raid';
@@ -87,8 +88,7 @@ export async function getEnabledAlertEventTypesBatch(streamerIds: number[]): Pro
     streamerIds,
   );
   for (const row of rows) {
-    if (!result.has(row.streamer_id)) result.set(row.streamer_id, new Set());
-    result.get(row.streamer_id)!.add(row.event_type);
+    getOrCreate(result, row.streamer_id, () => new Set<AlertEventType>()).add(row.event_type);
   }
   return result;
 }

--- a/src/db/customCommands.ts
+++ b/src/db/customCommands.ts
@@ -1,6 +1,7 @@
 import mysql from 'mysql2/promise';
 import { getPool, runInTransaction } from './pool';
 import { fromBit, getRowCount } from './utils';
+import { getOrCreate } from '../shared/mapUtils';
 import { AccessLevel } from './users';
 import type { AccessLevelValue } from './users';
 import { assertNotReservedCommand } from './reservedCommands';
@@ -72,15 +73,13 @@ export async function getAllCustomCommandsWithAssignments(): Promise<DbCustomCom
   const commandMap = new Map<number, DbCustomCommandWithAssignments>();
 
   for (const row of rows) {
-    if (!commandMap.has(row.command_id)) {
-      commandMap.set(row.command_id, {
-        ...mapCustomCommand(row),
-        assigned_users: [],
-      });
-    }
+    const commandEntry = getOrCreate(commandMap, row.command_id, () => ({
+      ...mapCustomCommand(row),
+      assigned_users: [],
+    }));
 
     if (row.assigned_discord_id !== null && row.assigned_discord_id !== undefined) {
-      commandMap.get(row.command_id)!.assigned_users.push({
+      commandEntry.assigned_users.push({
         discord_id: String(row.assigned_discord_id),
         discord_name: row.discord_name ?? null,
         twitch_name: row.twitch_name ?? null,

--- a/src/db/overlayVideos.ts
+++ b/src/db/overlayVideos.ts
@@ -1,5 +1,6 @@
 import mysql from 'mysql2/promise';
 import { getPool, withTransactionOrNotFound } from './pool';
+import { getOrCreate } from '../shared/mapUtils';
 
 export interface OverlayVideo {
   id: number;
@@ -127,16 +128,14 @@ export async function getRewardsForStreamer(streamerId: number): Promise<Overlay
 
   const rewardMap = new Map<number, OverlayRewardWithVideos>();
   for (const row of rewardRows) {
-    if (!rewardMap.has(row.id)) {
-      rewardMap.set(row.id, {
-        id: row.id,
-        streamer_id: row.streamer_id,
-        twitch_reward_id: row.twitch_reward_id,
-        videos: [],
-      });
-    }
+    const rewardEntry = getOrCreate(rewardMap, row.id, () => ({
+      id: row.id,
+      streamer_id: row.streamer_id,
+      twitch_reward_id: row.twitch_reward_id,
+      videos: [],
+    }));
     if (row.video_id != null) {
-      rewardMap.get(row.id)!.videos.push({
+      rewardEntry.videos.push({
         video_id: row.video_id,
         weight: row.weight,
         name: row.name,

--- a/src/db/sfx.ts
+++ b/src/db/sfx.ts
@@ -1,6 +1,7 @@
 import mysql from 'mysql2/promise';
 import { getPool, withTransactionOrNotFound } from './pool';
 import { fromBit, affectedOrExists, rowExists, getRowCount } from './utils';
+import { getOrCreate } from '../shared/mapUtils';
 
 export interface SfxTrigger {
   id: bigint;
@@ -343,19 +344,17 @@ export async function getAllSfxTriggers(): Promise<SfxTriggerRow[]> {
 
   const map = new Map<string, SfxTriggerRow>();
   for (const r of rows) {
-    if (!map.has(r.triggerId)) {
-      map.set(r.triggerId, {
-        triggerId: r.triggerId,
-        triggerCommand: r.triggerCommand,
-        description: r.description ?? null,
-        hidden: fromBit(r.triggerHidden),
-        categoryId: r.categoryId ?? null,
-        categoryName: r.categoryName ?? null,
-        files: [],
-      });
-    }
+    const triggerEntry = getOrCreate(map, r.triggerId, () => ({
+      triggerId: r.triggerId,
+      triggerCommand: r.triggerCommand,
+      description: r.description ?? null,
+      hidden: fromBit(r.triggerHidden),
+      categoryId: r.categoryId ?? null,
+      categoryName: r.categoryName ?? null,
+      files: [],
+    }));
     if (r.sfxId !== null) {
-      map.get(r.triggerId)!.files.push({
+      triggerEntry.files.push({
         id: r.sfxId,
         file: r.file,
         weight: r.weight,

--- a/src/db/timerCommands.ts
+++ b/src/db/timerCommands.ts
@@ -4,6 +4,7 @@ import { fromBit, affectedOrExists, rowExists } from './utils';
 import { AccessLevel } from './users';
 import type { AccessLevelValue } from './users';
 import { normalizeTwitchChannelName } from '../twitch/twitchChannelName';
+import { getOrCreate } from '../shared/mapUtils';
 
 /** A timer command row from the database. */
 export interface DbTimerCommand {
@@ -91,15 +92,13 @@ export async function getAllTimerCommandsWithAssignments(): Promise<DbTimerComma
   const timerMap = new Map<number, DbTimerCommandWithAssignments>();
 
   for (const row of rows) {
-    if (!timerMap.has(row.id)) {
-      timerMap.set(row.id, {
-        ...mapRow(row),
-        assigned_users: [],
-      });
-    }
+    const timerEntry = getOrCreate(timerMap, row.id, () => ({
+      ...mapRow(row),
+      assigned_users: [],
+    }));
 
     if (row.assigned_discord_id !== null && row.assigned_discord_id !== undefined) {
-      timerMap.get(row.id)!.assigned_users.push({
+      timerEntry.assigned_users.push({
         discord_id: String(row.assigned_discord_id),
         discord_name: row.discord_name ?? null,
         twitch_name: row.twitch_name ?? null,


### PR DESCRIPTION
## Summary
`customCommands.ts`, `timerCommands.ts`, `overlayVideos.ts`, `sfx.ts`, and `alertConfig.ts` each built a grouped map from flat JOIN rows using the same `has()`/`set()` then `map.get(id)!` idiom. Use the existing `getOrCreate` helper from `mapUtils.ts` instead, for consistency with `statusStore.ts` and to remove the non-null assertions.

Stacked on #633. Part of the same cleanup stack as #625 (closed) / #626–#633.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test`
- [x] `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ENwyn2MzgiF9mqvu7C4Bbo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined internal data aggregation for alert events, custom commands, overlay videos, sound effects, and timer commands.
  - Preserved existing behavior while simplifying how grouped records are initialized and populated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->