### PR TITLE
Prune chat-activity counts when a channel is parted

### DIFF
--- a/src/twitch/twitchBot.test.ts
+++ b/src/twitch/twitchBot.test.ts
@@ -133,6 +133,7 @@ vi.mock('../commands/countdownHandler', () => ({
 
 vi.mock('./twitchChatActivity', () => ({
   recordChatMessage: vi.fn(),
+  forgetChannelChatActivity: vi.fn(),
 }));
 
 // ─── Imports (after mocks) ────────────────────────────────────────────────────

--- a/src/twitch/twitchChannelMembership.test.ts
+++ b/src/twitch/twitchChannelMembership.test.ts
@@ -27,6 +27,7 @@ import {
 import { getTwitchEnabledChannels } from '../db';
 import { getUsers } from './twitchApi';
 import { setTwitchChannel } from '../shared/statusStore';
+import { recordChatMessage, getMessageCount, clearChatActivity } from './twitchChatActivity';
 
 /**
  * Builds a minimal fake Twurple chat client, pre-seeded with the given already-joined channels.
@@ -47,6 +48,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.useFakeTimers();
   clearMembershipState();
+  clearChatActivity();
   setChatClient(null);
   setConnected(false);
   setChannelJoinedHook(() => {});
@@ -225,6 +227,32 @@ describe('partTwitchChannel', () => {
     await expect(partTwitchChannel('alice')).rejects.toThrow('part failed');
 
     expect(getActiveChannels().has('alice')).toBe(false);
+  });
+
+  it('forgets recorded chat activity when parting via the client', async () => {
+    const client = makeMockClient(['alice']);
+    setChatClient(client as any);
+    setConnected(true);
+    await joinTwitchChannel('alice');
+    recordChatMessage('alice');
+    expect(getMessageCount('alice')).toBe(1);
+
+    await partTwitchChannel('alice');
+
+    expect(getMessageCount('alice')).toBe(0);
+  });
+
+  it('forgets recorded chat activity when parting while disconnected', async () => {
+    const client = makeMockClient();
+    setChatClient(client as any);
+    setConnected(false);
+    await joinTwitchChannel('alice');
+    recordChatMessage('alice');
+    expect(getMessageCount('alice')).toBe(1);
+
+    await partTwitchChannel('alice');
+
+    expect(getMessageCount('alice')).toBe(0);
   });
 });
 

--- a/src/twitch/twitchChannelMembership.ts
+++ b/src/twitch/twitchChannelMembership.ts
@@ -7,6 +7,7 @@ import { createMutationQueue } from '../shared/mutationQueue';
 import { withTimeout } from './twitchSendQueue';
 import { createLogger } from '../shared/logger';
 import { throttledJoin, compensateIfStale, resetJoinGate, partAsync, JOIN_PART_TIMEOUT_MS, MembershipDeps } from './twitchChannelNetworkOps';
+import { forgetChannelChatActivity } from './twitchChatActivity';
 
 const log = createLogger('Twitch');
 
@@ -362,6 +363,7 @@ export async function partTwitchChannel(channel: string): Promise<void> {
       // any stale Twurple channel memberships on the next successful connect.
       activeChannels.delete(normalized);
       activeChannelUserIds.delete(normalized);
+      forgetChannelChatActivity(normalized);
       setTwitchChannel(normalized, false);
       return;
     }
@@ -369,6 +371,7 @@ export async function partTwitchChannel(channel: string): Promise<void> {
     try {
       activeChannels.delete(normalized);
       activeChannelUserIds.delete(normalized);
+      forgetChannelChatActivity(normalized);
       setTwitchChannel(normalized, false);
       if (isChannelJoined(normalized)) {
         const generation = captureGeneration();

--- a/src/twitch/twitchChatActivity.ts
+++ b/src/twitch/twitchChatActivity.ts
@@ -16,6 +16,15 @@ export function getMessageCount(channel: string): number {
   return messageCounts.get(channel) ?? 0;
 }
 
+/**
+ * Forgets a channel's recorded chat activity, so it stops occupying memory once the bot is no
+ * longer active in it. Safe to call for a channel with no state (no-op). Called from
+ * `partTwitchChannel`; a channel the bot joins again later starts fresh.
+ */
+export function forgetChannelChatActivity(channel: string): void {
+  messageCounts.delete(channel);
+}
+
 /** Clears all recorded chat activity. Test-only. */
 export function clearChatActivity(): void {
   messageCounts.clear();


### PR DESCRIPTION
## Summary
- `messageCounts` in `src/twitch/twitchChatActivity.ts` is a plain `Map<string, number>` keyed by channel, with no pruning when a channel is parted/disabled — unlike every other per-channel/per-login map in this codebase (e.g. the discord/custom-command cooldown gates, which have an explicit `forgetGuild*` cleanup called from the relevant leave/delete handler).
- Practically bounded by the small number of configured channels, so not a real leak, but worth fixing for consistency.
- Added `forgetChannelChatActivity(channel)` and call it from `partTwitchChannel` in `src/twitch/twitchChannelMembership.ts`, alongside the existing `activeChannels`/`activeChannelUserIds` cleanup (both the disconnected-client early-return and the normal part path).

## Test plan
- Added two tests to `twitchChannelMembership.test.ts` covering both part paths (connected-with-client-part, and disconnected-local-only), asserting `getMessageCount` returns to 0 after parting.
- Updated the `./twitchChatActivity` mock in `twitchBot.test.ts` (which also exercises `partTwitchChannel`) to include the new export.
- `npx tsc --noEmit && npm run check:circular && npm test` — all 3520 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTTsxupLZELmetjUwtZpCS

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTTsxupLZELmetjUwtZpCS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Leaving a Twitch channel now clears its recorded chat activity.
  - Chat message counts reset correctly whether the channel is left while connected or disconnected.
  - Removed channel activity data is no longer retained in memory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->