### PR TITLE
Add exponential-backoff retry when Discord login fails

### DIFF
--- a/src/discord/discordBot.test.ts
+++ b/src/discord/discordBot.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mockLogger } from '../test-utils/loggerMock';
 import { ACCESS_LEVEL_MOCK } from '../test-utils/accessLevelMock';
 import { flushMicrotasks } from '../test-utils/flushMicrotasks';
@@ -539,6 +539,99 @@ describe('startDiscordBot — gateway watchdog', () => {
     const handler = findHandler('shardDisconnect');
     handler({ code: 4004 }, 0);
     expect(vi.mocked(healthStore.recordDiscordConnected)).toHaveBeenCalledWith(false);
+  });
+});
+
+// ─── startDiscordBot — login failure reconnect backoff ─────────────────────────
+//
+// A failed shardDisconnect self-heal (or the very first boot) must not leave the process
+// permanently disconnected from Discord — startDiscordBot() schedules its own retry rather
+// than requiring some other caller to notice and retry manually.
+
+describe('startDiscordBot — login failure reconnect backoff', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('schedules a retry when login fails, and eventually reconnects on its own', async () => {
+    mockInstance.login.mockRejectedValueOnce(new Error('network unreachable'));
+    mod.startDiscordBot();
+    await flushMicrotasks();
+
+    expect(mockLog.error).toHaveBeenCalledWith('Login failed:', expect.any(Error));
+    expect(mod.getDiscordClient()).toBeNull();
+
+    // First retry backs off 5s (RECONNECT_BASE_DELAY_MS).
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(mockInstance.login).toHaveBeenCalledTimes(2);
+
+    // This attempt succeeds — fire clientReady.
+    const readyCb = mockInstance.once.mock.calls.find(([event]: string[]) => event === 'clientReady')?.[1];
+    await readyCb(mockInstance);
+    expect(mod.getDiscordClient()).toBe(mockInstance);
+  });
+
+  it('backs off exponentially across repeated login failures, capped at the max delay', async () => {
+    mockInstance.login.mockRejectedValue(new Error('still down'));
+    mod.startDiscordBot();
+    await flushMicrotasks();
+    expect(mockInstance.login).toHaveBeenCalledTimes(1);
+
+    // 5s, then 10s, then 20s — each attempt itself also rejects and reschedules.
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(mockInstance.login).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(mockInstance.login).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(mockInstance.login).toHaveBeenCalledTimes(4);
+  });
+
+  it('does not stack a second pending retry when two login failures happen in quick succession', async () => {
+    // Two failures back-to-back (e.g. two shardDisconnect events) must not schedule two
+    // independent timers — that would double the reconnect attempts once both fire.
+    mockInstance.login.mockRejectedValueOnce(new Error('first failure'));
+    mod.startDiscordBot();
+    await flushMicrotasks();
+    expect(mockInstance.login).toHaveBeenCalledTimes(1);
+
+    mockInstance.login.mockRejectedValueOnce(new Error('second failure'));
+    mod.startDiscordBot();
+    await flushMicrotasks();
+    expect(mockInstance.login).toHaveBeenCalledTimes(2);
+
+    // Only one retry timer should be pending — advancing past the base delay once fires exactly
+    // one more attempt, not two.
+    mockInstance.login.mockResolvedValueOnce(undefined);
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(mockInstance.login).toHaveBeenCalledTimes(3);
+  });
+
+  it('resets the backoff after a successful reconnect, so a later failure starts from the base delay again', async () => {
+    mockInstance.login.mockRejectedValueOnce(new Error('first failure'));
+    mod.startDiscordBot();
+    await flushMicrotasks();
+
+    await vi.advanceTimersByTimeAsync(5_000); // first retry, succeeds this time
+    expect(mockInstance.login).toHaveBeenCalledTimes(2);
+    const readyCb = mockInstance.once.mock.calls.find(([event]: string[]) => event === 'clientReady')?.[1];
+    await readyCb(mockInstance);
+    expect(mod.getDiscordClient()).toBe(mockInstance);
+
+    // A later shard disconnect forces a fresh login, which fails again — the backoff for this
+    // new failure must start from RECONNECT_BASE_DELAY_MS again, not continue from where the
+    // previous (already-recovered) failure episode left off.
+    const disconnectHandler = mockInstance.on.mock.calls.find(([e]: string[]) => e === 'shardDisconnect')?.[1];
+    mockInstance.login.mockRejectedValueOnce(new Error('second failure'));
+    disconnectHandler({ code: 4004 }, 0);
+    await flushMicrotasks();
+    expect(mockInstance.login).toHaveBeenCalledTimes(3);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(mockInstance.login).toHaveBeenCalledTimes(4);
   });
 });
 

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -22,6 +22,39 @@ let bootingClient: Client | null = null;
 
 export { getDiscordClient };
 
