### PR TITLE
Guard against missing twitch_user_id during EventSub token refresh

### DIFF
--- a/src/twitch/eventsub/twitchApiEventSub.test.ts
+++ b/src/twitch/eventsub/twitchApiEventSub.test.ts
@@ -135,6 +135,17 @@ describe('getValidToken', () => {
     expect(token).toBeNull();
     expect(twitchFetch).not.toHaveBeenCalled();
   });
+
+  it('returns null and never calls twitchFetch/saveStreamerToken when twitch_user_id is unexpectedly null', async () => {
+    const streamer = makeStreamer({
+      eventsub_token_expiry: String(Date.now() + 1 * 60 * 1000),
+      twitch_user_id: null,
+    });
+    const token = await getValidToken(streamer);
+    expect(token).toBeNull();
+    expect(twitchFetch).not.toHaveBeenCalled();
+    expect(saveStreamerToken).not.toHaveBeenCalled();
+  });
 });
 
 // ─── exchangeCode ─────────────────────────────────────────────────────────────

--- a/src/twitch/eventsub/twitchApiEventSub.ts
+++ b/src/twitch/eventsub/twitchApiEventSub.ts
@@ -24,10 +24,18 @@ export async function getValidToken(streamer: DbStreamerEventSub): Promise<strin
     log.warn(`No refresh token for ${streamer.twitch_name ?? 'unknown'}`);
     return null;
   }
+  if (!streamer.twitch_user_id) {
+    // Should not happen: eventsub_access_token and twitch_user_id are only ever written/cleared
+    // together (see saveStreamerToken/clearStreamerToken). Treat as a permanent failure rather
+    // than asserting non-null and letting mysql2 reject `undefined` as a bind parameter, which
+    // would otherwise be misclassified below as a transient error that never self-heals.
+    log.error(`Token refresh for ${streamer.twitch_name ?? 'unknown'} has an access token but no twitch_user_id — refusing to save; re-authorization required.`);
+    return null;
+  }
   try {
     const tokens = await refreshUserToken(streamer.eventsub_refresh_token);
     const expiryMs = tokens.expires_in != null ? Date.now() + tokens.expires_in * 1000 - 60_000 : null;
-    await saveStreamerToken(streamer.id, streamer.twitch_user_id!, tokens.access_token, tokens.refresh_token, expiryMs);
+    await saveStreamerToken(streamer.id, streamer.twitch_user_id, tokens.access_token, tokens.refresh_token, expiryMs);
     log.info(`Token refreshed for ${streamer.twitch_name ?? 'unknown'}`);
     return tokens.access_token;
   } catch (err) {

--- a/src/twitch/eventsub/twitchApiEventSub.ts
+++ b/src/twitch/eventsub/twitchApiEventSub.ts
@@ -20,22 +20,40 @@ export async function getValidToken(streamer: DbStreamerEventSub): Promise<strin
   const needsRefresh = streamer.eventsub_token_expiry != null
     && Date.now() > Number(streamer.eventsub_token_expiry) - TOKEN_BUFFER_MS;
   if (!needsRefresh) return streamer.eventsub_access_token;
-  if (!streamer.eventsub_refresh_token) {
-    log.warn(`No refresh token for ${streamer.twitch_name ?? 'unknown'}`);
+
+  if (!streamer.eventsub_refresh_token || !streamer.twitch_user_id) {
+    if (!streamer.eventsub_refresh_token) {
+      log.warn(`No refresh token for ${streamer.twitch_name ?? 'unknown'}`);
+    } else {
+      // Should not happen: eventsub_access_token and twitch_user_id are only ever written/cleared
+      // together (see saveStreamerToken/clearStreamerToken). Treat as a permanent failure rather
+      // than asserting non-null and letting mysql2 reject `undefined` as a bind parameter, which
+      // would otherwise be misclassified below as a transient error that never self-heals.
+      log.error(`Token refresh for ${streamer.twitch_name ?? 'unknown'} has an access token but no twitch_user_id — refusing to save; re-authorization required.`);
+    }
     return null;
   }
-  if (!streamer.twitch_user_id) {
-    // Should not happen: eventsub_access_token and twitch_user_id are only ever written/cleared
-    // together (see saveStreamerToken/clearStreamerToken). Treat as a permanent failure rather
-    // than asserting non-null and letting mysql2 reject `undefined` as a bind parameter, which
-    // would otherwise be misclassified below as a transient error that never self-heals.
-    log.error(`Token refresh for ${streamer.twitch_name ?? 'unknown'} has an access token but no twitch_user_id — refusing to save; re-authorization required.`);
-    return null;
-  }
+
+  return refreshAndSaveToken(streamer, streamer.eventsub_refresh_token, streamer.twitch_user_id);
+}
+
+/**
+ * Exchanges `refreshToken` for a fresh EventSub token via Twitch and persists it to `streamer`'s
+ * row. On an unrecoverable auth failure (400/401), clears the stored token instead.
+ * @param streamer - Streamer row to refresh/persist the token for.
+ * @param refreshToken - The current refresh token to exchange.
+ * @param twitchUserId - The streamer's Twitch user ID, persisted alongside the new token.
+ * @returns The refreshed access token, or null if the refresh failed.
+ */
+async function refreshAndSaveToken(
+  streamer: DbStreamerEventSub,
+  refreshToken: string,
+  twitchUserId: string,
+): Promise<string | null> {
   try {
-    const tokens = await refreshUserToken(streamer.eventsub_refresh_token);
+    const tokens = await refreshUserToken(refreshToken);
     const expiryMs = tokens.expires_in != null ? Date.now() + tokens.expires_in * 1000 - 60_000 : null;
-    await saveStreamerToken(streamer.id, streamer.twitch_user_id, tokens.access_token, tokens.refresh_token, expiryMs);
+    await saveStreamerToken(streamer.id, twitchUserId, tokens.access_token, tokens.refresh_token, expiryMs);
     log.info(`Token refreshed for ${streamer.twitch_name ?? 'unknown'}`);
     return tokens.access_token;
   } catch (err) {


### PR DESCRIPTION
## Summary
- `getValidToken` in `src/twitch/eventsub/twitchApiEventSub.ts` used a non-null assertion (`streamer.twitch_user_id!`) when saving a refreshed token, even though the field is typed `string | null`.
- `eventsub_access_token` and `twitch_user_id` are only ever written/cleared together (see `saveStreamerToken`/`clearStreamerToken` in `src/db/eventSub.ts`), so this is latent rather than currently reachable — but if a row ever drifted into that state, the `mysql2` bind would throw on `undefined`, and the surrounding `catch` would log it as a "transient error, will retry on next reload" that in fact never retries successfully, since the same null value persists.
- Added an explicit guard that logs distinctly and returns `null` before attempting the refresh, so this failure mode is visible instead of silently non-self-healing.

## Test plan
- Added a test asserting `getValidToken` returns `null` and never calls `twitchFetch`/`saveStreamerToken` when `twitch_user_id` is null.
- `npx tsc --noEmit && npm test` — all 3519 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTTsxupLZELmetjUwtZpCS

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTTsxupLZELmetjUwtZpCS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling when a streamer’s Twitch user ID is missing, preventing unnecessary token refresh attempts and returning a clear failure result.
  - Added error logging for invalid token data.

- **Tests**
  - Added coverage confirming that token refresh and token-saving actions are skipped when the Twitch user ID is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->