### PR TITLE
Guild-scope counters end to end (admin panel, DB layer, chat matching)

### DIFF
--- a/DATABASE-SCHEMA.md
+++ b/DATABASE-SCHEMA.md
@@ -411,7 +411,7 @@ Expected constraints and behavior:
 
 - `trigger_command` and `check_command` should be unique **per guild** (the same counter command may exist in different guilds).
 - Both command columns should store single-token commands including any prefix.
-- Current panel support includes CRUD and manual reset of `current_value`; runtime command handling/scheduler wiring can be implemented independently.
+- The admin panel (CRUD and manual reset of `current_value`) and runtime chat-command matching/increment are both guild-scoped by `guild_id`.
 
 Per-guild uniqueness (applied by `migrations/multi_guild.sql`, which also drops any earlier global `uq_counter_*` constraints):
 

--- a/src/commands/counterHandler.test.ts
+++ b/src/commands/counterHandler.test.ts
@@ -104,6 +104,19 @@ describe('executeCounterCommandForDiscord', () => {
     expect(msg.reply).not.toHaveBeenCalled();
   });
 
+  it('does nothing for a DM (no guildId, and none explicitly provided)', async () => {
+    const msg = makeMockMessage('!count', { guildId: null });
+    await executeCounterCommandForDiscord(msg as any);
+    expect(vi.mocked(findCounterByCommand)).not.toHaveBeenCalled();
+  });
+
+  it('prefers an explicit guildId over message.guildId', async () => {
+    vi.mocked(findCounterByCommand).mockResolvedValue(CHECK_COUNTER as any);
+    const msg = makeMockMessage('!count', { guildId: 'guild-from-message' });
+    await executeCounterCommandForDiscord(msg as any, null, 'guild-explicit');
+    expect(vi.mocked(findCounterByCommand)).toHaveBeenCalledWith('guild-explicit', '!count');
+  });
+
   it('replies with formatted increment message for a trigger counter', async () => {
     vi.mocked(findCounterByCommand).mockResolvedValue(TRIGGER_COUNTER as any);
     vi.mocked(incrementCounter).mockResolvedValue(5);
@@ -172,13 +185,25 @@ describe('executeCounterCommandForDiscord', () => {
 
 describe('executeCounterCommandForTwitch', () => {
   it('does nothing when the message has no command', async () => {
-    await executeCounterCommandForTwitch('#chan', '', null);
+    await executeCounterCommandForTwitch('#chan', '', null, 'guild-1');
     expect(vi.mocked(findCounterByCommand)).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no guild could be resolved for the channel', async () => {
+    await executeCounterCommandForTwitch('#chan', '!hits', null, null);
+    expect(vi.mocked(findCounterByCommand)).not.toHaveBeenCalled();
+    expect(mockTwitchRuntime.send).not.toHaveBeenCalled();
+  });
+
+  it('looks up the counter scoped to the resolved guild', async () => {
+    vi.mocked(findCounterByCommand).mockResolvedValue(CHECK_COUNTER as any);
+    await executeCounterCommandForTwitch('#chan', '!count', null, 'guild-xyz');
+    expect(vi.mocked(findCounterByCommand)).toHaveBeenCalledWith('guild-xyz', '!count');
   });
 
   it('does nothing when the command is not a counter', async () => {
     vi.mocked(findCounterByCommand).mockResolvedValue(null);
-    await executeCounterCommandForTwitch('#chan', '!other', null);
+    await executeCounterCommandForTwitch('#chan', '!other', null, 'guild-1');
     expect(mockTwitchRuntime.send).not.toHaveBeenCalled();
   });
 
@@ -186,7 +211,7 @@ describe('executeCounterCommandForTwitch', () => {
     vi.mocked(findCounterByCommand).mockResolvedValue(TRIGGER_COUNTER as any);
     vi.mocked(incrementCounter).mockResolvedValue(10);
 
-    await executeCounterCommandForTwitch('#mychan', '!hits', 'viewer1');
+    await executeCounterCommandForTwitch('#mychan', '!hits', 'viewer1', 'guild-1');
 
     expect(mockTwitchRuntime.send).toHaveBeenCalledWith('#mychan', 'Count is now 10!');
   });
@@ -195,7 +220,7 @@ describe('executeCounterCommandForTwitch', () => {
     vi.mocked(findCounterByCommand).mockResolvedValue(TRIGGER_COUNTER as any);
     vi.mocked(incrementCounter).mockRejectedValue(new Error('DB down'));
 
-    await executeCounterCommandForTwitch('#chan', '!hits', null);
+    await executeCounterCommandForTwitch('#chan', '!hits', null, 'guild-1');
 
     expect(mockTwitchRuntime.send).not.toHaveBeenCalled();
   });
@@ -252,11 +277,11 @@ describe('counter cooldown', () => {
     vi.mocked(findCounterByCommand).mockResolvedValue(TRIGGER_COUNTER as any);
     vi.mocked(incrementCounter).mockResolvedValue(5);
 
-    await executeCounterCommandForTwitch('#chan', '!hits', null);
+    await executeCounterCommandForTwitch('#chan', '!hits', null, 'guild-1');
     expect(mockTwitchRuntime.send).toHaveBeenCalledTimes(1);
     expect(vi.mocked(incrementCounter)).toHaveBeenCalledTimes(1);
 
-    await executeCounterCommandForTwitch('#chan', '!hits', null);
+    await executeCounterCommandForTwitch('#chan', '!hits', null, 'guild-1');
     expect(mockTwitchRuntime.send).toHaveBeenCalledTimes(1);
     expect(vi.mocked(incrementCounter)).toHaveBeenCalledTimes(1);
   });
@@ -264,10 +289,10 @@ describe('counter cooldown', () => {
   it("does not apply one Twitch channel's cooldown to another channel", async () => {
     vi.mocked(findCounterByCommand).mockResolvedValue(CHECK_COUNTER as any);
 
-    await executeCounterCommandForTwitch('#chan-a', '!count', null);
+    await executeCounterCommandForTwitch('#chan-a', '!count', null, 'guild-a');
     expect(mockTwitchRuntime.send).toHaveBeenCalledTimes(1);
 
-    await executeCounterCommandForTwitch('#chan-b', '!count', null);
+    await executeCounterCommandForTwitch('#chan-b', '!count', null, 'guild-b');
     expect(mockTwitchRuntime.send).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/commands/counterHandler.ts
+++ b/src/commands/counterHandler.ts
@@ -63,25 +63,28 @@ interface CounterResult {
 }
 
 /**
- * Looks up a counter by `command`, increments it if it's a trigger-type counter,
- * and formats the resulting response message. Shared by the Discord and Twitch
+ * Looks up a counter by `command` within `guildId`, increments it if it's a trigger-type
+ * counter, and formats the resulting response message. Shared by the Discord and Twitch
  * counter handlers so the lookup/increment/format logic isn't duplicated.
  *
  * A match is throttled via `cooldownKey` (`GLOBAL_COOLDOWN_MS` per guild/channel) — a match
  * found while that key's cooldown is active is treated the same as no match, before any
  * increment or reply happens.
  *
+ * @param guildId - The guild whose counters to search; counters are per-guild, so the same
+ *   command string in a different guild never matches here.
  * @param command - The full command string (e.g. `!clap`) used to find the counter.
  * @param errorPrefix - Log-line prefix identifying the calling platform (e.g. `[Discord]`).
  * @param cooldownKey - Cooldown-gate key for the invoking guild/channel.
- * @returns The response text, display label, and whether it's safe to send it; null if no counter matches `command`, or if the match is on cooldown.
+ * @returns The response text, display label, and whether it's safe to send it; null if no counter matches `command` in this guild, or if the match is on cooldown.
  */
 async function buildCounterResponse(
+  guildId: string,
   command: string,
   errorPrefix: string,
   cooldownKey: string,
 ): Promise<CounterResult | null> {
-  const counter = await findCounterByCommand(command);
+  const counter = await findCounterByCommand(guildId, command);
   if (!counter) return null;
 
   // No log here: a spammed matching command would otherwise emit one log line per rejected
@@ -123,8 +126,13 @@ async function buildCounterResponse(
  * command, builds the counter response, and replies in-channel if the counter
  * was safely resolved. Throttled per guild by `GLOBAL_COOLDOWN_MS`.
  *
+ * Guild context is resolved in priority order: the explicit `guildId` argument, then
+ * `message.guildId`. Returns without action when no guild context is available — counters
+ * are per-guild, so there's no meaningful catalog to search without one.
+ *
  * @param message - The Discord message to check for a counter command.
  * @param username - Display name of the sender (unused; kept for call-site symmetry with the Twitch handler).
+ * @param guildId - Explicit guild ID to search; falls back to message.guildId.
  * @param precomputedCommand - Already-parsed command token from the caller's single
  *   `extractCommand` call for this message, or omit to parse `message.content` here.
  * @returns Resolves once the reply (or a no-op) has completed.
@@ -132,12 +140,16 @@ async function buildCounterResponse(
 export async function executeCounterCommandForDiscord(
   message: Message,
   username?: string | null,
+  guildId?: string,
   precomputedCommand?: string | null,
 ): Promise<void> {
   const command = resolveCommand(message.content, precomputedCommand);
   if (!command) return;
 
-  const result = await buildCounterResponse(command, '[Discord]', discordCooldownKey(message));
+  const resolvedGuildId = guildId ?? message.guildId;
+  if (!resolvedGuildId) return;
+
+  const result = await buildCounterResponse(resolvedGuildId, command, '[Discord]', discordCooldownKey(message));
   if (!result) return;
 
   if (!result.canReply) return;
@@ -161,6 +173,9 @@ export async function executeCounterCommandForDiscord(
  * @param channel - Twitch channel the message was sent in (also the send target).
  * @param rawMessage - Raw chat message text.
  * @param username - Twitch login of the sender (unused; kept for call-site symmetry with the Discord handler).
+ * @param guildId - Guild whose counters to search — resolved by the caller from the linked
+ *   streamer's active voice guild (same resolution `commandRouter.ts`'s SFX triggers use). No-ops
+ *   without one, since counters are per-guild and there's nothing to search otherwise.
  * @param precomputedCommand - Already-parsed command token from the caller's single
  *   `extractCommand` call for this message, or omit to parse `rawMessage` here.
  * @returns Resolves once the send (or a no-op) has completed.
@@ -169,12 +184,14 @@ export async function executeCounterCommandForTwitch(
   channel: string,
   rawMessage: string,
   username?: string | null,
+  guildId?: string | null,
   precomputedCommand?: string | null,
 ): Promise<void> {
   const command = resolveCommand(rawMessage, precomputedCommand);
   if (!command) return;
+  if (!guildId) return;
 
-  const result = await buildCounterResponse(command, `[Twitch:${channel}]`, `twitch:${channel}`);
+  const result = await buildCounterResponse(guildId, command, `[Twitch:${channel}]`, `twitch:${channel}`);
   if (!result) return;
 
   if (!result.canReply) return;

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -402,15 +402,17 @@ describe('unassignUserFromCommand', () => {
 // db.ts's wrappers invalidate the counter lookup cache after each write.
 
 describe('addCounter', () => {
+  const NEW_COUNTER = { triggerCommand: '!hits', checkCommand: '!checkhits', message: 'msg', incrementMessage: 'inc', resetYearly: false };
+
   it('calls the record function and invalidates the cache on success', async () => {
-    await addCounter('guild-1', '!hits', '!checkhits', 'msg', 'inc', false);
-    expect(addCounterRecord).toHaveBeenCalledWith('guild-1', '!hits', '!checkhits', 'msg', 'inc', false);
+    await addCounter('guild-1', NEW_COUNTER);
+    expect(addCounterRecord).toHaveBeenCalledWith('guild-1', NEW_COUNTER);
     expect(invalidateCounterLookupCache).toHaveBeenCalledOnce();
   });
 
   it('propagates errors without calling invalidate', async () => {
     vi.mocked(addCounterRecord).mockRejectedValue(new Error('DB error'));
-    await expect(addCounter('guild-1', '!hits', '!checkhits', 'msg', 'inc', false)).rejects.toThrow('DB error');
+    await expect(addCounter('guild-1', NEW_COUNTER)).rejects.toThrow('DB error');
     expect(invalidateCounterLookupCache).not.toHaveBeenCalled();
   });
 });

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -403,14 +403,14 @@ describe('unassignUserFromCommand', () => {
 
 describe('addCounter', () => {
   it('calls the record function and invalidates the cache on success', async () => {
-    await addCounter('!hits', '!checkhits', 'msg', 'inc', false);
-    expect(addCounterRecord).toHaveBeenCalledWith('!hits', '!checkhits', 'msg', 'inc', false);
+    await addCounter('guild-1', '!hits', '!checkhits', 'msg', 'inc', false);
+    expect(addCounterRecord).toHaveBeenCalledWith('guild-1', '!hits', '!checkhits', 'msg', 'inc', false);
     expect(invalidateCounterLookupCache).toHaveBeenCalledOnce();
   });
 
   it('propagates errors without calling invalidate', async () => {
     vi.mocked(addCounterRecord).mockRejectedValue(new Error('DB error'));
-    await expect(addCounter('!hits', '!checkhits', 'msg', 'inc', false)).rejects.toThrow('DB error');
+    await expect(addCounter('guild-1', '!hits', '!checkhits', 'msg', 'inc', false)).rejects.toThrow('DB error');
     expect(invalidateCounterLookupCache).not.toHaveBeenCalled();
   });
 });
@@ -418,24 +418,24 @@ describe('addCounter', () => {
 describe('updateCounter', () => {
   it('calls the record function and invalidates the cache on success', async () => {
     const input = { id: 1, triggerCommand: '!hits', checkCommand: '!checkhits', message: 'm', incrementMessage: 'i', resetYearly: false };
-    await updateCounter(input);
-    expect(updateCounterRecord).toHaveBeenCalledWith(input);
+    await updateCounter('guild-1', input);
+    expect(updateCounterRecord).toHaveBeenCalledWith('guild-1', input);
     expect(invalidateCounterLookupCache).toHaveBeenCalledOnce();
   });
 });
 
 describe('removeCounter', () => {
   it('calls the record function and invalidates the cache on success', async () => {
-    await removeCounter(1);
-    expect(removeCounterRecord).toHaveBeenCalledWith(1);
+    await removeCounter('guild-1', 1);
+    expect(removeCounterRecord).toHaveBeenCalledWith('guild-1', 1);
     expect(invalidateCounterLookupCache).toHaveBeenCalledOnce();
   });
 });
 
 describe('resetCounterCurrentValue', () => {
   it('calls the record function and invalidates the cache on success', async () => {
-    await resetCounterCurrentValue(1);
-    expect(resetCounterCurrentValueRecord).toHaveBeenCalledWith(1);
+    await resetCounterCurrentValue('guild-1', 1);
+    expect(resetCounterCurrentValueRecord).toHaveBeenCalledWith('guild-1', 1);
     expect(invalidateCounterLookupCache).toHaveBeenCalledOnce();
   });
 });

--- a/src/db.ts
+++ b/src/db.ts
@@ -252,7 +252,7 @@ export { ReservedCommandError } from './db/reservedCommands';
 
 // ─── Counter commands ───────────────────────────────────────────────────────
 
-export { CounterNotFoundError, getAllCounters, getCounterCount, getCounterHistory } from './db/counters';
+export { CounterNotFoundError, getAllCounters, getCountersForGuild, getCounterCount, getCounterHistory } from './db/counters';
 export { findCounterByCommand, isCounterCommandTaken } from './db/counterCache';
 
 import {
@@ -271,6 +271,7 @@ import { invalidateCounterLookupCache } from './db/counterCache';
 
 /**
  * Creates a new counter and invalidates the counter lookup cache.
+ * @param guildId - The guild this counter belongs to.
  * @param triggerCommand - Command that increments the counter.
  * @param checkCommand - Command that reports the counter's current value.
  * @param message - Message shown when the counter is checked.
@@ -279,39 +280,42 @@ import { invalidateCounterLookupCache } from './db/counterCache';
  * @returns Resolves once the insert (and cache invalidation) completes.
  */
 export async function addCounter(
-  triggerCommand: string, checkCommand: string, message: string, incrementMessage: string, resetYearly: boolean,
+  guildId: string, triggerCommand: string, checkCommand: string, message: string, incrementMessage: string, resetYearly: boolean,
 ): Promise<void> {
   await withInvalidation(
-    () => addCounterRecord(triggerCommand, checkCommand, message, incrementMessage, resetYearly),
+    () => addCounterRecord(guildId, triggerCommand, checkCommand, message, incrementMessage, resetYearly),
     invalidateCounterLookupCache,
   );
 }
 
 /**
  * Updates an existing counter's fields and invalidates the counter lookup cache.
+ * @param guildId - The guild the counter must belong to.
  * @param input - The counter's id and updated fields.
  * @returns Resolves once the update (and cache invalidation) completes.
  */
-export async function updateCounter(input: UpdateCounterInput): Promise<void> {
-  await withInvalidation(() => updateCounterRecord(input), invalidateCounterLookupCache);
+export async function updateCounter(guildId: string, input: UpdateCounterInput): Promise<void> {
+  await withInvalidation(() => updateCounterRecord(guildId, input), invalidateCounterLookupCache);
 }
 
 /**
  * Deletes a counter by id and invalidates the counter lookup cache.
+ * @param guildId - The guild the counter must belong to.
  * @param id - The counter's numeric id.
  * @returns Resolves once the deletion (and cache invalidation) completes.
  */
-export async function removeCounter(id: number): Promise<void> {
-  await withInvalidation(() => removeCounterRecord(id), invalidateCounterLookupCache);
+export async function removeCounter(guildId: string, id: number): Promise<void> {
+  await withInvalidation(() => removeCounterRecord(guildId, id), invalidateCounterLookupCache);
 }
 
 /**
  * Resets a counter's current value to 0 and invalidates the counter lookup cache.
+ * @param guildId - The guild the counter must belong to.
  * @param id - The counter's numeric id.
  * @returns Resolves once the update (and cache invalidation) completes.
  */
-export async function resetCounterCurrentValue(id: number): Promise<void> {
-  await withInvalidation(() => resetCounterCurrentValueRecord(id), invalidateCounterLookupCache);
+export async function resetCounterCurrentValue(guildId: string, id: number): Promise<void> {
+  await withInvalidation(() => resetCounterCurrentValueRecord(guildId, id), invalidateCounterLookupCache);
 }
 
 /**

--- a/src/db.ts
+++ b/src/db.ts
@@ -263,7 +263,7 @@ import {
   incrementCounter as incrementCounterRecord,
   archiveAndResetYearlyCounters as archiveAndResetYearlyCountersRecord,
 } from './db/counters';
-import type { UpdateCounterInput } from './db/counters';
+import type { UpdateCounterInput, CounterFieldsInput } from './db/counters';
 import { invalidateCounterLookupCache } from './db/counterCache';
 
 // counters.ts is now a pure DB layer with no cache knowledge (breaks its import cycle with
@@ -272,18 +272,12 @@ import { invalidateCounterLookupCache } from './db/counterCache';
 /**
  * Creates a new counter and invalidates the counter lookup cache.
  * @param guildId - The guild this counter belongs to.
- * @param triggerCommand - Command that increments the counter.
- * @param checkCommand - Command that reports the counter's current value.
- * @param message - Message shown when the counter is checked.
- * @param incrementMessage - Message shown when the counter is incremented.
- * @param resetYearly - Whether the counter's value is archived and reset each new year.
+ * @param input - The counter's initial fields.
  * @returns Resolves once the insert (and cache invalidation) completes.
  */
-export async function addCounter(
-  guildId: string, triggerCommand: string, checkCommand: string, message: string, incrementMessage: string, resetYearly: boolean,
-): Promise<void> {
+export async function addCounter(guildId: string, input: CounterFieldsInput): Promise<void> {
   await withInvalidation(
-    () => addCounterRecord(guildId, triggerCommand, checkCommand, message, incrementMessage, resetYearly),
+    () => addCounterRecord(guildId, input),
     invalidateCounterLookupCache,
   );
 }

--- a/src/db/commandLocks.test.ts
+++ b/src/db/commandLocks.test.ts
@@ -202,6 +202,25 @@ describe('isAnyCommandTakenAcrossTables', () => {
     expect(customCmdCall).toBeDefined();
     expect(customCmdCall![1]).toContain(7);
   });
+
+  it('scopes the counter query to guildId when given, without affecting the custom_command query', async () => {
+    const pool = { execute: vi.fn().mockResolvedValue([[]]) };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await isAnyCommandTakenAcrossTables('!test', { guildId: 'guild-1' }, pool as any);
+    const counterCall = pool.execute.mock.calls.find((args) => (args[0] as string).includes('counter'));
+    const customCmdCall = pool.execute.mock.calls.find((args) => (args[0] as string).includes('custom_command'));
+    expect(counterCall![0]).toContain('AND guild_id = ?');
+    expect(counterCall![1]).toContain('guild-1');
+    expect(customCmdCall![0]).not.toContain('guild_id');
+  });
+
+  it('checks the counter table across every guild when guildId is omitted', async () => {
+    const pool = { execute: vi.fn().mockResolvedValue([[]]) };
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await isAnyCommandTakenAcrossTables('!test', undefined, pool as any);
+    const counterCall = pool.execute.mock.calls.find((args) => (args[0] as string).includes('counter'));
+    expect(counterCall![0]).not.toContain('guild_id');
+  });
 });
 
 // ─── commandExists ────────────────────────────────────────────────────────────

--- a/src/db/commandLocks.ts
+++ b/src/db/commandLocks.ts
@@ -195,15 +195,24 @@ function buildCustomCommandExistsCheckPlan(
  * @param placeholders - `IN (...)` placeholder string sized for `normalizedCommands.length`.
  * @param normalizedCommands - Normalized command strings to check for a collision.
  * @param options.excludeCounterId - A counter `id` to exclude from the check.
+ * @param options.guildId - When given, scopes the check to counters in this guild only (the same
+ *   trigger/check command may exist in a different guild's counter without colliding). Omit to
+ *   check across every guild's counters — used when validating a *global* custom_command
+ *   trigger, which must not collide with any guild's counter.
  * @returns The SQL and params to run via {@link executeExistsCheck}.
  */
 function buildCounterExistsCheckPlan(
   placeholders: string,
   normalizedCommands: string[],
-  options?: { excludeCustomCommandId?: number; excludeCounterId?: number },
+  options?: { excludeCustomCommandId?: number; excludeCounterId?: number; guildId?: string },
 ): SqlExistsCheckPlan {
   let sql = `SELECT 1 FROM counter WHERE (trigger_command IN (${placeholders}) OR check_command IN (${placeholders}))`;
   const params: Array<string | number> = [...normalizedCommands, ...normalizedCommands];
+
+  if (options?.guildId !== undefined) {
+    sql += ' AND guild_id = ?';
+    params.push(options.guildId);
+  }
 
   if (options?.excludeCounterId !== undefined) {
     sql += ' AND id != ?';
@@ -230,7 +239,9 @@ async function executeExistsCheck(executor: SqlExecutor, plan: SqlExistsCheckPla
  * `counter` row (whichever tables `checks` enables), optionally excluding a specific
  * command/counter id from the check (used when updating an existing row in place).
  * @param commandOrCommands - A single command string or array of command strings to check.
- * @param options - Ids to exclude from the collision check, if updating an existing row.
+ * @param options - Ids to exclude from the collision check, if updating an existing row, and
+ *   `guildId` to scope the counter-table half of the check (see {@link buildCounterExistsCheckPlan}).
+ *   `guildId` has no effect on the custom_command half of the check, which is always global.
  * @param executor - Query executor to run the checks on; defaults to the pool, but a
  *   transaction connection is passed when called from {@link runSerializedCommandWrite}.
  * @param checks - Which tables to check; both default to enabled.
@@ -238,7 +249,7 @@ async function executeExistsCheck(executor: SqlExecutor, plan: SqlExistsCheckPla
  */
 export async function isAnyCommandTakenAcrossTables(
   commandOrCommands: string | string[],
-  options?: { excludeCustomCommandId?: number; excludeCounterId?: number },
+  options?: { excludeCustomCommandId?: number; excludeCounterId?: number; guildId?: string },
   executor: SqlExecutor = getPool(),
   checks: { includeCustomCommandTable?: boolean; includeCounterTable?: boolean } = {
     includeCustomCommandTable: true,
@@ -302,7 +313,9 @@ export async function commandExists(id: number, executor: SqlExecutor = getPool(
  * release is attempted and the connection returned to the pool in a `finally`; a release
  * failure is logged and swallowed rather than masking the original error.
  * @param commandOrCommands - The command(s) this write claims; also used for the collision check.
- * @param options - Ids to exclude from the collision check, if updating an existing row.
+ * @param options - Ids to exclude from the collision check, if updating an existing row, and
+ *   `guildId` to scope the counter-table half of the check to one guild (see
+ *   {@link isAnyCommandTakenAcrossTables}).
  * @param writeOperation - The transactional write to perform once locks are held and no collision exists.
  * @param checks - Which tables to include in the collision check; both default to enabled.
  * @returns The value returned by `writeOperation`.
@@ -310,7 +323,7 @@ export async function commandExists(id: number, executor: SqlExecutor = getPool(
  */
 export async function runSerializedCommandWrite<T>(
   commandOrCommands: string | string[],
-  options: { excludeCustomCommandId?: number; excludeCounterId?: number } | undefined,
+  options: { excludeCustomCommandId?: number; excludeCounterId?: number; guildId?: string } | undefined,
   writeOperation: (connection: mysql.PoolConnection) => Promise<T>,
   checks: { includeCustomCommandTable?: boolean; includeCounterTable?: boolean } = {
     includeCustomCommandTable: true,

--- a/src/db/counterCache.test.ts
+++ b/src/db/counterCache.test.ts
@@ -39,9 +39,10 @@ import { getAllCounters } from './counters';
 import { isAnyCommandTakenAcrossTables } from './commandLocks';
 import type { DbCounter } from './counters';
 
-function makeCounter(id: number, trigger: string, check: string): DbCounter {
+function makeCounter(id: number, trigger: string, check: string, guildId = 'guild-1'): DbCounter {
   return {
     id,
+    guild_id: guildId,
     trigger_command: trigger,
     check_command: check,
     message: '',
@@ -60,13 +61,13 @@ beforeEach(() => {
 
 describe('findCounterByCommand', () => {
   it('returns null for an empty string without making a DB call', async () => {
-    const result = await findCounterByCommand('');
+    const result = await findCounterByCommand('guild-1', '');
     expect(result).toBeNull();
     expect(getAllCounters).not.toHaveBeenCalled();
   });
 
   it('returns null for a whitespace-only string without making a DB call', async () => {
-    const result = await findCounterByCommand('   ');
+    const result = await findCounterByCommand('guild-1', '   ');
     expect(result).toBeNull();
     expect(getAllCounters).not.toHaveBeenCalled();
   });
@@ -75,7 +76,7 @@ describe('findCounterByCommand', () => {
     const counter = makeCounter(1, '!hits', '!checkhits');
     vi.mocked(getAllCounters).mockResolvedValue([counter]);
 
-    const result = await findCounterByCommand('!hits');
+    const result = await findCounterByCommand('guild-1', '!hits');
 
     expect(result).not.toBeNull();
     expect(result!.id).toBe(1);
@@ -86,7 +87,7 @@ describe('findCounterByCommand', () => {
     const counter = makeCounter(1, '!hits', '!checkhits');
     vi.mocked(getAllCounters).mockResolvedValue([counter]);
 
-    const result = await findCounterByCommand('!checkhits');
+    const result = await findCounterByCommand('guild-1', '!checkhits');
 
     expect(result).not.toBeNull();
     expect(result!.id).toBe(1);
@@ -97,7 +98,7 @@ describe('findCounterByCommand', () => {
     const counter = makeCounter(1, '!hits', '!checkhits');
     vi.mocked(getAllCounters).mockResolvedValue([counter]);
 
-    const result = await findCounterByCommand('!HITS');
+    const result = await findCounterByCommand('guild-1', '!HITS');
 
     expect(result).not.toBeNull();
     expect(result!.id).toBe(1);
@@ -108,7 +109,7 @@ describe('findCounterByCommand', () => {
     const counter = makeCounter(1, '!hits', '!checkhits');
     vi.mocked(getAllCounters).mockResolvedValue([counter]);
 
-    const result = await findCounterByCommand('  !hits  ');
+    const result = await findCounterByCommand('guild-1', '  !hits  ');
 
     expect(result).not.toBeNull();
     expect(result!.id).toBe(1);
@@ -117,7 +118,7 @@ describe('findCounterByCommand', () => {
   it('returns null when no counter matches the command', async () => {
     vi.mocked(getAllCounters).mockResolvedValue([makeCounter(1, '!hits', '!checkhits')]);
 
-    const result = await findCounterByCommand('!unknown');
+    const result = await findCounterByCommand('guild-1', '!unknown');
 
     expect(result).toBeNull();
   });
@@ -126,11 +127,11 @@ describe('findCounterByCommand', () => {
     const counter = makeCounter(1, '!hits', '!checkhits');
     vi.mocked(getAllCounters).mockResolvedValue([counter]);
 
-    const first = await findCounterByCommand('!hits');
+    const first = await findCounterByCommand('guild-1', '!hits');
     expect(first).not.toBeNull();
     first!.current_value = 9999;
 
-    const second = await findCounterByCommand('!hits');
+    const second = await findCounterByCommand('guild-1', '!hits');
     expect(second).not.toBeNull();
     expect(second).not.toBe(first);
     expect(second!.current_value).toBe(0);
@@ -145,7 +146,7 @@ describe('buildCounterLookupCache (via findCounterByCommand)', () => {
     const loser = makeCounter(2, '!hits', '!checkhits2');
     vi.mocked(getAllCounters).mockResolvedValue([winner, loser]);
 
-    const result = await findCounterByCommand('!hits');
+    const result = await findCounterByCommand('guild-1', '!hits');
 
     expect(result).not.toBeNull();
     expect(result!.id).toBe(1);
@@ -157,13 +158,13 @@ describe('buildCounterLookupCache (via findCounterByCommand)', () => {
     const loser = makeCounter(2, '!hits', '!checkhits2');
     vi.mocked(getAllCounters).mockResolvedValue([winner, loser]);
 
-    await findCounterByCommand('!hits');
+    await findCounterByCommand('guild-1', '!hits');
 
-    const hitsCalls = vi.mocked(registerFirstWinsWithWarning).mock.calls.filter((call) => call[1] === '!hits');
+    const hitsCalls = vi.mocked(registerFirstWinsWithWarning).mock.calls.filter((call) => call[1] === 'guild-1:!hits');
     expect(hitsCalls).toHaveLength(2);
     const describeCollision = hitsCalls[1][3] as (existing: unknown) => string;
     expect(describeCollision({ ...winner, matchType: 'trigger' })).toBe(
-      "Counter trigger_command collision: '!hits' is already registered (counter id=1); ignoring duplicate from counter id=2.",
+      "Counter trigger_command collision: '!hits' in guild guild-1 is already registered (counter id=1); ignoring duplicate from counter id=2.",
     );
   });
 
@@ -172,7 +173,7 @@ describe('buildCounterLookupCache (via findCounterByCommand)', () => {
     const winner = makeCounter(1, '!hits', '!checkhits1');
     vi.mocked(getAllCounters).mockResolvedValue([loser, winner]);
 
-    const result = await findCounterByCommand('!hits');
+    const result = await findCounterByCommand('guild-1', '!hits');
 
     expect(result).not.toBeNull();
     expect(result!.id).toBe(1);
@@ -181,7 +182,7 @@ describe('buildCounterLookupCache (via findCounterByCommand)', () => {
   it('returns null for any command when the counter list is empty', async () => {
     vi.mocked(getAllCounters).mockResolvedValue([]);
 
-    const result = await findCounterByCommand('!anything');
+    const result = await findCounterByCommand('guild-1', '!anything');
 
     expect(result).toBeNull();
   });
@@ -191,25 +192,62 @@ describe('buildCounterLookupCache (via findCounterByCommand)', () => {
 
 describe('isCounterCommandTaken', () => {
   it('returns true immediately for an array containing duplicates without delegating to isAnyCommandTakenAcrossTables', async () => {
-    const result = await isCounterCommandTaken(['!hits', '!hits']);
+    const result = await isCounterCommandTaken('guild-1', ['!hits', '!hits']);
 
     expect(result).toBe(true);
     expect(isAnyCommandTakenAcrossTables).not.toHaveBeenCalled();
   });
 
-  it('delegates to isAnyCommandTakenAcrossTables for a single string input', async () => {
+  it('delegates to isAnyCommandTakenAcrossTables for a single string input, scoped to the given guild', async () => {
     vi.mocked(isAnyCommandTakenAcrossTables).mockResolvedValue(false);
 
-    await isCounterCommandTaken('!hits', 42);
+    await isCounterCommandTaken('guild-1', '!hits', 42);
 
-    expect(isAnyCommandTakenAcrossTables).toHaveBeenCalledWith('!hits', { excludeCounterId: 42 });
+    expect(isAnyCommandTakenAcrossTables).toHaveBeenCalledWith('!hits', { excludeCounterId: 42, guildId: 'guild-1' });
   });
 
-  it('delegates to isAnyCommandTakenAcrossTables for an array with no duplicates', async () => {
+  it('delegates to isAnyCommandTakenAcrossTables for an array with no duplicates, scoped to the given guild', async () => {
     vi.mocked(isAnyCommandTakenAcrossTables).mockResolvedValue(false);
 
-    await isCounterCommandTaken(['!hits', '!checkhits']);
+    await isCounterCommandTaken('guild-1', ['!hits', '!checkhits']);
 
-    expect(isAnyCommandTakenAcrossTables).toHaveBeenCalledWith(['!hits', '!checkhits'], { excludeCounterId: undefined });
+    expect(isAnyCommandTakenAcrossTables).toHaveBeenCalledWith(['!hits', '!checkhits'], { excludeCounterId: undefined, guildId: 'guild-1' });
+  });
+});
+
+// ─── guild scoping ────────────────────────────────────────────────────────────
+
+describe('guild scoping', () => {
+  it('does not find a counter registered in a different guild', async () => {
+    const counter = makeCounter(1, '!hits', '!checkhits', 'guild-a');
+    vi.mocked(getAllCounters).mockResolvedValue([counter]);
+
+    const result = await findCounterByCommand('guild-b', '!hits');
+
+    expect(result).toBeNull();
+  });
+
+  it('finds the correct guild\'s counter when two guilds share the same trigger_command', async () => {
+    const counterA = makeCounter(1, '!hits', '!checkhitsA', 'guild-a');
+    const counterB = makeCounter(2, '!hits', '!checkhitsB', 'guild-b');
+    vi.mocked(getAllCounters).mockResolvedValue([counterA, counterB]);
+
+    const resultA = await findCounterByCommand('guild-a', '!hits');
+    const resultB = await findCounterByCommand('guild-b', '!hits');
+
+    expect(resultA!.id).toBe(1);
+    expect(resultB!.id).toBe(2);
+  });
+
+  it('does not log a collision warning for the same trigger_command used by two different guilds', async () => {
+    const { registerFirstWinsWithWarning } = await import('./lookupCache.js');
+    const counterA = makeCounter(1, '!hits', '!checkhitsA', 'guild-a');
+    const counterB = makeCounter(2, '!hits', '!checkhitsB', 'guild-b');
+    vi.mocked(getAllCounters).mockResolvedValue([counterA, counterB]);
+
+    await findCounterByCommand('guild-a', '!hits');
+
+    const triggerCalls = vi.mocked(registerFirstWinsWithWarning).mock.calls.filter((call) => call[1] === 'guild-a:!hits' || call[1] === 'guild-b:!hits');
+    expect(triggerCalls).toHaveLength(2);
   });
 });

--- a/src/db/counterCache.ts
+++ b/src/db/counterCache.ts
@@ -32,10 +32,17 @@ function createEmptyCounterLookupCache(): CounterLookupCache {
   };
 }
 
+/** Builds this cache's composite key: counters are per-guild, so the same command string in two
+ *  different guilds must never collide with each other. */
+function cacheKey(guildId: string, normalizedCommand: string): string {
+  return `${guildId}:${normalizedCommand}`;
+}
+
 /**
- * Builds a counter lookup cache keyed by normalized trigger/check command, sorted by counter id
- * so the lowest id wins on collision. Logs a warning and skips the duplicate on any collision.
- * @param counters Counters to index.
+ * Builds a counter lookup cache keyed by guild + normalized trigger/check command, sorted by
+ * counter id so the lowest id wins on collision within the same guild. Logs a warning and skips
+ * the duplicate on any collision.
+ * @param counters Counters to index, across every guild.
  * @returns The populated `CounterLookupCache`.
  */
 function buildCounterLookupCache(counters: DbCounter[]): CounterLookupCache {
@@ -52,9 +59,9 @@ function buildCounterLookupCache(counters: DbCounter[]): CounterLookupCache {
 
     registerFirstWinsWithWarning(
       byCommand,
-      normalizedCommand,
+      cacheKey(counter.guild_id, normalizedCommand),
       { ...counter, matchType },
-      (existingCounter) => `Counter ${commandFieldLabel} collision: '${normalizedCommand}' is already registered (counter id=${existingCounter.id}); ignoring duplicate from counter id=${counter.id}.`,
+      (existingCounter) => `Counter ${commandFieldLabel} collision: '${normalizedCommand}' in guild ${counter.guild_id} is already registered (counter id=${existingCounter.id}); ignoring duplicate from counter id=${counter.id}.`,
     );
   };
 
@@ -84,18 +91,20 @@ export function invalidateCounterLookupCache(): void {
   counterLookupCacheState.invalidate();
 }
 
-/** Looks up a counter by its trigger or check command string; returns null if not found. */
-export async function findCounterByCommand(command: string): Promise<DbMatchedCounter | null> {
+/** Looks up a counter by its trigger or check command string within one guild; returns null if
+ *  not found in that guild (even if the same command matches a counter in a different guild). */
+export async function findCounterByCommand(guildId: string, command: string): Promise<DbMatchedCounter | null> {
   const normalizedCommand = normalizeCommand(command);
   if (!normalizedCommand) return null;
 
   const cache = await counterLookupCacheState.getCache();
-  const counter = cache.byCommand.get(normalizedCommand);
+  const counter = cache.byCommand.get(cacheKey(guildId, normalizedCommand));
   return counter ? { ...counter } : null;
 }
 
-/** Returns true if any of the given commands conflict with an existing counter (optionally excluding one by ID). */
-export async function isCounterCommandTaken(commandOrCommands: string | string[], excludeCounterId?: number): Promise<boolean> {
+/** Returns true if any of the given commands conflict with an existing counter in this guild
+ *  (optionally excluding one by ID). Counters in other guilds never collide. */
+export async function isCounterCommandTaken(guildId: string, commandOrCommands: string | string[], excludeCounterId?: number): Promise<boolean> {
   if (Array.isArray(commandOrCommands)) {
     const normalizedCommands = normalizeCommandList(commandOrCommands);
     if (new Set(normalizedCommands).size !== normalizedCommands.length) {
@@ -103,5 +112,5 @@ export async function isCounterCommandTaken(commandOrCommands: string | string[]
     }
   }
 
-  return isAnyCommandTakenAcrossTables(commandOrCommands, { excludeCounterId });
+  return isAnyCommandTakenAcrossTables(commandOrCommands, { excludeCounterId, guildId });
 }

--- a/src/db/counters.test.ts
+++ b/src/db/counters.test.ts
@@ -324,15 +324,19 @@ describe('getCounterHistory', () => {
 // ─── addCounter ──────────────────────────────────────────────────────────────
 
 describe('addCounter', () => {
+  function newCounter(overrides: Partial<{ triggerCommand: string; checkCommand: string; message: string; incrementMessage: string; resetYearly: boolean }> = {}) {
+    return { triggerCommand: '!hits', checkCommand: '!checkhits', message: 'msg', incrementMessage: 'inc', resetYearly: false, ...overrides };
+  }
+
   it('throws when trigger and check command are the same', async () => {
     vi.mocked(getPool).mockReturnValue(makePool() as any);
-    await expect(addCounter('guild-1', '!hits', '!hits', 'msg', 'inc', false)).rejects.toThrow('must be different');
+    await expect(addCounter('guild-1', newCounter({ checkCommand: '!hits' }))).rejects.toThrow('must be different');
   });
 
   it('calls assertNotReservedCommand for both commands', async () => {
     vi.mocked(getPool).mockReturnValue(makePool() as any);
     mockConnection.execute.mockResolvedValue([{}, []]);
-    await addCounter('guild-1', '!hits', '!checkhits', 'msg', 'inc', false);
+    await addCounter('guild-1', newCounter());
     expect(assertNotReservedCommand).toHaveBeenCalledWith('!hits');
     expect(assertNotReservedCommand).toHaveBeenCalledWith('!checkhits');
   });
@@ -340,7 +344,7 @@ describe('addCounter', () => {
   it('calls runSerializedCommandWrite with both commands, scoped to the given guild', async () => {
     vi.mocked(getPool).mockReturnValue(makePool() as any);
     mockConnection.execute.mockResolvedValue([{}, []]);
-    await addCounter('guild-1', '!hits', '!checkhits', 'msg', 'inc', true);
+    await addCounter('guild-1', newCounter({ resetYearly: true }));
     expect(runSerializedCommandWrite).toHaveBeenCalledWith(
       ['!hits', '!checkhits'],
       { guildId: 'guild-1' },
@@ -351,7 +355,7 @@ describe('addCounter', () => {
   it('inserts the counter with the given guild id', async () => {
     vi.mocked(getPool).mockReturnValue(makePool() as any);
     mockConnection.execute.mockResolvedValue([{}, []]);
-    await addCounter('guild-1', '!hits', '!checkhits', 'msg', 'inc', true);
+    await addCounter('guild-1', newCounter({ resetYearly: true }));
     const [sql, params] = mockConnection.execute.mock.calls[0];
     expect(sql).toContain('INSERT INTO counter (guild_id,');
     expect(params).toEqual(['guild-1', '!hits', '!checkhits', 'msg', 'inc', 1]);
@@ -359,7 +363,7 @@ describe('addCounter', () => {
 
   it('throws when trigger and check differ only by case (normalized to same value)', async () => {
     vi.mocked(getPool).mockReturnValue(makePool() as any);
-    await expect(addCounter('guild-1', '!HITS', '!hits', 'msg', 'inc', false)).rejects.toThrow('must be different');
+    await expect(addCounter('guild-1', newCounter({ triggerCommand: '!HITS', checkCommand: '!hits' }))).rejects.toThrow('must be different');
   });
 });
 

--- a/src/db/counters.test.ts
+++ b/src/db/counters.test.ts
@@ -66,6 +66,7 @@ const mockConnection = makeMockConnection();
 import { getPool } from './pool';
 import {
   getAllCounters,
+  getCountersForGuild,
   getCounterCount,
   getCounterHistory,
   addCounter,
@@ -79,7 +80,6 @@ import {
 } from './counters';
 import { runSerializedCommandWrite } from './commandLocks';
 import { assertNotReservedCommand } from './reservedCommands';
-import { getRowCount } from './utils';
 import { makeMockPool } from '../test-utils/mockMysqlPool';
 
 /** Builds a fake pool via the shared helper, matching this file's historical `(rows, meta)` call shape. */
@@ -116,10 +116,18 @@ describe('CounterNotFoundError', () => {
 // ─── getCounterCount ────────────────────────────────────────────────────────
 
 describe('getCounterCount', () => {
-  it('delegates to getRowCount for the counter table', async () => {
-    vi.mocked(getRowCount).mockResolvedValue(4);
-    expect(await getCounterCount()).toBe(4);
-    expect(getRowCount).toHaveBeenCalledWith('counter');
+  it('returns the counter row count scoped to the given guild', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([{ count: '4' }]) as any);
+    expect(await getCounterCount('guild-1')).toBe(4);
+  });
+
+  it('scopes the query to the given guild id', async () => {
+    const pool = makePool([{ count: '0' }]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await getCounterCount('guild-1');
+    const [sql, params] = pool.execute.mock.calls[0];
+    expect(sql).toContain('WHERE guild_id = ?');
+    expect(params).toEqual(['guild-1']);
   });
 });
 
@@ -145,12 +153,43 @@ describe('getAllCounters', () => {
   });
 });
 
+// ─── getCountersForGuild ────────────────────────────────────────────────────
+
+describe('getCountersForGuild', () => {
+  it('scopes the query to the given guild id', async () => {
+    const pool = makePool([]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await getCountersForGuild('guild-1');
+    const [sql, params] = pool.execute.mock.calls[0];
+    expect(sql).toContain('WHERE guild_id = ?');
+    expect(params).toEqual(['guild-1']);
+  });
+
+  it('maps guild_id onto each returned counter', async () => {
+    const rows = [
+      { id: 1, guild_id: '900000000000000001', trigger_command: '!hits', check_command: '!checkhits', message: 'msg', increment_message: 'inc', reset_yearly: 1, current_value: 5 },
+    ];
+    vi.mocked(getPool).mockReturnValue(makePool(rows) as any);
+    const result = await getCountersForGuild('900000000000000001');
+    expect(result[0].guild_id).toBe('900000000000000001');
+  });
+});
+
 // ─── getCounterHistory ─────────────────────────────────────────────────────────
 
 describe('getCounterHistory', () => {
   it('returns null when the counter does not exist', async () => {
     vi.mocked(getPool).mockReturnValue(makePool([]) as any);
-    expect(await getCounterHistory(99)).toBeNull();
+    expect(await getCounterHistory('guild-1', 99)).toBeNull();
+  });
+
+  it('scopes the lookup to the given guild id', async () => {
+    const pool = makePool([]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await getCounterHistory('guild-1', 1);
+    const [sql, params] = pool.execute.mock.calls[0];
+    expect(sql).toContain('WHERE id = ? AND guild_id = ?');
+    expect(params).toEqual([1, 'guild-1']);
   });
 
   it('returns the counter and archived years newest-first, filtering out nulls', async () => {
@@ -172,7 +211,7 @@ describe('getCounterHistory', () => {
       {},
     ]);
     vi.mocked(getPool).mockReturnValue(pool as any);
-    const result = await getCounterHistory(1);
+    const result = await getCounterHistory('guild-1', 1);
     expect(result).not.toBeNull();
     expect(result!.counter.id).toBe(1);
     expect(result!.counter.reset_yearly).toBe(true);
@@ -193,7 +232,7 @@ describe('getCounterHistory', () => {
       current_value: 0,
     };
     vi.mocked(getPool).mockReturnValue(makePool([row]) as any);
-    const result = await getCounterHistory(2);
+    const result = await getCounterHistory('guild-1', 2);
     expect(result).not.toBeNull();
     expect(result!.history).toEqual([]);
   });
@@ -217,7 +256,7 @@ describe('getCounterHistory', () => {
     pool.query.mockResolvedValue([[{ COLUMN_NAME: 'value2025' }], {}]);
     vi.mocked(getPool).mockReturnValue(pool as any);
 
-    const result = await getCounterHistory(3);
+    const result = await getCounterHistory('guild-1', 3);
 
     expect(result!.history).toEqual([{ year: 2025, value: 7 }]);
     const [sql] = pool.execute.mock.calls[0];
@@ -230,7 +269,7 @@ describe('getCounterHistory', () => {
     const pool = makePool([]);
     vi.mocked(getPool).mockReturnValue(pool as any);
 
-    await getCounterHistory(1);
+    await getCounterHistory('guild-1', 1);
 
     const [sql] = pool.query.mock.calls[0];
     expect(sql).toContain('information_schema.COLUMNS');
@@ -242,9 +281,9 @@ describe('getCounterHistory', () => {
     pool.query.mockResolvedValue([[{ COLUMN_NAME: 'value2025' }], {}]);
     vi.mocked(getPool).mockReturnValue(pool as any);
 
-    await getCounterHistory(1);
-    await getCounterHistory(2);
-    await getCounterHistory(3);
+    await getCounterHistory('guild-1', 1);
+    await getCounterHistory('guild-1', 2);
+    await getCounterHistory('guild-1', 3);
 
     expect(pool.query).toHaveBeenCalledTimes(1);
   });
@@ -273,7 +312,7 @@ describe('getCounterHistory', () => {
     ]);
     vi.mocked(getPool).mockReturnValue(pool as any);
 
-    const result = await getCounterHistory(4);
+    const result = await getCounterHistory('guild-1', 4);
 
     expect(result!.history).toEqual([{ year: lastYear, value: 42 }]);
     const [sql] = pool.execute.mock.calls[0];
@@ -287,31 +326,40 @@ describe('getCounterHistory', () => {
 describe('addCounter', () => {
   it('throws when trigger and check command are the same', async () => {
     vi.mocked(getPool).mockReturnValue(makePool() as any);
-    await expect(addCounter('!hits', '!hits', 'msg', 'inc', false)).rejects.toThrow('must be different');
+    await expect(addCounter('guild-1', '!hits', '!hits', 'msg', 'inc', false)).rejects.toThrow('must be different');
   });
 
   it('calls assertNotReservedCommand for both commands', async () => {
     vi.mocked(getPool).mockReturnValue(makePool() as any);
     mockConnection.execute.mockResolvedValue([{}, []]);
-    await addCounter('!hits', '!checkhits', 'msg', 'inc', false);
+    await addCounter('guild-1', '!hits', '!checkhits', 'msg', 'inc', false);
     expect(assertNotReservedCommand).toHaveBeenCalledWith('!hits');
     expect(assertNotReservedCommand).toHaveBeenCalledWith('!checkhits');
   });
 
-  it('calls runSerializedCommandWrite with both commands', async () => {
+  it('calls runSerializedCommandWrite with both commands, scoped to the given guild', async () => {
     vi.mocked(getPool).mockReturnValue(makePool() as any);
     mockConnection.execute.mockResolvedValue([{}, []]);
-    await addCounter('!hits', '!checkhits', 'msg', 'inc', true);
+    await addCounter('guild-1', '!hits', '!checkhits', 'msg', 'inc', true);
     expect(runSerializedCommandWrite).toHaveBeenCalledWith(
       ['!hits', '!checkhits'],
-      undefined,
+      { guildId: 'guild-1' },
       expect.any(Function),
     );
   });
 
+  it('inserts the counter with the given guild id', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool() as any);
+    mockConnection.execute.mockResolvedValue([{}, []]);
+    await addCounter('guild-1', '!hits', '!checkhits', 'msg', 'inc', true);
+    const [sql, params] = mockConnection.execute.mock.calls[0];
+    expect(sql).toContain('INSERT INTO counter (guild_id,');
+    expect(params).toEqual(['guild-1', '!hits', '!checkhits', 'msg', 'inc', 1]);
+  });
+
   it('throws when trigger and check differ only by case (normalized to same value)', async () => {
     vi.mocked(getPool).mockReturnValue(makePool() as any);
-    await expect(addCounter('!HITS', '!hits', 'msg', 'inc', false)).rejects.toThrow('must be different');
+    await expect(addCounter('guild-1', '!HITS', '!hits', 'msg', 'inc', false)).rejects.toThrow('must be different');
   });
 });
 
@@ -320,24 +368,45 @@ describe('addCounter', () => {
 describe('updateCounter', () => {
   it('throws when trigger and check are the same', async () => {
     vi.mocked(getPool).mockReturnValue(makePool([{ trigger_command: '!old', check_command: '!oldcheck' }]) as any);
-    await expect(updateCounter({ id: 1, triggerCommand: '!hits', checkCommand: '!hits', message: 'm', incrementMessage: 'i', resetYearly: false }))
+    await expect(updateCounter('guild-1', { id: 1, triggerCommand: '!hits', checkCommand: '!hits', message: 'm', incrementMessage: 'i', resetYearly: false }))
       .rejects.toThrow('must be different');
   });
 
   it('throws CounterNotFoundError when getCounterCommandsById returns null', async () => {
     vi.mocked(getPool).mockReturnValue(makePool([]) as any);
-    await expect(updateCounter({ id: 99, triggerCommand: '!hits', checkCommand: '!check', message: 'm', incrementMessage: 'i', resetYearly: false }))
+    await expect(updateCounter('guild-1', { id: 99, triggerCommand: '!hits', checkCommand: '!check', message: 'm', incrementMessage: 'i', resetYearly: false }))
       .rejects.toBeInstanceOf(CounterNotFoundError);
   });
 
   it('calls assertNotReservedCommand for both commands', async () => {
     vi.mocked(getPool).mockReturnValue(makePool([{ trigger_command: '!old', check_command: '!oldcheck' }]) as any);
     mockConnection.execute.mockResolvedValue([{ affectedRows: 1 }, []]);
-    await updateCounter({ id: 1, triggerCommand: '!new', checkCommand: '!newcheck', message: 'm', incrementMessage: 'i', resetYearly: false });
+    await updateCounter('guild-1', { id: 1, triggerCommand: '!new', checkCommand: '!newcheck', message: 'm', incrementMessage: 'i', resetYearly: false });
     expect(assertNotReservedCommand).toHaveBeenCalledWith('!new');
     expect(assertNotReservedCommand).toHaveBeenCalledWith('!newcheck');
   });
 
+  it('treats a counter id belonging to a different guild as not found (never reads its commands)', async () => {
+    // The lookup query itself is scoped by guild_id, so a counter belonging to another guild
+    // returns no rows here — the same as a genuinely nonexistent id — rather than leaking its
+    // current trigger/check commands to a caller in the wrong guild.
+    const pool = makePool([]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(updateCounter('guild-1', { id: 1, triggerCommand: '!new', checkCommand: '!newcheck', message: 'm', incrementMessage: 'i', resetYearly: false }))
+      .rejects.toBeInstanceOf(CounterNotFoundError);
+    const [sql, params] = pool.execute.mock.calls[0];
+    expect(sql).toContain('AND guild_id = ?');
+    expect(params).toEqual([1, 'guild-1']);
+  });
+
+  it('scopes the UPDATE statement to the given guild id', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([{ trigger_command: '!old', check_command: '!oldcheck' }]) as any);
+    mockConnection.execute.mockResolvedValue([{ affectedRows: 1 }, []]);
+    await updateCounter('guild-1', { id: 1, triggerCommand: '!new', checkCommand: '!newcheck', message: 'm', incrementMessage: 'i', resetYearly: false });
+    const [sql, params] = mockConnection.execute.mock.calls[0];
+    expect(sql).toContain('WHERE id = ? AND guild_id = ?');
+    expect(params).toEqual(['!new', '!newcheck', 'm', 'i', 0, 1, 'guild-1']);
+  });
 });
 
 // ─── removeCounter ────────────────────────────────────────────────────────────
@@ -345,20 +414,36 @@ describe('updateCounter', () => {
 describe('removeCounter', () => {
   it('throws CounterNotFoundError when counter does not exist', async () => {
     vi.mocked(getPool).mockReturnValue(makePool([]) as any);
-    await expect(removeCounter(99)).rejects.toBeInstanceOf(CounterNotFoundError);
+    await expect(removeCounter('guild-1', 99)).rejects.toBeInstanceOf(CounterNotFoundError);
   });
 
   it('calls runSerializedCommandWrite with existing commands', async () => {
     vi.mocked(getPool).mockReturnValue(makePool([{ trigger_command: '!hits', check_command: '!checkhits' }]) as any);
     mockConnection.execute.mockResolvedValue([{ affectedRows: 1 }, []]);
-    await removeCounter(1);
+    await removeCounter('guild-1', 1);
     expect(runSerializedCommandWrite).toHaveBeenCalledWith(
       ['!hits', '!checkhits'],
-      { excludeCounterId: 1 },
+      { excludeCounterId: 1, guildId: 'guild-1' },
       expect.any(Function),
     );
   });
 
+  it('treats a counter id belonging to a different guild as not found', async () => {
+    const pool = makePool([]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await expect(removeCounter('guild-1', 1)).rejects.toBeInstanceOf(CounterNotFoundError);
+    const [, params] = pool.execute.mock.calls[0];
+    expect(params).toEqual([1, 'guild-1']);
+  });
+
+  it('scopes the DELETE statement to the given guild id', async () => {
+    vi.mocked(getPool).mockReturnValue(makePool([{ trigger_command: '!hits', check_command: '!checkhits' }]) as any);
+    mockConnection.execute.mockResolvedValue([{ affectedRows: 1 }, []]);
+    await removeCounter('guild-1', 1);
+    const [sql, params] = mockConnection.execute.mock.calls[0];
+    expect(sql).toContain('WHERE id = ? AND guild_id = ?');
+    expect(params).toEqual([1, 'guild-1']);
+  });
 });
 
 // ─── resetCounterCurrentValue ─────────────────────────────────────────────────
@@ -370,14 +455,24 @@ describe('resetCounterCurrentValue', () => {
       .mockResolvedValueOnce([{ affectedRows: 0 }, []])  // UPDATE: ResultSetHeader (affectedRows=0)
       .mockResolvedValueOnce([[], []]);                    // EXISTS check: no rows
     vi.mocked(getPool).mockReturnValue(pool as any);
-    await expect(resetCounterCurrentValue(99)).rejects.toBeInstanceOf(CounterNotFoundError);
+    await expect(resetCounterCurrentValue('guild-1', 99)).rejects.toBeInstanceOf(CounterNotFoundError);
   });
 
   it('does not throw when affectedRows > 0', async () => {
     const pool = makePool();
     pool.execute.mockResolvedValue([{ affectedRows: 1 }, []]);
     vi.mocked(getPool).mockReturnValue(pool as any);
-    await expect(resetCounterCurrentValue(1)).resolves.not.toThrow();
+    await expect(resetCounterCurrentValue('guild-1', 1)).resolves.not.toThrow();
+  });
+
+  it('scopes the UPDATE statement to the given guild id', async () => {
+    const pool = makePool();
+    pool.execute.mockResolvedValue([{ affectedRows: 1 }, []]);
+    vi.mocked(getPool).mockReturnValue(pool as any);
+    await resetCounterCurrentValue('guild-1', 1);
+    const [sql, params] = pool.execute.mock.calls[0];
+    expect(sql).toContain('WHERE id = ? AND guild_id = ?');
+    expect(params).toEqual([1, 'guild-1']);
   });
 });
 

--- a/src/db/counters.ts
+++ b/src/db/counters.ts
@@ -3,7 +3,7 @@ import { getPool, withTransaction } from './pool';
 import { requireTrimmedString, normalizeCommand, type SqlExecutor } from './commandStringUtils';
 import { runSerializedCommandWrite } from './commandLocks';
 import { assertNotReservedCommand } from './reservedCommands';
-import { fromBit, rowExists, affectedOrExists, getRowCount } from './utils';
+import { fromBit, affectedOrExists } from './utils';
 import {
   createManagedLookupCache,
   type RefreshingLookupCache,
@@ -25,6 +25,7 @@ const ARCHIVE_YEAR_COLUMNS = new Map<number, string>(
 
 export interface DbCounter {
   id: number;
+  guild_id: string;
   trigger_command: string;
   check_command: string;
   message: string;
@@ -64,10 +65,12 @@ export interface CounterHistoryEntry {
 
 // ─── Row mapper ───────────────────────────────────────────────────────────────
 
-/** Maps a raw `counter` table row to a {@link DbCounter}. */
+/** Maps a raw `counter` table row to a {@link DbCounter}. `guild_id` is a Discord snowflake
+ *  (BIGINT) — kept as the string the driver returns, never coerced to `Number`. */
 function mapCounter(row: mysql.RowDataPacket): DbCounter {
   return {
     id: row.id,
+    guild_id: String(row.guild_id),
     trigger_command: row.trigger_command,
     check_command: row.check_command,
     message: row.message,
@@ -112,22 +115,50 @@ function normalizeCounterFields(
 
 // ─── Queries ─────────────────────────────────────────────────────────────────
 
+const COUNTER_COLUMNS = 'id, guild_id, trigger_command, check_command, message, increment_message, reset_yearly, current_value';
+
 /**
- * Fetches all counters, ordered by trigger command.
- * @returns All counters.
+ * Fetches every counter across every guild, ordered by trigger command. Used by the runtime
+ * command-lookup cache ({@link findCounterByCommand}), which buckets the result per guild in
+ * memory — for a single guild's counters (e.g. the admin panel), use {@link getCountersForGuild}
+ * instead.
+ * @returns All counters, across every guild.
  */
 export async function getAllCounters(): Promise<DbCounter[]> {
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    `SELECT id, trigger_command, check_command, message, increment_message, reset_yearly, current_value
+    `SELECT ${COUNTER_COLUMNS}
      FROM counter
      ORDER BY trigger_command`,
   );
   return rows.map(mapCounter);
 }
 
-/** Return the total number of counters, for the dashboard's usage-stats summary. */
-export async function getCounterCount(): Promise<number> {
-  return getRowCount('counter');
+/**
+ * Fetches all counters belonging to one guild, ordered by trigger command.
+ * @param guildId The guild to fetch counters for.
+ * @returns That guild's counters.
+ */
+export async function getCountersForGuild(guildId: string): Promise<DbCounter[]> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    `SELECT ${COUNTER_COLUMNS}
+     FROM counter
+     WHERE guild_id = ?
+     ORDER BY trigger_command`,
+    [guildId],
+  );
+  return rows.map(mapCounter);
+}
+
+/** Return the number of counters belonging to one guild, for the dashboard's usage-stats summary. */
+export async function getCounterCount(guildId: string): Promise<number> {
+  const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
+    'SELECT COUNT(*) AS count FROM counter WHERE guild_id = ?',
+    [guildId],
+  );
+  // COUNT(*) is protocol-typed BIGINT, so bigNumberStrings stringifies it — but like
+  // getRowCount in utils.ts, this value is bounded by how many counters a human configures in
+  // one guild's admin panel, nowhere near Number.MAX_SAFE_INTEGER, so parsing it back is safe.
+  return Number.parseInt((rows[0] as mysql.RowDataPacket).count, 10);
 }
 
 /**
@@ -204,11 +235,13 @@ async function getExistingArchiveColumns(): Promise<string[]> {
  * columns that actually exist on the `counter` table right now (see
  * `getExistingArchiveColumns`), since not every year in `ARCHIVE_YEAR_COLUMNS` is
  * guaranteed to be a physical column yet.
+ * @param guildId - The guild the counter must belong to.
  * @param id - The counter's numeric id.
  * @returns The counter and its archived history (years with a non-null value,
- *   newest first), or `null` if no counter exists with the given id.
+ *   newest first), or `null` if no counter with the given id exists in this guild.
  */
 export async function getCounterHistory(
+  guildId: string,
   id: number,
 ): Promise<{ counter: DbCounter; history: CounterHistoryEntry[] } | null> {
   const existingColumns = await getExistingArchiveColumns();
@@ -216,11 +249,11 @@ export async function getCounterHistory(
     ? `, ${existingColumns.map((col) => `\`${col}\``).join(', ')}`
     : '';
   const [rows] = await getPool().execute<mysql.RowDataPacket[]>(
-    `SELECT id, trigger_command, check_command, message, increment_message, reset_yearly, current_value${selectColumns}
+    `SELECT ${COUNTER_COLUMNS}${selectColumns}
      FROM counter
-     WHERE id = ?
+     WHERE id = ? AND guild_id = ?
      LIMIT 1`,
-    [id],
+    [id, guildId],
   );
   if (rows.length === 0) return null;
 
@@ -239,7 +272,10 @@ export async function getCounterHistory(
 
 /**
  * Creates a new counter, starting at 0, after validating fields and checking the trigger/check
- * commands don't conflict with other reserved or in-use commands.
+ * commands don't conflict with other reserved or in-use commands (globally for other guilds'
+ * custom commands, and within this guild for other counters — the same trigger/check command may
+ * exist in a different guild's counter without colliding).
+ * @param guildId The guild this counter belongs to.
  * @param triggerCommand Command that increments the counter.
  * @param checkCommand Command that reports the counter's current value.
  * @param message Message shown when the counter is checked.
@@ -249,6 +285,7 @@ export async function getCounterHistory(
  *   already taken by another command.
  */
 export async function addCounter(
+  guildId: string,
   triggerCommand: string,
   checkCommand: string,
   message: string,
@@ -265,40 +302,48 @@ export async function addCounter(
 
   await runSerializedCommandWrite(
     [fields.triggerCommand, fields.checkCommand],
-    undefined,
+    { guildId },
     async (connection) => {
       await connection.execute(
-        `INSERT INTO counter (trigger_command, check_command, message, increment_message, reset_yearly, current_value)
-         VALUES (?, ?, ?, ?, ?, 0)`,
-        [fields.triggerCommand, fields.checkCommand, fields.message, fields.incrementMessage, resetYearly ? 1 : 0],
+        `INSERT INTO counter (guild_id, trigger_command, check_command, message, increment_message, reset_yearly, current_value)
+         VALUES (?, ?, ?, ?, ?, ?, 0)`,
+        [guildId, fields.triggerCommand, fields.checkCommand, fields.message, fields.incrementMessage, resetYearly ? 1 : 0],
       );
     },
   );
 }
 
 /**
- * Checks whether a counter with the given id exists.
+ * Checks whether a counter with the given id exists in this guild.
+ * @param guildId The guild the counter must belong to.
  * @param id The counter's numeric id.
  * @param executor Pool or transaction connection to query with.
- * @returns True if the counter exists.
+ * @returns True if a counter with that id exists in this guild.
  */
-async function counterExists(id: number, executor: SqlExecutor = getPool()): Promise<boolean> {
-  return rowExists(executor, 'counter', 'id', id);
+async function counterExists(guildId: string, id: number, executor: SqlExecutor = getPool()): Promise<boolean> {
+  const [rows] = await executor.execute<mysql.RowDataPacket[]>(
+    'SELECT 1 FROM counter WHERE id = ? AND guild_id = ? LIMIT 1',
+    [id, guildId],
+  );
+  return rows.length > 0;
 }
 
 /**
- * Looks up a counter's current trigger/check command strings by id.
+ * Looks up a counter's current trigger/check command strings by id, scoped to one guild.
+ * @param guildId The guild the counter must belong to.
  * @param id The counter's numeric id.
  * @param executor Pool or transaction connection to query with.
- * @returns The counter's trigger and check commands, or `null` if no counter exists with the given id.
+ * @returns The counter's trigger and check commands, or `null` if no counter with the given id
+ *   exists in this guild.
  */
 async function getCounterCommandsById(
+  guildId: string,
   id: number,
   executor: SqlExecutor = getPool(),
 ): Promise<{ trigger_command: string; check_command: string } | null> {
   const [rows] = await executor.execute<mysql.RowDataPacket[]>(
-    'SELECT trigger_command, check_command FROM counter WHERE id = ? LIMIT 1',
-    [id],
+    'SELECT trigger_command, check_command FROM counter WHERE id = ? AND guild_id = ? LIMIT 1',
+    [id, guildId],
   );
   if (rows.length === 0) return null;
   return { trigger_command: rows[0].trigger_command, check_command: rows[0].check_command };
@@ -307,12 +352,13 @@ async function getCounterCommandsById(
 /**
  * Updates an existing counter's fields, locking both its old and new trigger/check commands
  * so concurrent writes can't create a conflict during the transition.
+ * @param guildId The guild the counter must belong to.
  * @param input The counter's id and updated fields.
- * @throws {CounterNotFoundError} If no counter exists with the given id.
+ * @throws {CounterNotFoundError} If no counter with the given id exists in this guild.
  * @throws If `triggerCommand` and `checkCommand` are the same, either is reserved, or either is
  *   already taken by another command.
  */
-export async function updateCounter(input: UpdateCounterInput): Promise<void> {
+export async function updateCounter(guildId: string, input: UpdateCounterInput): Promise<void> {
   const { id, triggerCommand, checkCommand, message, incrementMessage, resetYearly } = input;
 
   const fields = normalizeCounterFields(triggerCommand, checkCommand, message, incrementMessage);
@@ -323,7 +369,7 @@ export async function updateCounter(input: UpdateCounterInput): Promise<void> {
   assertNotReservedCommand(fields.triggerCommand);
   assertNotReservedCommand(fields.checkCommand);
 
-  const current = await getCounterCommandsById(id);
+  const current = await getCounterCommandsById(guildId, id);
   if (!current) throw new CounterNotFoundError(id);
 
   // Lock old commands too so concurrent adds/updates can't sneak in during the
@@ -337,7 +383,7 @@ export async function updateCounter(input: UpdateCounterInput): Promise<void> {
 
   await runSerializedCommandWrite(
     commandsToLock,
-    { excludeCounterId: id },
+    { excludeCounterId: id, guildId },
     async (connection) => {
       const [result] = await connection.execute<mysql.ResultSetHeader>(
         `UPDATE counter
@@ -346,11 +392,11 @@ export async function updateCounter(input: UpdateCounterInput): Promise<void> {
              message = ?,
              increment_message = ?,
              reset_yearly = ?
-         WHERE id = ?`,
-        [fields.triggerCommand, fields.checkCommand, fields.message, fields.incrementMessage, resetYearly ? 1 : 0, id],
+         WHERE id = ? AND guild_id = ?`,
+        [fields.triggerCommand, fields.checkCommand, fields.message, fields.incrementMessage, resetYearly ? 1 : 0, id, guildId],
       );
 
-      if (!(await affectedOrExists(result.affectedRows, () => counterExists(id, connection)))) {
+      if (!(await affectedOrExists(result.affectedRows, () => counterExists(guildId, id, connection)))) {
         throw new CounterNotFoundError(id);
       }
     },
@@ -359,20 +405,21 @@ export async function updateCounter(input: UpdateCounterInput): Promise<void> {
 
 /**
  * Deletes a counter by id, locking its trigger/check commands during the delete.
+ * @param guildId The guild the counter must belong to.
  * @param id The counter's numeric id.
- * @throws {CounterNotFoundError} If no counter exists with the given id.
+ * @throws {CounterNotFoundError} If no counter with the given id exists in this guild.
  */
-export async function removeCounter(id: number): Promise<void> {
-  const current = await getCounterCommandsById(id);
+export async function removeCounter(guildId: string, id: number): Promise<void> {
+  const current = await getCounterCommandsById(guildId, id);
   if (!current) throw new CounterNotFoundError(id);
 
   await runSerializedCommandWrite(
     [current.trigger_command, current.check_command],
-    { excludeCounterId: id },
+    { excludeCounterId: id, guildId },
     async (connection) => {
       const [result] = await connection.execute<mysql.ResultSetHeader>(
-        'DELETE FROM counter WHERE id = ?',
-        [id],
+        'DELETE FROM counter WHERE id = ? AND guild_id = ?',
+        [id, guildId],
       );
       if (result.affectedRows === 0) throw new CounterNotFoundError(id);
     },
@@ -381,16 +428,17 @@ export async function removeCounter(id: number): Promise<void> {
 
 /**
  * Resets a counter's `current_value` to 0.
+ * @param guildId The guild the counter must belong to.
  * @param id The counter's numeric id.
- * @throws {CounterNotFoundError} If no counter exists with the given id.
+ * @throws {CounterNotFoundError} If no counter with the given id exists in this guild.
  */
-export async function resetCounterCurrentValue(id: number): Promise<void> {
+export async function resetCounterCurrentValue(guildId: string, id: number): Promise<void> {
   const [result] = await getPool().execute<mysql.ResultSetHeader>(
-    'UPDATE counter SET current_value = 0 WHERE id = ?',
-    [id],
+    'UPDATE counter SET current_value = 0 WHERE id = ? AND guild_id = ?',
+    [id, guildId],
   );
 
-  if (!(await affectedOrExists(result.affectedRows, () => counterExists(id)))) {
+  if (!(await affectedOrExists(result.affectedRows, () => counterExists(guildId, id)))) {
     throw new CounterNotFoundError(id);
   }
 }

--- a/src/db/counters.ts
+++ b/src/db/counters.ts
@@ -40,13 +40,17 @@ export interface DbMatchedCounter extends DbCounter {
   matchType: CounterMatchType;
 }
 
-export interface UpdateCounterInput {
-  id: number;
+/** A counter's editable fields, shared by {@link addCounter} and {@link UpdateCounterInput}. */
+export interface CounterFieldsInput {
   triggerCommand: string;
   checkCommand: string;
   message: string;
   incrementMessage: string;
   resetYearly: boolean;
+}
+
+export interface UpdateCounterInput extends CounterFieldsInput {
+  id: number;
 }
 
 /** Thrown when a counter lookup/mutation matches no row. */
@@ -276,22 +280,12 @@ export async function getCounterHistory(
  * custom commands, and within this guild for other counters — the same trigger/check command may
  * exist in a different guild's counter without colliding).
  * @param guildId The guild this counter belongs to.
- * @param triggerCommand Command that increments the counter.
- * @param checkCommand Command that reports the counter's current value.
- * @param message Message shown when the counter is checked.
- * @param incrementMessage Message shown when the counter is incremented.
- * @param resetYearly Whether the counter's value is archived and reset each new year.
+ * @param input The counter's initial fields.
  * @throws If `triggerCommand` and `checkCommand` are the same, either is reserved, or either is
  *   already taken by another command.
  */
-export async function addCounter(
-  guildId: string,
-  triggerCommand: string,
-  checkCommand: string,
-  message: string,
-  incrementMessage: string,
-  resetYearly: boolean,
-): Promise<void> {
+export async function addCounter(guildId: string, input: CounterFieldsInput): Promise<void> {
+  const { triggerCommand, checkCommand, message, incrementMessage, resetYearly } = input;
   const fields = normalizeCounterFields(triggerCommand, checkCommand, message, incrementMessage);
   if (fields.triggerCommand === fields.checkCommand) {
     throw new Error('Counter trigger_command and check_command must be different');

--- a/src/discord/discordBot.ts
+++ b/src/discord/discordBot.ts
@@ -179,7 +179,7 @@ function registerMessageCreateHandler(client: Client): void {
     const command = extractCommand(message.content);
 
     fireAndForget(executeCustomCommandForDiscord(message, displayName, guildId, command), 'Custom command error', log);
-    fireAndForget(executeCounterCommandForDiscord(message, displayName, command), 'Counter command error', log);
+    fireAndForget(executeCounterCommandForDiscord(message, displayName, guildId, command), 'Counter command error', log);
     fireAndForget(handleCommand(message.content, 'discord', guildId, command), 'Command handler error', log);
     fireAndForget(executeHealthCommandForDiscord(message, command), 'Health command error', log);
   });

--- a/src/twitch/twitchBot.test.ts
+++ b/src/twitch/twitchBot.test.ts
@@ -344,13 +344,14 @@ describe('handleTwitchMessage', () => {
     sendMessage('#streamer', 'alice', '!cmd', { displayName: 'Alice' });
 
     expect(executeCustomCommandForTwitch).toHaveBeenCalledWith('streamer', '!cmd', 'Alice', '!cmd');
-    expect(executeCounterCommandForTwitch).toHaveBeenCalledWith('streamer', '!cmd', 'Alice', '!cmd');
     expect(executeMultiCommandForTwitch).toHaveBeenCalledWith('streamer', '!cmd', 'Alice', '!cmd');
     expect(executeShoutoutForTwitch).toHaveBeenCalledWith('streamer', '!cmd', 'Alice', false, '!cmd');
-    // Guild resolution (Twitch-channel → discord_id → active voice guild) runs
-    // asynchronously before handleCommand is invoked.
+    // Guild resolution (Twitch-channel → discord_id → active voice guild) runs asynchronously
+    // before handleCommand and executeCounterCommandForTwitch are invoked.
     await vi.waitFor(() => expect(handleCommand).toHaveBeenCalledOnce());
     expect(handleCommand).toHaveBeenCalledWith('!cmd', 'twitch', 'guild-A', '!cmd');
+    await vi.waitFor(() => expect(executeCounterCommandForTwitch).toHaveBeenCalledOnce());
+    expect(executeCounterCommandForTwitch).toHaveBeenCalledWith('streamer', '!cmd', 'Alice', 'guild-A', '!cmd');
     expect(executeCountdownForTwitch).toHaveBeenCalledWith('streamer', '!cmd', '!cmd');
   });
 

--- a/src/twitch/twitchBot.ts
+++ b/src/twitch/twitchBot.ts
@@ -182,7 +182,12 @@ function handleTwitchMessage(channel: string, user: string, message: string, msg
     const command = extractCommand(message);
 
     fireAndForget(executeCustomCommandForTwitch(normalizedChannel, message, displayName, command), 'Custom command error', log);
-    fireAndForget(executeCounterCommandForTwitch(normalizedChannel, message, displayName, command), 'Counter command error', log);
+    fireAndForget(
+      resolveGuildIdForTwitchCommand(normalizedChannel).then((guildId) =>
+        executeCounterCommandForTwitch(normalizedChannel, message, displayName, guildId, command)),
+      'Counter command error',
+      log,
+    );
     fireAndForget(executeMultiCommandForTwitch(normalizedChannel, message, displayName, command), 'Multi command error', log);
     fireAndForget(executeShoutoutForTwitch(normalizedChannel, message, displayName, isMod, command), 'Shoutout error', log);
     fireAndForget(

--- a/src/web/routes/counterHistory.test.ts
+++ b/src/web/routes/counterHistory.test.ts
@@ -19,7 +19,12 @@ vi.mock('../csrf', () => ({
 }));
 
 vi.mock('../middleware', () => ({
-  requireAuth: (_req: any, _res: any, next: any) => next(),
+  requireGuildContext: (_req: any, _res: any, next: any) => next(),
+}));
+
+const GUILD_ID = '900000000000000001';
+vi.mock('../session', () => ({
+  getCurrentGuildId: vi.fn(() => GUILD_ID),
 }));
 
 /** Mocks the shared logger so route handlers don't write real log output during tests. */
@@ -59,7 +64,7 @@ describe('GET /counters/:id/history', () => {
 
     expect(res.status).toBe(200);
     expect(res.text).toBe('rendered:counterHistory');
-    expect(getCounterHistory).toHaveBeenCalledWith(1);
+    expect(getCounterHistory).toHaveBeenCalledWith(GUILD_ID, 1);
   });
 
   it('renders a 404 error page when id is non-numeric', async () => {

--- a/src/web/routes/counterHistory.ts
+++ b/src/web/routes/counterHistory.ts
@@ -2,7 +2,8 @@ import { createLogger } from '../../shared/logger';
 import { Router } from 'express';
 import { getCounterHistory } from '../../db';
 import { csrfProtection } from '../csrf';
-import { requireAuth } from '../middleware';
+import { requireGuildContext } from '../middleware';
+import { getCurrentGuildId } from '../session';
 import { parsePositiveIntId } from './validation';
 import { renderError, renderView } from './viewHelpers';
 
@@ -14,20 +15,22 @@ const router = Router();
 
 /**
  * GET /counters/:id/history — renders a counter's archived yearly-reset history
- * (open to any logged-in user, same gating as the main counters page since counter
- * values are already publicly readable via chat commands).
- * @param req - Express request; reads the `id` route param and `req.session.user`.
+ * (open to any logged-in user with the current guild selected, same gating as the
+ * main counters page since counter values are already publicly readable via chat
+ * commands). The counter must belong to the current guild.
+ * @param req - Express request; reads the `id` route param, `req.session.user`, and
+ *   the current guild from session.
  * @param res - Express response; renders the `counterHistory` view, or a 404 error
- *   page if `id` is malformed or no counter exists with that id.
+ *   page if `id` is malformed or no counter with that id exists in this guild.
  */
-router.get('/counters/:id/history', requireAuth, csrfProtection, async (req, res) => {
+router.get('/counters/:id/history', requireGuildContext, csrfProtection, async (req, res) => {
   const parsedId = parsePositiveIntId(req.params.id);
   if (parsedId === null) {
     return renderError(res, 404, 'Counter not found.', req.session.user);
   }
 
   try {
-    const result = await getCounterHistory(parsedId);
+    const result = await getCounterHistory(getCurrentGuildId(req), parsedId);
     if (!result) {
       return renderError(res, 404, 'Counter not found.', req.session.user);
     }

--- a/src/web/routes/counters.test.ts
+++ b/src/web/routes/counters.test.ts
@@ -229,7 +229,9 @@ describe('POST /counters/add', () => {
   it('scopes the duplicate-command check and the insert to the current guild', async () => {
     await supertest(buildApp()).post('/counters/add').type('form').send(VALID_ADD);
     expect(isCounterCommandTaken).toHaveBeenCalledWith(GUILD_ID, ['!hits', '!count']);
-    expect(addCounter).toHaveBeenCalledWith(GUILD_ID, '!hits', '!count', 'Count: %d', 'Now %d!', false);
+    expect(addCounter).toHaveBeenCalledWith(GUILD_ID, {
+      triggerCommand: '!hits', checkCommand: '!count', message: 'Count: %d', incrementMessage: 'Now %d!', resetYearly: false,
+    });
   });
 });
 

--- a/src/web/routes/counters.test.ts
+++ b/src/web/routes/counters.test.ts
@@ -6,7 +6,7 @@ vi.mock('../../db', () => {
   class CounterNotFoundError extends Error {}
   class ReservedCommandError extends Error {}
   return {
-    getAllCounters: vi.fn().mockResolvedValue([]),
+    getCountersForGuild: vi.fn().mockResolvedValue([]),
     addCounter: vi.fn().mockResolvedValue(undefined),
     updateCounter: vi.fn().mockResolvedValue(undefined),
     removeCounter: vi.fn().mockResolvedValue(undefined),
@@ -19,6 +19,11 @@ vi.mock('../../db', () => {
     AccessLevel: ACCESS_LEVEL_MOCK,
   };
 });
+
+const GUILD_ID = '900000000000000001';
+vi.mock('../session', () => ({
+  getCurrentGuildId: vi.fn(() => GUILD_ID),
+}));
 
 vi.mock('../csrf', () => ({
   csrfProtection: (req: any, res: any, next: any) => {
@@ -42,7 +47,7 @@ vi.mock('../../logger', () => ({
 import supertest from 'supertest';
 import router from './counters';
 import {
-  getAllCounters,
+  getCountersForGuild,
   addCounter,
   updateCounter,
   removeCounter,
@@ -84,7 +89,7 @@ const VALID_UPDATE = {
 beforeEach(() => {
   vi.clearAllMocks();
   middlewareCallOrder.length = 0;
-  vi.mocked(getAllCounters).mockResolvedValue([]);
+  vi.mocked(getCountersForGuild).mockResolvedValue([]);
   vi.mocked(addCounter).mockResolvedValue(undefined);
   vi.mocked(updateCounter).mockResolvedValue(undefined);
   vi.mocked(removeCounter).mockResolvedValue(undefined);
@@ -96,18 +101,19 @@ beforeEach(() => {
 // --- GET /counters ---
 
 describe('GET /counters', () => {
-  it('renders the counters view with the loaded counters', async () => {
+  it('renders the counters view with the current guild\'s counters', async () => {
     const counters = [{ id: 1, trigger_command: '!hits', check_command: '!count' }];
-    vi.mocked(getAllCounters).mockResolvedValue(counters as any);
+    vi.mocked(getCountersForGuild).mockResolvedValue(counters as any);
 
     const res = await supertest(buildApp()).get('/counters');
 
     expect(res.status).toBe(200);
     expect(res.text).toBe('rendered:counters');
+    expect(getCountersForGuild).toHaveBeenCalledWith(GUILD_ID);
   });
 
   it('renders a 500 error page when loading counters fails', async () => {
-    vi.mocked(getAllCounters).mockRejectedValue(new Error('db down'));
+    vi.mocked(getCountersForGuild).mockRejectedValue(new Error('db down'));
 
     const res = await supertest(buildApp()).get('/counters');
 
@@ -219,6 +225,12 @@ describe('POST /counters/add', () => {
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/counters');
   });
+
+  it('scopes the duplicate-command check and the insert to the current guild', async () => {
+    await supertest(buildApp()).post('/counters/add').type('form').send(VALID_ADD);
+    expect(isCounterCommandTaken).toHaveBeenCalledWith(GUILD_ID, ['!hits', '!count']);
+    expect(addCounter).toHaveBeenCalledWith(GUILD_ID, '!hits', '!count', 'Count: %d', 'Now %d!', false);
+  });
 });
 
 // --- POST /counters/update ---
@@ -284,6 +296,14 @@ describe('POST /counters/update', () => {
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/counters');
   });
+
+  it('scopes the duplicate-command check and the update to the current guild', async () => {
+    await supertest(buildApp()).post('/counters/update').type('form').send(VALID_UPDATE);
+    expect(isCounterCommandTaken).toHaveBeenCalledWith(GUILD_ID, ['!hits', '!count'], 42);
+    expect(updateCounter).toHaveBeenCalledWith(GUILD_ID, {
+      id: 42, triggerCommand: '!hits', checkCommand: '!count', message: 'Count: %d', incrementMessage: 'Now %d!', resetYearly: false,
+    });
+  });
 });
 
 // --- POST /counters/remove ---
@@ -321,6 +341,11 @@ describe('POST /counters/remove', () => {
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/counters');
   });
+
+  it('scopes the delete to the current guild', async () => {
+    await supertest(buildApp()).post('/counters/remove').type('form').send({ id: '5' });
+    expect(removeCounter).toHaveBeenCalledWith(GUILD_ID, 5);
+  });
 });
 
 // --- POST /counters/reset/:id ---
@@ -343,5 +368,10 @@ describe('POST /counters/reset/:id', () => {
       .post('/counters/reset/7');
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/counters?reset=1');
+  });
+
+  it('scopes the reset to the current guild', async () => {
+    await supertest(buildApp()).post('/counters/reset/7');
+    expect(resetCounterCurrentValue).toHaveBeenCalledWith(GUILD_ID, 7);
   });
 });

--- a/src/web/routes/counters.ts
+++ b/src/web/routes/counters.ts
@@ -128,14 +128,13 @@ router.post('/counters/add', requireGuildContext, requireMod, csrfProtection, as
       return res.redirect('/counters?error=duplicate_command');
     }
 
-    await addCounter(
-      guildId,
-      form.triggerCommand,
-      form.checkCommand,
-      form.message,
-      form.incrementMessage,
-      form.resetYearly,
-    );
+    await addCounter(guildId, {
+      triggerCommand: form.triggerCommand,
+      checkCommand: form.checkCommand,
+      message: form.message,
+      incrementMessage: form.incrementMessage,
+      resetYearly: form.resetYearly,
+    });
   } catch (err) {
     if (handleReservedOrConflictCommandError(err, res, COUNTER_WRITE_ERROR_OPTIONS)) return;
     return logAndRedirectError({ res, log, logLabel: 'Add counter error:', err, basePath: '/counters', errorCode: 'add_failed' });

--- a/src/web/routes/counters.ts
+++ b/src/web/routes/counters.ts
@@ -3,14 +3,15 @@ import { Router } from 'express';
 import {
   addCounter,
   CounterNotFoundError,
-  getAllCounters,
+  getCountersForGuild,
   isCounterCommandTaken,
   removeCounter,
   resetCounterCurrentValue,
   updateCounter,
 } from '../../db';
 import { csrfProtection } from '../csrf';
-import { requireAuth, requireGuildContext, requireMod, requireManager } from '../middleware';
+import { requireGuildContext, requireMod, requireManager } from '../middleware';
+import { getCurrentGuildId } from '../session';
 import { normalizeRequiredText, normalizeSingleTokenRequiredText, parsePositiveIntId, parseCheckboxField, filterQueryParam } from './validation';
 import { renderView } from './viewHelpers';
 import { logAndRedirectError, handleReservedOrConflictCommandError, renderOrError } from './errorHandling';
@@ -81,15 +82,15 @@ function validateAndNormalizeCounterForm(
 }
 
 /**
- * GET /counters — renders the counters page listing every counter.
+ * GET /counters — renders the counters page listing the current guild's counters.
  * @param req - Express request; reads `req.session.user`, `error`, and `reset`
- *   query params.
+ *   query params, and the current guild from session.
  * @param res - Express response; renders the `counters` view, or a 500 error page
  *   if loading counters fails.
  */
-router.get('/counters', requireAuth, csrfProtection, async (req, res) => {
+router.get('/counters', requireGuildContext, csrfProtection, async (req, res) => {
   await renderOrError({ res, log, logLabel: 'Counters page error:', sessionUser: req.session.user, errorMessage: 'Failed to load counters page.' }, async () => {
-    const counters = await getAllCounters();
+    const counters = await getCountersForGuild(getCurrentGuildId(req));
 
     renderView(res, 'counters', {
       user: req.session.user,
@@ -103,7 +104,7 @@ router.get('/counters', requireAuth, csrfProtection, async (req, res) => {
 
 /**
  * POST /counters/add — creates a new counter with a trigger command, check command,
- * increment/check messages, and yearly-reset flag.
+ * increment/check messages, and yearly-reset flag, in the current guild.
  * @param req - Express request; reads `trigger_command`, `check_command`, `message`,
  *   `increment_message`, and `reset_yearly` from `req.body`.
  * @param res - Express response; redirects to `/counters` on success, or to
@@ -112,13 +113,14 @@ router.get('/counters', requireAuth, csrfProtection, async (req, res) => {
  *   (`add_failed`).
  */
 router.post('/counters/add', requireGuildContext, requireMod, csrfProtection, async (req, res) => {
+  const guildId = getCurrentGuildId(req);
   const form = validateAndNormalizeCounterForm(req.body as Record<string, string | undefined>);
   if (form.error) {
     return res.redirect(`/counters?error=${form.error}`);
   }
 
   try {
-    const hasDuplicateCommand = await isCounterCommandTaken([
+    const hasDuplicateCommand = await isCounterCommandTaken(guildId, [
       form.triggerCommand,
       form.checkCommand,
     ]);
@@ -127,6 +129,7 @@ router.post('/counters/add', requireGuildContext, requireMod, csrfProtection, as
     }
 
     await addCounter(
+      guildId,
       form.triggerCommand,
       form.checkCommand,
       form.message,
@@ -143,16 +146,17 @@ router.post('/counters/add', requireGuildContext, requireMod, csrfProtection, as
 
 /**
  * POST /counters/update — updates an existing counter's commands, messages, and
- * yearly-reset flag.
+ * yearly-reset flag. The counter must belong to the current guild.
  * @param req - Express request; reads `id`, `trigger_command`, `check_command`,
  *   `message`, `increment_message`, and `reset_yearly` from `req.body`.
  * @param res - Express response; redirects to `/counters` on success, or to
  *   `/counters?error=<code>` for validation failures (`missing_fields`,
  *   `same_commands`, `invalid_id`, `duplicate_command`, `reserved_command`), if the
- *   counter no longer exists (`counter_not_found`), or the update fails
+ *   counter doesn't exist in this guild (`counter_not_found`), or the update fails
  *   (`update_failed`).
  */
 router.post('/counters/update', requireGuildContext, requireMod, csrfProtection, async (req, res) => {
+  const guildId = getCurrentGuildId(req);
   const { id } = req.body as Record<string, string | undefined>;
 
   const parsedId = parsePositiveIntId(id);
@@ -167,6 +171,7 @@ router.post('/counters/update', requireGuildContext, requireMod, csrfProtection,
 
   try {
     const hasDuplicateCommand = await isCounterCommandTaken(
+      guildId,
       [form.triggerCommand, form.checkCommand],
       parsedId,
     );
@@ -174,7 +179,7 @@ router.post('/counters/update', requireGuildContext, requireMod, csrfProtection,
       return res.redirect('/counters?error=duplicate_command');
     }
 
-    await updateCounter({
+    await updateCounter(guildId, {
       id: parsedId,
       triggerCommand: form.triggerCommand,
       checkCommand: form.checkCommand,
@@ -194,13 +199,14 @@ router.post('/counters/update', requireGuildContext, requireMod, csrfProtection,
 });
 
 /**
- * POST /counters/remove — deletes a counter.
+ * POST /counters/remove — deletes a counter. The counter must belong to the current guild.
  * @param req - Express request; reads `id` from `req.body`.
  * @param res - Express response; redirects to `/counters` on success, or to
  *   `/counters?error=<code>` if `id` is malformed (`invalid_id`), the counter
- *   doesn't exist (`counter_not_found`), or the delete fails (`remove_failed`).
+ *   doesn't exist in this guild (`counter_not_found`), or the delete fails (`remove_failed`).
  */
 router.post('/counters/remove', requireGuildContext, requireMod, csrfProtection, async (req, res) => {
+  const guildId = getCurrentGuildId(req);
   const { id } = req.body as { id?: string };
   const parsedId = parsePositiveIntId(id);
 
@@ -209,7 +215,7 @@ router.post('/counters/remove', requireGuildContext, requireMod, csrfProtection,
   }
 
   try {
-    await removeCounter(parsedId);
+    await removeCounter(guildId, parsedId);
   } catch (err) {
     if (err instanceof CounterNotFoundError) {
       return res.redirect('/counters?error=counter_not_found');
@@ -223,13 +229,14 @@ router.post('/counters/remove', requireGuildContext, requireMod, csrfProtection,
 
 /**
  * POST /counters/reset/:id — resets a counter's current value back to zero
- * (Manager+).
+ * (Manager+). The counter must belong to the current guild.
  * @param req - Express request; reads the `id` route param.
  * @param res - Express response; redirects to `/counters?reset=1` on success, or
  *   to `/counters?error=<code>` if `id` is malformed (`invalid_id`), the counter
- *   doesn't exist (`counter_not_found`), or the reset fails (`reset_failed`).
+ *   doesn't exist in this guild (`counter_not_found`), or the reset fails (`reset_failed`).
  */
 router.post('/counters/reset/:id', requireGuildContext, requireManager, csrfProtection, async (req, res) => {
+  const guildId = getCurrentGuildId(req);
   const rawId = req.params.id;
   const parsedId = parsePositiveIntId(typeof rawId === 'string' ? rawId : undefined);
   if (parsedId === null) {
@@ -237,7 +244,7 @@ router.post('/counters/reset/:id', requireGuildContext, requireManager, csrfProt
   }
 
   try {
-    await resetCounterCurrentValue(parsedId);
+    await resetCounterCurrentValue(guildId, parsedId);
   } catch (err) {
     if (err instanceof CounterNotFoundError) {
       return res.redirect('/counters?error=counter_not_found');

--- a/src/web/routes/dashboard.test.ts
+++ b/src/web/routes/dashboard.test.ts
@@ -75,8 +75,14 @@ describe('GET /', () => {
   });
 
   it('includes usage-stat counts from the db layer', async () => {
-    const res = await supertest(buildApp()).get('/');
+    const res = await supertest(buildApp({ discordId: '100', currentGuildId: 'guild-A' })).get('/');
     expect(res.body.usageStats).toEqual({ sfxCount: 3, commandCount: 5, counterCount: 2 });
+  });
+
+  it('reports counterCount as 0 without querying the DB when no guild is selected (e.g. not logged in)', async () => {
+    const res = await supertest(buildApp()).get('/');
+    expect(res.body.usageStats).toEqual({ sfxCount: 3, commandCount: 5, counterCount: 0 });
+    expect(getCounterCount).not.toHaveBeenCalled();
   });
 
   it('scopes status to the session\'s current guild', async () => {
@@ -140,7 +146,7 @@ describe('GET /', () => {
     vi.mocked(getGuildScopedStatus).mockReturnValue(new Promise((resolve) => { resolveStatus = resolve; }) as any);
     vi.mocked(getStreamerByDiscordId).mockResolvedValue(null);
 
-    const responsePromise = supertest(buildApp({ discordId: '100' })).get('/');
+    const responsePromise = supertest(buildApp({ discordId: '100', currentGuildId: 'guild-A' })).get('/');
     // supertest's Test is a lazy thenable — the request isn't actually dispatched until it's
     // awaited/`.then()`ed, so attach a no-op handler now to kick it off without consuming the
     // promise this test still awaits below.
@@ -154,7 +160,7 @@ describe('GET /', () => {
     await vi.waitFor(() => expect(getStreamerByDiscordId).toHaveBeenCalled());
     expect(getSfxTriggerCount).toHaveBeenCalled();
     expect(getCustomCommandCount).toHaveBeenCalled();
-    expect(getCounterCount).toHaveBeenCalled();
+    expect(getCounterCount).toHaveBeenCalledWith('guild-A');
 
     resolveStatus(STATUS);
     const res = await responsePromise;

--- a/src/web/routes/dashboard.ts
+++ b/src/web/routes/dashboard.ts
@@ -22,9 +22,13 @@ const router = Router();
  */
 router.get('/', csrfProtection, async (req, res) => {
   await renderOrError({ res, log, logLabel: 'Dashboard error:', sessionUser: req.session.user, errorMessage: 'Failed to load dashboard data.' }, async () => {
+    const currentGuildId = req.session.user?.currentGuildId ?? null;
     const [status, sfxCount, commandCount, counterCount, streamer] = await Promise.all([
-      getGuildScopedStatus(req.session.user?.currentGuildId ?? null),
-      getSfxTriggerCount(), getCustomCommandCount(), getCounterCount(),
+      getGuildScopedStatus(currentGuildId),
+      getSfxTriggerCount(), getCustomCommandCount(),
+      // Counters are per-guild (unlike SFX/custom commands, which are global) — 0 when no
+      // guild is selected (e.g. not logged in) rather than querying with a null guild id.
+      currentGuildId ? getCounterCount(currentGuildId) : Promise.resolve(0),
       req.session.user ? getStreamerByDiscordId(req.session.user.discordId) : Promise.resolve(null),
     ]);
 


### PR DESCRIPTION
## Summary

`counter.guild_id` was added to the schema by `migrations/multi_guild.sql`, but no application code actually read it.

**Web admin IDOR:** `GET /counters` listed every guild's counters to any logged-in user, and `POST /counters/add|update|remove|reset/:id` only checked the acting user's access level in their *own* current guild — never that the target counter id actually belonged to it. A mod/manager in any guild (even a throwaway one they control) could view, edit, delete, or reset a counter belonging to a completely unrelated guild just by passing its numeric id.

**Runtime cross-guild matching:** the deeper, more severe version of the same gap — the in-memory command-lookup cache (`counterCache.ts`) indexed every guild's counters into one flat `Map` keyed only by normalized command string. A chat message in one guild could match and increment a counter belonging to a different guild whenever their trigger/check commands happened to coincide (or, on a collision, one guild's counter would silently shadow another's entirely).

## Changes

- `src/db/counters.ts` — every CRUD function now takes/checks `guild_id`; added `getCountersForGuild()` for the admin list (`getAllCounters()` stays global, used only by the runtime cache's bulk load).
- `src/db/commandLocks.ts` — `isAnyCommandTakenAcrossTables()`/`runSerializedCommandWrite()` take an optional `guildId` that scopes only the counter-table half of the collision check (the global `custom_command` check is unaffected — the same command may exist as one guild's counter without colliding with another guild's).
- `src/db/counterCache.ts` — the lookup cache is keyed by guild+command (`` `${guildId}:${command}` ``), so two guilds' counters never collide or cross-match.
- `src/web/routes/counters.ts`, `counterHistory.ts` — scoped to `getCurrentGuildId(req)`; a counter id from another guild is treated as not found, matching the ownership-check pattern already used by `commandGuildOverrides.ts`/`overlayVideos.ts`.
- `src/web/routes/dashboard.ts` — the usage-stats counter tile is scoped to the session's current guild (0 when none selected), unlike the genuinely-global sfx/custom-command counts shown alongside it.
- `src/commands/counterHandler.ts`, `src/discord/discordBot.ts`, `src/twitch/twitchBot.ts` — `guildId` threaded through to chat-triggered matching: Discord via `message.guildId` (mirroring `customCommandHandler.ts`'s existing pattern), Twitch via the same `resolveGuildIdForTwitchCommand()` already used for SFX triggers.
- `DATABASE-SCHEMA.md` updated to reflect that runtime command handling is now guild-scoped (previously noted as a follow-up).

## Test plan

- Updated all affected unit/route test suites (`counters.test.ts`, `counterCache.test.ts`, `commandLocks.test.ts`, `counterHandler.test.ts`, `discordBot.test.ts`/`twitchBot.test.ts`, `web/routes/counters.test.ts`/`counterHistory.test.ts`/`dashboard.test.ts`) plus new tests specifically covering: cross-guild ownership checks (update/remove/reset treat another guild's counter id as not found), the guild-scoped lookup cache (two guilds sharing a trigger command don't collide or cross-match), and guildId threading through both Discord and Twitch chat paths.
- `npx tsc --noEmit && npm run lint && npm run check:circular && npm test` — all 3542 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTTsxupLZELmetjUwtZpCS

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTTsxupLZELmetjUwtZpCS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Counters are now scoped to the selected guild, including creation, editing, deletion, resets, history, counts, and command matching.
  - Counter commands from Discord and Twitch now use guild context and do not run when no guild can be identified.
  - Counter management and history pages require an active guild and only display that guild’s counters.
  - Dashboard counter totals now reflect the selected guild.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->