### PR TITLE
Floor curve to a positive minimum in computePrice

### DIFF
--- a/src/twitch/pricing/rewardPricingMath.test.ts
+++ b/src/twitch/pricing/rewardPricingMath.test.ts
@@ -60,6 +60,21 @@ describe('computePrice', () => {
   it('is unaffected by a missing roundToNearest', () => {
     expect(computePrice(0.5, config)).toBe(483);
   });
+
+  it('floors curve=0 instead of pinning the price to max at every demand level', () => {
+    const zeroCurve = { baseCost: 200, maxMultiplier: 4, curve: 0 };
+    // Math.pow(x, 0) === 1 for every x, including 0 — without a floor this would return
+    // baseCost * (1 + maxMultiplier) even at demand=0, defeating the curve entirely.
+    expect(computePrice(0, zeroCurve)).toBe(200);
+    // Still less than the max at partial demand, since a near-zero curve is nearly flat but not 1.
+    expect(computePrice(0.5, zeroCurve)).toBeLessThan(1000);
+  });
+
+  it('floors a negative curve the same way as curve=0', () => {
+    const negativeCurve = { baseCost: 200, maxMultiplier: 4, curve: -1 };
+    expect(computePrice(0, negativeCurve)).toBe(200);
+    expect(computePrice(0.5, negativeCurve)).toBeLessThan(1000);
+  });
 });
 
 describe('decayDemand', () => {

--- a/src/twitch/pricing/rewardPricingMath.ts
+++ b/src/twitch/pricing/rewardPricingMath.ts
@@ -2,10 +2,14 @@
 export interface RewardPricingConfig {
   baseCost: number;
   maxMultiplier: number;
+  /** Must be strictly positive — see {@link computePrice} for why `curve <= 0` breaks the formula. */
   curve: number;
   /** Rounds the computed price to the nearest multiple of this many points (e.g. 5 or 10). Omit, 0, or a non-positive value disables rounding. */
   roundToNearest?: number;
 }
+
+/** Smallest `curve` value {@link computePrice} will actually use — see there for why. */
+const MIN_CURVE = 0.01;
 
 /**
  * Computes the current redemption price from demand and a reward's pricing config.
@@ -14,13 +18,22 @@ export interface RewardPricingConfig {
  * back into range — rounding to a coarse step can otherwise push the price below `baseCost`
  * (even to a Twitch-invalid 0) or above the max.
  *
+ * `config.curve` is floored to {@link MIN_CURVE} if it isn't strictly positive: the admin panel
+ * already rejects `curve <= 0` at write time (`parsePositiveNumberField`), but `Math.pow(x, 0)`
+ * is `1` for every `x` including `0`, so a `curve` of `0` (or negative) reaching this function —
+ * a stale row predating that validation, or a value edited directly in the DB, which is managed
+ * outside this repo — would otherwise pin the price to the maximum at *every* demand level,
+ * including zero, defeating the curve entirely instead of just crashing or being a config-space
+ * curiosity.
+ *
  * @param demand - Current demand value; clamped to [0,1] before use.
  * @param config - The reward's pricing configuration.
  * @returns The price, always bounded to [baseCost, baseCost*(1+maxMultiplier)].
  */
 export function computePrice(demand: number, config: RewardPricingConfig): number {
   const usage = Math.min(1, Math.max(0, demand));
-  const curved = Math.pow(usage, config.curve);
+  const curve = config.curve > 0 ? config.curve : MIN_CURVE;
+  const curved = Math.pow(usage, curve);
   const raw = config.baseCost * (1 + curved * config.maxMultiplier);
   if (config.roundToNearest && config.roundToNearest > 0) {
     const max = config.baseCost * (1 + config.maxMultiplier);


### PR DESCRIPTION
## Summary
- `computePrice` in `src/twitch/pricing/rewardPricingMath.ts` computed `Math.pow(usage, config.curve)` with no lower bound on `curve`. `Math.pow(x, 0)` is `1` for every `x` including `0`, so a `curve` of `0` (or negative) pinned the price to `baseCost * (1 + maxMultiplier)` — the maximum — at every demand level, including demand `0`, defeating the entire point of the demand curve.
- The admin panel already rejects `curve <= 0` at write time (`parsePositiveNumberField` in `channelPointsAdminShared.ts`), so this is a defense-in-depth gap: only reachable via a stale row predating that validation, or a value edited directly in the DB (which `DATABASE-SCHEMA.md` notes is managed outside this repo).
- Floored `curve` to a small positive minimum (`0.01`) inside `computePrice` itself, so the single point of truth for the pricing formula can't be broken this way regardless of how a bad value got there.

## Test plan
- Added tests for `curve: 0` and `curve: -1`, asserting the price no longer pins to the max at `demand=0` and stays below it at partial demand.
- `npx tsc --noEmit && npm test` — all 3520 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTTsxupLZELmetjUwtZpCS

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTTsxupLZELmetjUwtZpCS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected reward pricing when the curve value is zero or negative.
  - Prices now start at the base cost and increase appropriately with demand instead of remaining fixed at the maximum.
  - Added validation guidance requiring a strictly positive curve value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->