### PR TITLE
Rename _buildCounterResponse to buildCounterResponse

### DIFF
--- a/src/commands/counterHandler.ts
+++ b/src/commands/counterHandler.ts
@@ -76,7 +76,7 @@ interface CounterResult {
  * @param cooldownKey - Cooldown-gate key for the invoking guild/channel.
  * @returns The response text, display label, and whether it's safe to send it; null if no counter matches `command`, or if the match is on cooldown.
  */
-async function _buildCounterResponse(
+async function buildCounterResponse(
   command: string,
   errorPrefix: string,
   cooldownKey: string,
@@ -137,7 +137,7 @@ export async function executeCounterCommandForDiscord(
   const command = resolveCommand(message.content, precomputedCommand);
   if (!command) return;
 
-  const result = await _buildCounterResponse(command, '[Discord]', discordCooldownKey(message));
+  const result = await buildCounterResponse(command, '[Discord]', discordCooldownKey(message));
   if (!result) return;
 
   if (!result.canReply) return;
@@ -174,7 +174,7 @@ export async function executeCounterCommandForTwitch(
   const command = resolveCommand(rawMessage, precomputedCommand);
   if (!command) return;
 
-  const result = await _buildCounterResponse(command, `[Twitch:${channel}]`, `twitch:${channel}`);
+  const result = await buildCounterResponse(command, `[Twitch:${channel}]`, `twitch:${channel}`);
   if (!result) return;
 
   if (!result.canReply) return;


### PR DESCRIPTION
## Summary
No other private helper in `commands/` uses a leading underscore; this was the sole exception.

Stacked on #634. Part of the same cleanup stack as #625 (closed) / #626–#634.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test`
- [x] `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ENwyn2MzgiF9mqvu7C4Bbo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed an internal counter-response helper without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->