### PR TITLE
Record a failed poll when no Twitch user IDs resolve

### DIFF
--- a/src/twitch/monitor/twitchMonitor.test.ts
+++ b/src/twitch/monitor/twitchMonitor.test.ts
@@ -33,6 +33,7 @@ import { getUsers, getStreams } from '../twitchApi';
 import { cancelOfflineTimersForLogin, handleStreamOffline } from './twitchMonitorOffline';
 import { getDiscordClient } from '../../discord/discordBot';
 import * as twitchMonitorAnnouncements from './twitchMonitorAnnouncements';
+import { getHealthSnapshot } from '../../shared/healthStore';
 
 function makeTextChannel(msgOverrides: Record<string, unknown> = {}) {
   const message = { id: 'msg1', channelId: '111', delete: vi.fn().mockResolvedValue(undefined), edit: vi.fn().mockResolvedValue(undefined), ...msgOverrides };
@@ -246,6 +247,34 @@ describe('60s poll interval', () => {
     vi.mocked(getStreams).mockResolvedValueOnce([makeStream()] as any);
     await vi.advanceTimersByTimeAsync(60_000);
     expect(getLiveStates('guild-1')).toHaveLength(1);
+  });
+});
+
+describe('60s poll interval with no resolved user IDs', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    // Streamers are configured, but none of their logins resolved to a Twitch user ID
+    // (e.g. every configured twitch_name is currently invalid, or getUsers failed to
+    // resolve any of them) — loginToUserId ends up empty even though streamersData isn't.
+    vi.mocked(getAllStreamersWithGroups).mockResolvedValue([makeStreamer()] as any);
+    vi.mocked(getUsers).mockResolvedValue([]);
+    vi.mocked(getDiscordClient).mockReturnValue(makeDiscordClient() as any);
+    await startTwitchMonitor();
+  });
+
+  afterEach(async () => {
+    await stopTwitchMonitor();
+    vi.useRealTimers();
+  });
+
+  it('records a failed poll instead of silently no-oping', async () => {
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(getStreams).not.toHaveBeenCalled();
+    const snapshot = getHealthSnapshot();
+    expect(snapshot.monitor.lastPollOk).toBe(false);
+    expect(snapshot.monitor.lastError).toBe('No Twitch user IDs resolved for any configured streamer.');
   });
 });
 

--- a/src/twitch/monitor/twitchMonitor.ts
+++ b/src/twitch/monitor/twitchMonitor.ts
@@ -47,7 +47,13 @@ async function pollStreams(): Promise<void> {
   currentPollPromise = (async () => {
     try {
       const userIds = Array.from(loginToUserId.values());
-      if (userIds.length === 0) return;
+      if (userIds.length === 0) {
+        // streamersData is non-empty (checked above) but no login resolved to a Twitch user ID —
+        // e.g. every configured twitch_name is currently invalid, or getUsers failed at startup/reload.
+        // Record this as a failed poll so the ops dashboard's health signal doesn't go stale/silent.
+        recordMonitorPoll(false, 'No Twitch user IDs resolved for any configured streamer.');
+        return;
+      }
 
       const liveStreams = await getStreams(userIds);
       const liveByUserId = new Map(


### PR DESCRIPTION
## Summary
- `pollStreams()` in `src/twitch/monitor/twitchMonitor.ts` returned early with no `healthStore` signal whenever `streamersData` was non-empty but `loginToUserId` resolved to zero entries (e.g. every configured `twitch_name` is currently invalid, or `getUsers` failed to resolve any of them at startup/reload).
- That left the ops dashboard showing a stale "last successful poll" timestamp instead of any failure indicator, undercutting the whole point of `healthStore` tracking this.
- Now calls `recordMonitorPoll(false, ...)` on that branch before returning, so the failure is visible.

## Test plan
- Added a test simulating streamers configured in the DB but `getUsers` resolving none of them, asserting `getHealthSnapshot().monitor.lastPollOk` is `false` with the expected error message.
- `npx tsc --noEmit && npm test` — all 3519 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTTsxupLZELmetjUwtZpCS

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTTsxupLZELmetjUwtZpCS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Twitch monitoring now reports a failed health status when configured streamers cannot be resolved, instead of silently skipping the monitoring poll.
  - Stream requests are no longer attempted when no streamer IDs are successfully resolved.
  - Health information now includes an error message explaining why the monitoring poll failed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->