### PR TITLE
Share the per-guild SFX cooldown/in-flight guard with the Streamdeck route

### DIFF
--- a/src/commands/commandRouter.ts
+++ b/src/commands/commandRouter.ts
@@ -11,15 +11,19 @@ import { resolveCommand } from './commandUtils';
 
 const log = createLogger('CommandRouter');
 
-interface GuildCommandState {
+export interface GuildCommandState {
   lastPlayedAt: number;
   inFlight: boolean;
 }
 
 const guildStates = new Map<string, GuildCommandState>();
 
-/** Returns the cooldown/in-flight state for a guild, creating a fresh record on first use. */
-function getGuildCommandState(guildId: string): GuildCommandState {
+/**
+ * Returns the cooldown/in-flight state for a guild, creating a fresh record on first use.
+ * Exported so other SFX-triggering entry points (e.g. the Streamdeck API route) share the
+ * same per-guild cooldown/in-flight guard as chat-triggered commands, rather than reimplementing it.
+ */
+export function getGuildCommandState(guildId: string): GuildCommandState {
   return getOrCreate(guildStates, guildId, () => ({ lastPlayedAt: 0, inFlight: false }));
 }
 
@@ -46,7 +50,7 @@ export function forgetGuildCommandState(guildId: string): void {
  */
 async function lookupAndPlay(
   command: string,
-  source: 'twitch' | 'discord',
+  source: 'twitch' | 'discord' | 'streamdeck',
   guildId: string,
   state: GuildCommandState,
 ): Promise<void> {
@@ -93,9 +97,9 @@ async function lookupAndPlay(
  * @returns True if the slot was claimed; false if the guild is on cooldown or already
  *   playing/in-flight, in which case `state` is left untouched.
  */
-function tryClaimGuildSlot(
+export function tryClaimGuildSlot(
   guildId: string,
-  source: 'twitch' | 'discord',
+  source: 'twitch' | 'discord' | 'streamdeck',
   command: string,
   state: GuildCommandState,
 ): boolean {
@@ -133,7 +137,7 @@ function tryClaimGuildSlot(
  */
 export async function handleCommand(
   rawMessage: string,
-  source: 'twitch' | 'discord',
+  source: 'twitch' | 'discord' | 'streamdeck',
   guildId: string | null,
   precomputedCommand?: string | null,
 ): Promise<void> {

--- a/src/web/routes/streamdeck.test.ts
+++ b/src/web/routes/streamdeck.test.ts
@@ -40,6 +40,11 @@ vi.mock('../../discord/discordUtils', () => ({
 vi.mock('../../audio/audioPlayer', () => ({
   connect: vi.fn(),
   disconnect: vi.fn(),
+  isPlaying: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('../../shared/config', () => ({
+  GLOBAL_COOLDOWN_MS: 3_000,
 }));
 
 vi.mock('../../discord/discordBot', () => ({

--- a/src/web/routes/streamdeckSfx.test.ts
+++ b/src/web/routes/streamdeckSfx.test.ts
@@ -29,6 +29,14 @@ vi.mock('../../audio/sfxPlayer', () => ({
   },
 }));
 
+vi.mock('../../audio/audioPlayer', () => ({
+  isPlaying: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('../../shared/config', () => ({
+  GLOBAL_COOLDOWN_MS: 3_000,
+}));
+
 vi.mock('../../shared/statusStore', () => ({
   setVoicePlaying: vi.fn(),
 }));
@@ -52,6 +60,7 @@ import { setVoicePlaying } from '../../shared/statusStore';
 import { getDiscordClient } from '../../discord/discordBot';
 import { getActiveGuildForUser } from '../../discord/voicePresence';
 import { buildTestApp } from '../../test-utils/expressTestApp';
+import { forgetGuildCommandState } from '../../commands/commandRouter';
 
 const TRIGGER: SfxTrigger = {
   id: BigInt(1),
@@ -79,6 +88,10 @@ function buildApp() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // POST /sfx shares its per-guild cooldown/in-flight guard with commandRouter.ts's real,
+  // module-singleton guildStates map — reset it so one test's successful play doesn't leave
+  // 'guild-123' on cooldown for the next.
+  forgetGuildCommandState('guild-123');
   vi.mocked(getAllSfxTriggers).mockResolvedValue([]);
   vi.mocked(findCachedSfxTrigger).mockResolvedValue(null);
   vi.mocked(pickWeightedRandom).mockReturnValue('ding.mp3');
@@ -220,6 +233,36 @@ describe('POST /sfx', () => {
       .expect(500);
 
     expect(res.body).toMatchObject({ ok: false });
+  });
+
+  it('returns 429 and does not play when the guild is still on cooldown from a prior play', async () => {
+    vi.mocked(findCachedSfxTrigger).mockResolvedValue(LOOKUP);
+    // Explicit, not relying on the ambient default: an earlier test in this file leaves
+    // playFile's mock permanently throwing (vi.clearAllMocks() doesn't undo a plain
+    // .mockImplementation()), so the first play here must set its own resolved behavior.
+    vi.mocked(playFile).mockResolvedValueOnce(undefined);
+
+    await supertest(buildApp()).post('/sfx').send({ command: '!ding' }).expect(200);
+    vi.mocked(playFile).mockClear();
+
+    const res = await supertest(buildApp()).post('/sfx').send({ command: '!ding' }).expect(429);
+
+    expect(res.body).toMatchObject({ ok: false });
+    expect(vi.mocked(playFile)).not.toHaveBeenCalled();
+  });
+
+  it('releases the in-flight slot even when playFile throws, so a later request is only blocked by cooldown', async () => {
+    vi.mocked(findCachedSfxTrigger).mockResolvedValue(LOOKUP);
+    vi.mocked(playFile).mockImplementationOnce(() => { throw new Error('FFMPEG crashed'); });
+
+    await supertest(buildApp()).post('/sfx').send({ command: '!ding' }).expect(500);
+
+    // Cooldown wasn't recorded on failure (lastPlayedAt only updates on success), so a second
+    // attempt on the same guild lands on the "already in-flight" branch's guard cleanly — it
+    // must not still be latched from the failed attempt.
+    vi.mocked(playFile).mockResolvedValueOnce(undefined);
+    const res = await supertest(buildApp()).post('/sfx').send({ command: '!ding' }).expect(200);
+    expect(res.body).toEqual({ ok: true, file: 'ding.mp3' });
   });
 });
 

--- a/src/web/routes/streamdeckSfx.ts
+++ b/src/web/routes/streamdeckSfx.ts
@@ -6,6 +6,7 @@ import { playFile, VoiceNotConnectedError } from '../../audio/sfxPlayer';
 import { setVoicePlaying } from '../../shared/statusStore';
 import { requireApiKey } from '../middleware';
 import { resolvePresenceGuildOrRespond, getReadyDiscordClientOrRespond } from './streamdeckGuildResolution';
+import { getGuildCommandState, tryClaimGuildSlot } from '../../commands/commandRouter';
 
 const log = createLogger('Streamdeck');
 const router = Router();
@@ -49,38 +50,52 @@ router.post('/sfx', requireApiKey, async (req, res) => {
 
   const normalizedCommand = command.trim().toLowerCase();
 
-  let lookup;
-  try {
-    lookup = await findCachedSfxTrigger(normalizedCommand);
-  } catch (err) {
-    log.error('DB error looking up trigger:', err);
-    res.status(500).json({ ok: false, error: 'Database error' });
-    return;
-  }
-  if (!lookup) {
-    res.status(404).json({ ok: false, error: 'Unknown command' });
-    return;
-  }
-  const { files } = lookup;
-  if (files.length === 0) {
-    res.status(404).json({ ok: false, error: 'No sound files for this command' });
+  // Same per-guild cooldown/in-flight guard chat-triggered SFX gets from commandRouter.ts —
+  // without it, rapid repeated Streamdeck presses (or a leaked API key) could retrigger
+  // playback back-to-back, cutting off in-progress playback each time.
+  const state = getGuildCommandState(guildId);
+  if (!tryClaimGuildSlot(guildId, 'streamdeck', normalizedCommand, state)) {
+    res.status(429).json({ ok: false, error: 'Already playing or on cooldown in this guild' });
     return;
   }
 
-  const filename = pickWeightedRandom(files);
-
   try {
-    await playFile(filename, guildId);
-    setVoicePlaying(guildId, filename, normalizedCommand, 'streamdeck');
-    log.info(`Playing '${filename.replace(/[\r\n]/g, '')}' for trigger '${normalizedCommand.replace(/[\r\n]/g, '')}' in guild ${guildId}`);
-    res.json({ ok: true, file: filename });
-  } catch (err: unknown) {
-    if (err instanceof VoiceNotConnectedError) {
-      res.status(503).json({ ok: false, error: 'Bot is not connected to a voice channel' });
-    } else {
-      log.error(`Failed to play ${filename.replace(/[\r\n]/g, '')}:`, err);
-      res.status(500).json({ ok: false, error: 'Failed to play sound' });
+    let lookup;
+    try {
+      lookup = await findCachedSfxTrigger(normalizedCommand);
+    } catch (err) {
+      log.error('DB error looking up trigger:', err);
+      res.status(500).json({ ok: false, error: 'Database error' });
+      return;
     }
+    if (!lookup) {
+      res.status(404).json({ ok: false, error: 'Unknown command' });
+      return;
+    }
+    const { files } = lookup;
+    if (files.length === 0) {
+      res.status(404).json({ ok: false, error: 'No sound files for this command' });
+      return;
+    }
+
+    const filename = pickWeightedRandom(files);
+
+    try {
+      await playFile(filename, guildId);
+      state.lastPlayedAt = Date.now();
+      setVoicePlaying(guildId, filename, normalizedCommand, 'streamdeck');
+      log.info(`Playing '${filename.replace(/[\r\n]/g, '')}' for trigger '${normalizedCommand.replace(/[\r\n]/g, '')}' in guild ${guildId}`);
+      res.json({ ok: true, file: filename });
+    } catch (err: unknown) {
+      if (err instanceof VoiceNotConnectedError) {
+        res.status(503).json({ ok: false, error: 'Bot is not connected to a voice channel' });
+      } else {
+        log.error(`Failed to play ${filename.replace(/[\r\n]/g, '')}:`, err);
+        res.status(500).json({ ok: false, error: 'Failed to play sound' });
+      }
+    }
+  } finally {
+    state.inFlight = false;
   }
 });
 


### PR DESCRIPTION
## Summary
- `POST /api/streamdeck/sfx` (`src/web/routes/streamdeckSfx.ts`) called `playFile()` directly with no cooldown or in-flight check, unlike chat-triggered SFX which goes through `commandRouter.ts`'s per-guild `tryClaimGuildSlot` guard.
- Only the coarse per-key HTTP rate limiter (`streamdeckLimiter`, 120 req/min) stood between rapid repeated Streamdeck presses — or a leaked API key — and back-to-back playback, cutting off in-progress sound each time.
- Exported `commandRouter.ts`'s existing `getGuildCommandState`/`tryClaimGuildSlot` (widened the `source` union to include `'streamdeck'`) and applied them in `streamdeckSfx.ts`, reusing the same guard instead of adding a separate one. A press outside the cooldown/in-flight window now returns `429` instead of interrupting the current sound.

## Test plan
- Added tests covering the new `429` response on a repeat request within cooldown, and confirming the in-flight slot is released after a failed play so a later request isn't stuck.
- Updated `streamdeckSfx.test.ts`/`streamdeck.test.ts` mocks (`shared/config`, `audio/audioPlayer`) now that the route transitively imports `commandRouter.ts`.
- `npx tsc --noEmit && npm run check:circular && npm test` — all 3520 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTTsxupLZELmetjUwtZpCS

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTTsxupLZELmetjUwtZpCS)_