### PR TITLE
Import getDiscordClient from discordClientStore in voicePresence

### DIFF
--- a/src/discord/voicePresence.test.ts
+++ b/src/discord/voicePresence.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('./guildRegistry', () => ({ getRegisteredGuildIds: vi.fn() }));
-vi.mock('./discordBot', () => ({ getDiscordClient: vi.fn() }));
+vi.mock('./discordClientStore', () => ({ getDiscordClient: vi.fn() }));
 
 import { getRegisteredGuildIds } from './guildRegistry';
-import { getDiscordClient } from './discordBot';
+import { getDiscordClient } from './discordClientStore';
 import { getActiveGuildForUser, resolveGuildIdForDiscordId } from './voicePresence';
 
 function makeClient(guildVoiceChannels: Record<string, Record<string, string>>) {

--- a/src/discord/voicePresence.ts
+++ b/src/discord/voicePresence.ts
@@ -1,6 +1,6 @@
 import { Client } from 'discord.js';
 import { getRegisteredGuildIds } from './guildRegistry';
-import { getDiscordClient } from './discordBot';
+import { getDiscordClient } from './discordClientStore';
 
 /**
  * Returns the guild ID in which the given Discord user currently has a live


### PR DESCRIPTION
## Summary
- `src/discord/voicePresence.ts` imported `getDiscordClient` from `./discordBot`, which only re-exports it from `./discordClientStore` (the module that actually owns it).
- This pulled `voicePresence.ts` — and transitively `streamdeckGuildResolution.ts`/`twitchGuildResolutionRuntime.ts` — into `discordBot.ts`'s much heavier import graph (command routers, DB, admin mutation queue, `ownerAlerts.ts`, guild registry) purely to get one accessor function.
- No circular dependency exists today (`npm run check:circular` passes both before and after), but importing from the lightweight source module directly is the pattern `discordUtils.ts` already follows, and avoids a latent risk as the import graph grows.
- Switched the import (and its test's `vi.mock` target) to `./discordClientStore` directly.

## Test plan
- `npx tsc --noEmit && npm run check:circular && npm test` — all pass (3518 tests; count is because one prior fix's test isn't on this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTTsxupLZELmetjUwtZpCS

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTTsxupLZELmetjUwtZpCS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal Discord client access without changing user-facing behavior or functionality.
* **Tests**
  * Updated voice presence test coverage to use the current Discord client source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->