### PR TITLE
Add a dedupe window to POST /companion-key/request

### DIFF
--- a/src/web/routes/companionKeys.test.ts
+++ b/src/web/routes/companionKeys.test.ts
@@ -20,7 +20,7 @@ vi.mock('./companionEvents', () => ({ disconnectCompanionConnections: vi.fn() })
 
 import express from 'express';
 import supertest from 'supertest';
-import router from './companionKeys';
+import router, { __resetRecentIssuesForTests } from './companionKeys';
 import { issueToken, getTokenStatus, revokeToken } from '../../db';
 import { AccessLevel } from '../../db';
 import { disconnectCompanionConnections } from './companionEvents';
@@ -43,6 +43,7 @@ function buildApp(sessionUser = SESSION_USER) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  __resetRecentIssuesForTests();
   vi.mocked(getTokenStatus).mockResolvedValue(null);
   vi.mocked(issueToken).mockResolvedValue('a'.repeat(64));
   vi.mocked(revokeToken).mockResolvedValue(undefined);
@@ -110,6 +111,45 @@ describe('POST /companion-key/request', () => {
     await supertest(buildApp()).post('/companion-key/request');
     expect(disconnectCompanionConnections).not.toHaveBeenCalled();
   });
+
+  it('a rapid duplicate request within the dedupe window reuses the first token instead of issuing again', async () => {
+    vi.mocked(issueToken).mockResolvedValue('first-plain-token');
+
+    const app = buildApp();
+    const first = await supertest(app).post('/companion-key/request');
+    expect((first.body as any).locals.newToken).toBe('first-plain-token');
+
+    // If the dedupe guard failed to kick in, this second call would return whatever
+    // issueToken resolves to now — which is unchanged, so a regression here wouldn't be
+    // masked by a queued "once" value.
+    const second = await supertest(app).post('/companion-key/request');
+
+    expect((second.body as any).locals.newToken).toBe('first-plain-token');
+    expect(issueToken).toHaveBeenCalledOnce();
+    expect(disconnectCompanionConnections).toHaveBeenCalledOnce();
+  });
+
+  it('issues again once the dedupe window has passed', async () => {
+    const dateNowSpy = vi.spyOn(Date, 'now');
+    try {
+      vi.mocked(issueToken).mockResolvedValueOnce('first-plain-token');
+      dateNowSpy.mockReturnValue(1_000_000);
+
+      const app = buildApp();
+      const first = await supertest(app).post('/companion-key/request');
+      expect((first.body as any).locals.newToken).toBe('first-plain-token');
+
+      vi.mocked(issueToken).mockResolvedValueOnce('second-plain-token');
+      dateNowSpy.mockReturnValue(1_000_000 + 10_000 + 1);
+
+      const second = await supertest(app).post('/companion-key/request');
+
+      expect((second.body as any).locals.newToken).toBe('second-plain-token');
+      expect(issueToken).toHaveBeenCalledTimes(2);
+    } finally {
+      dateNowSpy.mockRestore();
+    }
+  });
 });
 
 // ─── POST /companion-key/revoke ───────────────────────────────────────────────
