### PR TITLE
Correct SEND_TIMEOUT_MS doc comment to match current call path

### DIFF
--- a/src/twitch/twitchSendQueue.ts
+++ b/src/twitch/twitchSendQueue.ts
@@ -43,11 +43,15 @@ const NON_PRIVILEGED_CHANNEL_FLOOR_MS = 1_000;
 const MAX_PRIVILEGE_RECHECKS = 5;
 
 /**
- * Every send in this module runs behind a single global queue, so one stalled `send()` (the raw
- * Twurple IRC send used by `sendRawChatMessage()` has no built-in timeout and can hang
- * indefinitely on a stalled socket) would otherwise wedge every later send, across every channel
- * and feature, forever. Bounding it here
- * guarantees the queue always frees up, even though the underlying send may still be stuck.
+ * Bounds how long a queued `send()` callback may run before {@link throttledTwitchSend} gives up
+ * on it and frees {@link globalQueue} for the next send. This guards the callback in general —
+ * for the current sole caller, `sendRawChatMessage()`'s underlying `ChatClient#irc.say()` is a
+ * synchronous, fire-and-forget IRC write with no ack/flush promise, so this specific call always
+ * settles on the same tick and the timeout never actually fires for it; a genuinely stalled
+ * socket write on that path shows up only as Twitch never receiving the message, not as a
+ * logged timeout. If a caller is ever added whose `send()` can itself hang (e.g. one that awaits
+ * a real network round-trip), this is what stops it from wedging every later send, across every
+ * channel and feature, forever.
  */
 const SEND_TIMEOUT_MS = 10_000;
 


### PR DESCRIPTION
## Summary
- `SEND_TIMEOUT_MS`'s doc comment in `src/twitch/twitchSendQueue.ts` claimed it exists because "the raw Twurple IRC send... has no built-in timeout and can hang indefinitely on a stalled socket."
- In practice the only caller wraps `sendRawChatMessage()`, which calls `ChatClient#irc.say()` — a synchronous, `void`-returning, fire-and-forget IRC write with no ack/flush promise. The wrapping `send()` always settles on the same tick regardless of socket health, so the timeout can never actually fire for this call path today.
- Not a functional bug (the timeout is inert, not wrong), but the stale rationale could mislead a future maintainer into thinking a stalled socket is guarded against here when it isn't — a genuinely stuck write currently shows up only as "Twitch never received the message," with nothing timing out or logging.
- Rewrote the comment to describe what the timeout actually guards against today and why it doesn't fire for the current caller.

## Test plan
- Comment-only change. `npx tsc --noEmit && npm test` — all 3518 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTTsxupLZELmetjUwtZpCS

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTTsxupLZELmetjUwtZpCS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the scope and current behavior of the queued send callback timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->