### PR TITLE
Add renderOrError to dedupe the GET-handler try/log/render-500 tail

### DIFF
--- a/src/web/routes/admin.ts
+++ b/src/web/routes/admin.ts
@@ -12,7 +12,8 @@ import { csrfProtection } from '../csrf';
 import { requireManager, requireAdmin } from '../middleware';
 import { getSessionUser, getCurrentGuildId } from '../session';
 import { trimField, filterQueryParam } from './validation';
-import { renderError, renderView } from './viewHelpers';
+import { renderView } from './viewHelpers';
+import { renderOrError } from './errorHandling';
 import { runUserMutation } from './adminUserMutationQueue';
 import adminRefreshRouter, { getRefreshState } from './adminRefresh';
 import {
@@ -51,7 +52,7 @@ const KNOWN_ERRORS = new Set([
  */
 router.get('/users', requireManager, csrfProtection, async (req, res) => {
   const guildId = getCurrentGuildId(req);
-  try {
+  await renderOrError({ res, log, logLabel: 'Admin users error:', sessionUser: req.session.user, errorMessage: 'Failed to load users.' }, async () => {
     const users = await getGuildMemberUsers(guildId);
     renderView(res, 'admin', {
       user: req.session.user,
@@ -61,10 +62,7 @@ router.get('/users', requireManager, csrfProtection, async (req, res) => {
       error: filterQueryParam(req.query.error, KNOWN_ERRORS),
       refreshState: getRefreshState(guildId),
     });
-  } catch (err) {
-    log.error('Admin users error:', err);
-    renderError(res, 500, 'Failed to load users.', req.session.user);
-  }
+  });
 });
 
 /** Refresh the guild registry after a membership change; log but never fail the request. */

--- a/src/web/routes/alertsAdmin.ts
+++ b/src/web/routes/alertsAdmin.ts
@@ -6,7 +6,8 @@ import { getSessionUser } from '../session';
 import { getStreamerByDiscordId, getAlertConfigsForStreamer, ALERT_EVENT_TYPES, ALERT_TEXT_ANIMATIONS } from '../../db';
 import { PUBLIC_URL, ALERT_STATUS_MAX_SSE_PER_STREAMER } from '../../shared/config';
 import { filterQueryParam } from './validation';
-import { renderError, renderView } from './viewHelpers';
+import { renderView } from './viewHelpers';
+import { renderOrError } from './errorHandling';
 import { router as mutationsRouter } from './alertsAdminMutations';
 import { router as assetMutationsRouter, MAX_IMAGE_MB, MAX_SOUND_MB } from './alertsAssetMutations';
 import { connections as alertsSourceConnections } from './alertsOverlaySource';
@@ -38,7 +39,7 @@ const KNOWN_SUCCESSES = new Set([
  *   loading settings fails.
  */
 router.get('/settings', requireAuth, csrfProtection, async (req, res) => {
-  try {
+  await renderOrError({ res, log, logLabel: 'Alerts settings page error:', sessionUser: req.session.user, errorMessage: 'Failed to load alerts settings.' }, async () => {
     const streamer = await getStreamerByDiscordId(getSessionUser(req).discordId);
     const configs = streamer ? await getAlertConfigsForStreamer(streamer.id) : [];
     const configByType = Object.fromEntries(configs.map((c) => [c.event_type, c]));
@@ -56,10 +57,7 @@ router.get('/settings', requireAuth, csrfProtection, async (req, res) => {
       error:   filterQueryParam(req.query.error,   KNOWN_ERRORS),
       success: filterQueryParam(req.query.success, KNOWN_SUCCESSES),
     });
-  } catch (err) {
-    log.error('Alerts settings page error:', err);
-    renderError(res, 500, 'Failed to load alerts settings.', req.session.user);
-  }
+  });
 });
 
 /**

--- a/src/web/routes/counters.ts
+++ b/src/web/routes/counters.ts
@@ -12,8 +12,8 @@ import {
 import { csrfProtection } from '../csrf';
 import { requireAuth, requireGuildContext, requireMod, requireManager } from '../middleware';
 import { normalizeRequiredText, normalizeSingleTokenRequiredText, parsePositiveIntId, parseCheckboxField, filterQueryParam } from './validation';
-import { renderError, renderView } from './viewHelpers';
-import { logAndRedirectError, handleReservedOrConflictCommandError } from './errorHandling';
+import { renderView } from './viewHelpers';
+import { logAndRedirectError, handleReservedOrConflictCommandError, renderOrError } from './errorHandling';
 
 const log = createLogger('Web');
 const router = Router();
@@ -88,7 +88,7 @@ function validateAndNormalizeCounterForm(
  *   if loading counters fails.
  */
 router.get('/counters', requireAuth, csrfProtection, async (req, res) => {
-  try {
+  await renderOrError({ res, log, logLabel: 'Counters page error:', sessionUser: req.session.user, errorMessage: 'Failed to load counters page.' }, async () => {
     const counters = await getAllCounters();
 
     renderView(res, 'counters', {
@@ -98,10 +98,7 @@ router.get('/counters', requireAuth, csrfProtection, async (req, res) => {
       error: filterQueryParam(req.query.error, KNOWN_ERRORS),
       reset: req.query.reset === '1',
     });
-  } catch (err) {
-    log.error('Counters page error:', err);
-    renderError(res, 500, 'Failed to load counters page.', req.session.user);
-  }
+  });
 });
 
 /**

--- a/src/web/routes/dashboard.ts
+++ b/src/web/routes/dashboard.ts
@@ -4,7 +4,8 @@ import { getGuildScopedStatus } from '../guildScopedStatus';
 import { csrfProtection } from '../csrf';
 import { getStreamerByDiscordId, getSfxTriggerCount, getCustomCommandCount, getCounterCount, getRecentStreamerEvents } from '../../db';
 import { hasAuthFailedSubs } from '../../twitch/eventsub/twitchEventSubSubscriptions';
-import { renderError, renderView } from './viewHelpers';
+import { renderView } from './viewHelpers';
+import { renderOrError } from './errorHandling';
 import { RECENT_EVENTS_LIMIT, type DashboardEvent } from './dashboardEvents';
 
 const log = createLogger('Web');
@@ -20,7 +21,7 @@ const router = Router();
  *   500 error page if loading status/streamer data fails.
  */
 router.get('/', csrfProtection, async (req, res) => {
-  try {
+  await renderOrError({ res, log, logLabel: 'Dashboard error:', sessionUser: req.session.user, errorMessage: 'Failed to load dashboard data.' }, async () => {
     const [status, sfxCount, commandCount, counterCount, streamer] = await Promise.all([
       getGuildScopedStatus(req.session.user?.currentGuildId ?? null),
       getSfxTriggerCount(), getCustomCommandCount(), getCounterCount(),
@@ -46,10 +47,7 @@ router.get('/', csrfProtection, async (req, res) => {
       csrfToken: req.csrfToken(),
       needsReconnect,
     });
-  } catch (err) {
-    log.error('Dashboard error:', err);
-    renderError(res, 500, 'Failed to load dashboard data.', req.session.user);
-  }
+  });
 });
 
 export default router;

--- a/src/web/routes/errorHandling.test.ts
+++ b/src/web/routes/errorHandling.test.ts
@@ -12,7 +12,46 @@ vi.mock('../../db', () => {
 });
 
 import { ReservedCommandError, CommandConflictError, isMysqlDuplicateEntryError } from '../../db';
-import { logAndRedirectError, handleReservedOrConflictCommandError } from './errorHandling';
+import { logAndRedirectError, handleReservedOrConflictCommandError, renderOrError } from './errorHandling';
+
+describe('renderOrError', () => {
+  function mockRes() {
+    const render = vi.fn();
+    const status = vi.fn().mockReturnThis();
+    return { res: { render, status } as unknown as Response, render, status };
+  }
+
+  function mockLog() {
+    const error = vi.fn();
+    return { log: { error } as unknown as import('winston').Logger, error };
+  }
+
+  it('runs render and never touches the error path on success', async () => {
+    const { res, render, status } = mockRes();
+    const { log, error } = mockLog();
+    const doRender = vi.fn().mockResolvedValue(undefined);
+
+    await renderOrError({ res, log, logLabel: 'Widget page error:', sessionUser: undefined, errorMessage: 'Failed to load widgets.' }, doRender);
+
+    expect(doRender).toHaveBeenCalledOnce();
+    expect(error).not.toHaveBeenCalled();
+    expect(status).not.toHaveBeenCalled();
+    expect(render).not.toHaveBeenCalled();
+  });
+
+  it('logs the error and renders the error view with a 500 status when render throws', async () => {
+    const { res, render, status } = mockRes();
+    const { log, error } = mockLog();
+    const boom = new Error('boom');
+    const doRender = vi.fn().mockRejectedValue(boom);
+
+    await renderOrError({ res, log, logLabel: 'Widget page error:', sessionUser: undefined, errorMessage: 'Failed to load widgets.' }, doRender);
+
+    expect(error).toHaveBeenCalledWith('Widget page error:', boom);
+    expect(status).toHaveBeenCalledWith(500);
+    expect(render).toHaveBeenCalledWith('error', expect.objectContaining({ message: 'Failed to load widgets.' }));
+  });
+});
 
 describe('logAndRedirectError', () => {
   function mockRes() {

--- a/src/web/routes/errorHandling.ts
+++ b/src/web/routes/errorHandling.ts
@@ -1,10 +1,12 @@
 import type { Response } from 'express';
 import type { Logger } from 'winston';
+import type { SessionUser } from '../../types/express';
 import {
   ReservedCommandError,
   CommandConflictError,
   isMysqlDuplicateEntryError,
 } from '../../db';
+import { renderError } from './viewHelpers';
 
 /** Arguments for {@link logAndRedirectError}. */
 export interface LogAndRedirectErrorOptions {
@@ -38,6 +40,36 @@ export function logAndRedirectError({
 }: LogAndRedirectErrorOptions): void {
   log.error(logLabel, err);
   res.redirect(`${basePath}?error=${errorCode}`);
+}
+
+/** Arguments for {@link renderOrError}. */
+export interface RenderOrErrorOptions {
+  /** Express response object. */
+  res: Response;
+  /** Logger to record the error on (module-scoped `createLogger` instance). */
+  log: Logger;
+  /** Message prefix passed to `log.error`, matching the handler's existing wording. */
+  logLabel: string;
+  /** Current session user, forwarded to `renderError` so the error page still shows a logged-in nav. */
+  sessionUser: SessionUser | undefined;
+  /** Human-readable message shown on the 500 error page. */
+  errorMessage: string;
+}
+
+/**
+ * Runs `render`, and on failure logs the error and renders a generic 500 error page instead.
+ * Standardizes the generic `try { ...renderView(...) } catch (err) { log.error(...);
+ * renderError(...) }` tail repeated across GET route handlers.
+ * @param options - See {@link RenderOrErrorOptions}.
+ * @param render - Async work that loads data and calls `renderView` on success.
+ */
+export async function renderOrError(options: RenderOrErrorOptions, render: () => Promise<void>): Promise<void> {
+  try {
+    await render();
+  } catch (err) {
+    options.log.error(options.logLabel, err);
+    renderError(options.res, 500, options.errorMessage, options.sessionUser);
+  }
 }
 
 /** Arguments for {@link handleReservedOrConflictCommandError}. */

--- a/src/web/routes/sfx.ts
+++ b/src/web/routes/sfx.ts
@@ -6,7 +6,8 @@ import { csrfProtection } from '../csrf';
 import { SFX_FOLDER, SFX_MAX_FILE_MB, OPENAI_API_KEY } from '../../shared/config';
 import { safeResolve } from '../../shared/pathUtils';
 import { filterQueryParam, parsePositiveIntId } from './validation';
-import { renderError, renderView } from './viewHelpers';
+import { renderView } from './viewHelpers';
+import { renderOrError } from './errorHandling';
 
 const log = createLogger('Web');
 const router = Router();
@@ -46,7 +47,7 @@ const KNOWN_SUCCESS = new Set([
  * matching the server-side requireOwnerJson guard on its route.
  */
 router.get('/sfx', csrfProtection, async (req, res) => {
-  try {
+  await renderOrError({ res, log, logLabel: 'SFX error:', sessionUser: req.session.user, errorMessage: 'Failed to load SFX data.' }, async () => {
     const [triggers, categories] = await Promise.all([getAllSfxTriggers(), getAllCategories()]);
     const canManage = (req.session.user?.accessLevel ?? 0) >= AccessLevel.MOD;
     const canSuggestDescriptions = !!req.session.user?.isOwner && OPENAI_API_KEY !== '';
@@ -61,10 +62,7 @@ router.get('/sfx', csrfProtection, async (req, res) => {
       error: filterQueryParam(req.query.error, KNOWN_ERRORS),
       success: filterQueryParam(req.query.success, KNOWN_SUCCESS),
     });
-  } catch (err) {
-    log.error('SFX error:', err);
-    renderError(res, 500, 'Failed to load SFX data.', req.session.user);
-  }
+  });
 });
 
 /**

--- a/src/web/routes/timers.ts
+++ b/src/web/routes/timers.ts
@@ -4,7 +4,8 @@ import { DbTimerCommandWithAssignments, DbUser, getAllTimerCommandsWithAssignmen
 import { csrfProtection } from '../csrf';
 import { requireGuildContext, requireManager } from '../middleware';
 import { filterQueryParam } from './validation';
-import { renderError, renderView } from './viewHelpers';
+import { renderView } from './viewHelpers';
+import { renderOrError } from './errorHandling';
 import timersMutationsRouter from './timersMutations';
 import timerAssignmentsRouter from './timerAssignments';
 
@@ -28,7 +29,7 @@ interface TimerViewModel extends DbTimerCommandWithAssignments {
  * assignments, so authentication alone isn't enough (mutations additionally require Mod+).
  */
 router.get('/timers', requireGuildContext, requireManager, csrfProtection, async (req, res) => {
-  try {
+  await renderOrError({ res, log, logLabel: 'Timers page error:', sessionUser: req.session.user, errorMessage: 'Failed to load timers page.' }, async () => {
     const [timers, users] = await Promise.all([
       getAllTimerCommandsWithAssignments(),
       getAllUsers(),
@@ -49,10 +50,7 @@ router.get('/timers', requireGuildContext, requireManager, csrfProtection, async
       csrfToken: req.csrfToken(),
       error: filterQueryParam(req.query.error, KNOWN_ERRORS),
     });
-  } catch (err) {
-    log.error('Timers page error:', err);
-    renderError(res, 500, 'Failed to load timers page.', req.session.user);
-  }
+  });
 });
 
 router.use(timersMutationsRouter);


### PR DESCRIPTION
## Summary
`logAndRedirectError` already standardized the POST error-redirect tail; add an analogous `renderOrError` for the repeated GET-handler shape (`try { ...renderView }`, `catch { log.error; renderError }`), and apply it to a representative sample of GET handlers (admin, alertsAdmin, counters, dashboard, sfx, timers) rather than sweeping every occurrence in one change. The remaining GET handlers can adopt the same helper incrementally.

Stacked on #635 — last PR in the stack. Part of the same cleanup stack as #625 (closed) / #626–#635.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test`
- [x] `npm run lint`
- [x] `npm run check:circular`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ENwyn2MzgiF9mqvu7C4Bbo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized error handling across administrative, dashboard, alerts, counters, SFX, and timers pages.
  - Rendering failures now consistently produce a 500 error page with the configured message while preserving the logged-in navigation experience.

- **Tests**
  - Added coverage for successful page rendering and error scenarios, including logging and HTTP 500 responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->