@@ -136,5 +176,19 @@ describe('POST /companion-key/revoke', () => {
     vi.mocked(revokeToken).mockRejectedValueOnce(new Error('DB error'));
     await supertest(buildApp()).post('/companion-key/revoke');
     expect(disconnectCompanionConnections).not.toHaveBeenCalled();
+  });
+
+  it('clears the issue dedupe cache, so a request right after a revoke issues a fresh token', async () => {
+    vi.mocked(issueToken).mockResolvedValueOnce('first-plain-token');
+    const app = buildApp();
+    await supertest(app).post('/companion-key/request');
+
+    await supertest(app).post('/companion-key/revoke');
+
+    vi.mocked(issueToken).mockResolvedValueOnce('second-plain-token');
+    const res = await supertest(app).post('/companion-key/request');
+
+    expect((res.body as any).locals.newToken).toBe('second-plain-token');
+    expect(issueToken).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/web/routes/companionKeys.ts
+++ b/src/web/routes/companionKeys.ts
@@ -13,6 +13,27 @@ const router = Router();
 
 const KNOWN_ERRORS = new Set(['request_failed', 'revoke_failed']);
 
+interface RecentIssue {
+  plain: string;
+  issuedAt: number;
+}
+
+// Tracks a just-issued token per discordId for a short window, so a rapid duplicate POST
+// /companion-key/request (double-click, browser retry/refresh) reuses the plaintext already
+// rendered instead of issuing again — issuing unconditionally replaces the prior token and
+// disconnects any open companion SSE connection, so a duplicate submit would otherwise silently
+// invalidate the token the user was just shown. Same pattern as streamdeckKeys.ts's
+// ROTATE_DEDUPE_WINDOW_MS/recentRotations. Entries expire lazily by age and are actively evicted
+// via a guarded timer once expired, so a plaintext token never lingers in process memory longer
+// than the dedupe window.
+const ISSUE_DEDUPE_WINDOW_MS = 10_000;
+const recentIssues = new Map<string, RecentIssue>();
+
+/** Test-only: clears the issue dedupe cache so each test starts from a clean slate. */
+export function __resetRecentIssuesForTests(): void {
+  recentIssues.clear();
+}
+
 /** Renders the current user's companion app token status page. */
 router.get('/companion-key', csrfProtection, async (req, res) => {
   try {
@@ -37,14 +58,26 @@ router.get('/companion-key', csrfProtection, async (req, res) => {
  * its own try/catch with a locally-derived fallback rather than risking the
  * already-issued token being lost behind a `request_failed` redirect. Issuing a
  * token replaces (invalidates) any prior one for this Discord ID, so this also ends
- * any companion SSE connection still open under the token just replaced.
+ * any companion SSE connection still open under the token just replaced. A request within
+ * {@link ISSUE_DEDUPE_WINDOW_MS} of the last one for this user reuses that plaintext instead of
+ * issuing (and invalidating) again — see {@link recentIssues}.
  */
 router.post('/companion-key/request', csrfProtection, async (req, res) => {
   const discordId = getSessionUser(req).discordId;
   let plain: string;
   try {
-    plain = await issueToken(discordId);
-    disconnectCompanionConnections(discordId);
+    const recent = recentIssues.get(discordId);
+    if (recent && Date.now() - recent.issuedAt < ISSUE_DEDUPE_WINDOW_MS) {
+      plain = recent.plain;
+    } else {
+      plain = await issueToken(discordId);
+      disconnectCompanionConnections(discordId);
+      const result: RecentIssue = { plain, issuedAt: Date.now() };
+      recentIssues.set(discordId, result);
+      setTimeout(() => {
+        if (recentIssues.get(discordId) === result) recentIssues.delete(discordId);
+      }, ISSUE_DEDUPE_WINDOW_MS).unref();
+    }
   } catch (err) {
     logAndRedirectError({ res, log, logLabel: 'Companion key request error:', err, basePath: '/companion-key', errorCode: 'request_failed' });
     return;
@@ -78,6 +111,7 @@ router.post('/companion-key/revoke', csrfProtection, async (req, res) => {
     const discordId = getSessionUser(req).discordId;
     await revokeToken(discordId);
     disconnectCompanionConnections(discordId);
+    recentIssues.delete(discordId);
     res.redirect('/companion-key');
   } catch (err) {
     logAndRedirectError({ res, log, logLabel: 'Companion key revoke error:', err, basePath: '/companion-key', errorCode: 'revoke_failed' });


### PR DESCRIPTION
## Summary
- `POST /companion-key/request` (`src/web/routes/companionKeys.ts`) unconditionally issued a new token on every call, replacing the prior one and disconnecting any open companion SSE connection.
- `/streamdeck-key/rotate` (a near-identical "issue a secret shown once" flow) already guards against exactly this — a rapid duplicate POST (double-click, browser refresh) via `ROTATE_DEDUPE_WINDOW_MS`/`recentRotations`. Note: `/streamdeck-key/request` turned out to already be idempotent through a different mechanism (its own status-based no-op check), so it needed no change — only `/companion-key/request` was actually missing this.
- Added the same short-lived dedupe cache pattern (`ISSUE_DEDUPE_WINDOW_MS`/`recentIssues`, 10s) here: a duplicate request within the window reuses the already-issued plaintext instead of minting (and invalidating) another one. Cleared on revoke so a request right after a revoke still issues fresh.

## Test plan
- Added tests: rapid-duplicate reuse (issues once, disconnects once), re-issue after the window elapses, and cache clearing on revoke.
- `npx tsc --noEmit && npm test` — all 3521 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTTsxupLZELmetjUwtZpCS

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTTsxupLZELmetjUwtZpCS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Rapidly repeated companion-key requests now reuse the currently issued token instead of invalidating it and issuing another.
  - Simultaneous requests for the same companion key now receive the same token without duplicate issuance.
  - Token issuance resumes normally after the deduplication window expires.
  - Revoking a companion key now clears cached issuance state, allowing the next request to generate a fresh token.
  - Revocations remain consistent even when a token request is still in progress.
  - Cache expiration is handled safely without removing newer token entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->