+// ─── Reconnect backoff ──────────────────────────────────────────────────────
+//
+// startDiscordBot()'s login() call can itself fail (a transient Discord outage exactly
+// overlapping a shardDisconnect self-heal, a revoked token, network unreachability at that
+// instant) — without a retry loop here, that single failed attempt would leave the process
+// alive-but-permanently-disconnected from Discord for the rest of its life, since nothing else
+// ever calls startDiscordBot() again. Mirrors audioPlayer.ts's per-guild voice reconnect backoff.
+
+const RECONNECT_BASE_DELAY_MS = 5_000;
+const RECONNECT_MAX_DELAY_MS = 5 * 60_000;
+let reconnectAttempts = 0;
+let reconnectTimer: NodeJS.Timeout | null = null;
+
+/** Cancels and nulls any pending Discord reconnect timer. */
+function clearReconnectTimer(): void {
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+}
+
+/** Schedules an exponential-backoff retry of {@link startDiscordBot}, skipping if one is already pending. */
+function scheduleReconnect(reason: string): void {
+  if (reconnectTimer) return;
+  const delay = Math.min(RECONNECT_BASE_DELAY_MS * 2 ** reconnectAttempts, RECONNECT_MAX_DELAY_MS);
+  reconnectAttempts += 1;
+  log.warn(`Scheduling Discord reconnect in ${delay}ms (${reason}).`);
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    startDiscordBot();
+  }, delay).unref();
+}
+
 /** How often a given shard's gateway connection errors are actually logged — see {@link logShardError}. */
 const SHARD_ERROR_LOG_INTERVAL_MS = 60_000;
 
@@ -246,6 +279,8 @@ function registerClientReadyHandler(client: Client): void {
       return;
     }
     bootingClient = null;
+    clearReconnectTimer();
+    reconnectAttempts = 0;
     setDiscordClient(c);
     log.info(`Logged in as ${c.user.tag}`);
     setDiscordReady(c.user.tag);
@@ -301,7 +336,8 @@ function registerConnectionHandlers(client: Client): void {
  * once `clientReady` fires, so callers cannot observe a partially-initialised
  * client. If {@link stopDiscordBot} is called before the connection completes,
  * the in-flight client is destroyed and the `clientReady` handler is discarded.
- * If login fails, `bootingClient` is cleared so the next call can retry.
+ * If login fails, `bootingClient` is cleared and a backoff retry of this function is scheduled
+ * automatically (see {@link scheduleReconnect}) — a caller never needs to retry manually.
  *
  * The guild registry must be loaded (see {@link reloadGuildRegistry}) before the
  * client connects, so the `messageCreate` gate can recognise registered guilds.
@@ -328,7 +364,8 @@ export function startDiscordBot(): void {
 
   localClient.login(DISCORD_TOKEN).catch((err) => {
     log.error('Login failed:', err);
-    bootingClient = null; // clear so the next startDiscordBot() call can retry
+    bootingClient = null; // clear so a retry can call startDiscordBot() again
+    scheduleReconnect('login failed');
   });
 }
 
@@ -343,6 +380,7 @@ export function stopDiscordBot(): void {
   const existingBooting = bootingClient;
   setDiscordClient(null);
   bootingClient = null;
+  clearReconnectTimer();
   recordDiscordConnected(false);
   existingReady?.destroy().catch((err: unknown) => log.error('Error destroying client:', err));
   existingBooting?.destroy().catch((err: unknown) => log.error('Error destroying booting client:', err));


### PR DESCRIPTION
## Summary
- `shardDisconnect` (`src/discord/discordBot.ts`) self-heals with one synchronous `stopDiscordBot(); startDiscordBot();` call and no retry loop, unlike the voice reconnect logic in `audioPlayer.ts` or the Twitch bot's reconnect handling. If that one retried `login()` itself failed — a transient Discord outage exactly overlapping the retry, or a revoked token — nothing was left to ever attempt reconnecting Discord again for the rest of the process's life.
- (Investigated but out of scope: `ownerAlerts.ts` already logs `Failed to send owner alert DM` unconditionally when a "Discord is down" DM can't be delivered because Discord itself is down — that part of the original finding turned out to already be handled. Adding a genuinely separate non-Discord notification channel would be a new subsystem, not a proportionate fix here.)
- Added a bounded exponential-backoff retry (`RECONNECT_BASE_DELAY_MS` 5s, capped at `RECONNECT_MAX_DELAY_MS` 5 minutes), mirroring `audioPlayer.ts`'s per-guild voice reconnect pattern: `startDiscordBot()`'s `login()` failure now schedules its own retry instead of requiring an external caller to notice and retry. Attempts reset to the base delay on a successful reconnect, and any pending retry is cancelled on an explicit `stopDiscordBot()` (e.g. graceful shutdown).

## Test plan
- Added tests: retry-and-eventually-reconnect on login failure, exponential backoff across repeated failures (5s → 10s → 20s), no duplicate timer stacking when two failures happen in quick succession, and backoff resetting to the base delay after a successful reconnect followed by a later failure.
- `npx tsc --noEmit && npm run check:circular && npm test` — all 3522 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTTsxupLZELmetjUwtZpCS

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTTsxupLZELmetjUwtZpCS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Discord bot recovery after failed login attempts with automatic retries.
  * Added exponential retry delays, capped at five minutes, to prevent excessive reconnect attempts.
  * Prevented duplicate pending retries and ensured scheduled retries are cancelled when the bot stops.
  * Reset retry delays after a successful reconnection.
  * Prevented stale login failures from triggering unwanted reconnect attempts after the bot has stopped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->