### PR TITLE
Hash tokens in the EventSub auth-failed skip-key instead of storing them raw

### DIFF
--- a/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.test.ts
@@ -120,6 +120,71 @@ describe('hasAuthFailedSubs / clearAuthFailedSubs', () => {
     expect(hasAuthFailedSubs('streamerA')).toBe(false);
     expect(hasAuthFailedSubs('streamerB')).toBe(true);
   });
+
+  it('retries automatically once the token changes, without needing clearAuthFailedSubs', async () => {
+    vi.mocked(getActiveChannels).mockReturnValue(new Set(['streamera']));
+    // Explicit persistent baseline: an earlier test in this describe block leaves
+    // createEventSubSubscription permanently rejecting via mockRejectedValue (not Once), which
+    // vi.clearAllMocks() does not undo — so only the first spec attempted here must reject.
+    vi.mocked(createEventSubSubscription).mockResolvedValue('sub-id-1');
+    vi.mocked(createEventSubSubscription).mockRejectedValueOnce(new TwitchAuthError('403'));
+
+    await subscribeForStreamer('sess-3', {
+      uid: 'uid-A3',
+      token: 'stale-token',
+      name: 'streamerA',
+      config: { follow_enabled: true, sub_enabled: false, raid_enabled: false } as any,
+      streamerId: 4,
+    });
+    expect(hasAuthFailedSubs('streamerA')).toBe(true);
+    const callsAfterFirstRound = vi.mocked(createEventSubSubscription).mock.calls.length;
+    expect(callsAfterFirstRound).toBeGreaterThan(0);
+
+    // A refreshed token computes a different (hashed) skip key, so every spec — including the
+    // one that failed under the stale token — is attempted again rather than the failed one
+    // being silently skipped forever. This is the whole point of keying on the token at all,
+    // which the hashing change must preserve even though the raw token is no longer stored.
+    await subscribeForStreamer('sess-3', {
+      uid: 'uid-A3',
+      token: 'refreshed-token',
+      name: 'streamerA',
+      config: { follow_enabled: true, sub_enabled: false, raid_enabled: false } as any,
+      streamerId: 4,
+    });
+
+    const callsAfterSecondRound = vi.mocked(createEventSubSubscription).mock.calls.length;
+    expect(callsAfterSecondRound - callsAfterFirstRound).toBe(callsAfterFirstRound);
+  });
+
+  it('keeps skipping only the same still-failing token+type across calls (does not retry that one every round)', async () => {
+    vi.mocked(getActiveChannels).mockReturnValue(new Set(['streamera']));
+    // Explicit persistent baseline — see the comment in the previous test for why.
+    vi.mocked(createEventSubSubscription).mockResolvedValue('sub-id-1');
+    vi.mocked(createEventSubSubscription).mockRejectedValueOnce(new TwitchAuthError('403'));
+
+    await subscribeForStreamer('sess-4', {
+      uid: 'uid-A4',
+      token: 'still-bad-token',
+      name: 'streamerA',
+      config: { follow_enabled: true, sub_enabled: false, raid_enabled: false } as any,
+      streamerId: 5,
+    });
+    const callsAfterFirstRound = vi.mocked(createEventSubSubscription).mock.calls.length;
+    expect(callsAfterFirstRound).toBeGreaterThan(0);
+
+    await subscribeForStreamer('sess-4', {
+      uid: 'uid-A4',
+      token: 'still-bad-token',
+      name: 'streamerA',
+      config: { follow_enabled: true, sub_enabled: false, raid_enabled: false } as any,
+      streamerId: 5,
+    });
+
+    // Same token again — the one spec that previously failed is skipped this round, so the
+    // second round makes exactly one fewer call than the first.
+    const callsAfterSecondRound = vi.mocked(createEventSubSubscription).mock.calls.length;
+    expect(callsAfterSecondRound - callsAfterFirstRound).toBe(callsAfterFirstRound - 1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/twitch/eventsub/twitchEventSubSubscriptions.ts
+++ b/src/twitch/eventsub/twitchEventSubSubscriptions.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { createLogger } from '../../shared/logger';
 import { getAllEventSubStreamers, getEnabledAlertEventTypesBatch } from '../../db';
 import type { DbStreamerEventSub, EventSubConfig, AlertEventType } from '../../db';
@@ -12,8 +13,17 @@ const log = createLogger('EventSub');
 
 export { dispatchNotification, handleRevocation, removeStreamerFromMap } from './twitchEventSubDispatch';
 
-// Tracks "login:type:token" triples that failed with 403 — skipped until bot restarts or token changes
+// Tracks "login:type:tokenHash" triples that failed with 403 — skipped until bot restarts or
+// token changes. Hashed rather than storing the raw access token: the key only needs to change
+// when the token does (so a refreshed token naturally computes a different key and retries),
+// not to retain the token's actual value in process memory for the (unbounded, until
+// clearAuthFailedSubs runs) lifetime of this Set.
 const authFailedSubs = new Set<string>();
+
+/** Derives the skip-key's token component without retaining the raw access token. */
+function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
 
 /** Returns true if any subscription for the given login has previously failed with a 403. */
 export function hasAuthFailedSubs(login: string): boolean {
@@ -291,7 +301,7 @@ export async function subscribeForStreamer(
  *  create call failed — callers use a non-null id to identify "the subscription created this
  *  round" when pruning stale duplicates in {@link deleteStaleSubscriptions}. */
 async function subscribe(sessionId: string, spec: SubSpec, token: string, login: string): Promise<string | null> {
-  const skipKey = `${login}:${spec.type}:${token}`;
+  const skipKey = `${login}:${spec.type}:${hashToken(token)}`;
   if (authFailedSubs.has(skipKey)) return null;
   try {
     const id = await createEventSubSubscription(spec.type, spec.version, spec.condition, sessionId, token);


### PR DESCRIPTION
## Summary
- `authFailedSubs` (`src/twitch/eventsub/twitchEventSubSubscriptions.ts`) keyed its skip-cache entries as `` `${login}:${type}:${token}` ``, retaining the raw OAuth access token as part of an in-memory `Set` key for as long as the entry lives — only cleared via `clearAuthFailedSubs(login)`, called from the reconnect callback flow, not guaranteed if a streamer rotates/revokes without going through it.
- The token only needs to be part of the key so a refreshed token naturally computes a different key and gets retried (rather than requiring an explicit clear) — it doesn't need to be the *raw* token for that purpose.
- Hashed the token (SHA-256) into the key instead, preserving the exact same "different token → retried; same token → still skipped" behavior without keeping the actual secret value resident in memory.

## Test plan
- Added two tests: one confirming a token change still triggers a retry for a previously auth-failed type (proving the hashing change didn't break the existing behavior), and one confirming the same token still gets skipped across calls.
- While adding these I found a pre-existing latent issue in this test file unrelated to my change: an earlier test sets `createEventSubSubscription`'s mock via a persistent `mockRejectedValue` (not `Once`), which `vi.clearAllMocks()` in later tests' `beforeEach` doesn't undo — silently poisoning any later test that assumes a working default. Worked around it in my new tests by explicitly resetting the mock's resolved-value baseline before queuing their one-time rejection (left the pre-existing tests as-is, out of scope for this fix).
- `npx tsc --noEmit && npm test` — all 3520 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTTsxupLZELmetjUwtZpCS

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTTsxupLZELmetjUwtZpCS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Authorization-failure tracking now protects access tokens by storing secure hashes instead of raw token values.
  - Refreshed tokens correctly retry previously failed subscription attempts.
  - Repeated failures with the same token continue to be skipped as expected.
- **Tests**
  - Added coverage for token refresh retries and repeated authorization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->